### PR TITLE
Add return type annotations to tests

### DIFF
--- a/backend/tests/benchmark/intensive/test_batch_create.py
+++ b/backend/tests/benchmark/intensive/test_batch_create.py
@@ -53,7 +53,7 @@ class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
         await db.execute_query(query=query, params=params, name="delete_nodes")
 
     @pytest.fixture
-    async def load_schema(self, client, branch, car_person_schema_unique_owner):
+    async def load_schema(self, client, branch, car_person_schema_unique_owner) -> None:
         res = await client.schema.load([car_person_schema_unique_owner], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 
@@ -85,6 +85,6 @@ class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
         )
 
 
-async def execute_batch(infrahub_batch):
+async def execute_batch(infrahub_batch) -> None:
     async for _, _ in infrahub_batch.execute():
         pass

--- a/backend/tests/benchmark/test_get_menu.py
+++ b/backend/tests/benchmark/test_get_menu.py
@@ -6,9 +6,9 @@ from infrahub.database import InfrahubDatabase
 
 
 @pytest.fixture
-async def init_menu(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def init_menu(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     await create_default_menu(db=db)
 
 
-def test_get_menu(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema, init_menu):
+def test_get_menu(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema, init_menu) -> None:
     aio_benchmark(get_menu, db=db, branch=default_branch, permission_manager=None)

--- a/backend/tests/benchmark/test_get_schema.py
+++ b/backend/tests/benchmark/test_get_schema.py
@@ -2,5 +2,5 @@ from infrahub.api.schema import get_schema
 from infrahub.database import InfrahubDatabase
 
 
-def test_get_schema(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema):
+def test_get_schema(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     aio_benchmark(get_schema, branch=default_branch, namespaces=None)

--- a/backend/tests/benchmark/test_graphql_generate_schema.py
+++ b/backend/tests/benchmark/test_graphql_generate_schema.py
@@ -8,7 +8,7 @@ from infrahub.graphql.manager import GraphQLSchemaManager
 
 def test_graphql_generate_schema(
     benchmark, db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
     schema = benchmark(gqlm.generate)

--- a/backend/tests/benchmark/test_graphql_query.py
+++ b/backend/tests/benchmark/test_graphql_query.py
@@ -52,11 +52,11 @@ async def register_default_schema(db: InfrahubDatabase, default_branch: Branch) 
 
 
 @pytest.fixture(scope="module")
-async def dataset04(db: InfrahubDatabase, default_branch, register_default_schema):
+async def dataset04(db: InfrahubDatabase, default_branch, register_default_schema) -> None:
     await load_data(db=db, nbr_query=250)
 
 
-def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04):
+def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04) -> None:
     query = """
     query {
         CoreGraphQLQuery {
@@ -96,7 +96,7 @@ def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, defaul
     )
 
 
-def test_query_rel_many(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04):
+def test_query_rel_many(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04) -> None:
     query = """
     query {
         CoreGraphQLQuery {
@@ -144,7 +144,7 @@ def test_query_rel_many(exec_async, aio_benchmark, db: InfrahubDatabase, default
     )
 
 
-def test_query_rel_one(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04):
+def test_query_rel_one(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04) -> None:
     query = """
     query {
         CoreGraphQLQuery {

--- a/backend/tests/benchmark/test_load_node_to_db.py
+++ b/backend/tests/benchmark/test_load_node_to_db.py
@@ -8,7 +8,7 @@ from infrahub.core.schema.manager import SchemaManager
 from infrahub.database import InfrahubDatabase
 
 
-def test_load_node_to_db_node_schema(aio_benchmark, db: InfrahubDatabase, default_branch):
+def test_load_node_to_db_node_schema(aio_benchmark, db: InfrahubDatabase, default_branch) -> None:
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
 

--- a/backend/tests/benchmark/test_nodemanager_peers.py
+++ b/backend/tests/benchmark/test_nodemanager_peers.py
@@ -28,7 +28,7 @@ async def relm(db: InfrahubDatabase, default_branch, register_core_models_schema
     return relm
 
 
-def test_nodemanager_querypeers(aio_benchmark, db: InfrahubDatabase, default_branch, test_account):
+def test_nodemanager_querypeers(aio_benchmark, db: InfrahubDatabase, default_branch, test_account) -> None:
     model = registry.schema.get(name="CoreAccount")
     aio_benchmark(
         NodeManager().query_peers,
@@ -40,5 +40,5 @@ def test_nodemanager_querypeers(aio_benchmark, db: InfrahubDatabase, default_bra
     )
 
 
-def test_relationshipmanager_getpeer(aio_benchmark, db: InfrahubDatabase, default_branch, relm):
+def test_relationshipmanager_getpeer(aio_benchmark, db: InfrahubDatabase, default_branch, relm) -> None:
     aio_benchmark(relm.get_peers, db=db)

--- a/backend/tests/benchmark/test_nodeschema_duplicate.py
+++ b/backend/tests/benchmark/test_nodeschema_duplicate.py
@@ -4,7 +4,7 @@ from infrahub.database import InfrahubDatabase
 
 def test_base_schema_duplicate_CoreProposedChange(
     benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema
-):
+) -> None:
     model = registry.schema.get(name="CoreProposedChange")
     new_node = benchmark(model.duplicate)
     assert new_node.kind == model.kind

--- a/backend/tests/benchmark/test_schemabranch_duplicate.py
+++ b/backend/tests/benchmark/test_schemabranch_duplicate.py
@@ -2,7 +2,7 @@ from infrahub.core import registry
 from infrahub.database import InfrahubDatabase
 
 
-def test_schemabranch_duplicate(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema):
+def test_schemabranch_duplicate(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     new_schema = benchmark(schema.duplicate)
     assert new_schema.get_hash() == schema.get_hash()

--- a/backend/tests/benchmark/test_schemabranch_process.py
+++ b/backend/tests/benchmark/test_schemabranch_process.py
@@ -2,6 +2,6 @@ from infrahub.core import registry
 from infrahub.database import InfrahubDatabase
 
 
-def test_schemabranch_process(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema):
+def test_schemabranch_process(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     benchmark(schema.process)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -75,11 +75,11 @@ pytest.register_assert_rewrite("tests.db_snapshot")
 graphql_registry.clear_cache()
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption("--neo4j", action="store_true", dest="neo4j", default=False, help="enable neo4j tests")
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     markexpr = getattr(config.option, "markexpr", "")
 
     if not markexpr:
@@ -101,7 +101,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def add_tracker():
+def add_tracker() -> None:
     os.environ["PYTEST_RUNNING"] = "true"
 
 
@@ -321,7 +321,7 @@ def redis(redis_container: dict[int, int] | None, reload_settings_before_each_mo
     return None
 
 
-def wait_for_memgraph_ready(host, port, timeout=15):
+def wait_for_memgraph_ready(host, port, timeout=15) -> bool:
     # Not retrieving host/port from config.SETTINGS here as they are set later in `db`fixture.
     URI = f"{config.SETTINGS.database.protocol}://{host}:{port}"
 
@@ -418,12 +418,12 @@ def prefect(prefect_container: dict[int, int] | None, reload_settings_before_eac
 
 
 @pytest.fixture(scope="session", autouse=True)
-def load_settings_before_session():
+def load_settings_before_session() -> None:
     load_and_exit()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reload_settings_before_each_module(tmpdir_factory):
+def reload_settings_before_each_module(tmpdir_factory) -> None:
     # Settings need to be reloaded between each test module, as some module might modify settings that might break tests within other modules.
     load_and_exit()
 
@@ -1060,7 +1060,7 @@ class BusRPCMock(InfrahubMessageBus):
     ) -> None:
         self.messages.append(message)
 
-    def add_mock_reply(self, response: InfrahubResponse):
+    def add_mock_reply(self, response: InfrahubResponse) -> None:
         self.response.append(response)
 
     async def rpc(self, message: InfrahubMessage, response_class: type[ResponseClass]) -> ResponseClass:

--- a/backend/tests/fixtures/checks/check01.py
+++ b/backend/tests/fixtures/checks/check01.py
@@ -4,7 +4,7 @@ from infrahub_sdk.checks import InfrahubCheck
 class Check01(InfrahubCheck):
     query = "my_query"
 
-    def validate(self, data):
+    def validate(self, data) -> None:
         self.log_error("Not Valid")
 
 

--- a/backend/tests/fixtures/checks/check02.py
+++ b/backend/tests/fixtures/checks/check02.py
@@ -5,7 +5,7 @@ class Check02(InfrahubCheck):
     """Non valid Check for testing.
     The query is missing."""
 
-    def validate(self, data):
+    def validate(self, data) -> None:
         self.log_error("Not Valid")
 
 

--- a/backend/tests/fixtures/project_02/checks/check_spine_interface_status.py
+++ b/backend/tests/fixtures/project_02/checks/check_spine_interface_status.py
@@ -4,7 +4,7 @@ from infrahub_sdk.checks import InfrahubCheck
 class InfrahubCheckSpineNbrInterfaceDisabled(InfrahubCheck):
     query = "check_spine_interface_status"
 
-    def validate(self, data):
+    def validate(self, data) -> None:
         for device in data["device"]:
             device_name = device["name"]["value"]
             device_id = device["id"]

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
@@ -6,7 +6,7 @@ from infrahub_sdk.checks import InfrahubCheck
 class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
     query = "check_backbone_link_redundancy"
 
-    def validate(self, data):
+    def validate(self, data) -> None:
         site_id_by_name = {}
 
         backbone_links_per_site = defaultdict(lambda: defaultdict(int))

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/checks/check_backbone_link_redundancy.py
@@ -6,7 +6,7 @@ from infrahub_sdk.checks import InfrahubCheck
 class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
     query = "check_backbone_link_redundancy"
 
-    def validate(self, data):
+    def validate(self, data) -> None:
         site_id_by_name = {}
 
         backbone_links_per_site = defaultdict(lambda: defaultdict(int))

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -109,7 +109,9 @@ CONVERSION_RESPONSE_COMMON_FIELDS = {
 
 class TestConvertRepository(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def local_repo(self, db: InfrahubDatabase, git_repos_source_dir_module_scope, git_repos_dir_module_scope):
+    async def local_repo(
+        self, db: InfrahubDatabase, git_repos_source_dir_module_scope, git_repos_dir_module_scope
+    ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
 

--- a/backend/tests/functional/ipam/test_ipam_merge_reconcile.py
+++ b/backend/tests/functional/ipam/test_ipam_merge_reconcile.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 class TestIpamMergeReconcile(TestIpamReconcileBase):
     @pytest.fixture(scope="class", autouse=True)
-    def enable_broker_settings(self):
+    def enable_broker_settings(self) -> None:
         config.SETTINGS.broker.enable = True
 
     @pytest.fixture(scope="class")

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -186,7 +186,7 @@ class TestIpamUtilization(TestIpam):
         step2_branch_addresses = step_02_dataset["branch_addresses"]
         await step2_branch_addresses[0].delete(db=db)
 
-    async def test_step01_main_utilization(self, db: InfrahubDatabase, default_branch: Branch, initial_dataset):
+    async def test_step01_main_utilization(self, db: InfrahubDatabase, default_branch: Branch, initial_dataset) -> None:
         container = initial_dataset["container"]
         prefix = initial_dataset["prefix"]
         prefix2 = initial_dataset["prefix2"]
@@ -198,7 +198,7 @@ class TestIpamUtilization(TestIpam):
 
     async def test_step01_graphql_prefix_pool_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, initial_dataset
-    ):
+    ) -> None:
         container = initial_dataset["container"]
         prefix_pool = initial_dataset["prefix_pool"]
         default_branch.update_schema_hash()
@@ -261,7 +261,7 @@ class TestIpamUtilization(TestIpam):
 
     async def test_step01_graphql_address_pool_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, initial_dataset
-    ):
+    ) -> None:
         prefix = initial_dataset["prefix"]
         address_pool = initial_dataset["address_pool"]
         default_branch.update_schema_hash()
@@ -322,7 +322,7 @@ class TestIpamUtilization(TestIpam):
 
     async def test_step02_branch_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, branch2: Branch, initial_dataset, step_02_dataset
-    ):
+    ) -> None:
         container = initial_dataset["container"]
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
@@ -498,7 +498,7 @@ class TestIpamUtilization(TestIpam):
         initial_dataset,
         step_02_dataset,
         step_03_dataset,
-    ):
+    ) -> None:
         container = initial_dataset["container"]
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]

--- a/backend/tests/functional/ipam/test_load_concurrent_prefixes.py
+++ b/backend/tests/functional/ipam/test_load_concurrent_prefixes.py
@@ -15,7 +15,7 @@ class TestLoadConcurrentPrefixes(TestIpam):
         client,
         default_ipnamespace,
         register_ipam_schema,
-    ):
+    ) -> None:
         prefixes_batch = await client.create_batch()
         network_8 = ipaddress.IPv4Network("10.0.0.0/8")
         networks_16 = list(network_8.subnets(new_prefix=16))
@@ -37,7 +37,7 @@ class TestLoadConcurrentPrefixes(TestIpam):
 
     async def test_too_many_relationships(
         self, db: InfrahubDatabase, default_branch, client, default_ipnamespace, prefix_with_rel_in_hfid_schema
-    ):
+    ) -> None:
         await load_schema(db=db, schema=prefix_with_rel_in_hfid_schema)
 
         prefixes = [IPv4Network("10.0.0.0/8"), IPv4Network("10.0.0.0/16"), IPv4Network("10.1.0.0/16")]

--- a/backend/tests/functional/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/functional/ipam/test_proposed_change_reconcile.py
@@ -27,11 +27,11 @@ if TYPE_CHECKING:
 
 class TestProposedChangeReconcile(TestIpamReconcileBase):
     @pytest.fixture(scope="class", autouse=True)
-    def enable_broker_settings(self):
+    def enable_broker_settings(self) -> None:
         config.SETTINGS.broker.enable = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...
+    def git_repos_dir(self, git_repos_source_dir_module_scope: Path) -> None: ...
 
     @pytest.fixture(scope="class")
     async def branch_1(self, db: InfrahubDatabase):

--- a/backend/tests/functional/ipam/test_upsert_default_filter_and_hfid.py
+++ b/backend/tests/functional/ipam/test_upsert_default_filter_and_hfid.py
@@ -24,7 +24,7 @@ schema = {
 
 
 class TestUpsertWithBothHfidAndDefaulFilter(TestInfrahubApp):
-    async def test_multiple_upsert(self, client: InfrahubClient):
+    async def test_multiple_upsert(self, client: InfrahubClient) -> None:
         res = await client.schema.load([schema])
         assert len(res.errors) == 0, res.errors
 

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -150,7 +150,7 @@ class TestProfiles(TestInfrahubApp):
         original_node: InfrahubNode,
         updated_node: InfrahubNode,
         expected_profile_attrs: list[AttributeProfileDetails],
-    ):
+    ) -> None:
         expected_profile_attrs_by_name = {attr.attribute_name: attr for attr in expected_profile_attrs}
         for attribute_name in updated_node._attributes:
             current_attribute = getattr(updated_node, attribute_name)
@@ -177,7 +177,7 @@ class TestProfiles(TestInfrahubApp):
         device_template: InfrahubNode,
         device_profile_1: InfrahubNode,
         branch: BranchData,
-    ):
+    ) -> None:
         pass
 
     async def test_profile_values_do_not_override_non_default_values(
@@ -186,7 +186,7 @@ class TestProfiles(TestInfrahubApp):
         device_profile_1: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         device_profile_1 = await client.get(
             branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_1.id, property=True
         )
@@ -207,7 +207,7 @@ class TestProfiles(TestInfrahubApp):
         device_profile_2_with_empty_node: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         fresh_device_2 = await client.get(branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id)
         fresh_device_2.manufacturer.is_default = True
         await fresh_device_2.save()
@@ -255,7 +255,7 @@ class TestProfiles(TestInfrahubApp):
         device_2_empty_attribute: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         updated_device_2 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
         )
@@ -323,7 +323,7 @@ class TestProfiles(TestInfrahubApp):
         device_profile_3_with_all_nodes: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         updated_device_1 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True
         )
@@ -383,7 +383,7 @@ class TestProfiles(TestInfrahubApp):
         device_profile_3_with_all_nodes: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         # make profile 3 the highest priority
         device_profile_3 = await client.get(
             branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_3_with_all_nodes.id
@@ -439,7 +439,7 @@ class TestProfiles(TestInfrahubApp):
         device_profile_3_with_all_nodes: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         # delete profile 3
         device_profile_3 = await client.get(
             branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_3_with_all_nodes.id
@@ -522,7 +522,7 @@ class TestProfiles(TestInfrahubApp):
         device_4_with_template: InfrahubNode,
         client: InfrahubClient,
         branch: BranchData,
-    ):
+    ) -> None:
         updated_device_4 = await client.get(
             branch=branch.name, kind=f"{TestKind.DEVICE}", id=device_4_with_template.id, property=True
         )

--- a/backend/tests/functional/schemas/test_load_on_branch_and_main.py
+++ b/backend/tests/functional/schemas/test_load_on_branch_and_main.py
@@ -51,7 +51,7 @@ class TestLoadOnBranchAndMain(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def load_schema_on_branch(
         self, client: InfrahubClient, load_schema, car_schema_updated: NodeSchema, branch: BranchData
-    ):
+    ) -> None:
         schema_root = SchemaRoot(nodes=[car_schema_updated], version="1.0")
         response = await client.schema.load(schemas=[schema_root.model_dump()], branch=branch.name)
         assert len(response.errors) == 0, response.errors
@@ -59,7 +59,7 @@ class TestLoadOnBranchAndMain(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def load_schema_on_main(
         self, client: InfrahubClient, load_schema, car_schema_updated: NodeSchema, default_branch: Branch
-    ):
+    ) -> None:
         schema_root = SchemaRoot(nodes=[car_schema_updated], version="1.0")
         response = await client.schema.load(schemas=[schema_root.model_dump()], branch=default_branch.name)
         assert len(response.errors) == 0, response.errors
@@ -106,7 +106,7 @@ class TestLoadOnBranchAndMain(TestInfrahubApp):
         load_schema_on_branch,
         load_schema_on_main,
         branch: BranchData,
-    ):
+    ) -> None:
         car_schema_main = await client.schema.get(kind="TestingCar", branch=default_branch.name, refresh=True)
         car_attributes_by_name_main = {attr.name: attr for attr in car_schema_main.attributes}
         smell_attr_main = car_attributes_by_name_main["smell"]
@@ -140,7 +140,7 @@ class TestLoadOnBranchAndMain(TestInfrahubApp):
 
     async def test_merge_succeeds_after_schema_duplicates_are_deleted(
         self, client: InfrahubClient, default_branch: Branch, branch: BranchData, car_schema_updated: NodeSchema
-    ):
+    ) -> None:
         car_schema_branch = await client.schema.get(kind="TestingCar", branch=branch.name, refresh=True)
         car_attributes_by_name_branch = {attr.name: attr for attr in car_schema_branch.attributes}
         smell_attr_branch = car_attributes_by_name_branch["smell"]

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -209,7 +209,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         db: InfrahubDatabase,
         enriched_diff: EnrichedDiffRoot,
         initial_dataset: dict[str, Node],
-    ):
+    ) -> None:
         delorean = initial_dataset["delorean"]
         marty = initial_dataset["marty"]
         doc_brown = initial_dataset["doc_brown"]
@@ -298,7 +298,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         default_branch: Branch,
         enriched_diff: EnrichedDiffRoot,
         initial_dataset: dict[str, Node],
-    ):
+    ) -> None:
         delorean = initial_dataset["delorean"]
         doc_brown = initial_dataset["doc_brown"]
         marty = initial_dataset["marty"]
@@ -389,7 +389,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         db: InfrahubDatabase,
         enriched_diff: EnrichedDiffRoot,
         initial_dataset: dict[str, Node],
-    ):
+    ) -> None:
         delorean = initial_dataset["delorean"]
         marty = initial_dataset["marty"]
         doc_brown = initial_dataset["doc_brown"]
@@ -474,7 +474,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         db: InfrahubDatabase,
         enriched_diff: EnrichedDiffRoot,
         initial_dataset: dict[str, Node],
-    ):
+    ) -> None:
         delorean = initial_dataset["delorean"]
         doc_brown = initial_dataset["doc_brown"]
         biff = initial_dataset["biff"]
@@ -555,7 +555,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         db: InfrahubDatabase,
         enriched_diff: EnrichedDiffRoot,
         initial_dataset: dict[str, Node],
-    ):
+    ) -> None:
         delorean = initial_dataset["delorean"]
         doc_brown = initial_dataset["doc_brown"]
         doc_brown_label = await doc_brown.get_display_label(db=db)

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -126,7 +126,7 @@ class TestDiffMerge(TestInfrahubApp):
         diff_branch: Branch,
         diff_coordinator: DiffCoordinator,
         diff_repository: DiffRepository,
-    ):
+    ) -> None:
         delorean_id = initial_dataset["delorean"].get_id()
         marty_id = initial_dataset["marty"].get_id()
 
@@ -159,7 +159,7 @@ class TestDiffMerge(TestInfrahubApp):
         diff_coordinator: DiffCoordinator,
         diff_repository: DiffRepository,
         delete_on_branch: bool,
-    ):
+    ) -> None:
         new_person = await Node.init(db=db, schema=PERSON_KIND)
         await new_person.new(db=db, name="Chuck Berry")
         await new_person.save(db=db)

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -70,12 +70,12 @@ mutation($branch: String!) {
 
 class TestDiffRebase(TestInfrahubApp):
     @pytest.fixture(scope="class", autouse=True)
-    def configure_settings(self):
+    def configure_settings(self) -> None:
         config.SETTINGS.broker.enable = True
         config.SETTINGS.cache.enable = False
 
     @pytest.fixture(scope="class", autouse=True)
-    def initialize_lock(self):
+    def initialize_lock(self) -> None:
         lock.initialize_lock(local_only=True)
 
     @pytest.fixture(scope="class")
@@ -199,7 +199,7 @@ class TestDiffRebase(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def add_branch_1_changes(
         self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_1: Branch
-    ):
+    ) -> None:
         kara_id = initial_dataset["kara"].id
         kara_branch_1 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_1)
         kara_branch_1.description.value = "branch-1-description"
@@ -216,7 +216,7 @@ class TestDiffRebase(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def add_branch_2_changes(
         self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_2: Branch
-    ):
+    ) -> None:
         kara_id = initial_dataset["kara"].id
         kara_branch_2 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_2)
         kara_branch_2.description.value = "branch-2-description"
@@ -233,7 +233,7 @@ class TestDiffRebase(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def add_branch_3_changes(
         self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_3: Branch
-    ):
+    ) -> None:
         antarctica_id = initial_dataset["antarctica"].id
         antarctica_branch_1 = await NodeManager.get_one(db=db, id=antarctica_id, branch=branch_3)
         await antarctica_branch_1.delete(db=db)
@@ -265,7 +265,7 @@ class TestDiffRebase(TestInfrahubApp):
         branch_1: Branch,
         branch_2: Branch,
         diff_repository: DiffRepository,
-    ):
+    ) -> None:
         kara_id = initial_dataset["kara"].id
         jesko_id = initial_dataset["jesko"].id
         koenigsegg_id = initial_dataset["koenigsegg"].id
@@ -360,7 +360,7 @@ class TestDiffRebase(TestInfrahubApp):
         branch_1: Branch,
         branch_2: Branch,
         diff_repository: DiffRepository,
-    ):
+    ) -> None:
         kara_id = initial_dataset["kara"].id
         jesko_id = initial_dataset["jesko"].id
         koenigsegg_id = initial_dataset["koenigsegg"].id
@@ -454,7 +454,7 @@ class TestDiffRebase(TestInfrahubApp):
         db: InfrahubDatabase,
         branch_2: Branch,
         initial_dataset,
-    ):
+    ) -> None:
         kara_id = initial_dataset["kara"].id
         jesko_id = initial_dataset["jesko"].id
         cyberdyne_id = initial_dataset["cyberdyne"].id
@@ -474,7 +474,7 @@ class TestDiffRebase(TestInfrahubApp):
         initial_dataset,
         branch_2: Branch,
         diff_repository: DiffRepository,
-    ):
+    ) -> None:
         jesko_id = initial_dataset["jesko"].id
         koenigsegg_id = initial_dataset["koenigsegg"].id
         cyberdyne_id = initial_dataset["cyberdyne"].id
@@ -552,7 +552,7 @@ class TestDiffRebase(TestInfrahubApp):
         client: InfrahubClient,
         branch_3: Branch,
         add_branch_3_changes,
-    ):
+    ) -> None:
         antarctica_id = initial_dataset["antarctica"].id
 
         # add a node on main

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 from unittest.mock import patch
 
 import pytest
@@ -39,7 +39,7 @@ class BrokenBranchMerger:
     async def merge(self, at=None) -> None:
         await self.real_merger.merge(at=at)
 
-    async def merge_graph(self, at):
+    async def merge_graph(self, at) -> Never:
         await self.real_merger.diff_merger.merge_graph(at=at)
         raise ValueError("This is broken on purpose")
 

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -24,7 +24,7 @@ from tests.helpers.test_app import TestInfrahubApp
 from tests.helpers.test_client import InfrahubTestClient
 
 
-async def load_infrastructure_schema(db: InfrahubDatabase):
+async def load_infrastructure_schema(db: InfrahubDatabase) -> None:
     base_dir = get_models_dir() / "base"
 
     default_branch_name = registry.default_branch
@@ -54,7 +54,7 @@ class TestInfrahubClient:
         config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class")
-    async def base_dataset(self, db: InfrahubDatabase, redis, nats):
+    async def base_dataset(self, db: InfrahubDatabase, redis, nats) -> None:
         await delete_all_nodes(db=db)
         await first_time_initialization(db=db)
         await load_infrastructure_schema(db=db)
@@ -115,7 +115,9 @@ class TestInfrahubClient:
 
         return repo
 
-    async def test_import_schema_files(self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository):
+    async def test_import_schema_files(
+        self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
+    ) -> None:
         commit = repo.get_commit_value(branch_name="main")
         config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
@@ -125,7 +127,7 @@ class TestInfrahubClient:
 
     async def test_import_schema_files_from_directory(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
-    ):
+    ) -> None:
         commit = repo.get_commit_value(branch_name="main")
         config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
@@ -137,7 +139,7 @@ class TestInfrahubClient:
 
     async def test_import_all_graphql_query(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
-    ):
+    ) -> None:
         commit = repo.get_commit_value(branch_name="main")
         config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
@@ -177,7 +179,7 @@ class TestInfrahubClient:
 
     async def test_import_all_python_files(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, query_99
-    ):
+    ) -> None:
         for group in ["backbone_services", "maintenance_circuits", "provisioning_circuits", "upstream_interfaces"]:
             obj = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
             await obj.new(
@@ -262,7 +264,7 @@ class TestInfrahubClient:
 
     async def test_import_all_yaml_files(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, query_99
-    ):
+    ) -> None:
         commit = repo.get_commit_value(branch_name="main")
         config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
@@ -307,7 +309,7 @@ class TestInfrahubClient:
 class TestGetMissingFile(TestInfrahubApp):
     async def test_get_missing_file(
         self, db: InfrahubDatabase, client: InfrahubClient, git_repo_car_dealership, test_client
-    ):
+    ) -> None:
         # Ideally above tests would rely on `TestInfrahubApp.repo` instead of TestInfrahubClient
         # and we would reuse `TestInfrahubClient.repo` fixture here.
         obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -35,12 +35,12 @@ if TYPE_CHECKING:
 
 
 class TestCreateReadOnlyRepository(TestInfrahubApp):
-    def setup_method(self):
+    def setup_method(self) -> None:
         lock_patcher = patch("infrahub.git.tasks.lock")
         self.mock_infra_lock = lock_patcher.start()
         self.mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         patch.stopall()
 
     @pytest.fixture(scope="class")
@@ -108,7 +108,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
 
     async def test_step02_validate_generated_artifacts(
         self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient, person_john: Node
-    ):
+    ) -> None:
         artifacts = await client.all(kind=CoreArtifact, branch="ro_repository")
         artifacts_dict = {item.name.value: item for item in artifacts}
         assert sorted(artifacts_dict.keys()) == [
@@ -151,7 +151,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         helper: TestHelper,
         context: InfrahubContext,
         service: InfrahubServices,
-    ):
+    ) -> None:
         await client.branch.merge(branch_name="ro_repository")
 
         check_definition: CoreCheckDefinition = await NodeManager.get_one_by_id_or_default_filter(
@@ -189,7 +189,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         person_john: Node,
         context: InfrahubContext,
         service: InfrahubServices,
-    ):
+    ) -> None:
         from infrahub.core import registry
         from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
 

--- a/backend/tests/integration/git/utils.py
+++ b/backend/tests/integration/git/utils.py
@@ -4,7 +4,7 @@ from infrahub.core.constants import RepositoryObjects
 from infrahub.core.manager import NodeManager
 
 
-async def check_repo_correctly_created(repo_id, db, branch_name: str):
+async def check_repo_correctly_created(repo_id, db, branch_name: str) -> None:
     # Check persons have been correctly loaded
     person_ethan = await NodeManager.get_one_by_default_filter(
         db=db, id="Ethan Carter", kind="TestingPerson", raise_on_error=True, branch=branch_name

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -162,7 +162,7 @@ class TestProposedChange(TestInfrahubApp):
         test_client: InfrahubTestClient,
         client: InfrahubClient,
         context: InfrahubContext,
-    ):
+    ) -> None:
         model = RequestProposedChangePipeline(
             source_branch="change1",
             source_branch_sync_with_git=True,
@@ -227,7 +227,7 @@ class TestProposedChange(TestInfrahubApp):
         test_client: InfrahubTestClient,
         client: InfrahubClient,
         context: InfrahubContext,
-    ):
+    ) -> None:
         pipeline_id = uuid.uuid4()
         model = RequestProposedChangeRunGenerators(
             source_branch="change1",

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -300,7 +300,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     async def test_step_01_one_person_no_profile(
         self, db: InfrahubDatabase, schema_root_01, person_1, person_profile_1, client: InfrahubClient
-    ):
+    ) -> None:
         retrieved_person = await client.get(kind="PretendPerson", id=person_1.id, property=True)
 
         assert retrieved_person.profiles.peer_ids == []
@@ -327,7 +327,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
@@ -611,7 +611,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
@@ -669,7 +669,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch,
         person_1,
         client: InfrahubClient,
-    ):
+    ) -> None:
         profile = await client.create(
             kind="ProfilePretendPerson",
             profile_name="profile-two",
@@ -681,7 +681,9 @@ class TestProfileLifecycle(TestInfrahubApp):
         )
         await profile.save()
 
-    async def test_step_06_get_person_multiple_profiles(self, person_1, person_profile_1, client: InfrahubClient):
+    async def test_step_06_get_person_multiple_profiles(
+        self, person_1, person_profile_1, client: InfrahubClient
+    ) -> None:
         person_profile_2 = await client.get(kind="ProfilePretendPerson", profile_name__value="profile-two")
         retrieved_person = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person.profiles.fetch()
@@ -725,7 +727,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         db: InfrahubDatabase,
         default_branch: Branch,
         client,
-    ):
+    ) -> None:
         person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
@@ -821,13 +823,13 @@ class TestProfileLifecycle(TestInfrahubApp):
         db: InfrahubDatabase,
         default_branch,
         client: InfrahubClient,
-    ):
+    ) -> None:
         person_profile_2 = await client.get(kind="ProfilePretendPerson", profile_name__value="profile-two")
         await person_profile_2.delete()
 
     async def test_step_09_check_persons(
         self, db: InfrahubDatabase, person_1, person_profile_1, client: InfrahubClient, default_branch: Branch
-    ):
+    ) -> None:
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
@@ -906,7 +908,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
@@ -964,7 +966,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         person_1,
         client: InfrahubClient,
-    ):
+    ) -> None:
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         person_profile_1.profile_priority.value = 11
         person_profile_1.height.value = 134
@@ -985,7 +987,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     async def test_step_12_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
-    ):
+    ) -> None:
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
@@ -1033,7 +1035,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         person_1,
         client: InfrahubClient,
-    ):
+    ) -> None:
         person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         await person_profile_1.related_nodes.fetch()
@@ -1049,7 +1051,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     async def test_step_14_check_persons_again(
         self, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
-    ):
+    ) -> None:
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
@@ -1154,7 +1156,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         lifeform_profile_1: Node,
         schema_root_02,
         client: InfrahubClient,
-    ):
+    ) -> None:
         updated_person_profile_schema = await client.schema.get(
             kind="ProfilePretendPerson", branch=default_branch.name, refresh=True
         )
@@ -1219,7 +1221,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1: Node,
         lifeform_profile_1: Node,
         client: InfrahubClient,
-    ):
+    ) -> None:
         updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         updated_person_profile_1.age.value = 25
         updated_person_profile_1.eye_color.value = "blurple"
@@ -1237,7 +1239,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         client: InfrahubClient,
         person_profile_1: Node,
         lifeform_profile_1: Node,
-    ):
+    ) -> None:
         person_two = await client.get(kind="PretendPerson", name__value="Apollo")
         await person_two.profiles.fetch()
         person_two.profiles.add(lifeform_profile_1.id)
@@ -1245,7 +1247,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     async def test_step_17_check_persons_again(
         self, default_branch: Branch, person_1, person_profile_1: Node, lifeform_profile_1: Node, client: InfrahubClient
-    ):
+    ) -> None:
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
@@ -1367,7 +1369,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         lifeform_profile_1,
         client: InfrahubClient,
-    ):
+    ) -> None:
         updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
             "age",
@@ -1431,7 +1433,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         lifeform_profile_1,
         client: InfrahubClient,
-    ):
+    ) -> None:
         await client.schema.get(kind="PretendPerson", branch=default_branch.name, refresh=True)
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)

--- a/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
@@ -200,7 +200,7 @@ class TestUpdateAttributeParameters(TestInfrahubApp):
         client: InfrahubClient,
         default_branch: Branch,
         schema_step_02: dict[str, Any],
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_02], branch=default_branch.name)
         assert success
         assert response == {
@@ -331,7 +331,7 @@ class TestUpdateAttributeParameters(TestInfrahubApp):
         regex_02,
         min_length_02,
         max_length_02,
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_02], branch=default_branch.name)
         assert not response.errors

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -286,7 +286,7 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
         branch: Branch,
         branch_data: dict[str, Node],
         proposed_change_id: str,
-    ):
+    ) -> None:
         result = await client.execute_graphql(
             query=DIFF_TREE_QUERY,
             variables={"branch": branch.name},
@@ -364,7 +364,7 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
         branch: Branch,
         branch_data: dict[str, Node],
         proposed_change_id: str,
-    ):
+    ) -> None:
         # merge proposed change
         result = await client.execute_graphql(
             query=PROPOSED_CHANGE_UPDATE,

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -443,7 +443,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
 
     async def test_step01_baseline_backend(
         self, db: InfrahubDatabase, branch: Branch, client: InfrahubClient, initial_dataset
-    ):
+    ) -> None:
         all_specifics = await registry.manager.query(db=db, schema=GENERIC_KIND)
         assert len(all_specifics) == 3
 
@@ -481,7 +481,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_02: dict[str, Any],
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_02], branch=branch.name)
         assert success
         assert response == {
@@ -606,7 +606,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_02: dict[str, Any],
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_02], branch=branch.name)
         assert not response.errors
@@ -754,7 +754,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_03: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_03)
         success, response = await client.schema.check(schemas=[schema_step_03], branch=branch.name)
         assert success
@@ -798,7 +798,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_03: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_03)
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_03], branch=branch.name)
@@ -896,7 +896,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_04: dict[str, Any],
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_04], branch=branch.name)
         assert success
         assert response == {
@@ -954,7 +954,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_04: dict[str, Any],
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
         assert not response.errors
@@ -1082,7 +1082,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_05: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_05)
         success, response = await client.schema.check(schemas=[schema_step_05], branch=branch.name)
         assert success
@@ -1183,7 +1183,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_05: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_05)
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_05], branch=branch.name)
@@ -1308,7 +1308,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_06: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_06)
         success, response = await client.schema.check(schemas=[schema_step_06], branch=branch.name)
         assert success
@@ -1345,7 +1345,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         initial_dataset,
         branch: Branch,
         schema_step_06: dict[str, Any],
-    ):
+    ) -> None:
         await self._finalize_deleted_fields(db=db, branch=branch, full_schema_dict=schema_step_06)
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_06], branch=branch.name)
@@ -1427,7 +1427,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         )
         assert not errors
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)
 

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -181,13 +181,13 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             ],
         }
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)
         assert len(persons) == 2
 
     async def test_step02_check_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND)
         attr = person_schema.get_attribute(name="name")
 
@@ -233,7 +233,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step02_load_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=self.branch1)
         attr = person_schema.get_attribute(name="name")
 
@@ -274,7 +274,9 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         john = persons[0]
         assert john.name.value == "John"  # type: ignore[attr-defined]
 
-    async def test_step03_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step03], branch=self.branch1.name)
         assert response == {
             "diff": {
@@ -304,7 +306,9 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step03_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step03], branch=self.branch1.name)
         assert not response.errors
 
@@ -317,7 +321,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         john = persons[0]
         assert not hasattr(john, "height")
 
-    async def test_rebase(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset):
+    async def test_rebase(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset) -> None:
         branch = await client.branch.rebase(branch_name=self.branch1.name)
         assert branch
 
@@ -369,7 +373,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
         await verify_no_edges_added_after_node_delete(db=db)
 
-    async def test_merge(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset):
+    async def test_merge(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset) -> None:
         branch = await client.branch.merge(branch_name=self.branch1.name)
         assert branch
 
@@ -390,7 +394,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         assert not hasattr(jane, "height")
         assert not hasattr(jane, "name")
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)
 

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -76,7 +76,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
 
     async def validate_indexed_state(
         self, db: InfrahubDatabase, branch: Branch, kind_index_map: dict[tuple[str, str], dict[str, bool]]
-    ):
+    ) -> None:
         kinds = {kind_and_uuid[0] for kind_and_uuid in kind_index_map.keys()}
         num_expected_results = sum(len(attr_map) for attr_map in kind_index_map.values())
         attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=list(kinds))
@@ -227,7 +227,9 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
 
         return objs
 
-    async def test_step01_baseline(self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch):
+    async def test_step01_baseline(
+        self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch
+    ) -> None:
         object_ids = [obj.id for obj in initial_objects.values()]
         objects = await NodeManager.get_many(db=db, ids=object_ids)
         assert len(objects) == len(object_ids)
@@ -255,7 +257,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         branch: Branch,
         schema_step_02: dict[str, Any],
         client: InfrahubClient,
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step_02], branch=branch.name)
         assert response.errors
         error_messages = response.errors["errors"][0]["message"].split("\n")
@@ -272,7 +274,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         branch: Branch,
         schema_step_03: dict[str, Any],
         client: InfrahubClient,
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step_03], branch=branch.name)
         assert not response.errors
 
@@ -299,7 +301,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         branch: Branch,
         schema_step_04: dict[str, Any],
         client: InfrahubClient,
-    ):
+    ) -> None:
         # first attempt fails because thing_one.text_area_value is too long
         response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
         assert response.errors
@@ -340,7 +342,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         branch: Branch,
         schema_step_05: dict[str, Any],
         client: InfrahubClient,
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step_05], branch=branch.name)
         assert not response.errors
 
@@ -367,7 +369,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         branch: Branch,
         schema_step_06: dict[str, Any],
         client: InfrahubClient,
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step_06], branch=branch.name)
         assert not response.errors
 

--- a/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
@@ -89,6 +89,6 @@ class TestSchemaLifecycleGenericRenaming(TestSchemaLifecycleBase):
         devices = await client.all(kind=DEVICE_KIND)
         assert len(devices) == 2
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_migration_hierarchy_change.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_hierarchy_change.py
@@ -120,7 +120,9 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
         assert rels_by_name["parent"].peer == "LocationCountry"
         assert rels_by_name["children"].peer == "LocationGeneric"
 
-    async def test_check_schema_02(self, client: InfrahubClient, branch_1: Branch, location_schema_02: SchemaRoot):
+    async def test_check_schema_02(
+        self, client: InfrahubClient, branch_1: Branch, location_schema_02: SchemaRoot
+    ) -> None:
         success, response = await client.schema.check(
             schemas=[location_schema_02.model_dump(mode="json")], branch=branch_1.name
         )
@@ -161,7 +163,7 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
 
     async def test_load_schema_02(
         self, db: InfrahubDatabase, client: InfrahubClient, branch_1: Branch, location_schema_02: SchemaRoot
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[location_schema_02.model_dump(mode="json")], branch=branch_1.name)
         assert not response.errors
 
@@ -188,6 +190,6 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
         assert site_schema.parent == "LocationMetro"
         assert site_schema.children == ""  # noqa: PLC1901
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
@@ -190,7 +190,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         await branch_specific_one.save(db=db)
         return branch_specific_one
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         all_specifics = await registry.manager.query(db=db, schema=GENERIC_KIND)
         assert len(all_specifics) == 1
 
@@ -205,7 +205,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         initial_dataset,
         branch_one: Branch,
         schema_step_02: dict[str, Any],
-    ):
+    ) -> None:
         current_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         current_specific_one_schema = current_schema_branch.get_node(name=SPECIFIC_ONE_KIND, duplicate=False)
         for schema_dict in schema_step_02["nodes"]:
@@ -232,7 +232,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         branch_one: Branch,
         schema_step_02: dict[str, Any],
         specific_one_update_01: Node,
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_02], branch=BRANCH_ONE)
         assert not response.errors
@@ -264,7 +264,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         branch_one: Branch,
         schema_step_02: dict[str, Any],
         specific_one_update_02: Node,
-    ):
+    ) -> None:
         retrieved_specific_one = await NodeManager.get_one(
             db=db, branch=branch_one, id=initial_dataset["specific_one"].id
         )
@@ -309,7 +309,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         schema_specific_one_base: dict[str, Any],
         schema_specific_one_new_kind: dict[str, Any],
         specific_one_update_02: Node,
-    ):
+    ) -> None:
         is_success = await client.branch.merge(branch_name=BRANCH_ONE)
         assert is_success
 
@@ -330,6 +330,6 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         assert len(updated_things_rels) == 1
         assert retrieved_things_rels[0].get_peer_id() == updated_things_rels[0].get_peer_id()
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -191,11 +191,13 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
             "nodes": [schema_person_tag, schema_car_main_driver, schema_manufacturer_base, schema_tag_no_persons],
         }
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)
         assert len(persons) == 2
 
-    async def test_step02_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02):
+    async def test_step02_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
+    ) -> None:
         car_schema = registry.schema.get_node_schema(name=CAR_KIND)
         rel = car_schema.get_relationship(name="owner")
 
@@ -251,7 +253,9 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step02_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02):
+    async def test_step02_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
+    ) -> None:
         car_schema = registry.schema.get_node_schema(name=CAR_KIND)
         rel = car_schema.get_relationship(name="owner")
 
@@ -284,7 +288,9 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         )
         assert len(john_cars_main) == 2
 
-    async def test_step03_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step03], branch=self.branch1.name)
         assert response == {
             "diff": {
@@ -314,7 +320,9 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step03_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step03], branch=self.branch1.name)
         assert not response.errors
 
@@ -331,7 +339,7 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         persons = await red_main.persons.get_peers(db=db)  # type: ignore[attr-defined]
         assert len(persons) == 1
 
-    async def test_rebase(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset):
+    async def test_rebase(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset) -> None:
         branch = await client.branch.rebase(branch_name=self.branch1.name)
         assert branch
 
@@ -345,7 +353,7 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         tags = await jane.tags.get_peers(db=db)
         assert len(tags) == 1
 
-    async def test_merge(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset):
+    async def test_merge(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset) -> None:
         branch = await client.branch.merge(branch_name=self.branch1.name)
         assert branch
 
@@ -365,6 +373,6 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         tags = await john.tags.get_peers(db=db)
         assert len(tags) == 2
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
@@ -125,13 +125,13 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
             ],
         }
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         assert len(persons) == 1
 
     async def test_step02_check_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step02])
         assert success
         assert response == {
@@ -161,7 +161,9 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
             ],
         }
 
-    async def test_step02_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02):
+    async def test_step02_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step02])
         assert not response.errors
 
@@ -176,7 +178,9 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
         assert john.firstname.value == "John"  # type: ignore[attr-defined]
         assert not hasattr(john, "height")
 
-    async def test_step03_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step03])
         assert response == {
             "diff": {
@@ -202,7 +206,9 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step03_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step03])
         assert not response.errors
 
@@ -228,6 +234,6 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
         john2 = persons2[0]
         assert john2.height.value == 200
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -154,13 +154,13 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
 
         return objs
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)
         assert len(persons) == 2
 
     async def test_step02_check_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND)
         attr = person_schema.get_attribute(name="name")
 
@@ -206,7 +206,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
 
     async def test_step02_load_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=self.branch1)
         attr = person_schema.get_attribute(name="name")
 
@@ -239,7 +239,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         john = persons[0]
         assert john.name.value == "John"  # type: ignore[attr-defined]
 
-    async def test_step03_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         manufacturer_schema = registry.schema.get_node_schema(name=MANUFACTURER_KIND_01, branch=self.branch1)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -300,7 +302,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step03_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         manufacturer_schema = registry.schema.get_node_schema(name=MANUFACTURER_KIND_01, branch=self.branch1)
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=self.branch1)
         height_attr_schema = person_schema.get_attribute(name="height")
@@ -335,7 +339,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         renault_cars = await renault.cars.get_peers(db=db)  # type: ignore[attr-defined]
         assert len(renault_cars) == 2
 
-    async def test_rebase(self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset):
+    async def test_rebase(
+        self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset
+    ) -> None:
         branch = await client.branch.rebase(branch_name=self.branch1.name)
         assert branch
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=default_branch)
@@ -362,7 +368,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         honda_cars = await honda.cars.get_peers(db=db)  # type: ignore[attr-defined]
         assert len(honda_cars) == 2
 
-    async def test_step04_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04):
+    async def test_step04_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04
+    ) -> None:
         tag_schema = registry.schema.get_node_schema(name=TAG_KIND, branch=self.branch1)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -383,7 +391,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step04_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04):
+    async def test_step04_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04
+    ) -> None:
         tag_schema = registry.schema.get_node_schema(name=TAG_KIND, branch=self.branch1)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -423,7 +433,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         tags = await registry.manager.query(db=db, schema=TAG_KIND)
         assert len(tags) == 2
 
-    async def test_step05_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05):
+    async def test_step05_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step05], branch=self.branch1.name)
 
         assert response == {
@@ -450,7 +462,9 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step05_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05):
+    async def test_step05_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step05], branch=self.branch1.name)
         assert not response.errors
 
@@ -461,7 +475,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
 
     async def test_step05_merge(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step06, schema_interior_base
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step06], branch=self.branch1.name)
         assert not response.errors
 
@@ -477,6 +491,6 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         assert updated_interiors_schema.attribute_names == ["material"]
         assert "cars" in updated_interiors_schema.relationship_names
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -83,13 +83,13 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
 
         return objs
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         assert len(persons) == 2
 
     async def test_step02_check_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND)
         attr = person_schema.get_attribute(name="name")
 
@@ -135,7 +135,7 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
 
     async def test_step02_load_attr_add_rename(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step02
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND)
         attr = person_schema.get_attribute(name="name")
 
@@ -152,7 +152,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         john = persons[0]
         assert john.firstname.value == "John"  # type: ignore[attr-defined]
 
-    async def test_step03_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         manufacturer_schema = registry.schema.get_node_schema(name=MANUFACTURER_KIND_01)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -213,7 +215,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step03_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03):
+    async def test_step03_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step03
+    ) -> None:
         manufacturer_schema = registry.schema.get_node_schema(name=MANUFACTURER_KIND_01)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -244,7 +248,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         honda_cars = await honda.cars.get_peers(db=db)  # type: ignore[attr-defined]
         assert len(honda_cars) == 2
 
-    async def test_step04_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04):
+    async def test_step04_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04
+    ) -> None:
         tag_schema = registry.schema.get_node_schema(name=TAG_KIND)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -265,7 +271,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step04_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04):
+    async def test_step04_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04
+    ) -> None:
         tag_schema = registry.schema.get_node_schema(name=TAG_KIND)
 
         # Insert the ID of the attribute name into the schema in order to rename it firstname
@@ -277,7 +285,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
 
         assert registry.schema.has(name=TAG_KIND) is False
 
-    async def test_step05_check(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05):
+    async def test_step05_check(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step05])
 
         assert response == {
@@ -304,7 +314,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         }
         assert success
 
-    async def test_step05_load(self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05):
+    async def test_step05_load(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step05
+    ) -> None:
         response = await client.schema.load(schemas=[schema_step05])
         assert not response.errors
 
@@ -312,6 +324,6 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         car_schema = registry.schema.get(name=CAR_KIND, duplicate=False)
         assert "profiles" in car_schema.relationship_names
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
@@ -67,6 +67,6 @@ class TestSchemaLifecycleTemplateUpdate(TestSchemaLifecycleBase):
         assert len(physical_interface_template.uniqueness_constraints) == 1
         assert physical_interface_template.uniqueness_constraints[0] == ["template_name__value", "device"]
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_update.py
@@ -45,16 +45,16 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             ],
         }
 
-    async def test_step_01_create_branch(self, client: InfrahubClient):
+    async def test_step_01_create_branch(self, client: InfrahubClient) -> None:
         branch = await client.branch.create(branch_name="test", sync_with_git=False)
         assert branch
 
-    async def test_step_02_load_schema(self, client: InfrahubClient, schema_network):
+    async def test_step_02_load_schema(self, client: InfrahubClient, schema_network) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_network], branch="test")
         assert not response.errors
 
-    async def test_step_03_load_data(self, db: InfrahubDatabase, client: InfrahubClient, schema_network):
+    async def test_step_03_load_data(self, db: InfrahubDatabase, client: InfrahubClient, schema_network) -> None:
         dev1 = await client.create(kind="NetworkDevice", hostname="device", model="switch", branch="test")
         await dev1.save()
         assert dev1.id
@@ -63,6 +63,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await intf1.save()
         assert intf1.id
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -243,7 +243,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "nodes": [schema_person_base, schema_car_mandatory_attr_no_default, schema_cylon_base],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cylons = await registry.manager.query(db=db, schema=CYLON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
@@ -253,7 +253,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_check_mandatory_attribute_failure(
         self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_attr
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_with_person_mandatory_attr])
 
         assert success is False
@@ -265,7 +265,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_check_mandatory_relationship_failure(
         self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_rel
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_with_person_mandatory_rel])
 
         assert success is False
@@ -277,7 +277,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_check_mandatory_attribute_after_deleting_nodes(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_attr
-    ):
+    ) -> None:
         """Validate that it's possible to add a new mandatory attribute after deleting all the nodes in scope."""
         branch = await client.branch.create(branch_name="add-attr-delete-nodes")
 
@@ -294,7 +294,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_check_mandatory_rel_after_deleting_nodes(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_rel
-    ):
+    ) -> None:
         """Validate that it's possible to add a new mandatory attribute after deleting all the nodes in scope."""
         branch = await client.branch.create(branch_name="add-rel-delete-nodes")
 
@@ -311,32 +311,32 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_check_mandatory_attribute_success_no_data(
         self, client: InfrahubClient, initial_dataset, schema_with_car_mandatory
-    ):
+    ) -> None:
         """Validate that it's possible to add a new mandatory attribute when there is no data in the database."""
         success, _ = await client.schema.check(schemas=[schema_with_car_mandatory])
         assert success is True
 
     async def test_load_mandatory_attribute_success_no_data(
         self, client: InfrahubClient, initial_dataset, schema_with_car_mandatory
-    ):
+    ) -> None:
         branch = await client.branch.create(branch_name="add-no-prior-data")
         response = await client.schema.load(schemas=[schema_with_car_mandatory], branch=branch.name)
         assert response.errors == {}
 
     async def test_check_mandatory_attribute_success_default_value(
         self, client: InfrahubClient, initial_dataset, schema_with_person_default_value
-    ):
+    ) -> None:
         """Validate that it's possible to add a new mandatory attribute with a default value."""
         success, _ = await client.schema.check(schemas=[schema_with_person_default_value])
         assert success is True
 
     async def test_load_mandatory_attribute_success_default_value(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_with_person_default_value
-    ):
+    ) -> None:
         branch = await client.branch.create(branch_name="add-default-value")
         response = await client.schema.load(schemas=[schema_with_person_default_value], branch=branch.name)
         assert response.errors == {}
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_common_parent_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_common_parent_rel.py
@@ -195,6 +195,6 @@ class TestSchemaLifecyclePeerParentUpdate(TestSchemaLifecycleBase):
 
         assert {n.device.id for n in nodes} == {device1.id}
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -261,7 +261,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "nodes": [schema_car_base, schema_04_person_constraint_failure, schema_04_cylon_constraint_failure],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cylons = await registry.manager.query(db=db, schema=CYLON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
@@ -271,7 +271,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_01_check_generic_uniqueness_constraint_failure(
         self, client: InfrahubClient, initial_dataset, schema_01_generic_uniqueness_failure
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_01_generic_uniqueness_failure])
 
         assert success is False
@@ -289,7 +289,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         initial_dataset,
         schema_02_generic_uniqueness_failure,
         branch_2,
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_02_generic_uniqueness_failure], branch=branch_2.name)
         assert not response.errors
 
@@ -317,7 +317,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         client: InfrahubClient,
         initial_dataset,
         schema_03_generic_and_node_uniqueness_failure,
-    ):
+    ) -> None:
         boomer_main = await NodeManager.get_one_by_id_or_default_filter(
             db=db, kind=CYLON_KIND, id=initial_dataset["boomer"]
         )
@@ -342,7 +342,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert initial_dataset["gaius"] not in err_msg
         assert "Node-level 'uniqueness_constraints'" in err_msg
 
-    async def test_step_03_reset(self, db: InfrahubDatabase, initial_dataset):
+    async def test_step_03_reset(self, db: InfrahubDatabase, initial_dataset) -> None:
         boomer_main = await NodeManager.get_one_by_id_or_default_filter(
             db=db, kind=CYLON_KIND, id=initial_dataset["boomer"]
         )
@@ -361,7 +361,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         initial_dataset,
         schema_04_generic_and_node_uniqueness_failure,
         branch_2,
-    ):
+    ) -> None:
         response = await client.schema.load(
             schemas=[schema_04_generic_and_node_uniqueness_failure], branch=branch_2.name
         )
@@ -433,6 +433,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
                 )
                 assert expected_error_msg in exc.value.errors[0]["message"]
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -185,7 +185,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "nodes": [schema_car_base, schema_person_base, schema_03_cylon_robot],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cylons = await registry.manager.query(db=db, schema=CYLON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
@@ -193,7 +193,9 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(cylons) == 2
         assert len(cars) == 1
 
-    async def test_step_02_add_generic(self, client: InfrahubClient, initial_dataset, schema_step_02_add_generic):
+    async def test_step_02_add_generic(
+        self, client: InfrahubClient, initial_dataset, schema_step_02_add_generic
+    ) -> None:
         success, _ = await client.schema.check(schemas=[schema_step_02_add_generic])
         assert success is True
 
@@ -203,7 +205,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         db: InfrahubDatabase,
         initial_dataset,
         schema_step_03_remove_generic,
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_03_remove_generic])
         assert success is False
         assert len(response["errors"]) == 1
@@ -211,6 +213,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert "Node-level 'inherit_from' constraint violation on schema 'SchemaNode'" in error["message"]
         assert "The error relates to field inherit_from=['TestingHumanoid']." in error["message"]
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -247,7 +247,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             ],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
         tags = await registry.manager.query(db=db, schema=TAG_KIND)
@@ -257,7 +257,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_01_check_attr_regex_add_failure(
         self, client: InfrahubClient, initial_dataset, schema_01_attr_regex_failure
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_01_attr_regex_failure])
 
         assert success is False
@@ -270,7 +270,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_02_check_attr_regex_add_success(
         self, client: InfrahubClient, initial_dataset, schema_02_attr_regex
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_02_attr_regex])
         assert success
         assert response == {
@@ -311,7 +311,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_03_check_relationship_cardinality_change_failure(
         self, client: InfrahubClient, initial_dataset, schema_03_relationship_cardinality_failure
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_03_relationship_cardinality_failure])
         assert success is False
         assert "errors" in response
@@ -322,7 +322,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_04_check_relationship_cardinality_change_success(
         self, client: InfrahubClient, initial_dataset, schema_04_relationship_cardinality
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_04_relationship_cardinality])
 
         assert success
@@ -352,7 +352,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_05_check_attribute_unique_change_failure(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_05_attribute_unique
-    ):
+    ) -> None:
         pinto = await Node.init(schema=CAR_KIND, db=db)
         await pinto.new(
             db=db,
@@ -375,7 +375,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_06_check_attribute_unique_change_success(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_05_attribute_unique
-    ):
+    ) -> None:
         pinto = await NodeManager.get_one_by_default_filter(db=db, id="pinto", kind="TestingCar", raise_on_error=True)
         await pinto.delete(db=db)
 
@@ -428,7 +428,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_08_check_generate_profile_failure(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_07_generate_profile_false
-    ):
+    ) -> None:
         car_profile_schema = registry.schema.get(name=f"Profile{CAR_KIND}", duplicate=False)
         car_profile_nodes = await NodeManager.query(
             db=db,
@@ -454,7 +454,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
     async def test_step_09_add_generic_and_profile(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_09_add_generic
-    ):
+    ) -> None:
         await load_schema(db=db, schema=schema_09_add_generic)
         schema_09_add_generic["generics"][0]["generate_profile"] = False
 
@@ -488,6 +488,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert "cool unicycle" in err_msg
         assert "Node-level 'generate_profile' constraint violation" in err_msg
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -122,7 +122,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             "nodes": [schema_person_base, schema_car_base, schema_02_car_unique, schema_tag_base],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
         tags = await registry.manager.query(db=db, schema=TAG_KIND)
@@ -132,7 +132,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
 
     async def test_step_01_attr_regex_add_rebase_failure(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_01_attr_regex, branch_2
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_01_attr_regex])
         assert not response.errors
         little_john = await Node.init(schema=PERSON_KIND, db=db, branch=branch_2)
@@ -147,7 +147,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
 
     async def test_step_02_node_unique_rebase_failure(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_02_node_unique, branch_2
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_02_node_unique])
         assert not response.errors
 
@@ -172,6 +172,6 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             assert another_civic.id in exc.value.message
             assert "node.uniqueness_constraints.update" in exc.value.message
 
-    async def test_final_validate(self, db: InfrahubDatabase):
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -224,7 +224,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "generics": [schema_generic_06_delete_unique_field],
         }
 
-    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset, branch_1: Branch):
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset, branch_1: Branch) -> None:
         # Check schema properties
         schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
         # check that unique attribute is correctly synced to uniqueness constraints
@@ -279,7 +279,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step02_load_more_fields(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_02
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_02], branch=branch_1.name)
         assert not response.errors
@@ -308,7 +308,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step03_check_unique_fields(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_03
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_03], branch=branch_1.name)
         assert success, response.get("errors") if response else None
         assert response == {
@@ -365,7 +365,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step03_load_unique_fields(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_03
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_03], branch=branch_1.name)
         assert not response.errors
@@ -397,7 +397,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step04_check_rename_name(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_04
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=branch_1)
         attr = person_schema.get_attribute(name="name")
 
@@ -447,7 +447,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step04_load_renamed_fields(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_04
-    ):
+    ) -> None:
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=branch_1)
         attr = person_schema.get_attribute(name="name")
 
@@ -522,7 +522,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step05_load_remove_original_unique(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_05
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_05], branch=branch_1.name)
         assert not response.errors
@@ -548,7 +548,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step06_check_remove_unique_attr_from_generic(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_06
-    ):
+    ) -> None:
         success, response = await client.schema.check(schemas=[schema_step_06], branch=branch_1.name)
         assert success, response.get("errors") if response else None
         assert response == {
@@ -590,7 +590,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
     async def test_step06_load_remove_unique_attr_from_generic(
         self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_06
-    ):
+    ) -> None:
         # Load the new schema and apply the migrations
         response = await client.schema.load(schemas=[schema_step_06], branch=branch_1.name)
         assert not response.errors

--- a/backend/tests/integration/sdk/test_node_create_constraint.py
+++ b/backend/tests/integration/sdk/test_node_create_constraint.py
@@ -197,7 +197,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
             "nodes": [schema_person_base, schema_03_car_uniqueness_constraint, schema_manufacturer_base],
         }
 
-    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         cars = await registry.manager.query(db=db, schema=CAR_KIND)
         assert len(persons) == 2
@@ -205,7 +205,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
 
     async def test_step_02_add_node_success(
         self, client: InfrahubClient, initial_dataset, schema_02_uniqueness_constraint
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_02_uniqueness_constraint])
         assert not response.errors
 
@@ -228,7 +228,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
 
     async def test_step_02_add_node_failure(
         self, client: InfrahubClient, initial_dataset, schema_02_uniqueness_constraint
-    ):
+    ) -> None:
         john_person = await client.get(kind=PERSON_KIND, id=initial_dataset["john"])
         renault_manufacturer = await client.get(kind=MANUFACTURER_KIND, id=initial_dataset["renault"])
         new_car = await client.create(
@@ -247,7 +247,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
 
     async def test_step_03_add_node_success(
         self, client: InfrahubClient, initial_dataset, schema_03_uniqueness_constraint
-    ):
+    ) -> None:
         response = await client.schema.load(schemas=[schema_03_uniqueness_constraint])
         assert not response.errors
 
@@ -272,7 +272,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
 
     async def test_step_03_add_node_failure(
         self, client: InfrahubClient, initial_dataset, schema_03_uniqueness_constraint
-    ):
+    ) -> None:
         john_person = await client.get(kind=PERSON_KIND, id=initial_dataset["john"])
         renault_manufacturer = await client.get(kind=MANUFACTURER_KIND, id=initial_dataset["renault"])
         new_car = await client.create(
@@ -289,7 +289,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
 
         assert "owner-nbr_seats" in exc.value.message
 
-    async def test_create_repository_with_slash_failure(self, db: InfrahubDatabase, initial_dataset):
+    async def test_create_repository_with_slash_failure(self, db: InfrahubDatabase, initial_dataset) -> None:
         repo = await Node.init(schema="CoreRepository", db=db)
         with pytest.raises(
             ValidationError, match=re.escape("repo/name must conform with the regex: '^[^/]*$' at name")

--- a/backend/tests/integration/services/adapters/workflow/test_setup.py
+++ b/backend/tests/integration/services/adapters/workflow/test_setup.py
@@ -10,7 +10,7 @@ from tests.helpers.test_worker import TestWorkerInfrahubAsync
 
 
 class TestTaskManagerSetup(TestWorkerInfrahubAsync):
-    async def test_setup_task_manager(self, prefect_client: PrefectClient):
+    async def test_setup_task_manager(self, prefect_client: PrefectClient) -> None:
         await setup_task_manager()
 
         response = await prefect_client.read_work_pool(INFRAHUB_WORKER_POOL.name)

--- a/backend/tests/integration/services/adapters/workflow/test_workflow_execution.py
+++ b/backend/tests/integration/services/adapters/workflow/test_workflow_execution.py
@@ -25,7 +25,7 @@ class TestWorkflowExecution(TestWorkerInfrahubAsync):
         dummy_flows_deployment,
         work_pool: WorkPool,
         client,
-    ):
+    ) -> None:
         service = WorkflowWorkerExecution()
 
         task = asyncio.create_task(
@@ -54,7 +54,7 @@ class TestWorkflowExecution(TestWorkerInfrahubAsync):
         dummy_flows_deployment,
         work_pool: WorkPool,
         client,
-    ):
+    ) -> None:
         service = WorkflowWorkerExecution()
 
         task = asyncio.create_task(

--- a/backend/tests/integration/shared.py
+++ b/backend/tests/integration/shared.py
@@ -5,5 +5,5 @@ from infrahub.database import InfrahubDatabase
 from tests.helpers.schema import load_schema as load_schema_root
 
 
-async def load_schema(db: InfrahubDatabase, schema: dict[str, Any]):
+async def load_schema(db: InfrahubDatabase, schema: dict[str, Any]) -> None:
     await load_schema_root(db=db, schema=SchemaRoot(**schema), update_db=True)

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 class TestTransforms(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def base_dataset(self, db: InfrahubDatabase, client):
+    async def base_dataset(self, db: InfrahubDatabase, client) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
@@ -87,7 +87,7 @@ class TestTransforms(TestInfrahubApp):
 
     async def test_transform_jinja(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset
-    ):
+    ) -> None:
         repositories = await NodeManager.query(db=db, schema=InfrahubKind.REPOSITORY)
         queries = await NodeManager.query(db=db, schema=InfrahubKind.GRAPHQLQUERY)
 
@@ -106,7 +106,7 @@ class TestTransforms(TestInfrahubApp):
 
     async def test_transform_python(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset
-    ):
+    ) -> None:
         repositories = await NodeManager.query(db=db, schema=InfrahubKind.REPOSITORY)
         queries = await NodeManager.query(db=db, schema=InfrahubKind.GRAPHQLQUERY)
 
@@ -126,7 +126,7 @@ class TestTransforms(TestInfrahubApp):
 
     async def test_convert_query_response_transform_python(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset
-    ):
+    ) -> None:
         repositories = await NodeManager.query(db=db, schema=InfrahubKind.REPOSITORY)
         queries = await NodeManager.query(db=db, schema=InfrahubKind.GRAPHQLQUERY)
 

--- a/backend/tests/integration/user_workflows/test_node_with_type_name_attr.py
+++ b/backend/tests/integration/user_workflows/test_node_with_type_name_attr.py
@@ -21,7 +21,7 @@ class TestNodeWithTypeNameAttr(TestInfrahubApp):
         default_branch,
         client,
         service,
-    ):
+    ) -> None:
         schema = {
             "version": "1.0",
             "nodes": [

--- a/backend/tests/integration/user_workflows/test_user_worflow.py
+++ b/backend/tests/integration/user_workflows/test_user_worflow.py
@@ -220,17 +220,17 @@ state = State()
 
 class TestUserWorkflow01(TestInfrahubApp):
     @pytest.fixture(scope="class", autouse=True)
-    async def dataset01(self, db: InfrahubDatabase, client):
+    async def dataset01(self, db: InfrahubDatabase, client) -> None:
         await load_infrastructure_schema(db=db)
         await ds01.load_data(db=db, nbr_devices=2)
         graphql_registry.clear_cache()
 
-    async def test_initialize_state(self):
+    async def test_initialize_state(self) -> None:
         state.data["spine1_id"] = None
         state.data["spine1_lo0_id"] = None
         state.data["time_start"] = None
 
-    async def test_query_all_devices(self, test_client, integration_helper):
+    async def test_query_all_devices(self, test_client, integration_helper) -> None:
         """
         Query all devices to ensure that we have some data in the database
         and overall that everything is working correctly
@@ -254,7 +254,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         # Initialize the start time
         state.data["time_start"] = Instant.now()
 
-    async def test_query_spine1_loobpack0(self, test_client, integration_helper):
+    async def test_query_spine1_loobpack0(self, test_client, integration_helper) -> None:
         """
         Query Loopback0 interface on spine one to ensure that the filters are working properly and to store:
             - the ID of the interface to reuse later
@@ -282,7 +282,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         state.data["spine1_lo0_id"] = intfs[0]["node"]["id"]
         state.data["spine1_lo0_description_start"] = intfs[0]["node"]["description"]["value"]
 
-    async def test_query_spine1_ethernet1(self, test_client, integration_helper):
+    async def test_query_spine1_ethernet1(self, test_client, integration_helper) -> None:
         """
         Query Ethernet1 to gather its ID
         """
@@ -311,7 +311,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         state.data["spine1_eth1_id"] = intfs[0]["node"]["id"]
         state.data["spine1_eth1_description_start"] = intfs[0]["node"]["description"]["value"]
 
-    async def test_create_first_branch(self, test_client, integration_helper):
+    async def test_create_first_branch(self, test_client, integration_helper) -> None:
         """
         Create a first Branch from Main
         """
@@ -334,7 +334,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         self,
         test_client,
         integration_helper,
-    ):
+    ) -> None:
         """
         Update the description of the interface in the new branch and validate that its being properly updated
         """
@@ -377,7 +377,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         state.data["time_after_intf_update_branch1"] = Instant.now().format_common_iso()
 
-    async def test_update_intf_description_main(self, test_client, integration_helper):
+    async def test_update_intf_description_main(self, test_client, integration_helper) -> None:
         """
         Update the description of the interface Ethernet1 in the main branch and validate that its being properly updated
         """
@@ -416,7 +416,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         assert intfs[0]["node"]["description"]["value"] == new_description
 
-    async def test_validate_diff_after_description_update(self, test_client, integration_helper):
+    async def test_validate_diff_after_description_update(self, test_client, integration_helper) -> None:
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post(
@@ -507,7 +507,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         assert DeepDiff(expected_result, result["data"]["DiffTree"], ignore_order=True).to_dict() == {}
 
-    async def test_update_intf_description_branch1_again(self, test_client, integration_helper):
+    async def test_update_intf_description_branch1_again(self, test_client, integration_helper) -> None:
         """
         Update the description of the interface in the new branch again and validate that its being properly updated
         """
@@ -547,7 +547,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         assert intfs[0]["node"]["description"]["value"] == new_description
 
-    async def test_validate_diff_again_after_description_update(self, test_client, integration_helper):
+    async def test_validate_diff_again_after_description_update(self, test_client, integration_helper) -> None:
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post(
@@ -638,7 +638,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         assert DeepDiff(expected_result, result["data"]["DiffTree"], ignore_order=True).to_dict() == {}
 
-    async def test_create_second_branch(self, test_client, integration_helper):
+    async def test_create_second_branch(self, test_client, integration_helper) -> None:
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post(
@@ -653,7 +653,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         result = response.json()["data"]
         assert result["BranchCreate"]["ok"]
 
-    async def test_update_intf_description_main_after_branch2(self, test_client, integration_helper):
+    async def test_update_intf_description_main_after_branch2(self, test_client, integration_helper) -> None:
         assert state.data["spine1_eth1_id"]
         headers = await integration_helper.admin_headers()
 
@@ -725,7 +725,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         assert len(intfs) == 1
         assert intfs[0]["node"]["description"]["value"] == old_description
 
-    async def test_rebase_branch2(self, test_client, integration_helper):
+    async def test_rebase_branch2(self, test_client, integration_helper) -> None:
         """
         Rebase Branch 2
         """
@@ -770,7 +770,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         assert len(intfs) == 1
         assert intfs[0]["node"]["description"]["value"] == main_description
 
-    async def test_query_spine1_lo0_at_start_time(self, test_client, integration_helper):
+    async def test_query_spine1_lo0_at_start_time(self, test_client, integration_helper) -> None:
         headers = await integration_helper.admin_headers()
 
         intf_name = "Loopback0"
@@ -796,7 +796,7 @@ class TestUserWorkflow01(TestInfrahubApp):
 
         state.data["spine1_lo0_description_start"] = intfs[0]["node"]["description"]["value"]
 
-    async def test_add_new_interface_in_first_branch(self, test_client, integration_helper):
+    async def test_add_new_interface_in_first_branch(self, test_client, integration_helper) -> None:
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post(
@@ -1075,7 +1075,7 @@ class TestUserWorkflow01(TestInfrahubApp):
             == {}
         )
 
-    async def test_merge_first_branch_into_main(self, test_client, integration_helper):
+    async def test_merge_first_branch_into_main(self, test_client, integration_helper) -> None:
         # Expected description for Loopback0 after the merge
         headers = await integration_helper.admin_headers()
 

--- a/backend/tests/integration/workers/test_infrahubasync.py
+++ b/backend/tests/integration/workers/test_infrahubasync.py
@@ -30,7 +30,7 @@ class TestWorker(TestWorkerInfrahubAsync):
         prefect_worker: InfrahubWorkerAsync,
         dummy_flows_deployment,
         client,
-    ):
+    ) -> None:
         # Schedule the execution of the deployment from the server
         flow: FlowRun = await run_deployment(
             name=DUMMY_FLOW.full_name, parameters={"data": DummyInput(firstname="John", lastname="Doe")}, timeout=0
@@ -61,7 +61,7 @@ class TestWorker(TestWorkerInfrahubAsync):
         prefect_worker: InfrahubWorkerAsync,
         dummy_flows_deployment,
         client,
-    ):
+    ) -> None:
         # Schedule the execution of the deployment from the server
         flow: FlowRun = await run_deployment(
             name=DUMMY_FLOW.full_name, parameters={"data": DummyInput(firstname="John", lastname="Doe")}, timeout=0
@@ -87,7 +87,7 @@ class TestWorker(TestWorkerInfrahubAsync):
         prefect_worker: InfrahubWorkerAsync,
         dummy_flows_deployment,
         client,
-    ):
+    ) -> None:
         # Schedule the execution of the deployment from the server
         flow: FlowRun = await run_deployment(
             name=DUMMY_FLOW_BROKEN.full_name,

--- a/backend/tests/query_benchmark/test_diff_query.py
+++ b/backend/tests/query_benchmark/test_diff_query.py
@@ -33,7 +33,7 @@ log = get_logger()
         BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_COMMUNITY_IMAGE, load_db_indexes=True),
     ],
 )
-async def test_diff(benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit):
+async def test_diff(benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit) -> None:
     # Initialization
     db_profiling_queries, default_branch = await start_db_and_create_default_branch(
         neo4j_image=benchmark_config.neo4j_image,

--- a/backend/tests/query_benchmark/test_node_get_list.py
+++ b/backend/tests/query_benchmark/test_node_get_list.py
@@ -39,7 +39,7 @@ log = get_logger()
 )
 async def test_node_get_list_ordering(
     benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit, ordering
-):
+) -> None:
     # Initialization
     db_profiling_queries, default_branch = await start_db_and_create_default_branch(
         neo4j_image=benchmark_config.neo4j_image,

--- a/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
+++ b/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
@@ -33,7 +33,7 @@ async def benchmark_uniqueness_query(
     benchmark_config: BenchmarkConfig,
     test_params_label: str,
     test_name: str,
-):
+) -> None:
     """
     Profile NodeUniqueAttributeConstraintQuery with a given query_request / configuration, using a Car generator.
     """
@@ -105,7 +105,7 @@ async def benchmark_uniqueness_query(
         ),
     ],
 )
-async def test_multiple_constraints(query_request, car_person_schema_root, graph_generator):
+async def test_multiple_constraints(query_request, car_person_schema_root, graph_generator) -> None:
     benchmark_config = BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_ENTERPRISE_IMAGE)
     await benchmark_uniqueness_query(
         query_request=query_request,
@@ -129,7 +129,7 @@ async def test_multiple_constraints(query_request, car_person_schema_root, graph
         BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_COMMUNITY_IMAGE, load_db_indexes=True),
     ],
 )
-async def test_single_constraint_multiple_runtimes(benchmark_config, car_person_schema_root, graph_generator):
+async def test_single_constraint_multiple_runtimes(benchmark_config, car_person_schema_root, graph_generator) -> None:
     query_request = NodeUniquenessQueryRequest(
         kind="TestCar",
         unique_attribute_paths={

--- a/backend/tests/scale/common/events.py
+++ b/backend/tests/scale/common/events.py
@@ -28,7 +28,7 @@ failed_request: bool = False
 
 
 @events.test_start.add_listener
-def setup_iteration_limit(environment: Environment, **kwargs):
+def setup_iteration_limit(environment: Environment, **kwargs) -> None:
     runner: Runner = environment.runner
     runner.iterations_started = 0
     runner.iteration_target_reached = False
@@ -63,7 +63,7 @@ def setup_iteration_limit(environment: Environment, **kwargs):
 @events.request.add_listener
 def request_event_handler(
     request_type, name, response_time, response_length, response, context, exception, start_time, **kwargs
-):
+) -> None:
     result = {
         "name": name,
         "start_time": f"{start_time:.2f}",

--- a/backend/tests/scale/common/stagers.py
+++ b/backend/tests/scale/common/stagers.py
@@ -14,7 +14,7 @@ def load_schema(
     branch: str | None = None,
     attributes: list[dict] | None = None,
     relationships: list[dict] | None = None,
-):
+) -> None:
     attributes = attributes or []
     relationships = relationships or []
     branch = branch or "main"

--- a/backend/tests/scale/common/users.py
+++ b/backend/tests/scale/common/users.py
@@ -28,7 +28,7 @@ class InfrahubClientUser(User):
         )
 
     @task
-    def crud(self):
+    def crud(self) -> None:
         print("--- staging")
         print("--- loading schema")
         if not hasattr(common.stagers, self.custom_options["stager"]):

--- a/backend/tests/unit/api/diff/test_diff_query_validation.py
+++ b/backend/tests/unit/api/diff/test_diff_query_validation.py
@@ -7,12 +7,12 @@ from infrahub.core.branch import Branch
 
 
 class TestDiffQueryValidation:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.branch = Branch(name="abc")
         self.time_start_str = "2023-06-11"
         self.time_end_str = "2023-06-13"
 
-    def test_valid_query(self):
+    def test_valid_query(self) -> None:
         query = DiffQueryValidated(
             branch=self.branch, time_from=self.time_start_str, time_to=self.time_end_str, branch_only=True
         )
@@ -22,21 +22,21 @@ class TestDiffQueryValidation:
         assert query.time_to == self.time_end_str
         assert query.branch_only is True
 
-    def test_invalid_time_from(self):
+    def test_invalid_time_from(self) -> None:
         with pytest.raises(TimestampFormatError):
             DiffQueryValidated(branch=self.branch, time_from="notatime")
 
-    def test_invalid_time_to(self):
+    def test_invalid_time_to(self) -> None:
         with pytest.raises(TimestampFormatError):
             DiffQueryValidated(branch=self.branch, time_to="notatime")
 
-    def test_invalid_time_range(self):
+    def test_invalid_time_range(self) -> None:
         with pytest.raises(ValidationError, match="time_from and time_to are not a valid time range"):
             DiffQueryValidated(
                 branch=self.branch, time_from=self.time_end_str, time_to=self.time_start_str, branch_only=True
             )
 
-    def test_time_from_required_for_default_branch(self):
+    def test_time_from_required_for_default_branch(self) -> None:
         self.branch.is_default = True
 
         with pytest.raises(ValidationError, match="time_from is mandatory when diffing on the default branch `abc`."):

--- a/backend/tests/unit/api/test_00_auth.py
+++ b/backend/tests/unit/api/test_00_auth.py
@@ -22,7 +22,7 @@ EXPIRED_REFRESH_TOKEN = (
 )
 
 
-async def test_password_based_login(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_password_based_login(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     with client:
         response = client.post("/api/auth/login", json={"username": "First Account", "password": "FirstPassword123"})
 
@@ -37,7 +37,7 @@ async def test_password_based_login(db: InfrahubDatabase, default_branch, client
     assert first_account.id == decoded["sub"]
 
 
-async def test_refresh_with_invalidated_token(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_refresh_with_invalidated_token(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     with client:
         response = client.post("/api/auth/login", json={"username": "First Account", "password": "FirstPassword123"})
 
@@ -64,7 +64,7 @@ async def test_refresh_with_invalidated_token(db: InfrahubDatabase, default_bran
     }
 
 
-async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     """Validate that it's possible to refresh an access token using a refresh token"""
     with client:
         login_response = client.post(
@@ -88,7 +88,7 @@ async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client
     assert decoded_access["session_id"] == decoded_refresh["session_id"]
 
 
-async def test_refresh_access_token_with_cookies(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_refresh_access_token_with_cookies(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     """Validate that it's possible to refresh an access token using a refresh token stored in cookies"""
     with client:
         login_response = client.post(
@@ -120,7 +120,7 @@ async def test_refresh_access_token_with_cookies(db: InfrahubDatabase, default_b
 
 async def test_fail_to_refresh_access_token_with_access_token(
     db: InfrahubDatabase, default_branch, client, first_account
-):
+) -> None:
     """Validate that it's not possible to refresh an access token using an access token"""
     with client:
         login_response = client.post(
@@ -143,7 +143,7 @@ async def test_fail_to_refresh_access_token_with_access_token(
     }
 
 
-async def test_password_based_login_unknown_user(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_password_based_login_unknown_user(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     with client:
         response = client.post("/api/auth/login", json={"username": "i-do-not-exist", "password": "something"})
 
@@ -154,7 +154,9 @@ async def test_password_based_login_unknown_user(db: InfrahubDatabase, default_b
     }
 
 
-async def test_password_based_login_invalid_password(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_password_based_login_invalid_password(
+    db: InfrahubDatabase, default_branch, client, first_account
+) -> None:
     with client:
         response = client.post("/api/auth/login", json={"username": "First Account", "password": "incorrect"})
 
@@ -188,7 +190,7 @@ async def test_refresh_access_token_with_expired_refresh_token(
     assert response.json() == {"data": None, "errors": [{"message": "Expired Signature", "extensions": {"code": 401}}]}
 
 
-async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     """It should not be possible to access a resource using a refresh token"""
     with client:
         login_response = client.post(
@@ -208,7 +210,7 @@ async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default
     }
 
 
-async def test_generate_api_token(db: InfrahubDatabase, default_branch, client, create_test_admin):
+async def test_generate_api_token(db: InfrahubDatabase, default_branch, client, create_test_admin) -> None:
     """It should not be possible to generate an API token using a JWT token"""
     with client:
         login_response = client.post(

--- a/backend/tests/unit/api/test_01_auth_cookies.py
+++ b/backend/tests/unit/api/test_01_auth_cookies.py
@@ -4,7 +4,7 @@ from infrahub import config
 from infrahub.database import InfrahubDatabase
 
 
-async def test_password_based_login(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_password_based_login(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     with client:
         response = client.post("/api/auth/login", json={"username": "First Account", "password": "FirstPassword123"})
 
@@ -19,7 +19,7 @@ async def test_password_based_login(db: InfrahubDatabase, default_branch, client
     assert first_account.id == decoded["sub"]
 
 
-async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     """Validate that it's possible to refresh an access token using a refresh token"""
     with client:
         login_response = client.post(
@@ -43,7 +43,7 @@ async def test_refresh_access_token(db: InfrahubDatabase, default_branch, client
     assert decoded_access["session_id"] == decoded_refresh["session_id"]
 
 
-async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default_branch, client, first_account):
+async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default_branch, client, first_account) -> None:
     """It should not be possible to access a resource using a refresh token"""
     with client:
         login_response = client.post(
@@ -64,7 +64,7 @@ async def test_access_resource_using_refresh_token(db: InfrahubDatabase, default
     }
 
 
-async def test_generate_api_token(db: InfrahubDatabase, default_branch, client, create_test_admin):
+async def test_generate_api_token(db: InfrahubDatabase, default_branch, client, create_test_admin) -> None:
     """It should not be possible to generate an API token using a JWT token"""
     with client:
         login_response = client.post(

--- a/backend/tests/unit/api/test_02_base.py
+++ b/backend/tests/unit/api/test_02_base.py
@@ -7,7 +7,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_get_invalid(
     client: TestClient, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
-):
+) -> None:
     with client:
         response = client.get("/api/so-such-route")
 

--- a/backend/tests/unit/api/test_03_menu.py
+++ b/backend/tests/unit/api/test_03_menu.py
@@ -11,7 +11,7 @@ async def test_get_menu_not_admin(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     await create_default_menu(db=db)
 
     with client:
@@ -32,7 +32,7 @@ async def test_get_menu_admin(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     await create_default_menu(db=db)
 
     with client:

--- a/backend/tests/unit/api/test_10_query.py
+++ b/backend/tests/unit/api/test_10_query.py
@@ -136,7 +136,7 @@ async def test_query_endpoint_group_params(
 
 async def test_query_endpoint_get_default_branch(
     db: InfrahubDatabase, client: TestClient, admin_headers, default_branch, create_test_admin, car_person_data
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get("/api/query/query01", headers=admin_headers)
@@ -159,7 +159,7 @@ async def test_query_endpoint_post_no_payload(
     default_branch,
     car_person_data,
     base_authentication,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
@@ -185,7 +185,7 @@ async def test_query_endpoint_post_with_params(
     default_branch,
     car_person_data,
     base_authentication,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post("/api/query/query02", headers=admin_headers, json={"variables": {"person": "John"}})
@@ -207,7 +207,7 @@ async def test_query_endpoint_branch1(
     create_test_admin,
     car_person_data,
     authentication_base,
-):
+) -> None:
     await create_branch(branch_name="branch1", db=db)
 
     # Must execute in a with block to execute the startup/shutdown events
@@ -232,7 +232,7 @@ async def test_query_endpoint_wrong_query(
     default_branch,
     car_person_schema,
     register_core_models_schema,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get(
@@ -250,7 +250,7 @@ async def test_query_endpoint_wrong_branch(
     default_branch,
     car_person_schema,
     register_core_models_schema,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get(
@@ -290,7 +290,7 @@ async def test_query_endpoint_missing_privs(
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_query_endpoint_anonymous_account(
     db: InfrahubDatabase, client: TestClient, default_branch, car_person_data, allow_anonymous_access: bool
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:

--- a/backend/tests/unit/api/test_11_artifact.py
+++ b/backend/tests/unit/api/test_11_artifact.py
@@ -86,7 +86,7 @@ class TestArtifact11(TestInfrahubApp):
         authentication_base: Node,
         client,
         test_client,
-    ):
+    ) -> None:
         _, _, definition = await self.setup_artifact_definition(
             db=db,
             register_core_models_schema=register_core_models_schema,
@@ -139,7 +139,7 @@ class TestArtifact11(TestInfrahubApp):
         car_person_data_generic,
         authentication_base,
         test_client,
-    ):
+    ) -> None:
         response = await test_client.get("/api/artifact/95008984-16ca-4e58-8323-0899bb60035f", headers=admin_headers)
         assert response.status_code == 404
 
@@ -164,7 +164,7 @@ class TestArtifact11(TestInfrahubApp):
         car_person_data_generic,
         allow_anonymous_access: bool,
         test_client,
-    ):
+    ) -> None:
         artifact = await self.setup_artifact(
             db=db,
             register_core_models_schema=register_core_models_schema,

--- a/backend/tests/unit/api/test_12_file.py
+++ b/backend/tests/unit/api/test_12_file.py
@@ -14,7 +14,7 @@ async def test_get_file(
     default_branch,
     rpc_bus,
     register_core_models_schema,
-):
+) -> None:
     r1 = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
     await r1.new(db=db, name="repo01", location="git@github.com:user/repo01.git")
     await r1.save(db=db)
@@ -71,7 +71,7 @@ async def test_get_file(
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_get_file_anonymous_account(
     db: InfrahubDatabase, client, default_branch, rpc_bus, register_core_models_schema, allow_anonymous_access: bool
-):
+) -> None:
     r1 = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
     await r1.new(
         db=db, name="repo01", location="git@github.com:user/repo01.git", commit="1345754212345678iuytrewqwertyu"

--- a/backend/tests/unit/api/test_15_diff.py
+++ b/backend/tests/unit/api/test_15_diff.py
@@ -9,7 +9,7 @@ from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 
 
-async def test_get_display_labels_per_kind(db: InfrahubDatabase, default_branch, car_person_data):
+async def test_get_display_labels_per_kind(db: InfrahubDatabase, default_branch, car_person_data) -> None:
     persons_list = await NodeManager.query(db=db, schema="TestPerson", branch=default_branch)
     person_ids = [item.id for item in persons_list]
     display_labels = await get_display_labels_per_kind(
@@ -18,7 +18,7 @@ async def test_get_display_labels_per_kind(db: InfrahubDatabase, default_branch,
     assert len(display_labels) == len(person_ids)
 
 
-async def test_get_display_labels_per_kind_with_branch(db: InfrahubDatabase, default_branch, car_person_data):
+async def test_get_display_labels_per_kind_with_branch(db: InfrahubDatabase, default_branch, car_person_data) -> None:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     # Add a new Person
@@ -35,7 +35,7 @@ async def test_get_display_labels_per_kind_with_branch(db: InfrahubDatabase, def
     assert len(display_labels) == len(person_ids)
 
 
-async def test_get_display_labels(db: InfrahubDatabase, default_branch, car_person_data):
+async def test_get_display_labels(db: InfrahubDatabase, default_branch, car_person_data) -> None:
     persons_list = await NodeManager.query(db=db, schema="TestPerson", branch=default_branch)
     person_ids = [item.id for item in persons_list]
     cars_list = await NodeManager.query(db=db, schema="TestCar", branch=default_branch)
@@ -45,7 +45,7 @@ async def test_get_display_labels(db: InfrahubDatabase, default_branch, car_pers
     assert len(display_labels["main"]) == len(car_ids) + len(person_ids)
 
 
-async def test_get_display_labels_with_branch(db: InfrahubDatabase, default_branch, car_person_data):
+async def test_get_display_labels_with_branch(db: InfrahubDatabase, default_branch, car_person_data) -> None:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     persons_list = await NodeManager.query(db=db, schema="TestPerson", branch=branch2)
@@ -133,7 +133,7 @@ async def r1_update_01(data_diff_attribute):
     return expected_response
 
 
-async def test_diff_artifact(db: InfrahubDatabase, client, client_headers, car_person_data_artifact_diff):
+async def test_diff_artifact(db: InfrahubDatabase, client, client_headers, car_person_data_artifact_diff) -> None:
     with client:
         response = client.get(
             "/api/diff/artifacts?branch=branch3",
@@ -209,7 +209,7 @@ async def test_diff_artifact(db: InfrahubDatabase, client, client_headers, car_p
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_diff_artifact_anonymous_access(
     db: InfrahubDatabase, client, client_headers, car_person_data_artifact_diff, allow_anonymous_access: bool
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:
@@ -221,7 +221,7 @@ async def test_diff_artifact_anonymous_access(
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_diff_files_anonymous_access(
     db: InfrahubDatabase, client, client_headers, car_person_data_artifact_diff, allow_anonymous_access: bool
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:

--- a/backend/tests/unit/api/test_20_graphql.py
+++ b/backend/tests/unit/api/test_20_graphql.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 async def test_graphql_endpoint(
     db: InfrahubDatabase, client: TestClient, admin_headers, default_branch: Branch, create_test_admin, car_person_data
-):
+) -> None:
     query = """
     query {
         TestPerson {
@@ -59,7 +59,7 @@ async def test_graphql_endpoint(
 
 async def test_graphql_endpoint_with_timestamp(
     db: InfrahubDatabase, client: TestClient, admin_headers, default_branch: Branch, create_test_admin, car_person_data
-):
+) -> None:
     time_before = Timestamp()
 
     p1 = car_person_data["p1"]
@@ -109,7 +109,7 @@ async def test_graphql_endpoint_with_timestamp(
 @pytest.mark.xfail(reason="Need to investigate, Currently working alone but failing when it's part of the test suite")
 async def test_graphql_endpoint_generics(
     db: InfrahubDatabase, default_branch: Branch, client, client_headers, car_person_data_generic
-):
+) -> None:
     query = """
     query {
         TestPerson {
@@ -145,7 +145,9 @@ async def test_graphql_endpoint_generics(
     assert len(result_per_name["Jane"]["cars"]) == 1
 
 
-async def test_graphql_options(db: InfrahubDatabase, client, client_headers, default_branch: Branch, car_person_data):
+async def test_graphql_options(
+    db: InfrahubDatabase, client, client_headers, default_branch: Branch, car_person_data
+) -> None:
     await create_branch(branch_name="branch2", db=db)
 
     # Must execute in a with block to execute the startup/shutdown events
@@ -181,7 +183,7 @@ async def test_read_profile(
     client,
     admin_headers,
     authentication_base,
-):
+) -> None:
     query = """
     query {
         AccountProfile {
@@ -203,7 +205,7 @@ async def test_read_profile(
     assert response.json() == {"data": {"AccountProfile": {"name": {"value": "test-admin"}}}}
 
 
-async def test_download_schema(db: InfrahubDatabase, client, client_headers):
+async def test_download_schema(db: InfrahubDatabase, client, client_headers) -> None:
     await create_branch(branch_name="branch2", db=db)
 
     # Must execute in a with block to execute the startup/shutdown events
@@ -221,7 +223,7 @@ async def test_download_schema(db: InfrahubDatabase, client, client_headers):
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_download_schema_anonymous_account(
     db: InfrahubDatabase, client, client_headers, allow_anonymous_access: bool
-):
+) -> None:
     await create_branch(branch_name="branch2", db=db)
 
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
@@ -235,7 +237,7 @@ async def test_download_schema_anonymous_account(
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_download_graphql_schema_sorted(
     db: InfrahubDatabase, client, client_headers, allow_anonymous_access: bool
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     # Must execute in a with block to execute the startup/shutdown events

--- a/backend/tests/unit/api/test_40_schema.py
+++ b/backend/tests/unit/api/test_40_schema.py
@@ -18,7 +18,7 @@ async def test_schema_read_endpoint_default_branch(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     with client:
         response = client.get(
             "/api/schema",
@@ -51,7 +51,7 @@ async def test_schema_read_endpoint_branch1(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     await create_branch(branch_name="branch1", db=db)
 
     # Must execute in a with block to execute the startup/shutdown events
@@ -75,7 +75,7 @@ async def test_schema_read_endpoint_branch1(
 
 async def test_schema_read_endpoint_wrong_branch(
     db: InfrahubDatabase, client: TestClient, client_headers, default_branch: Branch, car_person_data_generic
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get(
@@ -94,7 +94,7 @@ async def test_schema_summary_default_branch(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     with client:
         response = client.get(
             "/api/schema/summary",
@@ -118,7 +118,7 @@ async def test_schema_kind_default_branch(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     with client:
         response = client.get(
             f"/api/schema/{InfrahubKind.TAG}",
@@ -142,7 +142,7 @@ async def test_json_schema_kind_default_branch(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     with client:
         response = client.get(
             f"/api/schema/json_schema/{InfrahubKind.IPPREFIX}",
@@ -170,7 +170,7 @@ async def test_schema_kind_not_valid(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     car_person_data_generic,
-):
+) -> None:
     with client:
         response = client.get(
             "/api/schema/NotPresent",
@@ -190,7 +190,7 @@ async def test_schema_load_permission_failure(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     token = await Node.init(db=db, schema=InfrahubKind.ACCOUNTTOKEN)
     await token.new(db=db, token="unprivileged", account=first_account)
     await token.save(db=db)
@@ -220,7 +220,7 @@ async def test_schema_load_restricted_namespace(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     with client:
         response = client.post(
             "/api/schema/load",
@@ -241,7 +241,7 @@ async def test_schema_load_endpoint_not_valid_simple_02(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
@@ -262,7 +262,7 @@ async def test_schema_load_endpoint_not_valid_simple_03(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
@@ -283,7 +283,7 @@ async def test_schema_load_endpoint_not_valid_simple_04(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
@@ -304,7 +304,7 @@ async def test_schema_load_endpoint_not_valid_simple_05(
     workflow_local,
     authentication_base,
     helper,
-):
+) -> None:
     with client:
         response = client.post(
             "/api/schema/load",
@@ -326,7 +326,7 @@ async def test_schema_load_endpoint_not_valid_with_generics_02(
     default_branch: Branch,
     authentication_base,
     helper,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
@@ -345,7 +345,7 @@ async def test_schema_load_endpoint_python_keyword_attribute(
     default_branch: Branch,
     authentication_base,
     helper,
-):
+) -> None:
     """Test that loading a schema with Python keyword as attribute name fails with proper error."""
     with client:
         response = client.post(
@@ -375,7 +375,7 @@ async def test_schema_load_endpoint_constraints_not_valid(
     car_volt_main,
     person_john_main,
     helper,
-):
+) -> None:
     # Load the schema in the database
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     await registry.schema.load_schema_to_db(schema=schema, branch=default_branch, db=db)
@@ -421,7 +421,7 @@ async def test_schema_read_endpoints_anonymous_account(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     allow_anonymous_access: bool,
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:

--- a/backend/tests/unit/api/test_50_internals.py
+++ b/backend/tests/unit/api/test_50_internals.py
@@ -9,7 +9,7 @@ from tests.helpers.fixtures import get_fixtures_dir
 
 async def test_config_endpoint(
     db: InfrahubDatabase, client: TestClient, client_headers, default_branch, register_core_models_schema: None
-):
+) -> None:
     with client:
         response = client.get("/api/config", headers=client_headers)
 
@@ -36,7 +36,7 @@ async def test_config_endpoint_anonymous_account(
     default_branch,
     register_core_models_schema: None,
     allow_anonymous_access: bool,
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:
@@ -47,7 +47,7 @@ async def test_config_endpoint_anonymous_account(
 
 async def test_info_endpoint(
     db: InfrahubDatabase, client: TestClient, client_headers, default_branch, register_core_models_schema: None
-):
+) -> None:
     with client:
         response = client.get("/api/info", headers=client_headers)
 
@@ -62,7 +62,7 @@ async def test_info_endpoint(
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_info_endpoint_anonymous_account(
     db: InfrahubDatabase, client, default_branch, register_core_models_schema: None, allow_anonymous_access: bool
-):
+) -> None:
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
     with client:
@@ -93,7 +93,7 @@ def no_search_index_path():
     internal.search_docs_loader = old_search_docs_loader
 
 
-async def test_search_docs(client, override_search_index_path):
+async def test_search_docs(client, override_search_index_path) -> None:
     response = client.get("/api/search/docs?query=guid")
 
     assert response.status_code == 200
@@ -103,7 +103,7 @@ async def test_search_docs(client, override_search_index_path):
     assert response_json[0]["title"] == "Guides"
 
 
-async def test_search_docs_limit(client, override_search_index_path):
+async def test_search_docs_limit(client, override_search_index_path) -> None:
     response = client.get("/api/search/docs?query=a&limit=1")
 
     assert response.status_code == 200
@@ -113,7 +113,7 @@ async def test_search_docs_limit(client, override_search_index_path):
     assert len(response_json) == 1
 
 
-async def test_no_search_docs(client, no_search_index_path):
+async def test_no_search_docs(client, no_search_index_path) -> None:
     response = client.get("/api/search/docs?query=guid")
 
     assert response.status_code == 404

--- a/backend/tests/unit/api/test_60_storage.py
+++ b/backend/tests/unit/api/test_60_storage.py
@@ -15,7 +15,7 @@ async def test_file_upload(
     admin_headers,
     default_branch: Branch,
     authentication_base,
-):
+) -> None:
     files_dir = helper.get_fixtures_dir() / "schemas"
     filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
     file_path = files_dir / filenames[0]
@@ -44,7 +44,7 @@ async def test_content_upload(
     admin_headers,
     default_branch: Branch,
     authentication_base,
-):
+) -> None:
     files_dir = helper.get_fixtures_dir() / "schemas"
     filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
 

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -29,10 +29,10 @@ class MockError(Error):
 
 
 class TestAPIExceptionHandler:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.error_message = "Value error, this is the error message"
 
-    async def test_plain_exception_error(self):
+    async def test_plain_exception_error(self) -> None:
         exception = ValueError(self.error_message)
 
         error_response = await generic_api_exception_handler(None, exception)
@@ -40,7 +40,7 @@ class TestAPIExceptionHandler:
         error_dict = loads(error_response.body.decode())
         assert error_dict["errors"] == [{"message": self.error_message, "extensions": {"code": 500}}]
 
-    async def test_pydantic_validation_error(self):
+    async def test_pydantic_validation_error(self) -> None:
         error_message_2 = "Value error, another error message"
         exception = Error()
         try:
@@ -55,7 +55,7 @@ class TestAPIExceptionHandler:
         assert {"message": error_message_2, "extensions": {"code": 400}} in error_dict["errors"]
         assert len(error_dict) == 2
 
-    async def test_infrahub_api_error(self):
+    async def test_infrahub_api_error(self) -> None:
         exception = MockError(self.error_message)
 
         error_response = await generic_api_exception_handler(None, exception)
@@ -63,7 +63,7 @@ class TestAPIExceptionHandler:
         error_dict = loads(error_response.body.decode())
         assert error_dict["errors"] == [{"message": self.error_message, "extensions": {"code": 418}}]
 
-    async def test_infrahub_api_error_default_message(self):
+    async def test_infrahub_api_error_default_message(self) -> None:
         exception = MockError(None)
 
         error_response = await generic_api_exception_handler(None, exception)
@@ -71,7 +71,7 @@ class TestAPIExceptionHandler:
         error_dict = loads(error_response.body.decode())
         assert error_dict["errors"] == [{"message": "the teapot error", "extensions": {"code": 418}}]
 
-    async def test_infrahub_api_error_code_override(self):
+    async def test_infrahub_api_error_code_override(self) -> None:
         exception = MockError(None)
 
         error_response = await generic_api_exception_handler(None, exception, http_code=500)

--- a/backend/tests/unit/cli/test_cli.py
+++ b/backend/tests/unit/cli/test_cli.py
@@ -5,25 +5,25 @@ from infrahub.cli import app
 runner = CliRunner()
 
 
-def test_main_app():
+def test_main_app() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
 
 
-def test_db_app():
+def test_db_app() -> None:
     result = runner.invoke(app, ["db", "--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
 
 
-def test_git_agent_app():
+def test_git_agent_app() -> None:
     result = runner.invoke(app, ["git-agent", "--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
 
 
-def test_server_app():
+def test_server_app() -> None:
     result = runner.invoke(app, ["server", "--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout

--- a/backend/tests/unit/computed_attribute/test_gather.py
+++ b/backend/tests/unit/computed_attribute/test_gather.py
@@ -9,12 +9,12 @@ from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 
 
-async def test_gather_trigger_computed_attribute_jinja2_empty(register_core_models_schema):
+async def test_gather_trigger_computed_attribute_jinja2_empty(register_core_models_schema) -> None:
     triggers = await gather_trigger_computed_attribute_jinja2()
     assert len(triggers) == 0
 
 
-async def test_gather_trigger_computed_attribute_jinja2_only_main(car_person_schema_computed_attr):
+async def test_gather_trigger_computed_attribute_jinja2_only_main(car_person_schema_computed_attr) -> None:
     triggers = await gather_trigger_computed_attribute_jinja2()
     assert len(triggers) == 1
     trigger = triggers[0]
@@ -25,7 +25,7 @@ async def test_gather_trigger_computed_attribute_jinja2_only_main(car_person_sch
 
 async def test_gather_trigger_computed_attribute_jinja2_different_branch(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_computed_attr
-):
+) -> None:
     branch = await create_branch(branch_name="branch2", db=db)
 
     schema_branch = registry.schema.get_schema_branch(name=branch.name)
@@ -64,7 +64,7 @@ async def test_gather_trigger_computed_attribute_jinja2_different_branch(
 
 async def test_gather_trigger_computed_attribute_python(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_computed_attr, transform01: Node
-):
+) -> None:
     triggers, trigger_queries = await gather_trigger_computed_attribute_python(db=db)
     assert triggers
     assert trigger_queries

--- a/backend/tests/unit/computed_attribute/test_models.py
+++ b/backend/tests/unit/computed_attribute/test_models.py
@@ -32,7 +32,7 @@ def generate_automation(
     )
 
 
-async def test_load_from_prefect():
+async def test_load_from_prefect() -> None:
     automations: list[Automation] = [
         generate_automation(
             name=PROCESS_AUTOMATION_NAME.format(

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -73,7 +73,7 @@ from tests.test_data import dataset01 as ds01
 
 
 @pytest.fixture(scope="module", autouse=True)
-def load_component_dependency_registry():
+def load_component_dependency_registry() -> None:
     build_component_registry()
 
 
@@ -3042,7 +3042,7 @@ def workflow_local(dependency_provider: Provider):
 
 
 @pytest.fixture
-async def generic_car_person_schema(default_branch: Branch, data_schema):
+async def generic_car_person_schema(default_branch: Branch, data_schema) -> None:
     schema: dict[str, Any] = {
         "generics": [
             {

--- a/backend/tests/unit/core/changelog/test_diff.py
+++ b/backend/tests/unit/core/changelog/test_diff.py
@@ -189,7 +189,7 @@ class TestConflict:
         car_accord_main: Node,
         conflict_selection: ConflictSelection,
         expected_value: Literal["John-main", "John-branch"],
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.value = "John-main"
@@ -246,7 +246,7 @@ class TestConflict:
         person_alfred_main: Node,
         car_accord_main: Node,
         conflict_selection: ConflictSelection,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.source = person_alfred_main

--- a/backend/tests/unit/core/changelog/test_models.py
+++ b/backend/tests/unit/core/changelog/test_models.py
@@ -13,7 +13,7 @@ from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 
 
-async def test_node_changelog_creation(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_node_changelog_creation(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -212,7 +212,7 @@ async def test_node_changelog_creation(db: InfrahubDatabase, default_branch, ani
 
 async def test_node_changelog_update_with_cardinality_one_relationship(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -286,7 +286,7 @@ async def test_node_changelog_update_with_cardinality_one_relationship(
 
 async def test_node_changelog_update_with_cardinality_many_relationship(
     db: InfrahubDatabase, default_branch, animal_person_schema, standard_group_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
 
     person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
@@ -333,7 +333,7 @@ async def test_node_changelog_update_with_cardinality_many_relationship(
 
 async def test_node_changelog_delete_with_cardinality_one_relationship(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -355,7 +355,7 @@ async def test_node_changelog_delete_with_cardinality_one_relationship(
 
 async def test_node_changelog_delete_with_cardinality_many_relationship(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 

--- a/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
@@ -13,7 +13,7 @@ from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
 
-async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     crit_low = await Node.init(db=db, schema=criticality_schema)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -41,7 +41,7 @@ async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, cr
     assert len(all_data_paths) == 0
 
 
-async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     crit_low = await Node.init(db=db, schema=criticality_schema)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -78,7 +78,7 @@ async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criti
     ]
 
 
-async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticality_schema):
+async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticality_schema) -> None:
     crit_low = await Node.init(db=db, schema=criticality_schema, branch=branch)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -131,7 +131,7 @@ async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticali
 
 async def test_attribute_update_on_branch(
     db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium
-):
+) -> None:
     criticality_low.status.value = "passive"
     await criticality_low.save(db=db)
 
@@ -190,7 +190,7 @@ async def test_attribute_update_on_branch(
 
 async def test_node_delete_on_branch(
     db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium
-):
+) -> None:
     criticality_low.status.value = "passive"
     await criticality_low.save(db=db)
 
@@ -246,7 +246,9 @@ async def test_node_delete_on_branch(
     )
 
 
-async def test_validator(db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium):
+async def test_validator(
+    db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium
+) -> None:
     await branch.rebase(db=db)
     crit_low = await NodeManager.get_one(id=criticality_low.id, db=db, branch=branch)
     crit_low.status.value = "active"
@@ -307,7 +309,7 @@ async def test_validator_generic_and_node_have_different_choices(
     criticality_low: Node,
     criticality_medium: Node,
     branch: Branch,
-):
+) -> None:
     # add different choices to the status attribute on the generic
     criticality_schema_root.generics[0].attributes.append(
         AttributeSchema(

--- a/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
@@ -9,7 +9,9 @@ from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_new_choice_value(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     transmission_attr = car_schema.get_attribute(name="transmission")
     transmission_attr.enum.append("warp-drive")
@@ -27,7 +29,9 @@ async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Bran
     assert len(all_data_paths) == 0
 
 
-async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_remove_choice(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=default_branch)
     car.transmission.value = "manual"
     await car.save(db=db)
@@ -60,7 +64,9 @@ async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch,
     )
 
 
-async def test_query_convert_to_enum(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_convert_to_enum(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=default_branch)
     car.color.value = "#123123"
     await car.save(db=db)
@@ -82,7 +88,7 @@ async def test_query_convert_to_enum(db: InfrahubDatabase, default_branch: Branc
     assert len(all_data_paths) == 0
 
 
-async def test_query_update_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main):
+async def test_query_update_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main) -> None:
     car_accord_main.color.value = "#654654"
     await car_accord_main.save(db=db)
     await branch.rebase(db=db)
@@ -107,7 +113,7 @@ async def test_query_update_on_branch(db: InfrahubDatabase, branch: Branch, car_
     assert len(all_data_paths) == 0
 
 
-async def test_query_delete_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main):
+async def test_query_delete_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main) -> None:
     car_accord_main.color.value = "#654654"
     await car_accord_main.save(db=db)
     await branch.rebase(db=db)
@@ -133,7 +139,7 @@ async def test_query_delete_on_branch(db: InfrahubDatabase, branch: Branch, car_
 
 async def test_validator(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_accord_main, car_camry_main, car_prius_main
-):
+) -> None:
     await branch.rebase(db=db)
     car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     car.color.value = "#123123"

--- a/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
@@ -12,7 +12,7 @@ from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_success(db: InfrahubDatabase, default_branch: Branch, person_john_main):
+async def test_query_success(db: InfrahubDatabase, default_branch: Branch, person_john_main) -> None:
     car_schema = registry.schema.get(name="TestCar")
     car = await Node.init(db=db, schema="TestCar", branch=default_branch)
     await car.new(db=db, name="http://www.accord.com", nbr_seats=5, is_electric=False, owner=person_john_main.id)
@@ -34,7 +34,7 @@ async def test_query_success(db: InfrahubDatabase, default_branch: Branch, perso
     assert len(all_data_paths) == 0
 
 
-async def test_query_failure(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_failure(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main) -> None:
     car_schema = registry.schema.get(name="TestCar")
     name_attr = car_schema.get_attribute(name="name")
     name_attr.kind = "IPNetwork"
@@ -82,7 +82,7 @@ async def test_query_update_on_branch(
     car_camry_main,
     car_volt_main,
     branch: Branch,
-):
+) -> None:
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     car_accord.name.value = "http://www.accord.com"
     await car_accord.save(db=db)
@@ -133,7 +133,7 @@ async def test_query_update_on_branch_with_too_large_value(
     db: InfrahubDatabase,
     default_branch: Branch,
     all_attribute_types_schema: NodeSchema,
-):
+) -> None:
     main_node = await Node.init(db=db, schema=all_attribute_types_schema.kind, branch=default_branch)
     await main_node.new(db=db, name="number_one", mystring="abc", mytextarea="abcdef")
     await main_node.save(db=db)
@@ -179,7 +179,7 @@ async def test_query_update_on_branch_with_parameters_violation(
     car_camry_main,
     car_volt_main,
     branch: Branch,
-):
+) -> None:
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     car_accord.name.value = "ACCORD"
     await car_accord.save(db=db)
@@ -233,7 +233,7 @@ async def test_query_delete_on_branch(
     car_camry_main,
     car_volt_main,
     branch: Branch,
-):
+) -> None:
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     car_accord.name.value = "1234"
     await car_accord.save(db=db)
@@ -286,7 +286,7 @@ async def test_validator(
     car_camry_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     car.name.value = "http://www.accord.com"
     await car.save(db=db)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_length.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_length.py
@@ -15,7 +15,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.mark.parametrize("min_length,max_length", [(None, None), (None, 30), (1, None), (2, 10), (4, 4)])
 async def test_query_length_success(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main, min_length, max_length
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     name_attr = person_schema.get_attribute(name="name")
     name_attr.parameters.min_length = min_length
@@ -37,7 +37,7 @@ async def test_query_length_success(
 
 async def test_query_length_too_short(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main, person_albert_main
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     name_attr = person_schema.get_attribute(name="name")
     name_attr.parameters.min_length = 5
@@ -79,7 +79,7 @@ async def test_query_length_too_short(
 
 async def test_query_length_too_long(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main, person_albert_main
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     name_attr = person_schema.get_attribute(name="name")
     name_attr.parameters.min_length = 2
@@ -111,7 +111,7 @@ async def test_query_length_too_long(
 
 async def test_query_update_on_branch(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, person_john_main, person_jane_main, person_albert_main
-):
+) -> None:
     person_john_main.name.value = "Jawnsy"
     await person_john_main.save(db=db)
 
@@ -151,7 +151,7 @@ async def test_query_update_on_branch(
 
 async def test_query_delete_on_branch(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, person_john_main, person_jane_main, person_albert_main
-):
+) -> None:
     person_john_main.name.value = "Jawnsy-John-Johnny"
     await person_john_main.save(db=db)
 
@@ -190,7 +190,7 @@ async def test_query_delete_on_branch(
 
 async def test_validator(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, person_john_main, person_albert_main
-):
+) -> None:
     await branch.rebase(db=db)
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     name_attr = person_schema.get_attribute(name="name")

--- a/backend/tests/unit/core/constraint_validators/test_attribute_number_constraints.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_number_constraints.py
@@ -16,7 +16,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.mark.parametrize("min_value,max_value", [(None, None), (None, 300), (1, None), (10, 300)])
 async def test_query_number_constraints_success(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main, min_value, max_value
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     height_attr = person_schema.get_attribute(name="height")
     height_attr.parameters.min_value = min_value
@@ -41,7 +41,7 @@ async def test_query_number_constraints_too_small(
     default_branch: Branch,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     height_attr = person_schema.get_attribute(name="height")
     height_attr.parameters.min_value = 300
@@ -88,7 +88,7 @@ async def test_query_number_too_large(
     default_branch: Branch,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     height_attr = person_schema.get_attribute(name="height")
     height_attr.parameters.min_value = None
@@ -136,7 +136,7 @@ async def test_query_update_on_branch(
     default_branch: Branch,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     person_john_main.height.value = 400
     await person_john_main.save(db=db)
 
@@ -170,7 +170,7 @@ async def test_query_delete_on_branch(
     default_branch: Branch,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     person_john_main.height.value = 200
     await person_john_main.save(db=db)
 
@@ -214,7 +214,7 @@ async def test_validator_min_max(
     default_branch: Branch,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     await branch.rebase(db=db)
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     height_attr = person_schema.get_attribute(name="height")
@@ -275,7 +275,7 @@ async def test_validator_excluded_values(
     person_john_main,
     person_jane_main,
     excluded_values: str,
-):
+) -> None:
     await branch.rebase(db=db)
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     height_attr = person_schema.get_attribute(name="height")
@@ -322,7 +322,7 @@ async def test_validator_excluded_values(
     )
 
 
-def test_get_excluded_values():
+def test_get_excluded_values() -> None:
     parameters = NumberAttributeParameters(excluded_values="100")
     assert parameters.get_excluded_single_values() == [100]
     assert parameters.get_excluded_ranges() == []

--- a/backend/tests/unit/core/constraint_validators/test_attribute_optional.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_optional.py
@@ -10,7 +10,9 @@ from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_optional_true(db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main):
+async def test_query_optional_true(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(
         db=db,
@@ -37,7 +39,9 @@ async def test_query_optional_true(db: InfrahubDatabase, default_branch: Branch,
     assert len(all_data_paths) == 0
 
 
-async def test_query_optional_false(db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main):
+async def test_query_optional_false(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(db=db, name="ALFRED")
     await person.save(db=db)
@@ -70,7 +74,7 @@ async def test_query_optional_false(db: InfrahubDatabase, default_branch: Branch
 
 async def test_query_optional_update_on_branch(
     db: InfrahubDatabase, branch: Branch, person_john_main, person_jane_main
-):
+) -> None:
     person_john_main.height.value = None
     await person_john_main.save(db=db)
 
@@ -110,7 +114,7 @@ async def test_query_optional_update_on_branch(
 
 async def test_query_optional_node_deleted_on_branch(
     db: InfrahubDatabase, branch: Branch, person_john_main, person_jane_main
-):
+) -> None:
     person_john_main.height.value = None
     await person_john_main.save(db=db)
 
@@ -147,7 +151,7 @@ async def test_query_optional_node_deleted_on_branch(
     ]
 
 
-async def test_validator(db: InfrahubDatabase, branch: Branch, person_john_main, person_jane_main):
+async def test_validator(db: InfrahubDatabase, branch: Branch, person_john_main, person_jane_main) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=branch)
     await person.new(db=db, name="ALFRED")
     await person.save(db=db)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_regex_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_regex_update.py
@@ -13,7 +13,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_query(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(db=db, name="ALFRED", height=160, cars=[car_accord_main.id])
     await person.save(db=db)
@@ -47,7 +47,7 @@ async def test_query(
 
 async def test_query_NULL_allowed(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     color_attr = car_schema.get_attribute(name="color")
     color_attr.optional = True
@@ -93,7 +93,7 @@ async def test_query_NULL_allowed(
 
 async def test_query_update_on_branch(
     db: InfrahubDatabase, branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person_john_main.name.value = "little john"
     await person_john_main.save(db=db)
 
@@ -125,7 +125,7 @@ async def test_query_update_on_branch(
 
 async def test_query_node_deleted_on_branch(
     db: InfrahubDatabase, branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person_john_main.name.value = "little john"
     await person_john_main.save(db=db)
 
@@ -156,7 +156,7 @@ async def test_query_node_deleted_on_branch(
 
 async def test_validator(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(db=db, name="ALFRED", height=160, cars=[car_accord_main.id])
     await person.save(db=db)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_unique_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_unique_update.py
@@ -19,7 +19,7 @@ async def test_query_no_violations(
     car_prius_main: Node,
     car_yaris_main: Node,
     car_volt_main: Node,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     seats_attr = car_schema.get_attribute(name="nbr_seats")
     seats_attr.unique = True
@@ -45,7 +45,7 @@ async def test_query_with_violations(
     car_yaris_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     await branch.rebase(db=db)
     car = await Node.init(db=db, schema="TestCar", branch=branch)
     await car.new(db=db, name="New Accord", nbr_seats=5, is_electric=False, owner=person_john_main.id)
@@ -103,7 +103,7 @@ async def test_query_no_violations_update_in_branch(
     car_yaris_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     car_accord_main.name.value = "New Accord"
     await car_accord_main.save(db=db)
 
@@ -137,7 +137,7 @@ async def test_query_no_violations_deleted_node(
     car_yaris_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     car_accord_main.name.value = "New Accord"
     await car_accord_main.save(db=db)
 
@@ -169,7 +169,7 @@ async def test_validator(
     car_yaris_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     await branch.rebase(db=db)
     car = await Node.init(db=db, schema="TestCar", branch=branch)
     await car.new(db=db, name="New Accord", nbr_seats=5, is_electric=False, owner=person_john_main.id)

--- a/backend/tests/unit/core/constraint_validators/test_determiner.py
+++ b/backend/tests/unit/core/constraint_validators/test_determiner.py
@@ -123,7 +123,7 @@ def person_cars_node_diff(
 
 
 class TestConstraintDeterminer:
-    async def test_no_node_diffs(self, car_person_schema, default_branch):
+    async def test_no_node_diffs(self, car_person_schema, default_branch) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
 
@@ -131,7 +131,9 @@ class TestConstraintDeterminer:
 
         assert constraints == []
 
-    async def test_one_attribute_update_node_diff(self, car_person_schema, default_branch, person_name_node_diff):
+    async def test_one_attribute_update_node_diff(
+        self, car_person_schema, default_branch, person_name_node_diff
+    ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
         node_diff, constraint_info_set = person_name_node_diff
@@ -146,7 +148,7 @@ class TestConstraintDeterminer:
         assert len(relevant_constraints) == len(constraint_info_set)
         assert set(relevant_constraints) == constraint_info_set
 
-    async def test_many_relationship_update(self, car_person_schema, default_branch, person_cars_node_diff):
+    async def test_many_relationship_update(self, car_person_schema, default_branch, person_cars_node_diff) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
         node_diff, constraint_info_set = person_cars_node_diff
@@ -156,7 +158,9 @@ class TestConstraintDeterminer:
         assert len(constraints) >= len(constraint_info_set)
         assert constraint_info_set < set(constraints)
 
-    async def test_node_property_constraints_included(self, car_person_schema, default_branch, person_name_node_diff):
+    async def test_node_property_constraints_included(
+        self, car_person_schema, default_branch, person_name_node_diff
+    ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         person_schema = schema_branch.get(name="TestPerson", duplicate=False)
         person_schema.uniqueness_constraints = [["name", "height"]]

--- a/backend/tests/unit/core/constraint_validators/test_models.py
+++ b/backend/tests/unit/core/constraint_validators/test_models.py
@@ -11,7 +11,7 @@ async def test_schema_validate_migrations(
     db: InfrahubDatabase,
     default_branch: Branch,
     car_person_schema,
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
 
     constraints = [

--- a/backend/tests/unit/core/constraint_validators/test_node_generate_profiles_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_generate_profiles_update.py
@@ -18,7 +18,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.mark.parametrize("generate_profile", [True, False])
 async def test_set_generate_profile_success(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema, generate_profile
-):
+) -> None:
     branch = await create_branch(branch_name="branch", db=db)
     updated_schema = registry.schema.get_node_schema(name="TestCar")
     updated_schema.generate_profile = generate_profile
@@ -39,7 +39,7 @@ async def test_set_generate_profile_success(
 @pytest.mark.parametrize("generate_profile", [True, False])
 async def test_set_generate_profile_success_generics(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema, generate_profile
-):
+) -> None:
     branch = await create_branch(branch_name="branch", db=db)
     updated_schema = registry.schema.get(name="TestAnimal")
     updated_schema.generate_profile = generate_profile
@@ -57,7 +57,7 @@ async def test_set_generate_profile_success_generics(
     assert len(list(chain(*[gdp.get_all_data_paths() for gdp in grouped_data_paths]))) == 0
 
 
-async def test_set_generate_profile_false_fail(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_set_generate_profile_false_fail(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     branch = await create_branch(branch_name="branch", db=db)
     profile_schema = registry.schema.get(name="ProfileTestCar", branch=branch)
     profile_node = await Node.init(db=db, schema=profile_schema, branch=branch)
@@ -85,7 +85,7 @@ async def test_set_generate_profile_false_fail(db: InfrahubDatabase, default_bra
 
 async def test_set_generate_profile_false_fail_generic(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema
-):
+) -> None:
     branch = await create_branch(branch_name="branch", db=db)
     profile_schema = registry.schema.get(name="ProfileTestAnimal", branch=branch)
     profile_node = await Node.init(db=db, schema=profile_schema, branch=branch)
@@ -113,7 +113,7 @@ async def test_set_generate_profile_false_fail_generic(
 
 async def test_set_generate_profile_false_branch_delete_profile_success(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema
-):
+) -> None:
     profile_schema = registry.schema.get(name="ProfileTestCar", branch=default_branch)
     profile_node = await Node.init(db=db, schema=profile_schema, branch=default_branch)
     await profile_node.new(db=db, profile_name="bus", nbr_seats=50)

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -20,19 +20,19 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_no_uniqueness_constraint(
         self, db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-    ):
+    ) -> None:
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
     async def test_uniqueness_constraint_no_conflicts(
         self, db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-    ):
+    ) -> None:
         car_accord_main.get_schema().uniqueness_constraints = [["name__value"]]
 
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
     async def test_uniqueness_constraint_conflict_attribute(
         self, db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-    ):
+    ) -> None:
         car_accord_main.name.value = "camry"
         car_accord_main.get_schema().uniqueness_constraints = [["name__value"]]
 
@@ -41,7 +41,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_conflict_attribute_with_null(
         self, db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-    ):
+    ) -> None:
         # this change is allowed
         car_camry_main.color.value = None
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_camry_main)
@@ -56,7 +56,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_filters(
         self, db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-    ):
+    ) -> None:
         car_accord_main.name.value = "camry"
         car_accord_main.get_schema().uniqueness_constraints = [
             ["name__value"],
@@ -73,7 +73,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main: Node,
         car_camry_main: Node,
         car_volt_main: Node,
-    ):
+    ) -> None:
         car_accord_main.get_schema().uniqueness_constraints = [["name__value", "color__value"]]
 
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
@@ -85,7 +85,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main: Node,
         car_camry_main: Node,
         car_volt_main: Node,
-    ):
+    ) -> None:
         car_accord_main.name.value = "camry"
         car_accord_main.get_schema().uniqueness_constraints = [
             ["name__value", "color__value"],
@@ -102,7 +102,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main: Node,
         car_camry_main: Node,
         car_volt_main: Node,
-    ):
+    ) -> None:
         car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
         car_schema.uniqueness_constraints = [["nbr_seats__value", "name__value"]]
         attr = car_schema.get_attribute("nbr_seats")
@@ -118,7 +118,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main: Node,
         car_camry_main: Node,
         car_volt_main: Node,
-    ):
+    ) -> None:
         car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
         attr = car_schema.get_attribute("nbr_seats")
         attr.optional = False
@@ -132,7 +132,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_no_conflict_one_relationship(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_node: Node = car_person_generics_data_simple["c1"]
         car_node.get_schema().uniqueness_constraints = [["previous_owner"]]
 
@@ -140,7 +140,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_conflict_one_relationship(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_node: Node = car_person_generics_data_simple["c1"]
         car_node.get_schema().uniqueness_constraints = [["owner"]]
 
@@ -149,7 +149,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_no_conflict_two_relationships(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_node: Node = car_person_generics_data_simple["c1"]
         car_node.get_schema().uniqueness_constraints = [["previous_owner", "owner"]]
 
@@ -157,7 +157,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_no_conflict_two_relationships_with_overlap(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         p1 = car_person_generics_data_simple["p1"]
         p2 = car_person_generics_data_simple["p2"]
         p3 = await Node.init(db=db, schema=registry.schema.get(name="TestPerson"))
@@ -179,7 +179,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_conflict_two_relationship(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         person_1 = car_person_generics_data_simple["p1"]
         car_node_1: Node = car_person_generics_data_simple["c1"]
         await car_node_1.previous_owner.update(data=person_1, db=db)
@@ -193,7 +193,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_no_conflict_relationship_and_attribute(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_node: Node = car_person_generics_data_simple["c1"]
         car_node.get_schema().uniqueness_constraints = [
             ["nbr_seats__value", "name__value"],
@@ -257,7 +257,7 @@ class TestNodeGroupedUniquenessConstraint:
         node_constraints: list[list[str]],
         parent_constraints: list[list[str]],
         expected_number_calls_by_kind: dict[str, int],
-    ):
+    ) -> None:
         car_node: Node = car_person_generics_data_simple["c1"]
         car_schema = car_node.get_schema()
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
@@ -278,7 +278,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_uniqueness_constraint_conflict_relationship_and_attribute(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         person_1 = car_person_generics_data_simple["p1"]
         car_node_1: Node = car_person_generics_data_simple["c1"]
         await car_node_1.previous_owner.update(data=person_1, db=db)
@@ -297,7 +297,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_generic_constraints_success(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_generic_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
         car_generic_schema.uniqueness_constraints = [["color__value", "owner"]]
         car_node_1: Node = car_person_generics_data_simple["c1"]
@@ -314,7 +314,7 @@ class TestNodeGroupedUniquenessConstraint:
 
     async def test_generic_constraints_failure(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
-    ):
+    ) -> None:
         car_generic_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
         car_generic_schema.uniqueness_constraints = [["color__value", "owner"]]
         car_node_1 = car_person_generics_data_simple["c1"]
@@ -324,7 +324,7 @@ class TestNodeGroupedUniquenessConstraint:
         with pytest.raises(ValidationError, match="Violates uniqueness constraint 'color-owner'"):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_node_1)
 
-    async def test_hfid_violated(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_hfid):
+    async def test_hfid_violated(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_hfid) -> None:
         person_john = await create_and_save(db=db, schema="TestPerson", name="John")
         _ = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person_john)
         car_mercedes_2 = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person_john)
@@ -332,7 +332,9 @@ class TestNodeGroupedUniquenessConstraint:
         with pytest.raises(HFIDViolatedError, match="Violates uniqueness constraint 'name-owner'"):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_mercedes_2)
 
-    async def test_subset_hfid_violated(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_hfid):
+    async def test_subset_hfid_violated(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_hfid
+    ) -> None:
         person_john = await create_and_save(db=db, schema="TestPerson", name="John")
         person_maria = await create_and_save(db=db, schema="TestPerson", name="Maria")
         _ = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person_john)

--- a/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
@@ -62,7 +62,9 @@ async def hierarchical_location_data_simple_and_small(
     return nodes
 
 
-async def test_query_children_success(db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple):
+async def test_query_children_success(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple
+) -> None:
     site_schema = registry.schema.get(name="LocationSite")
     schema_path = SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children")
 
@@ -77,7 +79,9 @@ async def test_query_children_success(db: InfrahubDatabase, default_branch: Bran
     assert len(all_data_paths) == 0
 
 
-async def test_query_parent_success(db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple):
+async def test_query_parent_success(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple
+) -> None:
     site_schema = registry.schema.get(name="LocationSite")
     schema_path = SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent")
 
@@ -94,7 +98,7 @@ async def test_query_parent_success(db: InfrahubDatabase, default_branch: Branch
 
 async def test_query_children_failure(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.children = "LocationRegion"
@@ -158,7 +162,7 @@ async def test_query_children_failure(
 
 async def test_query_parent_failure(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.parent = "LocationRack"
@@ -222,7 +226,7 @@ async def test_query_parent_failure(
 
 async def test_query_update_on_branch_failure(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.children = "LocationRegion"
@@ -301,7 +305,7 @@ async def test_query_update_on_branch_failure(
 
 async def test_query_delete_on_branch_failure(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.children = "LocationRegion"
@@ -358,7 +362,7 @@ async def test_query_delete_on_branch_failure(
 
 async def test_validator_parents_failure(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.parent = "LocationRack"
@@ -389,7 +393,7 @@ async def test_validator_parents_failure(
 
 async def test_validator_parents_success(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     site_schema = registry.schema.get(name="LocationSite")
 
     request = SchemaConstraintValidatorRequest(
@@ -410,7 +414,7 @@ async def test_validator_parents_success(
 
 async def test_validator_children_failure(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     hldsas = hierarchical_location_data_simple_and_small
     site_schema = registry.schema.get(name="LocationSite")
     site_schema.children = "LocationRegion"
@@ -441,7 +445,7 @@ async def test_validator_children_failure(
 
 async def test_validator_children_success(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple_and_small
-):
+) -> None:
     site_schema = registry.schema.get(name="LocationSite")
 
     request = SchemaConstraintValidatorRequest(

--- a/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
@@ -14,7 +14,7 @@ from infrahub.core.validators.node.inherit_from import NodeInheritFromChecker
 from infrahub.database import InfrahubDatabase
 
 
-async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema) -> None:
     branch = await create_branch(branch_name="branch", db=db)
 
     good_animal_schema = GenericSchema(
@@ -42,7 +42,7 @@ async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch,
     assert len(all_data_paths) == 0
 
 
-async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch, animal_person_schema) -> None:
     branch = await create_branch(branch_name="branch", db=db)
 
     dog_schema = registry.schema.get_node_schema(name="TestDog")
@@ -77,7 +77,7 @@ async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch,
     )
 
 
-async def test_rename_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+async def test_rename_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema) -> None:
     branch = await create_branch(branch_name="branch", db=db)
 
     animal_schema = registry.schema.get(name="TestAnimal")

--- a/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
@@ -11,7 +11,7 @@ from infrahub.exceptions import ValidationError
 
 async def test_node_validate_constraint_node_uniqueness_failure(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
     new_john = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await new_john.new(db=db, name="John", height=160)
@@ -24,7 +24,7 @@ async def test_node_validate_constraint_node_uniqueness_failure(
 
 async def test_node_validate_constraint_node_uniqueness_success(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
     alfred = await Node.init(db=db, schema="TestPerson", branch=default_branch)
 
@@ -35,7 +35,7 @@ async def test_node_validate_constraint_node_uniqueness_success(
 
 async def test_hierarchical_uniqueness_constraint(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple_unregistered: SchemaRoot
-):
+) -> None:
     site_schema = hierarchical_location_schema_simple_unregistered.get(name="LocationSite")
     site_schema.human_friendly_id = ["parent__name__value", "name__value"]
     site_schema.uniqueness_constraints = [["parent", "name__value"]]

--- a/backend/tests/unit/core/constraint_validators/test_query_node_not_present.py
+++ b/backend/tests/unit/core/constraint_validators/test_query_node_not_present.py
@@ -8,7 +8,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_query_node_present_with_data(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
 
     schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name")
@@ -25,7 +25,7 @@ async def test_query_node_present_with_data(
 
 async def test_query_node_present_with_data_rel(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
 
     schema_path = SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestPerson", field_name="cars")
@@ -42,7 +42,7 @@ async def test_query_node_present_with_data_rel(
 
 async def test_query_node_present_no_data(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
 
     schema_path = SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar")

--- a/backend/tests/unit/core/constraint_validators/test_relationship_count.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_count.py
@@ -22,7 +22,7 @@ async def test_query_success(
     person_john_main,
     min_count,
     max_count,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     cars_rel = person_schema.get_relationship(name="cars")
     cars_rel.min_count = min_count
@@ -46,7 +46,7 @@ async def test_query_failure_cardinality_one(
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     cars_rel = person_schema.get_relationship(name="cars")
     cars_rel.max_count = 1
@@ -79,7 +79,7 @@ async def test_query_success_cardinality_one(
     default_branch: Branch,
     car_accord_main: Node,
     car_camry_main: Node,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     cars_rel = person_schema.get_relationship(name="cars")
     cars_rel.cardinality = RelationshipCardinality.ONE
@@ -106,7 +106,7 @@ async def test_query_success_cardinality_many(
     default_branch: Branch,
     car_accord_main: Node,
     car_camry_main: Node,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     owner_rel = car_schema.get_relationship(name="owner")
     owner_rel.cardinality = RelationshipCardinality.MANY
@@ -140,7 +140,7 @@ async def test_query_failure(
     person_john_main,
     min_count,
     max_count,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestPerson")
     cars_rel = car_schema.get_relationship(name="cars")
     cars_rel.min_count = min_count
@@ -178,7 +178,7 @@ async def test_query_update_on_branch_failure(
     car_camry_main: Node,
     car_yaris_main: Node,
     person_john_main,
-):
+) -> None:
     branch = await create_branch(branch_name=str("branch2"), db=db)
     person_john = await NodeManager.get_one(db=db, id=person_john_main.id, branch=default_branch)
     car = await Node.init(db=db, schema="TestCar", branch=branch)
@@ -233,7 +233,7 @@ async def test_query_update_on_branch_success(
     car_camry_main: Node,
     car_yaris_main: Node,
     person_john_main,
-):
+) -> None:
     branch = await create_branch(branch_name=str("branch2"), db=db)
     person_john = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
     await person_john.cars.update(db=db, data=[car_accord_main.id, car_volt_main.id])
@@ -266,7 +266,7 @@ async def test_query_delete_on_branch_failure(
     car_yaris_main: Node,
     person_john_main,
     person_jane_main,
-):
+) -> None:
     branch = await create_branch(branch_name=str("branch2"), db=db)
     old_car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
     await old_car.delete(db=db)
@@ -330,7 +330,7 @@ async def test_query_delete_on_branch_success(
     car_camry_main: Node,
     car_yaris_main: Node,
     person_john_main,
-):
+) -> None:
     branch = await create_branch(branch_name=str("branch2"), db=db)
     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
     await car.delete(db=db)
@@ -352,7 +352,9 @@ async def test_query_delete_on_branch_success(
     assert len(all_paths) == 0
 
 
-async def test_hierarchical_success(db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple):
+async def test_hierarchical_success(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple
+) -> None:
     site_schema = registry.schema.get(name="LocationSite", duplicate=False)
 
     schema_path = SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="LocationSite", field_name="parent")
@@ -367,7 +369,9 @@ async def test_hierarchical_success(db: InfrahubDatabase, default_branch: Branch
     assert len(all_paths) == 0
 
 
-async def test_hierarchical_failure(db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple):
+async def test_hierarchical_failure(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_simple
+) -> None:
     paris_site = hierarchical_location_data_simple["paris"]
     branch = await create_branch(branch_name=str("branch2"), db=db)
     schema_path = SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="LocationSite", field_name="children")
@@ -444,7 +448,7 @@ async def test_validator(
     car_accord_main,
     car_prius_main,
     car_volt_main,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     cars_attr = person_schema.get_relationship(name="cars")
     cars_attr.min_count = 1
@@ -487,7 +491,7 @@ async def test_validator_cardinality_failure(
     car_prius_main,
     car_volt_main,
     car_yaris_main,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     cars_attr = person_schema.get_relationship(name="cars")
     cars_attr.cardinality = RelationshipCardinality.ONE

--- a/backend/tests/unit/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_manager.py
@@ -9,7 +9,7 @@ from infrahub.exceptions import ValidationError
 
 async def test_node_validate_constraint_relationship_count_failure(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     constraint = RelationshipCountConstraint(db=db, branch=default_branch)
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(db=db, name="Alfred", height=160, cars=[car_accord_main.id])
@@ -22,7 +22,7 @@ async def test_node_validate_constraint_relationship_count_failure(
 
 async def test_node_validate_constraint_relationship_count_success(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     constraint = RelationshipCountConstraint(db=db, branch=default_branch)
 
     await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema(), node=person_john_main)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_optional_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_optional_update.py
@@ -14,7 +14,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_query(
     db: InfrahubDatabase, branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=branch)
     await person.new(db=db, name="Alfred", height=160)
     await person.save(db=db)
@@ -44,7 +44,7 @@ async def test_query(
 
 async def test_validator(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person.new(db=db, name="Alfred", height=160)
     await person.save(db=db)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_common_parent_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_common_parent_update.py
@@ -113,7 +113,7 @@ async def expected_invalid_lag_data_paths(
     }
 
 
-async def test_query_no_relationships(db: InfrahubDatabase, branch: Branch, data_empty_lags: dict[str, Any]):
+async def test_query_no_relationships(db: InfrahubDatabase, branch: Branch, data_empty_lags: dict[str, Any]) -> None:
     lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
     interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
 
@@ -141,7 +141,7 @@ async def test_query_invalid_lag(
     data_invalid_lag: dict[str, Node],
     expected_invalid_lag_data_paths: set[DataPath],
     branch: Branch,
-):
+) -> None:
     lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
     interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
 
@@ -163,7 +163,9 @@ async def test_query_invalid_lag(
     assert set(all_paths) == expected_invalid_lag_data_paths
 
 
-async def test_query_deleted_lag_members(db: InfrahubDatabase, data_invalid_lag: dict[str, Node], branch: Branch):
+async def test_query_deleted_lag_members(
+    db: InfrahubDatabase, data_invalid_lag: dict[str, Node], branch: Branch
+) -> None:
     lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
     interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
 
@@ -198,7 +200,7 @@ async def test_validator(
     data_invalid_lag: dict[str, Node],
     expected_invalid_lag_data_paths: set[DataPath],
     branch: Branch,
-):
+) -> None:
     lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
 
     request = SchemaConstraintValidatorRequest(

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
@@ -58,7 +58,7 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
 
         return device
 
-    async def test_same_parent(self, db: InfrahubDatabase, device_1: Node):
+    async def test_same_parent(self, db: InfrahubDatabase, device_1: Node) -> None:
         lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
 
         constraint = RelationshipPeerParentConstraint(db=db)
@@ -71,7 +71,7 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
 
         await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)
 
-    async def test_different_parent(self, db: InfrahubDatabase, device_1: Node, device_2: Node):
+    async def test_different_parent(self, db: InfrahubDatabase, device_1: Node, device_2: Node) -> None:
         lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
 
         constraint = RelationshipPeerParentConstraint(db=db)
@@ -134,7 +134,7 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
 
         return device
 
-    async def test_common_relatives_allowed(self, db: InfrahubDatabase, device_1: Node):
+    async def test_common_relatives_allowed(self, db: InfrahubDatabase, device_1: Node) -> None:
         lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
 
         constraint = RelationshipPeerRelativesConstraint(db=db)
@@ -147,7 +147,7 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
 
         await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)
 
-    async def test_common_relatives_disallowed(self, db: InfrahubDatabase, device_1: Node, device_2: Node):
+    async def test_common_relatives_disallowed(self, db: InfrahubDatabase, device_1: Node, device_2: Node) -> None:
         lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
 
         constraint = RelationshipPeerRelativesConstraint(db=db)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_update.py
@@ -120,7 +120,7 @@ async def test_query(
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     owner_rel = car_schema.get_relationship(name="owner")
     owner_rel.peer = "TestCar"
@@ -161,7 +161,7 @@ async def test_query(
 
 async def test_query_no_relationships(
     db: InfrahubDatabase, branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
-):
+) -> None:
     await branch.rebase(db=db)
     car_schema = registry.schema.get(name="TestCar", duplicate=False)
     owner_rel = car_schema.get_relationship(name="owner")
@@ -185,7 +185,9 @@ async def test_query_no_relationships(
     assert len(all_paths) == 0
 
 
-async def test_query_switch_from_generic_to_node_success(db: InfrahubDatabase, branch: Branch, car_person_generic_data):
+async def test_query_switch_from_generic_to_node_success(
+    db: InfrahubDatabase, branch: Branch, car_person_generic_data
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     cars_rel = person_schema.get_relationship(name="cars")
     cars_rel.peer = "TestElectricCar"
@@ -202,7 +204,9 @@ async def test_query_switch_from_generic_to_node_success(db: InfrahubDatabase, b
     assert len(all_paths) == 0
 
 
-async def test_query_switch_from_generic_to_node_failure(db: InfrahubDatabase, branch: Branch, car_person_generic_data):
+async def test_query_switch_from_generic_to_node_failure(
+    db: InfrahubDatabase, branch: Branch, car_person_generic_data
+) -> None:
     p_1 = car_person_generic_data["p_1"]
     g_car = await Node.init(db=db, schema="TestGazCar", branch=branch)
     await g_car.new(db=db, name="GCar", nbr_seats=3, mpg=23, owner=p_1)
@@ -233,7 +237,9 @@ async def test_query_switch_from_generic_to_node_failure(db: InfrahubDatabase, b
     ]
 
 
-async def test_query_switch_from_node_to_generic_success(db: InfrahubDatabase, branch: Branch, car_person_generic_data):
+async def test_query_switch_from_node_to_generic_success(
+    db: InfrahubDatabase, branch: Branch, car_person_generic_data
+) -> None:
     p_1 = car_person_generic_data["p_1"]
     e_car = car_person_generic_data["e_car"]
     g_car = await Node.init(db=db, schema="TestGazCar", branch=branch)
@@ -260,7 +266,9 @@ async def test_query_switch_from_node_to_generic_success(db: InfrahubDatabase, b
     assert len(all_paths) == 0
 
 
-async def test_query_switch_from_node_to_generic_failure(db: InfrahubDatabase, branch: Branch, car_person_generic_data):
+async def test_query_switch_from_node_to_generic_failure(
+    db: InfrahubDatabase, branch: Branch, car_person_generic_data
+) -> None:
     await branch.rebase(db=db)
     p_1 = await NodeManager.get_one(db=db, id=car_person_generic_data["p_1"].id, branch=branch)
     e_car = await NodeManager.get_one(db=db, id=car_person_generic_data["e_car"].id, branch=branch)
@@ -312,7 +320,7 @@ async def test_query_switch_from_node_to_generic_failure(db: InfrahubDatabase, b
 
 async def test_query_update_on_branch_success(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_person_generic_data
-):
+) -> None:
     p_1 = car_person_generic_data["p_1"]
     g_car = await Node.init(db=db, schema="TestGazCar", branch=default_branch)
     await g_car.new(db=db, name="GCar", nbr_seats=3, mpg=29, owner=p_1)
@@ -342,7 +350,7 @@ async def test_query_update_on_branch_success(
 
 async def test_query_update_on_branch_failure(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_person_generic_data
-):
+) -> None:
     p_2 = car_person_generic_data["p_2"]
     g_car = await Node.init(db=db, schema="TestGazCar", branch=default_branch)
     await g_car.new(db=db, name="GCar", nbr_seats=3, mpg=29, owner=p_2)
@@ -394,7 +402,7 @@ async def test_query_update_on_branch_failure(
 
 async def test_query_delete_on_branch(
     db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_person_generic_data
-):
+) -> None:
     p_1 = car_person_generic_data["p_1"]
     g_car = await Node.init(db=db, schema="TestGazCar", branch=default_branch)
     await g_car.new(db=db, name="GCar", nbr_seats=3, mpg=29, owner=p_1)
@@ -430,7 +438,7 @@ async def test_validator(
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     owner_rel = car_schema.get_relationship(name="owner")
     owner_rel.peer = "TestCar"

--- a/backend/tests/unit/core/constraint_validators/test_relationship_profiles_kind.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_profiles_kind.py
@@ -76,13 +76,13 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_profile.save(db=db)
         return ship_profile
 
-    async def test_empty_profiles_allowed(self, db: InfrahubDatabase, ship_one: Node, ship_profile: Node):
+    async def test_empty_profiles_allowed(self, db: InfrahubDatabase, ship_one: Node, ship_profile: Node) -> None:
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
 
         constraint = RelationshipProfilesKindConstraint(db=db)
         await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
-    async def test_profile_for_schema_allowed(self, db: InfrahubDatabase, ship_one: Node, ship_profile: Node):
+    async def test_profile_for_schema_allowed(self, db: InfrahubDatabase, ship_one: Node, ship_profile: Node) -> None:
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
 
         constraint = RelationshipProfilesKindConstraint(db=db)
@@ -91,7 +91,9 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
 
         await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
-    async def test_generic_profile_allowed(self, db: InfrahubDatabase, ship_one: Node, space_object_profile: Node):
+    async def test_generic_profile_allowed(
+        self, db: InfrahubDatabase, ship_one: Node, space_object_profile: Node
+    ) -> None:
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
 
         constraint = RelationshipProfilesKindConstraint(db=db)
@@ -100,7 +102,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
 
         await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
-    async def test_wrong_profile_not_allowed(self, db: InfrahubDatabase, ship_one: Node):
+    async def test_wrong_profile_not_allowed(self, db: InfrahubDatabase, ship_one: Node) -> None:
         wrong_profile = await Node.init(db=db, schema="ProfileTestOtherGeneric")
         await wrong_profile.new(db=db, profile_name="something", profile_priority=400, smell="not good")
         await wrong_profile.save(db=db)
@@ -118,7 +120,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
 
     async def test_generic_profile_not_allowed_when_generic_generate_profile_is_false(
         self, db: InfrahubDatabase, ship_one: Node, space_object_profile: Node
-    ):
+    ) -> None:
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
         generic_schema = registry.schema.get(name="TestGenericSpaceObject", duplicate=False)
         generic_schema.generate_profile = False
@@ -135,7 +137,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
 
     async def test_profile_not_allowed_when_generate_profile_is_false(
         self, db: InfrahubDatabase, ship_one: Node, space_object_profile: Node
-    ):
+    ) -> None:
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
         ship_schema.generate_profile = False
 

--- a/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
+++ b/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
@@ -17,7 +17,7 @@ async def test_schema_validate_migrations(
     car_volt_main: Node,
     person_john_main,
     helper,
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
     person_schema = schema.get(name="TestPerson")
     name_attr = person_schema.get_attribute(name="name")

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
@@ -36,7 +36,7 @@ class TestUniquenessChecker:
         car_yaris_main,
         car_prius_main,
         branch: Branch,
-    ):
+    ) -> None:
         schema = registry.schema.get("TestCar", branch=branch)
 
         grouped_data_paths = await self.__call_system_under_test(db, branch, schema)
@@ -51,7 +51,7 @@ class TestUniquenessChecker:
         car_prius_main,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         schema = registry.schema.get("TestCar", branch=branch)
         schema.get_attribute("nbr_seats").unique = True
         schema_root = SchemaRoot(nodes=[schema])
@@ -94,7 +94,7 @@ class TestUniquenessChecker:
         car_accord_main,
         car_prius_main,
         branch: Branch,
-    ):
+    ) -> None:
         node_to_delete = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
         await node_to_delete.delete(db=db)
         schema = registry.schema.get("TestCar", branch=branch)
@@ -111,7 +111,7 @@ class TestUniquenessChecker:
         car_accord_main,
         car_prius_main,
         branch: Branch,
-    ):
+    ) -> None:
         car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
         car_to_update.nbr_seats.value = 3
         await car_to_update.save(db=db)
@@ -130,7 +130,7 @@ class TestUniquenessChecker:
         car_volt_main,
         car_yaris_main,
         branch: Branch,
-    ):
+    ) -> None:
         cars_to_update = await NodeManager.get_many(
             db=db, ids=[car_accord_main.id, car_prius_main.id, car_volt_main.id, car_yaris_main.id], branch=branch
         )
@@ -156,7 +156,7 @@ class TestUniquenessChecker:
         person_john_main,
         default_branch: Branch,
         branch: Branch,
-    ):
+    ) -> None:
         cars_to_update = await NodeManager.get_many(
             db=db, ids=[car_accord_main.id, car_prius_main.id, car_volt_main.id], branch=branch
         )
@@ -236,7 +236,7 @@ class TestUniquenessChecker:
         person_jane_main,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         cars_to_update = await NodeManager.get_many(db=db, ids=[car_volt_main.id, car_yaris_main.id], branch=branch)
         color = 111111
         for car in cars_to_update.values():
@@ -317,7 +317,7 @@ class TestUniquenessChecker:
         car_person_generics_data_simple,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         nolt_car = await NodeManager.get_one_by_id_or_default_filter(db=db, kind="TestGazCar", id="nolt", branch=branch)
         volt_car = await NodeManager.get_one_by_id_or_default_filter(
             db=db, kind="TestElectricCar", id="volt", branch=branch
@@ -364,7 +364,7 @@ class TestUniquenessChecker:
         car_person_generics_data_simple,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         person = registry.schema.get(name="TestPerson")
         nolt_owner = await Node.init(db=db, schema=person)
         await nolt_owner.new(db=db, name="Rupert", height=180)
@@ -447,7 +447,7 @@ class TestUniquenessChecker:
         car_person_generics_data_simple,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         owner = car_person_generics_data_simple["p1"]
         volt_car = await NodeManager.get_one_by_id_or_default_filter(
             db=db, kind="TestElectricCar", id="volt", branch=branch
@@ -527,7 +527,7 @@ class TestUniquenessChecker:
         person_john_main,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         car_to_update = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
         await car_to_update.owner.update(data=person_john_main, db=db)
         await car_to_update.save(db=db)
@@ -587,7 +587,7 @@ class TestUniquenessChecker:
         person_john_main,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         schema_on_branch = registry.schema.get_node_schema(name="TestCar", branch=branch)
         schema_on_branch.relationships.append(
             RelationshipSchema(
@@ -662,7 +662,7 @@ class TestUniquenessChecker:
         car_prius_main,
         car_camry_main,
         default_branch: Branch,
-    ):
+    ) -> None:
         car_accord_main.color.value = "#111111"
         await car_accord_main.save(db=db)
         car_prius_main.color.value = "#222222"
@@ -688,7 +688,7 @@ class TestUniquenessChecker:
         person_jane_main,
         branch: Branch,
         default_branch: Branch,
-    ):
+    ) -> None:
         await branch.rebase(db=db)
         car_accord_main.color.value = "#111111"
         car_accord_main.nbr_seats.value = 3

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_constraint_query.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_constraint_query.py
@@ -20,7 +20,7 @@ async def test_query_uniqueness_no_violations(
     car_yaris_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     query = await NodeUniqueAttributeConstraintQuery.init(
         db=db,
         branch=branch,
@@ -38,7 +38,7 @@ async def test_query_uniqueness_no_violations(
 
 async def test_query_uniqueness_one_violation(
     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     query = await NodeUniqueAttributeConstraintQuery.init(
         db=db,
         branch=branch,
@@ -66,7 +66,7 @@ async def test_query_uniqueness_deleted_node_ignored(
     car_accord_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     node_to_delete = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
 
@@ -91,7 +91,7 @@ async def test_query_uniqueness_get_latest_update(
     car_accord_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     car_to_update.nbr_seats.value = 3
     await car_to_update.save(db=db)
@@ -118,7 +118,7 @@ async def test_query_uniqueness_cross_branch_conflict(
     car_prius_main,
     person_john_main,
     default_branch: Branch,
-):
+) -> None:
     branch_2 = await create_branch(branch_name="branch2", db=db)
     new_car_main = await Node.init(db=db, schema="TestCar", branch=default_branch)
     await new_car_main.new(db=db, name="Thunderbolt", nbr_seats=2, is_electric=True, owner=person_john_main)
@@ -171,7 +171,7 @@ async def test_query_uniqueness_multiple_attribute_violations(
     car_camry_main,
     branch: Branch,
     default_branch: Branch,
-):
+) -> None:
     for car_id in (car_volt_main.id, car_camry_main.id):
         car_to_update = await NodeManager.get_one(id=car_id, db=db, branch=branch)
         car_to_update.color.value = "#ffffff"
@@ -238,7 +238,7 @@ async def test_query_relationship_uniqueness_no_violations(
     person_jane_main,
     person_john_main,
     branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await car_to_update.owner.update(data=person_jane_main, db=db)
     await car_to_update.save(db=db)
@@ -273,7 +273,7 @@ async def test_query_relationship_uniqueness_one_violation(
     person_john_main,
     branch: Branch,
     default_branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await car_to_update.owner.update(data=person_jane_main, db=db)
     await car_to_update.save(db=db)
@@ -328,7 +328,7 @@ async def test_query_relationship_and_attribute_uniqueness_violations(
     person_john_main,
     branch: Branch,
     default_branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await car_to_update.owner.update(data=person_jane_main, db=db)
     await car_to_update.save(db=db)
@@ -400,7 +400,7 @@ async def test_query_relationship_violation_no_attribute(
     person_john_main,
     branch: Branch,
     default_branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
     await car_to_update.owner.update(data=person_john_main, db=db)
     await car_to_update.save(db=db)
@@ -451,7 +451,7 @@ async def test_query_relationship_violation_no_attribute(
 
 async def test_query_relationship_no_violation_same_peer_different_rels(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
-):
+) -> None:
     john = await Node.init(schema="TestPerson", db=db)
     await john.new(db=db, name="John", height=175)
     await john.save(db=db)
@@ -530,7 +530,7 @@ async def test_query_relationship_no_violation_same_peer_different_rels(
 
 async def test_query_response_min_count_0_attribute_paths(
     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     expected_result_dicts = [
         {
             "attr_name": "nbr_seats",
@@ -588,7 +588,7 @@ async def test_query_response_min_count_0_attribute_paths(
 
 async def test_query_response_min_count_0_relationship_paths(
     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     expected_result_dicts = [
         {
             "attr_name": "name",
@@ -646,7 +646,7 @@ async def test_query_response_min_count_0_relationship_paths(
 
 async def test_query_response_min_count_0_attribute_paths_with_value(
     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     expected_result_dicts = [
         {
             "attr_name": "nbr_seats",
@@ -696,7 +696,7 @@ async def test_query_response_min_count_0_attribute_paths_with_value(
 
 async def test_query_response_min_count_0_relationship_paths_with_value(
     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     expected_result_dicts = [
         {
             "attr_name": "name",

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
@@ -20,7 +20,7 @@ async def test_query_uniqueness_no_violations(
     car_yaris_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     query = await UniquenessValidationQuery.init(
         db=db,
         branch=branch,
@@ -35,7 +35,7 @@ async def test_query_uniqueness_no_violations(
 
 async def test_query_uniqueness_one_attr_violation(
     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-):
+) -> None:
     query_request = NodeUniquenessQueryRequestValued(
         kind="TestCar",
         unique_valued_paths=[QueryAttributePathValued(attribute_name="nbr_seats", value=5)],
@@ -63,7 +63,7 @@ async def test_query_uniqueness_deleted_node_ignored(
     car_accord_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     node_to_delete = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
 
@@ -83,7 +83,7 @@ async def test_query_uniqueness_get_latest_update(
     car_accord_main,
     car_prius_main,
     branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     car_to_update.nbr_seats.value = 3
     await car_to_update.save(db=db)
@@ -106,7 +106,7 @@ async def test_query_uniqueness_multiple_attribute_violations(
     car_camry_main,
     branch: Branch,
     default_branch: Branch,
-):
+) -> None:
     for car_id in (car_volt_main.id, car_camry_main.id, car_accord_main.id):
         car_to_update = await NodeManager.get_one(id=car_id, db=db, branch=branch)
         car_to_update.color.value = "#ffffff"
@@ -133,7 +133,7 @@ async def test_query_relationship_uniqueness_no_violations(
     person_john_main,
     person_albert_main,
     branch: Branch,
-):
+) -> None:
     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await car_to_update.owner.update(data=person_jane_main, db=db)
     await car_to_update.save(db=db)
@@ -218,7 +218,7 @@ async def test_query_relationship_uniqueness_one_violation(
     person_john_main,
     person_albert_main,
     branch: Branch,
-):
+) -> None:
     car_accord_branch = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     await car_accord_branch.owner.update(data=person_jane_main, db=db)
     await car_accord_branch.save(db=db)
@@ -303,7 +303,7 @@ async def test_query_relationship_uniqueness_one_violation(
 
 async def test_query_relationship_no_violation_same_peer_different_rels(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
-):
+) -> None:
     john = await Node.init(schema="TestPerson", db=db)
     await john.new(db=db, name="John", height=175)
     await john.save(db=db)

--- a/backend/tests/unit/core/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/unit/core/convert_object_type/test_convert_object_type.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 class TestSchemaConversionMapping(TestInfrahubApp):
     async def test_schema_conversion_mapping(
         self, db: InfrahubDatabase, client: InfrahubClient, branch, schemas_conversion
-    ):
+    ) -> None:
         res = await client.schema.load(schemas=[schemas_conversion], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 

--- a/backend/tests/unit/core/diff/query/test_read.py
+++ b/backend/tests/unit/core/diff/query/test_read.py
@@ -220,7 +220,9 @@ class TestDiffReadQuery(TestInfrahub):
             ),
         ],
     )
-    async def test_summary_no_filter(self, db: InfrahubDatabase, default_branch: Branch, load_data, filters, counters):
+    async def test_summary_no_filter(
+        self, db: InfrahubDatabase, default_branch: Branch, load_data, filters, counters
+    ) -> None:
         query = await DiffSummaryQuery.init(
             db=db,
             base_branch_name=default_branch.name,
@@ -236,7 +238,7 @@ class TestDiffReadQuery(TestInfrahub):
         counters.to_time = load_data["to_time"]
         assert summary == counters
 
-    async def test_get_without_parent(self, db: InfrahubDatabase, default_branch: Branch, load_data):
+    async def test_get_without_parent(self, db: InfrahubDatabase, default_branch: Branch, load_data) -> None:
         repository = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer(DiffParentNodeAdder()))
         diffs_without = await repository.get(
             base_branch_name=default_branch.name,

--- a/backend/tests/unit/core/diff/repository/base.py
+++ b/backend/tests/unit/core/diff/repository/base.py
@@ -32,7 +32,7 @@ class DiffRepositoryTestBase:
         await initialize_registry(db=db, initialize=True)
 
     @pytest.fixture
-    async def reset_database(self, db: InfrahubDatabase, default_branch):
+    async def reset_database(self, db: InfrahubDatabase, default_branch) -> None:
         await delete_all_nodes(db=db)
 
     def build_diff_node(self, num_sub_fields=2, no_recurse=False) -> EnrichedDiffNode:

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -55,7 +55,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         config.SETTINGS.database.max_depth_search_hierarchy = original_depth
         config.SETTINGS.database.query_size_limit = original_size
 
-    async def test_get_non_existent_diff(self, diff_repository: DiffRepository, reset_database):
+    async def test_get_non_existent_diff(self, diff_repository: DiffRepository, reset_database) -> None:
         right_now = Timestamp()
         enriched_diffs = await diff_repository.get(
             base_branch_name=self.base_branch_name,
@@ -65,7 +65,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         )
         assert len(enriched_diffs) == 0
 
-    async def test_save_and_retrieve(self, diff_repository: DiffRepository, reset_database):
+    async def test_save_and_retrieve(self, diff_repository: DiffRepository, reset_database) -> None:
         enriched_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
             diff_branch_name=self.diff_branch_name,
@@ -91,7 +91,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         diff_root.exists_on_database = False
         assert diff_root == enriched_diff
 
-    async def test_save_and_retrieve_large_diff(self, diff_repository: DiffRepository, reset_database):
+    async def test_save_and_retrieve_large_diff(self, diff_repository: DiffRepository, reset_database) -> None:
         enriched_branch_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
             diff_branch_name=self.diff_branch_name,
@@ -133,7 +133,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         retrieved_pair.base_branch_diff.exists_on_database = False
         assert retrieved_pair == enriched_diffs
 
-    async def test_base_branch_name_filter(self, diff_repository: DiffRepository, reset_database):
+    async def test_base_branch_name_filter(self, diff_repository: DiffRepository, reset_database) -> None:
         name_uuid_map = {name: str(uuid4()) for name in (self.base_branch_name, "more-main", "most-main")}
         for base_branch_name, root_uuid in name_uuid_map.items():
             enriched_diff = EnrichedRootFactory.build(
@@ -158,7 +158,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert retrieved[0].base_branch_name == self.base_branch_name
         assert retrieved[0].uuid == name_uuid_map[self.base_branch_name]
 
-    async def test_diff_branch_name_filter(self, diff_repository: DiffRepository, reset_database):
+    async def test_diff_branch_name_filter(self, diff_repository: DiffRepository, reset_database) -> None:
         diff_branch_1, diff_branch_2, diff_branch_3 = "diff1", "diff2", "diff3"
         diff_uuids_by_name = {diff_branch_1: set(), diff_branch_2: set(), diff_branch_3: set()}
         for diff_branch_name in (diff_branch_1, diff_branch_2, diff_branch_3):
@@ -202,7 +202,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         retrieved_uuids = {root_diff.uuid for root_diff in retrieved}
         assert retrieved_uuids == expected_uuids
 
-    async def test_filter_time_ranges(self, diff_repository: DiffRepository, reset_database):
+    async def test_filter_time_ranges(self, diff_repository: DiffRepository, reset_database) -> None:
         root_uuid = str(uuid4())
         enriched_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
@@ -266,7 +266,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         )
         assert len(retrieved) == 0
 
-    async def test_filter_root_node_uuids(self, diff_repository: DiffRepository, reset_database):
+    async def test_filter_root_node_uuids(self, diff_repository: DiffRepository, reset_database) -> None:
         enriched_diffs: list[EnrichedDiffRoot] = []
         for i in range(5):
             nodes = self._build_nodes(num_nodes=4, num_sub_fields=3)
@@ -420,7 +420,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         retrieved[0].exists_on_database = False
         assert retrieved[0] == replace(this_diff, nodes={parent_node, thin_middle_node, expected_leaf_node})
 
-    async def test_save_and_retrieve_many_diffs(self, diff_repository: DiffRepository, reset_database):
+    async def test_save_and_retrieve_many_diffs(self, diff_repository: DiffRepository, reset_database) -> None:
         diffs_to_retrieve: list[EnrichedDiffRoot] = []
         start_time = self.diff_from_time.add(seconds=1)
         for i in range(5):
@@ -461,7 +461,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             r.exists_on_database = False
         assert set(retrieved) == set(diffs_to_retrieve)
 
-    async def test_delete_diff_by_uuid(self, diff_repository: DiffRepository, reset_database):
+    async def test_delete_diff_by_uuid(self, diff_repository: DiffRepository, reset_database) -> None:
         diffs: list[EnrichedDiffRoot] = []
         start_time = self.diff_from_time.add(seconds=1)
         for i in range(5):
@@ -495,7 +495,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             r.exists_on_database = False
         assert set(retrieved) == set(diffs)
 
-    async def test_delete_all_diffs(self, diff_repository: DiffRepository, reset_database):
+    async def test_delete_all_diffs(self, diff_repository: DiffRepository, reset_database) -> None:
         diffs: list[EnrichedDiffRoot] = []
         for _ in range(5):
             nodes = self._build_nodes(num_nodes=2, num_sub_fields=1)
@@ -513,7 +513,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         )
         assert len(retrieved) == 0
 
-    async def test_get_by_tracking_id(self, diff_repository: DiffRepository, reset_database):
+    async def test_get_by_tracking_id(self, diff_repository: DiffRepository, reset_database) -> None:
         branch_tracking_id = BranchTrackingId(name=self.diff_branch_name)
         name_tracking_id = NameTrackingId(name="an very cool diff")
         end_time = self.diff_from_time.add(minutes=5)
@@ -574,7 +574,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
                 diff_branch_name=self.diff_branch_name,
             )
 
-    async def test_get_node_field_summaries(self, diff_repository: DiffRepository):
+    async def test_get_node_field_summaries(self, diff_repository: DiffRepository) -> None:
         diff_nodes = self._build_nodes(num_nodes=5, num_sub_fields=2)
         for diff_node in list(diff_nodes)[:3]:
             same_kind_diff_node = self.build_diff_node(num_sub_fields=3, no_recurse=True)
@@ -617,7 +617,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         retrieved_map = {summary.kind: summary for summary in retrieved_node_field_summaries}
         assert expected_map == retrieved_map
 
-    async def test_merge_tracking_ids(self, diff_repository: DiffRepository, reset_database):
+    async def test_merge_tracking_ids(self, diff_repository: DiffRepository, reset_database) -> None:
         base_branch_name = "main"
         tracking_id_diff_1 = EnrichedRootFactory.build(base_branch_name=base_branch_name)
         tracking_id_1 = BranchTrackingId(name=tracking_id_diff_1.diff_branch_name)
@@ -652,7 +652,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         diff_uuids = {d.uuid for d in diffs}
         assert tracking_id_diff_1.uuid not in diff_uuids
 
-    async def test_limit_and_offset(self, diff_repository: DiffRepository, reset_database):
+    async def test_limit_and_offset(self, diff_repository: DiffRepository, reset_database) -> None:
         nodes_by_kind = defaultdict(list)
         all_nodes = set()
         for kind in ("KindOne", "KindTwo", "KindThree"):
@@ -748,7 +748,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             n.uuid for n in sorted(nodes_by_kind["KindOne"], key=lambda x: x.uuid)[7:]
         }
 
-    async def test_update_existing(self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database):
+    async def test_update_existing(self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database) -> None:
         node_with_removes = self.build_diff_node(no_recurse=True, num_sub_fields=3)
         node_with_updates = self.build_diff_node(no_recurse=True, num_sub_fields=3)
         # there are no conflicts by default
@@ -983,7 +983,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
 
     async def test_update_existing_hierarchy(
         self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
-    ):
+    ) -> None:
         nodes = self._build_nodes(num_nodes=2, num_sub_fields=3)
         for n in nodes:
             for r in n.relationships:

--- a/backend/tests/unit/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/unit/core/diff/test_calculate_artifact_diff.py
@@ -193,7 +193,7 @@ async def car_person_data_artifact_diff(
 
 async def test_calculate_artifact_diff(
     db: InfrahubDatabase, default_branch: Branch, car_person_data_artifact_diff: dict[str, Node]
-):
+) -> None:
     source_branch = car_person_data_artifact_diff["branch3"]
     art1_main = car_person_data_artifact_diff["art1"]
     art1_branch = car_person_data_artifact_diff["art1_branch"]

--- a/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
+++ b/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
@@ -20,7 +20,7 @@ from .factories import (
 
 
 class TestDiffCardinalityOneEnricher:
-    async def test_no_cardinality_one_relationships(self, db: InfrahubDatabase, car_person_schema):
+    async def test_no_cardinality_one_relationships(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         enricher = DiffCardinalityOneEnricher(db=db)
         diff_relationship = EnrichedRelationshipGroupFactory.build(
@@ -37,7 +37,7 @@ class TestDiffCardinalityOneEnricher:
 
         assert diff_root == diff_root_copy
 
-    async def test_cardinality_one_relationship_update(self, db: InfrahubDatabase, car_person_schema):
+    async def test_cardinality_one_relationship_update(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         enricher = DiffCardinalityOneEnricher(db=db)
         peer_id_1 = str(uuid4())
@@ -113,7 +113,9 @@ class TestDiffCardinalityOneEnricher:
             in diff_properties
         )
 
-    async def test_cardinality_one_relationship_simulataneous_update(self, db: InfrahubDatabase, car_person_schema):
+    async def test_cardinality_one_relationship_simulataneous_update(
+        self, db: InfrahubDatabase, car_person_schema
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         enricher = DiffCardinalityOneEnricher(db=db)
         peer_id_1 = str(uuid4())
@@ -213,7 +215,7 @@ class TestDiffCardinalityOneEnricher:
             in diff_properties
         )
 
-    async def test_cardinality_one_relationship_reverted_update(self, db: InfrahubDatabase, car_person_schema):
+    async def test_cardinality_one_relationship_reverted_update(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         enricher = DiffCardinalityOneEnricher(db=db)
         peer_id = str(uuid4())

--- a/backend/tests/unit/core/diff/test_conflict_transferer.py
+++ b/backend/tests/unit/core/diff/test_conflict_transferer.py
@@ -23,7 +23,7 @@ class TestDiffConflictsTransferer:
     async def conflict_transferer(self):
         return DiffConflictTransferer(diff_combiner=DiffCombiner())
 
-    async def test_node_conflicts(self, conflict_transferer: DiffConflictTransferer):
+    async def test_node_conflicts(self, conflict_transferer: DiffConflictTransferer) -> None:
         conflict_early_only = EnrichedConflictFactory.build()
         node_early_only_1 = EnrichedNodeFactory.build(conflict=conflict_early_only)
         node_early_only_2 = EnrichedNodeFactory.build(
@@ -51,7 +51,7 @@ class TestDiffConflictsTransferer:
         assert node_later_only_2.conflict == conflict_later_only
         assert node_transfer_2.conflict == conflict_transfer_1
 
-    async def test_attr_conflicts(self, conflict_transferer: DiffConflictTransferer):
+    async def test_attr_conflicts(self, conflict_transferer: DiffConflictTransferer) -> None:
         conflict_early_only = EnrichedConflictFactory.build()
         prop_early_only_1 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.IS_RELATED, conflict=conflict_early_only
@@ -86,7 +86,7 @@ class TestDiffConflictsTransferer:
         assert prop_later_only_2.conflict == conflict_later_only
         assert prop_transfer_2.conflict == conflict_transfer_1
 
-    async def test_rel_conflicts(self, conflict_transferer: DiffConflictTransferer):
+    async def test_rel_conflicts(self, conflict_transferer: DiffConflictTransferer) -> None:
         conflict_early_only = EnrichedConflictFactory.build()
         element_early_only_1 = EnrichedRelationshipElementFactory.build(conflict=conflict_early_only)
         element_early_only_2 = EnrichedRelationshipElementFactory.build(
@@ -121,7 +121,7 @@ class TestDiffConflictsTransferer:
         assert element_later_only_2.conflict == conflict_later_only
         assert element_transfer_2.conflict == conflict_transfer_1
 
-    async def test_rel_prop_conflicts(self, conflict_transferer: DiffConflictTransferer):
+    async def test_rel_prop_conflicts(self, conflict_transferer: DiffConflictTransferer) -> None:
         conflict_early_only = EnrichedConflictFactory.build()
         prop_early_only_1 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.IS_RELATED, conflict=conflict_early_only

--- a/backend/tests/unit/core/diff/test_conflicts_enricher.py
+++ b/backend/tests/unit/core/diff/test_conflicts_enricher.py
@@ -24,7 +24,7 @@ from .factories import (
 
 
 class TestConflictsEnricher:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.base_branch = Branch(name="main")
         self.diff_branch = Branch(name="branch")
         self.from_time = Timestamp("2024-07-28T13:45:22Z")
@@ -36,7 +36,7 @@ class TestConflictsEnricher:
             base_diff_root=base_enriched_diff, branch_diff_root=branch_enriched_diff
         )
 
-    async def test_no_conflicts(self, db: InfrahubDatabase):
+    async def test_no_conflicts(self, db: InfrahubDatabase) -> None:
         base_root = EnrichedRootFactory.build(nodes=[])
         branch_root = EnrichedRootFactory.build(nodes=[])
         for diff_root in (base_root, branch_root):
@@ -60,7 +60,7 @@ class TestConflictsEnricher:
                     for element_prop in element.properties:
                         assert element_prop.conflict is None
 
-    async def test_one_node_conflict(self, db: InfrahubDatabase):
+    async def test_one_node_conflict(self, db: InfrahubDatabase) -> None:
         node_uuid = str(uuid4())
         node_kind = "SomethingSmelly"
         base_conflict_node = EnrichedNodeFactory.build(
@@ -93,7 +93,7 @@ class TestConflictsEnricher:
             else:
                 assert node.conflict is None
 
-    async def test_one_attribute_conflict(self, db: InfrahubDatabase):
+    async def test_one_attribute_conflict(self, db: InfrahubDatabase) -> None:
         property_type = DatabaseEdgeType.HAS_OWNER
         attribute_name = "smell"
         node_uuid = str(uuid4())
@@ -168,7 +168,7 @@ class TestConflictsEnricher:
                     else:
                         assert prop.conflict is None
 
-    async def test_cardinality_one_conflicts(self, db: InfrahubDatabase, car_person_schema):
+    async def test_cardinality_one_conflicts(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         property_type = DatabaseEdgeType.IS_RELATED
         relationship_name = "owner"
@@ -262,7 +262,7 @@ class TestConflictsEnricher:
                             selected_branch=None,
                         )
 
-    async def test_cardinality_many_conflicts(self, db: InfrahubDatabase, car_person_schema):
+    async def test_cardinality_many_conflicts(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         peer_id_1 = str(uuid4())
         peer_id_2 = str(uuid4())
@@ -406,7 +406,7 @@ class TestConflictsEnricher:
                         else:
                             assert element_prop.conflict is None
 
-    async def test_manually_fixed_attribute_property_conflict_cleared(self, db: InfrahubDatabase):
+    async def test_manually_fixed_attribute_property_conflict_cleared(self, db: InfrahubDatabase) -> None:
         attribute_name = "smell"
         node_uuid = str(uuid4())
         node_kind = "SomethingSmelly"
@@ -466,7 +466,7 @@ class TestConflictsEnricher:
                 for prop in attribute.properties:
                     assert prop.conflict is None
 
-    async def test_unchanged_attribute_property_clears_conflict(self, db: InfrahubDatabase):
+    async def test_unchanged_attribute_property_clears_conflict(self, db: InfrahubDatabase) -> None:
         attribute_name = "smell"
         node_uuid = str(uuid4())
         node_kind = "SomethingSmelly"
@@ -540,7 +540,9 @@ class TestConflictsEnricher:
                 for prop in attribute.properties:
                     assert prop.conflict is None
 
-    async def test_manually_fixed_cardinality_one_conflict_cleared(self, db: InfrahubDatabase, car_person_schema):
+    async def test_manually_fixed_cardinality_one_conflict_cleared(
+        self, db: InfrahubDatabase, car_person_schema
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         property_type = DatabaseEdgeType.IS_RELATED
         relationship_name = "owner"
@@ -622,7 +624,7 @@ class TestConflictsEnricher:
     )
     async def test_unchanged_cardinality_one_clears_conflicts(
         self, db: InfrahubDatabase, car_person_schema, base_action, branch_action
-    ):
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         property_type = DatabaseEdgeType.IS_RELATED
         relationship_name = "owner"
@@ -702,7 +704,9 @@ class TestConflictsEnricher:
                     for prop in rel_element.properties:
                         assert prop.conflict is None
 
-    async def test_unchanged_cardinality_many_rel_clears_conflict(self, db: InfrahubDatabase, car_person_schema):
+    async def test_unchanged_cardinality_many_rel_clears_conflict(
+        self, db: InfrahubDatabase, car_person_schema
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         peer_id_1 = str(uuid4())
         peer_id_2 = str(uuid4())
@@ -814,7 +818,7 @@ class TestConflictsEnricher:
         "base_action,branch_action",
         [(DiffAction.UNCHANGED, DiffAction.UPDATED), (DiffAction.ADDED, DiffAction.UNCHANGED)],
     )
-    async def test_unchanged_node_clears_conflict(self, db: InfrahubDatabase, base_action, branch_action):
+    async def test_unchanged_node_clears_conflict(self, db: InfrahubDatabase, base_action, branch_action) -> None:
         node_uuid = str(uuid4())
         node_kind = "SomethingSmelly"
         base_node = EnrichedNodeFactory.build(uuid=node_uuid, kind=node_kind, action=base_action, relationships=set())
@@ -835,7 +839,7 @@ class TestConflictsEnricher:
         for node in branch_root.nodes:
             assert node.conflict is None
 
-    async def test_manually_fixed_node_conflict_cleared(self, db: InfrahubDatabase):
+    async def test_manually_fixed_node_conflict_cleared(self, db: InfrahubDatabase) -> None:
         node_uuid = str(uuid4())
         node_kind = "SomethingSmelly"
         base_node = EnrichedNodeFactory.build(

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -45,7 +45,7 @@ class TestDiffCoordinator:
 
     async def test_node_deleted_after_branching(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
-    ):
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         person_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
         await person_main.delete(db=db)
@@ -84,7 +84,7 @@ class TestDiffCoordinator:
 
     async def test_node_added_diff_updated_node_removed(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
-    ):
+    ) -> None:
         main_person_2 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
         await main_person_2.new(db=db, name="Rex", height=190)
         await main_person_2.save(db=db)
@@ -142,7 +142,9 @@ class TestDiffCoordinator:
         branch_john_diff = nodes_by_id[person_john_main.id]
         assert branch_john_diff.action is DiffAction.UPDATED
 
-    async def test_overlapping_diffs(self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node):
+    async def test_overlapping_diffs(
+        self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         component_registry = get_component_registry()
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
@@ -210,7 +212,7 @@ class TestDiffCoordinator:
 
     async def test_no_changes_skips_expensive_operations(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
-    ):
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         wrapped_diff_coordinator = await self.get_wrapped_diff_coordinator(db=db, branch=branch)
         component_registry = get_component_registry()
@@ -248,7 +250,7 @@ class TestDiffCoordinator:
 
     async def test_unrelated_changes_skip_some_expensive_operations(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
-    ):
+    ) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         wrapped_diff_coordinator = await self.get_wrapped_diff_coordinator(db=db, branch=branch)
         component_registry = get_component_registry()

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -67,7 +67,7 @@ class TestDiffCoordinatorLocks:
 
     async def test_incremental_diff_locks_do_not_queue_up(
         self, db: InfrahubDatabase, default_branch: Branch, branch_with_data: Branch
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 
@@ -83,7 +83,7 @@ class TestDiffCoordinatorLocks:
 
     async def test_arbitrary_diff_locks_queue_up(
         self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 
@@ -120,7 +120,7 @@ class TestDiffCoordinatorLocks:
 
     async def test_arbitrary_diff_blocks_incremental_diff(
         self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 
@@ -151,7 +151,7 @@ class TestDiffCoordinatorLocks:
 
     async def test_incremental_diff_blocks_arbitrary_diff(
         self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 
@@ -187,7 +187,7 @@ class TestDiffCoordinatorLocks:
         diff_repository: DiffRepository,
         branch_with_data: Branch,
         dummy_repository_schema: None,
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
         branch_merger = BranchMerger(
@@ -222,7 +222,7 @@ class TestDiffCoordinatorLocks:
         diff_repository: DiffRepository,
         branch_with_data: Branch,
         dummy_repository_schema: None,
-    ):
+    ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -51,7 +51,7 @@ class TestDiffAndMerge:
 
     async def test_diff_and_merge_with_list_attribute(
         self, db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-    ):
+    ) -> None:
         new_node = await Node.init(db=db, schema=all_attribute_types_schema.kind)
         await new_node.new(db=db, mylist=["a", "b", 1, 2])
         await new_node.save(db=db)
@@ -74,7 +74,7 @@ class TestDiffAndMerge:
         default_branch: Branch,
         register_core_models_schema: SchemaBranch,
         car_person_schema: SchemaBranch,
-    ):
+    ) -> None:
         schema_main = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.update_schema_branch(
             db=db, branch=default_branch, schema=schema_main, limit=["TestCar", "TestPerson"], update_db=True
@@ -135,7 +135,7 @@ class TestDiffAndMerge:
         car_accord_main: Node,
         conflict_selection: ConflictSelection,
         expected_value: dict[Literal["name", "hfid"], str | list[str]],
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.value = "John-main"
@@ -184,7 +184,7 @@ class TestDiffAndMerge:
         car_accord_main: Node,
         car_camry_main: Node,
         conflict_selection: ConflictSelection,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data=person_alfred_main)
@@ -236,7 +236,7 @@ class TestDiffAndMerge:
         person_alfred_main: Node,
         car_accord_main: Node,
         conflict_selection: ConflictSelection,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.source = person_alfred_main
@@ -290,7 +290,7 @@ class TestDiffAndMerge:
         car_accord_main: Node,
         car_camry_main: Node,
         conflict_selection: ConflictSelection,
-    ):
+    ) -> None:
         person_schema = db.schema.get(name="TestPerson", duplicate=False)
         cars_rel_schema = person_schema.get_relationship(name="cars")
         branch2 = await create_branch(db=db, branch_name="branch2")
@@ -352,7 +352,7 @@ class TestDiffAndMerge:
         person_john_main,
         person_jane_main,
         new_height,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_jane_main.id)
         person_branch.height.value = new_height
@@ -383,7 +383,7 @@ class TestDiffAndMerge:
         person_john_main,
         person_jane_main,
         car_camry_main,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         branch_car = await Node.init(db=db, schema="TestCar", branch=branch2)
         await branch_car.new(db=db, name="new camry", nbr_seats=5, is_electric=False, owner=person_jane_main.id)
@@ -414,7 +414,7 @@ class TestDiffAndMerge:
 
     async def test_relationship_set_to_null(
         self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, animal_person_schema
-    ):
+    ) -> None:
         person_main = await Node.init(db=db, schema="TestPerson")
         await person_main.new(db=db, name="Dude")
         await person_main.save(db=db)
@@ -459,7 +459,7 @@ class TestDiffAndMerge:
         default_branch: Branch,
         diff_repository: DiffRepository,
         car_person_schema_branch_local: SchemaBranch,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
         await person.new(db=db, name="Guy", height=180)
@@ -530,7 +530,7 @@ class TestDiffAndMerge:
 
     async def test_agnostic_and_aware_nodes_added_on_branch(
         self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, car_person_schema_global
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
         await person.new(db=db, name="Guy", height=180)
@@ -616,7 +616,7 @@ class TestDiffAndMerge:
         person_jane_main,
         car_accord_main,
         car_camry_main,
-    ):
+    ) -> None:
         person_schema = db.schema.get(name="TestPerson", duplicate=False)
         cars_rel_schema = person_schema.get_relationship(name="cars")
         branch2 = await create_branch(db=db, branch_name="branch2")
@@ -674,7 +674,7 @@ class TestDiffAndMerge:
         person_alfred_main,
         car_accord_main,
         car_camry_main,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
@@ -741,7 +741,7 @@ class TestDiffAndMerge:
         person_alfred_main,
         car_accord_main,
         car_camry_main,
-    ):
+    ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
@@ -793,7 +793,7 @@ class TestDiffAndMerge:
 
     async def test_delete_with_many_relationship_added(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_unregistered: SchemaRoot
-    ):
+    ) -> None:
         # remove TestCar relationship to TestPerson
         car_schema = car_person_schema_unregistered.get(name="TestCar")
         car_schema.relationships = []
@@ -850,7 +850,7 @@ class TestDiffAndMerge:
         diff_repository: DiffRepository,
         person_john_main: Node,
         selection: ConflictSelection,
-    ):
+    ) -> None:
         main_value = 200
         branch_value = 150
         branch2 = await create_branch(db=db, branch_name="branch2")
@@ -949,7 +949,7 @@ class TestDiffAndMerge:
         car_camry_main: Node,
         person_jane_main: Node,
         person_john_main: Node,
-    ):
+    ) -> None:
         schema_main = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.update_schema_branch(db=db, branch=default_branch, schema=schema_main, update_db=True)
         original_car_owner = person_john_main
@@ -1059,7 +1059,7 @@ class TestDiffAndMerge:
         register_internal_models_schema: SchemaBranch,
         register_core_models_schema: SchemaBranch,
         car_person_schema_generics: SchemaBranch,
-    ):
+    ) -> None:
         # schema with multiple generics
         root_with_another_generic = SchemaRoot(
             generics=[

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -38,7 +38,7 @@ def low_query_size_limit():
 
 async def test_diff_attribute_branch_update(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -125,7 +125,7 @@ async def test_diff_attribute_branch_update(
 
 async def test_attribute_property_main_update(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     from_time = Timestamp()
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
     alfred_main.name.is_visible = False
@@ -173,7 +173,7 @@ async def test_attribute_property_main_update(
     assert before_change < property_diff.changed_at < after_change
 
 
-async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: Branch, car_accord_main):
+async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: Branch, car_accord_main) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -214,7 +214,9 @@ async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: B
     assert before_change < property_diff.changed_at < after_change
 
 
-async def test_attribute_branch_update_from_null(db: InfrahubDatabase, default_branch: Branch, person_john_main: Node):
+async def test_attribute_branch_update_from_null(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+) -> None:
     car = await Node.init(db=db, schema="TestCar", branch=default_branch)
     await car.new(db=db, name="accord", is_electric=False, owner=person_john_main.id)
     await car.save(db=db)
@@ -259,7 +261,9 @@ async def test_attribute_branch_update_from_null(db: InfrahubDatabase, default_b
 
 
 @pytest.mark.parametrize("use_branch", [True, False])
-async def test_node_delete(db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main, use_branch):
+async def test_node_delete(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main, use_branch
+) -> None:
     if use_branch:
         branch = await create_branch(db=db, branch_name="branch")
     else:
@@ -339,7 +343,7 @@ async def test_node_delete(db: InfrahubDatabase, default_branch: Branch, car_acc
 
 async def test_node_base_delete_branch_update(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
@@ -388,7 +392,7 @@ async def test_node_base_delete_branch_update(
     assert diff_property.new_value == 10
 
 
-async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car_accord_main):
+async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car_accord_main) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     new_person = await Node.init(db=db, schema="TestPerson", branch=branch)
@@ -431,7 +435,7 @@ async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car
 
 async def test_attribute_property_multiple_branch_updates(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     alfred_branch = await NodeManager.get_one(db=db, branch=branch, id=person_alfred_main.id)
@@ -487,7 +491,7 @@ async def test_attribute_property_multiple_branch_updates(
 
 async def test_attribute_property_branch_create_multiple_updates(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     person = await Node.init(db=db, schema="TestPerson", branch=branch)
@@ -574,7 +578,7 @@ async def test_relationship_one_peer_branch_and_main_update(
     person_jane_main,
     person_john_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
@@ -794,7 +798,7 @@ async def test_relationship_one_property_branch_update(
     person_jane_main,
     person_john_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
@@ -967,7 +971,7 @@ async def test_add_node_branch(
     person_jane_main,
     person_john_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     new_car = await Node.init(db=db, branch=branch, schema="TestCar")
@@ -1066,7 +1070,7 @@ async def test_many_relationship_property_update(
     person_john_main,
     person_jane_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -1140,7 +1144,7 @@ async def test_cardinality_one_peer_conflicting_updates(
     person_jane_main,
     person_albert_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -1375,7 +1379,7 @@ async def test_relationship_property_owner_conflicting_updates(
     default_branch: Branch,
     person_john_main,
     car_accord_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     main_john = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
@@ -1503,7 +1507,7 @@ async def test_agnostic_source_relationship_update(
     db: InfrahubDatabase,
     default_branch: Branch,
     car_person_schema_global,
-):
+) -> None:
     person_1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person_1.new(db=db, name="Herb", height=165)
     await person_1.save(db=db)
@@ -1559,7 +1563,7 @@ async def test_agnostic_owner_relationship_added(
     db: InfrahubDatabase,
     default_branch: Branch,
     car_person_schema_global,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     person_1 = await Node.init(db=db, schema="TestPerson", branch=branch)
@@ -1656,7 +1660,7 @@ async def test_update_attribute_under_agnostic_node(
     db: InfrahubDatabase,
     default_branch: Branch,
     fruit_tag_schema_global,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     fruit_1 = await Node.init(db=db, schema="GardenFruit", branch=branch)
@@ -1705,7 +1709,7 @@ async def test_update_attribute_under_agnostic_node(
 
 async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     # change that will be ignored
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
@@ -1770,7 +1774,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
 
 async def test_diff_attribute_branch_update_with_concurrent_base_update_captured(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     # change that will be ignored
@@ -1864,7 +1868,7 @@ async def test_diff_attribute_branch_update_with_concurrent_base_update_captured
 
 async def test_diff_attribute_branch_update_with_previous_base_update_captured(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     # change that will be ignored
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
@@ -1955,7 +1959,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_captured(
 
 async def test_diff_attribute_branch_update_with_separate_previous_base_update_captured(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
     alfred_main.name.value = "Big Alfred"
@@ -2070,7 +2074,7 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
 
 async def test_branch_node_delete_with_base_updates(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main, person_jane_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -2233,7 +2237,7 @@ async def test_branch_node_delete_with_base_updates(
 
 async def test_branch_relationship_delete_with_property_update(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
     persons = []
@@ -2362,7 +2366,7 @@ async def test_branch_relationship_delete_with_property_update(
 
 async def test_node_deleted_on_base_update_on_branch(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -2433,7 +2437,7 @@ async def test_node_deleted_on_base_update_on_branch(
 
 async def test_node_deleted_on_both(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -2479,7 +2483,7 @@ async def test_relationship_updated_then_node_deleted(
     person_jane_main,
     car_accord_main,
     car_camry_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_camry_main.id)
@@ -2676,7 +2680,7 @@ async def test_node_added_and_deleted_on_branch(
     person_jane_main,
     car_accord_main,
     car_camry_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     new_car = await Node.init(schema="TestCar", db=db, branch=branch)
@@ -2708,7 +2712,7 @@ async def test_property_update_then_relationship_deleted(
     person_jane_main,
     car_accord_main,
     car_camry_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
@@ -2839,7 +2843,7 @@ async def test_hierarchy_with_same_kind_parent_and_child(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix")
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
     await ip_namespace.new(db=db, name="ns1")
@@ -2986,7 +2990,7 @@ async def test_hierarchy_with_same_kind_parent_and_child(
 
 async def test_diff_unchanged_included_when_not_first_diff(
     db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
     alfred_main.name.value = "Big Alfred"
@@ -3099,7 +3103,7 @@ async def test_diff_unchanged_included_when_not_first_diff(
 
 async def test_create_local_and_aware_nodes_on_branch(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_branch_local: SchemaBranch
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     person = await Node.init(db=db, schema="TestPerson", branch=branch)
@@ -3133,7 +3137,7 @@ async def test_create_local_and_aware_nodes_on_branch(
 
 async def test_create_aware_and_agnostic_nodes_on_branch(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_global
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     # person is an agnostic node
@@ -3186,7 +3190,7 @@ async def test_diff_relationship_update_includes_unchanged_properties(
     person_alfred_main: Node,
     person_john_main: Node,
     car_accord_main: Node,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -3304,7 +3308,7 @@ async def test_diff_relationship_property_update_on_main(
     person_alfred_main: Node,
     person_john_main: Node,
     car_accord_main: Node,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
     await car_main.owner.update(db=db, data=person_alfred_main)
@@ -3357,7 +3361,7 @@ async def test_calculate_with_migrated_kind_node(
     person_jane_main,
     person_alfred_main,
     person_albert_main,
-):
+) -> None:
     """Test that the diff can correctly handle a schema kind migration, which results in 2 nodes with the same UUID"""
     branch = await create_branch(db=db, branch_name="branch-migrated-kind")
     branch_car = await Node.init(db=db, schema="TestCar", branch=branch)
@@ -3971,7 +3975,7 @@ async def test_calculate_with_migrated_kind_node(
 
 async def test_calculate_with_migrated_attr_name(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
-):
+) -> None:
     """Test that the diff can correctly handle an attribute name migration"""
     branch = await create_branch(db=db, branch_name="branch")
     schema = registry.schema.get_schema_branch(name=default_branch.name)
@@ -4056,7 +4060,7 @@ async def test_calculate_with_migrated_attr_name(
 
 async def test_calculate_with_renamed_relationships(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
-):
+) -> None:
     """Test that the diff can correctly handle an attribute name migration"""
     branch = await create_branch(db=db, branch_name="branch")
     new_rel_identifier = "brand_new_identifier"
@@ -4226,7 +4230,7 @@ async def test_migrated_kind_node_then_peer_delete(
     person_jane_main,
     person_alfred_main,
     person_albert_main,
-):
+) -> None:
     # migrate TestPerson kind on main
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     original_person_schema = schema_branch.get_node(name="TestPerson")
@@ -4310,7 +4314,7 @@ async def test_migrated_kind_with_property_level_changes(
     person_john_main,
     person_jane_main,
     person_alfred_main,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="lets-migrate")
 
     # property-level changes before migration

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -34,7 +34,7 @@ from .factories import (
 
 
 class TestDiffCombiner:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.diff_from_1 = Timestamp(Instant.from_utc(2024, 3, 5, 7, 9, 11))
         self.diff_to_1 = Timestamp(Instant.from_utc(2024, 3, 5, 9, 11, 13))
         self.diff_from_2 = Timestamp(Instant.from_utc(2024, 3, 5, 7, 9, 14))
@@ -73,7 +73,7 @@ class TestDiffCombiner:
         self.combiner = DiffCombiner()
 
     @pytest.fixture
-    def with_schema_manager(self, car_person_schema_unregistered):
+    def with_schema_manager(self, car_person_schema_unregistered) -> None:
         for node_schema in car_person_schema_unregistered.nodes:
             if node_schema.kind == "TestCar":
                 car_schema = node_schema
@@ -114,7 +114,7 @@ class TestDiffCombiner:
             (DiffAction.UNCHANGED, DiffAction.UNCHANGED),
         ],
     )
-    async def test_add_and_remove_node_cancel_one_another(self, action_1, action_2):
+    async def test_add_and_remove_node_cancel_one_another(self, action_1, action_2) -> None:
         diff_node_1 = EnrichedNodeFactory.build(action=action_1, attributes=set(), relationships=set())
         diff_node_2 = EnrichedNodeFactory.build(
             identifier=diff_node_1.identifier, action=action_2, attributes=set(), relationships=set()
@@ -140,7 +140,7 @@ class TestDiffCombiner:
             (DiffAction.UNCHANGED, DiffAction.UPDATED, DiffAction.UPDATED),
         ],
     )
-    async def test_node_action_addition(self, action_1, action_2, expected_action):
+    async def test_node_action_addition(self, action_1, action_2, expected_action) -> None:
         node_1_conflict = EnrichedConflictFactory.build()
         node_2_conflict = replace(node_1_conflict, selected_branch=ConflictSelection.DIFF_BRANCH)
         diff_node_1_attr = EnrichedAttributeFactory.build(action=DiffAction.ADDED)
@@ -177,7 +177,7 @@ class TestDiffCombiner:
         }
         assert combined == self.expected_combined
 
-    async def test_stale_parent_node_removed(self):
+    async def test_stale_parent_node_removed(self) -> None:
         parent_node_1 = EnrichedNodeFactory.build(action=DiffAction.UNCHANGED, attributes=set(), relationships=set())
         element_1 = EnrichedRelationshipElementFactory.build(action=DiffAction.UPDATED)
         relationship_1 = EnrichedRelationshipGroupFactory.build(
@@ -226,7 +226,7 @@ class TestDiffCombiner:
         self.expected_combined.nodes = {expected_parent_node, expected_child_node}
         assert combined == self.expected_combined
 
-    async def test_attributes_combined(self):
+    async def test_attributes_combined(self) -> None:
         added_attr_name = "width"
         added_attr_owner_property_1 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.HAS_OWNER,
@@ -359,7 +359,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_relationship_one_combined(self, with_schema_manager):
+    async def test_relationship_one_combined(self, with_schema_manager) -> None:
         relationship_name = "owner"
         old_peer_id = str(uuid4())
         intermediate_peer_id = str(uuid4())
@@ -473,7 +473,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_relationship_many_combined(self, with_schema_manager):
+    async def test_relationship_many_combined(self, with_schema_manager) -> None:
         rel_prop_types = [DatabaseEdgeType.HAS_OWNER, DatabaseEdgeType.HAS_SOURCE, DatabaseEdgeType.IS_RELATED]
         relationship_name = "cars"
         removed_element_peer_id = str(uuid4())
@@ -641,7 +641,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_relationship_with_only_nodes(self, with_schema_manager):
+    async def test_relationship_with_only_nodes(self, with_schema_manager) -> None:
         relationship_name = "owner"
         early_parent_node = EnrichedNodeFactory.build(
             action=DiffAction.UNCHANGED, relationships=set(), attributes=set()
@@ -706,7 +706,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_early_conflict_removed(self):
+    async def test_early_conflict_removed(self) -> None:
         node_uuid = str(uuid4())
         early_conflict = EnrichedConflictFactory.build()
         later_conflict = None
@@ -723,7 +723,7 @@ class TestDiffCombiner:
         assert combined_node.uuid == node_uuid
         assert combined_node.conflict is None
 
-    async def test_later_conflict_added(self):
+    async def test_later_conflict_added(self) -> None:
         node_uuid = str(uuid4())
         early_conflict = None
         later_conflict = EnrichedConflictFactory.build()
@@ -778,7 +778,7 @@ class TestDiffCombiner:
             ),
         ],
     )
-    async def test_conflict_value_and_selection_update(self, early_values, later_values, selections):
+    async def test_conflict_value_and_selection_update(self, early_values, later_values, selections) -> None:
         node_uuid = str(uuid4())
         early_conflict_uuid = str(uuid4())
         early_base_value, early_diff_value = early_values
@@ -811,7 +811,7 @@ class TestDiffCombiner:
             later_conflict, uuid=early_conflict_uuid, selected_branch=expected_selection
         )
 
-    async def test_unchanged_parents_correctly_updated(self):
+    async def test_unchanged_parents_correctly_updated(self) -> None:
         child_node_uuid = str(uuid4())
         relationship_name = "related-things"
         parent_node_1 = EnrichedNodeFactory.build(action=DiffAction.UNCHANGED, attributes=set(), relationships=set())
@@ -878,7 +878,7 @@ class TestDiffCombiner:
         self.expected_combined.nodes = {expected_parent_node, expected_child_node}
         assert combined == self.expected_combined
 
-    async def test_updated_parents_correctly_updated(self):
+    async def test_updated_parents_correctly_updated(self) -> None:
         child_node_uuid = str(uuid4())
         relationship_name = "related-things"
         parent_node_1 = EnrichedNodeFactory.build(
@@ -954,7 +954,7 @@ class TestDiffCombiner:
         self.expected_combined.nodes = {expected_parent_1, expected_parent_2, expected_child_node}
         assert combined == self.expected_combined
 
-    async def test_resetting_attr_makes_it_unchanged(self):
+    async def test_resetting_attr_makes_it_unchanged(self) -> None:
         updated_attr_name = "length"
         previous_value = str(uuid4())
         new_value = str(uuid4())
@@ -1015,7 +1015,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_resetting_relationship_one_makes_it_unchanged(self, with_schema_manager):
+    async def test_resetting_relationship_one_makes_it_unchanged(self, with_schema_manager) -> None:
         relationship_name = "owner"
         old_peer_id = str(uuid4())
         intermediate_peer_id = str(uuid4())
@@ -1118,7 +1118,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_resetting_relationship_many_makes_it_unchanged(self, with_schema_manager):
+    async def test_resetting_relationship_many_makes_it_unchanged(self, with_schema_manager) -> None:
         rel_prop_types = [DatabaseEdgeType.HAS_OWNER, DatabaseEdgeType.HAS_SOURCE, DatabaseEdgeType.IS_RELATED]
         relationship_name = "cars"
         peer_id_1 = str(uuid4())

--- a/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
+++ b/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
@@ -44,7 +44,7 @@ class TestDiffGetAllConflicts:
             base_branch_diff=base_diff_root,
         )
 
-    async def test_query_initialization_failure(self, diff_repository: DiffRepository):
+    async def test_query_initialization_failure(self, diff_repository: DiffRepository) -> None:
         with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
             [_ async for _ in diff_repository.get_all_conflicts_for_diff(diff_branch_name="a")]
 
@@ -56,7 +56,7 @@ class TestDiffGetAllConflicts:
                 )
             ]
 
-    async def test_no_conflicts(self, diff_repository: DiffRepository):
+    async def test_no_conflicts(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         await diff_repository.save(enriched_diffs=enriched_diffs)
 
@@ -69,7 +69,7 @@ class TestDiffGetAllConflicts:
         }
         assert conflicts == {}
 
-    async def test_get_node_level_conflict(self, diff_repository: DiffRepository):
+    async def test_get_node_level_conflict(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         node.conflict = EnrichedConflictFactory.build()
@@ -95,7 +95,7 @@ class TestDiffGetAllConflicts:
         assert len(conflicts_map) == 1
         assert conflicts_map == {node.path_identifier: node.conflict}
 
-    async def test_get_attribute_level_conflict(self, diff_repository: DiffRepository):
+    async def test_get_attribute_level_conflict(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         diff_prop = EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())
@@ -123,7 +123,7 @@ class TestDiffGetAllConflicts:
         assert len(conflicts_map) == 1
         assert conflicts_map == {diff_prop.path_identifier: diff_prop.conflict}
 
-    async def test_get_relationship_level_conflicts(self, diff_repository: DiffRepository):
+    async def test_get_relationship_level_conflicts(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         diff_rel_element = EnrichedRelationshipElementFactory.build(conflict=EnrichedConflictFactory.build())
@@ -151,7 +151,7 @@ class TestDiffGetAllConflicts:
         assert len(conflicts_map) == 1
         assert conflicts_map == {diff_rel_element.path_identifier: diff_rel_element.conflict}
 
-    async def test_get_relationship_property_level_conflicts(self, diff_repository: DiffRepository):
+    async def test_get_relationship_property_level_conflicts(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         diff_prop = EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())

--- a/backend/tests/unit/core/diff/test_diff_has_conflicts_query.py
+++ b/backend/tests/unit/core/diff/test_diff_has_conflicts_query.py
@@ -44,7 +44,7 @@ class TestDiffHasConflictsCheck:
             base_branch_diff=base_diff_root,
         )
 
-    async def test_query_initialization_failure(self, diff_repository: DiffRepository):
+    async def test_query_initialization_failure(self, diff_repository: DiffRepository) -> None:
         with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
             await diff_repository.diff_has_conflicts(diff_branch_name="a")
 
@@ -53,7 +53,7 @@ class TestDiffHasConflictsCheck:
                 diff_branch_name="a", tracking_id=BranchTrackingId(name="abc"), diff_id="123"
             )
 
-    async def test_has_conflicts_false(self, diff_repository: DiffRepository):
+    async def test_has_conflicts_false(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         await diff_repository.save(enriched_diffs=enriched_diffs)
 
@@ -63,7 +63,7 @@ class TestDiffHasConflictsCheck:
         )
         assert has_conflicts is False
 
-    async def test_has_conflicts_true_node(self, diff_repository: DiffRepository):
+    async def test_has_conflicts_true_node(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         node.conflict = EnrichedConflictFactory.build()
@@ -81,7 +81,7 @@ class TestDiffHasConflictsCheck:
         )
         assert has_conflicts is True
 
-    async def test_has_conflicts_true_attribute_property(self, diff_repository: DiffRepository):
+    async def test_has_conflicts_true_attribute_property(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         node.attributes.add(
@@ -103,7 +103,7 @@ class TestDiffHasConflictsCheck:
         )
         assert has_conflicts is True
 
-    async def test_has_conflicts_true_relationship(self, diff_repository: DiffRepository):
+    async def test_has_conflicts_true_relationship(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         node.relationships.add(
@@ -125,7 +125,7 @@ class TestDiffHasConflictsCheck:
         )
         assert has_conflicts is True
 
-    async def test_has_conflicts_true_relationship_property(self, diff_repository: DiffRepository):
+    async def test_has_conflicts_true_relationship_property(self, diff_repository: DiffRepository) -> None:
         enriched_diffs = self._get_enriched_diffs()
         node = enriched_diffs.diff_branch_diff.nodes.pop()
         node.relationships.add(

--- a/backend/tests/unit/core/diff/test_diff_hierarchy_enricher.py
+++ b/backend/tests/unit/core/diff/test_diff_hierarchy_enricher.py
@@ -9,7 +9,7 @@ from .factories import EnrichedNodeFactory, EnrichedRelationshipGroupFactory, En
 from .get_one_node import get_one_diff_node
 
 
-async def test_node_no_parent_no_rel(db: InfrahubDatabase, default_branch, person_jane_main, car_yaris_main):
+async def test_node_no_parent_no_rel(db: InfrahubDatabase, default_branch, person_jane_main, car_yaris_main) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     diff_node = EnrichedNodeFactory.build(
         identifier=NodeIdentifier(
@@ -40,7 +40,7 @@ async def test_node_no_parent_no_rel(db: InfrahubDatabase, default_branch, perso
     assert len(jane_node.relationships) == 0
 
 
-async def test_node_no_parent_rel(db: InfrahubDatabase, default_branch, person_jane_main, car_yaris_main):
+async def test_node_no_parent_rel(db: InfrahubDatabase, default_branch, person_jane_main, car_yaris_main) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     diff_rel = EnrichedRelationshipGroupFactory.build(name="owner", action=DiffAction.UPDATED, nodes=set())
     diff_node = EnrichedNodeFactory.build(
@@ -72,7 +72,7 @@ async def test_node_no_parent_rel(db: InfrahubDatabase, default_branch, person_j
     assert len(jane_node.relationships) == 0
 
 
-async def test_node_hierarchy(db: InfrahubDatabase, default_branch, hierarchical_location_schema):
+async def test_node_hierarchy(db: InfrahubDatabase, default_branch, hierarchical_location_schema) -> None:
     branch = await create_branch(db=db, branch_name="branch")
 
     # we need hierarchies where the

--- a/backend/tests/unit/core/diff/test_diff_init.py
+++ b/backend/tests/unit/core/diff/test_diff_init.py
@@ -9,7 +9,7 @@ from infrahub.exceptions import DiffFromRequiredOnDefaultBranchError, DiffRangeV
 
 
 class TestDiffInit:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.db = MagicMock()
         self.origin_branch = Branch(name="origin")
         self.created_at_str = "2023-11-01"
@@ -23,19 +23,19 @@ class TestDiffInit:
     async def __call_system_under_test(self, branch, **kwargs):
         return await BranchDiffer.init(self.db, branch, **kwargs)
 
-    async def test_diff_from_required_for_default_branch(self):
+    async def test_diff_from_required_for_default_branch(self) -> None:
         self.branch.is_default = True
 
         with pytest.raises(DiffFromRequiredOnDefaultBranchError):
             await self.__call_system_under_test(self.branch)
 
-    async def test_diff_to_cannot_precede_diff_from(self):
+    async def test_diff_to_cannot_precede_diff_from(self) -> None:
         bad_diff_to = "2023-10-31"
 
         with pytest.raises(DiffRangeValidationError):
             await self.__call_system_under_test(self.branch, diff_to=bad_diff_to)
 
-    async def test_diff_from_default_is_set(self):
+    async def test_diff_from_default_is_set(self) -> None:
         diff_to_str = "2023-11-15"
 
         diff = await self.__call_system_under_test(self.branch, diff_to=diff_to_str)

--- a/backend/tests/unit/core/diff/test_diff_labels_enricher.py
+++ b/backend/tests/unit/core/diff/test_diff_labels_enricher.py
@@ -18,7 +18,7 @@ from .factories import (
 
 async def test_labels_added(
     db: InfrahubDatabase, default_branch, car_yaris_main, person_jane_main, person_alfred_main, person_john_main
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     yaris_label_main = await car_yaris_main.get_display_label(db=db)
     yaris_branch = await NodeManager.get_one(db=db, branch=branch, id=car_yaris_main.get_id())
@@ -147,7 +147,7 @@ async def test_labels_added(
     assert deleted_node.label == await person_alfred_main.get_display_label(db=db)
 
 
-async def test_labels_skipped(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_labels_skipped(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     diff_rel_element = EnrichedRelationshipElementFactory.build(peer_id="not-a-real-one", peer_label=None)
     diff_rel = EnrichedRelationshipGroupFactory.build(

--- a/backend/tests/unit/core/diff/test_diff_merger.py
+++ b/backend/tests/unit/core/diff/test_diff_merger.py
@@ -332,7 +332,7 @@ class TestMergeDiff:
         empty_diff_root: EnrichedDiffRoot,
         added_person_node_diff: EnrichedDiffNode,
         check_idempotent: bool,
-    ):
+    ) -> None:
         empty_diff_root.nodes = {added_person_node_diff}
         mock_diff_repository.get_roots_metadata.return_value = [empty_diff_root]
         mock_diff_repository.get_one.return_value = empty_diff_root
@@ -384,7 +384,7 @@ class TestMergeDiff:
         empty_diff_root: EnrichedDiffRoot,
         deleted_person_node_diff: EnrichedDiffNode,
         check_idempotent: bool,
-    ):
+    ) -> None:
         person_branch = await NodeManager.get_one(db=db, branch=source_branch, id=person_node_main.id)
         await person_branch.delete(db=db)
         empty_diff_root.nodes = {deleted_person_node_diff}
@@ -430,7 +430,7 @@ class TestMergeDiff:
         empty_diff_root: EnrichedDiffRoot,
         conflict_selection: ConflictSelection,
         expect_deleted: bool,
-    ):
+    ) -> None:
         person_node_branch = await NodeManager.get_one(db=db, branch=source_branch, id=person_node_main.id)
         await person_node_branch.delete(db=db)
         deleted_node_diff = self._get_empty_node_diff(node=person_node_branch, action=DiffAction.REMOVED)
@@ -631,7 +631,7 @@ class TestMergeDiff:
         updated_person_node_diff: EnrichedDiffNode,
         updated_car_diff: EnrichedDiffNode,
         check_idempotent: bool,
-    ):
+    ) -> None:
         car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_node_main.id)
         await car_main.owner.update(
             db=db,

--- a/backend/tests/unit/core/diff/test_path_identifier_enricher.py
+++ b/backend/tests/unit/core/diff/test_path_identifier_enricher.py
@@ -16,7 +16,7 @@ from .factories import (
 
 
 class TestPathIdentifierEnricher:
-    async def test_path_identifiers_added(self, db: InfrahubDatabase, car_person_schema):
+    async def test_path_identifiers_added(self, db: InfrahubDatabase, car_person_schema) -> None:
         branch = await create_branch(db=db, branch_name="branch")
         diff_attribute_value_property = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.HAS_VALUE)
         diff_attribute_property = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.HAS_OWNER)

--- a/backend/tests/unit/core/graph/test_graph_constraints.py
+++ b/backend/tests/unit/core/graph/test_graph_constraints.py
@@ -15,7 +15,7 @@ from infrahub.core.graph.schema import GRAPH_SCHEMA
 from infrahub.database import InfrahubDatabase
 
 
-def test_item_node_neo4j():
+def test_item_node_neo4j() -> None:
     item = ConstraintNodeNeo4j(item_name="node", item_label="CoreNode", property="uuid", type="STRING")
     assert item.name_main == "node_node_uuid_type"
     assert item.name_exist == "node_node_uuid_exist"
@@ -31,7 +31,7 @@ def test_item_node_neo4j():
     assert item.get_query_main_drop() == "DROP CONSTRAINT node_node_uuid_type IF EXISTS"
 
 
-def test_item_rel_neo4j():
+def test_item_rel_neo4j() -> None:
     item = ConstraintRelNeo4j(item_name="attr_value", item_label="HAS_VALUE", property="from", type="STRING")
     assert item.name_main == "rel_attr_value_from_type"
     assert item.name_exist == "rel_attr_value_from_exist"
@@ -47,7 +47,7 @@ def test_item_rel_neo4j():
     assert item.get_query_main_drop() == "DROP CONSTRAINT rel_attr_value_from_type IF EXISTS"
 
 
-def test_item_node_memgraph():
+def test_item_node_memgraph() -> None:
     item = ConstraintNodeMemgraph(item_name="node", item_label="CoreNode", property="uuid", type="STRING")
     assert item.get_query_exist_add() == "CREATE CONSTRAINT ON (n:CoreNode) ASSERT EXISTS (n.uuid)"
     assert item.get_query_exist_drop() == "DROP CONSTRAINT ON (n:CoreNode) ASSERT EXISTS (n.uuid)"
@@ -57,7 +57,7 @@ def test_item_node_memgraph():
     os.getenv("INFRAHUB_DB_TYPE") != "neo4j",
     reason="Must use Neo4j to run this test",
 )
-def test_constraint_manager_from_graph_schema_neo4j(db: InfrahubDatabase):
+def test_constraint_manager_from_graph_schema_neo4j(db: InfrahubDatabase) -> None:
     gm = ConstraintManagerNeo4j.from_graph_schema(db=db, schema=GRAPH_SCHEMA)
 
     assert gm.nodes == [
@@ -478,7 +478,7 @@ def test_constraint_manager_from_graph_schema_neo4j(db: InfrahubDatabase):
     os.getenv("INFRAHUB_DB_TYPE") != "memgraph",
     reason="Must use Memgraph to run this test",
 )
-def test_constraint_manager_from_graph_schema_memgraph(db: InfrahubDatabase):
+def test_constraint_manager_from_graph_schema_memgraph(db: InfrahubDatabase) -> None:
     gm = ConstraintManagerMemgraph.from_graph_schema(db=db, schema=GRAPH_SCHEMA)
 
     assert gm.nodes == [
@@ -610,7 +610,7 @@ def test_constraint_manager_from_graph_schema_memgraph(db: InfrahubDatabase):
     os.getenv("INFRAHUB_DB_TYPE") != "neo4j",
     reason="Must use Neo4j to run this test",
 )
-async def test_constraint_manager_database_neo4j(db: InfrahubDatabase, default_branch):
+async def test_constraint_manager_database_neo4j(db: InfrahubDatabase, default_branch) -> None:
     gm = ConstraintManagerNeo4j.from_graph_schema(db=db, schema=GRAPH_SCHEMA)
 
     previous_constraints = await gm.list()
@@ -789,7 +789,7 @@ async def test_constraint_manager_database_neo4j(db: InfrahubDatabase, default_b
     os.getenv("INFRAHUB_DB_TYPE") != "memgraph",
     reason="Must use Memgraph to run this test",
 )
-async def test_constraint_manager_database_memgraph(db: InfrahubDatabase, default_branch):
+async def test_constraint_manager_database_memgraph(db: InfrahubDatabase, default_branch) -> None:
     gm = ConstraintManagerMemgraph.from_graph_schema(db=db, schema=GRAPH_SCHEMA)
 
     previous_constraints = await gm.list()

--- a/backend/tests/unit/core/hierarchy/test_hierarchy_create.py
+++ b/backend/tests/unit/core/hierarchy/test_hierarchy_create.py
@@ -7,7 +7,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 
 
-async def test_create_node_with_invalid_hierarchy(db: InfrahubDatabase, hierarchical_location_data):
+async def test_create_node_with_invalid_hierarchy(db: InfrahubDatabase, hierarchical_location_data) -> None:
     region_schema = registry.schema.get_node_schema(name="LocationRegion", duplicate=True)
     rack_schema = registry.schema.get_node_schema(name="LocationRack", duplicate=True)
     europe = await NodeManager.get_one(db=db, id=hierarchical_location_data["europe"].id)

--- a/backend/tests/unit/core/hierarchy/test_hierarchy_update.py
+++ b/backend/tests/unit/core/hierarchy/test_hierarchy_update.py
@@ -11,7 +11,7 @@ RETURN rel
 """
 
 
-async def test_update_node_with_hierarchy(db: InfrahubDatabase, hierarchical_location_data):
+async def test_update_node_with_hierarchy(db: InfrahubDatabase, hierarchical_location_data) -> None:
     site_schema = registry.schema.get(name="LocationSite", duplicate=False)
     retrieved_node = await NodeManager.get_one(db=db, id=hierarchical_location_data["seattle"].id)
     new_parent = await NodeManager.get_one(db=db, id=hierarchical_location_data["europe"].id)
@@ -35,7 +35,7 @@ async def test_update_node_with_hierarchy(db: InfrahubDatabase, hierarchical_loc
     assert {node.name.value for node in nodes} == {"paris", "london", "seattle"}
 
 
-async def test_update_node_invalid_hierarchy(db: InfrahubDatabase, hierarchical_location_data):
+async def test_update_node_invalid_hierarchy(db: InfrahubDatabase, hierarchical_location_data) -> None:
     city = await NodeManager.get_one(db=db, id=hierarchical_location_data["seattle"].id, raise_on_error=True)
     region = await NodeManager.get_one(db=db, id=hierarchical_location_data["europe"].id, raise_on_error=True)
     rack = await NodeManager.get_one(db=db, id=hierarchical_location_data["paris-r1"].id, raise_on_error=True)

--- a/backend/tests/unit/core/ipam/test_ipam.py
+++ b/backend/tests/unit/core/ipam/test_ipam.py
@@ -21,7 +21,7 @@ async def test_ipprefix_creation(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
     prefix1 = await Node.init(db=db, schema=prefix_schema)
@@ -38,7 +38,7 @@ async def test_ipaddress_creation(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
     address1 = await Node.init(db=db, schema=address_schema)
@@ -57,7 +57,7 @@ async def test_ipaddress_creation(
         (ipaddress.ip_network("2001:db8::/32"), ["2001:db8::/48"]),
     ],
 )
-async def test_ipprefix_subnets(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01, input, response):
+async def test_ipprefix_subnets(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01, input, response) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixSubnetFetch.init(db=db, branch=default_branch, obj=input, namespace=ns1_id)
     await query.execute(db=db)
@@ -71,7 +71,7 @@ async def test_ipprefix_subnets_small_dataset(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
     ns1 = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -97,7 +97,7 @@ async def test_ipaddress_is_within_ipprefix(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -121,7 +121,7 @@ async def test_ipaddress_is_within_ipprefix(
     assert ip_addresses[0].address == address_ip_address
 
 
-async def test_query_by_parent_ids(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_query_by_parent_ids(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     reconciler = IpamReconciler(db=db, branch=default_branch)
     ns1 = ip_dataset_01["ns1"]

--- a/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
+++ b/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
@@ -10,7 +10,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 
 
-async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     branch_2 = await create_branch(db=db, branch_name="branch_2")
 
     # updated prefix value
@@ -53,7 +53,7 @@ async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Bra
     )
 
 
-async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     branch_2 = await create_branch(db=db, branch_name="branch_22")
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
@@ -98,7 +98,7 @@ async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Bra
     )
 
 
-async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     branch_2 = await create_branch(db=db, branch_name="branch_222")
     net_140 = ip_dataset_01["net140"]
     net_143 = ip_dataset_01["net143"]

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -13,7 +13,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
-async def test_ipprefix_reconcile_query_simple(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconcile_query_simple(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     prefix_140 = ip_dataset_01["net140"]
@@ -40,7 +40,9 @@ async def test_ipprefix_reconcile_query_simple(db: InfrahubDatabase, default_bra
     }
 
 
-async def test_ipprefix_reconcile_query_for_new_prefix(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconcile_query_for_new_prefix(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_network("10.10.0.0/22"), namespace=ns1_id
@@ -59,7 +61,9 @@ async def test_ipprefix_reconcile_query_for_new_prefix(db: InfrahubDatabase, def
     }
 
 
-async def test_ipprefix_reconcile_query_for_new_address(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconcile_query_for_new_address(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_interface("10.10.3.0"), namespace=ns1_id
@@ -75,7 +79,7 @@ async def test_ipprefix_reconcile_query_for_new_address(db: InfrahubDatabase, de
 
 async def test_ipprefix_reconcile_query_for_new_address_with_node(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
     new_address = await Node.init(db=db, schema=address_schema)
@@ -96,7 +100,7 @@ async def test_ipprefix_reconcile_query_for_new_address_with_node(
 
 async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_parents(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_network("10.10.1.8/30"), namespace=ns1_id
@@ -112,7 +116,7 @@ async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_parents
 
 async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_children(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_network("10.8.0.0/14"), namespace=ns1_id
@@ -128,7 +132,7 @@ async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_childre
 
 async def test_ipprefix_reconcile_query_for_new_address_multiple_possible_children(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_interface("10.8.0.0"), namespace=ns1_id
@@ -144,7 +148,7 @@ async def test_ipprefix_reconcile_query_for_new_address_multiple_possible_childr
 
 async def test_ipprefix_reconcile_query_for_new_prefix_exactly_one_possible_child_address(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_network("10.10.0.0/30"), namespace=ns1_id
@@ -158,7 +162,9 @@ async def test_ipprefix_reconcile_query_for_new_prefix_exactly_one_possible_chil
     assert query.get_calculated_children_uuids() == [ip_dataset_01["address10"].id]
 
 
-async def test_ipprefix_reconcile_query_for_new_prefix_v6(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconcile_query_for_new_prefix_v6(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_network("2001:db8::/50"), namespace=ns1_id
@@ -172,7 +178,9 @@ async def test_ipprefix_reconcile_query_for_new_prefix_v6(db: InfrahubDatabase, 
     assert query.get_calculated_children_uuids() == [ip_dataset_01["net162"].id]
 
 
-async def test_ipprefix_reconcile_query_for_new_address_v6(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconcile_query_for_new_address_v6(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, ip_value=ipaddress.ip_interface("2001:db8::"), namespace=ns1_id
@@ -188,7 +196,7 @@ async def test_ipprefix_reconcile_query_for_new_address_v6(db: InfrahubDatabase,
 
 async def test_ipprefix_reconcile_query_get_deleted_node_by_prefix(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     net140 = ip_dataset_01["net140"]
     await net140.delete(db=db)
@@ -212,7 +220,7 @@ async def test_ipprefix_reconcile_query_get_deleted_node_by_prefix(
 
 async def test_ipprefix_reconcile_query_get_deleted_node_by_uuid(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     ns1_id = ip_dataset_01["ns1"].id
     net140 = ip_dataset_01["net140"]
     await net140.delete(db=db)
@@ -240,7 +248,7 @@ async def test_ipprefix_reconcile_query_get_deleted_node_by_uuid(
 
 async def test_ipprefix_reconcile_query_deleted_children_ignored_on_branch(
     db: InfrahubDatabase, ip_dataset_01: dict[str, Node]
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch2")
 
     ns1_id = ip_dataset_01["ns1"].id
@@ -275,7 +283,7 @@ async def test_ipprefix_reconcile_query_deleted_children_ignored_on_branch(
 
 async def test_ipprefix_reconcile_query_deleted_parent_ignored_on_branch(
     db: InfrahubDatabase, ip_dataset_01: dict[str, Node]
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch2")
 
     ns1_id = ip_dataset_01["ns1"].id
@@ -305,7 +313,7 @@ async def test_ipprefix_reconcile_query_deleted_parent_ignored_on_branch(
     }
 
 
-async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -371,7 +379,7 @@ async def test_reconcile_parent_child_identification(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -447,7 +455,7 @@ async def test_address_cannot_be_parent(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -474,7 +482,7 @@ async def test_adjacent_parents_and_addresses(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -570,7 +578,7 @@ async def test_root_ip_prefix_exists_reconcile(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
     await ip_namespace.new(db=db, name="ns1")
@@ -592,7 +600,7 @@ async def test_root_ip_prefix_added_reconcile(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
     await ip_namespace.new(db=db, name="ns1")
@@ -609,7 +617,9 @@ async def test_root_ip_prefix_added_reconcile(
     assert query.get_calculated_children_uuids() == [child_prefix_node.id]
 
 
-async def test_reconcile_query_on_migrated_kind_node(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_reconcile_query_on_migrated_kind_node(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     prefix_140 = ip_dataset_01["net140"]

--- a/backend/tests/unit/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconciler.py
@@ -16,7 +16,9 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import NodeNotFoundError
 
 
-async def test_missing_value_raises_error(db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node):
+async def test_missing_value_raises_error(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node
+) -> None:
     reconciler = IpamReconciler(db=db, branch=default_branch)
     with pytest.raises(NodeNotFoundError) as exc_info:
         await reconciler.reconcile(ip_value=ipaddress.ip_network("10.10.0.0/24"), namespace=default_ipnamespace)
@@ -31,7 +33,7 @@ async def test_first_prefix(
     register_core_models_schema,
     register_ipam_schema,
     default_ipnamespace: Node,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     net161 = await Node.init(db=db, schema=prefix_schema)
     await net161.new(db=db, prefix="2001:db8::/48", ip_namespace=default_ipnamespace)
@@ -46,7 +48,7 @@ async def test_first_prefix(
     assert all_prefixes[0].is_top_level.value is True
 
 
-async def test_invalid_ip_node_raises_error(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_invalid_ip_node_raises_error(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
 
     reconciler = IpamReconciler(db=db, branch=default_branch)
@@ -54,7 +56,7 @@ async def test_invalid_ip_node_raises_error(db: InfrahubDatabase, default_branch
         await reconciler.reconcile(ip_value=ipaddress.ip_interface("192.168.1.1"), namespace=default_ipnamespace)
 
 
-async def test_ipprefix_reconciler_no_change(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconciler_no_change(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     prefix_140 = ip_dataset_01["net140"]
@@ -75,7 +77,9 @@ async def test_ipprefix_reconciler_no_change(db: InfrahubDatabase, default_branc
     assert prefix_146_children_rels[0].peer_id == updated_prefix_140.id
 
 
-async def test_ipprefix_reconciler_new_prefix_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconciler_new_prefix_update(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
@@ -125,7 +129,9 @@ async def test_ipprefix_reconciler_new_prefix_update(db: InfrahubDatabase, defau
         assert child_parent_rels[0].peer_id == updated_prefix.id
 
 
-async def test_ipprefix_reconciler_new_address_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconciler_new_address_update(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
@@ -150,7 +156,7 @@ async def test_ipprefix_reconciler_new_address_update(db: InfrahubDatabase, defa
     assert ip_address_rels[0].peer_id == new_address.id
 
 
-async def test_ip_prefix_reconciler_delete_prefix(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ip_prefix_reconciler_delete_prefix(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -188,7 +194,7 @@ async def test_ip_prefix_reconciler_delete_prefix(db: InfrahubDatabase, default_
         assert child_parent_rels[0].peer_id == updated_parent.id
 
 
-async def test_ip_prefix_reconciler_delete_address(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ip_prefix_reconciler_delete_address(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -211,7 +217,9 @@ async def test_ip_prefix_reconciler_delete_address(db: InfrahubDatabase, default
     assert len(updated_address_child_rels) == 0
 
 
-async def test_ipprefix_reconciler_prefix_value_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_reconciler_prefix_value_update(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -263,7 +271,7 @@ async def test_ipprefix_reconciler_prefix_value_update(db: InfrahubDatabase, def
 
 async def test_ipprefix_reconciler_increment_prefix_length_on_branch(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -297,7 +305,7 @@ async def test_ipprefix_reconciler_increment_prefix_length_on_branch(
 
 async def test_ipprefix_reconciler_decrement_prefix_length_on_branch(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -335,7 +343,7 @@ async def test_ipprefix_reconciler_decrement_prefix_length_on_branch(
     assert updated_parent_rel[0].peer_id == net_143_branch.id
 
 
-async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]
@@ -373,7 +381,7 @@ async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: 
     assert updated_parent_rel[0].peer_id == ip_dataset_01["net146"].id
 
 
-async def test_ipprefix_swap_values_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_ipprefix_swap_values_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     namespace = ip_dataset_01["ns1"]

--- a/backend/tests/unit/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/unit/core/ipam/test_ipam_utilization.py
@@ -4,7 +4,7 @@ from infrahub.core.ipam.utilization import PrefixUtilizationGetter
 from infrahub.database import InfrahubDatabase
 
 
-async def test_use_percentage(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+async def test_use_percentage(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01) -> None:
     net240 = ip_dataset_01["net240"]
     net240.member_type.value = PrefixMemberType.ADDRESS.value
     utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net240])
@@ -19,7 +19,7 @@ async def test_use_percentage(db: InfrahubDatabase, default_branch: Branch, ip_d
     assert percentage == 0.2197265625
 
 
-async def test_use_percentage_no_prefixes(db: InfrahubDatabase, default_branch: Branch):
+async def test_use_percentage_no_prefixes(db: InfrahubDatabase, default_branch: Branch) -> None:
     utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[])
     percentage = await utilization.get_use_percentage()
 

--- a/backend/tests/unit/core/migrations/graph/test_001.py
+++ b/backend/tests/unit/core/migrations/graph/test_001.py
@@ -4,7 +4,7 @@ from infrahub.core.migrations.graph import Migration001
 from infrahub.database import InfrahubDatabase
 
 
-async def test_migration_001_no_version(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db):
+async def test_migration_001_no_version(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db) -> None:
     query_init_root = """
     CREATE (root:Root { uuid: "%(uuid)s", default_branch: "main" })
     RETURN root
@@ -19,7 +19,7 @@ async def test_migration_001_no_version(db: InfrahubDatabase, reset_registry, de
     assert not validation_result.errors
 
 
-async def test_migration_001_initial_version(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db):
+async def test_migration_001_initial_version(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db) -> None:
     query_init_root = """
     CREATE (root:Root { uuid: "%(uuid)s", graph_version: 0, default_branch: "main" })
     RETURN root
@@ -34,7 +34,7 @@ async def test_migration_001_initial_version(db: InfrahubDatabase, reset_registr
     assert not validation_result.errors
 
 
-async def test_migration_001_validate(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db):
+async def test_migration_001_validate(db: InfrahubDatabase, reset_registry, delete_all_nodes_in_db) -> None:
     root_id = str(UUIDT().new())
 
     query_init_root = """

--- a/backend/tests/unit/core/migrations/graph/test_003.py
+++ b/backend/tests/unit/core/migrations/graph/test_003.py
@@ -14,7 +14,7 @@ async def migration_003_data(
     default_branch,
     delete_all_nodes_in_db,
     register_core_models_schema: SchemaBranch,
-):
+) -> None:
     node_schema = register_core_models_schema.get(name="SchemaNode")
     rel_schema = register_core_models_schema.get(name="SchemaRelationship")
 
@@ -33,7 +33,7 @@ async def migration_003_data(
 
 async def test_migration_003_query1(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_003_data
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
     query = await Migration003Query01.init(db=db)
     await query.execute(db=db)
@@ -49,7 +49,7 @@ async def test_migration_003_query1(
 
 async def test_migration_003(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_003_data
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
 
     migration = Migration003()

--- a/backend/tests/unit/core/migrations/graph/test_012.py
+++ b/backend/tests/unit/core/migrations/graph/test_012.py
@@ -135,7 +135,7 @@ ATTRIBUTE_SCHEMA = NodeSchema(
 @pytest.fixture
 async def migration_012_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, register_core_models_schema
-):
+) -> None:
     user1 = await Node.init(db=db, schema=ACCOUNT_SCHEMA)
     await user1.new(db=db, name="User1", type="User")
     await user1.save(db=db)
@@ -160,7 +160,7 @@ async def migration_012_data(
 @pytest.fixture
 async def migration_012_schema(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, register_core_models_schema
-):
+) -> None:
     node1 = await Node.init(db=db, schema=NODE_SCHEMA)
     await node1.new(
         db=db, name="Account", namespace="Core", inherit_from=[InfrahubKind.LINEAGEOWNER, InfrahubKind.LINEAGESOURCE]
@@ -186,7 +186,7 @@ async def migration_012_schema(
 
 async def test_migration_012_add_label_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_data
-):
+) -> None:
     nbr_nodes_before = await count_nodes(db=db, label="CoreAccount")
 
     query = await Migration012AddLabelData.init(db=db)
@@ -203,7 +203,7 @@ async def test_migration_012_add_label_data(
 
 async def test_migration_012_rename_type_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_data
-):
+) -> None:
     nbr_attrs_before = await count_nodes(db=db, label="Attribute")
 
     query = await Migration012RenameTypeAttributeData.init(db=db)
@@ -220,7 +220,7 @@ async def test_migration_012_rename_type_data(
 
 async def test_migration_012_rename_type_schema(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_schema
-):
+) -> None:
     nbr_attrs_value_before = await count_nodes(db=db, label="AttributeValue")
 
     query = await Migration012RenameTypeAttributeSchema.init(db=db)
@@ -235,7 +235,7 @@ async def test_migration_012_rename_type_schema(
 
 async def test_migration_012_rename_relationship_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_data
-):
+) -> None:
     nbr_rels_before = await count_nodes(db=db, label="Relationship")
     nbr_rels_related_before = await count_relationships(db=db, label="IS_RELATED")
 
@@ -256,7 +256,7 @@ async def test_migration_012_rename_relationship_data(
 
 async def test_migration_012_delete_old_attribute_schema(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_schema
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
     # nbr_rels_related_before = await count_relationships(db=db, label="IS_RELATED")
 
@@ -273,7 +273,7 @@ async def test_migration_012_delete_old_attribute_schema(
 
 async def test_migration_012(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_012_data
-):
+) -> None:
     nbr_nodes_before = await count_nodes(db=db, label="CoreAccount")
     nbr_attrs_before = await count_nodes(db=db, label="Attribute")
 

--- a/backend/tests/unit/core/migrations/graph/test_013.py
+++ b/backend/tests/unit/core/migrations/graph/test_013.py
@@ -142,7 +142,7 @@ ATTRIBUTE_SCHEMA = NodeSchema(
 @pytest.fixture
 async def migration_013_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, register_core_models_schema
-):
+) -> None:
     repo1 = await Node.init(db=db, schema=GIT_SCHEMA)
     await repo1.new(db=db, name="repo1 initial", username="user1 initial", password="pwd1 initial")
     await repo1.save(db=db)
@@ -165,7 +165,7 @@ async def migration_013_data(
 @pytest.fixture
 async def migration_013_schema(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, register_core_models_schema
-):
+) -> None:
     node1 = await Node.init(db=db, schema=NODE_SCHEMA)
     await node1.new(db=db, name="GenericRepository", namespace="Core")
     await node1.save(db=db)
@@ -189,7 +189,7 @@ async def migration_013_schema(
 
 async def test_migration_013_query_01(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_013_data
-):
+) -> None:
     registry.branch[default_branch.name] = default_branch
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
@@ -225,7 +225,7 @@ async def test_migration_013_query_01(
 
 async def test_migration_013_query_02(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_013_data
-):
+) -> None:
     registry.branch[default_branch.name] = default_branch
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
@@ -253,7 +253,7 @@ async def test_migration_013_query_02(
 
 async def test_migration_013_delete_username_password_schema(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_013_schema
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
 
     query = await Migration013DeleteUsernamePasswordGenericSchema.init(db=db)
@@ -269,7 +269,7 @@ async def test_migration_013_delete_username_password_schema(
 
 async def test_migration_013_add_internal_status_data(
     db: InfrahubDatabase, reset_registry, default_branch, delete_all_nodes_in_db, migration_013_data
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
 
     query = await Migration013AddInternalStatusData.init(db=db)
@@ -292,7 +292,7 @@ async def test_migration_013(
     delete_all_nodes_in_db,
     migration_013_data,
     migration_013_schema,
-):
+) -> None:
     nbr_rels_before = await count_relationships(db=db)
     nbr_nodes_before = await count_nodes(db=db)
 

--- a/backend/tests/unit/core/migrations/graph/test_014.py
+++ b/backend/tests/unit/core/migrations/graph/test_014.py
@@ -13,7 +13,7 @@ async def test_migration_014(
     reset_registry,
     default_branch,
     delete_all_nodes_in_db,
-):
+) -> None:
     indexes = [
         IndexItem(name="node_uuid", label="Node", properties=["uuid"], type=IndexType.RANGE),
         IndexItem(name="attr_value", label="AttributeValue", properties=["value"], type=IndexType.RANGE),

--- a/backend/tests/unit/core/migrations/graph/test_017.py
+++ b/backend/tests/unit/core/migrations/graph/test_017.py
@@ -7,7 +7,7 @@ async def test_migration_017(
     db: InfrahubDatabase,
     default_branch,
     register_internal_models_schema,
-):
+) -> None:
     """
     Test migration correctly adds CoreProfile schema node.
     """

--- a/backend/tests/unit/core/migrations/graph/test_018_025.py
+++ b/backend/tests/unit/core/migrations/graph/test_018_025.py
@@ -63,7 +63,7 @@ async def test_migration_018_success(
     car_red,
     car_invisible,
     migration,
-):
+) -> None:
     # check no validation errors for now
     async with db.start_session() as dbs:
         execution_result = await migration.execute(db=dbs)
@@ -82,7 +82,7 @@ async def test_migration_018_fail(
     car_invisible,
     car_person_schema: SchemaBranch,
     migration,
-):
+) -> None:
     """
     Test migration correctly identifies nodes with NULL attribute values that violate uniqueness constraint
     """

--- a/backend/tests/unit/core/migrations/graph/test_019.py
+++ b/backend/tests/unit/core/migrations/graph/test_019.py
@@ -11,7 +11,7 @@ from tests.helpers.db_validation import validate_node_relationships
 async def test_migration_019(
     db: InfrahubDatabase,
     default_branch,
-):
+) -> None:
     """
     Reproduce corrupted state introduced by migration 12, and apply the migration fixing it.
     """
@@ -129,7 +129,7 @@ async def test_migration_019(
 
 async def test_incorrectly_deleted_aware_nodes_and_relationship(
     db: InfrahubDatabase, branch, car_person_schema_unregistered
-):
+) -> None:
     """
     Reproduce a state where a branch aware node would have been incorrectly deleted, this node being
     connected to another node through a branch aware relationship.
@@ -167,7 +167,9 @@ async def test_incorrectly_deleted_aware_nodes_and_relationship(
     await validate_node_relationships(node=car, branch=branch, db=db)
 
 
-async def test_incorrectly_deleted_agnostic_node(db: InfrahubDatabase, branch, car_person_branch_agnostic_schema):
+async def test_incorrectly_deleted_agnostic_node(
+    db: InfrahubDatabase, branch, car_person_branch_agnostic_schema
+) -> None:
     """
     Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
     connected to another node through 2 relationships, both aware and agnostic.
@@ -206,7 +208,7 @@ async def test_incorrectly_deleted_agnostic_node(db: InfrahubDatabase, branch, c
     await validate_node_relationships(node=agnostic_car, branch=registry.get_global_branch(), db=db)
 
 
-async def test_incorrectly_deleted_aware_node(db: InfrahubDatabase, branch, car_person_branch_agnostic_schema):
+async def test_incorrectly_deleted_aware_node(db: InfrahubDatabase, branch, car_person_branch_agnostic_schema) -> None:
     """
     Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
     connected to another node through 2 relationships, both aware and agnostic.

--- a/backend/tests/unit/core/migrations/graph/test_023.py
+++ b/backend/tests/unit/core/migrations/graph/test_023.py
@@ -12,7 +12,7 @@ from infrahub.database import InfrahubDatabase
 # redis is required as we will call `initialization` later
 
 
-async def test_migration_023(db: InfrahubDatabase, branch, car_person_schema, redis):
+async def test_migration_023(db: InfrahubDatabase, branch, car_person_schema, redis) -> None:
     """
     Reproduce corrupted state where two nodes would be connected by multiple relationships while relationship
     cardinality is one.
@@ -119,7 +119,7 @@ async def test_migration_023(db: InfrahubDatabase, branch, car_person_schema, re
     assert len(rels) == 0
 
 
-async def add_extra_relationship(db, node_1_id, node_2_id, before_time, branch, rel_name):
+async def add_extra_relationship(db, node_1_id, node_2_id, before_time, branch, rel_name) -> None:
     add_extra_relationship_query = """
     MATCH (node_1: Node {uuid: $node_1_id})
     MATCH (node_2: Node {uuid: $node_2_id})
@@ -144,7 +144,7 @@ async def add_extra_relationship(db, node_1_id, node_2_id, before_time, branch, 
     )
 
 
-async def check_number_path_between_nodes(db, node_id_1, node_id_2, expected_path_number):
+async def check_number_path_between_nodes(db, node_id_1, node_id_2, expected_path_number) -> None:
     check_single_relationship_query = """
         MATCH path = (car:Node {uuid: $node_id_1})-[:IS_RELATED]-(rel: Relationship)-[:IS_RELATED]-(maria:Node {uuid: $node_id_2})
         RETURN COUNT(path) AS pathCount

--- a/backend/tests/unit/core/migrations/graph/test_027.py
+++ b/backend/tests/unit/core/migrations/graph/test_027.py
@@ -5,7 +5,7 @@ from infrahub.database import InfrahubDatabase
 async def test_migration_027(
     db: InfrahubDatabase,
     default_branch,
-):
+) -> None:
     query = """
     CREATE (valid_node:Node {uuid: '123'})
     CREATE (isolated_node:Node {uuid: '456'})

--- a/backend/tests/unit/core/migrations/graph/test_029/test_029.py
+++ b/backend/tests/unit/core/migrations/graph/test_029/test_029.py
@@ -13,7 +13,7 @@ from tests.helpers.db_validation import verify_no_duplicate_paths
 
 class TestMigration029:
     @pytest.fixture(scope="class", autouse=True)
-    async def load_bad_data(self, db: InfrahubDatabase):
+    async def load_bad_data(self, db: InfrahubDatabase) -> None:
         await delete_all_nodes(db=db)
         export_dir = Path(__file__).parent / ("data_export")
         await load_export(db=db, export_dir=export_dir)
@@ -41,7 +41,7 @@ CALL () {
         await db.execute_query(query=query)
 
     @pytest.mark.skip("Flaky, migration is already released")
-    async def test_migration_029(self, db: InfrahubDatabase):
+    async def test_migration_029(self, db: InfrahubDatabase) -> None:
         snapshotter = DbSnapshotterDeduplicated(db=db)
         before_snapshot = await snapshotter.snapshot()
 

--- a/backend/tests/unit/core/migrations/graph/test_030.py
+++ b/backend/tests/unit/core/migrations/graph/test_030.py
@@ -50,7 +50,7 @@ async def test_migration_030(
     db: InfrahubDatabase,
     person_tag_schema,
     default_branch,
-):
+) -> None:
     create_before_branch = await Node.init(db=db, schema="BuiltinTag")
     await create_before_branch.new(db=db, name="create-before-branch")
     await create_before_branch.save(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_032.py
+++ b/backend/tests/unit/core/migrations/graph/test_032.py
@@ -9,7 +9,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import NodeNotFoundError
 
 
-async def test_migration_032(db: InfrahubDatabase, default_branch: Branch, person_tag_schema):
+async def test_migration_032(db: InfrahubDatabase, default_branch: Branch, person_tag_schema) -> None:
     # Step 1: Create a couple of branches
     branch1 = await create_branch(db=db, branch_name="test-branch-1")
     branch2 = await create_branch(db=db, branch_name="test-branch-2")

--- a/backend/tests/unit/core/migrations/graph/test_033.py
+++ b/backend/tests/unit/core/migrations/graph/test_033.py
@@ -203,7 +203,7 @@ class TestMigration033:
         db: InfrahubDatabase,
         legal_relationship_dicts: list[dict[str, str | int]],
         illegal_relationship_dicts: list[dict[str, str | int]],
-    ):
+    ) -> None:
         await delete_all_nodes(db=db)
         root_and_branch_query = """
 MERGE (root:Root {default_branch: "main"})
@@ -335,7 +335,7 @@ CREATE (rel_node_two)-[:IS_RELATED {status: "active", branch: rel.branch, branch
             params={"relationships": legal_relationship_dicts + illegal_relationship_dicts},
         )
 
-    async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts):
+    async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts) -> None:
         # Run the migration
         migration = Migration033()
         execution_result = await migration.execute(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_034.py
+++ b/backend/tests/unit/core/migrations/graph/test_034.py
@@ -8,7 +8,9 @@ from tests.helpers.test_app import TestInfrahubApp
 
 
 class TestMigration034(TestInfrahubApp):
-    async def test_migration_034(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics):
+    async def test_migration_034(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics
+    ) -> None:
         main_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.load_schema_to_db(db=db, branch=default_branch, schema=main_schema_branch)
         main_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)

--- a/backend/tests/unit/core/migrations/graph/test_041.py
+++ b/backend/tests/unit/core/migrations/graph/test_041.py
@@ -89,7 +89,7 @@ class TestMigration041(TestInfrahubApp):
         return await create_branch(db=db, branch_name="deleted_profile_branch")
 
     @pytest.fixture
-    async def profile_2_deleted(self, db: InfrahubDatabase, deleted_profile_branch: Branch, profile_2: Node):
+    async def profile_2_deleted(self, db: InfrahubDatabase, deleted_profile_branch: Branch, profile_2: Node) -> None:
         profile = await NodeManager.get_one(db=db, branch=deleted_profile_branch, id=profile_2.id)
         await profile.delete(db=db)
 
@@ -98,7 +98,9 @@ class TestMigration041(TestInfrahubApp):
         return await create_branch(db=db, branch_name="deleted_node_branch")
 
     @pytest.fixture
-    async def criticality_low_deleted(self, db: InfrahubDatabase, deleted_node_branch: Branch, criticality_low: Node):
+    async def criticality_low_deleted(
+        self, db: InfrahubDatabase, deleted_node_branch: Branch, criticality_low: Node
+    ) -> None:
         profile = await NodeManager.get_one(db=db, branch=deleted_node_branch, id=criticality_low.id)
         await profile.delete(db=db)
 
@@ -112,7 +114,7 @@ class TestMigration041(TestInfrahubApp):
         criticality_high: Node,
         profile_1: Node,
         profile_2: Node,
-    ):
+    ) -> None:
         crit_low = await NodeManager.get_one(db=db, id=criticality_low.id)
         await crit_low.profiles.update(db=db, data=[profile_1])
         await crit_low.save(db=db)
@@ -134,7 +136,7 @@ class TestMigration041(TestInfrahubApp):
         profile_2_deleted: Node,
         deleted_node_branch: Branch,
         criticality_low_deleted: Node,
-    ):
+    ) -> None:
         pass
 
     def validate_node(
@@ -142,7 +144,7 @@ class TestMigration041(TestInfrahubApp):
         original_node: Node,
         updated_node: Node,
         expected_profile_attrs: list[AttributeProfileDetails],
-    ):
+    ) -> None:
         expected_profile_attrs_by_name = {attr.attribute_name: attr for attr in expected_profile_attrs}
         for attribute_name in updated_node._attributes:
             current_attribute = getattr(updated_node, attribute_name)
@@ -173,7 +175,7 @@ class TestMigration041(TestInfrahubApp):
         priority_branch: Branch,
         deleted_profile_branch: Branch,
         deleted_node_branch: Branch,
-    ):
+    ) -> None:
         migration = WrappedMigration041()
         execution_result = await migration.execute(db=db)
         assert not execution_result.errors

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -17,7 +17,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_query_default_branch(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, car_profile1_main
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     prev_car_schema = schema.get(name="TestCar")
     prev_attr = prev_car_schema.get_attribute(name="color")
@@ -56,7 +56,7 @@ async def test_query_default_branch(
 
 async def test_query_branch1(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, car_profile1_main
-):
+) -> None:
     branch1 = await create_branch(db=db, branch_name="branch1", isolated=True)
 
     schema = registry.schema.get_schema_branch(name=branch1.name)
@@ -97,7 +97,7 @@ async def test_query_branch1(
 
 async def test_migration(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, car_profile1_main
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     prev_car_schema = schema.get(name="TestCar")
     prev_attr = prev_car_schema.get_attribute(name="color")

--- a/backend/tests/unit/core/migrations/schema/test_models.py
+++ b/backend/tests/unit/core/migrations/schema/test_models.py
@@ -8,7 +8,7 @@ from infrahub.database import InfrahubDatabase
 
 def test_SchemaApplyMigrationData_serializer(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, car_person_schema
-):
+) -> None:
     schema_main = registry.schema.get_schema_branch(name=default_branch.name)
 
     data = SchemaApplyMigrationData(

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -36,7 +36,7 @@ async def schema_aware():
 
 
 @pytest.fixture
-async def init_database(db: InfrahubDatabase):
+async def init_database(db: InfrahubDatabase) -> None:
     params = {
         "nodes": [],
         "rel_props": {"branch": "main", "branch_level": "1", "status": "active", "from": Timestamp().to_string()},
@@ -62,7 +62,7 @@ async def init_database(db: InfrahubDatabase):
     await db.execute_query(query=query_init_root, params=params)
 
 
-async def test_query01(db: InfrahubDatabase, default_branch, init_database, schema_aware):
+async def test_query01(db: InfrahubDatabase, default_branch, init_database, schema_aware) -> None:
     node = schema_aware
 
     assert await count_nodes(db=db, label="TestCar") == 5
@@ -137,7 +137,7 @@ async def test_query01_re_add(db: InfrahubDatabase, default_branch: Branch, car_
     assert await count_nodes(db=db, label="Attribute") == 24
 
 
-async def test_migration(db: InfrahubDatabase, default_branch, init_database, schema_aware):
+async def test_migration(db: InfrahubDatabase, default_branch, init_database, schema_aware) -> None:
     node = schema_aware
     migration = NodeAttributeAddMigration(
         new_node_schema=node,

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -14,7 +14,9 @@ from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
@@ -47,7 +49,7 @@ async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch
 
 async def test_query_default_branch_generic_with_override(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics_unregistered: dict[str, Any]
-):
+) -> None:
     for node_schema_dict in car_person_schema_generics_unregistered["nodes"]:
         if node_schema_dict["name"] == "ElectricCar":
             node_schema_dict["attributes"].append(
@@ -98,7 +100,7 @@ async def test_query_default_branch_generic_with_override(
     assert await count_relationships(db=db) == count_rels + 4
 
 
-async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -15,7 +15,9 @@ from tests.helpers.db_validation import validate_node_relationships, verify_no_d
 from tests.helpers.schema import LOCATION_SCHEMA, load_schema
 
 
-async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
@@ -58,7 +60,7 @@ async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch
 
 async def test_migration_aware_relationship(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
@@ -92,7 +94,7 @@ async def test_migration_aware_relationship(
 
 async def test_migration_agnostic_relationship(
     db: InfrahubDatabase, default_branch: Branch, car_person_branch_agnostic_schema
-):
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(**car_person_branch_agnostic_schema))
 
     person_john = await Node.init(db=db, schema="TestPerson")
@@ -131,7 +133,7 @@ async def test_migration_agnostic_relationship(
     await validate_node_relationships(node=car, db=db, branch=registry.get_global_branch())
 
 
-async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch):
+async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch) -> None:
     await load_schema(db=db, schema=LOCATION_SCHEMA)
 
     continent_europe = await Node.init(db=db, schema=TestKind.CONTINENT)
@@ -185,7 +187,7 @@ async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch)
 
 async def test_inheritance_migration_on_branch_and_main(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_alfred_main: Node
-):
+) -> None:
     # 0. add a deleted relationship
     accord_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
     await accord_main.owner.update(db=db, data=person_alfred_main.id)

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -15,7 +15,9 @@ from tests.helpers.schema import load_schema
 from tests.unit.core.migrations.schema.test_node_kind_update import validate_node_relationships
 
 
-async def test_query_out_default_branch(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_out_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     candidate_schema.delete(name="TestCar")
@@ -47,7 +49,9 @@ async def test_query_out_default_branch(db: InfrahubDatabase, default_branch: Br
     assert await count_nodes(db=db, label="TestCar") == 2
 
 
-async def test_query_in_default_branch(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_query_in_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main
+) -> None:
     """This test is a bit silly for now because there is nothing to migrate but it least we validate that the generated query is valid"""
 
     schema = registry.schema.get_schema_branch(name=default_branch.name)
@@ -80,7 +84,7 @@ async def test_query_in_default_branch(db: InfrahubDatabase, default_branch: Bra
     assert await count_nodes(db=db, label="TestCar") == 2
 
 
-async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     candidate_schema.delete(name="TestCar")
@@ -107,7 +111,7 @@ async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car
 
 async def test_migration_agnostic_relationship(
     db: InfrahubDatabase, default_branch: Branch, car_person_branch_agnostic_schema
-):
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(**car_person_branch_agnostic_schema))
 
     person_john = await Node.init(db=db, schema="TestPerson")

--- a/backend/tests/unit/core/node/test_node_field_name_update.py
+++ b/backend/tests/unit/core/node/test_node_field_name_update.py
@@ -23,7 +23,7 @@ class TestNodeUpdate:
             name="Shname",
         )
 
-    def test_no_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+    def test_no_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema) -> None:
         original_node_schema.update(other=new_node_schema)
 
         assert original_node_schema.uniqueness_constraints is None
@@ -31,7 +31,7 @@ class TestNodeUpdate:
         assert original_node_schema.display_labels is None
         assert original_node_schema.order_by is None
 
-    def test_new_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+    def test_new_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema) -> None:
         new_node_schema.uniqueness_constraints = [["abc__value"]]
         new_node_schema.human_friendly_id = ["abc__value"]
         new_node_schema.display_labels = ["abc__value"]
@@ -44,7 +44,7 @@ class TestNodeUpdate:
         assert original_node_schema.display_labels == new_node_schema.display_labels
         assert original_node_schema.order_by == new_node_schema.order_by
 
-    def test_old_fields_no_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+    def test_old_fields_no_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema) -> None:
         original_node_schema.attributes = [AttributeSchema(name="abc", kind="Text")]
         uniqueness_constraints = [["abc__value"]]
         human_friendly_id = ["abc__value"]
@@ -74,7 +74,7 @@ class TestNodeUpdate:
         human_friendly_id,
         display_labels,
         order_by,
-    ):
+    ) -> None:
         original_node_schema.attributes = [AttributeSchema(name="abc", kind="Text")]
         original_node_schema.relationships = [RelationshipSchema(name="xyz", peer="TestingXyz")]
         original_node_schema.uniqueness_constraints = [["abc__value"]]
@@ -101,7 +101,7 @@ class TestNodeUpdate:
         self,
         original_node_schema: BaseNodeSchema,
         new_node_schema: BaseNodeSchema,
-    ):
+    ) -> None:
         attribute_id = str(uuid4())
         relationship_id = str(uuid4())
         original_node_schema.attributes = [AttributeSchema(id=attribute_id, name="abc", kind="Text")]
@@ -128,7 +128,7 @@ class TestNodeUpdate:
         self,
         original_node_schema: BaseNodeSchema,
         new_node_schema: BaseNodeSchema,
-    ):
+    ) -> None:
         attribute_id = str(uuid4())
         relationship_id = str(uuid4())
         original_node_schema.attributes = [AttributeSchema(id=attribute_id, name="abc", kind="Text")]

--- a/backend/tests/unit/core/profiles/test_node_applier.py
+++ b/backend/tests/unit/core/profiles/test_node_applier.py
@@ -44,7 +44,7 @@ async def test_get_many_with_profile(
     criticality_low: Node,
     criticality_medium: Node,
     branch: Branch,
-):
+) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=branch)
     crit_profile_1 = await Node.init(db=db, branch=branch, schema=profile_schema)
     await crit_profile_1.new(db=db, profile_name="crit_profile_1", color="green", profile_priority=1001)
@@ -102,7 +102,7 @@ async def test_get_many_with_profile_generic(
     criticality_low: Node,
     criticality_medium: Node,
     branch: Branch,
-):
+) -> None:
     generic_profile_schema = registry.schema.get("ProfileTestGenericCriticality", branch=branch)
     generic_profile = await Node.init(db=db, branch=branch, schema=generic_profile_schema)
     await generic_profile.new(
@@ -167,7 +167,7 @@ async def test_get_many_with_multiple_profiles_same_priority(
     criticality_low: Node,
     criticality_medium: Node,
     branch: Branch,
-):
+) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=branch)
     crit_profiles = []
     for i in range(1, 10):

--- a/backend/tests/unit/core/resource_manager/test_ipaddress_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_ipaddress_pool.py
@@ -16,7 +16,7 @@ async def test_get_next(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net145 = ip_dataset_prefix_v4["net145"]
 
@@ -48,7 +48,7 @@ async def test_get_next_weighted(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net144 = ip_dataset_prefix_v4["net144"]
     net145 = ip_dataset_prefix_v4["net145"]
@@ -88,7 +88,7 @@ async def test_get_next_full(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net147 = ip_dataset_prefix_v4["net147"]
 

--- a/backend/tests/unit/core/resource_manager/test_number_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool.py
@@ -13,7 +13,9 @@ from infrahub.graphql.queries.resource_manager import resolve_number_pool_utiliz
 from tests.helpers.schema import TICKET, load_schema
 
 
-async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_allocate_from_number_pool(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     await initialize_registry(db=db)
 
@@ -43,7 +45,7 @@ async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: B
     assert await np1.get_used(db=db, branch=default_branch) == [1, 2]
 
 
-async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
     """
     Allocates:
     - 1 ticket in first number pool
@@ -121,7 +123,7 @@ async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch
 
 async def test_allocate_from_number_pool_for_generic(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
-):
+) -> None:
     ticket = GenericSchema(
         name="Ticket",
         namespace="Testing",
@@ -180,7 +182,7 @@ async def test_allocate_from_number_pool_for_generic(
 
 async def test_allocate_from_number_pool_with_excluded_values(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
-):
+) -> None:
     speeding_ticket = NodeSchema(
         name="SpeedingTicket",
         namespace="Testing",

--- a/backend/tests/unit/core/resource_manager/test_prefix_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_prefix_pool.py
@@ -16,7 +16,7 @@ async def test_get_next(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
     net141 = ip_dataset_prefix_v4["net141"]
@@ -49,7 +49,7 @@ async def test_get_next_weighted(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
     net141 = ip_dataset_prefix_v4["net141"]
@@ -87,7 +87,7 @@ async def test_get_one(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
     net141 = ip_dataset_prefix_v4["net141"]
@@ -133,7 +133,7 @@ async def test_get_all_resources(
     default_ipnamespace: Node,
     register_ipam_schema: SchemaBranch,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
     net141 = ip_dataset_prefix_v4["net141"]

--- a/backend/tests/unit/core/schema/schema_branch/test_number_attribute_default_value.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_number_attribute_default_value.py
@@ -13,7 +13,7 @@ class TestNumberAttrForbidsBool(TestInfrahubApp):
         db: InfrahubDatabase,
         default_branch,
         client,
-    ):
+    ) -> None:
         schema = {
             "version": "1.0",
             "nodes": [

--- a/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
@@ -81,7 +81,7 @@ _SCHEMA = {
         (["owner__name__value", "owner__age__value", "driver__name__value"], [["name__value", "age__value"]], True),
     ],
 )
-async def test_schema_constraints(human_friendly_id, uniqueness_constraints, should_raise):
+async def test_schema_constraints(human_friendly_id, uniqueness_constraints, should_raise) -> None:
     schema_root = SchemaRoot(**_SCHEMA)
 
     person_schema = schema_root.get(name="TestPerson")

--- a/backend/tests/unit/core/schema/schema_branch/test_schema_uniqueness_constraints.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_schema_uniqueness_constraints.py
@@ -63,7 +63,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
         ),
     ],
 )
-async def test_schema_protected_generics(schema_root: SchemaRoot, expected_error: str):
+async def test_schema_protected_generics(schema_root: SchemaRoot, expected_error: str) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=schema_root)
 

--- a/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
@@ -365,7 +365,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
         ),
     ],
 )
-async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, expected_error: str):
+async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, expected_error: str) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=schema_root)
 

--- a/backend/tests/unit/core/schema/test_check_dup_schema_fields_cmd.py
+++ b/backend/tests/unit/core/schema/test_check_dup_schema_fields_cmd.py
@@ -12,7 +12,7 @@ from infrahub.database import InfrahubDatabase
 
 async def merge_nodes(
     db: InfrahubDatabase, node_uuids: list[str], source_branch_name: str, target_branch_name: str, at: Timestamp
-):
+) -> None:
     """
     Do a simplified graph merge of any active edges for particular Nodes on a source branch into a target branch.
     """
@@ -162,7 +162,7 @@ class TestCheckDuplicateSchemaFields:
         load_main_schema: dict[str, Node],
         load_broken_schema: dict[str, Node],
         branch: Branch,
-    ):
+    ) -> None:
         node_schema_id = load_main_schema["node_schema"].id
         attr_schema_1_main_id = load_main_schema["attribute_schema_1"].id
         attr_schema_2_branch_id = load_broken_schema["attribute_schema_2_branch"].id

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -46,7 +46,7 @@ from tests.helpers.schema.device import LAG_INTERFACE
 from .conftest import _get_schema_by_kind
 
 
-async def test_schema_branch_set():
+async def test_schema_branch_set() -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Builtin",
@@ -68,7 +68,7 @@ async def test_schema_branch_set():
     assert len(schema_branch._cache) == 1
 
 
-async def test_schema_branch_get(default_branch: Branch):
+async def test_schema_branch_get(default_branch: Branch) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Builtin",
@@ -89,7 +89,7 @@ async def test_schema_branch_get(default_branch: Branch):
     assert schema11 == schema
 
 
-async def test_schema_branch_load_schema_initial(schema_all_in_one):
+async def test_schema_branch_load_schema_initial(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -97,7 +97,7 @@ async def test_schema_branch_load_schema_initial(schema_all_in_one):
     assert isinstance(schema.get(name="InfraGenericInterface"), GenericSchema)
 
 
-async def test_schema_branch_process_inheritance(schema_all_in_one):
+async def test_schema_branch_process_inheritance(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -129,7 +129,7 @@ async def test_schema_branch_process_inheritance(schema_all_in_one):
     }
 
 
-async def test_schema_process_inheritance_different_generic_attribute_types(schema_diff_attr_inheritance_types):
+async def test_schema_process_inheritance_different_generic_attribute_types(schema_diff_attr_inheritance_types) -> None:
     """Test that we raise an exception if a node is inheriting from two generics with different attribute types for a specific attribute."""
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_diff_attr_inheritance_types))
@@ -140,7 +140,9 @@ async def test_schema_process_inheritance_different_generic_attribute_types(sche
     assert exc.value.args[0] == 'TestWidget.choice inherited from TestStatus must be the same kind ["Number", "Text"]'
 
 
-async def test_schema_process_inheritance_different_generic_attribute_types_on_node(schema_diff_attr_inheritance_types):
+async def test_schema_process_inheritance_different_generic_attribute_types_on_node(
+    schema_diff_attr_inheritance_types,
+) -> None:
     """Test that we raise an exception if a node is inheriting an attribute with different attribute type that already exists on node."""
     schema = SchemaBranch(cache={}, name="test")
     schema_new = copy.deepcopy(schema_diff_attr_inheritance_types)
@@ -155,7 +157,7 @@ async def test_schema_process_inheritance_different_generic_attribute_types_on_n
     assert exc.value.args[0] == 'TestWidget.choice inherited from TestAdapter must be the same kind ["Text", "List"]'
 
 
-async def test_schema_branch_process_inheritance_node_level(animal_person_schema_dict):
+async def test_schema_branch_process_inheritance_node_level(animal_person_schema_dict) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**animal_person_schema_dict))
 
@@ -178,7 +180,7 @@ async def test_schema_branch_process_inheritance_node_level(animal_person_schema
     assert dog.icon == animal.icon
 
 
-async def test_schema_branch_process_inheritance_update_inherited_elements(animal_person_schema_dict):
+async def test_schema_branch_process_inheritance_update_inherited_elements(animal_person_schema_dict) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**animal_person_schema_dict))
 
@@ -216,7 +218,7 @@ async def test_validate_human_friendly_id_assign_uniquess_constraints(
     unique_attributes: list[str],
     human_friendly_id: list[str] | None,
     animal_person_schema_dict,
-):
+) -> None:
     schema = SchemaBranch(cache={}, name="test")
     animal_schema = animal_person_schema_dict["generics"][0]
     assert animal_schema["name"] == "Animal" and animal_schema["namespace"] == "Test"
@@ -261,7 +263,7 @@ async def test_validate_human_friendly_id_uniqueness_success(
     unique_attributes: list[str],
     human_friendly_id: list[str] | None,
     animal_person_schema_dict,
-):
+) -> None:
     schema = SchemaBranch(cache={}, name="test")
     for node_schema in animal_person_schema_dict["generics"]:
         if node_schema["name"] == "Animal" and node_schema["namespace"] == "Test":
@@ -289,7 +291,7 @@ async def test_validate_human_friendly_id_uniqueness_success(
         schema.validate_human_friendly_id()
 
 
-async def test_schema_branch_process_human_friendly_id(animal_person_schema_dict):
+async def test_schema_branch_process_human_friendly_id(animal_person_schema_dict) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**animal_person_schema_dict))
 
@@ -307,7 +309,7 @@ async def test_schema_branch_process_human_friendly_id(animal_person_schema_dict
     assert dog.uniqueness_constraints == [["owner", "name__value"]]
 
 
-async def test_schema_branch_infer_human_friendly_id_from_uniqueness_constraints(animal_person_schema_dict):
+async def test_schema_branch_infer_human_friendly_id_from_uniqueness_constraints(animal_person_schema_dict) -> None:
     for node_schema_dict in animal_person_schema_dict["nodes"]:
         if node_schema_dict["name"] == "Dog" and node_schema_dict["namespace"] == "Test":
             node_schema_dict["uniqueness_constraints"] = [["name__value"]]
@@ -345,7 +347,7 @@ async def test_schema_branch_infer_human_friendly_id_from_uniqueness_constraints
     assert person.uniqueness_constraints == [["name__value"], ["name__value", "other_name__value"]]
 
 
-async def test_schema_branch_process_branch_support(schema_all_in_one):
+async def test_schema_branch_process_branch_support(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -365,7 +367,7 @@ async def test_schema_branch_process_branch_support(schema_all_in_one):
     assert criticality.get_attribute(name="description").branch == BranchSupportType.AGNOSTIC
 
 
-async def test_schema_branch_process_default_values(schema_all_in_one):
+async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -379,7 +381,7 @@ async def test_schema_branch_process_default_values(schema_all_in_one):
     assert criticality.get_attribute(name="color").optional is True
 
 
-async def test_schema_branch_add_groups(schema_all_in_one):
+async def test_schema_branch_add_groups(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -395,7 +397,7 @@ async def test_schema_branch_add_groups(schema_all_in_one):
     assert std_group.get_relationship_or_none(name="subscriber_of_groups") is None
 
 
-async def test_schema_branch_cleanup_inherited_elements(schema_all_in_one):
+async def test_schema_branch_cleanup_inherited_elements(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -549,7 +551,7 @@ async def test_schema_branch_cleanup_inherited_elements(schema_all_in_one):
         ),
     ],
 )
-async def test_schema_protected_generics(schema_dict, expected_error):
+async def test_schema_protected_generics(schema_dict, expected_error) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_dict))
 
@@ -559,7 +561,7 @@ async def test_schema_protected_generics(schema_dict, expected_error):
     assert str(exc.value) == expected_error
 
 
-async def test_schema_branch_generate_weight(schema_all_in_one):
+async def test_schema_branch_generate_weight(schema_all_in_one) -> None:
     def extract_weights(schema: SchemaBranch):
         weights = []
         for node in schema.get_all().values():
@@ -605,7 +607,7 @@ async def test_schema_branch_generate_weight(schema_all_in_one):
     assert len(in_second) == 1 and in_second[0].startswith(new_attr2_partial_id)
 
 
-def test_schema_branch_processes_generic_template_schema_weight(register_core_models_schema):
+def test_schema_branch_processes_generic_template_schema_weight(register_core_models_schema) -> None:
     schema = {
         "generics": [
             {
@@ -705,7 +707,7 @@ def test_schema_branch_processes_generic_template_schema_weight(register_core_mo
     )
 
 
-async def test_schema_branch_add_profile_schema(schema_all_in_one):
+async def test_schema_branch_add_profile_schema(schema_all_in_one) -> None:
     core_profile_schema = _get_schema_by_kind(core_models, kind=InfrahubKind.PROFILE)
     schema_all_in_one["generics"].append(core_profile_schema)
 
@@ -747,7 +749,7 @@ async def test_schema_branch_add_profile_schema(schema_all_in_one):
     }
 
 
-async def test_schema_branch_diff_core_profile(schema_all_in_one):
+async def test_schema_branch_diff_core_profile(schema_all_in_one) -> None:
     core_profile_schema = _get_schema_by_kind(core_models, kind=InfrahubKind.PROFILE)
     schema_all_in_one["generics"].append(core_profile_schema)
 
@@ -765,7 +767,7 @@ async def test_schema_branch_diff_core_profile(schema_all_in_one):
     assert diff.all == ["CoreProfile"]
 
 
-async def test_schema_branch_add_profile_schema_respects_flag(schema_all_in_one):
+async def test_schema_branch_add_profile_schema_respects_flag(schema_all_in_one) -> None:
     core_profile_schema = _get_schema_by_kind(core_models, kind=InfrahubKind.PROFILE)
     schema_all_in_one["generics"].append(core_profile_schema)
     builtin_tag_schema = _get_schema_by_kind(schema_all_in_one, kind="BuiltinTag")
@@ -791,7 +793,7 @@ async def test_schema_branch_add_profile_schema_respects_flag(schema_all_in_one)
     }
 
 
-async def test_schema_branch_generate_identifiers(schema_all_in_one):
+async def test_schema_branch_generate_identifiers(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
 
@@ -801,7 +803,7 @@ async def test_schema_branch_generate_identifiers(schema_all_in_one):
     assert generic.relationships[1].identifier == "builtinstatus__infragenericinterface"
 
 
-async def test_schema_branch_validate_names():
+async def test_schema_branch_validate_names() -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -844,7 +846,7 @@ async def test_schema_branch_validate_names():
     assert str(exc.value) == "TestCriticality: Names of attributes and relationships must be unique : ['dupname']"
 
 
-async def test_schema_branch_validate_identifiers():
+async def test_schema_branch_validate_identifiers() -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -890,7 +892,7 @@ async def test_schema_branch_validate_identifiers():
     schema.validate_identifiers()
 
 
-async def test_schema_branch_validate_identifiers_direction():
+async def test_schema_branch_validate_identifiers_direction() -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -936,7 +938,7 @@ async def test_schema_branch_validate_identifiers_direction():
     )
 
 
-async def test_schema_branch_validate_identifiers_matching_direction():
+async def test_schema_branch_validate_identifiers_matching_direction() -> None:
     SCHEMA = {
         "nodes": [
             {
@@ -1050,7 +1052,7 @@ async def test_schema_branch_validate_identifiers_matching_direction():
     )
 
 
-async def test_schema_branch_validate_kinds_peer():
+async def test_schema_branch_validate_kinds_peer() -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -1073,7 +1075,7 @@ async def test_schema_branch_validate_kinds_peer():
     assert str(exc.value) == "TestCriticality: Relationship 'first' is referring an invalid peer 'TestNotPresent'"
 
 
-async def test_schema_branch_validate_kinds_common_relatives():
+async def test_schema_branch_validate_kinds_common_relatives() -> None:
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
     lag_interface_schema.relationships[0].common_parent = None
@@ -1092,7 +1094,7 @@ async def test_schema_branch_validate_kinds_common_relatives():
     )
 
 
-async def test_schema_branch_validate_common_parent():
+async def test_schema_branch_validate_common_parent() -> None:
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
     lag_interface_schema.relationships[0].common_parent = "device"
@@ -1104,7 +1106,7 @@ async def test_schema_branch_validate_common_parent():
     schema.validate_kinds()
 
 
-async def test_schema_branch_validate_common_parent_without_valid_parent():
+async def test_schema_branch_validate_common_parent_without_valid_parent() -> None:
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
     lag_interface_schema.relationships[0].common_parent = "device"
@@ -1123,7 +1125,7 @@ async def test_schema_branch_validate_common_parent_without_valid_parent():
     )
 
 
-async def test_schema_branch_validate_common_parent_invalid_relationship_name():
+async def test_schema_branch_validate_common_parent_invalid_relationship_name() -> None:
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
     lag_interface_schema.relationships[0].common_parent = "foo"
@@ -1141,7 +1143,7 @@ async def test_schema_branch_validate_common_parent_invalid_relationship_name():
     )
 
 
-async def test_schema_branch_validate_common_parent_invalid_relationship_kind():
+async def test_schema_branch_validate_common_parent_invalid_relationship_kind() -> None:
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
     lag_interface_schema.relationships[0].common_parent = "device"
@@ -1162,7 +1164,7 @@ async def test_schema_branch_validate_common_parent_invalid_relationship_kind():
     )
 
 
-async def test_schema_branch_validate_kinds_inherit():
+async def test_schema_branch_validate_kinds_inherit() -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -1215,7 +1217,7 @@ async def test_schema_branch_validate_kinds_inherit():
     )
 
 
-async def test_schema_branch_validate_kinds_core(register_core_models_schema: SchemaBranch):
+async def test_schema_branch_validate_kinds_core(register_core_models_schema: SchemaBranch) -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -1241,7 +1243,7 @@ async def test_schema_branch_validate_kinds_core(register_core_models_schema: Sc
         [["my_generic_name__value", "primary_tag"]],
     ],
 )
-async def test_validate_uniqueness_constraints_success(schema_all_in_one, uniqueness_constraints):
+async def test_validate_uniqueness_constraints_success(schema_all_in_one, uniqueness_constraints) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["uniqueness_constraints"] = uniqueness_constraints
 
@@ -1272,7 +1274,7 @@ async def test_synchronize_uniqueness_constraints_and_attributes(
     expected_constraints: list[list[str]] | None,
     expected_unique_attributes: list[str],
     animal_person_schema_dict,
-):
+) -> None:
     schema = SchemaBranch(cache={}, name="test")
     for node_schema in animal_person_schema_dict["generics"]:
         if node_schema["name"] == "Animal" and node_schema["namespace"] == "Test":
@@ -1296,7 +1298,7 @@ async def test_synchronize_uniqueness_constraints_and_attributes(
 
 async def test_validate_exception_ipam_ip_namespace(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
-):
+) -> None:
     SCHEMA: dict = {
         "nodes": [
             {
@@ -1375,7 +1377,7 @@ async def test_validate_exception_ipam_ip_namespace(
         ),
     ],
 )
-async def test_validate_uniqueness_constraints_error(schema_all_in_one, uniqueness_constraints, expected_error):
+async def test_validate_uniqueness_constraints_error(schema_all_in_one, uniqueness_constraints, expected_error) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["uniqueness_constraints"] = uniqueness_constraints
 
@@ -1387,7 +1389,7 @@ async def test_validate_uniqueness_constraints_error(schema_all_in_one, uniquene
 
 
 @pytest.mark.parametrize("display_labels", [["my_generic_name__value", "mybool__value"], ["my_generic_name__value"]])
-async def test_validate_display_labels_success(schema_all_in_one, display_labels):
+async def test_validate_display_labels_success(schema_all_in_one, display_labels) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["display_labels"] = display_labels
 
@@ -1400,7 +1402,7 @@ async def test_validate_display_labels_success(schema_all_in_one, display_labels
 @pytest.mark.parametrize(
     "display_label", ["{{ my_generic_name__value }} {{ mybool__value }}", "my_generic_name__value"]
 )
-async def test_validate_display_label_success(schema_all_in_one, display_label: str):
+async def test_validate_display_label_success(schema_all_in_one, display_label: str) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["display_label"] = display_label
 
@@ -1434,7 +1436,7 @@ async def test_validate_display_label_success(schema_all_in_one, display_label: 
         ),
     ],
 )
-async def test_validate_display_labels_error(schema_all_in_one, display_labels, expected_error):
+async def test_validate_display_labels_error(schema_all_in_one, display_labels, expected_error) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["display_labels"] = display_labels
 
@@ -1476,7 +1478,7 @@ async def test_validate_display_labels_error(schema_all_in_one, display_labels, 
         ),
     ],
 )
-async def test_validate_display_label_error(schema_all_in_one, display_label: str, expected_error: str):
+async def test_validate_display_label_error(schema_all_in_one, display_label: str, expected_error: str) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["display_label"] = display_label
 
@@ -1496,7 +1498,7 @@ async def test_validate_display_label_error(schema_all_in_one, display_label: st
         ["status__name__value", "mybool__value"],
     ],
 )
-async def test_validate_order_by_success(schema_all_in_one, order_by):
+async def test_validate_order_by_success(schema_all_in_one, order_by) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["order_by"] = order_by
 
@@ -1531,7 +1533,7 @@ async def test_validate_order_by_success(schema_all_in_one, order_by):
         ),
     ],
 )
-async def test_validate_order_by_error(schema_all_in_one, order_by, expected_error):
+async def test_validate_order_by_error(schema_all_in_one, order_by, expected_error) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["order_by"] = order_by
 
@@ -1546,7 +1548,7 @@ async def test_validate_order_by_error(schema_all_in_one, order_by, expected_err
     "default_filter",
     ["my_generic_name__value"],
 )
-async def test_validate_default_filter_success(schema_all_in_one, default_filter):
+async def test_validate_default_filter_success(schema_all_in_one, default_filter) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["default_filter"] = default_filter
 
@@ -1583,7 +1585,7 @@ async def test_validate_default_filter_success(schema_all_in_one, default_filter
         ),
     ],
 )
-async def test_validate_default_filter_error(schema_all_in_one, default_filter, expected_error):
+async def test_validate_default_filter_error(schema_all_in_one, default_filter, expected_error) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     schema_dict["default_filter"] = default_filter
 
@@ -1601,7 +1603,7 @@ async def test_validate_default_filter_error(schema_all_in_one, default_filter, 
         {"name": "something", "kind": "Text", "optional": True, "default_value": "abcdef"},
     ],
 )
-async def test_validate_default_value_success(schema_all_in_one, default_value_attr):
+async def test_validate_default_value_success(schema_all_in_one, default_value_attr) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
     schema_dict["attributes"].append(default_value_attr)
 
@@ -1628,7 +1630,7 @@ async def test_validate_default_value_success(schema_all_in_one, default_value_a
         ),
     ],
 )
-async def test_validate_default_value_error(schema_all_in_one, default_value_attr, expected_error):
+async def test_validate_default_value_error(schema_all_in_one, default_value_attr, expected_error) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
     schema_dict["attributes"].append(default_value_attr)
 
@@ -1641,7 +1643,7 @@ async def test_validate_default_value_error(schema_all_in_one, default_value_att
 
 async def test_schema_branch_load_schema_extension(
     db: InfrahubDatabase, default_branch, builtin_schema, helper: TestHelper
-):
+) -> None:
     schema = SchemaRoot(**core_models)
 
     schema_branch = SchemaBranch(cache={}, name="test")
@@ -1667,7 +1669,7 @@ async def test_schema_branch_load_schema_extension(
     assert schema_branch.get(name="InfraDevice")
 
 
-async def test_schema_branch_validate_count_against_cardinality_valid(organization_schema):
+async def test_schema_branch_validate_count_against_cardinality_valid(organization_schema) -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -1717,7 +1719,7 @@ async def test_schema_branch_validate_count_against_cardinality_valid(organizati
         {"name": "third", "peer": "CoreOrganization", "cardinality": "many", "min_count": 0, "max_count": 1},
     ),
 )
-async def test_schema_branch_validate_count_against_cardinality_invalid(relationship, organization_schema):
+async def test_schema_branch_validate_count_against_cardinality_invalid(relationship, organization_schema) -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -1744,7 +1746,7 @@ async def test_schema_branch_validate_count_against_cardinality_invalid(relation
         schema_branch.validate_count_against_cardinality()
 
 
-async def test_schema_branch_from_dict_schema_object():
+async def test_schema_branch_from_dict_schema_object() -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
 
     # Load the core models and a model with a computed_attribute
@@ -1764,7 +1766,7 @@ async def test_schema_branch_from_dict_schema_object():
     )
 
 
-async def test_process_relationships_on_delete_defaults_set(schema_all_in_one):
+async def test_process_relationships_on_delete_defaults_set(schema_all_in_one) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "BuiltinCriticality")
     schema_dict["relationships"][0]["kind"] = "Component"
     schema = SchemaBranch(cache={}, name="test")
@@ -1781,7 +1783,7 @@ async def test_process_relationships_on_delete_defaults_set(schema_all_in_one):
                 assert relationship.on_delete == RelationshipDeleteBehavior.NO_ACTION
 
 
-async def test_process_relationships_component_can_be_overridden(schema_all_in_one):
+async def test_process_relationships_component_can_be_overridden(schema_all_in_one) -> None:
     schema_dict = _get_schema_by_kind(schema_all_in_one, "BuiltinCriticality")
     schema_dict["relationships"][0]["kind"] = "Component"
     schema_dict["relationships"][0]["on_delete"] = "no-action"
@@ -1795,7 +1797,7 @@ async def test_process_relationships_component_can_be_overridden(schema_all_in_o
     assert processed_relationship.on_delete == RelationshipDeleteBehavior.NO_ACTION
 
 
-async def test_hierarchy_update(hierarchical_location_schema_simple: SchemaRoot):
+async def test_hierarchy_update(hierarchical_location_schema_simple: SchemaRoot) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=hierarchical_location_schema_simple)
     schema.process_inheritance()
@@ -1852,7 +1854,7 @@ async def test_hierarchy_update(hierarchical_location_schema_simple: SchemaRoot)
 
 async def test_schema_branch_copy(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -1910,7 +1912,7 @@ async def test_schema_branch_copy(
 
 async def test_schema_branch_diff_attribute(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -1989,7 +1991,7 @@ async def test_schema_branch_diff_attribute(
 
 async def test_schema_branch_diff_rename_element(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -2110,7 +2112,7 @@ async def test_schema_branch_diff_rename_element(
 
 async def test_schema_branch_diff_add_node_relationship(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     SCHEMA1 = {
         "nodes": [
             {
@@ -2199,7 +2201,7 @@ async def test_schema_branch_diff_add_node_relationship(
 
 async def test_schema_branch_validate_check_missing(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -2276,7 +2278,7 @@ async def test_schema_branch_validate_check_missing(
 
 async def test_schema_branch_validate_node_deletion(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -2332,7 +2334,7 @@ async def test_schema_branch_validate_node_deletion(
 
 async def test_schema_branch_validate_add_node_relationships(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     SCHEMA1 = {
         "nodes": [
             {
@@ -2433,7 +2435,7 @@ async def test_schema_branch_validate_add_node_relationships(
 # -----------------------------------------------------------------
 # SchemaManager
 # -----------------------------------------------------------------
-async def test_schema_manager_set():
+async def test_schema_manager_set() -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Builtin",
@@ -2454,7 +2456,7 @@ async def test_schema_manager_set():
     assert len(manager._cache) == cache_size
 
 
-async def test_schema_manager_get(default_branch: Branch):
+async def test_schema_manager_get(default_branch: Branch) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Builtin",
@@ -2534,7 +2536,7 @@ async def test_schema_manager_purge(default_branch: Branch, reset_registry: None
 # -----------------------------------------------------------------
 
 
-async def test_load_node_to_db_node_schema(db: InfrahubDatabase, default_branch: Branch):
+async def test_load_node_to_db_node_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
 
@@ -2566,7 +2568,7 @@ async def test_load_node_to_db_node_schema(db: InfrahubDatabase, default_branch:
     assert node_from_db
 
 
-async def test_load_node_to_db_generic_schema(db: InfrahubDatabase, default_branch):
+async def test_load_node_to_db_generic_schema(db: InfrahubDatabase, default_branch) -> None:
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
 
@@ -2612,7 +2614,7 @@ async def test_get_incorrect_kinds(default_branch: Branch) -> None:
         manager.get_generic_schema(name="TestPerson", branch=default_branch.name, duplicate=False)
 
 
-async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branch: Branch):
+async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Builtin",
@@ -2647,7 +2649,7 @@ async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branc
     assert results[new_node.attributes[0].id].unique.value is False
 
 
-async def test_load_schema_to_db_internal_models(db: InfrahubDatabase, default_branch: Branch):
+async def test_load_schema_to_db_internal_models(db: InfrahubDatabase, default_branch: Branch) -> None:
     schema = SchemaRoot(**internal_schema)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
@@ -2661,7 +2663,7 @@ async def test_load_schema_to_db_internal_models(db: InfrahubDatabase, default_b
 
 async def test_load_schema_to_db_core_models(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     schema = SchemaRoot(**core_models)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
@@ -2675,7 +2677,7 @@ async def test_load_schema_to_db_core_models(
 
 async def test_clean_diff_after_reload_from_db(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     schema = SchemaRoot(**core_models)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
@@ -2695,7 +2697,7 @@ async def test_load_schema_to_db_simple_01(
     register_core_models_schema: SchemaBranch,
     register_builtin_models_schema: SchemaBranch,
     helper,
-):
+) -> None:
     schema = SchemaRoot(**helper.schema_file("infra_simple_01.json"))
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
     await registry.schema.load_schema_to_db(schema=new_schema, db=db, branch=default_branch)
@@ -2713,7 +2715,7 @@ async def test_load_schema_to_db_w_generics_01(
     register_core_models_schema: SchemaBranch,
     register_builtin_models_schema: SchemaBranch,
     helper,
-):
+) -> None:
     schema = SchemaRoot(**helper.schema_file("infra_w_generics_01.json"))
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
     await registry.schema.load_schema_to_db(schema=new_schema, db=db, branch=default_branch)
@@ -2727,7 +2729,7 @@ async def test_load_schema_to_db_w_generics_01(
 
 async def test_load_schema_from_db(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -2826,7 +2828,7 @@ async def test_load_schema_from_db(
 
 async def test_load_schema(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -2920,7 +2922,7 @@ async def test_load_schema(
 )
 async def test_load_schema_with_parameters(
     db: InfrahubDatabase, reset_registry, register_internal_models_schema, default_branch: Branch, attr_details
-):
+) -> None:
     color_attr_dict = {
         "name": "color",
         "kind": "Text",
@@ -2965,7 +2967,7 @@ async def test_load_schema_with_parameters(
 
 async def test_load_schemas(
     db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     part1 = SchemaRoot(
         extensions={
             "nodes": [
@@ -3042,7 +3044,7 @@ async def test_load_schemas(
         pytest.fail(reason="Relationship 'models' must be present in 'RandomOrganization'")
 
 
-def test_schema_branch_load_schema_append_to_list(schema_all_in_one):
+def test_schema_branch_load_schema_append_to_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**schema_all_in_one))
     core_group_schema = _get_schema_by_kind(schema_all_in_one, "CoreGroup")
@@ -3054,7 +3056,7 @@ def test_schema_branch_load_schema_append_to_list(schema_all_in_one):
     assert updated_core_group_schema.display_labels == ["label__value", "name__value"]
 
 
-def test_schema_branch_load_schema_remove_from_list(schema_all_in_one):
+def test_schema_branch_load_schema_remove_from_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**schema_all_in_one))
     core_group_schema = _get_schema_by_kind(schema_all_in_one, "CoreGroup")
@@ -3066,7 +3068,7 @@ def test_schema_branch_load_schema_remove_from_list(schema_all_in_one):
     assert updated_core_group_schema.display_labels == ["name__value"]
 
 
-def test_schema_branch_load_schema_empty_list(schema_all_in_one):
+def test_schema_branch_load_schema_empty_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**schema_all_in_one))
     core_group_schema = _get_schema_by_kind(schema_all_in_one, "CoreGroup")
@@ -3078,7 +3080,7 @@ def test_schema_branch_load_schema_empty_list(schema_all_in_one):
     assert updated_core_group_schema.display_labels == []
 
 
-def test_schema_branch_load_schema_set_nested_list(schema_all_in_one):
+def test_schema_branch_load_schema_set_nested_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**schema_all_in_one))
     generic_interface_schema = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
@@ -3093,7 +3095,7 @@ def test_schema_branch_load_schema_set_nested_list(schema_all_in_one):
     ]
 
 
-def test_schema_branch_load_schema_append_to_nested_list(schema_all_in_one):
+def test_schema_branch_load_schema_append_to_nested_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     generic_interface_schema = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     generic_interface_schema["uniqueness_constraints"] = [["primary_tag", "status"]]
@@ -3109,7 +3111,7 @@ def test_schema_branch_load_schema_append_to_nested_list(schema_all_in_one):
     ]
 
 
-def test_schema_branch_load_schema_remove_from_nested_list(schema_all_in_one):
+def test_schema_branch_load_schema_remove_from_nested_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     generic_interface_schema = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     generic_interface_schema["uniqueness_constraints"] = [["primary_tag", "status"], ["my_generic_name", "mybool"]]
@@ -3122,7 +3124,7 @@ def test_schema_branch_load_schema_remove_from_nested_list(schema_all_in_one):
     assert updated_core_group_schema.uniqueness_constraints == [["primary_tag", "status"]]
 
 
-def test_schema_branch_load_schema_update_nested_list(schema_all_in_one):
+def test_schema_branch_load_schema_update_nested_list(schema_all_in_one) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     generic_interface_schema = _get_schema_by_kind(schema_all_in_one, "InfraGenericInterface")
     generic_interface_schema["uniqueness_constraints"] = [
@@ -3144,7 +3146,7 @@ def test_schema_branch_load_schema_update_nested_list(schema_all_in_one):
     ]
 
 
-def test_schema_branch_conflicting_required_relationships(schema_all_in_one):
+def test_schema_branch_conflicting_required_relationships(schema_all_in_one) -> None:
     tag_schema = _get_schema_by_kind(full_schema=schema_all_in_one, kind="BuiltinTag")
     tag_schema["relationships"] = [
         {
@@ -3477,7 +3479,7 @@ INHERITED_RELATIONSHIPS_TEST_CASES = [
     "test_case",
     [pytest.param(tc, id=tc.name) for tc in INHERITED_RELATIONSHIPS_TEST_CASES],
 )
-def test_schema_branch_validates_inherited_relationships_fields(test_case: InheritedRelationshipsTestData):
+def test_schema_branch_validates_inherited_relationships_fields(test_case: InheritedRelationshipsTestData) -> None:
     schema = SchemaBranch(cache={}, name=test_case.name)
     schema.load_schema(schema=SchemaRoot(**test_case.schema))
 
@@ -3489,7 +3491,7 @@ def test_schema_branch_validates_inherited_relationships_fields(test_case: Inher
 
 async def test_schema_branch_processes_relationships_state(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     schema = {
         "nodes": [
             {
@@ -3527,7 +3529,7 @@ async def test_schema_branch_processes_relationships_state(
 
 async def test_schema_branch_processes_nodes_state(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     schema = {
         "generics": [
             {
@@ -3570,7 +3572,7 @@ async def test_schema_branch_processes_nodes_state(
 
 async def test_schema_branch_processes_attributes_state(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
-):
+) -> None:
     schema = {
         "generics": [
             {
@@ -3636,7 +3638,7 @@ async def test_schema_branch_processes_attributes_state(
     assert "my_generic_name" in returned_schema.get(name="TestGenericInterface").attribute_names
 
 
-async def test_process_deprecations(organization_schema):
+async def test_process_deprecations(organization_schema) -> None:
     SCHEMA1 = {
         "name": "Criticality",
         "namespace": "Test",
@@ -3683,7 +3685,7 @@ async def test_process_deprecations(organization_schema):
 
 async def test_hierarchical_validate_parent_children(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple_unregistered: SchemaRoot
-):
+) -> None:
     site_schema = hierarchical_location_schema_simple_unregistered.get(name="LocationSite")
     site_schema.human_friendly_id = ["parent__name__value", "name__value"]
     site_schema.uniqueness_constraints = [["parent", "name__value"]]
@@ -3716,7 +3718,7 @@ async def test_hierarchical_validate_parent_children(
     await uk.save(db=db)
 
 
-async def test_schema_branch_add_object_template_schema():
+async def test_schema_branch_add_object_template_schema() -> None:
     SIMPLE_DEVICE = copy.deepcopy(DEVICE)
     SIMPLE_DEVICE.inherit_from = []
     device_schema = SchemaRoot(generics=[core_object_template], nodes=[SIMPLE_DEVICE])
@@ -3732,7 +3734,7 @@ async def test_schema_branch_add_object_template_schema():
     assert set(core_template_schema.used_by) == {f"Template{TestKind.DEVICE}"}
 
 
-async def test_schema_branch_remove_object_template_schema():
+async def test_schema_branch_remove_object_template_schema() -> None:
     SIMPLE_DEVICE = copy.deepcopy(DEVICE)
     SIMPLE_DEVICE.inherit_from = []
     device_schema = SchemaRoot(generics=[core_object_template], nodes=[SIMPLE_DEVICE])
@@ -3761,7 +3763,7 @@ async def test_schema_branch_remove_object_template_schema():
     assert not core_template_schema.used_by
 
 
-async def test_schema_branch_diff_core_object_template():
+async def test_schema_branch_diff_core_object_template() -> None:
     SIMPLE_DEVICE = copy.deepcopy(DEVICE)
     SIMPLE_DEVICE.inherit_from = []
     device_schema = SchemaRoot(generics=[core_object_template, core_object_component_template], nodes=[SIMPLE_DEVICE])
@@ -3798,7 +3800,7 @@ async def test_schema_branch_diff_core_object_template():
 
 
 @pytest.mark.parametrize("relationship_kind", (RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC))
-async def test_manage_object_templates(relationship_kind: RelationshipKind):
+async def test_manage_object_templates(relationship_kind: RelationshipKind) -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     THING_WITH_TEMPLATE = copy.deepcopy(THING)
     THING_WITH_TEMPLATE.generate_template = True
@@ -3831,7 +3833,7 @@ async def test_manage_object_templates(relationship_kind: RelationshipKind):
     ) == sorted([r.name for r in THING_WITH_TEMPLATE.relationships])
 
 
-async def test_manage_object_templates_with_component_relationships():
+async def test_manage_object_templates_with_component_relationships() -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**core_models).merge(schema=DEVICE_SCHEMA))
     schema_branch.process_inheritance()
@@ -3916,7 +3918,7 @@ async def test_manage_object_templates_with_component_relationships():
     }
 
 
-async def test_identify_object_templates_with_generics():
+async def test_identify_object_templates_with_generics() -> None:
     USELESS_DEVICE_SCHEMA = copy.deepcopy(DEVICE_SCHEMA)
     USELESS_DEVICE_SCHEMA.nodes.append(
         NodeSchema(

--- a/backend/tests/unit/core/schema_manager/test_parent_component_validation.py
+++ b/backend/tests/unit/core/schema_manager/test_parent_component_validation.py
@@ -8,14 +8,14 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from .conftest import _get_schema_by_kind
 
 
-async def test_one_parent_relationship_allowed(schema_parent_component):
+async def test_one_parent_relationship_allowed(schema_parent_component) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_parent_component))
 
     schema.validate_parent_component()
 
 
-async def test_many_parent_relationships_not_allowed(schema_parent_component):
+async def test_many_parent_relationships_not_allowed(schema_parent_component) -> None:
     schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentNodeOne")
     schema_dict["relationships"].append(
         {
@@ -38,7 +38,7 @@ async def test_many_parent_relationships_not_allowed(schema_parent_component):
     assert "parent_two" in err_msg
 
 
-async def test_parent_relationship_must_be_cardinality_one(schema_parent_component):
+async def test_parent_relationship_must_be_cardinality_one(schema_parent_component) -> None:
     schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentNodeOne")
     schema_dict["relationships"][0]["cardinality"] = "many"
 
@@ -51,7 +51,7 @@ async def test_parent_relationship_must_be_cardinality_one(schema_parent_compone
         schema.validate_parent_component()
 
 
-async def test_parent_relationship_must_be_mandatory(schema_parent_component):
+async def test_parent_relationship_must_be_mandatory(schema_parent_component) -> None:
     schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentNodeOne")
     schema_dict["relationships"][0]["optional"] = True
 
@@ -64,7 +64,7 @@ async def test_parent_relationship_must_be_mandatory(schema_parent_component):
         schema.validate_parent_component()
 
 
-async def test_only_one_parent_relationship_when_inheriting_from_generic(schema_parent_component):
+async def test_only_one_parent_relationship_when_inheriting_from_generic(schema_parent_component) -> None:
     schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentGenericOne")
     schema_dict["relationships"].append(
         {
@@ -87,7 +87,7 @@ async def test_only_one_parent_relationship_when_inheriting_from_generic(schema_
     assert "parent_two" in err_msg
 
 
-async def test_hierarchy_cannot_contain_loop(schema_parent_component):
+async def test_hierarchy_cannot_contain_loop(schema_parent_component) -> None:
     schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentGenericOne")
     schema_dict["relationships"].append(
         {
@@ -111,7 +111,7 @@ async def test_hierarchy_cannot_contain_loop(schema_parent_component):
         schema.validate_parent_component()
 
 
-async def test_hierarchy_cannot_contain_implied_loop(schema_parent_component):
+async def test_hierarchy_cannot_contain_implied_loop(schema_parent_component) -> None:
     component_schema_dict = _get_schema_by_kind(schema_parent_component, "TestComponentNodeOne")
     component_schema_dict["relationships"].append(
         {

--- a/backend/tests/unit/core/schema_manager/test_validate_schema_path.py
+++ b/backend/tests/unit/core/schema_manager/test_validate_schema_path.py
@@ -63,7 +63,7 @@ class TestValidateSchemaPath:
         schema_branch.load_schema(schema=schema)
         return schema_branch
 
-    def test_attr_only(self, schema: SchemaBranch):
+    def test_attr_only(self, schema: SchemaBranch) -> None:
         criticality_schema = schema.get(name="TestCriticality")
 
         allowed_types = SchemaElementPathType.ATTR
@@ -96,14 +96,14 @@ class TestValidateSchemaPath:
             ("primary_tag", SchemaElementPathType.REL_ONE_NO_ATTR | SchemaElementPathType.REL_MANY_NO_ATTR),
         ],
     )
-    def test_rel_one_valid(self, schema: SchemaBranch, path, allowed_types):
+    def test_rel_one_valid(self, schema: SchemaBranch, path, allowed_types) -> None:
         criticality_schema = schema.get(name="TestCriticality")
         schema_path = schema.validate_schema_path(
             node_schema=criticality_schema, path=path, allowed_path_types=allowed_types
         )
         assert schema_path.is_type_relationship
 
-    def test_rel_one_fail(self, schema: SchemaBranch):
+    def test_rel_one_fail(self, schema: SchemaBranch) -> None:
         criticality_schema = schema.get(name="TestCriticality")
 
         with pytest.raises(ValueError) as exc:
@@ -147,14 +147,14 @@ class TestValidateSchemaPath:
             ("tags", SchemaElementPathType.REL_MANY_NO_ATTR | SchemaElementPathType.REL_ONE_NO_ATTR),
         ],
     )
-    def test_rel_many_valid(self, schema: SchemaBranch, path, allowed_types):
+    def test_rel_many_valid(self, schema: SchemaBranch, path, allowed_types) -> None:
         criticality_schema = schema.get(name="TestCriticality")
         schema_path = schema.validate_schema_path(
             node_schema=criticality_schema, path=path, allowed_path_types=allowed_types
         )
         assert schema_path.is_type_relationship
 
-    def test_rel_many_fail(self, schema: SchemaBranch):
+    def test_rel_many_fail(self, schema: SchemaBranch) -> None:
         criticality_schema = schema.get(name="TestCriticality")
 
         with pytest.raises(ValueError) as exc:

--- a/backend/tests/unit/core/test_account.py
+++ b/backend/tests/unit/core/test_account.py
@@ -14,7 +14,7 @@ from infrahub.exceptions import AuthorizationError
 from infrahub.models import PasswordCredential
 
 
-async def test_validate_user_create(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_validate_user_create(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     account_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
     account_token_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
 
@@ -26,7 +26,7 @@ async def test_validate_user_create(db: InfrahubDatabase, default_branch, regist
     await token1.save(db=db)
 
 
-async def test_validate_token(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_validate_token(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     account_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
     account_token_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
 
@@ -95,7 +95,7 @@ async def test_validate_token(db: InfrahubDatabase, default_branch, register_cor
     assert await validate_token(token="123454321", db=db) is None
 
 
-async def test_account_status(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_account_status(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     account_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
 
     user1 = await Node.init(db=db, schema=account_schema)
@@ -111,7 +111,7 @@ async def test_account_status(db: InfrahubDatabase, default_branch, register_cor
         await validate_active_account(db=db, account_id=user2.id)
 
 
-async def test_authenticate_with_password(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_authenticate_with_password(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     account_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
 
     user1 = await Node.init(db=db, schema=account_schema)
@@ -130,7 +130,7 @@ async def test_authenticate_with_password(db: InfrahubDatabase, default_branch, 
         )
 
 
-async def test_authenticate_token(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_authenticate_token(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
     account_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
     account_token_schema = registry.schema.get_node_schema(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
 

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -34,7 +34,7 @@ async def test_init(
     criticality_schema: NodeSchema,
     first_account: Node,
     second_account: Node,
-):
+) -> None:
     schema = criticality_schema.get_attribute("name")
     attr = String(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="mystring")
 
@@ -61,7 +61,7 @@ async def test_init(
 
 async def test_validate_format_ipnetwork_and_iphost(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
-):
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     # 1/ test with prefixlen
@@ -101,7 +101,9 @@ async def test_validate_format_ipnetwork_and_iphost(
         )
 
 
-async def test_validate_validate_url(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_validate_url(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     assert URL(
@@ -114,7 +116,7 @@ async def test_validate_validate_url(db: InfrahubDatabase, default_branch: Branc
 
 async def test_validate_format_datetime_valid(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
-):
+) -> None:
     schema = criticality_schema.get_attribute("time")
 
     assert DateTime(
@@ -127,7 +129,7 @@ async def test_validate_format_datetime_valid(
 
 async def test_validate_format_datetime_invalid(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
-):
+) -> None:
     schema = criticality_schema.get_attribute("time")
 
     with pytest.raises(ValidationError, match=r"invalid-datetime is not a valid DateTime"):
@@ -144,7 +146,9 @@ async def test_validate_format_datetime_invalid(
         )
 
 
-async def test_validate_iphost_returns(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_iphost_returns(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     test_ipv4 = IPHost(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="10.0.2.1/31")
@@ -197,7 +201,9 @@ async def test_validate_iphost_returns(db: InfrahubDatabase, default_branch: Bra
     }
 
 
-async def test_validate_ipnetwork_returns(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_ipnetwork_returns(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     test_ipv4 = IPNetwork(
@@ -257,7 +263,7 @@ async def test_validate_ipnetwork_returns(db: InfrahubDatabase, default_branch: 
 
 async def test_validate_mac_address_returns(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
-):
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     mac_address = "60:23:6c:c4:9f:7e"
@@ -294,7 +300,9 @@ async def test_validate_mac_address_returns(
         )
 
 
-async def test_validate_content_dropdown(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_content_dropdown(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     schema = criticality_schema.get_attribute("status")
     Dropdown(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="active")
 
@@ -304,7 +312,9 @@ async def test_validate_content_dropdown(db: InfrahubDatabase, default_branch: B
 
 
 @pytest.mark.parametrize("params_only", [False, True])
-async def test_validate_content_text_parameters(db: InfrahubDatabase, default_branch: Branch, params_only: bool):
+async def test_validate_content_text_parameters(
+    db: InfrahubDatabase, default_branch: Branch, params_only: bool
+) -> None:
     regex = "^[a-z]*$"
     min_length = 2
     max_length = 5
@@ -336,7 +346,9 @@ async def test_validate_content_text_parameters(db: InfrahubDatabase, default_br
     assert new_node.text_test.value == "abc"
 
 
-async def test_dropdown_properties(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_dropdown_properties(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     schema = criticality_schema.get_attribute("status")
     active = Dropdown(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="active")
     passive = Dropdown(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="passive")
@@ -353,7 +365,9 @@ async def test_dropdown_properties(db: InfrahubDatabase, default_branch: Branch,
     assert passive.color == "#ed6a5a"
 
 
-async def test_validate_format_string(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_format_string(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     name_schema = criticality_schema.get_attribute("name")
 
     String(name="test", schema=name_schema, branch=default_branch, at=Timestamp(), node=None, data="five")
@@ -369,7 +383,9 @@ async def test_validate_format_string(db: InfrahubDatabase, default_branch: Bran
         )
 
 
-async def test_validate_format_integer(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_format_integer(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     level_schema = criticality_schema.get_attribute("level")
 
     Integer(name="test", schema=level_schema, branch=default_branch, at=Timestamp(), node=None, data=88)
@@ -378,7 +394,7 @@ async def test_validate_format_integer(db: InfrahubDatabase, default_branch: Bra
         Integer(name="test", schema=level_schema, branch=default_branch, at=Timestamp(), node=None, data="notaninteger")
 
 
-async def test_validate_enum(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_enum(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     schema = criticality_schema.get_attribute("name")
 
     # 1/ there is no enum defined in the schema
@@ -393,7 +409,7 @@ async def test_validate_enum(db: InfrahubDatabase, default_branch: Branch, criti
         String(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="five")
 
 
-async def test_validate_regex(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_regex(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     schema = criticality_schema.get_attribute("name")
 
     # 1/ there is no regex defined in the schema
@@ -413,7 +429,7 @@ async def test_validate_regex(db: InfrahubDatabase, default_branch: Branch, crit
         String(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="FIVE999")
 
 
-async def test_validate_length(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_validate_length(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     schema = criticality_schema.get_attribute("name")
 
     # 1/ there is no min_length or max_length defined in the schema
@@ -432,7 +448,7 @@ async def test_validate_length(db: InfrahubDatabase, default_branch: Branch, cri
         String(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="thisstringistoolong")
 
 
-async def test_node_property_getter(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_property_getter(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     schema = criticality_schema.get_attribute("name")
     attr = String(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="mystring")
 
@@ -457,7 +473,7 @@ async def test_node_property_getter(db: InfrahubDatabase, default_branch: Branch
     assert attr.owner_id == "yetotheruuid"
 
 
-async def test_get_query_filter_string_value(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_string_value(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     filters, params, matchs = await attr_schema.get_query_filter(
         name="description", filter_name="value", filter_value="test"
@@ -487,7 +503,7 @@ async def test_get_query_filter_string_value(db: InfrahubDatabase, default_branc
     assert matchs == []
 
 
-async def test_get_query_filter_any(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_any(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     filters, params, matchs = await attr_schema.get_query_filter(name="any", filter_name="value", filter_value="test")
     expected_response = [
@@ -502,7 +518,7 @@ async def test_get_query_filter_any(db: InfrahubDatabase, default_branch: Branch
     assert matchs == []
 
 
-async def test_get_query_filter_flag_property(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_flag_property(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     filters, params, matchs = await attr_schema.get_query_filter(
         name="descr", filter_name="is_protected", filter_value=False
@@ -519,7 +535,7 @@ async def test_get_query_filter_flag_property(db: InfrahubDatabase, default_bran
     assert matchs == []
 
 
-async def test_get_query_filter_any_node_property(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_any_node_property(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     filters, params, matchs = await attr_schema.get_query_filter(
         name="any", filter_name="source__id", filter_value="abcdef"
@@ -536,7 +552,7 @@ async def test_get_query_filter_any_node_property(db: InfrahubDatabase, default_
     assert matchs == []
 
 
-async def test_get_query_filter_multiple_values(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_multiple_values(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     filters, params, matchs = await attr_schema.get_query_filter(
         name="name", filter_name="values", filter_value=["test1", "test2"]
@@ -553,7 +569,7 @@ async def test_get_query_filter_multiple_values(db: InfrahubDatabase, default_br
     assert matchs == ["av.value IN $attr_name_value"]
 
 
-async def test_get_query_filter_list_attribute(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_list_attribute(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="List")
     filters, params, matchs = await attr_schema.get_query_filter(
         name="name", filter_name="values", filter_value=["test1", "test2"]
@@ -574,7 +590,7 @@ async def test_get_query_filter_list_attribute(db: InfrahubDatabase, default_bra
     assert matchs == ["toString(av.value) =~ $attr_name_values"]
 
 
-async def test_query_filter_enum(db: InfrahubDatabase, default_branch: Branch):
+async def test_query_filter_enum(db: InfrahubDatabase, default_branch: Branch) -> None:
     config.SETTINGS.experimental_features.graphql_enums = True
 
     class ExternalEnum(Enum):
@@ -597,13 +613,13 @@ async def test_query_filter_enum(db: InfrahubDatabase, default_branch: Branch):
     assert matchs == ["av.value IN $attr_name_value"]
 
 
-async def test_get_query_filter_multiple_values_invalid_type(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_query_filter_multiple_values_invalid_type(db: InfrahubDatabase, default_branch: Branch) -> None:
     attr_schema = AttributeSchema(name="something", kind="Text")
     with pytest.raises(TypeError):
         await attr_schema.get_query_filter(name="name", filter_name="values", filter_value=["test1", 1.0])
 
 
-async def test_base_serialization(db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema):
+async def test_base_serialization(db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema) -> None:
     obj1 = await Node.init(db=db, schema="TestAllAttributeTypes")
     await obj1.new(db=db, name="obj1", mystring="abc", mybool=False, myint=123, mylist=["1", 2, False])
     await obj1.save(db=db)
@@ -645,7 +661,9 @@ async def test_base_serialization(db: InfrahubDatabase, default_branch: Branch, 
     assert obj13.mylist.value == obj11.mylist.value
 
 
-async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account: Node):
+async def test_to_graphql(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account: Node
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     attr1 = String(
@@ -693,7 +711,7 @@ async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, critical
 
 async def test_to_graphql_no_fields(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account: Node
-):
+) -> None:
     schema = criticality_schema.get_attribute("name")
 
     attr1 = String(
@@ -743,7 +761,7 @@ async def test_to_graphql_no_fields(
     assert await attr2.to_graphql(db=db) == expected_data
 
 
-async def test_attribute_size(db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema):
+async def test_attribute_size(db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema) -> None:
     obj = await Node.init(db=db, schema="TestAllAttributeTypes")
 
     large_string = "a" * 9_000  # It's over 9000!!!!
@@ -774,7 +792,7 @@ async def test_enum_with_default_preserves_is_default(
     hierarchical_location_data_simple: dict[str, Node],
     updated_status,
     expected_is_default,
-):
+) -> None:
     site = hierarchical_location_data_simple["paris"]
     rack = await Node.init(db=db, schema="LocationRack")
     await rack.new(db=db, name="new-rack", parent=site)

--- a/backend/tests/unit/core/test_attribute_query.py
+++ b/backend/tests/unit/core/test_attribute_query.py
@@ -4,7 +4,7 @@ from infrahub.core.query.attribute import AttributeGetQuery
 from infrahub.database import InfrahubDatabase
 
 
-async def test_AttributeGetQuery(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_AttributeGetQuery(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     obj = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await obj.new(db=db, name="John", height=180)
     await obj.save(db=db)

--- a/backend/tests/unit/core/test_branch.py
+++ b/backend/tests/unit/core/test_branch.py
@@ -13,7 +13,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import BranchNotFoundError, ValidationError
 
 
-async def test_branch_name_validator(db: InfrahubDatabase):
+async def test_branch_name_validator(db: InfrahubDatabase) -> None:
     assert Branch(name="new-branch")
     assert Branch(name="cr1234")
     assert Branch(name="new.branch")
@@ -106,7 +106,7 @@ async def test_branch_name_validator(db: InfrahubDatabase):
     assert Branch(name="cr1234-qwerty-qwerty")
 
 
-async def test_branch_branched_form_format_validator(db: InfrahubDatabase):
+async def test_branch_branched_form_format_validator(db: InfrahubDatabase) -> None:
     assert Branch(name="new-branch").branched_from is not None
 
     time1 = Timestamp().to_string()
@@ -116,7 +116,7 @@ async def test_branch_branched_form_format_validator(db: InfrahubDatabase):
         Branch(name="cr1234", branched_from="not a date")
 
 
-async def test_get_query_filter_relationships_main(db: InfrahubDatabase, base_dataset_02):
+async def test_get_query_filter_relationships_main(db: InfrahubDatabase, base_dataset_02) -> None:
     default_branch = await registry.get_branch(branch="main", db=db)
 
     filters, params = default_branch.get_query_filter_relationships(
@@ -135,7 +135,7 @@ async def test_get_query_filter_relationships_main(db: InfrahubDatabase, base_da
     assert sorted(params.keys()) == ["branch0", "time0"]
 
 
-async def test_get_query_filter_relationships_branch1(db: InfrahubDatabase, base_dataset_02):
+async def test_get_query_filter_relationships_branch1(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await registry.get_branch(branch="branch1", db=db)
 
     filters, params = branch1.get_query_filter_relationships(
@@ -148,7 +148,7 @@ async def test_get_query_filter_relationships_branch1(db: InfrahubDatabase, base
     assert sorted(params.keys()) == ["branch0", "branch1", "time0", "time1"]
 
 
-async def test_get_branches_and_times_to_query_main(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_to_query_main(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp("1s")
 
     main_branch = await registry.get_branch(branch="main", db=db)
@@ -161,7 +161,7 @@ async def test_get_branches_and_times_to_query_main(db: InfrahubDatabase, base_d
     assert results[frozenset(["main"])] == t1.to_string()
 
 
-async def test_get_branches_and_times_to_query_branch1(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_to_query_branch1(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp("1s")
 
     branch1 = await registry.get_branch(branch="branch1", db=db)
@@ -177,7 +177,7 @@ async def test_get_branches_and_times_to_query_branch1(db: InfrahubDatabase, bas
     assert results[frozenset(["main"])] == base_dataset_02["time_m45"]
 
 
-async def test_get_branches_and_times_to_query_global_main(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_to_query_global_main(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp("1s")
 
     main_branch = await registry.get_branch(branch="main", db=db)
@@ -190,7 +190,7 @@ async def test_get_branches_and_times_to_query_global_main(db: InfrahubDatabase,
     assert results[frozenset((GLOBAL_BRANCH_NAME, "main"))] == t1.to_string()
 
 
-async def test_get_branches_and_times_to_query_global_branch1(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_to_query_global_branch1(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp("1s")
 
     branch1 = await registry.get_branch(branch="branch1", db=db)
@@ -206,7 +206,7 @@ async def test_get_branches_and_times_to_query_global_branch1(db: InfrahubDataba
     assert results[frozenset((GLOBAL_BRANCH_NAME, "main"))] == base_dataset_02["time_m45"]
 
 
-async def test_get_branches_and_times_for_range_main(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_for_range_main(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp()
     main_branch = await registry.get_branch(branch="main", db=db)
 
@@ -225,7 +225,7 @@ async def test_get_branches_and_times_for_range_main(db: InfrahubDatabase, base_
     assert end_times["main"] == t1.to_string()
 
 
-async def test_get_branches_and_times_for_range_branch1(db: InfrahubDatabase, base_dataset_02):
+async def test_get_branches_and_times_for_range_branch1(db: InfrahubDatabase, base_dataset_02) -> None:
     now = Timestamp()
     branch1 = await registry.get_branch(branch="branch1", db=db)
 
@@ -248,7 +248,7 @@ async def test_get_branches_and_times_for_range_branch1(db: InfrahubDatabase, ba
     assert start_times["main"] == t10.to_string()
 
 
-async def test_get_branches_and_times_for_range_branch2(db: InfrahubDatabase, base_dataset_03):
+async def test_get_branches_and_times_for_range_branch2(db: InfrahubDatabase, base_dataset_03) -> None:
     now = Timestamp()
     branch2 = await registry.get_branch(branch="branch2", db=db)
 
@@ -271,7 +271,7 @@ async def test_get_branches_and_times_for_range_branch2(db: InfrahubDatabase, ba
     assert start_times["main"] == t10.to_string()
 
 
-async def test_is_isolated(db: InfrahubDatabase, base_dataset_02):
+async def test_is_isolated(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     branch1.is_isolated = True
@@ -287,7 +287,7 @@ async def test_is_isolated(db: InfrahubDatabase, base_dataset_02):
     assert cars[0].name.value == "volt"
 
 
-async def test_delete_branch(db: InfrahubDatabase, default_branch: Branch, repos_in_main, car_person_schema):
+async def test_delete_branch(db: InfrahubDatabase, default_branch: Branch, repos_in_main, car_person_schema) -> None:
     branch_name = "delete-me"
     branch = await create_branch(branch_name=branch_name, db=db)
     found = await Branch.get_by_name(name=branch_name, db=db)
@@ -315,7 +315,7 @@ async def test_delete_branch(db: InfrahubDatabase, default_branch: Branch, repos
     assert not post_delete
 
 
-async def test_create_branch(db: InfrahubDatabase, empty_database):
+async def test_create_branch(db: InfrahubDatabase, empty_database) -> None:
     """Validate that creating a branch with quotes in descriptions work and are properly handled with params"""
     branch_name = "branching-out"
     description = "It's supported with quotes"

--- a/backend/tests/unit/core/test_branch_diff.py
+++ b/backend/tests/unit/core/test_branch_diff.py
@@ -21,7 +21,7 @@ from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_has_conflict_graph(db: InfrahubDatabase, base_dataset_02):
+async def test_diff_has_conflict_graph(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     diff = await BranchDiffer.init(branch=branch1, db=db)
@@ -41,7 +41,7 @@ async def test_diff_has_conflict_graph(db: InfrahubDatabase, base_dataset_02):
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_get_modified_paths_graph(db: InfrahubDatabase, base_dataset_02):
+async def test_diff_get_modified_paths_graph(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     expected_paths_main = [
@@ -113,7 +113,7 @@ async def test_diff_get_modified_paths_graph(db: InfrahubDatabase, base_dataset_
     assert modified_branch1 == sorted(expected_paths_branch1)
 
 
-async def test_diff_get_files_repository(db: InfrahubDatabase, repos_in_main, base_dataset_02):
+async def test_diff_get_files_repository(db: InfrahubDatabase, repos_in_main, base_dataset_02) -> None:
     def execute_workflow_side_effect(workflow, parameters):
         model = GitDiffNamesOnlyResponse(
             files_changed=["readme.md", "mydir/myfile.py"],
@@ -152,7 +152,7 @@ async def test_diff_get_files_repository(db: InfrahubDatabase, repos_in_main, ba
 
 async def test_diff_get_files_repositories_for_branch_case01(
     db: InfrahubDatabase, default_branch: Branch, repos_in_main
-):
+) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
     but only one has a different commit value between 2 and from so we expect only 2 files"""
 
@@ -193,7 +193,7 @@ async def test_diff_get_files_repositories_for_branch_case02(
     db: InfrahubDatabase,
     default_branch: Branch,
     repos_in_main,
-):
+) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
     both repositories have a new commit value so we expect both to return something"""
 
@@ -241,7 +241,7 @@ async def test_diff_get_files_repositories_for_branch_case02(
     assert sorted([fde.location for fde in resp]) == ["anotherfile.rb", "mydir/myfile.py", "readme.md"]
 
 
-async def test_diff_get_files(db: InfrahubDatabase, default_branch: Branch, repos_in_main):
+async def test_diff_get_files(db: InfrahubDatabase, default_branch: Branch, repos_in_main) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
     both repositories have a new commit value so we expect both to return something"""
 
@@ -291,7 +291,7 @@ async def test_diff_get_files(db: InfrahubDatabase, default_branch: Branch, repo
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_get_nodes_entire_branch(db: InfrahubDatabase, default_branch, read_only_repos_in_main):
+async def test_diff_get_nodes_entire_branch(db: InfrahubDatabase, default_branch, read_only_repos_in_main) -> None:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     repo01b2 = await NodeManager.get_one(id=read_only_repos_in_main["repo01"].id, branch=branch2, db=db)
@@ -404,7 +404,7 @@ async def test_diff_get_nodes_entire_branch(db: InfrahubDatabase, default_branch
 
 
 @pytest.mark.xfail(reason="Need to investigate, fails on every other run")
-async def test_diff_get_nodes_multiple_changes(db: InfrahubDatabase, default_branch, repos_in_main):
+async def test_diff_get_nodes_multiple_changes(db: InfrahubDatabase, default_branch, repos_in_main) -> None:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     repo01b2 = await NodeManager.get_one(id=repos_in_main["repo01"].id, branch=branch2, db=db)
@@ -460,7 +460,7 @@ async def test_diff_get_nodes_multiple_changes(db: InfrahubDatabase, default_bra
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_get_nodes_dataset_02(db: InfrahubDatabase, base_dataset_02):
+async def test_diff_get_nodes_dataset_02(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     diff = await BranchDiffer.init(branch=branch1, db=db)
@@ -565,7 +565,7 @@ async def test_diff_get_nodes_dataset_02(db: InfrahubDatabase, base_dataset_02):
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_get_nodes_rebased_branch(db: InfrahubDatabase, base_dataset_03):
+async def test_diff_get_nodes_rebased_branch(db: InfrahubDatabase, base_dataset_03) -> None:
     branch2 = await Branch.get_by_name(name="branch2", db=db)
 
     # Calculate the diff with the default value
@@ -578,7 +578,7 @@ async def test_diff_get_nodes_rebased_branch(db: InfrahubDatabase, base_dataset_
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_get_relationships(db: InfrahubDatabase, base_dataset_02):
+async def test_diff_get_relationships(db: InfrahubDatabase, base_dataset_02) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     diff = await BranchDiffer.init(branch=branch1, db=db)
@@ -704,7 +704,9 @@ async def test_diff_get_relationships(db: InfrahubDatabase, base_dataset_02):
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_relationship_one_conflict(db: InfrahubDatabase, default_branch: Branch, car_person_data_generic):
+async def test_diff_relationship_one_conflict(
+    db: InfrahubDatabase, default_branch: Branch, car_person_data_generic
+) -> None:
     c1_main = car_person_data_generic["c1"]
     p1_main = car_person_data_generic["p1"]
     p2_main = car_person_data_generic["p2"]
@@ -907,7 +909,7 @@ async def test_diff_relationship_one_conflict(db: InfrahubDatabase, default_bran
 
 
 @pytest.mark.skip(reason="Update for new diff logic")
-async def test_diff_relationship_many(db: InfrahubDatabase, default_branch: Branch, base_dataset_04):
+async def test_diff_relationship_many(db: InfrahubDatabase, default_branch: Branch, base_dataset_04) -> None:
     branch1 = await registry.get_branch(branch="branch1", db=db)
 
     diff = await BranchDiffer.init(branch=branch1, db=db)
@@ -1024,7 +1026,7 @@ async def test_diff_relationship_many(db: InfrahubDatabase, default_branch: Bran
 @pytest.mark.skip(reason="Update for new diff logic")
 async def test_diff_schema_changes(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, car_person_schema
-):
+) -> None:
     schema_main = registry.schema.get_schema_branch(name=default_branch.name)
     await registry.schema.update_schema_branch(
         db=db, branch=default_branch, schema=schema_main, limit=["TestCar", "TestPerson"], update_db=True
@@ -1067,7 +1069,7 @@ async def test_diff_schema_changes(
     }
 
 
-async def test_base_diff_element():
+async def test_base_diff_element() -> None:
     class CL3(BaseDiffElement):
         name: str
 

--- a/backend/tests/unit/core/test_branch_merge.py
+++ b/backend/tests/unit/core/test_branch_merge.py
@@ -35,7 +35,7 @@ async def _get_branch_merger(
     )
 
 
-async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02, register_core_models_schema):
+async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02, register_core_models_schema) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
     at = Timestamp()
     component_registry = get_component_registry()
@@ -79,7 +79,9 @@ async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02
     await diff_merger.merge_graph(at=at)
 
 
-async def test_merge_graph_delete(db: InfrahubDatabase, default_branch, base_dataset_02, register_core_models_schema):
+async def test_merge_graph_delete(
+    db: InfrahubDatabase, default_branch, base_dataset_02, register_core_models_schema
+) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch1)
@@ -101,7 +103,7 @@ async def test_merge_graph_delete(db: InfrahubDatabase, default_branch, base_dat
 
 async def test_merge_relationship_many(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, register_organization_schema
-):
+) -> None:
     blue = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
     await blue.new(db=db, name="Blue", description="The Blue tag")
     await blue.save(db=db)
@@ -145,7 +147,7 @@ async def test_merge_update_schema(
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main,
-):
+) -> None:
     schema_main = registry.schema.get_schema_branch(name=default_branch.name)
     await registry.schema.update_schema_branch(
         db=db, branch=default_branch, schema=schema_main, limit=["TestCar", "TestPerson"], update_db=True

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -15,7 +15,7 @@ from infrahub.exceptions import ValidationError
 from infrahub.workers.dependencies import build_database
 
 
-async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
+async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core_models_schema) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
     await branch1.rebase(db=db)
 
@@ -36,7 +36,7 @@ async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core
     assert cars[2].name.value == "volt"
 
 
-async def test_rebase_graph_delete(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
+async def test_rebase_graph_delete(db: InfrahubDatabase, base_dataset_02, register_core_models_schema) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
     persons = sorted(await NodeManager.query(schema="TestPerson", db=db), key=lambda p: p.id)
@@ -54,7 +54,7 @@ async def test_rebase_graph_delete(db: InfrahubDatabase, base_dataset_02, regist
 
 async def test_merge_relationship_many(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, register_organization_schema
-):
+) -> None:
     blue = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
     await blue.new(db=db, name="Blue", description="The Blue tag")
     await blue.save(db=db)
@@ -97,7 +97,7 @@ async def test_branch_rebase_diff_conflict(
     dependency_provider,
     car_person_schema,
     car_camry_main,
-):
+) -> None:
     # NOTE: Ideally, this should be somewhere else for all tests to benefit from it
     with dependency_provider.scope(build_database, lambda: db):
         branch2 = await create_branch(db=db, branch_name="branch2")

--- a/backend/tests/unit/core/test_core_utils.py
+++ b/backend/tests/unit/core/test_core_utils.py
@@ -10,11 +10,11 @@ from infrahub.core.utils import (
 from infrahub.database import InfrahubDatabase
 
 
-async def test_delete_all_nodes(db: InfrahubDatabase):
+async def test_delete_all_nodes(db: InfrahubDatabase) -> None:
     assert await delete_all_nodes(db) == []
 
 
-def test_parse_node_kind():
+def test_parse_node_kind() -> None:
     assert parse_node_kind(kind="TestMyModel") == NodeKind(namespace="Test", name="MyModel")
     assert parse_node_kind(kind="Test3Myname1234") == NodeKind(namespace="Test3", name="Myname1234")
 
@@ -25,7 +25,7 @@ def test_parse_node_kind():
         parse_node_kind(kind="Test3myname1234")
 
 
-async def test_get_paths_between_nodes(db: InfrahubDatabase, empty_database):
+async def test_get_paths_between_nodes(db: InfrahubDatabase, empty_database) -> None:
     query = """
     CREATE (p1:Person { name: "Jim" })
     CREATE (p2:Person { name: "Jane" })
@@ -61,7 +61,7 @@ async def test_get_paths_between_nodes(db: InfrahubDatabase, empty_database):
     assert len(paths) == 0
 
 
-async def test_count_relationships(db: InfrahubDatabase, empty_database):
+async def test_count_relationships(db: InfrahubDatabase, empty_database) -> None:
     query = """
     CREATE (p1:Person { name: "Jim" })
     CREATE (p2:Person { name: "Jane" })

--- a/backend/tests/unit/core/test_enums.py
+++ b/backend/tests/unit/core/test_enums.py
@@ -3,7 +3,7 @@ import enum
 from infrahub.core.enums import generate_python_enum
 
 
-def test_generate_python_enum():
+def test_generate_python_enum() -> None:
     enum_class = generate_python_enum(name="Color", options=["blue", "red"])
     assert isinstance(enum_class, enum.EnumType)
 
@@ -12,7 +12,7 @@ def test_generate_python_enum():
     assert {enum.name for enum in enum_class} == {"RED", "BLUE"}
 
 
-def test_generate_python_enum_with_integers():
+def test_generate_python_enum_with_integers() -> None:
     enum_class = generate_python_enum(name="DHGroup", options=[2, 5, 14])
     assert isinstance(enum_class, enum.EnumType)
 

--- a/backend/tests/unit/core/test_get_kinds_lock.py
+++ b/backend/tests/unit/core/test_get_kinds_lock.py
@@ -22,7 +22,7 @@ class TestGetKindsLock(TestInfrahubApp):
         default_branch,
         register_core_models_schema,
         client,
-    ):
+    ) -> None:
         # CoreCredential has no uniqueness_constraint, but generic CorePasswordCredential has one
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         assert _get_kinds_to_lock_on_object_mutation(kind="CorePasswordCredential", schema_branch=schema_branch) == [
@@ -45,7 +45,7 @@ class TestGetKindsLock(TestInfrahubApp):
         default_branch,
         register_core_models_schema,
         client,
-    ):
+    ) -> None:
         graphql_query = await client.create(
             kind=GRAPHQLQUERY,
             name="a_gql_query",
@@ -123,7 +123,7 @@ class TestGetKindsLock(TestInfrahubApp):
         default_branch,
         client,
         car_person_schema,
-    ):
+    ) -> None:
         other_branch = await create_branch(branch_name="other_branch", db=db)
         schema_branch = registry.schema.get_schema_branch(name=other_branch.name)
 
@@ -138,7 +138,7 @@ class TestGetKindsLock(TestInfrahubApp):
         default_branch,
         client,
         car_person_schema_unregistered,
-    ):
+    ) -> None:
         car_person_schema_unregistered = deepcopy(car_person_schema_unregistered)
         car_person_schema_unregistered.nodes[0].uniqueness_constraints = [
             ["name__value", "color__value", "owner__name"]
@@ -158,7 +158,7 @@ class TestGetKindsLock(TestInfrahubApp):
         default_branch,
         client,
         car_person_schema_unregistered,
-    ):
+    ) -> None:
         car_person_schema_unregistered = deepcopy(car_person_schema_unregistered)
         car_person_schema_unregistered.nodes[1].uniqueness_constraints = [["height__value"]]
         registry.schema.register_schema(schema=car_person_schema_unregistered, branch=default_branch.name)

--- a/backend/tests/unit/core/test_initialization.py
+++ b/backend/tests/unit/core/test_initialization.py
@@ -2,6 +2,6 @@ from infrahub.core.initialization import first_time_initialization
 from infrahub.database import InfrahubDatabase
 
 
-async def test_first_time_initialization(db: InfrahubDatabase, default_branch):
+async def test_first_time_initialization(db: InfrahubDatabase, default_branch) -> None:
     await first_time_initialization(db=db)
     assert True

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -19,7 +19,7 @@ from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA
 
 
-async def test_get_one_attribute(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_get_one_attribute(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -56,7 +56,7 @@ async def test_get_one_attribute(db: InfrahubDatabase, default_branch: Branch, c
 
 async def test_get_one_attribute_with_node_property(
     db: InfrahubDatabase, default_branch, criticality_schema, first_account, second_account
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4, _source=first_account)
     await obj1.save(db=db)
@@ -91,7 +91,7 @@ async def test_get_one_attribute_with_node_property(
 
 async def test_get_one_attribute_with_flag_property(
     db: InfrahubDatabase, default_branch, criticality_schema, first_account, second_account
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name={"value": "low", "is_protected": True}, level={"value": 4, "is_visible": False})
     await obj1.save(db=db)
@@ -116,7 +116,7 @@ async def test_get_one_attribute_with_flag_property(
     assert obj.color.is_protected is False
 
 
-async def test_get_one_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_get_one_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -151,7 +151,9 @@ async def test_get_one_relationship(db: InfrahubDatabase, default_branch: Branch
         await NodeManager.get_one(db=db, id="e57fef37-d9eb-4548-b890-b5e31d76f56b", raise_on_error=True)
 
 
-async def test_get_one_relationship_with_flag_property(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_get_one_relationship_with_flag_property(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -203,7 +205,7 @@ async def test_get_one_by_id_or_default_filter(
     criticality_schema: SchemaBranch,
     criticality_low: Node,
     criticality_medium: Node,
-):
+) -> None:
     node1 = await NodeManager.get_one_by_id_or_default_filter(
         db=db, id=criticality_low.id, kind=criticality_schema.kind
     )
@@ -221,7 +223,7 @@ async def test_get_one_by_hfid(
     db: InfrahubDatabase,
     default_branch: Branch,
     animal_person_schema: SchemaBranch,
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -252,7 +254,7 @@ async def test_get_one_by_hfid(
         await NodeManager.get_one_by_hfid(db=db, hfid=["Not", "Dog"], kind=dog_schema.kind, raise_on_error=True)
 
 
-async def test_get_by_hfid_with_invalid_hfid(db: InfrahubDatabase, branch: Branch):
+async def test_get_by_hfid_with_invalid_hfid(db: InfrahubDatabase, branch: Branch) -> None:
     schema = copy.deepcopy(DEVICE_SCHEMA)
     # Change device schema to add a HFID
     schema.nodes[0].human_friendly_id = ["name__value"]
@@ -272,7 +274,7 @@ async def test_get_by_hfid_with_invalid_hfid(db: InfrahubDatabase, branch: Branc
         await NodeManager.get_one_by_hfid(db=db, branch=branch, kind=TestKind.DEVICE, hfid=device_hfid + ["foo"])
 
 
-async def test_get_many(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
+async def test_get_many(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium) -> None:
     nodes = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
     assert len(nodes) == 2
 
@@ -286,7 +288,7 @@ async def test_get_many_with_pagination(
     criticality_high: Node,
     query_limit_of_one: None,
     neo4j_runtime_parallel: None,
-):
+) -> None:
     new_node_ids: list[str] = []
     for index in range(10):
         bulk_node = await Node.init(db=db, schema=criticality_schema, branch=default_branch)
@@ -304,7 +306,7 @@ async def test_get_many_with_pagination(
 
 async def test_get_many_prefetch(
     db: InfrahubDatabase, person_jack_tags_main, tag_blue_main, tag_red_main, branch: Branch
-):
+) -> None:
     nodes = await NodeManager.get_many(
         db=db, branch=branch, ids=[person_jack_tags_main.id], prefetch_relationships=True
     )
@@ -339,7 +341,7 @@ async def test_get_many_prefetch(
 
 async def test_get_many_prefetch_hierarchical(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     nodes_to_query = ["europe", "asia", "paris", "chicago", "london-r1"]
     node_ids = [hierarchical_location_data[value].id for value in nodes_to_query]
     nodes = await NodeManager.get_many(db=db, ids=node_ids, prefetch_relationships=True)
@@ -365,7 +367,7 @@ async def test_get_many_prefetch_hierarchical(
 
 async def test_get_many_branch_agnostic(
     db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     crit_schema = registry.schema.get(name="TestCriticality", branch=branch, duplicate=False)
     new_crit = await Node.init(schema=crit_schema, db=db, branch=branch)
@@ -398,7 +400,7 @@ async def test_get_many_branch_agnostic(
 
 async def test_get_many_relationship_fields(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     nodes_to_query = ["europe", "asia", "paris", "chicago", "london-r1"]
     node_ids = [hierarchical_location_data[value].id for value in nodes_to_query]
     fields = {"parent": None}
@@ -442,7 +444,7 @@ async def test_query_no_filter(
     criticality_low: Node,
     criticality_medium: Node,
     criticality_high: Node,
-):
+) -> None:
     nodes = await NodeManager.query(db=db, schema=criticality_schema)
     assert len(nodes) == 3
 
@@ -454,7 +456,7 @@ async def test_query_protocol(
     criticality_low: Node,
     criticality_medium: Node,
     criticality_high: Node,
-):
+) -> None:
     nodes = await NodeManager.query(db=db, schema=criticality_protocol)
     assert len(nodes) == 3
 
@@ -466,7 +468,7 @@ async def test_query_with_filter_string_int(
     criticality_low: Node,
     criticality_medium: Node,
     criticality_high: Node,
-):
+) -> None:
     nodes = await NodeManager.query(db=db, schema=criticality_schema, filters={"color__value": "#333333"})
     assert len(nodes) == 2
 
@@ -486,7 +488,7 @@ async def test_query_filter_with_multiple_values_string_int(
     criticality_low: Node,
     criticality_medium: Node,
     criticality_high: Node,
-):
+) -> None:
     nodes = await NodeManager.query(db=db, schema=criticality_schema, filters={"level__values": [2, 3]})
     assert len(nodes) == 2
 
@@ -503,7 +505,7 @@ async def test_query_with_filter_bool_rel(
     car_yaris_main,
     car_camry_main,
     branch: Branch,
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
 
     # Check filter with a boolean
@@ -524,7 +526,7 @@ async def test_query_filter_with_multiple_values_rel(
     car_yaris_main,
     car_camry_main,
     branch: Branch,
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
 
     nodes = await NodeManager.query(db=db, schema=car, branch=branch, filters={"owner__name__values": ["John", "Jane"]})
@@ -540,7 +542,7 @@ async def test_qeury_with_multiple_values_invalid_type(
     car_yaris_main,
     car_camry_main,
     branch: Branch,
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
 
     with pytest.raises(TypeError):
@@ -556,7 +558,7 @@ async def test_query_non_default_class(
     criticality_schema: NodeSchema,
     criticality_low: Node,
     criticality_medium: Node,
-):
+) -> None:
     class TestCriticality(Node):
         def always_true(self):
             return True
@@ -575,12 +577,12 @@ async def test_query_class_name(
     criticality_schema: NodeSchema,
     criticality_low: Node,
     criticality_medium: Node,
-):
+) -> None:
     nodes = await NodeManager.query(db=db, schema="TestCriticality")
     assert len(nodes) == 2
 
 
-async def test_identify_node_class(db: InfrahubDatabase, car_schema, default_branch):
+async def test_identify_node_class(db: InfrahubDatabase, car_schema, default_branch) -> None:
     node = NodeToProcess(
         schema=car_schema,
         node_id=33,
@@ -610,7 +612,9 @@ async def test_identify_node_class(db: InfrahubDatabase, car_schema, default_bra
 # ------------------------------------------------------------------------
 
 
-async def test_get_one_local_attribute_with_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_get_one_local_attribute_with_branch(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -653,7 +657,7 @@ async def test_get_one_local_attribute_with_branch(db: InfrahubDatabase, default
 # ------------------------------------------------------------------------
 
 
-async def test_get_one_global(db: InfrahubDatabase, default_branch: Branch, base_dataset_12):
+async def test_get_one_global(db: InfrahubDatabase, default_branch: Branch, base_dataset_12) -> None:
     branch1 = await registry.get_branch(db=db, branch="branch1")
 
     obj1 = await NodeManager.get_one(db=db, id="p1", branch=branch1)

--- a/backend/tests/unit/core/test_model_hashable.py
+++ b/backend/tests/unit/core/test_model_hashable.py
@@ -4,7 +4,7 @@ from infrahub.core.constants import HashableModelState
 from infrahub.core.models import HashableModel, HashableModelDiff
 
 
-def test_hashable_diff():
+def test_hashable_diff() -> None:
     diff1 = HashableModelDiff()
     diff2 = HashableModelDiff(added={"first": None})
     diff3 = HashableModelDiff(changed={"first": None})
@@ -16,7 +16,7 @@ def test_hashable_diff():
     assert diff4.has_diff is True
 
 
-def test_model_sorting():
+def test_model_sorting() -> None:
     class MySchema(HashableModel):
         _sort_by: list[str] = ["first_name", "last_name"]
         first_name: str
@@ -33,7 +33,7 @@ def test_model_sorting():
     assert sorted_names == [("David", "Doe"), ("David", "Smith"), ("John", "Doe")]
 
 
-def test_model_hashing():
+def test_model_hashing() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -53,7 +53,7 @@ def test_model_hashing():
     assert node1.get_hash() == node2.get_hash()
 
 
-def test_hashing_dict():
+def test_hashing_dict() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -74,7 +74,7 @@ def test_hashing_dict():
     assert node1.get_hash() == node2.get_hash()
 
 
-def test_update():
+def test_update() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -120,7 +120,7 @@ def test_update():
     assert DeepDiff(expected_result, node1.update(node2).model_dump()).to_dict() == {}
 
 
-def test_update_element_absent():
+def test_update_element_absent() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -168,7 +168,7 @@ def test_update_element_absent():
     assert DeepDiff(expected_result, node1.update(node2).model_dump()).to_dict() == {}
 
 
-def test_update_rename():
+def test_update_rename() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -222,7 +222,7 @@ def test_update_rename():
     assert DeepDiff(expected_result, node1.update(node2).model_dump()).to_dict() == {}
 
 
-def test_diff_simple_object():
+def test_diff_simple_object() -> None:
     class ModelA(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -253,7 +253,7 @@ def test_diff_simple_object():
     assert diff_13.model_dump() == {"added": {"value1": None}, "changed": {"value3": None}, "removed": {}}
 
 
-def test_diff_nested_objects():
+def test_diff_nested_objects() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
@@ -291,7 +291,7 @@ def test_diff_nested_objects():
     }
 
 
-def test_update_nested_objects():
+def test_update_nested_objects() -> None:
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -18,7 +18,7 @@ from infrahub.graphql.constants import KIND_GRAPHQL_FIELD_NAME
 
 async def test_node_init(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema, first_account: Node
-):
+) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="low", level=4)
 
@@ -60,7 +60,7 @@ async def test_node_init(
     assert obj._source == first_account
 
 
-async def test_node_init_schema_name(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_schema_name(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     registry.schema.set(name="TestCriticality", schema=criticality_schema)
     obj = await Node.init(db=db, schema="TestCriticality")
     await obj.new(db=db, name="low", level=4)
@@ -74,7 +74,7 @@ async def test_node_init_schema_name(db: InfrahubDatabase, default_branch: Branc
     assert obj.color.is_default is True
 
 
-async def test_node_init_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     uuid1 = str(UUIDT())
@@ -85,7 +85,7 @@ async def test_node_init_id(db: InfrahubDatabase, default_branch: Branch, critic
     assert obj._existing is False
 
 
-async def test_node_init_id_conflict(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_id_conflict(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     uuid1 = str(UUIDT())
@@ -100,7 +100,7 @@ async def test_node_init_id_conflict(db: InfrahubDatabase, default_branch: Branc
     assert "already in use" in str(exc.value)
 
 
-async def test_node_init_invalid_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_invalid_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     obj = await Node.init(db=db, schema="TestCriticality")
@@ -110,7 +110,7 @@ async def test_node_init_invalid_id(db: InfrahubDatabase, default_branch: Branch
     assert "UUID" in str(exc.value)
 
 
-async def test_node_init_mandatory_missing(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_mandatory_missing(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
 
     with pytest.raises(ValidationError) as exc:
@@ -119,7 +119,7 @@ async def test_node_init_mandatory_missing(db: InfrahubDatabase, default_branch:
     assert "mandatory" in str(exc.value)
 
 
-async def test_node_init_mandatory_field_null(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_mandatory_field_null(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
 
     with pytest.raises(ValidationError) as direct_exc:
@@ -132,7 +132,7 @@ async def test_node_init_mandatory_field_null(db: InfrahubDatabase, default_bran
     assert "A value must be provided for name at name" in str(dict_exc.value)
 
 
-async def test_node_init_invalid_attribute(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_invalid_attribute(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
 
     await obj.new(db=db, name="low", level=4, notvalid=False)
@@ -145,7 +145,7 @@ async def test_node_init_invalid_attribute(db: InfrahubDatabase, default_branch:
     assert not hasattr(node, "notvalid")
 
 
-async def test_node_init_invalid_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_init_invalid_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     with pytest.raises(ValidationError) as exc:
         await obj.new(db=db, name="low", level="notanint")
@@ -159,7 +159,7 @@ async def test_node_init_invalid_value(db: InfrahubDatabase, default_branch: Bra
     assert "False is not a valid Text at name" in str(exc.value)
 
 
-async def test_node_default_value(db: InfrahubDatabase, default_branch: Branch):
+async def test_node_default_value(db: InfrahubDatabase, default_branch: Branch) -> None:
     SCHEMA = {
         "name": "OneOfEachKind",
         "namespace": "Test",
@@ -193,7 +193,7 @@ async def test_node_default_value(db: InfrahubDatabase, default_branch: Branch):
     assert obj.mybool_default_false.value is False
 
 
-async def test_render_display_label(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_render_display_label(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     schema_01 = {
         "name": "Display",
         "namespace": "Test",
@@ -274,7 +274,7 @@ async def test_render_display_label(db: InfrahubDatabase, default_branch: Branch
 )
 async def test_display_label(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema, display_label: str, expected: str
-):
+) -> None:
     schema_01 = {
         "name": "Display",
         "namespace": "Test",
@@ -307,7 +307,7 @@ async def test_display_label(
     assert await obj.get_display_label(db=db) == expected
 
 
-async def test_get_hfid(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_get_hfid(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -338,7 +338,7 @@ async def test_get_hfid(db: InfrahubDatabase, default_branch, animal_person_sche
     assert await dog1.get_hfid_as_string(db=db, include_kind=True) == "TestDog__Jack__Rocky"
 
 
-async def test_get_path_value(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_get_path_value(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -362,7 +362,9 @@ async def test_get_path_value(db: InfrahubDatabase, default_branch, animal_perso
     assert "value of a path without property" in str(exc.value)
 
 
-async def test_node_init_with_single_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_node_init_with_single_relationship(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -393,7 +395,7 @@ async def test_node_init_with_single_relationship(db: InfrahubDatabase, default_
     assert c2_peer.id == p1.id
 
 
-async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -428,7 +430,7 @@ async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, car_pers
     assert await c1.to_graphql(db=db, fields={"display_label": None, "name": {"is_protected": None}}) == expected_data
 
 
-async def test_to_graphql_no_fields(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_to_graphql_no_fields(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -493,7 +495,7 @@ async def test_to_graphql_no_fields(db: InfrahubDatabase, default_branch: Branch
     assert await c1.to_graphql(db=db) == expected_data
 
 
-async def test_to_graphql_without_properties(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_to_graphql_without_properties(db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -538,7 +540,7 @@ async def test_to_graphql_without_properties(db: InfrahubDatabase, default_branc
 # --------------------------------------------------------------------------
 
 
-async def test_node_create_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_create_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="low", level=4)
     await obj.save(db=db)
@@ -590,7 +592,7 @@ async def test_node_create_local_attrs(db: InfrahubDatabase, default_branch: Bra
 
 async def test_node_create_attribute_with_source(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account
-):
+) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="low", level=4, _source=first_account)
     await obj.save(db=db)
@@ -614,7 +616,7 @@ async def test_node_create_attribute_with_source(
 
 async def test_node_create_attribute_with_different_sources(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account, second_account
-):
+) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name={"value": "low", "source": second_account.id}, level=4, _source=first_account)
     await obj.save(db=db)
@@ -638,7 +640,7 @@ async def test_node_create_attribute_with_different_sources(
 
 async def test_node_create_attribute_with_owner(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account
-):
+) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="low", level=4, _owner=first_account)
     await obj.save(db=db)
@@ -662,7 +664,7 @@ async def test_node_create_attribute_with_owner(
 
 async def test_node_create_attribute_with_different_owner(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account, second_account
-):
+) -> None:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name={"value": "low", "owner": second_account.id}, level=4, _owner=first_account)
     await obj.save(db=db)
@@ -684,7 +686,9 @@ async def test_node_create_attribute_with_different_owner(
     assert obj.color.owner_id == first_account.id
 
 
-async def test_node_create_with_single_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_node_create_with_single_relationship(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -754,7 +758,9 @@ async def test_node_create_with_single_relationship(db: InfrahubDatabase, defaul
     assert len(paths) == 1
 
 
-async def test_node_create_with_multiple_relationship(db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema):
+async def test_node_create_with_multiple_relationship(
+    db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema
+) -> None:
     fruit = registry.schema.get(name="GardenFruit")
     tag = registry.schema.get(name=InfrahubKind.TAG)
 
@@ -788,7 +794,7 @@ async def test_node_create_with_multiple_relationship(db: InfrahubDatabase, defa
 
 async def test_node_create_with_object_template(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
-):
+) -> None:
     DUMMY = NodeSchema(
         name="Dummy",
         namespace="Testing",
@@ -890,7 +896,7 @@ async def test_node_create_with_object_template(
 # --------------------------------------------------------------------------
 
 
-async def test_node_update_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_update_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -930,7 +936,9 @@ async def test_node_update_local_attrs(db: InfrahubDatabase, default_branch: Bra
     assert await count_relationships(db=db) == nbr_rels
 
 
-async def test_node_update_local_attrs_with_flags(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_update_local_attrs_with_flags(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     fields_to_query = {"name": True, "level": True}
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
@@ -948,7 +956,7 @@ async def test_node_update_local_attrs_with_flags(db: InfrahubDatabase, default_
 
 async def test_node_update_local_attrs_with_metadata(
     db: InfrahubDatabase, criticality_schema, first_account, second_account, branch: Branch
-):
+) -> None:
     obj1 = await Node.init(db=db, branch=branch, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     obj1.name.source = first_account
@@ -996,7 +1004,7 @@ async def test_node_update_local_attrs_with_metadata(
 
 
 @pytest.mark.parametrize("use_branch", [True, False])
-async def test_update_related_node(db: InfrahubDatabase, data_schema, default_branch: Branch, use_branch: bool):
+async def test_update_related_node(db: InfrahubDatabase, data_schema, default_branch: Branch, use_branch: bool) -> None:
     """
     This test has been written to troubleshoot a specific issue
     where a relationship between 2 nodes was being deleted when one of the node was getting updated.
@@ -1148,7 +1156,7 @@ async def test_update_related_node(db: InfrahubDatabase, data_schema, default_br
 # --------------------------------------------------------------------------
 
 
-async def test_node_delete_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_delete_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj2 = await Node.init(db=db, schema=criticality_schema)
     await obj2.new(db=db, name="medium", level=3, description="My desc", color="#333333")
     await obj2.save(db=db)
@@ -1168,7 +1176,7 @@ async def test_node_delete_local_attrs(db: InfrahubDatabase, default_branch: Bra
     assert not await NodeManager.get_one(id=obj2.id, db=db)
 
 
-async def test_node_delete_query_past(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_delete_query_past(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -1189,7 +1197,9 @@ async def test_node_delete_query_past(db: InfrahubDatabase, default_branch: Bran
     assert await NodeManager.get_one(id=obj2.id, at=time1, db=db)
 
 
-async def test_node_delete_local_attrs_in_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_delete_local_attrs_in_branch(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -1217,7 +1227,9 @@ async def test_node_delete_local_attrs_in_branch(db: InfrahubDatabase, default_b
     assert len(resp) == 1
 
 
-async def test_node_delete_with_relationship_bidir(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_node_delete_with_relationship_bidir(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -1251,7 +1263,7 @@ async def test_node_delete_with_relationship_bidir(db: InfrahubDatabase, default
 # --------------------------------------------------------------------------
 
 
-async def test_node_create_in_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_create_in_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     branch1 = await create_branch(branch_name="branch1", db=db)
 
     obj = await Node.init(db=db, schema=criticality_schema, branch=branch1)
@@ -1263,7 +1275,7 @@ async def test_node_create_in_branch(db: InfrahubDatabase, default_branch: Branc
     assert obj2.id == obj.id
 
 
-async def test_node_update_in_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_node_update_in_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -1289,7 +1301,9 @@ async def test_node_update_in_branch(db: InfrahubDatabase, default_branch: Branc
 # --------------------------------------------------------------------------
 
 
-async def test_node_create_in_branch_global(db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global):
+async def test_node_create_in_branch_global(
+    db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global
+) -> None:
     branch1 = await create_branch(branch_name="branch1", db=db)
 
     obj = await Node.init(db=db, schema="GardenFruit", branch=branch1)
@@ -1303,7 +1317,9 @@ async def test_node_create_in_branch_global(db: InfrahubDatabase, default_branch
     assert obj22.id == obj.id
 
 
-async def test_node_update_in_branch_global(db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global):
+async def test_node_update_in_branch_global(
+    db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global
+) -> None:
     obj1 = await Node.init(db=db, schema="GardenFruit")
     await obj1.new(db=db, name="RedApple")
     await obj1.save(db=db)
@@ -1326,7 +1342,7 @@ async def test_node_update_in_branch_global(db: InfrahubDatabase, default_branch
 
 async def test_node_update_attribute_hybrid_in_branch_global(
     db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global
-):
+) -> None:
     red = await Node.init(db=db, schema=InfrahubKind.TAG)
     await red.new(db=db, name="red")
     await red.save(db=db)
@@ -1363,7 +1379,7 @@ async def test_node_update_attribute_hybrid_in_branch_global(
 
 async def test_node_relationship_in_branch_global(
     db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global
-):
+) -> None:
     red = await Node.init(db=db, schema=InfrahubKind.TAG)
     await red.new(db=db, name="red")
     await red.save(db=db)
@@ -1413,7 +1429,9 @@ async def test_node_relationship_in_branch_global(
     assert len(await f2_main.related_fruits.get(db=db)) == 0
 
 
-async def test_node_delete_in_branch_global(db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global):
+async def test_node_delete_in_branch_global(
+    db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema_global
+) -> None:
     red = await Node.init(db=db, schema=InfrahubKind.TAG)
     await red.new(db=db, name="red")
     await red.save(db=db)
@@ -1449,7 +1467,9 @@ async def test_node_delete_in_branch_global(db: InfrahubDatabase, default_branch
 # --------------------------------------------------------------------------
 
 
-async def test_node_relationship_interface(db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema):
+async def test_node_relationship_interface(
+    db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema
+) -> None:
     d1 = await Node.init(db=db, schema="TestCar")
     await d1.new(db=db, name="Porsche 911", nbr_doors=2)
     await d1.save(db=db)
@@ -1472,7 +1492,7 @@ async def test_node_relationship_interface(db: InfrahubDatabase, default_branch:
 # --------------------------------------------------------------------------
 
 
-async def test_node_serialize_prefix(db: InfrahubDatabase, default_branch: Branch, prefix_schema):
+async def test_node_serialize_prefix(db: InfrahubDatabase, default_branch: Branch, prefix_schema) -> None:
     prefix = registry.schema.get(name="TestPrefix")
 
     p1 = await Node.init(db=db, schema=prefix)
@@ -1497,7 +1517,7 @@ async def test_node_serialize_prefix(db: InfrahubDatabase, default_branch: Branc
     assert retrieve_p3.prefix.value == "2001:db8::/128"
 
 
-async def test_node_serialize_address(db: InfrahubDatabase, default_branch: Branch, prefix_schema):
+async def test_node_serialize_address(db: InfrahubDatabase, default_branch: Branch, prefix_schema) -> None:
     ip = registry.schema.get(name="TestIp")
 
     i1 = await Node.init(db=db, schema=ip)

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -21,7 +21,7 @@ from tests.helpers.schema import WIDGET
 
 async def test_query_NodeGetListQuery(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema)
@@ -31,7 +31,7 @@ async def test_query_NodeGetListQuery(
 
 async def test_query_NodeGetListQuery_filter_id(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"id": person_john_main.id})
     await query.execute(db=db)
@@ -40,7 +40,7 @@ async def test_query_NodeGetListQuery_filter_id(
 
 async def test_query_NodeGetListQuery_filter_ids(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     node_to_delete = await NodeManager.get_one(id=person_jim_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
 
@@ -58,7 +58,7 @@ async def test_query_NodeGetListQuery_filter_ids(
 
 async def test_query_NodeGetListQuery_filter_attribute_isnull(
     db: InfrahubDatabase, person_albert_main, person_alfred_main, person_jane_main, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch, duplicate=False)
     person_branch = await NodeManager.get_one(db=db, branch=branch, id=person_albert_main.id)
     person_branch.height.value = None
@@ -107,7 +107,7 @@ async def test_query_NodeGetListQuery_filter_attribute_isnull(
 
 async def test_query_NodeGetListQuery_filter_relationship_isnull_one(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, person_jane_main, branch: Branch
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
     owner_rel = car_schema.get_relationship(name="owner")
     owner_rel.optional = True
@@ -165,7 +165,7 @@ async def test_query_NodeGetListQuery_filter_relationship_isnull_many(
     person_jane_main,
     person_john_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     person_schema.order_by = ["name__value"]
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
@@ -193,7 +193,7 @@ async def test_query_NodeGetListQuery_filter_relationship_isnull_many(
 
 async def test_query_NodeGetListQuery_filter_relationship_attribute_isnull_not_allowed(
     db: InfrahubDatabase, car_person_schema, default_branch
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=default_branch, duplicate=False)
 
     with pytest.raises(RuntimeError, match=r"owner__height__isnull is not allowed"):
@@ -207,7 +207,7 @@ async def test_query_NodeGetListQuery_filter_relationship_attribute_isnull_not_a
 
 async def test_query_NodeGetListQuery_filter_height(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestPerson", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"height__value": 160})
     await query.execute(db=db)
@@ -216,7 +216,7 @@ async def test_query_NodeGetListQuery_filter_height(
 
 async def test_query_NodeGetListQuery_filter_owner(
     db: InfrahubDatabase, default_branch: Branch, person_john_main: Node, first_account: Node, branch: Branch
-):
+) -> None:
     person = await Node.init(db=db, schema="TestPerson", branch=branch)
     await person.new(db=db, name={"value": "Diane", "owner": first_account.id}, height=165)
     await person.save(db=db)
@@ -245,7 +245,7 @@ async def test_query_NodeGetListQuery_filter_owner(
 
 async def test_query_NodeGetListQuery_filter_boolean(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"is_electric__value": False})
     await query.execute(db=db)
@@ -254,7 +254,7 @@ async def test_query_NodeGetListQuery_filter_boolean(
 
 async def test_query_NodeGetListQuery_deleted_node(
     db: InfrahubDatabase, car_accord_main, car_camry_main: Node, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     node_to_delete = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
 
@@ -268,7 +268,7 @@ async def test_query_NodeGetListQuery_deleted_node(
 
 async def test_query_NodeGetListQuery_deleted_node_no_filter(
     db: InfrahubDatabase, car_accord_main, car_camry_main: Node, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     node_to_delete = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
 
@@ -282,7 +282,7 @@ async def test_query_NodeGetListQuery_deleted_node_no_filter(
 
 async def test_query_NodeGetListQuery_filter_relationship(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"owner__name__value": "John"})
     await query.execute(db=db)
@@ -297,7 +297,7 @@ async def test_query_NodeGetListQuery_filter_relationship_ids(
     car_volt_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     query = await NodeGetListQuery.init(
         db=db, branch=branch, schema=schema, filters={"owner__ids": [person_john_main.id]}
@@ -315,7 +315,7 @@ async def test_query_NodeGetListQuery_filter_relationship_ids_with_update(
     car_volt_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     await car_accord.owner.update(db=db, data=person_jane_main)
@@ -331,7 +331,7 @@ async def test_query_NodeGetListQuery_filter_relationship_ids_with_update(
 
 async def test_query_NodeGetListQuery_filter_and_sort(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "is_electric__value"]
 
@@ -347,7 +347,7 @@ async def test_query_NodeGetListQuery_filter_and_sort(
 
 async def test_query_NodeGetListQuery_filter_and_sort_with_revision(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     node = await NodeManager.get_one(id=car_volt_main.id, db=db, branch=branch)
     node.is_electric.value = False
     await node.save(db=db)
@@ -365,7 +365,7 @@ async def test_query_NodeGetListQuery_filter_and_sort_with_revision(
     assert len(query.get_node_ids()) == 2
 
 
-async def test_query_NodeGetListQuery_with_generics(db: InfrahubDatabase, group_group1_main, branch: Branch):
+async def test_query_NodeGetListQuery_with_generics(db: InfrahubDatabase, group_group1_main, branch: Branch) -> None:
     schema = registry.schema.get(name=InfrahubKind.GENERICGROUP, branch=branch)
     query = await NodeGetListQuery.init(
         db=db,
@@ -378,7 +378,7 @@ async def test_query_NodeGetListQuery_with_generics(db: InfrahubDatabase, group_
 
 async def test_query_NodeGetListQuery_order_by(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "name__value"]
 
@@ -393,7 +393,7 @@ async def test_query_NodeGetListQuery_order_by(
 
 async def test_query_NodeGetListQuery_order_by_disabled(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "name__value"]
 
@@ -409,7 +409,7 @@ async def test_query_NodeGetListQuery_order_by_disabled(
 
 async def test_query_NodeGetListQuery_order_by_optional_relationship_nulls(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
     schema.relationships.append(
         RelationshipSchema(
@@ -454,7 +454,7 @@ async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
     car_volt_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
     schema.relationships.append(
         RelationshipSchema(
@@ -503,7 +503,7 @@ async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
 
 async def test_query_NodeGetListQuery_filter_with_profiles(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
@@ -548,7 +548,7 @@ async def test_query_NodeGetListQuery_filter_with_profiles(
 
 async def test_query_NodeGetListQuery_filter_with_generic_profiles(
     db: InfrahubDatabase, animal_person_schema, default_branch: Branch
-):
+) -> None:
     animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
     animal_profile = await Node.init(db=db, schema=animal_profile_schema)
     await animal_profile.new(db=db, profile_name="animal_profile", profile_priority=1000, weight=100)
@@ -612,7 +612,7 @@ async def test_query_NodeGetListQuery_filter_with_generic_profiles(
 
 async def test_query_NodeGetListQuery_order_with_profiles(
     db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
-):
+) -> None:
     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
@@ -649,7 +649,7 @@ async def test_query_NodeGetListQuery_order_with_profiles(
 
 async def test_query_NodeGetListQuery_pagination_order_by(
     db: InfrahubDatabase, default_branch: Branch, node_group_schema
-):
+) -> None:
     """Validate that pagination works for nodes which have an order_by clause on non unique attributes."""
     schema_root = SchemaRoot(nodes=[WIDGET])
 

--- a/backend/tests/unit/core/test_node_manager_delete.py
+++ b/backend/tests/unit/core/test_node_manager_delete.py
@@ -22,7 +22,7 @@ async def test_delete_succeeds(
     car_camry_main: Node,
     car_accord_main: Node,
     person_albert_main: Node,
-):
+) -> None:
     deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[person_albert_main])
 
     assert {d.id for d in deleted} == {person_albert_main.id}
@@ -32,7 +32,7 @@ async def test_delete_succeeds(
 
 async def test_delete_prevented(
     db, default_branch, car_camry_main, car_accord_main, person_albert_main, person_jane_main
-):
+) -> None:
     with pytest.raises(ValidationError) as exc:
         await NodeManager.delete(db=db, branch=default_branch, nodes=[person_jane_main])
 
@@ -51,7 +51,7 @@ async def test_one_sided_relationship(
     person_albert_main,
     person_jane_main,
     car_person_schema_unregistered,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     person_schema = schema_branch.get(name="TestPerson", duplicate=False)
     person_schema.relationships.append(
@@ -80,7 +80,7 @@ async def test_one_sided_relationship(
 
 async def test_source_node_already_deleted(
     db, default_branch, car_camry_main, car_accord_main, person_albert_main, person_jane_main
-):
+) -> None:
     car = await NodeManager.get_one(db=db, id=car_camry_main.id)
     await car.delete(db=db)
 
@@ -98,7 +98,7 @@ async def test_cascade_delete_not_prevented(
     car_accord_main: Node,
     person_albert_main: Node,
     person_jane_main: Node,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     person_schema = schema_branch.get(name="TestPerson", duplicate=False)
     person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
@@ -112,7 +112,7 @@ async def test_cascade_delete_not_prevented(
 
 async def test_delete_with_cascade_on_many_relationship(
     db, default_branch, car_camry_main, car_accord_main, car_prius_main, person_john_main, person_jane_main
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     person_schema = schema_branch.get(name="TestPerson", duplicate=False)
     person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
@@ -126,7 +126,7 @@ async def test_delete_with_cascade_on_many_relationship(
 
 async def test_delete_with_cascade_on_one_relationship(
     db, default_branch, car_camry_main, car_accord_main, person_john_main
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     car_schema = schema_branch.get(name="TestCar", duplicate=False)
     car_schema.get_relationship("owner").on_delete = RelationshipDeleteBehavior.CASCADE
@@ -140,7 +140,7 @@ async def test_delete_with_cascade_on_one_relationship(
 
 async def test_delete_with_cascade_multiple_input_nodes(
     db, default_branch, car_camry_main, car_accord_main, car_prius_main, person_john_main, person_jane_main
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     car_schema = schema_branch.get(name="TestCar", duplicate=False)
     car_schema.get_relationship("owner").on_delete = RelationshipDeleteBehavior.CASCADE
@@ -154,7 +154,7 @@ async def test_delete_with_cascade_multiple_input_nodes(
 
 async def test_delete_with_cascade_both_directions_succeeds(
     db, default_branch, car_camry_main, car_accord_main, car_prius_main, person_john_main, person_jane_main
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     car_schema = schema_branch.get(name="TestCar", duplicate=False)
     car_schema.get_relationship("owner").on_delete = RelationshipDeleteBehavior.CASCADE
@@ -168,7 +168,9 @@ async def test_delete_with_cascade_both_directions_succeeds(
     assert node_map == {}
 
 
-async def test_delete_with_required_on_generic_prevented(db, default_branch, dependent_generics_schema: SchemaBranch):
+async def test_delete_with_required_on_generic_prevented(
+    db, default_branch, dependent_generics_schema: SchemaBranch
+) -> None:
     human = await Node.init(db=db, schema="TestHuman", branch=default_branch)
     await human.new(db=db, name="Jane", height=180)
     await human.save(db=db)
@@ -186,7 +188,9 @@ async def test_delete_with_required_on_generic_prevented(db, default_branch, dep
     assert retrieved_human.id == human.id
 
 
-async def test_delete_with_cascade_on_generic_allowed(db, default_branch, dependent_generics_schema: SchemaBranch):
+async def test_delete_with_cascade_on_generic_allowed(
+    db, default_branch, dependent_generics_schema: SchemaBranch
+) -> None:
     # set TestPerson.animals to be cascade delete
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     for schema_kind in ("TestPerson", "TestHuman", "TestCylon"):
@@ -208,7 +212,7 @@ async def test_delete_with_cascade_on_generic_allowed(db, default_branch, depend
 
 
 class TestDeleteUnidirectionalRelationship(TestInfrahubApp):
-    async def test_delete_unidirectional_optional_relationship(self, db, client, default_branch):
+    async def test_delete_unidirectional_optional_relationship(self, db, client, default_branch) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
         owner = await Node.init(schema=TestKind.PERSON, db=db)

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -28,7 +28,9 @@ from infrahub.core.utils import count_nodes, get_nodes
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_NodeCreateAllQuery(db: InfrahubDatabase, default_branch: Branch, car_person_schema, first_account):
+async def test_query_NodeCreateAllQuery(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, first_account
+) -> None:
     obj = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await obj.new(db=db, name="John", height=180)
     await obj.save(db=db)
@@ -51,7 +53,7 @@ async def test_query_NodeCreateAllQuery(db: InfrahubDatabase, default_branch: Br
 
 async def test_query_NodeCreateAllQuery_iphost(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema
-):
+) -> None:
     obj = await Node.init(db=db, schema="TestAllAttributeTypes", branch=default_branch)
     await obj.new(db=db, ipaddress="10.2.5.2/24")
 
@@ -72,7 +74,7 @@ async def test_query_NodeCreateAllQuery_iphost(
 
 async def test_query_NodeCreateAllQuery_ipnetwork(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema
-):
+) -> None:
     obj = await Node.init(db=db, schema="TestAllAttributeTypes", branch=default_branch)
     await obj.new(db=db, prefix="10.2.5.0/24")
 
@@ -94,7 +96,7 @@ async def test_query_NodeCreateAllQuery_ipnetwork(
 
 async def test_query_NodeListGetInfoQuery(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id]
     query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
     await query.execute(db=db)
@@ -103,7 +105,7 @@ async def test_query_NodeListGetInfoQuery(
 
 async def test_query_NodeListGetInfoQuery_renamed(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     person_schema = candidate_schema.get(name="TestPerson")
@@ -131,7 +133,7 @@ async def test_query_NodeListGetInfoQuery_renamed(
         assert sorted(result) == ["CoreNode", "Node", "Test2NewPerson"]
 
 
-async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, base_dataset_02):
+async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, base_dataset_02) -> None:
     default_branch = await registry.get_branch(db=db, branch="main")
     branch1 = await registry.get_branch(db=db, branch="branch1")
 
@@ -156,7 +158,7 @@ async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, 
 
 async def test_query_NodeListGetAttributeQuery_with_source(
     db: InfrahubDatabase, default_branch, criticality_schema, first_account, second_account
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4, _source=first_account)
     await obj1.save(db=db)
@@ -190,7 +192,7 @@ async def test_query_NodeListGetAttributeQuery_with_source(
     )
 
 
-async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_dataset_02):
+async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_dataset_02) -> None:
     default_branch = await registry.get_branch(db=db, branch="main")
     branch1 = await registry.get_branch(db=db, branch="branch1")
 
@@ -233,7 +235,7 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
     assert query.results[0].branch_score != query.results[1].branch_score
 
 
-async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, base_dataset_02):
+async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, base_dataset_02) -> None:
     default_branch = await registry.get_branch(db=db, branch="main")
     branch1 = await registry.get_branch(db=db, branch="branch1")
 
@@ -280,7 +282,7 @@ async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, bas
 
 async def test_query_NodeListGetRelationshipsQuery(
     db: InfrahubDatabase, default_branch: Branch, person_jack_tags_main, tag_blue_main, tag_red_main
-):
+) -> None:
     default_branch = await registry.get_branch(db=db, branch="main")
     query = await NodeListGetRelationshipsQuery.init(
         db=db,
@@ -298,7 +300,7 @@ async def test_query_NodeListGetRelationshipsQuery(
 
 async def test_query_NodeListGetRelationshipsQuery_hierarchical(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     node_ids = [value.id for value in hierarchical_location_data.values()]
     europe_id = hierarchical_location_data["europe"].id
     paris_id = hierarchical_location_data["paris"].id
@@ -370,7 +372,7 @@ async def test_query_NodeDeleteQuery(
     default_branch: Branch,
     person_jack_tags_main: Node,
     tag_blue_main: Node,
-):
+) -> None:
     tags_before = await NodeManager.query(db=db, schema=InfrahubKind.TAG, branch=default_branch)
 
     query = await NodeDeleteQuery.init(db=db, node=tag_blue_main, branch=default_branch)
@@ -384,7 +386,7 @@ async def test_query_NodeGetHierarchyQuery_ancestors(
     db: InfrahubDatabase,
     default_branch: Branch,
     hierarchical_location_data,
-):
+) -> None:
     node_schema = registry.schema.get(name="LocationRack", branch=default_branch)
 
     europe = hierarchical_location_data["europe"]
@@ -406,7 +408,7 @@ async def test_query_NodeGetHierarchyQuery_filters(
     db: InfrahubDatabase,
     default_branch: Branch,
     hierarchical_location_data: dict[str, Node],
-):
+) -> None:
     node_schema = registry.schema.get(name="LocationRack", branch=default_branch)
 
     europe = hierarchical_location_data["europe"]

--- a/backend/tests/unit/core/test_node_standard.py
+++ b/backend/tests/unit/core/test_node_standard.py
@@ -30,7 +30,7 @@ class PadanticStdNode(StandardNode):
     mylistofmodel: list[MyModel]
 
 
-async def test_node_standard_create(db: InfrahubDatabase, empty_database):
+async def test_node_standard_create(db: InfrahubDatabase, empty_database) -> None:
     obj1 = MyStdNode(
         attr1_str="obj1", attr2_int=1, attr4_bool=True, attr5_dict={"key1": "value2", "key2": {"key21": "Value21"}}
     )
@@ -39,7 +39,7 @@ async def test_node_standard_create(db: InfrahubDatabase, empty_database):
     assert obj1.id is not None
 
 
-async def test_node_standard_delete(db: InfrahubDatabase, empty_database):
+async def test_node_standard_delete(db: InfrahubDatabase, empty_database) -> None:
     obj1 = OtherStdNode(name="obj1")
     await obj1.save(db=db)
     obj2 = OtherStdNode(name="obj2")
@@ -53,7 +53,7 @@ async def test_node_standard_delete(db: InfrahubDatabase, empty_database):
     assert len(objs) == 1
 
 
-async def test_node_standard_get(db: InfrahubDatabase, empty_database):
+async def test_node_standard_get(db: InfrahubDatabase, empty_database) -> None:
     obj1 = MyStdNode(
         attr1_str="obj1", attr2_int="1", attr4_bool=True, attr5_dict={"key1": "value2", "key2": {"key21": "Value21"}}
     )
@@ -65,7 +65,7 @@ async def test_node_standard_get(db: InfrahubDatabase, empty_database):
     assert obj11.attr3_int is None
 
 
-async def test_node_standard_update(db: InfrahubDatabase, empty_database):
+async def test_node_standard_update(db: InfrahubDatabase, empty_database) -> None:
     attr5_value = {"key1": "value2", "key2": {"key21": "Value21"}}
     obj1 = MyStdNode(attr1_str="obj1", attr2_int=1, attr4_bool=True, attr5_dict=attr5_value)
     assert await obj1.save(db=db)
@@ -85,7 +85,7 @@ async def test_node_standard_update(db: InfrahubDatabase, empty_database):
     assert obj12.model_dump(exclude={"uuid"}) == obj11.model_dump(exclude={"uuid"})
 
 
-async def test_node_standard_list(db: InfrahubDatabase, empty_database):
+async def test_node_standard_list(db: InfrahubDatabase, empty_database) -> None:
     obj1 = OtherStdNode(name="obj1")
     await obj1.save(db=db)
     obj2 = OtherStdNode(name="obj2")
@@ -105,7 +105,7 @@ async def test_node_standard_list(db: InfrahubDatabase, empty_database):
     assert objs[0].model_dump(exclude={"uuid"}) == obj2.model_dump(exclude={"uuid"})
 
 
-async def test_node_standard_pydantic(db: InfrahubDatabase, empty_database):
+async def test_node_standard_pydantic(db: InfrahubDatabase, empty_database) -> None:
     obj1 = PadanticStdNode(
         name="obj1",
         mymodel={"key1": 1, "key2": "value2"},

--- a/backend/tests/unit/core/test_path.py
+++ b/backend/tests/unit/core/test_path.py
@@ -4,7 +4,7 @@ from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.path import DataPath, SchemaPath
 
 
-def test_data_path():
+def test_data_path() -> None:
     path1 = DataPath(
         branch="branch",
         path_type=PathType.ATTRIBUTE,
@@ -26,7 +26,7 @@ def test_data_path():
         (SchemaPathType.NODE, "TestPerson", "height", "height", "schema/TestPerson/height"),
     ],
 )
-def test_schema_path(path_type, kind, field_name, prop_name, expected):
+def test_schema_path(path_type, kind, field_name, prop_name, expected) -> None:
     path = SchemaPath(
         path_type=path_type,
         schema_kind=kind,

--- a/backend/tests/unit/core/test_protocols.py
+++ b/backend/tests/unit/core/test_protocols.py
@@ -1,5 +1,5 @@
 from infrahub.core import protocols
 
 
-def test_sanity_protocol_defined():
+def test_sanity_protocol_defined() -> None:
     assert protocols.CoreNode

--- a/backend/tests/unit/core/test_query.py
+++ b/backend/tests/unit/core/test_query.py
@@ -17,7 +17,7 @@ from infrahub.database import InfrahubDatabase
 class Query01(Query):
     type = QueryType.READ
 
-    async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
+    async def query_init(self, db: InfrahubDatabase, *args, **kwargs) -> None:
         self.order_by = ["at.name", "r2.from"]
 
         query = """
@@ -34,7 +34,7 @@ class Query01(Query):
 class Query02(Query):
     type = QueryType.WRITE
 
-    async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
+    async def query_init(self, db: InfrahubDatabase, *args, **kwargs) -> None:
         query = """
         CREATE (n1:NewNode { name: "test1"})-[:IS_CONNECTED]->(n2:NewNode { name: "test2"})
         """
@@ -43,20 +43,20 @@ class Query02(Query):
         self.add_to_query(query)
 
 
-def test_cleanup_return_labels():
+def test_cleanup_return_labels() -> None:
     assert cleanup_return_labels(["r", "n", "l"]) == ["r", "n", "l"]
     assert cleanup_return_labels(["r.uuid", "n", "l"]) == ["r.uuid", "n", "l"]
     assert cleanup_return_labels(["ID(r) as  myid", "n", "l"]) == ["myid", "n", "l"]
 
 
-async def test_query_base(db: InfrahubDatabase):
+async def test_query_base(db: InfrahubDatabase) -> None:
     query = await Query01.init(db=db)
     expected_query = "MATCH (n) WHERE n.uuid = $uuid\nMATCH (n)-[r1]-(at:Attribute)-[r2]-(av)\nRETURN n,at,av,r1,r2\nORDER BY at.name,r2.from"
 
     assert query.get_query() == expected_query
 
 
-async def test_insert_variables_in_query(db: InfrahubDatabase, simple_dataset_01):
+async def test_insert_variables_in_query(db: InfrahubDatabase, simple_dataset_01) -> None:
     params = {
         "my": "tooshort",
         "mystring": "5ffa45d4",
@@ -88,7 +88,7 @@ async def test_insert_variables_in_query(db: InfrahubDatabase, simple_dataset_01
     assert result == "\n".join(expected_query_lines)
 
 
-async def test_query_results(db: InfrahubDatabase, simple_dataset_01):
+async def test_query_results(db: InfrahubDatabase, simple_dataset_01) -> None:
     query = await Query01.init(db=db)
 
     assert query.has_been_executed is False
@@ -100,7 +100,7 @@ async def test_query_results(db: InfrahubDatabase, simple_dataset_01):
     assert query.results[0].get("at") is not None
 
 
-async def test_query_stats(db: InfrahubDatabase, simple_dataset_01):
+async def test_query_stats(db: InfrahubDatabase, simple_dataset_01) -> None:
     query = await Query02.init(db=db)
     await query.execute(db=db)
 
@@ -110,7 +110,7 @@ async def test_query_stats(db: InfrahubDatabase, simple_dataset_01):
     assert query.stats.get_counter("relationships_created") == 1
 
 
-async def test_query_results_limit_offset(db: InfrahubDatabase, simple_dataset_01):
+async def test_query_results_limit_offset(db: InfrahubDatabase, simple_dataset_01) -> None:
     query = await Query01.init(db=db, limit=2, offset=1)
     await query.execute(db=db)
     assert query.num_of_results == 2
@@ -130,7 +130,7 @@ async def test_query_results_limit_offset(db: InfrahubDatabase, simple_dataset_0
     assert expected_values == [5]
 
 
-async def test_query_async(db: InfrahubDatabase, simple_dataset_01):
+async def test_query_async(db: InfrahubDatabase, simple_dataset_01) -> None:
     query = await Query01.init(db=db)
 
     assert query.has_been_executed is False
@@ -142,12 +142,12 @@ async def test_query_async(db: InfrahubDatabase, simple_dataset_01):
     assert query.results[0].get("at") is not None
 
 
-async def test_query_count(db: InfrahubDatabase, simple_dataset_01):
+async def test_query_count(db: InfrahubDatabase, simple_dataset_01) -> None:
     query = await Query01.init(db=db)
     assert await query.count(db=db) == 3
 
 
-async def test_query_result_getters(neo4j_factory):
+async def test_query_result_getters(neo4j_factory) -> None:
     time0 = Timestamp()
 
     n1 = neo4j_factory.hydrate_node(111, {"Car"}, {"uuid": "n1"}, "111")
@@ -193,7 +193,7 @@ async def test_query_result_getters(neo4j_factory):
         qr.get("r3")
 
 
-async def test_sort_results_by_time(neo4j_factory):
+async def test_sort_results_by_time(neo4j_factory) -> None:
     time0 = Timestamp()
 
     n1 = neo4j_factory.hydrate_node(111, {"Car"}, {"uuid": "n1"}, "111")
@@ -241,7 +241,7 @@ async def test_sort_results_by_time(neo4j_factory):
     assert list(results) == [qr3, qr1, qr2]
 
 
-def test_query_node():
+def test_query_node() -> None:
     assert str(QueryNode()) == "()"
     assert str(QueryNode(name="n")) == "(n)"
     assert str(QueryNode(name="n", labels=["MyObject"])) == "(n:MyObject)"
@@ -251,7 +251,7 @@ def test_query_node():
     assert str(QueryNode(name="n", labels=["MyObject"], params={"name": "$myvar"})) == "(n:MyObject { name: $myvar })"
 
 
-def test_query_rel():
+def test_query_rel() -> None:
     assert str(QueryRel()) == "-[]-"
     assert str(QueryRel(name="r2")) == "-[r2]-"
     assert str(QueryRel(name="r2", direction=QueryRelDirection.INBOUND)) == "<-[r2]-"

--- a/backend/tests/unit/core/test_query_branch.py
+++ b/backend/tests/unit/core/test_query_branch.py
@@ -4,7 +4,9 @@ from infrahub.core.registry import registry
 from infrahub.database import InfrahubDatabase
 
 
-async def test_GetAllBranchInternalRelationshipQuery(db: InfrahubDatabase, default_branch: Branch, base_dataset_02):
+async def test_GetAllBranchInternalRelationshipQuery(
+    db: InfrahubDatabase, default_branch: Branch, base_dataset_02
+) -> None:
     branch1 = await registry.get_branch(branch="branch1", db=db)
 
     query = await GetAllBranchInternalRelationshipQuery.init(db=db, branch=branch1)

--- a/backend/tests/unit/core/test_query_subquery.py
+++ b/backend/tests/unit/core/test_query_subquery.py
@@ -7,7 +7,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_build_subquery_filter_attribute_text(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     attr_schema = all_attribute_types_schema.get_attribute(name="mystring")
 
     query, params, result_name = await build_subquery_filter(
@@ -44,7 +44,7 @@ async def test_build_subquery_filter_attribute_text(
 
 async def test_build_subquery_filter_attribute_text_area(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     attr_schema = all_attribute_types_schema.get_attribute(name="mytextarea")
 
     query, params, result_name = await build_subquery_filter(
@@ -81,7 +81,7 @@ async def test_build_subquery_filter_attribute_text_area(
 
 async def test_build_subquery_filter_attribute_list(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     attr_schema = all_attribute_types_schema.get_attribute(name="mylist")
 
     query, params, result_name = await build_subquery_filter(
@@ -118,7 +118,7 @@ async def test_build_subquery_filter_attribute_list(
 
 async def test_build_subquery_filter_attribute_int(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     attr_schema = all_attribute_types_schema.get_attribute(name="myint")
 
     query, params, result_name = await build_subquery_filter(
@@ -153,7 +153,9 @@ async def test_build_subquery_filter_attribute_int(
     assert result_name == "filter2"
 
 
-async def test_build_subquery_filter_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_build_subquery_filter_relationship(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship(name="owner")
 
@@ -194,7 +196,9 @@ async def test_build_subquery_filter_relationship(db: InfrahubDatabase, default_
     assert result_name == "filter1"
 
 
-async def test_build_subquery_filter_relationship_ids(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_build_subquery_filter_relationship_ids(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship(name="owner")
 
@@ -231,7 +235,9 @@ async def test_build_subquery_filter_relationship_ids(db: InfrahubDatabase, defa
     assert result_name == "filter1"
 
 
-async def test_build_subquery_order_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+async def test_build_subquery_order_relationship(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship(name="owner")
 
@@ -262,7 +268,7 @@ async def test_build_subquery_order_relationship(db: InfrahubDatabase, default_b
 
 async def test_build_subquery_filter_attribute_multiple_values(
     db: InfrahubDatabase, default_branch: Branch, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     attr_schema = all_attribute_types_schema.get_attribute(name="mystring")
 
     query, params, result_name = await build_subquery_filter(
@@ -299,7 +305,7 @@ async def test_build_subquery_filter_attribute_multiple_values(
 
 async def test_build_subquery_filter_relationship_multiple_values(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship(name="owner")
 

--- a/backend/tests/unit/core/test_query_utils.py
+++ b/backend/tests/unit/core/test_query_utils.py
@@ -3,7 +3,7 @@ from infrahub.core.query.utils import find_node_schema
 from infrahub.database import InfrahubDatabase
 
 
-async def test_find_node_schema(db: InfrahubDatabase, neo4j_factory, group_schema, branch):
+async def test_find_node_schema(db: InfrahubDatabase, neo4j_factory, group_schema, branch) -> None:
     n1 = neo4j_factory.hydrate_node(111, {"Node", "Group", InfrahubKind.STANDARDGROUP}, {"uuid": "n1"}, "111")
     schema = find_node_schema(db=db, node=n1, branch=branch, duplicate=True)
     assert schema.kind == InfrahubKind.STANDARDGROUP

--- a/backend/tests/unit/core/test_registry.py
+++ b/backend/tests/unit/core/test_registry.py
@@ -6,7 +6,7 @@ from infrahub.core.schema.manager import SchemaManager
 from infrahub.database import InfrahubDatabase
 
 
-async def test_get_branch_from_registry(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_branch_from_registry(db: InfrahubDatabase, default_branch: Branch) -> None:
     br1 = registry.get_branch_from_registry()
     assert br1.name == default_branch.name
 
@@ -14,7 +14,7 @@ async def test_get_branch_from_registry(db: InfrahubDatabase, default_branch: Br
     assert br2.name == default_branch.name
 
 
-async def test_get_branch_not_in_registry(db: InfrahubDatabase, default_branch: Branch):
+async def test_get_branch_not_in_registry(db: InfrahubDatabase, default_branch: Branch) -> None:
     # initialize internal registry
     registry.schema = SchemaManager()
     schema = SchemaRoot(**internal_schema)

--- a/backend/tests/unit/core/test_relationship.py
+++ b/backend/tests/unit/core/test_relationship.py
@@ -16,7 +16,7 @@ from infrahub.database import InfrahubDatabase
 
 async def test_relationship_init(
     db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -48,7 +48,7 @@ async def test_relationship_init_w_node_property(
     tag_blue_main: Node,
     person_jack_main: Node,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -82,7 +82,7 @@ async def car_smart_properties_main(db: InfrahubDatabase, default_branch: Branch
 
 async def test_relationship_load_existing(
     db: InfrahubDatabase, person_john_main: Node, car_smart_properties_main: Node, branch: Branch
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship("owner")
 
@@ -110,7 +110,9 @@ async def test_relationship_load_existing(
     assert rel.is_visible is False
 
 
-async def test_relationship_peer(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
+async def test_relationship_peer(
+    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -126,7 +128,9 @@ async def test_relationship_peer(db: InfrahubDatabase, tag_blue_main: Node, pers
     assert await rel.get_peer(db=db) == tag_blue_main
 
 
-async def test_relationship_save(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
+async def test_relationship_save(
+    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -142,7 +146,7 @@ async def test_relationship_save(db: InfrahubDatabase, tag_blue_main: Node, pers
 
 async def test_relationship_hash(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch, first_account
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -175,7 +179,7 @@ async def test_relationship_hash(
     assert hash4 != hash5
 
 
-async def test_relationship_validate_one_init_empty_success():
+async def test_relationship_validate_one_init_empty_success() -> None:
     result = RelationshipValidatorList(name="name", min_count=1, max_count=1)
 
     # Assert that the list is empty
@@ -185,7 +189,7 @@ async def test_relationship_validate_one_init_empty_success():
     assert isinstance(result, RelationshipValidatorList)
 
 
-async def test_relationship_validate_many_init_empty_success():
+async def test_relationship_validate_many_init_empty_success() -> None:
     result = RelationshipValidatorList(name="name", min_count=100, max_count=100)
 
     # Assert that the list is empty
@@ -194,7 +198,7 @@ async def test_relationship_validate_many_init_empty_success():
     assert result.max_count == 100
 
 
-async def test_relationship_validate_empty_init_success():
+async def test_relationship_validate_empty_init_success() -> None:
     result = RelationshipValidatorList(name="name")
 
     # Assert that the list is empty
@@ -204,12 +208,14 @@ async def test_relationship_validate_empty_init_success():
     assert isinstance(result, RelationshipValidatorList)
 
 
-async def test_relationship_validate_many_init_empty_raise_min_ge_max():
+async def test_relationship_validate_many_init_empty_raise_min_ge_max() -> None:
     with pytest.raises(infra_execs.ValidationError):
         RelationshipValidatorList(name="name", min_count=200, max_count=100)
 
 
-async def test_relationship_validate_init_below_min_raise(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_relationship_validate_init_below_min_raise(
+    db: InfrahubDatabase, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -219,7 +225,9 @@ async def test_relationship_validate_init_below_min_raise(db: InfrahubDatabase, 
         RelationshipValidatorList(rel_jack, name="name", min_count=3, max_count=0)
 
 
-async def test_relationship_validate_init_above_max_raise(db: InfrahubDatabase, person_jack_main: None, branch: Branch):
+async def test_relationship_validate_init_above_max_raise(
+    db: InfrahubDatabase, person_jack_main: None, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -231,7 +239,7 @@ async def test_relationship_validate_init_above_max_raise(db: InfrahubDatabase, 
         RelationshipValidatorList(rel_1, rel_2, rel_3, name="name", min_count=0, max_count=2)
 
 
-async def test_relationship_validate_one_success(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_relationship_validate_one_success(db: InfrahubDatabase, person_jack_main: Node, branch: Branch) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -249,7 +257,9 @@ async def test_relationship_validate_one_success(db: InfrahubDatabase, person_ja
     assert result.max_count == 1
 
 
-async def test_relationship_validate_one_append_raise(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_relationship_validate_one_append_raise(
+    db: InfrahubDatabase, person_jack_main: Node, branch: Branch
+) -> None:
     """Validate that it raises when appending a second relationship onto cardinality of one."""
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
@@ -271,7 +281,7 @@ async def test_relationship_validate_one_append_raise(db: InfrahubDatabase, pers
 
 async def test_relationship_validate_one_append_extend_duplicate(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     """Attempting to use the methods that would insert over the max_count but are duplicates."""
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
@@ -291,7 +301,9 @@ async def test_relationship_validate_one_append_extend_duplicate(
     assert result.get(0) == rel_jack
 
 
-async def test_relationship_validate_one_extend_raise(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_relationship_validate_one_extend_raise(
+    db: InfrahubDatabase, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -304,7 +316,9 @@ async def test_relationship_validate_one_extend_raise(db: InfrahubDatabase, pers
         result.extend([rel_albert])
 
 
-async def test_relationship_validate_one_remove_raise(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_relationship_validate_one_remove_raise(
+    db: InfrahubDatabase, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -325,7 +339,7 @@ async def test_relationship_validate_one_remove_raise(db: InfrahubDatabase, pers
 
 async def test_relationship_validate_many_no_limit_success(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -342,7 +356,7 @@ async def test_relationship_validate_many_no_limit_success(
 
 async def test_relationship_validate_many_no_limit_duplicate_success(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -358,7 +372,7 @@ async def test_relationship_validate_many_no_limit_duplicate_success(
 
 async def test_relationship_validate_many_above_max_count_raise(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -384,7 +398,7 @@ async def test_relationship_validate_many_above_max_count_raise(
 
 async def test_relationship_validate_many_less_than_min_raise(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -414,7 +428,7 @@ async def test_relationship_assign_from_pool(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 
@@ -441,7 +455,7 @@ async def test_relationship_assign_from_pool(
 
 async def test_relationship_timestamp_changes(
     db: InfrahubDatabase, person_jack_main: Node, tag_blue_main: Node, tag_red_main: Node, branch: Branch
-):
+) -> None:
     # test going back in time after adding a relationship
     before_add = Timestamp()
     person_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_main.id)
@@ -487,7 +501,7 @@ async def test_relationship_timestamp_changes(
 
 async def test_relationship_second_delete_is_ignored(
     db: InfrahubDatabase, person_jack_main: Node, tag_blue_main: Node, branch: Branch
-):
+) -> None:
     person_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_main.id)
     await person_jack.tags.update(db=db, data=[tag_blue_main.id])
     await person_jack.save(db=db)
@@ -517,7 +531,7 @@ RETURN count(*) AS num_paths
 
 async def test_can_create_relationship_with_min_count_only(
     db: InfrahubDatabase, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 

--- a/backend/tests/unit/core/test_relationship_manager.py
+++ b/backend/tests/unit/core/test_relationship_manager.py
@@ -11,7 +11,7 @@ from infrahub.core.utils import get_paths_between_nodes
 from infrahub.database import InfrahubDatabase
 
 
-async def test_one_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_one_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
@@ -28,7 +28,7 @@ async def test_one_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: 
 
 async def test_one_init_no_input_existing_rel(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_primary_tag_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
@@ -44,7 +44,7 @@ async def test_one_init_no_input_existing_rel(
     assert peer.id == tag_blue_main.id
 
 
-async def test_many_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
+async def test_many_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -59,7 +59,9 @@ async def test_many_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main:
     assert not len(await relm.get(db=db))
 
 
-async def test_many_init_no_input_existing_rel(db: InfrahubDatabase, person_jack_tags_main: Node, branch: Branch):
+async def test_many_init_no_input_existing_rel(
+    db: InfrahubDatabase, person_jack_tags_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -70,7 +72,9 @@ async def test_many_init_no_input_existing_rel(db: InfrahubDatabase, person_jack
     assert len(await relm.get(db=db)) == 2
 
 
-async def test_one_init_input_obj(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
+async def test_one_init_input_obj(
+    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
@@ -87,7 +91,9 @@ async def test_one_init_input_obj(db: InfrahubDatabase, tag_blue_main: Node, per
     assert peer.id == tag_blue_main.id
 
 
-async def test_one_save_input_obj(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
+async def test_one_save_input_obj(
+    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
@@ -117,7 +123,7 @@ async def test_one_save_input_obj(db: InfrahubDatabase, tag_blue_main: Node, per
 
 async def test_one_udpate(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_primary_tag_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
@@ -147,7 +153,7 @@ async def test_one_udpate(
 
 async def test_many_init_input_obj(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -165,7 +171,7 @@ async def test_many_init_input_obj(
 
 async def test_many_save_input_obj(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -203,7 +209,7 @@ async def test_many_save_input_obj(
 
 async def test_many_update(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -252,7 +258,7 @@ async def test_many_update(
 
 async def test_many_add(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -298,7 +304,7 @@ async def test_many_add(
     assert len(paths) == 2
 
 
-async def test_get_parent(db: InfrahubDatabase, car_accord_main: Node, person_john_main: Node, branch: Branch):
+async def test_get_parent(db: InfrahubDatabase, car_accord_main: Node, person_john_main: Node, branch: Branch) -> None:
     car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship("owner")
 
@@ -365,7 +371,7 @@ async def test_can_create_relationship_manager_with_optional_and_count_constrain
     person_jack_primary_tag_main: Node,
     branch: Branch,
     test_case: RelationshipManagerOptionalAndCountTestCaseData,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
     rel_schema.optional = test_case.optional

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -31,7 +31,7 @@ from tests.helpers.db_validation import verify_no_duplicate_paths
 
 
 class DummyRelationshipQuery(RelationshipQuery):
-    async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
+    async def query_init(self, db: InfrahubDatabase, *args, **kwargs) -> None:
         pass
 
 
@@ -96,7 +96,7 @@ async def get_relationship_properties(
 
 async def test_RelationshipQuery_init(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -138,7 +138,7 @@ async def test_RelationshipQuery_init(
 
 async def test_query_RelationshipCreateQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -166,7 +166,7 @@ async def test_query_RelationshipCreateQuery(
 
 async def test_query_RelationshipCreateQuery_w_node_property(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, first_account: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -204,7 +204,7 @@ async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
     tag_red_main: Node,
     person_jack_main: Node,
     branch: Branch,
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=branch.name)
     person_schema = schema.get(name="TestPerson")
     person_schema.name = "GreatPerson"
@@ -286,7 +286,7 @@ async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
 
 async def test_query_RelationshipDeleteQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -417,7 +417,7 @@ async def test_query_RelationshipDeleteQuery(
 
 async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
     paths = await get_paths_between_nodes(
@@ -464,7 +464,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
     await verify_no_duplicate_paths(db=db)
 
 
-async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch, tag_blue_main: Node):
+async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch, tag_blue_main: Node) -> None:
     person = await Node.init(db=db, branch=default_branch, schema="TestPerson")
     await person.new(db=db, firstname="Kara", lastname="Thrace", tags=[tag_blue_main])
     create_before = Timestamp()
@@ -500,7 +500,7 @@ async def test_branch_delete_with_updated_main_relationship(
     person_jack_primary_tag_main: Node,
     tag_blue_main: Node,
     tag_black_main: Node,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch2")
     before_main_update = Timestamp()
     person_main = await NodeManager.get_one(db=db, id=person_jack_primary_tag_main.id)
@@ -551,7 +551,7 @@ async def test_main_delete_with_updated_branch_relationship(
     person_jack_primary_tag_main: Node,
     tag_blue_main: Node,
     tag_black_main: Node,
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch2")
     before_branch_update = Timestamp()
     person_branch = await NodeManager.get_one(db=db, branch=branch, id=person_jack_primary_tag_main.id)
@@ -609,7 +609,7 @@ async def test_main_delete_with_updated_branch_relationship(
 
 async def test_relationship_update_with_delete_peer(
     db: InfrahubDatabase, default_branch, tag_blue_main: Node, tag_red_main: Node
-):
+) -> None:
     person = await Node.init(db=db, branch=default_branch, schema="TestPerson")
     await person.new(db=db, firstname="Kara", lastname="Thrace", tags=[tag_blue_main])
     create_before = Timestamp()
@@ -642,7 +642,7 @@ async def test_relationship_update_with_delete_peer(
 
 async def test_query_RelationshipGetPeerQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -679,7 +679,7 @@ async def test_query_RelationshipGetPeerQuery_with_filter(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -707,7 +707,7 @@ async def test_query_RelationshipGetPeerQuery_with_id(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -734,7 +734,7 @@ async def test_query_RelationshipGetPeerQuery_with_ids(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -761,7 +761,7 @@ async def test_query_RelationshipGetPeerQuery_with_sort(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=branch)
     car_schema.order_by = ["name__value"]
     registry.schema.set(name="TestCar", branch=branch.name, schema=car_schema)
@@ -792,7 +792,7 @@ async def test_query_RelationshipGetPeerQuery_deleted_node(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     node = await NodeManager.get_one(id=car_volt_main.id, db=db, branch=branch)
     await node.delete(db=db)
 
@@ -821,7 +821,7 @@ async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -849,7 +849,7 @@ async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get_node_schema(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -885,7 +885,7 @@ async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
 
 async def test_query_RelationshipDataDeleteQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
@@ -937,7 +937,7 @@ async def test_query_RelationshipDataDeleteQuery(
 
 async def test_query_RelationshipDataDeleteQuery_on_migrated_kind_node(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_tags_main: Node, branch: Branch
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     rel_schema = person_schema.get_relationship("tags")
 
@@ -1031,7 +1031,7 @@ async def test_query_RelationshipCountPerNodeQuery(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
@@ -1085,7 +1085,7 @@ async def test_query_RelationshipGetByIdentifierQuery(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     with pytest.raises(ValueError) as exc:
         query = await RelationshipGetByIdentifierQuery.init(
             db=db, branch=branch, identifiers=[], excluded_namespaces=[]
@@ -1123,7 +1123,7 @@ async def test_query_RelationshipGetQuery(
     car_prius_main: Node,
     person_john_main: Node,
     branch: Branch,
-):
+) -> None:
     person_john = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
     car_prius = await NodeManager.get_one(db=db, branch=branch, id=car_prius_main.id)
     owner_rels = await car_prius.owner.get_relationships(db=db)

--- a/backend/tests/unit/core/test_relationships_rebase.py
+++ b/backend/tests/unit/core/test_relationships_rebase.py
@@ -75,7 +75,7 @@ class TestRelationshipsWithRebase:
         branch_peer_id: str,
         branch_name: str,
         rebase_time: Timestamp,
-    ):
+    ) -> None:
         database_paths = await get_database_edges_state(
             db=db, node_uuids=[car_uuid], rel_identiers=["testcar__testperson"]
         )
@@ -173,7 +173,7 @@ class TestRelationshipsWithRebase:
         person_jim_main: Node,
         car_accord_main: Node,
         num_updates: int,
-    ):
+    ) -> None:
         branch_2 = await create_branch(db=db, branch_name="branch_2")
         car_branch = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch_2)
         await car_branch.owner.update(db=db, data=person_alfred_main)
@@ -212,7 +212,7 @@ class TestRelationshipsWithRebase:
         car_person_id_map_branch: dict[str, str],
         branch_name: str,
         rebase_time: Timestamp,
-    ):
+    ) -> None:
         database_paths = await get_database_edges_state(
             db=db, node_uuids=person_uuids, rel_identiers=["testcar__testperson"]
         )
@@ -295,7 +295,7 @@ class TestRelationshipsWithRebase:
         db: InfrahubDatabase,
         default_branch: Branch,
         car_person_schema: SchemaBranch,
-    ):
+    ) -> None:
         people = []
         cars = []
         car_person_id_map_main = {}

--- a/backend/tests/unit/core/test_schema.py
+++ b/backend/tests/unit/core/test_schema.py
@@ -138,7 +138,7 @@ async def test_schema_warnings(
     assert test_case.schema.gather_warnings() == test_case.warnings
 
 
-def test_schema_root_no_generic():
+def test_schema_root_no_generic() -> None:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -156,7 +156,7 @@ def test_schema_root_no_generic():
     assert SchemaRoot(**FULL_SCHEMA)
 
 
-def test_node_schema_property_unique_attributes():
+def test_node_schema_property_unique_attributes() -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -173,7 +173,7 @@ def test_node_schema_property_unique_attributes():
     assert schema.unique_attributes[0].name == "name"
 
 
-async def test_node_schema_hashable():
+async def test_node_schema_hashable() -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -193,7 +193,7 @@ async def test_node_schema_hashable():
     assert schema.get_hash()
 
 
-async def test_attribute_schema_hashable():
+async def test_attribute_schema_hashable() -> None:
     SCHEMA = {"name": "name", "kind": "Text", "unique": True}
 
     schema = AttributeSchema(**SCHEMA)
@@ -202,7 +202,7 @@ async def test_attribute_schema_hashable():
     assert schema.get_hash()
 
 
-async def test_relationship_schema_hashable():
+async def test_relationship_schema_hashable() -> None:
     SCHEMA = {"name": "first", "peer": "Criticality", "identifier": "cardinality__peer", "cardinality": "one"}
 
     schema = RelationshipSchema(**SCHEMA)
@@ -211,7 +211,7 @@ async def test_relationship_schema_hashable():
     assert schema.get_hash()
 
 
-async def test_node_schema_generate_fields_for_display_label():
+async def test_node_schema_generate_fields_for_display_label() -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -231,7 +231,7 @@ async def test_node_schema_generate_fields_for_display_label():
     assert schema.generate_fields_for_display_label() == {"level": {"value": None}, "name": {"value": None}}
 
 
-async def test_node_schema_generate_fields_for_display_label_with_generic(default_branch: Branch):
+async def test_node_schema_generate_fields_for_display_label_with_generic(default_branch: Branch) -> None:
     generic_schema = GenericSchema(
         name="ThingGeneric",
         namespace="Test",
@@ -264,7 +264,7 @@ async def test_node_schema_generate_fields_for_display_label_with_generic(defaul
     assert generic_display_label == {"name": {"value": None}, "height": {"value": None}}
 
 
-async def test_rel_schema_query_filter(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_rel_schema_query_filter(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     person = registry.schema.get(name="TestPerson")
     rel = person.relationships[0]
 
@@ -299,7 +299,7 @@ async def test_rel_schema_query_filter(db: InfrahubDatabase, default_branch, car
     assert matches == []
 
 
-async def test_rel_schema_query_filter_no_value(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_rel_schema_query_filter_no_value(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     person = registry.schema.get(name="TestPerson")
     rel = person.relationships[0]
 
@@ -334,7 +334,9 @@ async def test_rel_schema_query_filter_no_value(db: InfrahubDatabase, default_br
     assert matches == []
 
 
-async def test_rel_schema_query_filter_large_attribute_type(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_rel_schema_query_filter_large_attribute_type(
+    db: InfrahubDatabase, default_branch, car_person_schema
+) -> None:
     person = registry.schema.get(name="TestPerson")
     rel = person.relationships[0]
     car_schema = registry.schema.get(name="TestCar", duplicate=False)
@@ -359,15 +361,15 @@ async def test_rel_schema_query_filter_large_attribute_type(db: InfrahubDatabase
     assert matches == []
 
 
-def test_core_models():
+def test_core_models() -> None:
     assert SchemaRoot(**core_models)
 
 
-def test_internal_schema():
+def test_internal_schema() -> None:
     assert SchemaRoot(**internal_schema)
 
 
-async def test_attribute_schema_parameters():
+async def test_attribute_schema_parameters() -> None:
     regex = "abc"
     min_length = 3
     max_length = 5
@@ -393,7 +395,7 @@ async def test_attribute_schema_parameters():
         attr_schema = AttributeSchema(name="something", kind="Number", parameters={"regex": "abc"})
 
 
-async def test_attribute_schema_choices_invalid_kind():
+async def test_attribute_schema_choices_invalid_kind() -> None:
     SCHEMA = {"name": "name", "kind": "Text", "choices": [DropdownChoice(name="active", color="#AAbb0f")]}
 
     with pytest.raises(ValidationError) as exc:
@@ -402,7 +404,7 @@ async def test_attribute_schema_choices_invalid_kind():
     assert "Can only specify 'choices' for kind=Dropdown" in str(exc.value)
 
 
-async def test_attribute_schema_dropdown_missing_choices():
+async def test_attribute_schema_dropdown_missing_choices() -> None:
     SCHEMA: dict[str, Any] = {"name": "name", "kind": "Dropdown"}
 
     with pytest.raises(ValidationError) as exc:
@@ -411,7 +413,7 @@ async def test_attribute_schema_dropdown_missing_choices():
     assert "The property 'choices' is required for kind=Dropdown" in str(exc.value)
 
 
-def test_dropdown_choice_colors():
+def test_dropdown_choice_colors() -> None:
     active = DropdownChoice(name="active", color="#AAbb0f")
     assert active.color == "#aabb0f"
     with pytest.raises(ValidationError) as exc:
@@ -420,13 +422,13 @@ def test_dropdown_choice_colors():
     assert "Color must be a valid HTML color code" in str(exc.value)
 
 
-def test_dropdown_choice_sort():
+def test_dropdown_choice_sort() -> None:
     active = DropdownChoice(name="active", color="#AAbb0f")
     passive = DropdownChoice(name="passive", color="#AAbb0f")
     assert active < passive
 
 
-def test_validate_python_keywords_with_attribute_and_relationship():
+def test_validate_python_keywords_with_attribute_and_relationship() -> None:
     """Test that validate_python_keywords rejects Python keywords in attribute and relationship names."""
     # Test schema with 'from' keyword as attribute name
     SCHEMA_WITH_KEYWORD_ATTR: dict[str, Any] = {
@@ -525,7 +527,7 @@ def test_validate_python_keywords_with_attribute_and_relationship():
     schema_branch.process_validate()
 
 
-def test_validate_python_keywords_multiple_keywords():
+def test_validate_python_keywords_multiple_keywords() -> None:
     """Test that validate_python_keywords catches multiple Python keywords."""
     SCHEMA_WITH_MULTIPLE_KEYWORDS: dict[str, Any] = {
         "nodes": [
@@ -566,7 +568,7 @@ def test_validate_python_keywords_multiple_keywords():
     assert keyword_found, f"Expected Python keyword error, got: {error_message}"
 
 
-def test_validate_namespaces_and_keyword_separation():
+def test_validate_namespaces_and_keyword_separation() -> None:
     """Test that namespace and Python keyword validation work separately in their proper contexts."""
     # Test that SchemaRoot.validate_namespaces() only catches namespace issues
     SCHEMA_WITH_NAMESPACE_ISSUE: dict[str, Any] = {

--- a/backend/tests/unit/core/test_schema_parse_schema_path.py
+++ b/backend/tests/unit/core/test_schema_parse_schema_path.py
@@ -6,45 +6,45 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 
 
 class TestSchemaParseSchemaPath:
-    def test_property_only_is_invalid(self, car_person_schema):
+    def test_property_only_is_invalid(self, car_person_schema) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         with pytest.raises(AttributePathParsingError, match=r"value is invalid on schema"):
             car_schema.parse_schema_path(path="value")
 
     @pytest.mark.parametrize("bad_path", ["blork", "person", "__", "__dunder__"])
-    def test_invalid_paths(self, car_person_schema, bad_path):
+    def test_invalid_paths(self, car_person_schema, bad_path) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         with pytest.raises(AttributePathParsingError, match=rf"{bad_path} is invalid on schema"):
             car_schema.parse_schema_path(path=bad_path)
 
-    def test_invalid_attribute_of_relationship_path(self, car_person_schema):
+    def test_invalid_attribute_of_relationship_path(self, car_person_schema) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         with pytest.raises(AttributePathParsingError, match=r"blork is not a valid attribute of TestPerson"):
             car_schema.parse_schema_path(path="owner__blork", schema=car_person_schema)
 
-    def test_invalid_property_of_attribute_path(self, car_person_schema):
+    def test_invalid_property_of_attribute_path(self, car_person_schema) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         with pytest.raises(AttributePathParsingError, match=r"blork is not a valid property of nbr_seats"):
             car_schema.parse_schema_path(path="nbr_seats__blork")
 
-    def test_invalid_path_with_map_override(self, car_person_schema: SchemaBranch):
+    def test_invalid_path_with_map_override(self, car_person_schema: SchemaBranch) -> None:
         car_schema = car_person_schema.get("TestCar")
 
         with pytest.raises(AttributePathParsingError, match=r"blork is not a valid attribute of TestPerson"):
             car_schema.parse_schema_path(path="owner__blork", schema=car_person_schema)
 
-    def test_attribute_only_is_valid(self, car_person_schema):
+    def test_attribute_only_is_valid(self, car_person_schema) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         schema_path = car_schema.parse_schema_path(path="nbr_seats")
 
         assert schema_path == SchemaAttributePath(attribute_schema=car_schema.get_attribute("nbr_seats"))
 
-    def test_relationship_only_is_valid(self, car_person_schema: SchemaBranch):
+    def test_relationship_only_is_valid(self, car_person_schema: SchemaBranch) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         schema_path = car_schema.parse_schema_path(path="owner", schema=car_person_schema)
@@ -54,7 +54,7 @@ class TestSchemaParseSchemaPath:
             related_schema=registry.schema.get(name="TestPerson"),
         )
 
-    def test_relationship_and_attribute_is_valid(self, car_person_schema: SchemaBranch):
+    def test_relationship_and_attribute_is_valid(self, car_person_schema: SchemaBranch) -> None:
         car_schema = registry.schema.get(name="TestCar")
 
         schema_path = car_schema.parse_schema_path(path="owner__name", schema=car_person_schema)
@@ -66,7 +66,7 @@ class TestSchemaParseSchemaPath:
             attribute_schema=owner_schema.get_attribute("name"),
         )
 
-    def test_relationship_attribute_and_property_is_valid(self, car_person_schema: SchemaBranch):
+    def test_relationship_attribute_and_property_is_valid(self, car_person_schema: SchemaBranch) -> None:
         car_schema = car_person_schema.get("TestCar")
         owner_schema = car_person_schema.get("TestPerson")
 

--- a/backend/tests/unit/core/test_utils.py
+++ b/backend/tests/unit/core/test_utils.py
@@ -14,7 +14,7 @@ from infrahub.database import InfrahubDatabase
         (ipaddress.ip_interface("192.0.22.23/22"), "11000000000000000001011000010111"),
     ],
 )
-def test_convert_ip_to_binary_str(input, response):
+def test_convert_ip_to_binary_str(input, response) -> None:
     assert convert_ip_to_binary_str(obj=input) == response
 
 

--- a/backend/tests/unit/event/test_event.py
+++ b/backend/tests/unit/event/test_event.py
@@ -4,7 +4,7 @@ from infrahub.core.constants import EventType as MainEventType
 from infrahub.events.utils import get_all_events
 
 
-def test_event_type_mapping():
+def test_event_type_mapping() -> None:
     event_names = [event.event_name for event in get_all_events()]
     main_event_types = MainEventType.available_types()
 

--- a/backend/tests/unit/git/test_git_read_only_repository.py
+++ b/backend/tests/unit/git/test_git_read_only_repository.py
@@ -12,7 +12,7 @@ from infrahub.services import InfrahubServices
 from tests.helpers.test_client import dummy_async_request
 
 
-async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path):
+async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:
     repo = await InfrahubReadOnlyRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -33,7 +33,7 @@ async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_re
 @patch("infrahub.git.base.Repo")
 async def test_new_invalid_branch(
     mock_repo: MagicMock, mock_clone_from: MagicMock, git_upstream_repo_01: dict[str, str | Path]
-):
+) -> None:
     mock_repo_instance = MagicMock()
     mock_repo_instance.git.checkout.side_effect = GitCommandError("checkout", stderr="error: pathspec")
     mock_repo.return_value = mock_repo_instance
@@ -55,13 +55,13 @@ async def test_new_invalid_branch(
         )
 
 
-async def test_get_commit_value(git_repo_01_read_only: InfrahubReadOnlyRepository):
+async def test_get_commit_value(git_repo_01_read_only: InfrahubReadOnlyRepository) -> None:
     repo = git_repo_01_read_only
     assert repo.get_commit_value(branch_name="does_not_matter") == "92700512b5b16c0144f7fd2869669273577f1bd8"
     assert repo.get_commit_value(branch_name="branch02", remote=True) == "92700512b5b16c0144f7fd2869669273577f1bd8"
 
 
-async def test_get_branches_from_local(git_repo_01_read_only: InfrahubReadOnlyRepository):
+async def test_get_branches_from_local(git_repo_01_read_only: InfrahubReadOnlyRepository) -> None:
     repo = git_repo_01_read_only
 
     local_branches = repo.get_branches_from_local()
@@ -69,7 +69,7 @@ async def test_get_branches_from_local(git_repo_01_read_only: InfrahubReadOnlyRe
     assert set(local_branches.keys()) == {"main", "branch01"}
 
 
-async def test_sync_from_remote_new_ref(git_repo_01_read_only: InfrahubReadOnlyRepository):
+async def test_sync_from_remote_new_ref(git_repo_01_read_only: InfrahubReadOnlyRepository) -> None:
     repo = git_repo_01_read_only
     repo.ref = "branch02"
     branch_02_head_commit = "49ac5e2a0f00b5eab6aedfdb19a1ef8127507f72"
@@ -85,7 +85,7 @@ async def test_sync_from_remote_new_ref(git_repo_01_read_only: InfrahubReadOnlyR
     )
 
 
-async def test_sync_from_remote_existing_ref(git_repo_01_read_only: InfrahubReadOnlyRepository):
+async def test_sync_from_remote_existing_ref(git_repo_01_read_only: InfrahubReadOnlyRepository) -> None:
     repo = git_repo_01_read_only
     repo.ref = "branch01"
     mock_client = AsyncMock(InfrahubClient)

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -47,7 +47,7 @@ def non_mocked_hosts() -> list:
     return ["127.0.0.1"]
 
 
-async def test_directories_props(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path):
+async def test_directories_props(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -61,7 +61,7 @@ async def test_directories_props(git_upstream_repo_01: dict[str, str | Path], gi
     assert repo.directory_temp == git_repos_dir / str(repo.id) / TEMPORARY_DIRECTORY_NAME
 
 
-async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path):
+async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -80,7 +80,7 @@ async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_re
 @patch("infrahub.git.base.Repo")
 async def test_new_invalid_branch(
     mock_repo: MagicMock, mock_clone_from: MagicMock, git_upstream_repo_01: dict[str, str | Path]
-):
+) -> None:
     mock_repo_instance = MagicMock()
     mock_repo_instance.git.checkout.side_effect = GitCommandError("checkout", stderr="error: pathspec")
     mock_repo.return_value = mock_repo_instance
@@ -102,7 +102,7 @@ async def test_new_invalid_branch(
         )
 
 
-async def test_new_existing_directory(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path):
+async def test_new_existing_directory(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:
     # Create a directory and a file where the repository will be created
     (git_repos_dir / git_upstream_repo_01["name"]).mkdir()
     (git_repos_dir / git_upstream_repo_01["name"] / "file1.txt").touch()
@@ -121,7 +121,7 @@ async def test_new_existing_directory(git_upstream_repo_01: dict[str, str | Path
     assert repo.directory_temp.is_dir()
 
 
-async def test_new_existing_file(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path):
+async def test_new_existing_file(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:
     # Create a file where the repository will be created
     (git_repos_dir / git_upstream_repo_01["name"]).touch()
 
@@ -139,7 +139,9 @@ async def test_new_existing_file(git_upstream_repo_01: dict[str, str | Path], gi
     assert repo.directory_temp.is_dir()
 
 
-async def test_new_wrong_location(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path):
+async def test_new_wrong_location(
+    git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path
+) -> None:
     with pytest.raises(RepositoryError) as exc:
         await InfrahubRepository.new(
             id=UUIDT.new(),
@@ -151,7 +153,9 @@ async def test_new_wrong_location(git_upstream_repo_01: dict[str, str | Path], g
     assert f"fatal: repository '{tmp_path}' does not exist" in str(exc.value)
 
 
-async def test_new_wrong_branch(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path):
+async def test_new_wrong_branch(
+    git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path
+) -> None:
     with pytest.raises(RepositoryInvalidBranchError) as exc:
         await InfrahubRepository.new(
             id=UUIDT.new(),
@@ -164,7 +168,7 @@ async def test_new_wrong_branch(git_upstream_repo_01: dict[str, str | Path], git
     assert "isn't a valid branch" in str(exc.value)
 
 
-async def test_init_existing_repository(git_repo_01: InfrahubRepository):
+async def test_init_existing_repository(git_repo_01: InfrahubRepository) -> None:
     repo = await InfrahubRepository.init(id=git_repo_01.id, name=git_repo_01.name)
 
     # Check if all the directories are present
@@ -175,7 +179,7 @@ async def test_init_existing_repository(git_repo_01: InfrahubRepository):
     assert repo.directory_temp.is_dir()
 
 
-async def test_get_git_repo_main(git_repo_01: InfrahubRepository):
+async def test_get_git_repo_main(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
 
     git_repo = repo.get_git_repo_main()
@@ -183,7 +187,7 @@ async def test_get_git_repo_main(git_repo_01: InfrahubRepository):
     assert isinstance(git_repo, Repo)
 
 
-async def test_create_commit_worktree(git_repo_01: InfrahubRepository):
+async def test_create_commit_worktree(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     git_repo = repo.get_git_repo_main()
 
@@ -203,7 +207,7 @@ async def test_create_commit_worktree(git_repo_01: InfrahubRepository):
     assert repo.create_commit_worktree(commit=commit) is False
 
 
-async def test_create_commit_worktree_wrong_commit(git_repo_01: InfrahubRepository):
+async def test_create_commit_worktree_wrong_commit(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     repo.get_git_repo_main()
 
@@ -213,7 +217,7 @@ async def test_create_commit_worktree_wrong_commit(git_repo_01: InfrahubReposito
         repo.create_commit_worktree(commit=commit)
 
 
-async def test_get_worktrees(git_repo_01: InfrahubRepository):
+async def test_get_worktrees(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
 
     worktrees = repo.get_worktrees()
@@ -225,14 +229,14 @@ async def test_get_worktrees(git_repo_01: InfrahubRepository):
     assert len(worktrees[1].identifier) == 40
 
 
-async def test_has_worktree(git_repo_01: InfrahubRepository):
+async def test_has_worktree(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
 
     assert not repo.has_worktree("notvalid")
     assert repo.has_worktree("main")
 
 
-async def test_get_commit_worktree(git_repo_01: InfrahubRepository):
+async def test_get_commit_worktree(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     git_repo = repo.get_git_repo_main()
 
@@ -252,7 +256,7 @@ async def test_get_commit_worktree(git_repo_01: InfrahubRepository):
     assert repo.has_worktree(identifier=commit) is True
 
 
-async def test_get_branch_worktree(git_repo_01: InfrahubRepository, branch99: BranchData):
+async def test_get_branch_worktree(git_repo_01: InfrahubRepository, branch99: BranchData) -> None:
     repo = git_repo_01
     git_repo = repo.get_git_repo_main()
 
@@ -263,7 +267,7 @@ async def test_get_branch_worktree(git_repo_01: InfrahubRepository, branch99: Br
     assert repo.has_worktree(identifier=branch99.name)
 
 
-async def test_get_branches_from_local(git_repo_01: InfrahubRepository):
+async def test_get_branches_from_local(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
 
     local_branches = repo.get_branches_from_local()
@@ -271,7 +275,7 @@ async def test_get_branches_from_local(git_repo_01: InfrahubRepository):
     assert sorted(local_branches.keys()) == ["main"]
 
 
-async def test_get_branches_from_remote(git_repo_01: InfrahubRepository):
+async def test_get_branches_from_remote(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
 
     remote_branches = repo.get_branches_from_remote()
@@ -284,7 +288,7 @@ async def test_get_branches_from_graph(
     mock_branches_list_query: HTTPXMock,
     mock_schema_query_01: HTTPXMock,
     mock_repositories_query: HTTPXMock,
-):
+) -> None:
     repo = git_repo_01_w_client
 
     branches = await repo.get_branches_from_graph()
@@ -293,7 +297,7 @@ async def test_get_branches_from_graph(
     assert branches["cr1234"].commit == "bbbbbbbbbbbbbbbbbbbb"
 
 
-async def test_get_commit_value(git_repo_01: InfrahubRepository):
+async def test_get_commit_value(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     assert repo.get_commit_value(branch_name="main", remote=True) == "0b341c0c64122bb2a7b208f7a9452146685bc7dd"
     assert repo.get_commit_value(branch_name="branch01", remote=True) == "92700512b5b16c0144f7fd2869669273577f1bd8"
@@ -303,7 +307,7 @@ async def test_get_commit_value(git_repo_01: InfrahubRepository):
         repo.get_commit_value(branch_name="branch01", remote=False)
 
 
-async def test_compare_remote_local_new_branches(git_repo_01: InfrahubRepository):
+async def test_compare_remote_local_new_branches(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     new_branches, updated_branches = await repo.compare_local_remote()
 
@@ -311,7 +315,7 @@ async def test_compare_remote_local_new_branches(git_repo_01: InfrahubRepository
     assert updated_branches == []
 
 
-async def test_compare_remote_local_no_diff(git_repo_02: InfrahubRepository):
+async def test_compare_remote_local_no_diff(git_repo_02: InfrahubRepository) -> None:
     repo = git_repo_02
     new_branches, updated_branches = await repo.compare_local_remote()
 
@@ -319,7 +323,7 @@ async def test_compare_remote_local_no_diff(git_repo_02: InfrahubRepository):
     assert updated_branches == []
 
 
-async def test_create_branch_in_git_present_remote(git_repo_01: InfrahubRepository, branch01: BranchData):
+async def test_create_branch_in_git_present_remote(git_repo_01: InfrahubRepository, branch01: BranchData) -> None:
     repo = git_repo_01
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
     worktrees = repo.get_worktrees()
@@ -328,7 +332,7 @@ async def test_create_branch_in_git_present_remote(git_repo_01: InfrahubReposito
     assert len(worktrees) == 4
 
 
-async def test_create_branch_in_git_not_in_remote(git_repo_01: InfrahubRepository, branch99: BranchData):
+async def test_create_branch_in_git_not_in_remote(git_repo_01: InfrahubRepository, branch99: BranchData) -> None:
     repo = git_repo_01
     await repo.create_branch_in_git(branch_name=branch99.name, branch_id=branch99.id)
     worktrees = repo.get_worktrees()
@@ -338,7 +342,7 @@ async def test_create_branch_in_git_not_in_remote(git_repo_01: InfrahubRepositor
 
 
 @pytest.mark.xfail(reason="Failing at reproducing conflicts without remote branches to trigger the function to test")
-async def test_has_conflicting_changes(git_repos_source_dir_module_scope: Path):
+async def test_has_conflicting_changes(git_repos_source_dir_module_scope: Path) -> None:
     test_repo = MultipleStagesFileRepo(name="conflicting-branches", sources_directory=git_repos_source_dir_module_scope)
     repository = await InfrahubRepository.new(
         id=UUIDT.new(),
@@ -350,7 +354,7 @@ async def test_has_conflicting_changes(git_repos_source_dir_module_scope: Path):
     assert repository.has_conflicting_changes(target_branch="main", source_branch="change1")
 
 
-async def test_pull_branch(git_repo_04: InfrahubRepository):
+async def test_pull_branch(git_repo_04: InfrahubRepository) -> None:
     repo = git_repo_04
     await repo.fetch()
 
@@ -369,7 +373,7 @@ async def test_pull_branch(git_repo_04: InfrahubRepository):
     assert response is True
 
 
-async def test_pull_new_branch(git_repo_01: InfrahubRepository):
+async def test_pull_new_branch(git_repo_01: InfrahubRepository) -> None:
     repo = git_repo_01
     await repo.fetch()
 
@@ -397,7 +401,7 @@ async def test_pull_new_branch(git_repo_01: InfrahubRepository):
     assert response is True
 
 
-async def test_pull_branch_conflict(git_repo_06: InfrahubRepository):
+async def test_pull_branch_conflict(git_repo_06: InfrahubRepository) -> None:
     repo = git_repo_06
     await repo.fetch()
 
@@ -413,7 +417,7 @@ async def test_pull_branch_conflict(git_repo_06: InfrahubRepository):
     assert "there are conflicts that must be resolved" in str(exc.value)
 
 
-async def test_pull_main(git_repo_05: InfrahubRepository):
+async def test_pull_main(git_repo_05: InfrahubRepository) -> None:
     repo = git_repo_05
     await repo.fetch()
 
@@ -429,7 +433,7 @@ async def test_pull_main(git_repo_05: InfrahubRepository):
     assert response == str(commit2)
 
 
-async def test_merge_branch01_into_main(git_repo_01: InfrahubRepository, branch01: BranchData):
+async def test_merge_branch01_into_main(git_repo_01: InfrahubRepository, branch01: BranchData) -> None:
     repo = git_repo_01
     await repo.fetch()
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
@@ -443,7 +447,7 @@ async def test_merge_branch01_into_main(git_repo_01: InfrahubRepository, branch0
     assert response == str(commit_after)
 
 
-async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData):
+async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData) -> None:
     repo = git_repo_01
     await repo.fetch()
 
@@ -467,7 +471,7 @@ async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData):
     assert str(response) == str(commit_after)
 
 
-async def test_sync_no_update(git_repo_02: InfrahubRepository):
+async def test_sync_no_update(git_repo_02: InfrahubRepository) -> None:
     repo = git_repo_02
     await repo.sync()
 
@@ -480,7 +484,7 @@ async def test_sync_new_branch(
     git_repo_03: InfrahubRepository,
     httpx_mock: HTTPXMock,
     mock_add_branch01_query: HTTPXMock,
-):
+) -> None:
     repo = git_repo_03
 
     await repo.fetch()
@@ -513,7 +517,7 @@ async def test_sync_new_branch(
     assert len(worktrees) == 4
 
 
-async def test_sync_updated_branch(prefect_test_fixture, git_repo_04: InfrahubRepository):
+async def test_sync_updated_branch(prefect_test_fixture, git_repo_04: InfrahubRepository) -> None:
     repo = git_repo_04
 
     branch = Branch(name="branch01", uuid=uuid4())
@@ -527,7 +531,7 @@ async def test_sync_updated_branch(prefect_test_fixture, git_repo_04: InfrahubRe
     assert repo.get_commit_value(branch_name="branch01") == str(commit)
 
 
-async def test_render_jinja2_template_success(prefect_test_fixture, git_repo_jinja: InfrahubRepository):
+async def test_render_jinja2_template_success(prefect_test_fixture, git_repo_jinja: InfrahubRepository) -> None:
     repo = git_repo_jinja
 
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
@@ -551,7 +555,7 @@ magnum
     assert rendered_tpl_main != rendered_tpl_branch
 
 
-async def test_render_jinja2_template_error(prefect_test_fixture, git_repo_jinja: InfrahubRepository):
+async def test_render_jinja2_template_error(prefect_test_fixture, git_repo_jinja: InfrahubRepository) -> None:
     repo = git_repo_jinja
 
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
@@ -564,7 +568,7 @@ async def test_render_jinja2_template_error(prefect_test_fixture, git_repo_jinja
 
 async def test_render_jinja2_template_missing(
     client: InfrahubClient, prefect_test_fixture, git_repo_jinja: InfrahubRepository
-):
+) -> None:
     repo = git_repo_jinja
 
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
@@ -578,7 +582,7 @@ async def test_execute_python_check_valid(
     prefect_test_fixture,
     git_repo_checks: InfrahubRepository,
     mock_gql_query_my_query: HTTPXMock,
-):
+) -> None:
     repo = git_repo_checks
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -591,7 +595,7 @@ async def test_execute_python_check_valid(
 
 async def test_execute_python_check_file_missing(
     client: InfrahubClient, prefect_test_fixture, git_repo_checks: InfrahubRepository
-):
+) -> None:
     repo = git_repo_checks
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -603,7 +607,7 @@ async def test_execute_python_check_file_missing(
 
 async def test_execute_python_check_class_missing(
     client: InfrahubClient, prefect_test_fixture, git_repo_checks: InfrahubRepository
-):
+) -> None:
     repo = git_repo_checks
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -615,7 +619,7 @@ async def test_execute_python_check_class_missing(
 
 async def test_execute_python_transform_w_data(
     client: InfrahubClient, prefect_test_fixture, git_repo_transforms: InfrahubRepository
-):
+) -> None:
     repo = git_repo_transforms
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -639,7 +643,7 @@ async def test_execute_python_transform_w_query(
     prefect_test_fixture,
     git_repo_transforms: InfrahubRepository,
     mock_gql_query_my_query: HTTPXMock,
-):
+) -> None:
     repo = git_repo_transforms
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -668,7 +672,7 @@ async def test_artifact_generate_python_new(
     mock_gql_query_03: HTTPXMock,
     mock_upload_content: HTTPXMock,
     mock_update_artifact: HTTPXMock,
-):
+) -> None:
     repo = git_repo_transforms_w_client
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -701,7 +705,7 @@ async def test_artifact_generate_python_existing_same(
     car_node_01: InfrahubNode,
     artifact_node_02: InfrahubNode,
     mock_gql_query_03: HTTPXMock,
-):
+) -> None:
     repo = git_repo_transforms_w_client
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -736,7 +740,7 @@ async def test_artifact_generate_python_existing_different(
     mock_gql_query_03: HTTPXMock,
     mock_upload_content: HTTPXMock,
     mock_update_artifact: HTTPXMock,
-):
+) -> None:
     repo = git_repo_transforms_w_client
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -771,7 +775,7 @@ async def test_artifact_generate_jinja2_new(
     mock_gql_query_04: HTTPXMock,
     mock_update_artifact: HTTPXMock,
     mock_upload_content: HTTPXMock,
-):
+) -> None:
     repo = git_repo_jinja_w_client
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -796,7 +800,7 @@ async def test_artifact_generate_jinja2_new(
 
 async def test_execute_python_transform_file_missing(
     client: InfrahubClient, prefect_test_fixture, git_repo_transforms: InfrahubRepository
-):
+) -> None:
     repo = git_repo_transforms
     commit_main = repo.get_commit_value(branch_name="main", remote=False)
 
@@ -810,7 +814,7 @@ async def test_execute_python_transform_file_missing(
         )
 
 
-async def test_find_files(git_repo_jinja: InfrahubRepository):
+async def test_find_files(git_repo_jinja: InfrahubRepository) -> None:
     repo = git_repo_jinja
 
     with pytest.raises(ValueError):
@@ -832,7 +836,7 @@ async def test_find_files(git_repo_jinja: InfrahubRepository):
     assert len(yaml_files) == 0
 
 
-async def test_find_files_by_commit(git_repo_jinja: InfrahubRepository):
+async def test_find_files_by_commit(git_repo_jinja: InfrahubRepository) -> None:
     repo = git_repo_jinja
 
     commit = repo.get_commit_value(branch_name="main")
@@ -849,7 +853,7 @@ async def test_find_files_by_commit(git_repo_jinja: InfrahubRepository):
 
 async def test_calculate_diff_between_commits(
     git_repo_01: InfrahubRepository, branch01: BranchData, branch02: BranchData
-):
+) -> None:
     repo = git_repo_01
 
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
@@ -907,7 +911,7 @@ async def test_calculate_diff_between_commits(
     assert removed == ["pyproject.toml"]
 
 
-async def test_list_all_files(git_repo_01: InfrahubRepository, branch01: BranchData, branch02: BranchData):
+async def test_list_all_files(git_repo_01: InfrahubRepository, branch01: BranchData, branch02: BranchData) -> None:
     repo = git_repo_01
 
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
@@ -955,7 +959,7 @@ async def test_list_all_files(git_repo_01: InfrahubRepository, branch01: BranchD
     ]
 
 
-def test_extract_repo_file_information(tmp_path_module_scope: Path):
+def test_extract_repo_file_information(tmp_path_module_scope: Path) -> None:
     file_info = extract_repo_file_information(
         full_filename=tmp_path_module_scope / "dir1/dir2/dir3/myfile.py",
         repo_directory=tmp_path_module_scope,
@@ -993,7 +997,7 @@ async def test_create_python_check_definition(
     mock_schema_query_01: HTTPXMock,
     gql_query_data_01: dict,
     mock_check_create: HTTPXMock,
-):
+) -> None:
     repo = git_repo_03_w_client
 
     module = helper.import_module_in_fixtures(module="checks/check01")
@@ -1024,7 +1028,7 @@ async def test_compare_python_check(
     gql_query_data_01: dict,
     gql_query_data_02: dict,
     check_definition_data_01: dict,
-):
+) -> None:
     repo = git_repo_03_w_client
 
     module = helper.import_module_in_fixtures(module="checks/check01")

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -75,7 +75,9 @@ class TestAddRepository:
 
             patch.stopall()
 
-    async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup):
+    async def test_git_rpc_create_successful(
+        self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup
+    ) -> None:
         repo_id = str(UUIDT())
         model = GitRepositoryAdd(
             repository_id=repo_id,
@@ -126,7 +128,7 @@ async def test_git_rpc_merge(
     branch01: BranchData,
     helper: TestHelper,
     create_test_admin: Node,
-):
+) -> None:
     repo = git_repo_01
 
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
@@ -170,7 +172,7 @@ async def test_git_rpc_diff(
     branch01: BranchData,
     branch02: BranchData,
     helper: TestHelper,
-):
+) -> None:
     repo = git_repo_01
 
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
@@ -232,7 +234,7 @@ class TestAddReadOnly:
             # teardown
             patch.stopall()
 
-    async def test_git_rpc_add_read_only_success(self, git_upstream_repo_01: dict[str, str], setup):
+    async def test_git_rpc_add_read_only_success(self, git_upstream_repo_01: dict[str, str], setup) -> None:
         repo_id = str(UUIDT())
         model = GitRepositoryAddReadOnly(
             repository_id=repo_id,
@@ -309,7 +311,7 @@ class TestPullReadOnly:
             # teardown
             patch.stopall()
 
-    async def test_improper_message(self, setup):
+    async def test_improper_message(self, setup) -> None:
         self.model.ref = None
         self.model.commit = None
 
@@ -318,7 +320,7 @@ class TestPullReadOnly:
         self.mock_repo_class.new.assert_not_awaited()
         self.mock_repo_class.init.assert_not_awaited()
 
-    async def test_existing_repository(self, setup):
+    async def test_existing_repository(self, setup) -> None:
         self.mock_repo.import_objects_from_files = AsyncMock()
 
         await pull_read_only(model=self.model)
@@ -340,7 +342,7 @@ class TestPullReadOnly:
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)
 
-    async def test_new_repository(self, setup, prefect_test_fixture):
+    async def test_new_repository(self, setup, prefect_test_fixture) -> None:
         self.mock_repo_class.init.side_effect = RepositoryError(self.repo_name, "it is broken")
         self.mock_repo.import_objects_from_files = AsyncMock()
 

--- a/backend/tests/unit/git/test_git_transform.py
+++ b/backend/tests/unit/git/test_git_transform.py
@@ -17,7 +17,7 @@ async def init_service():
 
 async def test_git_transform_jinja2_success(
     git_repo_jinja: InfrahubRepository, init_service, prefect_test_fixture, helper
-):
+) -> None:
     commit = git_repo_jinja.get_commit_value(branch_name="main")
     message = TransformJinjaTemplateData(
         repository_id=str(git_repo_jinja.id),
@@ -41,7 +41,7 @@ magnum
 
 async def test_git_transform_jinja2_missing(
     git_repo_jinja: InfrahubRepository, init_service, prefect_test_fixture, helper
-):
+) -> None:
     commit = git_repo_jinja.get_commit_value(branch_name="main")
 
     message = TransformJinjaTemplateData(
@@ -67,7 +67,7 @@ async def test_git_transform_jinja2_invalid(
     helper,
     caplog,
     init_service,
-):
+) -> None:
     commit = git_repo_jinja.get_commit_value(branch_name="main")
 
     message = TransformJinjaTemplateData(
@@ -89,7 +89,7 @@ async def test_git_transform_jinja2_invalid(
 
 async def test_transform_python_success(
     git_fixture_repo: InfrahubRepository, init_service, prefect_test_fixture, helper
-):
+) -> None:
     commit = git_fixture_repo.get_commit_value(branch_name="main")
 
     message = TransformPythonData(

--- a/backend/tests/unit/git/test_utils.py
+++ b/backend/tests/unit/git/test_utils.py
@@ -27,7 +27,7 @@ async def repository_02(db: InfrahubDatabase, register_core_models_schema, defau
 
 async def test_get_repositories_commit_per_branch_main(
     db: InfrahubDatabase, register_core_models_schema, repository_01: Node, repository_02: Node
-):
+) -> None:
     repositories = await get_repositories_commit_per_branch(db=db)
     assert list(repositories.keys()) == ["repo01", "repo02"]
 
@@ -47,7 +47,7 @@ async def test_get_repositories_commit_per_branch_main(
 
 async def test_get_repositories_commit_per_branch_branches(
     db: InfrahubDatabase, register_core_models_schema, repository_01: Node, repository_02: Node
-):
+) -> None:
     branch2 = await create_branch(db=db, branch_name="branch2")
     repo01_branch = await NodeManager.get_one(db=db, id=repository_01.id, branch=branch2)
     repo01_branch.commit.value = "commit21"

--- a/backend/tests/unit/git_credential/test_git_askpass.py
+++ b/backend/tests/unit/git_credential/test_git_askpass.py
@@ -5,7 +5,7 @@ from infrahub.git_credential.askpass import app
 runner = CliRunner(mix_stderr=False)
 
 
-def test_askpass_username(mock_core_schema_01, mock_repositories_query, mock_credential_query):
+def test_askpass_username(mock_core_schema_01, mock_repositories_query, mock_credential_query) -> None:
     input_data = "Username for 'https://github.com/opsmill/infrahub-demo-edge.git'"
 
     result = runner.invoke(app=app, args=[input_data], env={"INFRAHUB_INSERT_TRACKER": "true"}, catch_exceptions=False)
@@ -14,7 +14,7 @@ def test_askpass_username(mock_core_schema_01, mock_repositories_query, mock_cre
     assert result.exit_code == 0
 
 
-def test_askpass_password(mock_core_schema_01, mock_repositories_query, mock_credential_query):
+def test_askpass_password(mock_core_schema_01, mock_repositories_query, mock_credential_query) -> None:
     input_data = "Password for 'https://username@github.com/opsmill/infrahub-demo-edge.git'"
 
     result = runner.invoke(app=app, args=[input_data], env={"INFRAHUB_INSERT_TRACKER": "true"}, catch_exceptions=False)

--- a/backend/tests/unit/git_credential/test_git_helper.py
+++ b/backend/tests/unit/git_credential/test_git_helper.py
@@ -12,7 +12,7 @@ with patch("sys.stdin"):
 runner = CliRunner(mix_stderr=False)
 
 
-def test_parse_helper_get_input():
+def test_parse_helper_get_input() -> None:
     data_in = "protocol=https\nhost=github.com\npath=opsmill/infrahub-demo-edge.git"
     assert parse_helper_get_input(text=data_in) == "https://github.com/opsmill/infrahub-demo-edge.git"
 
@@ -25,7 +25,7 @@ def test_parse_helper_get_input():
         parse_helper_get_input(text=data_in)
 
 
-def test_get_with_path(mock_core_schema_01, mock_repositories_query, mock_credential_query):
+def test_get_with_path(mock_core_schema_01, mock_repositories_query, mock_credential_query) -> None:
     input_data = "protocol=https\nhost=github.com\npath=opsmill/infrahub-demo-edge.git"
 
     result = runner.invoke(
@@ -36,7 +36,7 @@ def test_get_with_path(mock_core_schema_01, mock_repositories_query, mock_creden
     assert result.exit_code == 0
 
 
-def test_get_no_path():
+def test_get_no_path() -> None:
     input_data = "protocol=https\nhost=github.com"
 
     result = runner.invoke(app=app, args=["get", input_data])

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -33,7 +33,7 @@ class TestDefaultBranchPermission:
         first_account: CoreAccount,
         second_account: CoreAccount,
         permissions_helper: PermissionsHelper,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -65,7 +65,7 @@ class TestDefaultBranchPermission:
     )
     async def test_supports_default_branch_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = DefaultBranchPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -82,7 +82,7 @@ class TestDefaultBranchPermission:
         permissions_helper: PermissionsHelper,
         contains_mutation: bool,
         branch_name: str,
-    ):
+    ) -> None:
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -127,7 +127,7 @@ class TestDefaultBranchPermission:
         permissions_helper: PermissionsHelper,
         contains_mutation: bool,
         branch_name: str,
-    ):
+    ) -> None:
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -33,7 +33,7 @@ class TestMergeBranchPermission:
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
         second_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -65,7 +65,7 @@ class TestMergeBranchPermission:
     )
     async def test_supports_merge_branch_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = MergeBranchPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -82,7 +82,7 @@ class TestMergeBranchPermission:
         db: InfrahubDatabase,
         default_permission_backend: None,
         permissions_helper: PermissionsHelper,
-    ):
+    ) -> None:
         checker = MergeBranchPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -119,7 +119,7 @@ class TestMergeBranchPermission:
         checker_resolution: CheckerResolution | None,
         db: InfrahubDatabase,
         permissions_helper: PermissionsHelper,
-    ):
+    ) -> None:
         checker = MergeBranchPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -239,7 +239,7 @@ class TestObjectPermissions:
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permissions = []
@@ -402,7 +402,7 @@ class TestAccountManagerPermissions:
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
         second_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -434,7 +434,7 @@ class TestAccountManagerPermissions:
     )
     async def test_supports_manage_accounts_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = AccountManagerPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -447,7 +447,7 @@ class TestAccountManagerPermissions:
         default_permission_backend: None,
         permissions_helper: PermissionsHelper,
         operation: str,
-    ):
+    ) -> None:
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -490,7 +490,7 @@ class TestAccountManagerPermissions:
         permissions_helper: PermissionsHelper,
         operation: str,
         must_raise: bool,
-    ):
+    ) -> None:
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -539,7 +539,7 @@ class TestPermissionManagerPermissions:
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
         second_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -571,7 +571,7 @@ class TestPermissionManagerPermissions:
     )
     async def test_supports_manage_accounts_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = PermissionManagerPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -593,7 +593,7 @@ class TestPermissionManagerPermissions:
         default_permission_backend: None,
         permissions_helper: PermissionsHelper,
         operation: str,
-    ):
+    ) -> None:
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -635,7 +635,7 @@ class TestPermissionManagerPermissions:
         permissions_helper: PermissionsHelper,
         kind: str,
         relationship: str,
-    ):
+    ) -> None:
         query = """
         query {
           CoreNode {
@@ -699,7 +699,7 @@ class TestPermissionManagerPermissions:
         permissions_helper: PermissionsHelper,
         operation: str,
         must_raise: bool,
-    ):
+    ) -> None:
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -751,7 +751,7 @@ class TestPermissionManagerPermissions:
         permissions_helper: PermissionsHelper,
         kind: str,
         relationship: str,
-    ):
+    ) -> None:
         query = """
         query {
           CoreNode {
@@ -808,7 +808,7 @@ class TestRepositoryManagerPermissions:
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
         second_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -840,7 +840,7 @@ class TestRepositoryManagerPermissions:
     )
     async def test_supports_manage_repositories_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = AccountManagerPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -855,7 +855,7 @@ class TestRepositoryManagerPermissions:
         default_permission_backend: None,
         permissions_helper: PermissionsHelper,
         operation: str,
-    ):
+    ) -> None:
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -897,7 +897,7 @@ class TestRepositoryManagerPermissions:
         permissions_helper: PermissionsHelper,
         operation: str,
         must_raise: bool,
-    ):
+    ) -> None:
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -32,7 +32,7 @@ class TestSuperAdminPermission:
         first_account: CoreAccount,
         second_account: CoreAccount,
         permissions_helper: PermissionsHelper,
-    ):
+    ) -> None:
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -64,7 +64,7 @@ class TestSuperAdminPermission:
     )
     async def test_supports_super_admin_permission_accounts(
         self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = SuperAdminPermissionChecker()
         with patch("infrahub.config.SETTINGS.main.allow_anonymous_access", False):
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
@@ -72,7 +72,7 @@ class TestSuperAdminPermission:
 
     async def test_account_with_permission(
         self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -96,7 +96,7 @@ class TestSuperAdminPermission:
 
     async def test_account_without_permission(
         self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ):
+    ) -> None:
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/auth/test_anonymous_checker.py
+++ b/backend/tests/unit/graphql/auth/test_anonymous_checker.py
@@ -12,7 +12,7 @@ from infrahub.graphql.initialization import GraphqlParams
 
 
 class TestAnonymousAuthChecker:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT)
         self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
         self.query_parameters = MagicMock(spec=GraphqlParams)
@@ -22,7 +22,7 @@ class TestAnonymousAuthChecker:
     @pytest.mark.parametrize("is_authenticated,is_supported", [(True, False), (False, True)])
     async def test_supports_unauthenticated_accounts(
         self, db: InfrahubDatabase, branch: Branch, is_authenticated, is_supported
-    ):
+    ) -> None:
         self.account_session.authenticated = is_authenticated
 
         has_support = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
@@ -32,7 +32,7 @@ class TestAnonymousAuthChecker:
     @pytest.mark.parametrize("anonymous_setting,query_has_mutations", [(False, False), (False, True), (True, True)])
     async def test_failures_raise_error(
         self, db: InfrahubDatabase, branch: Branch, anonymous_setting, query_has_mutations
-    ):
+    ) -> None:
         self.mock_anonymous_setting_get.return_value = anonymous_setting
         self.graphql_query.contains_mutation = query_has_mutations
 
@@ -45,7 +45,7 @@ class TestAnonymousAuthChecker:
                 branch=branch,
             )
 
-    async def test_check_passes(self, db: InfrahubDatabase, branch: Branch):
+    async def test_check_passes(self, db: InfrahubDatabase, branch: Branch) -> None:
         self.mock_anonymous_setting_get.return_value = True
         self.graphql_query.contains_mutation = False
 

--- a/backend/tests/unit/graphql/auth/test_parent_checker.py
+++ b/backend/tests/unit/graphql/auth/test_parent_checker.py
@@ -16,7 +16,7 @@ from infrahub.graphql.initialization import GraphqlParams
 
 
 class TestParentAuthChecker:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT)
         self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
         self.query_parameters = MagicMock(spec=GraphqlParams)
@@ -39,7 +39,7 @@ class TestParentAuthChecker:
             branch=branch,
         )
 
-    async def test_only_checks_one(self, db: InfrahubDatabase, branch: Branch):
+    async def test_only_checks_one(self, db: InfrahubDatabase, branch: Branch) -> None:
         await self.__call_system_under_test(db=db, branch=branch)
 
         self.sub_auth_checker_one.supports.assert_awaited_once_with(
@@ -57,7 +57,7 @@ class TestParentAuthChecker:
             branch=branch,
         )
 
-    async def test_error_if_no_support(self, db: InfrahubDatabase, branch: Branch):
+    async def test_error_if_no_support(self, db: InfrahubDatabase, branch: Branch) -> None:
         self.sub_auth_checker_two.supports.return_value = False
 
         with pytest.raises(PermissionDeniedError):

--- a/backend/tests/unit/graphql/conftest.py
+++ b/backend/tests/unit/graphql/conftest.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def load_component_dependency_registry():
+def load_component_dependency_registry() -> None:
     build_component_registry()
 
 

--- a/backend/tests/unit/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/diff/test_diff_tree_query.py
@@ -213,7 +213,7 @@ async def test_diff_tree_no_changes(
     criticality_low,
     diff_coordinator: DiffCoordinator,
     diff_branch: Branch,
-):
+) -> None:
     enriched_diff_metadata = await diff_coordinator.update_branch_diff(
         base_branch=default_branch, diff_branch=diff_branch
     )
@@ -249,7 +249,7 @@ async def test_diff_tree_no_changes(
 
 async def test_diff_tree_no_diffs(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema, diff_branch: Branch
-):
+) -> None:
     default_branch.update_schema_hash()
     params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
@@ -265,7 +265,9 @@ async def test_diff_tree_no_diffs(
     assert result.data["DiffTree"] is None
 
 
-async def test_diff_tree_no_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_diff_tree_no_branch(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     default_branch.update_schema_hash()
     params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
@@ -288,7 +290,7 @@ async def test_diff_tree_one_attr_change(
     diff_branch: Branch,
     diff_coordinator: DiffCoordinator,
     diff_repository: DiffRepository,
-):
+) -> None:
     main_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
     main_crit.color.value = "#fedcba"
     branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
@@ -422,7 +424,7 @@ async def test_diff_tree_one_relationship_change(
     diff_branch: Branch,
     diff_coordinator: DiffCoordinator,
     diff_repository: DiffRepository,
-):
+) -> None:
     branch_car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=diff_branch)
     await branch_car.owner.update(db=db, data=[person_jane_main])
     before_change_datetime = Timestamp()
@@ -676,7 +678,7 @@ async def test_diff_tree_hierarchy_change(
     hierarchical_location_data,
     diff_branch: Branch,
     diff_coordinator: DiffCoordinator,
-):
+) -> None:
     europe_main = hierarchical_location_data["europe"]
     paris_main = hierarchical_location_data["paris"]
     rack1_main = hierarchical_location_data["paris-r1"]
@@ -718,7 +720,7 @@ async def test_diff_tree_hierarchy_change(
 
 async def test_diff_tree_summary_no_diffs(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema, diff_branch: Branch
-):
+) -> None:
     default_branch.update_schema_hash()
     params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
@@ -740,7 +742,7 @@ async def test_diff_tree_summary_no_changes(
     criticality_low,
     diff_coordinator: DiffCoordinator,
     diff_branch: Branch,
-):
+) -> None:
     enriched_diff_metadata = await diff_coordinator.update_branch_diff(
         base_branch=default_branch, diff_branch=diff_branch
     )
@@ -907,7 +909,7 @@ async def test_diff_summary_filters(
 )
 async def test_diff_get_filters(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data, filters, labels
-):
+) -> None:
     rack1_main = hierarchical_location_data["paris-r1"]
     rack2_main = hierarchical_location_data["paris-r2"]
 

--- a/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
+++ b/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
@@ -88,7 +88,7 @@ class TestDiffUpdateMutation:
         service_testing: InfrahubServices,
         criticality_schema,
         diff_branch: Branch,
-    ):
+    ) -> None:
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
         default_branch.update_schema_hash()
         params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
@@ -115,7 +115,7 @@ class TestDiffUpdateMutation:
         service_testing: InfrahubServices,
         criticality_schema,
         diff_branch: Branch,
-    ):
+    ) -> None:
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
         default_branch.update_schema_hash()
         params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
@@ -143,7 +143,7 @@ class TestDiffUpdateMutation:
         criticality_schema,
         diff_branch: Branch,
         named_diff: EnrichedDiffRootMetadata,
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
@@ -185,7 +185,7 @@ class TestDiffUpdateMutation:
         criticality_schema,
         diff_branch: Branch,
         named_diff: EnrichedDiffRootMetadata,
-    ):
+    ) -> None:
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
         default_branch.update_schema_hash()
         params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
@@ -213,7 +213,7 @@ class TestDiffUpdateMutation:
         criticality_schema,
         diff_branch: Branch,
         named_diff: EnrichedDiffRootMetadata,
-    ):
+    ) -> None:
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
         default_branch.update_schema_hash()
         params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -25,7 +25,7 @@ class TestBranchCreate(TestInfrahubApp):
         session_admin,
         client: InfrahubClient,
         service: InfrahubServices,
-    ):
+    ) -> None:
         query = """
             mutation {
                 BranchCreate(data: { name: "branch2", sync_with_git: false, origin_branch: "main" }) {
@@ -129,7 +129,7 @@ class TestBranchCreate(TestInfrahubApp):
         session_admin,
         client,
         service,
-    ):
+    ) -> None:
         query = """
         mutation($branch_name: String!) {
             BranchCreate(data: { name: $branch_name, sync_with_git: false }) {
@@ -172,7 +172,7 @@ class TestBranchCreate(TestInfrahubApp):
         register_core_models_schema,
         session_admin,
         service,
-    ):
+    ) -> None:
         query = """
         mutation($branch_name: String!) {
             BranchCreate(data: { name: $branch_name, sync_with_git: false }) {
@@ -201,7 +201,7 @@ class TestBranchCreate(TestInfrahubApp):
         session_admin,
         client,
         service,
-    ):
+    ) -> None:
         query = """
         mutation {
             BranchCreate(data: { name: "branch5", sync_with_git: false }) {
@@ -246,7 +246,7 @@ class TestBranchCreate(TestInfrahubApp):
         default_branch: Branch,
         session_admin,
         service: InfrahubServices,
-    ):
+    ) -> None:
         query = """
         mutation AddBranch {
             BranchCreate(data: {
@@ -291,7 +291,7 @@ async def test_branch_delete(
     register_core_models_schema,
     session_admin,
     local_services: InfrahubServices,
-):
+) -> None:
     delete_query = """
     mutation {
         BranchDelete(data: { name: "branch3" }) {
@@ -309,7 +309,7 @@ async def test_branch_delete(
 
 async def test_branch_rebase_wrong_branch(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema, session_admin, local_services: InfrahubServices
-):
+) -> None:
     query = """
     mutation {
         BranchRebase(data: { name: "branch2" }) {
@@ -341,7 +341,9 @@ async def test_branch_rebase_wrong_branch(
     assert result.errors[0].message == "Branch: branch2 not found."
 
 
-async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02, local_services: InfrahubServices):
+async def test_branch_update_description(
+    db: InfrahubDatabase, base_dataset_02, local_services: InfrahubServices
+) -> None:
     branch4 = await create_branch(branch_name="branch4", db=db)
 
     query = """
@@ -378,7 +380,7 @@ async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02, 
 
 async def test_branch_merge_wrong_branch(
     db: InfrahubDatabase, base_dataset_02, register_core_models_schema, session_admin, local_services: InfrahubServices
-):
+) -> None:
     branch1 = await Branch.get_by_name(db=db, name="branch1")
 
     query = """
@@ -411,7 +413,7 @@ async def test_branch_merge_wrong_branch(
 
 async def test_branch_merge_with_conflict_fails(
     db: InfrahubDatabase, car_person_schema, car_camry_main, session_admin, local_services: InfrahubServices
-):
+) -> None:
     query = """
     mutation {
         BranchMerge(data: { name: "branch2" }) {

--- a/backend/tests/unit/graphql/mutations/test_ipam.py
+++ b/backend/tests/unit/graphql/mutations/test_ipam.py
@@ -271,7 +271,9 @@ mutation NamespaceDelete($namespace_id: String!) {
 """
 
 
-async def test_protected_default_ipnamespace(db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node):
+async def test_protected_default_ipnamespace(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node
+) -> None:
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
@@ -285,7 +287,9 @@ async def test_protected_default_ipnamespace(db: InfrahubDatabase, default_branc
     assert result.errors[0].message == "Cannot delete default IPAM namespace"
 
 
-async def test_delete_regular_ipnamespace(db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node):
+async def test_delete_regular_ipnamespace(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node
+) -> None:
     ns1 = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
     await ns1.new(db=db, name="ns1")
     await ns1.save(db=db)
@@ -310,7 +314,7 @@ async def test_ipprefix_create(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure prefix can be created and parent/children relationships are set."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -376,7 +380,7 @@ async def test_ipprefix_create_with_ipnamespace(
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
     branch: Branch,
-):
+) -> None:
     ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE, branch=branch)
     await ns.new(db=db, name="ns1")
     await ns.save(db=db)
@@ -470,7 +474,7 @@ async def test_ipprefix_create_reverse(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure parent/children relationship are set when creating a parent after a child."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -517,7 +521,7 @@ async def test_ipprefix_update(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure a prefix can be updated."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -552,7 +556,7 @@ async def test_ipprefix_update_within_namespace(
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
     branch: Branch,
-):
+) -> None:
     """Make sure a prefix can be updated within a namespace."""
     test_ns = await Node.init(db=db, branch=branch, schema=InfrahubKind.NAMESPACE)
     await test_ns.new(db=db, name="test")
@@ -717,7 +721,7 @@ async def test_ipprefix_upsert(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure a prefix can be upserted."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -754,7 +758,7 @@ async def test_ipprefix_delete(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure deleting a prefix relocates its children."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -830,7 +834,7 @@ async def test_ipaddress_create(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure IP address is properly created and nested under a subnet."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -907,7 +911,7 @@ async def test_ipaddress_update(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure an IP address can be updated."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -942,7 +946,7 @@ async def test_ipaddress_update_within_namespace(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure an IP address can be updated within a namespace."""
     test_ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
     await test_ns.new(db=db, name="test")
@@ -1031,7 +1035,7 @@ async def test_ipaddress_upsert(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure an IP address can be upsert."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -1069,7 +1073,7 @@ async def test_ipaddress_change_ipprefix(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     """Make sure relationship between an address and its prefix is properly managed."""
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -1216,7 +1220,7 @@ async def test_prefix_ancestors_descendants(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
     ns1 = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -1328,7 +1332,7 @@ async def test_delete_top_level_prefix(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> None:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
     ns1 = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)

--- a/backend/tests/unit/graphql/mutations/test_menu.py
+++ b/backend/tests/unit/graphql/mutations/test_menu.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-async def test_menu_create(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
+async def test_menu_create(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch) -> None:
     service = await InfrahubServices.new(database=db)
 
     CREATE_MENU = """
@@ -36,7 +36,9 @@ async def test_menu_create(db: InfrahubDatabase, register_core_models_schema: No
     assert "Builtin is not valid" in result.errors[0].args[0]
 
 
-async def test_menu_update_protected(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
+async def test_menu_update_protected(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
     service = await InfrahubServices.new(database=db)
 
     menu_item = MenuItemDefinition(
@@ -76,7 +78,9 @@ async def test_menu_update_protected(db: InfrahubDatabase, register_core_models_
     assert "This object is protected" in result.errors[0].args[0]
 
 
-async def test_menu_delete_protected(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
+async def test_menu_delete_protected(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
     service = await InfrahubServices.new(database=db)
 
     menu_item = MenuItemDefinition(

--- a/backend/tests/unit/graphql/mutations/test_mutation_context.py
+++ b/backend/tests/unit/graphql/mutations/test_mutation_context.py
@@ -28,7 +28,7 @@ async def test_add_context_invalid_account(
     car_person_schema: None,
     first_account: Node,
     session_first_account: AccountSession,
-):
+) -> None:
     await define_permissions(
         account=first_account,
         db=db,
@@ -72,7 +72,7 @@ async def test_add_context_valid_account(
     session_first_account: AccountSession,
     first_account: Node,
     second_account: Node,
-):
+) -> None:
     await define_permissions(
         account=first_account,
         db=db,
@@ -127,7 +127,7 @@ async def test_add_context_missing_permissions(
     session_second_account: AccountSession,
     first_account: Node,
     second_account: Node,
-):
+) -> None:
     query = """
     mutation {
         TestPersonCreate(data: {name: { value: "John"}, height: {value: 182}}, context: { account: { id: "%s" }}) {

--- a/backend/tests/unit/graphql/mutations/test_number_supports_large_integers.py
+++ b/backend/tests/unit/graphql/mutations/test_number_supports_large_integers.py
@@ -14,7 +14,7 @@ class TestNumberSupportsLargeInter(TestInfrahubApp):
         session_admin,
         person_john_main,
         service,
-    ):
+    ) -> None:
         query = """
         mutation {
             TestCarCreate(data: {

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -100,7 +100,9 @@ mutation UpdateProposedChange(
 """
 
 
-async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_branch, register_core_models_schema):
+async def test_create_invalid_branch_combinations(
+    db: InfrahubDatabase, default_branch, register_core_models_schema
+) -> None:
     branch_name = str(uuid4().hex)
     invalid_branch = str(uuid4().hex)
     source_branch = Branch(name=branch_name)
@@ -321,7 +323,7 @@ class TestTriggerProposedChange(TestInfrahubApp):
             mock_submit_workflow.assert_not_called()
 
 
-async def test_update_merged_proposed_change(db: InfrahubDatabase, register_core_models_schema: None):
+async def test_update_merged_proposed_change(db: InfrahubDatabase, register_core_models_schema: None) -> None:
     branch_name = "merged-proposed-change"
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)
@@ -345,7 +347,7 @@ async def test_update_merged_proposed_change(db: InfrahubDatabase, register_core
     assert "A proposed change in the merged state is not allowed to be updated" in str(update_status.errors[0])
 
 
-async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_models_schema: None):
+async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_models_schema: None) -> None:
     branch_name = "draft-proposed-change"
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)
@@ -392,7 +394,7 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         session_admin: AccountSession,
         client: InfrahubClient,
         dependency_provider,
-    ):
+    ) -> None:
         with dependency_provider.scope(build_client, lambda: client):
             cache = MemoryCache()
             message_bus = BusRecorder()
@@ -458,7 +460,7 @@ async def test_create_thread(
     register_core_models_schema: None,
     session_first_account: AccountSession,
     session_admin: AccountSession,
-):
+) -> None:
     service = await InfrahubServices.new(
         database=db, message_bus=BusRecorder(), workflow=WorkflowLocalExecution(), cache=MemoryCache()
     )

--- a/backend/tests/unit/graphql/mutations/test_repository.py
+++ b/backend/tests/unit/graphql/mutations/test_repository.py
@@ -82,7 +82,9 @@ async def test_trigger_repository_import(
         mock_submit_workflow.assert_has_calls(expected_calls)
 
 
-async def test_repository_update(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
+async def test_repository_update(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
     branch2 = await create_branch(branch_name="branch2", db=db)
     repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
     recorder = BusRecorder()
@@ -156,6 +158,6 @@ async def test_repository_update(db: InfrahubDatabase, register_core_models_sche
         ),
     ],
 )
-def test_cleanup_payload(test_input, expected):
+def test_cleanup_payload(test_input, expected) -> None:
     cleanup_payload(data=test_input)
     assert test_input == expected

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -46,7 +46,9 @@ async def prefix_pool_01(
     return ip_dataset_prefix_v4
 
 
-async def test_create_object_and_assign_prefix_from_pool(db: InfrahubDatabase, default_branch: Branch, prefix_pool_01):
+async def test_create_object_and_assign_prefix_from_pool(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pool_01
+) -> None:
     pool = prefix_pool_01["pool"]
 
     query = (
@@ -108,7 +110,9 @@ async def test_create_object_and_assign_prefix_from_pool(db: InfrahubDatabase, d
     }
 
 
-async def test_update_object_and_assign_prefix_from_pool(db: InfrahubDatabase, default_branch: Branch, prefix_pool_01):
+async def test_update_object_and_assign_prefix_from_pool(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pool_01
+) -> None:
     pool = prefix_pool_01["pool"]
     net142 = prefix_pool_01["net142"]
 
@@ -181,7 +185,7 @@ async def test_create_object_and_assign_address_from_pool(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net145 = ip_dataset_prefix_v4["net145"]
 
@@ -263,7 +267,7 @@ async def test_prefix_pool_get_resource(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 
@@ -323,7 +327,7 @@ async def test_prefix_pool_get_resource_with_identifier(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 
@@ -390,7 +394,7 @@ async def test_prefix_pool_get_resource_with_prefix_length(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 
@@ -451,7 +455,7 @@ async def test_address_pool_get_resource(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net145 = ip_dataset_prefix_v4["net145"]
 
@@ -510,7 +514,7 @@ async def test_address_pool_get_resource_with_identifier(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net145 = ip_dataset_prefix_v4["net145"]
 
@@ -576,7 +580,7 @@ async def test_address_pool_get_resource_with_prefix_length(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> None:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net145 = ip_dataset_prefix_v4["net145"]
 
@@ -712,7 +716,7 @@ query NumberPool(
 
 async def test_test_number_pool_creation_errors(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
-):
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -797,7 +801,9 @@ async def test_test_number_pool_creation_errors(
     assert "start_range can't be larger than end_range" in str(invalid_range.errors[0])
 
 
-async def test_test_number_pool_update(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_test_number_pool_update(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -35,7 +35,7 @@ async def test_delete_last_dropdown_option(
 
 async def test_delete_last_enum_option(
     db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
-):
+) -> None:
     query = """
     mutation {
         SchemaEnumRemove(data: {kind: "BaseChoice", attribute: "measuring_system", enum: "metric"}) {
@@ -83,7 +83,7 @@ async def test_delete_enum_option_that_does_not_exist(
 
 async def test_delete_drop_option_that_does_not_exist(
     db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
-):
+) -> None:
     query = """
     mutation {
         SchemaDropdownRemove(data: {kind: "BaseChoice", attribute: "section", dropdown: "ci"}) {
@@ -107,7 +107,7 @@ async def test_delete_drop_option_that_does_not_exist(
 
 async def test_add_enum_option_that_exist(
     db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
-):
+) -> None:
     query = """
     mutation {
         SchemaEnumAdd(data: {kind: "BaseChoice", attribute: "color", enum: "red"}) {
@@ -131,7 +131,7 @@ async def test_add_enum_option_that_exist(
 
 async def test_delete_dropdown_option_in_use(
     db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
-):
+) -> None:
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive", temperature_scale="celsius")
     await obj1.save(db=db)
@@ -159,7 +159,7 @@ async def test_delete_dropdown_option_in_use(
 
 async def test_delete_enum_option_in_use(
     db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
-):
+) -> None:
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive")
     await obj1.save(db=db)
@@ -185,7 +185,7 @@ async def test_delete_enum_option_in_use(
     assert "There are still TestChoice objects using this enum" in str(result.errors[0])
 
 
-async def test_validate_kind_exceptions(db: InfrahubDatabase, choices_schema):
+async def test_validate_kind_exceptions(db: InfrahubDatabase, choices_schema) -> None:
     node = await Node.init(db=db, schema="TestChoice")
     restricted_node = await Node.init(db=db, schema="LineageOwner")
 
@@ -205,7 +205,7 @@ async def test_validate_kind_exceptions(db: InfrahubDatabase, choices_schema):
     assert "Attribute color on TestChoice is inherited and must be changed on the generic" in str(exc.value)
 
 
-async def test_validate_kind_dropdown_exceptions(db: InfrahubDatabase, choices_schema):
+async def test_validate_kind_dropdown_exceptions(db: InfrahubDatabase, choices_schema) -> None:
     node = await Node.init(db=db, schema="TestChoice")
 
     with pytest.raises(ValidationError) as exc:
@@ -214,7 +214,7 @@ async def test_validate_kind_dropdown_exceptions(db: InfrahubDatabase, choices_s
     assert "Attribute comment on TestChoice is not a Dropdown" in str(exc.value)
 
 
-async def test_validate_kind_enum_exceptions(db: InfrahubDatabase, choices_schema):
+async def test_validate_kind_enum_exceptions(db: InfrahubDatabase, choices_schema) -> None:
     node = await Node.init(db=db, schema="TestChoice")
 
     with pytest.raises(ValidationError) as exc:

--- a/backend/tests/unit/graphql/profiles/test_mutation_create.py
+++ b/backend/tests/unit/graphql/profiles/test_mutation_create.py
@@ -6,7 +6,7 @@ from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.helpers.graphql import graphql
 
 
-async def test_create_profile(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_profile(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     query = """
     mutation {
         ProfileTestPersonCreate(data: {

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -16,7 +16,7 @@ from tests.helpers.graphql import graphql
 
 
 @pytest.fixture
-def criticality_schema(default_branch: Branch, data_schema, node_group_schema):
+def criticality_schema(default_branch: Branch, data_schema, node_group_schema) -> None:
     GENERIC_SCHEMA = {
         "name": "GenericCriticality",
         "namespace": "Test",
@@ -56,7 +56,7 @@ def criticality_schema(default_branch: Branch, data_schema, node_group_schema):
     registry.schema.process_schema_branch(name=default_branch.name)
 
 
-async def test_create_profile_in_schema(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_create_profile_in_schema(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     profile = registry.schema.get("ProfileTestCriticality", branch=default_branch)
 
     obj1 = await Node.init(db=db, schema=profile)
@@ -91,7 +91,7 @@ async def test_create_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     assert result.data["ProfileTestCriticality"]["edges"][0]["node"]["display_label"] == obj1.profile_name.value
 
 
-async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     profile = registry.schema.get("ProfileTestCriticality", branch=default_branch)
 
     obj1 = await Node.init(db=db, schema=profile)
@@ -141,7 +141,7 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     assert retrieved_object.profile_priority.value == 1234
 
 
-async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
     prof_1 = await Node.init(db=db, schema=profile_schema)
     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
@@ -216,7 +216,7 @@ async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criti
     } in crits
 
 
-async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     profile_generic_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
     prof_1 = await Node.init(db=db, schema=profile_generic_schema)
     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
@@ -295,7 +295,9 @@ async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branc
     } in crits
 
 
-async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_setting_illegal_profiles_raises_error(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     profile_generic_schema = registry.schema.get(
         "ProfileTestGenericCriticality", branch=default_branch, duplicate=False
     )
@@ -383,7 +385,7 @@ async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, defau
     }
 
 
-async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
     prof_1 = await Node.init(db=db, schema=profile_schema)
     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
@@ -465,7 +467,9 @@ async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branc
     assert crit_2_profile.id in gql_params.context.related_node_ids
 
 
-async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_is_profile_source_set_correctly(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
     prof_1 = await Node.init(db=db, schema=profile_schema)
     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -16,7 +16,7 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-    ):
+    ) -> None:
         create_branch_query = """
         mutation {
             BranchCreate(data: { name: "branch3", description: "my description" }) {

--- a/backend/tests/unit/graphql/queries/test_display_label.py
+++ b/backend/tests/unit/graphql/queries/test_display_label.py
@@ -12,7 +12,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
 
-async def test_display_label_one_item(db: InfrahubDatabase, default_branch: Branch, data_schema: None):
+async def test_display_label_one_item(db: InfrahubDatabase, default_branch: Branch, data_schema: None) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -59,7 +59,7 @@ async def test_display_label_one_item(db: InfrahubDatabase, default_branch: Bran
     assert result.data["TestCriticality"]["edges"][0]["node"]["display_label"] == "Low"
 
 
-async def test_display_label_multiple_items(db: InfrahubDatabase, default_branch: Branch, data_schema: None):
+async def test_display_label_multiple_items(db: InfrahubDatabase, default_branch: Branch, data_schema: None) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -114,7 +114,7 @@ async def test_display_label_multiple_items(db: InfrahubDatabase, default_branch
     ]
 
 
-async def test_display_label_default_value(db: InfrahubDatabase, default_branch: Branch, data_schema: None):
+async def test_display_label_default_value(db: InfrahubDatabase, default_branch: Branch, data_schema: None) -> None:
     SCHEMA = {
         "name": "Criticality",
         "namespace": "Test",
@@ -162,7 +162,9 @@ async def test_display_label_default_value(db: InfrahubDatabase, default_branch:
     assert result.data["TestCriticality"]["edges"][0]["node"]["display_label"] == f"TestCriticality(ID: {obj1.id})"
 
 
-async def test_display_label_generic(db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch):
+async def test_display_label_generic(
+    db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
     cat_schema = animal_person_schema.get(name="TestCat")
@@ -209,7 +211,7 @@ async def test_display_label_generic(db: InfrahubDatabase, default_branch: Branc
 
 async def test_display_label_nested_query(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -304,7 +306,7 @@ async def test_display_label_nested_query(
     assert DeepDiff(result.data["TestPerson"]["edges"][0]["node"], expected_result, ignore_order=True).to_dict() == {}
 
 
-async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch: Branch, data_schema: None):
+async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch: Branch, data_schema: None) -> None:
     object_a_schema = NodeSchema(
         name="ObjectA",
         namespace="Test",

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -430,7 +430,7 @@ async def test_event_query_prefect(
     register_core_models_schema: None,
     events_data,
     event_ids_inscope,
-):
+) -> None:
     result = await run_query(
         db=db,
         branch=default_branch,

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -127,7 +127,7 @@ async def test_ipprefix_nextavailable(
     prefix,
     prefix_length,
     response,
-):
+) -> None:
     obj = ip_dataset_01[prefix]
 
     default_branch.update_schema_hash()
@@ -169,7 +169,7 @@ async def test_ipaddress_nextavailable(
     prefix,
     prefix_length,
     response,
-):
+) -> None:
     obj = ip_dataset_02[prefix]
 
     default_branch.update_schema_hash()
@@ -524,7 +524,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         ip_dataset_ranges: dict[str, Node],
         prefix: str,
         result: list[str],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
@@ -576,7 +576,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         ip_dataset_range_various_kinds: dict[str, Node],
         limit: int,
         kinds: list[str],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         query = """
@@ -631,7 +631,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         default_ipnamespace: Node,
         register_ipam_schema: SchemaBranch,
         ip_dataset_range_various_kinds: dict[str, Node],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         query = """
@@ -737,7 +737,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         limit: int,
         offset: int,
         result: list[str],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
@@ -884,7 +884,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         ip_dataset_available_prefixes: dict[str, Node],
         prefix: str,
         result: list[str],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
@@ -1046,7 +1046,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         limit: int,
         offset: int,
         result: list[str],
-    ):
+    ) -> None:
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -95,7 +95,7 @@ class TestObjectPermissions:
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._first = first_account
         permissions_helper._default_branch = default_branch
 
@@ -366,7 +366,7 @@ class TestAttributePermissions:
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
-    ):
+    ) -> None:
         permissions_helper._first = first_account
         permissions_helper._default_branch = default_branch
 

--- a/backend/tests/unit/graphql/queries/test_order.py
+++ b/backend/tests/unit/graphql/queries/test_order.py
@@ -8,7 +8,7 @@ from tests.helpers.test_app import TestInfrahubApp
 class TestQueryOrder(TestInfrahubApp):
     async def test_query_default_order(
         self, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, session_admin, client
-    ):
+    ) -> None:
         for i in range(5, 0, -1):
             node = await Node.init(db=db, schema="BuiltinTag")
             await node.new(db=db, name=f"tag-{i}")

--- a/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
+++ b/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
@@ -28,7 +28,7 @@ query actions($proposed_change_id: String!) {
 
 async def test_proposed_change_open(
     db: InfrahubDatabase, register_core_models_schema: None, session_admin: AccountSession
-):
+) -> None:
     registry.permission_backends = [LocalPermissionBackend()]
 
     branch_name = "pc-1"
@@ -86,7 +86,7 @@ async def test_proposed_change_open(
 
 async def test_proposed_change_closed(
     db: InfrahubDatabase, register_core_models_schema: None, session_admin: AccountSession
-):
+) -> None:
     registry.permission_backends = [LocalPermissionBackend()]
 
     branch_name = "pc-3"
@@ -148,7 +148,7 @@ async def test_proposed_change_draft(
     register_core_models_schema: None,
     session_admin: AccountSession,
     session_first_account: AccountSession,
-):
+) -> None:
     registry.permission_backends = [LocalPermissionBackend()]
 
     branch_name = "pc-4"

--- a/backend/tests/unit/graphql/queries/test_relationship.py
+++ b/backend/tests/unit/graphql/queries/test_relationship.py
@@ -14,7 +14,7 @@ async def test_relationship(
     car_prius_main,
     car_yaris_main,
     branch: Branch,
-):
+) -> None:
     query = """
     query (
         $relationship_identifiers: [String!]!

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -183,7 +183,9 @@ query Resources($pool_ids: [ID]) {
 """
 
 
-async def test_create_ipv6_prefix_and_read_allocations(db: InfrahubDatabase, default_branch: Branch, prefix_pools_02):
+async def test_create_ipv6_prefix_and_read_allocations(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pools_02
+) -> None:
     ipv6_prefix_resource = prefix_pools_02["ipv6_prefix_resource"]
     ipv6_prefix_pool = prefix_pools_02["ipv6_prefix_pool"]
 
@@ -291,7 +293,9 @@ async def test_create_ipv6_prefix_and_read_allocations(db: InfrahubDatabase, def
     }
 
 
-async def test_create_ipv4_prefix_and_read_allocations(db: InfrahubDatabase, default_branch: Branch, prefix_pools_02):
+async def test_create_ipv4_prefix_and_read_allocations(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pools_02
+) -> None:
     ipv4_prefix_resource = prefix_pools_02["ipv4_prefix_resource"]
     ipv4_prefix_pool = prefix_pools_02["ipv4_prefix_pool"]
 
@@ -363,7 +367,9 @@ async def test_create_ipv4_prefix_and_read_allocations(db: InfrahubDatabase, def
     assert site3_prefix in prefixes
 
 
-async def test_create_ipv4_address_and_read_allocations(db: InfrahubDatabase, default_branch: Branch, prefix_pools_02):
+async def test_create_ipv4_address_and_read_allocations(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pools_02
+) -> None:
     ipv4_address_resource = prefix_pools_02["ipv4_address_resource"]
     ipv4_address_pool = prefix_pools_02["ipv4_address_pool"]
 
@@ -432,7 +438,9 @@ async def test_create_ipv4_address_and_read_allocations(db: InfrahubDatabase, de
     assert device3_address in addresses
 
 
-async def test_read_resources_in_pool_with_branch(db: InfrahubDatabase, default_branch: Branch, prefix_pools_02):
+async def test_read_resources_in_pool_with_branch(
+    db: InfrahubDatabase, default_branch: Branch, prefix_pools_02
+) -> None:
     ns1 = prefix_pools_02["ns1"]
     ipv4_address_pool = prefix_pools_02["ipv4_address_pool"]
     peers = await ipv4_address_pool.resources.get_peers(db=db)
@@ -515,7 +523,7 @@ async def test_read_resources_in_pool_new_schema_in_branch(
     init_nodes_registry,
     default_ipnamespace,
     ipam_schema: SchemaRoot,
-):
+) -> None:
     branch2 = await create_branch(db=db, branch_name="branch2")
 
     schema_branch2 = registry.schema.get_schema_branch(name=branch2.name)
@@ -677,7 +685,7 @@ async def test_read_resources_in_pool_new_schema_in_branch(
 
 async def test_read_resources_in_pool_with_branch_with_mutations(
     db: InfrahubDatabase, default_branch: Branch, prefix_pools_02
-):
+) -> None:
     ns1 = prefix_pools_02["ns1"]
     ipv4_address_pool = prefix_pools_02["ipv4_address_pool"]
     peers = await ipv4_address_pool.resources.get_peers(db=db)
@@ -782,7 +790,9 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
     } == {peer_id, prefix_id}
 
 
-async def test_number_pool_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_number_pool_utilization(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
+) -> None:
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)

--- a/backend/tests/unit/graphql/queries/test_search.py
+++ b/backend/tests/unit/graphql/queries/test_search.py
@@ -60,7 +60,7 @@ async def test_search_anywhere_by_string(
     car_prius_main: Node,
     car_yaris_main: Node,
     branch: Branch,
-):
+) -> None:
     branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=branch)
 
@@ -147,7 +147,7 @@ async def test_search_ipv6_network_extended_format(
     db: InfrahubDatabase,
     ip_dataset_01,
     branch: Branch,
-):
+) -> None:
     branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=branch)
 
@@ -287,7 +287,7 @@ async def test_search_ipv4(
         ("2001:0db8:0001:0000:0002:0000:0003", "2001:db8:1:0:2:0:3"),
     ],
 )
-def test_collapse_ipv6_address_or_network(query, expected):
+def test_collapse_ipv6_address_or_network(query, expected) -> None:
     assert _collapse_ipv6(query) == expected
 
 
@@ -295,7 +295,7 @@ def test_collapse_ipv6_address_or_network(query, expected):
     "query",
     ["invalid", "invalid:case", "2001:invalid", "2001:0db81:0000", "10.0.0.0", "2001:db8:1"],
 )
-def test_collapse_ipv6_address_or_network_invalid_cases(query):
+def test_collapse_ipv6_address_or_network_invalid_cases(query) -> None:
     with pytest.raises(ValueError):
         _collapse_ipv6(query)
 

--- a/backend/tests/unit/graphql/queries/test_status.py
+++ b/backend/tests/unit/graphql/queries/test_status.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-async def test_status_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None):
+async def test_status_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None) -> None:
     cache = MemoryCache()
     bus = BusRecorder()
     service = await InfrahubServices.new(

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -144,7 +144,7 @@ async def prefect_client(prefect_test_fixture):
 
 
 @pytest.fixture
-async def delete_flow_runs(prefect_client: PrefectClient):
+async def delete_flow_runs(prefect_client: PrefectClient) -> None:
     flows = await prefect_client.read_flow_runs()
     for flow in flows:
         await prefect_client.delete_flow_run(flow_run_id=flow.id)
@@ -247,7 +247,7 @@ async def test_task_query_prefect(
     register_core_models_schema: None,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     result = await run_query(
         db=db,
         branch=default_branch,
@@ -276,7 +276,7 @@ async def test_task_query_filter_workflow(
     register_core_models_schema: None,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     QUERY = """
     query {
         InfrahubTask(workflow: ["dummy-flow"]) {
@@ -313,7 +313,7 @@ async def test_task_query_filter_workflow(
 
 async def test_task_query_filter_workflow_state(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, delete_flow_runs, flow_runs_data
-):
+) -> None:
     QUERY = """
     query {
         InfrahubTask(workflow: ["dummy-flow"], state: [RUNNING, SCHEDULED]) {
@@ -344,7 +344,7 @@ async def test_task_query_filter_workflow_state(
 
 async def test_task_query_filter_id(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, delete_flow_runs, flow_runs_data
-):
+) -> None:
     dummy_completed_br1_db = flow_runs_data["dummy-completed-br1-db"]
     dummy_running_br1 = flow_runs_data["dummy-running-br1"]
 
@@ -377,7 +377,7 @@ async def test_task_query_filter_id(
 
 async def test_task_query_filter_branch(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, delete_flow_runs, flow_runs_data
-):
+) -> None:
     QUERY = """
     query TaskQuery(
         $branch_name: String!
@@ -415,7 +415,7 @@ async def test_task_query_filter_branch(
 
 async def test_task_query_filter_state(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, delete_flow_runs, flow_runs_data
-):
+) -> None:
     QUERY = """
     query {
         InfrahubTask(state: [RUNNING, COMPLETED]) {
@@ -451,7 +451,7 @@ async def test_task_query_filter_state(
 
 async def test_task_query_partial_text(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, delete_flow_runs, flow_runs_data
-):
+) -> None:
     QUERY = """
     query {
         InfrahubTask(q: "br1") {
@@ -495,7 +495,7 @@ async def test_task_query_filter_node(
     account_bill,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     result = await run_query(
         db=db,
         branch=default_branch,
@@ -602,7 +602,7 @@ async def test_task_query_both(
     account_bob,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     result = await run_query(
         db=db,
         branch=default_branch,
@@ -633,7 +633,7 @@ async def test_task_query_with_log_offset(
     account_bob,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     """
     In unit tests logs are not forwarded to the Prefect server for unknown reasons.
     Therefore this test mainly tests log_offset and log_limit do not break the query when they are specified,
@@ -670,7 +670,7 @@ async def test_task_branch_status(
     account_bob,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     QUERY = """
     query TaskQuery(
         $branch_name: String!
@@ -706,7 +706,7 @@ async def test_task_query_progress(
     prefect_client: PrefectClient,
     register_core_models_schema: None,
     tag_red,
-):
+) -> None:
     flow = await prefect_client.create_flow_run(
         flow=dummy_flow,
         name="dummy-running-red_tag",
@@ -769,7 +769,7 @@ async def test_task_no_count(
     account_bob,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     QUERY = """
     query TaskQuery {
         InfrahubTask {
@@ -812,7 +812,7 @@ async def test_task_only_count(
     account_bob,
     delete_flow_runs,
     flow_runs_data: dict[str, FlowRun],
-):
+) -> None:
     QUERY = """
     query TaskQuery {
         InfrahubTask {

--- a/backend/tests/unit/graphql/test_graphql_partial_match.py
+++ b/backend/tests/unit/graphql/test_graphql_partial_match.py
@@ -10,7 +10,7 @@ from tests.helpers.graphql import graphql_query
 @pytest.mark.parametrize("filter_value", ["l", "o", "w", "low", "L", "LOW"])
 async def test_query_filter_local_attrs_partial_match(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema, filter_value
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -44,7 +44,7 @@ async def test_query_filter_local_attrs_partial_match(
 
 async def test_query_filter_local_int_attr_partial_match(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -77,7 +77,7 @@ async def test_query_filter_local_int_attr_partial_match(
 
 async def test_query_filter_local_bool_attr_partial_match(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4, is_false=True)
     await obj1.save(db=db)
@@ -110,7 +110,7 @@ async def test_query_filter_local_bool_attr_partial_match(
 
 async def test_query_filter_relationships_with_generic_filter_partial_match(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data
-):
+) -> None:
     query = """
     query {
         TestPerson(cars__name__value: "v", partial_match: true) {
@@ -152,7 +152,7 @@ async def test_query_filter_relationships_with_generic_filter_partial_match(
 
 async def test_query_filter_relationships_with_generic_filter_mutliple_partial_match(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema, person_john_main, person_jane_main
-):
+) -> None:
     volt_car = await Node.init(db=db, schema="TestCar", branch=default_branch)
     await volt_car.new(db=db, name="volt", nbr_seats=4, is_electric=True, owner=person_john_main.id)
     await volt_car.save(db=db)

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -904,7 +904,7 @@ async def test_query_filter_attribute_isnull(
     person_jane_main: Node,
     car_camry_main: Node,
     car_accord_main: Node,
-):
+) -> None:
     person_albert = await NodeManager.get_one(db=db, id=person_albert_main.id)
     person_albert.height.value = None
     await person_albert.save(db=db)
@@ -1051,7 +1051,7 @@ async def test_query_filter_on_enum(
 
 async def test_query_multiple_filters(
     db: InfrahubDatabase, default_branch: Branch, car_person_manufacturer_schema: None
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
     manufacturer = registry.schema.get(name="TestManufacturer")
@@ -1247,7 +1247,7 @@ async def test_query_multiple_filters(
 
 async def test_query_filter_relationships(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -1314,7 +1314,7 @@ async def test_query_filter_relationships(
 
 async def test_query_filter_relationships_with_generic(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         TestPerson(name__value: "John") {
@@ -1358,7 +1358,7 @@ async def test_query_filter_relationships_with_generic(
 
 async def test_query_filter_relationships_with_generic_filter(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         TestPerson(cars__name__value: "volt") {
@@ -1408,7 +1408,7 @@ async def test_query_filter_relationships_with_generic_filter(
 
 async def test_query_filter_relationship_id(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -1536,7 +1536,7 @@ async def test_query_filter_list(
     criticality_schema: NodeSchema,
     graphql_filter: str,
     expected_results: list[str],
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="obj1", level=1, mylist=["one", "two", "tree", 5])
     await obj1.save(db=db)
@@ -1584,7 +1584,7 @@ async def test_query_filter_list(
 
 async def test_query_attribute_multiple_values(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
-):
+) -> None:
     person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
@@ -1619,7 +1619,7 @@ async def test_query_attribute_multiple_values(
 
 async def test_query_relationship_multiple_values(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -1683,7 +1683,7 @@ async def test_query_relationship_multiple_values(
     assert result.data["TestPerson"]["edges"][1]["node"]["cars"]["edges"][0]["node"]["name"]["value"] == "nolt"
 
 
-async def test_query_oneway_relationship(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_query_oneway_relationship(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="Blue", description="The Blue tag")
     await t1.save(db=db)
@@ -1729,7 +1729,7 @@ async def test_query_oneway_relationship(db: InfrahubDatabase, default_branch: B
     assert len(result.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"]) == 2
 
 
-async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="Blue", description="The Blue tag")
     await t1.save(db=db)
@@ -1802,7 +1802,9 @@ async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Bran
     assert names == ["Blue", "Red"]
 
 
-async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_query_attribute_updated_at(
+    db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None
+) -> None:
     p11 = await Node.init(db=db, schema="TestPerson")
     await p11.new(db=db, firstname="John", lastname="Doe")
     await p11.save(db=db)
@@ -1867,7 +1869,7 @@ async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: 
     )
 
 
-async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, firstname="John", lastname="Doe")
     await p1.save(db=db)
@@ -1925,7 +1927,9 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
     )
 
 
-async def test_query_relationship_updated_at(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_query_relationship_updated_at(
+    db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None
+) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="Blue", description="The Blue tag")
     await t1.save(db=db)
@@ -2003,7 +2007,7 @@ async def test_query_attribute_node_property_source(
     register_core_models_schema: SchemaBranch,
     person_tag_schema: None,
     first_account: Node,
-):
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, firstname="John", lastname="Doe", _source=first_account)
     await p1.save(db=db)
@@ -2049,7 +2053,7 @@ async def test_query_attribute_node_property_owner(
     register_core_models_schema: SchemaBranch,
     car_person_schema: SchemaBranch,
     first_account: Node,
-):
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", _owner=first_account)
     await p1.save(db=db)
@@ -2154,7 +2158,7 @@ async def test_query_attribute_node_property_owner(
 
 async def test_query_relationship_node_property(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch, first_account: Node
-):
+) -> None:
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")
 
@@ -2486,7 +2490,7 @@ async def test_query_attribute_flag_property(
     register_core_models_schema: SchemaBranch,
     person_tag_schema: None,
     first_account: Node,
-):
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(
         db=db,
@@ -2531,7 +2535,9 @@ async def test_query_attribute_flag_property(
     assert result1.data["TestPerson"]["edges"][0]["node"]["lastname"]["is_visible"] is False
 
 
-async def test_query_branches(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch):
+async def test_query_branches(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
     query = """
     query {
         Branch {
@@ -2559,7 +2565,7 @@ async def test_query_branches(db: InfrahubDatabase, default_branch: Branch, regi
 
 async def test_query_multiple_branches(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
-):
+) -> None:
     query = """
     query {
         branch1: Branch {
@@ -2592,7 +2598,7 @@ async def test_query_multiple_branches(
     assert result1.data["branch2"][0]["name"] == "main"
 
 
-async def test_multiple_queries(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None):
+async def test_multiple_queries(db: InfrahubDatabase, default_branch: Branch, person_tag_schema: None) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, firstname="John", lastname="Doe")
     await p1.save(db=db)
@@ -2643,7 +2649,7 @@ async def test_multiple_queries(db: InfrahubDatabase, default_branch: Branch, pe
     assert gql_params.context.related_node_ids == {p1.id, p2.id}
 
 
-async def test_model_node_interface(db: InfrahubDatabase, default_branch: Branch, car_schema: NodeSchema):
+async def test_model_node_interface(db: InfrahubDatabase, default_branch: Branch, car_schema: NodeSchema) -> None:
     d1 = await Node.init(db=db, schema="TestCar")
     await d1.new(db=db, name="Porsche 911", nbr_doors=2)
     await d1.save(db=db)
@@ -2691,7 +2697,7 @@ async def test_model_node_interface(db: InfrahubDatabase, default_branch: Branch
     assert gql_params.context.related_node_ids == {d1.id, d2.id}
 
 
-async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema: None):
+async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema: None) -> None:
     d1 = await Node.init(db=db, schema="TestCar")
     await d1.new(db=db, name="Porsche 911", nbr_doors=2)
     await d1.save(db=db)
@@ -2761,7 +2767,9 @@ async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch,
     assert DeepDiff(result.data["TestPerson"]["edges"][0]["node"], expected_results, ignore_order=True).to_dict() == {}
 
 
-async def test_model_rel_interface_reverse(db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema: None):
+async def test_model_rel_interface_reverse(
+    db: InfrahubDatabase, default_branch: Branch, vehicule_person_schema: None
+) -> None:
     d1 = await Node.init(db=db, schema="TestCar")
     await d1.new(db=db, name="Porsche 911", nbr_doors=2)
     await d1.save(db=db)
@@ -2814,7 +2822,7 @@ async def test_model_rel_interface_reverse(db: InfrahubDatabase, default_branch:
 
 async def test_generic_root_with_pagination(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         TestCar(limit: 2) {
@@ -2854,7 +2862,7 @@ async def test_generic_root_with_pagination(
 
 async def test_generic_root_with_filters(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         TestCar(owner__name__value: "John" ) {
@@ -2894,7 +2902,7 @@ async def test_generic_root_with_filters(
 
 async def test_member_of_groups(
     db: InfrahubDatabase, default_branch: Branch, car_person_generics_data: dict[str, Node]
-):
+) -> None:
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
     c3 = car_person_generics_data["c3"]
@@ -2982,7 +2990,7 @@ async def test_member_of_groups(
 
 async def test_hierarchical_location_parent_filter(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     query = """
     query GetRack {
         LocationRack(parent__name__values: "europe") {
@@ -3017,7 +3025,7 @@ async def test_hierarchical_location_parent_filter(
 
 async def test_hierarchical_location_ancestors(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         LocationRack(name__value: "paris-r1") {
@@ -3073,7 +3081,7 @@ async def test_hierarchical_location_ancestors(
 
 async def test_hierarchical_location_descendants(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         LocationRegion(name__value: "asia") {
@@ -3136,7 +3144,7 @@ async def test_hierarchical_location_descendants(
 
 async def test_hierarchical_location_descendants_filters_attr(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         LocationRegion(name__value: "asia") {
@@ -3185,7 +3193,7 @@ async def test_hierarchical_location_descendants_filters_attr(
 
 async def test_hierarchical_location_descendants_filters_ids(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         LocationRegion(name__value: "asia") {
@@ -3239,7 +3247,7 @@ async def test_hierarchical_location_descendants_filters_ids(
 
 async def test_hierarchical_location_include_descendants(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_thing: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         LocationRegion(name__value: "asia") {
@@ -3298,7 +3306,7 @@ async def test_properties_on_different_query_paths(
     hierarchical_location_data_thing: dict[str, Node],
     account_bob: Node,
     account_bill: Node,
-):
+) -> None:
     paris_owner = account_bob
     paris_rack_ids = [node.id for name, node in hierarchical_location_data_thing.items() if name.startswith("paris-r")]
     paris_racks = await NodeManager.get_many(db=db, ids=paris_rack_ids)
@@ -3421,7 +3429,7 @@ async def test_properties_on_different_query_paths(
 
 async def test_hierarchical_groups_descendants(
     db: InfrahubDatabase, default_branch: Branch, hierarchical_groups_data: dict[str, Node]
-):
+) -> None:
     query = """
     query {
         CoreStandardGroup(name__value: "grp1") {

--- a/backend/tests/unit/graphql/test_graphql_utils.py
+++ b/backend/tests/unit/graphql/test_graphql_utils.py
@@ -50,7 +50,7 @@ async def test_schema_models(
 
 async def test_schema_models_generics(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_02: str
-):
+) -> None:
     document = parse(query_02)
     default_branch.update_schema_hash()
     schema = generate_graphql_schema(db=db, branch=default_branch)

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -12,11 +12,11 @@ from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.graphql.types import InfrahubObject
 
 
-async def test_input_type_registration():
+async def test_input_type_registration() -> None:
     assert registry.input_type is not {}  # noqa
 
 
-async def test_generate_interface_object(db: InfrahubDatabase, default_branch: Branch, generic_vehicule_schema):
+async def test_generate_interface_object(db: InfrahubDatabase, default_branch: Branch, generic_vehicule_schema) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
 
@@ -64,7 +64,7 @@ async def test_generate_graphql_object(
 
 async def test_generate_graphql_object_with_interface(
     db: InfrahubDatabase, default_branch: Branch, data_schema, generic_vehicule_schema, car_schema
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
     gqlm.generate_interface_object(schema=generic_vehicule_schema, populate_cache=True)
@@ -84,7 +84,9 @@ async def test_generate_graphql_object_with_interface(
     ]
 
 
-async def test_generate_graphql_mutation_create(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_generate_graphql_mutation_create(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
 
@@ -96,7 +98,9 @@ async def test_generate_graphql_mutation_create(db: InfrahubDatabase, default_br
     assert sorted(result._meta.fields.keys()) == ["object", "ok"]
 
 
-async def test_generate_graphql_mutation_update(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_generate_graphql_mutation_update(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
 
@@ -108,7 +112,9 @@ async def test_generate_graphql_mutation_update(db: InfrahubDatabase, default_br
     assert sorted(result._meta.fields.keys()) == ["object", "ok"]
 
 
-async def test_generate_object_types(db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema):
+async def test_generate_object_types(
+    db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
 
@@ -180,7 +186,9 @@ async def test_generate_object_types(db: InfrahubDatabase, default_branch: Branc
     ]
 
 
-async def test_generate_filters(db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema_generics):
+async def test_generate_filters(
+    db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema_generics
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)
 
@@ -281,7 +289,7 @@ async def test_branch_caching_hit(
     car_person_schema_generics,
     schema_changed_at_null: bool,
     schema_hash_null: bool,
-):
+) -> None:
     default_branch.update_schema_hash()
     same_branch = default_branch.model_copy()
     if schema_changed_at_null:
@@ -301,7 +309,7 @@ async def test_branch_caching_miss(
     default_branch: Branch,
     data_schema,
     car_person_schema_generics,
-):
+) -> None:
     default_branch.update_schema_hash()
     same_branch = default_branch.model_copy()
     schema_branch = registry.schema.get_schema_branch(default_branch.name)

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -74,7 +74,7 @@ async def test_create_artifact_definition(
     group1: Node,
     transformation1: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         CoreArtifactDefinitionCreate(data: {
@@ -154,7 +154,7 @@ async def test_update_artifact_definition(
     create_test_admin: Node,
     definition1: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         CoreArtifactDefinitionUpdate(data: {

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -77,7 +77,7 @@ async def test_create_simple_object_with_ok_return(
     assert result.data["TestPersonCreate"]["ok"] is True
 
 
-async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     uuid1 = "79c83773-6b23-4537-a3ce-b214b625ff1d"
     query = (
         """
@@ -132,7 +132,7 @@ async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_s
     assert "not-valid is not a valid UUID" in result.errors[0].message
 
 
-async def test_create_check_unique(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_check_unique(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -162,7 +162,7 @@ async def test_create_check_unique(db: InfrahubDatabase, default_branch, car_per
     assert "Violates uniqueness constraint" in result.errors[0].message
 
 
-async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -195,7 +195,7 @@ async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_b
     assert "Violates uniqueness constraint" in result.errors[0].message
 
 
-async def test_create_check_unique_in_branch(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_check_unique_in_branch(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     branch1 = await create_branch(branch_name="branch1", db=db)
 
     p1 = await Node.init(db=db, schema="TestPerson", branch=branch1)
@@ -269,7 +269,7 @@ async def test_attr_optional_uniqueness_constraint_create(
     assert result.errors[0].message == "Violates uniqueness constraint 'name-description'"
 
 
-async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribute_types_schema):
+async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribute_types_schema) -> None:
     query = """
     mutation {
         TestAllAttributeTypesCreate(
@@ -322,7 +322,9 @@ async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribut
     assert obj1.prefix.is_default is False
 
 
-async def test_all_attributes_default_value(db: InfrahubDatabase, default_branch, all_attribute_default_types_schema):
+async def test_all_attributes_default_value(
+    db: InfrahubDatabase, default_branch, all_attribute_default_types_schema
+) -> None:
     query = """
     mutation {
         TestAllAttributeTypesCreate(
@@ -387,7 +389,7 @@ async def test_all_attributes_default_value(db: InfrahubDatabase, default_branch
     assert obj1.mylist_none.is_default is True
 
 
-async def test_create_object_with_flag_property(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_object_with_flag_property(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     query = """
     mutation {
         TestPersonCreate(
@@ -455,7 +457,7 @@ async def test_create_object_with_flag_property(db: InfrahubDatabase, default_br
 
 async def test_create_object_with_node_property(
     db: InfrahubDatabase, default_branch, car_person_schema, first_account, second_account
-):
+) -> None:
     query = """
     mutation {
         TestPersonCreate(
@@ -538,7 +540,7 @@ async def test_create_object_with_node_property(
     ] == await second_account.get_display_label(db=db)
 
 
-async def test_create_object_with_single_relationship(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_object_with_single_relationship(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -578,7 +580,7 @@ async def test_create_object_with_single_relationship(db: InfrahubDatabase, defa
 
 async def test_create_object_with_invalid_single_relationship_fails(
     db: InfrahubDatabase, default_branch, hierarchical_location_schema
-):
+) -> None:
     query = """
     mutation {
         LocationSiteCreate(
@@ -611,7 +613,7 @@ async def test_create_object_with_invalid_single_relationship_fails(
 
 async def test_create_object_with_single_relationship_flag_property(
     db: InfrahubDatabase, default_branch, car_person_schema
-):
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -653,7 +655,7 @@ async def test_create_object_with_single_relationship_flag_property(
 
 async def test_create_object_with_single_relationship_node_property(
     db: InfrahubDatabase, default_branch, car_person_schema, first_account, second_account
-):
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -700,7 +702,9 @@ async def test_create_object_with_single_relationship_node_property(
     assert owner.id == first_account.id
 
 
-async def test_create_object_with_multiple_relationships(db: InfrahubDatabase, default_branch, fruit_tag_schema):
+async def test_create_object_with_multiple_relationships(
+    db: InfrahubDatabase, default_branch, fruit_tag_schema
+) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="tag1")
     await t1.save(db=db)
@@ -747,7 +751,7 @@ async def test_create_object_with_multiple_relationships(db: InfrahubDatabase, d
 
 async def test_create_object_with_multiple_relationships_with_node_property(
     db: InfrahubDatabase, default_branch, fruit_tag_schema, first_account, second_account
-):
+) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="tag1")
     await t1.save(db=db)
@@ -824,7 +828,7 @@ async def test_create_object_with_multiple_relationships_with_node_property(
 
 async def test_create_object_with_multiple_relationships_flag_property(
     db: InfrahubDatabase, default_branch, fruit_tag_schema
-):
+) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t1.new(db=db, name="tag1")
     await t1.save(db=db)
@@ -883,7 +887,7 @@ async def test_create_relationship_for_node_with_migrated_kind(
     register_internal_models_schema,
     car_person_schema: Node,
     person_alfred_main: Node,
-):
+) -> None:
     schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
     default_branch.update_schema_hash()
@@ -1061,7 +1065,7 @@ async def test_create_relationship_for_node_with_migrated_kind(
     assert peer_count == 1
 
 
-async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     query = """
     mutation {
         TestPersonCreate(data: {
@@ -1090,7 +1094,7 @@ async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car
     assert result.errors[0].message == "Expected value of type 'BigInt', found \"182\"."
 
 
-async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -1126,7 +1130,9 @@ async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_bra
     assert "#44444444 must have a maximum length of 7 at color" in result.errors[0].message
 
 
-async def test_create_with_uniqueness_constraint_violation(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_with_uniqueness_constraint_violation(
+    db: InfrahubDatabase, default_branch, car_person_schema
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     car_schema = schema_branch.get("TestCar", duplicate=True)
     car_schema.uniqueness_constraints = [["owner", "color"]]
@@ -1169,7 +1175,7 @@ async def test_create_with_uniqueness_constraint_violation(db: InfrahubDatabase,
     assert "Violates uniqueness constraint 'owner-color'" in result.errors[0].message
 
 
-async def test_relationship_with_hfid(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_relationship_with_hfid(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
 
     person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
@@ -1206,7 +1212,7 @@ async def test_relationship_with_hfid(db: InfrahubDatabase, default_branch, anim
     assert result.data["TestDogCreate"]["object"]["id"]
 
 
-async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -1282,7 +1288,7 @@ async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branc
     )
 
 
-async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branch, criticality_schema):
+async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branch, criticality_schema) -> None:
     query = """
     mutation {
         TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "2021-01-01T00:00:00Z"}}) {
@@ -1312,7 +1318,7 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
     assert crit.level.value == 1
 
 
-async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branch, criticality_schema):
+async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branch, criticality_schema) -> None:
     query = """
     mutation {
         TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "10:1010"}}) {
@@ -1337,7 +1343,7 @@ async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branc
 
 async def test_create_with_object_template(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
-):
+) -> None:
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
     branch.update_schema_hash()
 
@@ -1525,7 +1531,7 @@ async def test_create_with_object_template(
 
 async def test_create_with_object_template_and_real_object(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
-):
+) -> None:
     """
     Test that relationships on sub-templates will correctly link the created sub-object to an existing object on non-component relationships
     """
@@ -1620,7 +1626,7 @@ async def test_create_with_object_template_and_real_object(
 
 async def test_create_without_object_template(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
-):
+) -> None:
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
     branch.update_schema_hash()
 
@@ -1663,7 +1669,7 @@ async def test_create_without_object_template(
 
 async def test_create_sub_object_template_by_hfid(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
-):
+) -> None:
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
     branch.update_schema_hash()
 
@@ -1735,7 +1741,7 @@ async def test_create_simple_object_with_enum(
     enum_value,
     response_value,
     reset_graphql_schema_between_tests,
-):
+) -> None:
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     query = """
     mutation {
@@ -1781,7 +1787,7 @@ async def test_create_enum_when_enums_off_fails(
     default_branch,
     person_john_main,
     car_person_schema,
-):
+) -> None:
     config.SETTINGS.experimental_features.graphql_enums = False
     query = """
     mutation {
@@ -1823,7 +1829,7 @@ async def test_create_string_when_enums_on_fails(
     person_john_main,
     car_person_schema,
     reset_graphql_schema_between_tests,
-):
+) -> None:
     config.SETTINGS.experimental_features.graphql_enums = True
     query = """
     mutation {

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -14,7 +14,7 @@ from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
 
 
-async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_schema) -> None:
     obj1 = await Node.init(db=db, schema="TestPerson")
     await obj1.new(db=db, name="John", height=180)
     await obj1.save(db=db)
@@ -54,7 +54,7 @@ async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_sc
 
 async def test_delete_prevented(
     db: InfrahubDatabase, default_branch, car_person_schema, car_camry_main, person_jane_main
-):
+) -> None:
     query = (
         """
     mutation {
@@ -90,7 +90,7 @@ async def test_delete_prevented(
 
 async def test_delete_allowed_when_peer_rel_optional_on_generic(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -133,7 +133,7 @@ async def test_delete_allowed_when_peer_rel_optional_on_generic(
 
 async def test_delete_prevented_when_peer_rel_required_on_generic(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 

--- a/backend/tests/unit/graphql/test_mutation_generator.py
+++ b/backend/tests/unit/graphql/test_mutation_generator.py
@@ -49,7 +49,7 @@ async def test_run_generator_definition(
     car_person_data_generic,
     create_test_admin: Node,
     definition1: Node,
-):
+) -> None:
     query = """
     mutation {
         CoreGeneratorDefinitionRun(data: { id: "%s" }, wait_until_completion: false) {

--- a/backend/tests/unit/graphql/test_mutation_graphqlquery.py
+++ b/backend/tests/unit/graphql/test_mutation_graphqlquery.py
@@ -7,7 +7,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
 
-async def test_create_query_no_vars(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_create_query_no_vars(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
     query_value = """
     query MyQuery {
         CoreRepository {
@@ -67,7 +67,9 @@ async def test_create_query_no_vars(db: InfrahubDatabase, default_branch: Branch
     assert query1.models.value == [InfrahubKind.REPOSITORY]
 
 
-async def test_create_query_with_vars(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_create_query_with_vars(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
+) -> None:
     query_value = """
     query MyQuery {
         CoreRepository {
@@ -135,7 +137,7 @@ async def test_create_query_with_vars(db: InfrahubDatabase, default_branch: Bran
     assert query2.models.value == [InfrahubKind.TAG, InfrahubKind.REPOSITORY]
 
 
-async def test_update_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_update_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
     query_create = """
     query MyQuery {
         CoreRepository {
@@ -230,7 +232,9 @@ async def test_update_query(db: InfrahubDatabase, default_branch: Branch, regist
     assert obj2.models.value == [InfrahubKind.TAG, InfrahubKind.REPOSITORY]
 
 
-async def test_update_query_no_update(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_update_query_no_update(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
+) -> None:
     query_create = """
     query MyQuery {
         CoreRepository {

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -46,7 +46,7 @@ async def test_relationship_add(
     enable_broker_config: None,
     session_first_account: AccountSession,
     first_account: Node,
-):
+) -> None:
     await define_permissions(
         account=first_account,
         db=db,
@@ -188,7 +188,7 @@ async def test_relationship_remove(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         RelationshipRemove(data: {
@@ -269,7 +269,7 @@ async def test_relationship_wrong_name(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         RelationshipAdd(data: {
@@ -335,7 +335,7 @@ async def test_relationship_wrong_node(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     # Non existing Node
     bad_uuid = str(UUIDT())
     query = """
@@ -406,7 +406,7 @@ async def test_relationship_groups_add(
     enable_broker_config: None,
     session_first_account: AccountSession,
     first_account: Node,
-):
+) -> None:
     await define_permissions(
         account=first_account,
         db=db,
@@ -556,7 +556,7 @@ async def test_relationship_groups_remove(
     enable_broker_config: None,
     session_first_account: AccountSession,
     first_account: Node,
-):
+) -> None:
     await define_permissions(
         account=first_account,
         db=db,
@@ -693,7 +693,9 @@ async def test_relationship_groups_remove(
     assert group_event.ancestors == []
 
 
-async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data):
+async def test_relationship_groups_add_remove(
+    db: InfrahubDatabase, default_branch: Branch, car_person_generics_data
+) -> None:
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
     c3 = car_person_generics_data["c3"]
@@ -856,7 +858,7 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
     assert len(members) == 1
 
 
-async def test_relationship_add_busy(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data):
+async def test_relationship_add_busy(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data) -> None:
     c1 = car_person_generics_data["c1"]
     p2 = car_person_generics_data["p2"]
 
@@ -894,7 +896,7 @@ async def test_relationship_add_for_node_with_migrated_kind(
     register_internal_models_schema,
     car_person_schema: Node,
     person_alfred_main: Node,
-):
+) -> None:
     schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
     default_branch.update_schema_hash()
@@ -1082,7 +1084,7 @@ async def test_relationship_add_for_node_with_migrated_kind(
 
 async def test_relationship_add_from_pool(
     db: InfrahubDatabase, default_branch: Branch, prefix_pool_01: dict[str, Node]
-):
+) -> None:
     hugh = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await hugh.new(db=db, name="Hugh Jackman")
     await hugh.save(db=db)
@@ -1128,7 +1130,7 @@ async def test_add_generic_related_node_with_hfid(
     db: InfrahubDatabase,
     default_branch: Branch,
     generic_car_person_schema,
-):
+) -> None:
     electric_car = await Node.init(db=db, schema="TestElectricCar", branch=default_branch)
     await electric_car.new(db=db, name="testing-car", color="blue")
     await electric_car.save(db=db)
@@ -1184,7 +1186,7 @@ async def test_with_permissions(
     first_account: CoreAccount,
     person_jack_main: Node,
     tag_blue_main: Node,
-):
+) -> None:
     permissions = []
     for object_permission in [
         ObjectPermission(
@@ -1259,7 +1261,7 @@ async def test_without_permissions(
     first_account: CoreAccount,
     person_jack_main: Node,
     tag_red_main: Node,
-):
+) -> None:
     first_session = AccountSession(
         authenticated=True, account_id=first_account.id, session_id=str(uuid4()), auth_type=AuthType.JWT
     )

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -22,7 +22,7 @@ from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
 
 
-async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
+async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node, branch: Branch) -> None:
     query = (
         """
     mutation {
@@ -58,7 +58,9 @@ async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node
     assert obj1.height.value == 180
 
 
-async def test_update_simple_object_with_ok_return(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
+async def test_update_simple_object_with_ok_return(
+    db: InfrahubDatabase, person_john_main: Node, branch: Branch
+) -> None:
     query = (
         """
     mutation {
@@ -100,7 +102,7 @@ async def test_update_simple_object_with_enum(
     graphql_enums_on,
     enum_value,
     response_value,
-):
+) -> None:
     graphql_registry.clear_cache()
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     query = """
@@ -165,7 +167,9 @@ async def test_update_simple_object_with_enum(
     assert updated_car.transmission.value.value == "flintstone-feet"
 
 
-async def test_update_check_unique(db: InfrahubDatabase, person_john_main: Node, person_jim_main: Node, branch: Branch):
+async def test_update_check_unique(
+    db: InfrahubDatabase, person_john_main: Node, person_jim_main: Node, branch: Branch
+) -> None:
     query = (
         """
     mutation {
@@ -197,7 +201,7 @@ async def test_update_check_unique(db: InfrahubDatabase, person_john_main: Node,
     assert "Violates uniqueness constraint" in result.errors[0].message
 
 
-async def test_update_object_with_flag_property(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
+async def test_update_object_with_flag_property(db: InfrahubDatabase, person_john_main: Node, branch: Branch) -> None:
     query = (
         """
     mutation {
@@ -243,7 +247,7 @@ async def test_update_all_attributes(
     all_attribute_types_schema,
     enable_broker_config: None,
     session_first_account: AccountSession,
-):
+) -> None:
     obj1 = await Node.init(db=db, schema="TestAllAttributeTypes")
     await obj1.new(
         db=db,
@@ -339,7 +343,7 @@ async def test_update_object_with_node_property(
     first_account: Node,
     second_account: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         TestPersonUpdate(data: {id: "%s", name: { source: "%s" }, height: { source: "%s" } }) {
@@ -373,7 +377,9 @@ async def test_update_object_with_node_property(
     assert obj1.height.source_id == second_account.id
 
 
-async def test_update_invalid_object(db: InfrahubDatabase, default_branch: Branch, car_person_schema, branch: Branch):
+async def test_update_invalid_object(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, branch: Branch
+) -> None:
     query = """
     mutation {
         TestPersonUpdate(data: {id: "XXXXXX", name: { value: "Jim"}}) {
@@ -402,7 +408,7 @@ async def test_update_invalid_object(db: InfrahubDatabase, default_branch: Branc
     assert "Unable to find the node XXXXXX / TestPerson in the database." in result.errors[0].message
 
 
-async def test_update_invalid_input(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
+async def test_update_invalid_input(db: InfrahubDatabase, person_john_main: Node, branch: Branch) -> None:
     query = (
         """
     mutation {
@@ -442,7 +448,7 @@ async def test_update_single_relationship(
     branch: Branch,
     enable_broker_config: None,
     session_first_account: AccountSession,
-):
+) -> None:
     query = """
     mutation {
         TestCarUpdate(data: {id: "%s", owner: { id: "%s" }}) {
@@ -512,7 +518,7 @@ async def test_update_single_relationship(
 
 async def test_update_default_value(
     db: InfrahubDatabase, person_john_main: Node, person_jim_main: Node, car_accord_main: Node, branch: Branch
-):
+) -> None:
     assert car_accord_main.color.is_default is True
 
     query = """
@@ -630,7 +636,7 @@ async def test_update_default_value(
 
 async def test_update_new_single_relationship_flag_property(
     db: InfrahubDatabase, person_john_main: Node, person_jim_main: Node, car_accord_main: Node, branch: Branch
-):
+) -> None:
     query = """
     mutation {
         TestCarUpdate(data: {id: "%s", owner: { id: "%s", _relation__is_protected: true }}) {
@@ -675,7 +681,7 @@ async def test_update_new_single_relationship_flag_property(
 
 async def test_update_delete_optional_relationship_cardinality_one(
     db: InfrahubDatabase, person_jim_main: Node, car_accord_main: Node, branch: Branch
-):
+) -> None:
     query = """
     mutation {
         TestCarUpdate(data: {id: "%s", owner: { id: "%s" }}) {
@@ -755,7 +761,7 @@ async def test_update_delete_optional_relationship_cardinality_one(
 
 async def test_update_existing_single_relationship_flag_property(
     db: InfrahubDatabase, default_branch: Branch, person_john_main: Node, car_accord_main: Node, branch: Branch
-):
+) -> None:
     query = """
     mutation {
         TestCarUpdate(data: {id: "%s", owner: { id: "%s", _relation__is_protected: true }}) {
@@ -822,7 +828,7 @@ async def test_update_existing_single_relationship_node_property(
     first_account: Node,
     second_account: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         TestCarUpdate(data: {id: "%s", owner: { id: "%s", _relation__source: "%s" }}) {
@@ -875,7 +881,7 @@ async def test_update_relationship_many(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         TestPersonUpdate(data: {id: "%s", tags: [ { id: "%s" } ] }) {
@@ -1012,7 +1018,7 @@ async def test_update_relationship_many2(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         TestPersonUpdate(data: {id: "%s", tags: [ { id: "%s" } ] }) {
@@ -1106,7 +1112,7 @@ async def test_update_relationship_previously_deleted(
     tag_red_main: Node,
     tag_black_main: Node,
     branch: Branch,
-):
+) -> None:
     query = """
     mutation {
         TestPersonUpdate(data: {id: "%s", tags: [ { id: "%s" } ] }) {
@@ -1228,7 +1234,7 @@ async def test_update_for_node_with_migrated_kind(
     register_internal_models_schema,
     car_person_schema: Node,
     person_alfred_main: Node,
-):
+) -> None:
     schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
     default_branch.update_schema_hash()
@@ -1413,7 +1419,9 @@ async def test_update_for_node_with_migrated_kind(
     assert peer_count == 1
 
 
-async def test_update_with_uniqueness_constraint_violation(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_update_with_uniqueness_constraint_violation(
+    db: InfrahubDatabase, default_branch, car_person_schema
+) -> None:
     car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
     car_schema.uniqueness_constraints = [["owner", "color__value"]]
 
@@ -1458,7 +1466,7 @@ async def test_update_with_uniqueness_constraint_violation(db: InfrahubDatabase,
     assert "Violates uniqueness constraint 'owner-color'" in result.errors[0].message
 
 
-async def test_with_hfid(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_with_hfid(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -1501,7 +1509,7 @@ async def test_with_hfid(db: InfrahubDatabase, default_branch, animal_person_sch
     assert result.data["TestDogUpdate"]["object"] == {"color": {"value": "black"}, "id": dog1.id}
 
 
-async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -1581,7 +1589,9 @@ async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branc
     assert owner.peer_id == person1.id
 
 
-async def test_removing_mandatory_relationship_not_allowed(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_removing_mandatory_relationship_not_allowed(
+    db: InfrahubDatabase, default_branch, animal_person_schema
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -1620,7 +1630,7 @@ async def test_removing_mandatory_relationship_not_allowed(db: InfrahubDatabase,
 
 async def test_updating_relationship_when_peer_side_is_required(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -1667,7 +1677,7 @@ async def test_updating_relationship_when_peer_side_is_required(
 
 async def test_updating_relationship_when_peer_side_is_optional(
     db: InfrahubDatabase, default_branch, animal_person_schema
-):
+) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -16,7 +16,9 @@ from tests.helpers.schema import COLOR, TICKET, TSHIRT
 from tests.node_creation import create_and_save
 
 
-async def test_upsert_existing_simple_object_by_id(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
+async def test_upsert_existing_simple_object_by_id(
+    db: InfrahubDatabase, person_john_main: Node, branch: Branch
+) -> None:
     query = (
         """
     mutation {
@@ -48,7 +50,7 @@ async def test_upsert_existing_simple_object_by_id(db: InfrahubDatabase, person_
 
 async def test_upsert_existing_simple_object_by_default_filter(
     db: InfrahubDatabase, person_schema_default_filter, default_branch
-):
+) -> None:
     registry.schema.register_schema(schema=person_schema_default_filter)
 
     person = await Node.init(db=db, schema="TestPersonDF")
@@ -158,7 +160,7 @@ async def test_upsert_event_on_no_change(
     assert len(memory_event.events) == 0
 
 
-async def test_upsert_create_simple_object_no_id(db: InfrahubDatabase, person_john_main, branch: Branch):
+async def test_upsert_create_simple_object_no_id(db: InfrahubDatabase, person_john_main, branch: Branch) -> None:
     query = """
     mutation {
         TestPersonUpsert(data: {name: { value: "%s"}, height: {value: %s}}) {
@@ -192,7 +194,7 @@ async def test_upsert_create_simple_object_no_id(db: InfrahubDatabase, person_jo
 
 async def test_id_for_other_schema_raises_error(
     db: InfrahubDatabase, person_john_main, car_accord_main, branch: Branch
-):
+) -> None:
     query = (
         """
     mutation {
@@ -220,7 +222,7 @@ async def test_id_for_other_schema_raises_error(
 
 async def test_update_by_id_to_nonunique_value_raises_error(
     db: InfrahubDatabase, person_john_main, person_jim_main, branch: Branch
-):
+) -> None:
     query = (
         """
     mutation {
@@ -246,7 +248,9 @@ async def test_update_by_id_to_nonunique_value_raises_error(
     assert any(expected_error in error.message for error in result.errors)
 
 
-async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch):
+async def test_non_unique_value_raises_error(
+    db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch
+) -> None:
     _ = await create_and_save(db=db, schema="TestPerson", name="Jack", bag="bag-jacks")
 
     # Make sure correct raised error is raised while violating uniqueness constraint of a non hfid-related attribute.
@@ -274,7 +278,7 @@ async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema
 
 async def test_upsert_existing_with_enough_information_for_hfid(
     db: InfrahubDatabase, person_schema_unique_attr_non_hfid, default_branch: Branch
-):
+) -> None:
     car_name = "Ferramboghinierati"
     car_color_1 = "blue"
     car_color_2 = "red"
@@ -389,7 +393,7 @@ async def test_upsert_existing_with_enough_information_for_hfid(
 
 async def test_upsert_existing_hfid_with_non_hfid_unique_attr(
     db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch
-):
+) -> None:
     _ = await create_and_save(db=db, schema="TestPerson", name="Fred", bag="bag-fred", branch=branch)
 
     query = """
@@ -411,7 +415,7 @@ async def test_upsert_existing_hfid_with_non_hfid_unique_attr(
     assert result.errors is None
 
 
-async def test_with_hfid_existing(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_with_hfid_existing(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -460,7 +464,7 @@ async def test_with_hfid_existing(db: InfrahubDatabase, default_branch, animal_p
     assert result.data["TestDogUpsert"]["object"] == {"color": {"value": "black"}, "id": dog1.id}
 
 
-async def test_with_hfid_new(db: InfrahubDatabase, default_branch, animal_person_schema):
+async def test_with_hfid_new(db: InfrahubDatabase, default_branch, animal_person_schema) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -658,7 +662,9 @@ async def test_with_constructed_hfid_with_numbers(
     }
 
 
-async def test_upsert_node_on_branch_with_hfid_on_default(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_upsert_node_on_branch_with_hfid_on_default(
+    db: InfrahubDatabase, default_branch, car_person_schema
+) -> None:
     # create a node on the default branch after the branch is created
     branch = await create_branch(branch_name="test-branch", db=db)
     person = await create_and_save(db=db, branch=default_branch, schema="TestPerson", name="John", height=182)

--- a/backend/tests/unit/graphql/test_parser.py
+++ b/backend/tests/unit/graphql/test_parser.py
@@ -123,7 +123,7 @@ async def test_directive_exclude(db: InfrahubDatabase, default_branch: Branch, c
 
 async def test_directive_merge_fields(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, person_tag_schema, first_account
-):
+) -> None:
     """This test validates that the @expand directive doesn't override the source field under username."""
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, firstname="John", lastname="Doe", _source=first_account)

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -13,7 +13,7 @@ from tests.helpers.schema.tshirt import TSHIRT
 
 async def test_analyzer_init_with_schema(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_01: str, bad_query_01: str
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -33,7 +33,7 @@ async def test_is_valid_simple_schema(
     query_04: str,
     query_introspection: str,
     car_person_schema_generics,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -78,7 +78,7 @@ async def test_is_valid_core_schema(
     default_branch: Branch,
     query_05: str,
     register_core_models_schema,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -98,7 +98,7 @@ async def test_get_models_in_use(
     query_02: str,
     query_03: str,
     car_person_schema_generics,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -183,7 +183,7 @@ async def test_get_models_in_use(
     assert gqa.query_report.requested_read[InfrahubKind.GENERICGROUP].relationships == set()
 
 
-async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics):
+async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)

--- a/backend/tests/unit/graphql/test_schema_sort.py
+++ b/backend/tests/unit/graphql/test_schema_sort.py
@@ -168,7 +168,7 @@ def complex_schema_document() -> DocumentNode:
 
 def test_sort_schema_ast_basic_sorting(
     unsorted_schema_document: DocumentNode, expected_sorted_schema_document: DocumentNode
-):
+) -> None:
     """Test that sort_schema_ast correctly sorts basic schema elements."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -179,7 +179,7 @@ def test_sort_schema_ast_basic_sorting(
     assert result_str == expected_str
 
 
-def test_sort_schema_ast_preserves_structure(unsorted_schema_document: DocumentNode):
+def test_sort_schema_ast_preserves_structure(unsorted_schema_document: DocumentNode) -> None:
     """Test that sorting preserves the overall document structure."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -192,7 +192,7 @@ def test_sort_schema_ast_preserves_structure(unsorted_schema_document: DocumentN
     assert original_types == result_types
 
 
-def test_sort_schema_ast_sorts_definitions_by_name(unsorted_schema_document: DocumentNode):
+def test_sort_schema_ast_sorts_definitions_by_name(unsorted_schema_document: DocumentNode) -> None:
     """Test that type definitions are sorted alphabetically by name."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -205,7 +205,7 @@ def test_sort_schema_ast_sorts_definitions_by_name(unsorted_schema_document: Doc
     assert definition_names == sorted(definition_names)
 
 
-def test_sort_schema_ast_sorts_object_fields(unsorted_schema_document: DocumentNode):
+def test_sort_schema_ast_sorts_object_fields(unsorted_schema_document: DocumentNode) -> None:
     """Test that object type fields are sorted alphabetically."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -221,7 +221,7 @@ def test_sort_schema_ast_sorts_object_fields(unsorted_schema_document: DocumentN
     assert field_names == sorted(field_names)
 
 
-def test_sort_schema_ast_sorts_enum_values(unsorted_schema_document: DocumentNode):
+def test_sort_schema_ast_sorts_enum_values(unsorted_schema_document: DocumentNode) -> None:
     """Test that enum values are sorted alphabetically."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -237,7 +237,7 @@ def test_sort_schema_ast_sorts_enum_values(unsorted_schema_document: DocumentNod
     assert enum_values == sorted(enum_values)
 
 
-def test_sort_schema_ast_sorts_input_fields(unsorted_schema_document: DocumentNode):
+def test_sort_schema_ast_sorts_input_fields(unsorted_schema_document: DocumentNode) -> None:
     """Test that input object fields are sorted alphabetically."""
     result = sort_schema_ast(unsorted_schema_document)
 
@@ -253,7 +253,7 @@ def test_sort_schema_ast_sorts_input_fields(unsorted_schema_document: DocumentNo
     assert field_names == sorted(field_names)
 
 
-def test_sort_schema_ast_complex_schema(complex_schema_document: DocumentNode):
+def test_sort_schema_ast_complex_schema(complex_schema_document: DocumentNode) -> None:
     """Test sorting with a more complex schema containing multiple types and arguments."""
     result = sort_schema_ast(complex_schema_document)
 
@@ -286,7 +286,7 @@ def test_sort_schema_ast_complex_schema(complex_schema_document: DocumentNode):
             assert field_names == sorted(field_names)
 
 
-def test_sort_schema_ast_empty_document():
+def test_sort_schema_ast_empty_document() -> None:
     """Test that sorting an empty document returns an empty document."""
     empty_doc = DocumentNode(definitions=[])
     result = sort_schema_ast(empty_doc)
@@ -295,7 +295,7 @@ def test_sort_schema_ast_empty_document():
     assert isinstance(result, DocumentNode)
 
 
-def test_sort_schema_ast_single_definition():
+def test_sort_schema_ast_single_definition() -> None:
     """Test sorting a document with a single definition."""
     single_type_str = """
     type User {
@@ -315,7 +315,7 @@ def test_sort_schema_ast_single_definition():
     assert field_names == sorted(field_names)
 
 
-def test_sort_schema_ast_preserves_metadata():
+def test_sort_schema_ast_preserves_metadata() -> None:
     """Test that sorting preserves important metadata like directives and descriptions."""
     # Test with a basic schema to ensure the function doesn't crash
     # and that the structure is preserved
@@ -373,7 +373,7 @@ def test_sort_schema_ast_preserves_metadata():
             assert enum_values == sorted(enum_values)
 
 
-def test_sort_schema_ast_idempotent():
+def test_sort_schema_ast_idempotent() -> None:
     """Test that sorting an already sorted document doesn't change it."""
     schema_str = """
     type User {
@@ -418,7 +418,7 @@ def schema_with_unsorted_interfaces() -> DocumentNode:
     return parse(schema_str)
 
 
-def test_sort_schema_ast_sorts_interfaces(schema_with_unsorted_interfaces: DocumentNode):
+def test_sort_schema_ast_sorts_interfaces(schema_with_unsorted_interfaces: DocumentNode) -> None:
     """Test that interfaces are sorted alphabetically when a type implements multiple interfaces."""
     result = sort_schema_ast(schema_with_unsorted_interfaces)
 
@@ -440,7 +440,7 @@ def test_sort_schema_ast_sorts_interfaces(schema_with_unsorted_interfaces: Docum
     assert interface_names == sorted(interface_names)
 
 
-def test_sort_schema_ast_sorts_all_interfaces_in_schema():
+def test_sort_schema_ast_sorts_all_interfaces_in_schema() -> None:
     """Test that all types with multiple interfaces get sorted."""
     schema_str = """
     type Article implements Publishable & Node & Timestamped {
@@ -462,7 +462,7 @@ def test_sort_schema_ast_sorts_all_interfaces_in_schema():
             assert interface_names == sorted(interface_names), f"{definition.name.value} interfaces not sorted"
 
 
-def test_sort_schema_ast_preserves_other_definition_types():
+def test_sort_schema_ast_preserves_other_definition_types() -> None:
     """Test that other definition types (scalars, unions, directives) are preserved."""
     schema_str = """
     scalar DateTime

--- a/backend/tests/unit/locks/test_clean_up_deadlocks.py
+++ b/backend/tests/unit/locks/test_clean_up_deadlocks.py
@@ -7,7 +7,7 @@ from infrahub.services.component import InfrahubComponent, WorkerInfo
 from tests.adapters.cache import MemoryCache
 
 
-async def test_clean_up_deadlocks(default_branch):
+async def test_clean_up_deadlocks(default_branch) -> None:
     cache = MemoryCache()
     await cache.set(
         key="lock.repository.sample-infrahub", value="2025-09-18T12:07:24.654862Z::800b4a90-87cd-458f-8c68-b0b5ebb81046"

--- a/backend/tests/unit/menu/conftest.py
+++ b/backend/tests/unit/menu/conftest.py
@@ -121,7 +121,7 @@ async def menu_repository(db: InfrahubDatabase) -> MenuRepository:
 @pytest.fixture
 async def menu_fixture_01(
     menu_repository: MenuRepository, default_branch: Branch, menu_fixture_01_data: list[MenuItemDefinition]
-):
+) -> None:
     await menu_repository.create_menu(menu=menu_fixture_01_data)
 
 

--- a/backend/tests/unit/menu/test_generator.py
+++ b/backend/tests/unit/menu/test_generator.py
@@ -39,7 +39,7 @@ async def test_generate_menu_placement(
     car_person_schema_generics: SchemaRoot,
     menu_repository: MenuRepository,
     helper,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
     schema_car = schema_branch.get(name="TestCar")
@@ -66,7 +66,7 @@ async def test_generate_menu_top_level(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     helper,
-):
+) -> None:
     await create_default_menu(db=db)
 
     new_menu_items = generate_menu_fixtures(nbr_item=2)
@@ -87,7 +87,7 @@ async def test_generate_menu_default(
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     helper,
-):
+) -> None:
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     schema_car = schema_branch.get(name="TestCar")
     schema_car.menu_placement = "DoesNotExist"

--- a/backend/tests/unit/menu/test_models.py
+++ b/backend/tests/unit/menu/test_models.py
@@ -1,7 +1,7 @@
 from infrahub.menu.models import MenuDict, MenuItemDefinition, MenuItemDict, MenuSection
 
 
-async def test_menu_item_dict(menu_fixture_01_data: list[MenuItemDefinition]):
+async def test_menu_item_dict(menu_fixture_01_data: list[MenuItemDefinition]) -> None:
     menu_item = MenuItemDict.from_definition(definition=menu_fixture_01_data[0])
     assert menu_item.identifier == "UserdefinedTest"
     assert menu_item.label == "Test"
@@ -11,14 +11,14 @@ async def test_menu_item_dict(menu_fixture_01_data: list[MenuItemDefinition]):
     assert menu_item.get_all_identifiers() == {"UserdefinedTest"}
 
 
-async def test_menu_item_diff_attributes(menu_fixture_01_data: list[MenuItemDefinition]):
+async def test_menu_item_diff_attributes(menu_fixture_01_data: list[MenuItemDefinition]) -> None:
     menu_item = MenuItemDict.from_definition(definition=menu_fixture_01_data[0])
     menu_item_2 = MenuItemDict.from_definition(definition=menu_fixture_01_data[0])
     menu_item_2.label = "Test2"
     assert menu_item.diff_attributes(other=menu_item_2) == {"label": "Test2"}
 
 
-async def test_menu_dict_from_definitions(menu_fixture_01_data: list[MenuItemDefinition]):
+async def test_menu_dict_from_definitions(menu_fixture_01_data: list[MenuItemDefinition]) -> None:
     menu = MenuDict.from_definition_list(menu_fixture_01_data)
     assert sorted(menu.data.keys()) == [
         "BuiltinDeployment",
@@ -29,7 +29,7 @@ async def test_menu_dict_from_definitions(menu_fixture_01_data: list[MenuItemDef
     ]
 
 
-async def test_menu_dict_get_all_identifiers(menu_fixture_01_data: list[MenuItemDefinition]):
+async def test_menu_dict_get_all_identifiers(menu_fixture_01_data: list[MenuItemDefinition]) -> None:
     menu = MenuDict.from_definition_list(menu_fixture_01_data)
     assert menu.get_all_identifiers() == {
         "UserdefinedTest",
@@ -45,7 +45,7 @@ async def test_menu_dict_get_all_identifiers(menu_fixture_01_data: list[MenuItem
     }
 
 
-async def test_menu_dict_get_item_location(menu_fixture_01_data: list[MenuItemDefinition]):
+async def test_menu_dict_get_item_location(menu_fixture_01_data: list[MenuItemDefinition]) -> None:
     menu = MenuDict.from_definition_list(menu_fixture_01_data)
     assert menu.get_item_location("BuiltinArtifact") == ["BuiltinDeployment", "BuiltinArtifactMenu"]
     assert menu.get_item_location("UserdefinedTest") == []

--- a/backend/tests/unit/menu/test_repository.py
+++ b/backend/tests/unit/menu/test_repository.py
@@ -12,7 +12,7 @@ async def test_get_menu(
     default_branch: Branch,
     register_core_models_schema: SchemaRoot,
     menu_fixture_01: list[MenuItemDefinition],
-):
+) -> None:
     existing_menu = await menu_repository.get_menu()
 
     assert sorted(existing_menu.data.keys()) == [
@@ -34,7 +34,7 @@ async def test_update_menu_small_dataset(
     register_core_models_schema: SchemaRoot,
     menu_fixture_11_data: list[MenuItemDefinition],
     menu_fixture_12_data: list[MenuItemDefinition],
-):
+) -> None:
     await menu_repository.create_menu(menu=menu_fixture_11_data)
 
     menu_nodes = await menu_repository.get_menu_db()
@@ -59,7 +59,7 @@ async def test_update_menu_default_menu(
     default_branch: Branch,
     register_core_models_schema: SchemaRoot,
     menu_fixture_02_data: list[MenuItemDefinition],
-):
+) -> None:
     await menu_repository.create_menu(menu=menu_fixture_02_data)
 
     menu_nodes = await menu_repository.get_menu_db()

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -40,7 +40,7 @@ def context():
     )
 
 
-async def test_merged(default_branch: Branch, prefect_test_fixture, context: InfrahubContext, init_service):
+async def test_merged(default_branch: Branch, prefect_test_fixture, context: InfrahubContext, init_service) -> None:
     """
     Test that merge flow triggers corrects events/workflows. It does not actually test these events/workflows behaviors
     as they are mocked.

--- a/backend/tests/unit/message_bus/operations/git/test_file.py
+++ b/backend/tests/unit/message_bus/operations/git/test_file.py
@@ -4,7 +4,7 @@ from infrahub.message_bus import messages
 from infrahub.workers.dependencies import build_message_bus
 
 
-async def test_file_get(git_fixture_repo: InfrahubRepository, helper, dependency_provider):
+async def test_file_get(git_fixture_repo: InfrahubRepository, helper, dependency_provider) -> None:
     repo = git_fixture_repo.get_git_repo_main()
 
     message = messages.GitFileGet(

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -22,7 +22,7 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
 
 async def test_graphql_group_update(
     db: InfrahubDatabase, httpx_mock: HTTPXMock, mock_schema_query_02, dependency_provider
-):
+) -> None:
     with dependency_provider.scope(
         build_client, lambda: InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
     ):

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -122,7 +122,7 @@ async def test_get_proposed_change_schema_integrity_constraints(
     car_person_schema,
     schema_integrity_01,
     branch_diff_01_summary: list[NodeDiff],
-):
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     constraints = await _get_proposed_change_schema_integrity_constraints(
         schema=schema, diff_summary=branch_diff_01_summary
@@ -275,7 +275,7 @@ async def test_schema_integrity(
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main: Node,
-):
+) -> None:
     cache = MemoryCache()
     with dependency_provider.scope(build_cache, lambda: cache):
         branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)

--- a/backend/tests/unit/message_bus/test_mappings.py
+++ b/backend/tests/unit/message_bus/test_mappings.py
@@ -9,7 +9,7 @@ from infrahub.message_bus.messages import MESSAGE_MAP
 from infrahub.message_bus.operations import COMMAND_MAP
 
 
-def test_message_command_overlap():
+def test_message_command_overlap() -> None:
     """
     Verify that a command is defined for each message
     except events that don't need to be associated with a command
@@ -33,7 +33,7 @@ operations_without_flows = [
     "operation",
     [pytest.param(function, id=key) for key, function in COMMAND_MAP.items() if key not in operations_without_flows],
 )
-def test_operations_decorated(operation: Callable):
+def test_operations_decorated(operation: Callable) -> None:
     if callable(operation) and hasattr(operation, "__name__") and "Flow" not in type(operation).__name__:
         pytest.fail(f"{operation.__name__} is not decorated with @flow")
     else:

--- a/backend/tests/unit/patch/kind_deduplication_patches/test_patches.py
+++ b/backend/tests/unit/patch/kind_deduplication_patches/test_patches.py
@@ -30,7 +30,7 @@ class TestKindMigrationDeduplicationPatches:
         temporary_directory.cleanup()
 
     @pytest.fixture(scope="class", autouse=True)
-    async def load_bad_data(self, db: InfrahubDatabase):
+    async def load_bad_data(self, db: InfrahubDatabase) -> None:
         await delete_all_nodes(db=db)
         export_dir = Path(__file__).parent / ("data_export")
         await load_export(db=db, export_dir=export_dir)
@@ -75,7 +75,7 @@ RETURN db_id_a, db_id_b, edge_type, branch, status, num_dups
             )
         return errors
 
-    async def test_edge_deduplication_patch(self, db: InfrahubDatabase, temporary_directory_path: Path):
+    async def test_edge_deduplication_patch(self, db: InfrahubDatabase, temporary_directory_path: Path) -> None:
         before_errors = await self.validate_edge_deduplication_patch(db=db)
         assert before_errors
 

--- a/backend/tests/unit/patch/test_patch_runner.py
+++ b/backend/tests/unit/patch/test_patch_runner.py
@@ -58,13 +58,13 @@ class TestingPatch(PatchQuery):
         self.edges_to_update = []
         self.edges_to_delete = []
 
-    def set_vertex_to_update(self, v: VertexToUpdate):
+    def set_vertex_to_update(self, v: VertexToUpdate) -> None:
         self.vertex_to_update = v
 
-    def set_vertices_to_delete(self, vertices: list[VertexToDelete]):
+    def set_vertices_to_delete(self, vertices: list[VertexToDelete]) -> None:
         self.vertices_to_delete = vertices
 
-    def set_edges_to_add(self, vertex_map: dict[str, str]):
+    def set_edges_to_add(self, vertex_map: dict[str, str]) -> None:
         for source_id, destination_id in vertex_map.items():
             self.edges_to_add.append(
                 EdgeToAdd(
@@ -75,10 +75,10 @@ class TestingPatch(PatchQuery):
                 )
             )
 
-    def set_edges_to_update(self, edges: list[EdgeToUpdate]):
+    def set_edges_to_update(self, edges: list[EdgeToUpdate]) -> None:
         self.edges_to_update = edges
 
-    def set_edges_to_delete(self, edges: list[EdgeToDelete]):
+    def set_edges_to_delete(self, edges: list[EdgeToDelete]) -> None:
         self.edges_to_delete = edges
 
     async def plan(self) -> PatchPlan:

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -8,7 +8,7 @@ from infrahub.permissions import LocalPermissionBackend
 
 async def test_load_permissions(
     db: InfrahubDatabase, default_branch: Branch, session_admin: AccountSession, session_first_account: AccountSession
-):
+) -> None:
     backend = LocalPermissionBackend()
 
     permissions = await backend.load_permissions(db=db, account_session=session_admin, branch=default_branch)

--- a/backend/tests/unit/permissions/test_manager.py
+++ b/backend/tests/unit/permissions/test_manager.py
@@ -38,7 +38,7 @@ async def test_load_permissions(
     default_branch: Branch,
     session_admin: AccountSession,
     session_first_account: AccountSession,
-):
+) -> None:
     permission_manager = PermissionManager(account_session=session_admin)
     await permission_manager.load_permissions(db=db, branch=default_branch)
 
@@ -64,7 +64,7 @@ async def test_load_permissions(
 
 async def test_load_permissions_multiple_backends(
     db: InfrahubDatabase, default_branch: Branch, session_first_account: AccountSession
-):
+) -> None:
     registry.permission_backends = [DummyBackendAllow(), DummyBackendDeny()]
 
     permission_manager = PermissionManager(account_session=session_first_account)
@@ -85,7 +85,7 @@ async def test_has_permission_global(
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
-):
+) -> None:
     allow_default_branch_edition = GlobalPermission(
         action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
@@ -151,7 +151,7 @@ async def test_has_permission_object(
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
-):
+) -> None:
     role1_permissions = []
     for p in [
         ObjectPermission(
@@ -235,7 +235,7 @@ async def test_has_permissions_object(
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
-):
+) -> None:
     role1_permissions = []
     for p in [
         ObjectPermission(
@@ -339,7 +339,7 @@ async def test_report_permission_object(
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
-):
+) -> None:
     role1_permissions = []
     for p in [
         ObjectPermission(

--- a/backend/tests/unit/permissions/test_types.py
+++ b/backend/tests/unit/permissions/test_types.py
@@ -19,7 +19,7 @@ from infrahub.permissions import get_global_permission_for_kind
 )
 def test_get_global_permission_for_kind(
     register_core_models_schema: None, kinds: list[str], permission: GlobalPermissions
-):
+) -> None:
     for kind in kinds:
         schema = registry.schema.get(name=kind)
         assert get_global_permission_for_kind(schema=schema) == permission

--- a/backend/tests/unit/pools/test_address.py
+++ b/backend/tests/unit/pools/test_address.py
@@ -5,7 +5,7 @@ from netaddr import IPNetwork
 from infrahub.pools.address import get_available
 
 
-def test_get_available():
+def test_get_available() -> None:
     network = ip_network("10.16.18.0/30")
     addresses = [ip_interface("10.16.18.1/30")]
     available = get_available(network=network, addresses=addresses, is_pool=False)
@@ -13,7 +13,7 @@ def test_get_available():
     assert available.iter_cidrs()[0] == IPNetwork("10.16.18.2/32")
 
 
-def test_get_available_pool():
+def test_get_available_pool() -> None:
     network = ip_network("10.16.18.0/30")
     addresses = [ip_interface("10.16.18.1/30")]
     available = get_available(network=network, addresses=addresses, is_pool=True)
@@ -22,7 +22,7 @@ def test_get_available_pool():
     assert available.iter_cidrs()[1] == IPNetwork("10.16.18.2/31")
 
 
-def test_get_available_full():
+def test_get_available_full() -> None:
     network = ip_network("10.16.18.0/30")
     addresses = [ip_interface("10.16.18.1/30"), ip_interface("10.16.18.2/30")]
     available = get_available(network=network, addresses=addresses, is_pool=False)

--- a/backend/tests/unit/pools/test_prefix.py
+++ b/backend/tests/unit/pools/test_prefix.py
@@ -6,7 +6,7 @@ from netaddr import IPSet
 from infrahub.pools.prefix import get_next_available_prefix
 
 
-def test_get_next_available_prefix_v4():
+def test_get_next_available_prefix_v4() -> None:
     """Tests getting the next available IPv4 prefix."""
     pool = IPSet(["192.0.2.0/24"])
     pool.remove("192.0.2.0/30")
@@ -14,7 +14,7 @@ def test_get_next_available_prefix_v4():
     assert next_prefix == ipaddress.IPv4Network("192.0.2.4/30")
 
 
-def test_get_next_available_prefix_v6():
+def test_get_next_available_prefix_v6() -> None:
     """Tests getting the next available IPv6 prefix."""
     pool = IPSet(["2001:db8::/32"])
     pool.remove("2001:db8::/64")
@@ -22,7 +22,7 @@ def test_get_next_available_prefix_v6():
     assert next_prefix == ipaddress.IPv6Network("2001:db8:0:1::/64")
 
 
-def test_get_next_available_prefix_mixed():
+def test_get_next_available_prefix_mixed() -> None:
     """Tests getting the next available prefix from a mixed pool."""
     pool = IPSet(["2001:db8::/32", "192.0.2.0/24"])
     next_prefix = get_next_available_prefix(pool, 30, 4)
@@ -33,14 +33,14 @@ def test_get_next_available_prefix_mixed():
     assert next_prefix == ipaddress.IPv6Network("2001:db8::/64")
 
 
-def test_get_next_available_prefix_exhausted_v4_pool():
+def test_get_next_available_prefix_exhausted_v4_pool() -> None:
     """Tests getting the next available prefix from an exhausted IPv4 pool."""
     pool = IPSet(["192.0.2.0/24"])
     with pytest.raises(ValueError):
         get_next_available_prefix(pool, 23, 4)
 
 
-def test_get_next_available_prefix_exhausted_v6_pool():
+def test_get_next_available_prefix_exhausted_v6_pool() -> None:
     """Tests getting the next available prefix from an exhausted IPv6 pool."""
     pool = IPSet(["2001:db8::/32"])
     with pytest.raises(ValueError):

--- a/backend/tests/unit/services/adapters/redis/test_redis.py
+++ b/backend/tests/unit/services/adapters/redis/test_redis.py
@@ -8,7 +8,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache.redis import RedisCache
 
 
-async def test_get(redis):
+async def test_get(redis) -> None:
     if config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         pytest.skip("Must use Redis to run this test")
 
@@ -26,7 +26,7 @@ async def test_get(redis):
     assert after_expiry is None
 
 
-async def test_list_keys(redis):
+async def test_list_keys(redis) -> None:
     if config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         pytest.skip("Must use Redis to run this test")
 

--- a/backend/tests/unit/services/test_scheduler.py
+++ b/backend/tests/unit/services/test_scheduler.py
@@ -20,7 +20,7 @@ async def log_once_and_stop(service: InfrahubServices) -> None:
         service.scheduler.running = False
 
 
-async def test_scheduler_return_on_not_running(fake_log: FakeLogger):
+async def test_scheduler_return_on_not_running(fake_log: FakeLogger) -> None:
     """The scheduler should return without writing entries to the log if it is not running."""
     service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=10, start_delay=1, function=log_once_and_stop)
@@ -29,7 +29,7 @@ async def test_scheduler_return_on_not_running(fake_log: FakeLogger):
     assert len(fake_log.info_logs) == 0
 
 
-async def test_scheduler_exit_after_first(fake_log: FakeLogger):
+async def test_scheduler_exit_after_first(fake_log: FakeLogger) -> None:
     """The scheduler should return without writing entries to the log if it is not running."""
 
     service = await InfrahubServices.new(log=fake_log)
@@ -43,7 +43,7 @@ async def test_scheduler_exit_after_first(fake_log: FakeLogger):
     assert fake_log.info_logs[2] == "Writing entry to the log"
 
 
-async def test_scheduler_task_with_error(fake_log: FakeLogger):
+async def test_scheduler_task_with_error(fake_log: FakeLogger) -> None:
     """The scheduler should return without writing entries to the log if it is not running."""
     service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=1, start_delay=0, function=nothing_to_see)

--- a/backend/tests/unit/storage/test_local_storage.py
+++ b/backend/tests/unit/storage/test_local_storage.py
@@ -9,31 +9,31 @@ from infrahub.exceptions import NodeNotFoundError
 from infrahub.storage import InfrahubObjectStorage
 
 
-async def test_init_local(helper, local_storage_dir: Path, file1_in_storage: str):
+async def test_init_local(helper, local_storage_dir: Path, file1_in_storage: str) -> None:
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
     assert isinstance(storage._storage, fastapi_storages.FileSystemStorage)
     assert config.SETTINGS.storage.local.path_ == local_storage_dir
 
 
-async def test_init_s3(helper, s3_storage_bucket: str):
+async def test_init_s3(helper, s3_storage_bucket: str) -> None:
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
     assert isinstance(storage._storage, fastapi_storages.InfrahubS3ObjectStorage)
     assert config.SETTINGS.storage.s3.endpoint_url == "storage.googleapis.com"
 
 
-async def test_retrieve_file(helper, local_storage_dir: Path, file1_in_storage: str):
+async def test_retrieve_file(helper, local_storage_dir: Path, file1_in_storage: str) -> None:
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
     file1 = storage.retrieve(identifier=file1_in_storage)
     assert file1
 
 
-async def test_retrieve_file_does_not_exist(helper, local_storage_dir: Path):
+async def test_retrieve_file_does_not_exist(helper, local_storage_dir: Path) -> None:
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
     with pytest.raises(NodeNotFoundError):
         storage.retrieve(identifier="doesnotexist")
 
 
-async def test_store_file(helper, local_storage_dir: Path):
+async def test_store_file(helper, local_storage_dir: Path) -> None:
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
 
     fixture_dir = helper.get_fixtures_dir()

--- a/backend/tests/unit/task_manager/test_event.py
+++ b/backend/tests/unit/task_manager/test_event.py
@@ -86,14 +86,14 @@ async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
     return [str(event.meta.id) for event in events_data.values()]
 
 
-async def test_query_no_filters(event_ids_inscope):
+async def test_query_no_filters(event_ids_inscope) -> None:
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
     events = await PrefectEvent.query(fields=fields, event_filter=InfrahubEventFilter())
     clean_events = filter_outofscope_events(events, event_ids_inscope)
     assert clean_events["count"] == 4
 
 
-async def test_query_branch_filter(events_data, event_ids_inscope):
+async def test_query_branch_filter(events_data, event_ids_inscope) -> None:
     expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch1_rebased"], data=events_data)
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
     event_filter = InfrahubEventFilter()
@@ -105,7 +105,7 @@ async def test_query_branch_filter(events_data, event_ids_inscope):
     assert received_ids == expected_ids
 
 
-async def test_query_ids_filter(events_data, event_ids_inscope):
+async def test_query_ids_filter(events_data, event_ids_inscope) -> None:
     expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch2_created"], data=events_data)
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
     event_filter = InfrahubEventFilter()

--- a/backend/tests/unit/telemetry/test_datatabase.py
+++ b/backend/tests/unit/telemetry/test_datatabase.py
@@ -2,16 +2,16 @@ from infrahub.database import InfrahubDatabase
 from infrahub.telemetry.database import gather_database_information, get_server_info, get_system_info
 
 
-async def test_get_server_info(db: InfrahubDatabase):
+async def test_get_server_info(db: InfrahubDatabase) -> None:
     servers = await get_server_info(db)
     assert len(servers) == 1
 
 
-async def test_get_system_info(db: InfrahubDatabase):
+async def test_get_system_info(db: InfrahubDatabase) -> None:
     system_info = await get_system_info(db)
     assert system_info is not None
 
 
-async def test_gather_database_information(db: InfrahubDatabase):
+async def test_gather_database_information(db: InfrahubDatabase) -> None:
     data = await gather_database_information.fn(db)
     assert data is not None

--- a/backend/tests/unit/telemetry/test_task_manager.py
+++ b/backend/tests/unit/telemetry/test_task_manager.py
@@ -1,6 +1,6 @@
 from infrahub.telemetry.task_manager import gather_prefect_information
 
 
-async def test_gather_prefect_information(prefect_test_fixture):
+async def test_gather_prefect_information(prefect_test_fixture) -> None:
     data = await gather_prefect_information()
     assert data

--- a/backend/tests/unit/test_database.py
+++ b/backend/tests/unit/test_database.py
@@ -25,7 +25,7 @@ from infrahub.database import InfrahubDatabase
 #         await validate_database(driver=db._driver, database_name=dbs_for_test[1])
 
 
-async def test_database_transaction(empty_database, db: InfrahubDatabase):
+async def test_database_transaction(empty_database, db: InfrahubDatabase) -> None:
     query1 = 'CREATE (b:Book {name: "book1"}) RETURN b'
     query2 = 'CREATE (b:Book {name: "book2"}) RETURN b'
     query3 = 'CREATE (b:Book "book1"}) RETURN b'

--- a/backend/tests/unit/test_lock.py
+++ b/backend/tests/unit/test_lock.py
@@ -25,7 +25,7 @@ async def do_nothing_global_graph(id=str, wait_sec=int) -> int:
     return id, start_time, end_time
 
 
-async def test_simple_infrahub_lock():
+async def test_simple_infrahub_lock() -> None:
     lock.initialize_lock(local_only=True)
 
     results = await gather(
@@ -37,7 +37,7 @@ async def test_simple_infrahub_lock():
     assert results[0][2] <= results[1][1]
 
 
-async def test_multi_global_graph_lock():
+async def test_multi_global_graph_lock() -> None:
     lock.initialize_lock(local_only=True)
 
     results = await gather(
@@ -50,7 +50,7 @@ async def test_multi_global_graph_lock():
     assert results[0][2] <= results[2][1]
 
 
-def test_generate_name():
+def test_generate_name() -> None:
     generate_name = lock.LockNameGenerator().generate_name
 
     assert generate_name("simple") == "simple"
@@ -62,7 +62,7 @@ def test_generate_name():
     assert generate_name("simple", namespace="other", local=False) == "global.other.simple"
 
 
-def test_unpack_name():
+def test_unpack_name() -> None:
     unpack_name = lock.LockNameGenerator().unpack_name
 
     assert unpack_name("simple") == ("simple", None, None)
@@ -73,7 +73,7 @@ def test_unpack_name():
     assert unpack_name("global.repository.simple") == ("simple", "repository", False)
 
 
-async def test_reentrant_lock_allows_nested_acquisitions():
+async def test_reentrant_lock_allows_nested_acquisitions() -> None:
     lock.initialize_lock(local_only=True)
 
     events: list[str] = []

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 from infrahub.utils import get_fixtures_dir
 
 
-def test_get_fixtures_dir():
+def test_get_fixtures_dir() -> None:
     assert get_fixtures_dir().exists()

--- a/backend/tests/unit/trigger/test_tasks.py
+++ b/backend/tests/unit/trigger/test_tasks.py
@@ -26,7 +26,7 @@ async def init_prefect(prefect_client: PrefectClient) -> None:
     await setup_deployments(client=prefect_client)
 
 
-async def test_setup_triggers(prefect_client: PrefectClient, init_prefect, cleanup_automation):
+async def test_setup_triggers(prefect_client: PrefectClient, init_prefect, cleanup_automation) -> None:
     report = await setup_triggers(client=prefect_client, triggers=builtin_triggers, trigger_type=TriggerType.BUILTIN)
 
     assert len(report.deleted) == 0

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -4,7 +4,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.webhook.models import StandardWebhook
 
 
-def test_standard_webhook():
+def test_standard_webhook() -> None:
     webhook = StandardWebhook(
         name="test", url="http://test.com", event_type="test", validate_certificates=True, shared_key="test"
     )
@@ -23,7 +23,7 @@ def test_standard_webhook():
     assert StandardWebhook.from_cache(cache_dict) == webhook
 
 
-def test_standard_webhook_header():
+def test_standard_webhook_header() -> None:
     webhook = StandardWebhook(
         name="test", url="http://test.com", event_type="test", validate_certificates=True, shared_key="test"
     )

--- a/backend/tests/unit/workflows/test_models.py
+++ b/backend/tests/unit/workflows/test_models.py
@@ -2,7 +2,7 @@ from infrahub.workflows.catalogue import BRANCH_REBASE
 from infrahub.workflows.models import WorkflowParameter
 
 
-def test_get_parameters():
+def test_get_parameters() -> None:
     assert BRANCH_REBASE.get_parameters() == {
         "branch": WorkflowParameter(name="branch", type="str", required=True),
         "context": WorkflowParameter(name="context", type="InfrahubContext", required=True),


### PR DESCRIPTION
Auto fixes for ruff violations returning None or Never

```toml
"backend/tests/**.py" = [
    "ANN201",   # Missing return type annotation for public function
]
```