### PR TITLE
Add interactive flag to select branches tor rebase

### DIFF
--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -126,7 +126,7 @@ jobs:
         run: invoke dev.build
 
       - name: Upgrade Infrahub and apply the latest database migrations
-        run: invoke dev.upgrade
+        run: invoke dev.upgrade --rebase-branches
 
       - name: Start Demo
         run: invoke dev.start

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -136,9 +136,6 @@ jobs:
           PORT=$(docker compose -p $INFRAHUB_BUILD_NAME port server 8000 | cut -d: -f2)
           echo "INFRAHUB_ADDRESS=http://localhost:${PORT}" >> $GITHUB_ENV
 
-      - name: Test branch rebase
-        run: poetry run invoke dev.test-branch-rebase --branch atl1-delete-upstream --data-to-check $DATA_NAME
-
       - name: Containers after tests
         if: always()
         run: docker ps -a

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -136,6 +136,9 @@ jobs:
           PORT=$(docker compose -p $INFRAHUB_BUILD_NAME port server 8000 | cut -d: -f2)
           echo "INFRAHUB_ADDRESS=http://localhost:${PORT}" >> $GITHUB_ENV
 
+      - name: Verify bracnh graph version
+        run: poetry run invoke dev.test-branch-graph-version --branch atl1-delete-upstream
+
       - name: Containers after tests
         if: always()
         run: docker ps -a

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -136,7 +136,7 @@ jobs:
           PORT=$(docker compose -p $INFRAHUB_BUILD_NAME port server 8000 | cut -d: -f2)
           echo "INFRAHUB_ADDRESS=http://localhost:${PORT}" >> $GITHUB_ENV
 
-      - name: Verify bracnh graph version
+      - name: Verify branch graph version
         run: poetry run invoke dev.test-branch-graph-version --branch atl1-delete-upstream
 
       - name: Containers after tests

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -354,7 +354,7 @@ async def migrate_database(
     return True
 
 
-async def detect_branches_needing_rebase(db: InfrahubDatabase) -> list[Branch]:
+async def mark_branches_needing_rebase(db: InfrahubDatabase) -> list[Branch]:
     branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
     if not branches:
         return []

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -21,6 +21,7 @@ from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.tasks import rebase_branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.graph import GRAPH_VERSION
@@ -353,14 +354,31 @@ async def migrate_database(
     return True
 
 
-async def trigger_rebase_branches(db: InfrahubDatabase) -> None:
-    """Trigger rebase of non-default branches, also triggering migrations in the process."""
+async def detect_branches_needing_rebase(db: InfrahubDatabase) -> list[Branch]:
     branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
+    if not branches:
+        return []
+
+    branches_needing_rebase: list[Branch] = []
+    for branch in branches:
+        if branch.graph_version == GRAPH_VERSION:
+            continue
+
+        branch.status = BranchStatus.NEED_UPGRADE_REBASE
+        await branch.save(db=db)
+        branches_needing_rebase.append(branch)
+
+    return branches_needing_rebase
+
+
+async def trigger_rebase_branches(db: InfrahubDatabase, branches: Sequence[Branch]) -> None:
+    """Trigger rebase of non-default branches, also triggering migrations in the process."""
     if not branches:
         return
 
     get_migration_console().log(
-        f"Planning rebase and migrations for {len(branches)} branches: {', '.join([b.name for b in branches])}"
+        f"Planning rebase and migrations for {len(branches)} {'branches' if len(branches) != 1 else 'branch'}: "
+        f"{', '.join([b.name for b in branches])}"
     )
 
     for branch in branches:

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -33,9 +33,9 @@ from infrahub.workflows.initialization import (
 )
 
 from .db import (
-    detect_branches_needing_rebase,
     detect_migration_to_run,
     initialize_internal_schema,
+    mark_branches_needing_rebase,
     migrate_database,
     trigger_rebase_branches,
     update_core_schema,
@@ -121,7 +121,7 @@ async def upgrade_cmd(
     # -------------------------------------------
     # Perform branch rebase and apply migrations to them
     # -------------------------------------------
-    branches = await detect_branches_needing_rebase(db=dbdriver)
+    branches = await mark_branches_needing_rebase(db=dbdriver)
     plural = len(branches) != 1
     rprint(
         f"Found {len(branches)} {'branches' if plural else 'branch'} that {'need' if plural else 'needs'} to be rebased"

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -123,7 +123,7 @@ async def upgrade_cmd(
     # -------------------------------------------
     branches = await mark_branches_needing_rebase(db=dbdriver)
     plural = len(branches) != 1
-    rprint(
+    get_migration_console().log(
         f"Found {len(branches)} {'branches' if plural else 'branch'} that {'need' if plural else 'needs'} to be rebased"
     )
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -33,6 +33,7 @@ from infrahub.workflows.initialization import (
 )
 
 from .db import (
+    detect_branches_needing_rebase,
     detect_migration_to_run,
     initialize_internal_schema,
     migrate_database,
@@ -42,6 +43,7 @@ from .db import (
 
 if TYPE_CHECKING:
     from infrahub.cli.context import CliContext
+    from infrahub.core.branch.models import Branch
     from infrahub.database import InfrahubDatabase
 
 app = AsyncTyper()
@@ -54,6 +56,9 @@ async def upgrade_cmd(
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
     check: bool = typer.Option(False, help="Check the state of the system without upgrading."),
     rebase_branches: bool = typer.Option(False, help="Rebase and apply migrations to branches if required."),
+    interactive: bool = typer.Option(
+        False, help="Use interactive prompt to accept or deny rebase of individual branches."
+    ),
 ) -> None:
     """Upgrade Infrahub to the latest version."""
 
@@ -116,8 +121,22 @@ async def upgrade_cmd(
     # -------------------------------------------
     # Perform branch rebase and apply migrations to them
     # -------------------------------------------
+    branches = await detect_branches_needing_rebase(db=dbdriver)
+    plural = len(branches) != 1
+    rprint(
+        f"Found {len(branches)} {'branches' if plural else 'branch'} that {'need' if plural else 'needs'} to be rebased"
+    )
+
     if rebase_branches:
-        await trigger_rebase_branches(db=dbdriver)
+        branches_to_rebase: list[Branch] = []
+        if not interactive:
+            branches_to_rebase = branches
+        else:
+            for branch in branches:
+                if typer.confirm(f"Rebase branch {branch.name}?"):
+                    branches_to_rebase.append(branch)
+
+        await trigger_rebase_branches(db=dbdriver, branches=branches_to_rebase)
 
     await dbdriver.close()
 

--- a/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
@@ -692,7 +692,7 @@ class Migration044(MigrationRequiringRebase):
                 )
                 await update_display_label_query.execute(db=db)
 
-            if progress and update_task is not None:
+            if progress is not None and update_task is not None:
                 progress.update(update_task, advance=num_updates)
 
             if num_updates == 0:

--- a/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
@@ -612,12 +612,7 @@ class Migration044(MigrationRequiringRebase):
     update_batch_size: int = 1000
     # skip these b/c the attributes on these schema-related nodes are used to define the values included in
     # the human_friendly_id and display_label attributes on instances of these schema, so should not be updated
-    kinds_to_skip: list[str] = [
-        "SchemaNode",
-        "SchemaAttribute",
-        "SchemaRelationship",
-        "SchemaGeneric",
-    ]
+    kinds_to_skip: list[str] = ["SchemaNode", "SchemaAttribute", "SchemaRelationship", "SchemaGeneric"]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
@@ -697,7 +692,7 @@ class Migration044(MigrationRequiringRebase):
                 )
                 await update_display_label_query.execute(db=db)
 
-            if progress is not None and update_task is not None:
+            if progress and update_task is not None:
                 progress.update(update_task, advance=num_updates)
 
             if num_updates == 0:

--- a/docs/docs/reference/infrahub-cli/infrahub-upgrade.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-upgrade.mdx
@@ -16,6 +16,7 @@ $ infrahub upgrade [OPTIONS] [CONFIG_FILE]
 
 * `--check / --no-check`: Check the state of the system without upgrading.  [default: no-check]
 * `--rebase-branches / --no-rebase-branches`: Rebase and apply migrations to branches if required.  [default: no-rebase-branches]
+* `--interactive / --no-interactive`: Use interactive prompt to accept or deny rebase of individual branches.  [default: no-interactive]
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/tasks/container_ops.py
+++ b/tasks/container_ops.py
@@ -140,13 +140,15 @@ def update_core_schema(context: Context, database: str, namespace: Namespace, de
         execute_command(context=context, command=command)
 
 
-def upgrade_infrahub(context: Context, database: str, namespace: Namespace) -> None:
+def upgrade_infrahub(context: Context, database: str, namespace: Namespace, rebase_branches: bool) -> None:
     """Update Infrahub to the latest version."""
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database, namespace=namespace)
         compose_cmd = get_compose_cmd(namespace=namespace)
         base_cmd = f"{get_env_vars(context, namespace=namespace)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
         command = f"{base_cmd} run {SERVICE_SERVER_NAME} infrahub upgrade"
+        if rebase_branches:
+            command += " --rebase-branches"
         execute_command(context=context, command=command)
 
 

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -257,3 +257,19 @@ def test_branch_rebase(context: Context, branch: str, data_to_check: str = "") -
 
     if data_to_check:
         client.get(kind="LocationContinent", hfid=data_to_check, branch=branch)
+
+
+@task
+def test_branch_graph_version(context: Context, branch: str) -> None:  # noqa: ARG001
+    from infrahub_sdk import InfrahubClientSync
+
+    client = InfrahubClientSync()
+
+    default_branch = client.branch.get(branch_name=client.default_branch)
+    other_branch = client.branch.get(branch_name=branch)
+
+    if default_branch.graph_version != other_branch.graph_version:
+        raise AssertionError(
+            f"Branch '{branch}' with graph version {other_branch.graph_version} has not been rebased and upgrade properly, "
+            f"expected graph version is {default_branch.graph_version}"
+        )

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -191,9 +191,9 @@ def stop(context: Context, database: str = INFRAHUB_DATABASE) -> None:
 
 
 @task(optional=["database"])
-def upgrade(context: Context, database: str = INFRAHUB_DATABASE) -> None:
+def upgrade(context: Context, database: str = INFRAHUB_DATABASE, rebase_branches: bool = False) -> None:
     """Upgrade Infrahub to the latest version and apply the required migrations."""
-    upgrade_infrahub(context=context, database=database, namespace=NAMESPACE)
+    upgrade_infrahub(context=context, database=database, namespace=NAMESPACE, rebase_branches=rebase_branches)
 
 
 @task

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -265,11 +265,8 @@ def test_branch_graph_version(context: Context, branch: str) -> None:  # noqa: A
 
     client = InfrahubClientSync()
 
-    default_branch = client.branch.get(branch_name=client.default_branch)
-    other_branch = client.branch.get(branch_name=branch)
-
-    if default_branch.graph_version != other_branch.graph_version:
+    b = client.branch.get(branch_name=branch)
+    if b.graph_version is None:
         raise AssertionError(
-            f"Branch '{branch}' with graph version {other_branch.graph_version} has not been rebased and upgrade properly, "
-            f"expected graph version is {default_branch.graph_version}"
+            f"Branch '{branch}' with graph version {b.graph_version} has not been rebased and upgrade properly"
         )


### PR DESCRIPTION
This change adds an `--interactive` flag to the `upgrade` command in order to be able to select which branches to rebase while using the `--rebase-branches` flag.

Branches that needs to be rebased will always be marked with the `NEED_UPGRADE_REBASE` status whether the user chooses to rebase them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --interactive option to the upgrade command for per-branch confirmation; non-interactive mode can auto-rebase all detected branches.

* **Documentation**
  * Documented the new --interactive / --no-interactive upgrade option.

* **Chores**
  * Upgrade now detects and marks branches needing rebase, performs per-branch rebase actions with clearer messaging, and accepts a rebase flag in automation tasks and workflows.

* **Tests**
  * Added a graph-version check to validate branch graph versions in the test flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->