### PR TITLE
hopefully fix flaky unit test

### DIFF
--- a/backend/infrahub/core/migrations/graph/m041_profile_attrs_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m041_profile_attrs_in_db.py
@@ -36,9 +36,10 @@ class GetUpdatedProfilesForBranchQuery(Query):
         query = """
 MATCH (profile:CoreProfile)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[e:HAS_VALUE]->(:AttributeValue)
 WHERE e.branch = $branch
+WITH DISTINCT profile.uuid AS profile_uuid
         """
         self.add_to_query(query)
-        self.return_labels = ["profile.uuid AS profile_uuid"]
+        self.return_labels = ["profile_uuid"]
 
     def get_profile_ids(self) -> list[str]:
         """Get list of updated profile UUIDs"""
@@ -101,7 +102,7 @@ class Migration041(MigrationRequiringRebase):
         result = MigrationResult()
         await get_or_load_schema_branch(db=db, branch=branch)
 
-        console.print(f"Gathering profiles for each branch {branch.name}...", end="")
+        console.print(f"Gathering profiles for branch {branch.name}...", end="")
         get_updated_profiles_for_branch_query = await GetUpdatedProfilesForBranchQuery.init(db=db, branch=branch)
         await get_updated_profiles_for_branch_query.execute(db=db)
         profile_ids = get_updated_profiles_for_branch_query.get_profile_ids()


### PR DESCRIPTION
the unit test for Migration041 can be flaky in CI for reasons I do not completely understand
the issue does not appear when running the test locally ~50 times
I am kind of guessing that this query which could return duplicated profile IDs during the migration might be the issue, but I guess we will see

here is an example of the failure in the CI
https://github.com/opsmill/infrahub/actions/runs/19039809210/job/54373693791

also fixed a type in a log message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal database query optimization and log message refinement for improved system performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->