### PR TITLE
Use GraphQL Query Analyzer when determining re-computation of artifacts

### DIFF
--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -92,6 +92,7 @@ class ProposedChangeArtifactDefinition(BaseModel):
     query_name: str  # Deprecated
     query_id: str
     query_models: list[str]
+    query_payload: str = Field(..., description="GraphQL query")
     repository_id: str
     transform_kind: str
     template_path: str = Field(default="")

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -11,6 +11,7 @@ import pytest
 from infrahub_sdk.exceptions import ModuleImportError
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import (
+    CoreArtifactDefinition,
     CoreArtifactValidator,
     CoreGeneratorDefinition,
     CoreGeneratorValidator,
@@ -44,7 +45,7 @@ from infrahub.core.diff.model.diff import DiffElementType, SchemaConflict
 from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
 from infrahub.core.manager import NodeManager
-from infrahub.core.protocols import CoreArtifactDefinition, CoreDataCheck, CoreValidator
+from infrahub.core.protocols import CoreDataCheck, CoreValidator
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.validators.checks_runner import run_checks_and_update_validator
@@ -59,6 +60,8 @@ from infrahub.git.base import extract_repo_file_information
 from infrahub.git.models import TriggerRepositoryInternalChecks, TriggerRepositoryUserChecks
 from infrahub.git.repository import InfrahubRepository, get_initialized_repo
 from infrahub.git.utils import fetch_artifact_definition_targets, fetch_proposed_change_generator_definition_targets
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.log import get_logger
 from infrahub.message_bus.types import (
     ProposedChangeArtifactDefinition,
@@ -664,6 +667,27 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
     impacted_artifacts = model.branch_diff.get_subscribers_ids(kind=InfrahubKind.ARTIFACT)
 
+    source_schema_branch = registry.schema.get_schema_branch(name=model.source_branch)
+    source_branch = registry.get_branch_from_registry(branch=model.source_branch)
+
+    graphql_params = await prepare_graphql_params(db=await get_database(), branch=model.source_branch)
+    query_analyzer = InfrahubGraphQLQueryAnalyzer(
+        query=model.artifact_definition.query_payload,
+        branch=source_branch,
+        schema_branch=source_schema_branch,
+        schema=graphql_params.schema,
+    )
+
+    only_has_unique_targets = query_analyzer.query_report.only_has_unique_targets
+    if not only_has_unique_targets:
+        log.warning(
+            f"Artifact definition {artifact_definition.name.value} query does not guarantee unique targets. All targets will be processed."
+        )
+
+    managed_branch = model.source_branch_sync_with_git and model.branch_diff.has_file_modifications
+    if managed_branch:
+        log.info("Source branch is synced with Git repositories with updates, all artifacts will be processed")
+
     checks = []
 
     for relationship in group.members.peers:
@@ -671,8 +695,9 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         artifact_id = artifacts_by_member.get(member.id)
         if _should_render_artifact(
             artifact_id=artifact_id,
-            managed_branch=model.source_branch_sync_with_git,
+            managed_branch=managed_branch,
             impacted_artifacts=impacted_artifacts,
+            only_has_unique_targets=only_has_unique_targets,
         ):
             log.info(f"Trigger Artifact processing for {member.display_label}")
 
@@ -718,21 +743,26 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     )
 
 
-def _should_render_artifact(artifact_id: str | None, managed_branch: bool, impacted_artifacts: list[str]) -> bool:  # noqa: ARG001
+def _should_render_artifact(
+    artifact_id: str | None,
+    managed_branch: bool,
+    impacted_artifacts: list[str],
+    only_has_unique_targets: bool,
+) -> bool:
     """Returns a boolean to indicate if an artifact should be generated or not.
     Will return true if:
         * The artifact_id wasn't set which could be that it's a new object that doesn't have a previous artifact
-        * The source brance is not data only which would indicate that it could contain updates in git to the transform
+        * The source branch is not data only which would indicate that it could contain updates in git to the transform
         * The artifact_id exists in the impacted_artifacts list
+        * The query failes the only_has_unique_targets check
     Will return false if:
         * The source branch is a data only branch and the artifact_id exists and is not in the impacted list
     """
 
-    # if not artifact_id or managed_branch:
-    #    return True
-    # return artifact_id in impacted_artifacts
-    # Temporary workaround tracked in https://github.com/opsmill/infrahub/issues/4991
-    return True
+    if not only_has_unique_targets or not artifact_id or managed_branch:
+        return True
+
+    return artifact_id in impacted_artifacts
 
 
 @flow(
@@ -1249,6 +1279,9 @@ query GatherArtifactDefinitions {
                 name {
                   value
                 }
+                query {
+                  value
+                }
               }
             }
             ... on CoreTransformJinja2 {
@@ -1466,6 +1499,7 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
             query_name=definition["node"]["transformation"]["node"]["query"]["node"]["name"]["value"],
             query_id=definition["node"]["transformation"]["node"]["query"]["node"]["id"],
             query_models=definition["node"]["transformation"]["node"]["query"]["node"]["models"]["value"] or [],
+            query_payload=definition["node"]["transformation"]["node"]["query"]["node"]["query"]["value"],
             repository_id=definition["node"]["transformation"]["node"]["repository"]["node"]["id"],
             transform_kind=definition["node"]["transformation"]["node"]["__typename"],
         )

--- a/changelog/4991.changed.md
+++ b/changelog/4991.changed.md
@@ -1,0 +1,1 @@
+Changed behaviour for when artifacts are regenerated during a proposed change. Infrahub now runs the query through the GraphQL query analyzer to check if it's feasible to use the GraphQLQueryGroup to track all of the members, if this is the case Infrahub can selectively regenerate artifacts on non git integrated branches to avoid regenerating all artifacts.


### PR DESCRIPTION
This PR reverts the workaround applied in #4992 so that it's possible to only selectively regenerate artifacts tied to an artifact definition within a proposed change.

This is done by analyzing the GraphQL query using the query_report within InfrahubGraphQLQueryAnalyzer. For this approach to work the query must be written in a way that would help Infrahub determine that we could catch any updated nodes based on previous membership within a GraphQLQueryGroup. If the query used within an artifact definition doesn't live up to this criteria a warning will be logged in the pipeline task.

The change does not address the fact that a branch with the "sync-with-git" property set to true would still regenerate all artifacts for that branch (before we can solve this we need to track changes for the artifact definitions themselves within the git repositories.

Fixes #4991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Proposed change artifact regeneration is now more selective and efficient using GraphQL query analysis to determine when regeneration is necessary
  * Reduces unnecessary regeneration cycles, particularly on non-git integrated branches, improving proposed change processing performance
  * Enhanced targeting logic to regenerate only affected artifacts based on query analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->