### PR TITLE
test and fixes for diff query in parallel mode

### DIFF
--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -141,8 +141,8 @@ class DiffCalculator:
             to_time=to_time,
             previous_node_field_specifiers=previous_node_specifiers,
         )
-        node_limit = int(config.SETTINGS.database.query_size_limit / 10)
-        fields_limit = int(config.SETTINGS.database.query_size_limit / 3)
+        node_limit = max(int(config.SETTINGS.database.query_size_limit / 10), 1)
+        fields_limit = max(int(config.SETTINGS.database.query_size_limit / 3), 1)
         properties_limit = config.SETTINGS.database.query_size_limit
 
         calculation_request = DiffCalculationRequest(

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -301,13 +301,14 @@ WITH p, q, diff_rel, CASE
     ELSE $from_time
 END AS row_from_time
 ORDER BY %(id_func)s(p) DESC
-SKIP $offset
-LIMIT $limit
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
 // -------------------------------------
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([p, q, diff_rel, row_from_time]) AS limited_results
-WITH limited_results, size(limited_results) = $limit AS has_more_data
+WITH limited_results + [[NULL, NULL, NULL, NULL]] AS limited_results
+WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result
 WITH one_result[0] AS p, one_result[1] AS q, one_result[2] AS diff_rel, one_result[3] AS row_from_time, has_more_data
 // -------------------------------------
@@ -470,14 +471,15 @@ AND (
 // Limit the number of paths
 // -------------------------------------
 WITH root, r_root, p, diff_rel, q
-ORDER BY r_root.from, p.uuid, q.uuid, diff_rel.branch, diff_rel.from
-SKIP $offset
-LIMIT $limit
+ORDER BY r_root.from, p.uuid, q.uuid, q.name, diff_rel.branch, diff_rel.from
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
 // -------------------------------------
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([root, r_root, p, diff_rel, q]) AS limited_results
-WITH limited_results, size(limited_results) = $limit AS has_more_data
+WITH limited_results + [[NULL, NULL, NULL, NULL, NULL]] AS limited_results
+WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result
 WITH one_result[0] AS root, one_result[1] AS r_root, one_result[2] AS p, one_result[3] AS diff_rel, one_result[4] AS q, has_more_data
 // -------------------------------------
@@ -740,13 +742,14 @@ AND [%(id_func)s(n), type(r_node)] <> [%(id_func)s(q), type(diff_rel)]
 // -------------------------------------
 WITH diff_rel_path, r_root, n, r_node, p, diff_rel
 ORDER BY r_root.from, n.uuid, p.uuid, type(diff_rel), diff_rel.branch, diff_rel.from
-SKIP $offset
-LIMIT $limit
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
 // -------------------------------------
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([diff_rel_path, r_root, n, r_node, p, diff_rel]) AS limited_results
-WITH limited_results, size(limited_results) = $limit AS has_more_data
+WITH limited_results + [[NULL, NULL, NULL, NULL, NULL, NULL]] AS limited_results
+WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result
 WITH one_result[0] AS diff_rel_path, one_result[1] AS r_root, one_result[2] AS n,
     one_result[3] AS r_node, one_result[4] AS p, one_result[5] AS diff_rel, has_more_data
@@ -842,8 +845,8 @@ WHERE num_nodes_with_uuid > 1
 // -------------------------------------
 WITH node_uuid
 ORDER BY node_uuid
-SKIP $offset
-LIMIT $limit
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
 WITH collect(node_uuid) AS node_uuids
 WITH node_uuids, size(node_uuids) = $limit AS has_more_data
 MATCH (:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(n:Node)

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -307,6 +307,7 @@ LIMIT toInteger($limit)
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([p, q, diff_rel, row_from_time]) AS limited_results
+// extra NULL row ensures that has_more_data is always returned, even if all results are filtered out below
 WITH limited_results + [[NULL, NULL, NULL, NULL]] AS limited_results
 WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result
@@ -478,6 +479,7 @@ LIMIT toInteger($limit)
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([root, r_root, p, diff_rel, q]) AS limited_results
+// extra NULL row ensures that has_more_data is always returned, even if all results are filtered out below
 WITH limited_results + [[NULL, NULL, NULL, NULL, NULL]] AS limited_results
 WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result
@@ -748,6 +750,7 @@ LIMIT toInteger($limit)
 // Add flag to indicate if there is more data after this
 // -------------------------------------
 WITH collect([diff_rel_path, r_root, n, r_node, p, diff_rel]) AS limited_results
+// extra NULL row ensures that has_more_data is always returned, even if all results are filtered out below
 WITH limited_results + [[NULL, NULL, NULL, NULL, NULL, NULL]] AS limited_results
 WITH limited_results, size(limited_results) = ($limit + 1) AS has_more_data
 UNWIND limited_results AS one_result

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -627,24 +627,24 @@ class NodeListGetAttributeQuery(Query):
         self.add_to_query(query)
 
         query = """
-        CALL (n, a) {
-            MATCH (n)-[r:HAS_ATTRIBUTE]->(a:Attribute)
-            WHERE %(branch_filter)s
-            RETURN r.status = "active" AS is_active
-            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
-            LIMIT 1
-        }
-        WITH n, a
-        WHERE is_active = TRUE
-        CALL (a) {
-            MATCH (a)-[r:HAS_VALUE]->(av:AttributeValue)
-            WHERE %(branch_filter)s
-            RETURN av, r AS r2
-            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
-            LIMIT 1
-        }
-        WITH n, a, av, r2
-        WHERE r2.status = "active"
+CALL (n, a) {
+    MATCH (n)-[r:HAS_ATTRIBUTE]->(a:Attribute)
+    WHERE %(branch_filter)s
+    RETURN r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+WITH n, a
+WHERE is_active = TRUE
+CALL (a) {
+    MATCH (a)-[r:HAS_VALUE]->(av:AttributeValue)
+    WHERE %(branch_filter)s
+    RETURN av, r AS r2
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+WITH n, a, av, r2
+WHERE r2.status = "active"
         """ % {"branch_filter": branch_filter}
         self.add_to_query(query)
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -628,31 +628,27 @@ class NodeListGetAttributeQuery(Query):
 
         query = """
         CALL (n, a) {
-            MATCH (n)-[r:HAS_ATTRIBUTE]-(a:Attribute)
+            MATCH (n)-[r:HAS_ATTRIBUTE]->(a:Attribute)
             WHERE %(branch_filter)s
-            RETURN n as n1, r as r1, a as a1
-            ORDER BY r.branch_level DESC, r.from DESC
+            RETURN r.status = "active" AS is_active
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
             LIMIT 1
         }
-        WITH n1 as n, r1, a1 as a
-        WHERE r1.status = "active"
-        WITH n, r1, a
-        MATCH (a)-[r:HAS_VALUE]-(av:AttributeValue)
-        WHERE %(branch_filter)s
-        CALL (a, av) {
-            MATCH (a)-[r:HAS_VALUE]-(av:AttributeValue)
+        WITH n, a
+        WHERE is_active = TRUE
+        CALL (a) {
+            MATCH (a)-[r:HAS_VALUE]->(av:AttributeValue)
             WHERE %(branch_filter)s
-            RETURN a as a1, r as r2, av as av1
-            ORDER BY r.branch_level DESC, r.from DESC
+            RETURN av, r AS r2
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
             LIMIT 1
         }
-        WITH n, r1, a1 as a, r2, av1 as av
+        WITH n, a, av, r2
         WHERE r2.status = "active"
-        WITH n, a, av, r1, r2
         """ % {"branch_filter": branch_filter}
         self.add_to_query(query)
 
-        self.return_labels = ["n", "a", "av", "r1", "r2"]
+        self.return_labels = ["n", "a", "av", "r2"]
 
         # Add Is_Protected and Is_visible
         rel_isv_branch_filter, _ = self.branch.get_query_filter_path(

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -651,17 +651,22 @@ class NodeListGetAttributeQuery(Query):
         self.return_labels = ["n", "a", "av", "r2"]
 
         # Add Is_Protected and Is_visible
-        rel_isv_branch_filter, _ = self.branch.get_query_filter_path(
-            at=self.at, branch_agnostic=self.branch_agnostic, variable_name="rel_isv"
-        )
-        rel_isp_branch_filter, _ = self.branch.get_query_filter_path(
-            at=self.at, branch_agnostic=self.branch_agnostic, variable_name="rel_isp"
-        )
         query = """
-        MATCH (a)-[rel_isv:IS_VISIBLE]-(isv:Boolean)
-        MATCH (a)-[rel_isp:IS_PROTECTED]-(isp:Boolean)
-        WHERE (%(rel_isv_branch_filter)s) AND (%(rel_isp_branch_filter)s)
-        """ % {"rel_isv_branch_filter": rel_isv_branch_filter, "rel_isp_branch_filter": rel_isp_branch_filter}
+CALL (a) {
+    MATCH (a)-[r:IS_VISIBLE]-(isv:Boolean)
+    WHERE (%(branch_filter)s)
+    RETURN r AS rel_isv, isv
+    ORDER BY rel_isv.branch_level DESC, rel_isv.from DESC, rel_isv.status ASC
+    LIMIT 1
+}
+CALL (a) {
+    MATCH (a)-[r:IS_PROTECTED]-(isp:Boolean)
+    WHERE (%(branch_filter)s)
+    RETURN r AS rel_isp, isp
+    ORDER BY rel_isp.branch_level DESC, rel_isp.from DESC, rel_isp.status ASC
+    LIMIT 1
+}
+        """ % {"branch_filter": branch_filter}
         self.add_to_query(query)
 
         self.return_labels.extend(["isv", "isp", "rel_isv", "rel_isp"])

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from infrahub import config
+from infrahub.constants.database import Neo4jRuntime
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, DiffAction, InfrahubKind, RelationshipCardinality, SchemaPathType
@@ -26,10 +27,20 @@ if TYPE_CHECKING:
     from infrahub.core.diff.model.path import DiffNode
 
 
+@pytest.fixture(autouse=True)
+def parallel_runtime(db: InfrahubDatabase):
+    original = db.default_neo4j_runtime
+    db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
+
+    yield
+
+    db.default_neo4j_runtime = original
+
+
 @pytest.fixture(autouse=True, scope="module")
 def low_query_size_limit():
     original = config.SETTINGS.database.query_size_limit
-    config.SETTINGS.database.query_size_limit = 30
+    config.SETTINGS.database.query_size_limit = 5
 
     yield
 

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -208,11 +208,10 @@ async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, 
     assert len(query.get_attributes_group_by_node()["c2"].attrs) == 4
 
     # Query all the nodes in branch1, only c1 and c3 present
-    # Expect 9 attributes because each node has 4 but c1at2 has a value both in Main and Branch1
     query = await NodeListGetAttributeQuery.init(db=db, ids=["c1", "c2", "c3"], branch=branch1)
     await query.execute(db=db)
     assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
-    assert len(list(query.get_results())) == 11
+    assert len(list(query.get_results())) == 8
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 4
     assert len(query.get_attributes_group_by_node()["c3"].attrs) == 4
 
@@ -269,7 +268,6 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
     assert len(list(query.get_results())) == 4
 
     # Query all the nodes in branch1: c1 and c3 present
-    # Expect 5 attributes because each node has 1 but c1at2 has its value and its protected flag defined both in Main and Branch1
     query = await NodeListGetAttributeQuery.init(
         db=db, ids=["c1", "c2", "c3"], branch=branch1, fields={"nbr_seats": True}
     )
@@ -277,23 +275,21 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
     assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 1
     assert len(query.get_attributes_group_by_node()["c3"].attrs) == 1
-    assert len(list(query.get_results())) == 5
+    assert len(list(query.get_results())) == 2
 
     # Query c1 in branch1
-    # Expect 4 attributes because c1at2 has its value and its protected flag defined both in Main and Branch1
     query = await NodeListGetAttributeQuery.init(db=db, ids=["c1"], branch=branch1, fields={"nbr_seats": True})
     await query.execute(db=db)
     assert sorted(query.get_attributes_group_by_node().keys()) == ["c1"]
-    assert len(list(query.get_results())) == 4
-    assert query.results[0].branch_score != query.results[1].branch_score
+    assert len(list(query.get_results())) == 1
 
     # Query all the nodes in branch1, only c1 and c3 present
-    # Expect 4 attributes because c1at2 has its value and its protected flag defined both in Main and Branch1
-    query = await NodeListGetAttributeQuery.init(db=db, ids=["c1"], branch=branch1, fields={"nbr_seats": True})
+    query = await NodeListGetAttributeQuery.init(
+        db=db, ids=["c1", "c2", "c3"], branch=branch1, fields={"nbr_seats": True}
+    )
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1"]
-    assert len(list(query.get_results())) == 4
-    assert query.results[0].branch_score != query.results[1].branch_score
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
+    assert len(list(query.get_results())) == 2
 
 
 async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, base_dataset_02):


### PR DESCRIPTION
IFC-2017

add tests and fix for diff calculation queries using parallel runtime
- needed to add a NULL row to the query before sorting and filtering for pagination, b/c if all results were filtered out after pagination, then nothing would be returned and the `DiffCalculator` would consider the query complete. but there could actually be more rows to read on later pages

also found an issue in the `NodeListGetAttributeQuery` that affected nodes that had their kind/inheritance migrated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pagination limits to ensure consistent minimum thresholds, preventing edge cases with small result sets.

* **Performance**
  * Optimized database query patterns for more efficient data retrieval and pagination.
  * Enhanced data consistency calculations to ensure accurate result availability indicators across filtered datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->