### PR TITLE
Update GraphQL query analyzer with regards to queries with a required ID

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -312,6 +312,13 @@ class GraphQLQueryReport:
         return []
 
     def required_argument(self, argument: GraphQLArgument) -> bool:
+        if argument.name == "ids" and argument.kind == "list_value":
+            for variable in self.variables:
+                if f"['${variable.name}']" == argument.as_variable_name and variable.required:
+                    return True
+
+            return False
+
         if not argument.is_variable:
             # If the argument isn't a variable it would have been
             # statically defined in the input and as such required
@@ -364,6 +371,8 @@ class GraphQLQueryReport:
                     if [[argument.name]] == query.infrahub_model.uniqueness_constraints:
                         if self.required_argument(argument=argument):
                             targets_single_query = True
+                    elif argument.name == "ids" and self.required_argument(argument=argument):
+                        targets_single_query = True
 
             if not targets_single_query:
                 return False

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -551,6 +551,90 @@ async def test_query_report_single_target(
     }
     """
 
+    query_required_id = """
+    query TshirtQuery($id: ID!) {
+        TestingTShirt(ids: [$id]) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_required_ids = """
+    query TshirtQuery($ids: [ID!]) {
+        TestingTShirt(ids: $ids) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_optional_id = """
+    query TshirtQuery($id: ID) {
+        TestingTShirt(ids: [$id]) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_optional_ids = """
+    query TshirtQuery($ids: [ID!]) {
+        TestingTShirt(ids: $ids) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
     gqa_required_name_variable = InfrahubGraphQLQueryAnalyzer(
         query=query_name_variable_required,
         schema=gql_params.schema,
@@ -591,6 +675,34 @@ async def test_query_report_single_target(
         schema_branch=schema_branch,
     )
 
+    gqa_required_id = InfrahubGraphQLQueryAnalyzer(
+        query=query_required_id,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_required_ids = InfrahubGraphQLQueryAnalyzer(
+        query=query_required_ids,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_optional_id = InfrahubGraphQLQueryAnalyzer(
+        query=query_optional_id,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_optional_ids = InfrahubGraphQLQueryAnalyzer(
+        query=query_optional_ids,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
     # A required variable matching a uniqueness constraint should indicate a single result query
     assert gqa_required_name_variable.query_report.only_has_unique_targets is True
     # If the variable is optional it's not a single result query
@@ -603,3 +715,11 @@ async def test_query_report_single_target(
     assert gqa_required_name_variable_extra_query.query_report.only_has_unique_targets is False
     # Adding a uniqueness constraint to the second query let's us use it as a single result query again
     assert gqa_required_name_variable_extra_query_required.query_report.only_has_unique_targets is True
+    # Querying by ID is always a single result query if the ID is required
+    assert gqa_required_id.query_report.only_has_unique_targets is True
+    # Querying by ID is not a single result query if the ID is required but defined as an array
+    assert gqa_required_ids.query_report.only_has_unique_targets is False
+    # Querying by ID is not always a single result query if the ID is optional
+    assert gqa_optional_id.query_report.only_has_unique_targets is False
+    # Querying by ID is not always a single result query if the ID is an optional array
+    assert gqa_optional_ids.query_report.only_has_unique_targets is False

--- a/changelog/+298e7542.changed.md
+++ b/changelog/+298e7542.changed.md
@@ -1,0 +1,1 @@
+Updated the internal GraphQLQueryAnalyzer to correctly report that queries that require a single unique ID should be reported as having a single response where any future updates would have been captured within a GraphQL query group.


### PR DESCRIPTION
Small update to the GraphQL query analyzer so that a query that targets a single ID, i.e something like this:

```graphql
    query TshirtQuery($id: ID!) {
        TestingTShirt(ids: [$id]) {
            edges {
                node {
                    name {
                        value
                    }
                    color {
                        node {
                            name {
                                value
                            }
                        }
                    }
                }
            }
        }
    }
```

Would indicate that the query report has a positive `only_has_unique_targets` value so that the query can be trusted to correctly update a GraphQL query group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL query analyzer now correctly identifies queries with required ID parameters as single-result queries, improving query grouping and data consistency reporting.

* **Tests**
  * Added test coverage for ID parameter handling in query analysis across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->