### PR TITLE
IFC-1480: Validate optional and unique attribute parameters

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1163,7 +1163,7 @@ class SchemaBranch:
     @staticmethod
     def _validate_attribute_parameter_combinations(attribute: AttributeSchema) -> None:
         if attribute.optional and attribute.unique:
-            raise ValidationError("You cannot load a schema that has an optional and unique attribute")
+            raise ValidationError(f"Attribute '{attribute.name}' cannot be both optional and unique")
 
     def _validate_number_pool_parameters(
         self, node_schema: NodeSchema, attribute: AttributeSchema, number_pool_parameters: NumberPoolParameters

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1134,6 +1134,8 @@ class SchemaBranch:
                             ) from None
 
     def validate_attribute_parameters(self) -> None:
+        schema_strict_mode = config.SETTINGS.main.schema_strict_mode
+
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)
             for attribute in generic_schema.attributes:
@@ -1144,6 +1146,9 @@ class SchemaBranch:
                 ):
                     attribute.parameters.number_pool_id = str(uuid4())
 
+                if schema_strict_mode:
+                    self._validate_attribute_parameter_combinations(attribute=attribute)
+
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
@@ -1151,6 +1156,14 @@ class SchemaBranch:
                     self._validate_number_pool_parameters(
                         node_schema=node_schema, attribute=attribute, number_pool_parameters=attribute.parameters
                     )
+
+                if schema_strict_mode:
+                    self._validate_attribute_parameter_combinations(attribute=attribute)
+
+    @staticmethod
+    def _validate_attribute_parameter_combinations(attribute: AttributeSchema) -> None:
+        if attribute.optional and attribute.unique:
+            raise ValidationError("You cannot load a schema that has an optional and unique attribute")
 
     def _validate_number_pool_parameters(
         self, node_schema: NodeSchema, attribute: AttributeSchema, number_pool_parameters: NumberPoolParameters

--- a/backend/tests/unit/core/schema_manager/conftest.py
+++ b/backend/tests/unit/core/schema_manager/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Generator
 
 import pytest
 
@@ -392,7 +392,7 @@ def schema_diff_attr_inheritance_types():
 
 
 @pytest.fixture
-def not_schema_strict_mode() -> None:
+def not_schema_strict_mode() -> Generator[None, None, None]:
     initial_schema_strict_mode = config.SETTINGS.main.schema_strict_mode
     config.SETTINGS.main.schema_strict_mode = False
     yield

--- a/backend/tests/unit/core/schema_manager/conftest.py
+++ b/backend/tests/unit/core/schema_manager/conftest.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from infrahub import config
 from infrahub.core.constants import BranchSupportType, InfrahubKind
 
 
@@ -388,3 +389,11 @@ def schema_diff_attr_inheritance_types():
         ],
     }
     return FULL_SCHEMA
+
+
+@pytest.fixture
+def not_schema_strict_mode() -> None:
+    initial_schema_strict_mode = config.SETTINGS.main.schema_strict_mode
+    config.SETTINGS.main.schema_strict_mode = False
+    yield
+    config.SETTINGS.main.schema_strict_mode = initial_schema_strict_mode

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3959,7 +3959,7 @@ async def test_validate_attribute_parameter_combinations() -> None:
                 "name": "Object",
                 "namespace": "Testing",
                 "attributes": [
-                    {"name": "name", "kind": "Text", "optional": True, "unique": True},
+                    {"name": "sample_name", "kind": "Text", "optional": True, "unique": True},
                     {"name": "other", "kind": "Text", "optional": True},
                 ],
             }
@@ -3967,7 +3967,7 @@ async def test_validate_attribute_parameter_combinations() -> None:
     }
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=SchemaRoot(**schema))
-    with pytest.raises(ValidationError, match="You cannot load a schema that has an optional and unique attribute"):
+    with pytest.raises(ValidationError, match="Attribute 'sample_name' cannot be both optional and unique"):
         schema_branch.process()
 
     schema2 = {
@@ -3984,7 +3984,7 @@ async def test_validate_attribute_parameter_combinations() -> None:
     }
     schema_branch = SchemaBranch(cache={}, name="test2")
     schema_branch.load_schema(schema=SchemaRoot(**schema2))
-    with pytest.raises(ValidationError, match="You cannot load a schema that has an optional and unique attribute"):
+    with pytest.raises(ValidationError, match="Attribute 'my_generic_name' cannot be both optional and unique"):
         schema_branch.process()
 
 

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3950,3 +3950,75 @@ async def test_identify_object_templates_with_generics() -> None:
         TestKind.SFP,
         TestKind.VIRTUAL_INTERFACE,
     }
+
+
+async def test_validate_attribute_parameter_combinations() -> None:
+    schema = {
+        "nodes": [
+            {
+                "name": "Object",
+                "namespace": "Testing",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "optional": True, "unique": True},
+                    {"name": "other", "kind": "Text", "optional": True},
+                ],
+            }
+        ],
+    }
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(**schema))
+    with pytest.raises(ValidationError, match="You cannot load a schema that has an optional and unique attribute"):
+        schema_branch.process()
+
+    schema2 = {
+        "generics": [
+            {
+                "namespace": "Test",
+                "name": "GenericInterface",
+                "label": "Generic Interface",
+                "attributes": [
+                    {"name": "my_generic_name", "kind": "Text", "optional": True, "unique": True},
+                ],
+            },
+        ],
+    }
+    schema_branch = SchemaBranch(cache={}, name="test2")
+    schema_branch.load_schema(schema=SchemaRoot(**schema2))
+    with pytest.raises(ValidationError, match="You cannot load a schema that has an optional and unique attribute"):
+        schema_branch.process()
+
+
+async def test_validate_attribute_parameter_combinations__does_not_raise_if_not_schema_strict_mode(
+    not_schema_strict_mode,
+) -> None:
+    schema = {
+        "nodes": [
+            {
+                "name": "Object",
+                "namespace": "Testing",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "optional": True, "unique": True},
+                    {"name": "other", "kind": "Text", "optional": True},
+                ],
+            }
+        ],
+    }
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(**schema))
+    schema_branch.process()
+
+    schema2 = {
+        "generics": [
+            {
+                "namespace": "Test",
+                "name": "GenericInterface",
+                "label": "Generic Interface",
+                "attributes": [
+                    {"name": "my_generic_name", "kind": "Text", "optional": True, "unique": True},
+                ],
+            },
+        ],
+    }
+    schema_branch = SchemaBranch(cache={}, name="test2")
+    schema_branch.load_schema(schema=SchemaRoot(**schema2))
+    schema_branch.process()

--- a/changelog/6364.added.md
+++ b/changelog/6364.added.md
@@ -1,0 +1,1 @@
+Validation of unique and optional attributes parameters of nodes and generics


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/6364

Validation to check the `optional` and `unique` attribute parameters that they are not both `True` for generics and nodes attributes
This check only occurs if `schema_strict_mode` configuration setting is `True`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent an attribute being configured as both optional and unique; enforcement respects the system's strict-schema validation setting.
* **Tests**
  * Added unit tests covering the new validation and behavior when strict-schema validation is disabled.
* **Documentation**
  * Changelog entry documenting the new attribute-parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->