### PR TITLE
Fix overloads for NodeManager.get_one()

### DIFF
--- a/backend/infrahub/api/artifact.py
+++ b/backend/infrahub/api/artifact.py
@@ -17,7 +17,7 @@ from infrahub.core import registry
 from infrahub.core.account import ObjectPermission
 from infrahub.core.branch.needs_rebase_status import check_need_rebase_status
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind, PermissionAction
-from infrahub.core.protocols import CoreArtifactDefinition
+from infrahub.core.protocols import CoreArtifact, CoreArtifactDefinition
 from infrahub.database import InfrahubDatabase  # noqa: TC001
 from infrahub.exceptions import NodeNotFoundError
 from infrahub.git.models import RequestArtifactDefinitionGenerate
@@ -50,14 +50,16 @@ async def get_artifact(
     branch_params: BranchParams = Depends(get_branch_params),
     _: AccountSession = Depends(get_current_user),
 ) -> Response:
-    artifact = await registry.manager.get_one(db=db, id=artifact_id, branch=branch_params.branch, at=branch_params.at)
+    artifact = await registry.manager.get_one(
+        db=db, id=artifact_id, branch=branch_params.branch, at=branch_params.at, kind=CoreArtifact
+    )
     if not artifact:
         raise NodeNotFoundError(
             branch_name=branch_params.branch.name, node_type=InfrahubKind.ARTIFACT, identifier=artifact_id
         )
 
     return Response(
-        content=registry.storage.retrieve(identifier=artifact.storage_id.value),
+        content=registry.storage.retrieve(identifier=str(artifact.storage_id.value)),
         headers={"Content-Type": artifact.content_type.value.value},
     )
 

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -20,7 +20,7 @@ from infrahub.core.account import validate_token
 from infrahub.core.constants import AccountStatus, InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.core.protocols import CoreAccount, CoreAccountGroup
+from infrahub.core.protocols import CoreAccount, CoreAccountGroup, CoreGenericAccount
 from infrahub.core.registry import registry
 from infrahub.exceptions import AuthorizationError, GatewayError, NodeNotFoundError
 from infrahub.log import get_logger
@@ -28,7 +28,6 @@ from infrahub.log import get_logger
 if TYPE_CHECKING:
     import httpx
 
-    from infrahub.core.protocols import CoreGenericAccount
     from infrahub.database import InfrahubDatabase
     from infrahub.services import InfrahubServices
 
@@ -53,7 +52,7 @@ class AccountSession(BaseModel):
 
 
 async def validate_active_account(db: InfrahubDatabase, account_id: str) -> None:
-    account: CoreGenericAccount = await NodeManager.get_one(db=db, id=account_id, raise_on_error=True)
+    account = await NodeManager.get_one(db=db, kind=CoreGenericAccount, id=account_id, raise_on_error=True)
     if account.status.value != AccountStatus.ACTIVE.value:
         raise AuthorizationError("This account has been deactivated")
 
@@ -114,7 +113,7 @@ async def create_fresh_access_token(
     if not refresh_token:
         raise AuthorizationError("The provided refresh token has been invalidated in the database")
 
-    account: CoreGenericAccount | None = await NodeManager.get_one(id=refresh_data.account_id, db=db)
+    account = await NodeManager.get_one(id=refresh_data.account_id, kind=CoreGenericAccount, db=db)
     if not account:
         raise NodeNotFoundError(
             branch_name=selected_branch.name,

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -955,6 +955,42 @@ class NodeManager:
         id: str,
         db: InfrahubDatabase,
         kind: str,
+        raise_on_error: Literal[True] = ...,
+        fields: dict | None = ...,
+        at: Timestamp | str | None = ...,
+        branch: Branch | str | None = ...,
+        include_source: bool = ...,
+        include_owner: bool = ...,
+        prefetch_relationships: bool = ...,
+        account=...,
+        branch_agnostic: bool = ...,
+    ) -> Node: ...
+
+    @overload
+    @classmethod
+    async def get_one(
+        cls,
+        id: str,
+        db: InfrahubDatabase,
+        kind: str,
+        raise_on_error: Literal[False] = ...,
+        fields: dict | None = ...,
+        at: Timestamp | str | None = ...,
+        branch: Branch | str | None = ...,
+        include_source: bool = ...,
+        include_owner: bool = ...,
+        prefetch_relationships: bool = ...,
+        account=...,
+        branch_agnostic: bool = ...,
+    ) -> Node | None: ...
+
+    @overload
+    @classmethod
+    async def get_one(
+        cls,
+        id: str,
+        db: InfrahubDatabase,
+        kind: str,
         raise_on_error: bool = ...,
         fields: dict | None = ...,
         at: Timestamp | str | None = ...,
@@ -964,7 +1000,43 @@ class NodeManager:
         prefetch_relationships: bool = ...,
         account=...,
         branch_agnostic: bool = ...,
-    ) -> Any: ...
+    ) -> Node | None: ...
+
+    @overload
+    @classmethod
+    async def get_one(
+        cls,
+        id: str,
+        db: InfrahubDatabase,
+        kind: None = ...,
+        raise_on_error: Literal[True] = ...,
+        fields: dict | None = ...,
+        at: Timestamp | str | None = ...,
+        branch: Branch | str | None = ...,
+        include_source: bool = ...,
+        include_owner: bool = ...,
+        prefetch_relationships: bool = ...,
+        account=...,
+        branch_agnostic: bool = ...,
+    ) -> Node: ...
+
+    @overload
+    @classmethod
+    async def get_one(
+        cls,
+        id: str,
+        db: InfrahubDatabase,
+        kind: None = ...,
+        raise_on_error: Literal[False] = ...,
+        fields: dict | None = ...,
+        at: Timestamp | str | None = ...,
+        branch: Branch | str | None = ...,
+        include_source: bool = ...,
+        include_owner: bool = ...,
+        prefetch_relationships: bool = ...,
+        account=...,
+        branch_agnostic: bool = ...,
+    ) -> Node | None: ...
 
     @overload
     @classmethod
@@ -982,7 +1054,7 @@ class NodeManager:
         prefetch_relationships: bool = ...,
         account=...,
         branch_agnostic: bool = ...,
-    ) -> Any: ...
+    ) -> Node | None: ...
 
     @classmethod
     async def get_one(
@@ -999,7 +1071,7 @@ class NodeManager:
         prefetch_relationships: bool = False,
         account=None,
         branch_agnostic: bool = False,
-    ) -> Any | None:
+    ) -> Node | SchemaProtocol | None:
         """Return one node based on its ID."""
         branch = await registry.get_branch(branch=branch, db=db)
 

--- a/backend/infrahub/core/node/ipam.py
+++ b/backend/infrahub/core/node/ipam.py
@@ -40,8 +40,8 @@ class BuiltinIPPrefix(Node):
                     retrieved = await NodeManager.get_one(
                         db=db, branch=self._branch, id=self.id, fields={"member_type": None, "prefix": None}
                     )
-                    self.member_type = retrieved.member_type  # type: ignore[union-attr]
-                    self.prefix = retrieved.prefix  # type: ignore[union-attr]
+                    self.member_type = retrieved.member_type  # type: ignore[attr-defined,union-attr]
+                    self.prefix = retrieved.prefix  # type: ignore[attr-defined,union-attr]
                 utilization_getter = PrefixUtilizationGetter(db=db, ip_prefixes=[self])
                 utilization = await utilization_getter.get_use_percentage(
                     ip_prefixes=[self], branch_names=[self._branch.name]
@@ -57,6 +57,6 @@ class BuiltinIPPrefix(Node):
             retrieved = await NodeManager.get_one(
                 db=db, branch=self._branch, id=self.id, fields={"member_type": None, "prefix": None}
             )
-            self.member_type = retrieved.member_type  # type: ignore[union-attr]
-            self.prefix = retrieved.prefix  # type: ignore[union-attr]
+            self.member_type = retrieved.member_type  # type: ignore[attr-defined,union-attr]
+            self.prefix = retrieved.prefix  # type: ignore[attr-defined,union-attr]
         return get_prefix_space(self)

--- a/backend/infrahub/core/task/user_task.py
+++ b/backend/infrahub/core/task/user_task.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 
 from infrahub.core import registry
 from infrahub.core.constants import Severity, TaskConclusion
+from infrahub.core.protocols import CoreGenericAccount
 from infrahub.log import get_logger
 
 from .task import Task
@@ -16,7 +17,6 @@ if TYPE_CHECKING:
 
     from structlog.stdlib import BoundLogger
 
-    from infrahub.core.protocols import CoreGenericAccount
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
     from infrahub.services.protocols import InfrahubLogger
@@ -67,7 +67,7 @@ class UserTask:
         if self._account:
             return False
 
-        account: CoreGenericAccount | None = await registry.manager.get_one(id=self.account_id, db=self.db)
+        account = await registry.manager.get_one(id=self.account_id, db=self.db, kind=CoreGenericAccount)
         if not account:
             raise ValueError(f"Unable to find the account associated with {self.account_id}")
         self._account = account

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -110,7 +110,7 @@ class UpdateComputedAttribute(Mutation):
             event = NodeUpdatedEvent(
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
-                changelog=target_node.node_changelog.model_dump(),
+                changelog=target_node.node_changelog,
                 fields=[str(data.attribute)],
                 meta=EventMeta(
                     context=graphql_context.get_context(),

--- a/backend/infrahub/graphql/mutations/convert_object_type.py
+++ b/backend/infrahub/graphql/mutations/convert_object_type.py
@@ -76,7 +76,7 @@ class ConvertObjectType(Mutation):
 
         if target_schema.kind in [REPOSITORY, READONLYREPOSITORY]:
             new_node = await convert_repository_type(
-                repository=node_to_convert,
+                repository=node_to_convert,  # type: ignore[arg-type]
                 target_schema=target_schema,
                 mapping=fields_mapping,
                 branch=graphql_context.branch,

--- a/backend/infrahub/graphql/mutations/display_label.py
+++ b/backend/infrahub/graphql/mutations/display_label.py
@@ -101,7 +101,7 @@ class UpdateDisplayLabel(Mutation):
             event = NodeUpdatedEvent(
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
-                changelog=target_node.node_changelog.model_dump(),
+                changelog=target_node.node_changelog,
                 fields=["display_label"],
                 meta=EventMeta(
                     context=graphql_context.get_context(),

--- a/backend/infrahub/graphql/mutations/hfid.py
+++ b/backend/infrahub/graphql/mutations/hfid.py
@@ -108,7 +108,7 @@ class UpdateHFID(Mutation):
             event = NodeUpdatedEvent(
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
-                changelog=target_node.node_changelog.model_dump(),
+                changelog=target_node.node_changelog,
                 fields=["human_friendly_id"],
                 meta=EventMeta(
                     context=graphql_context.get_context(),

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -186,6 +186,7 @@ class InfrahubProfilesRefresh(Mutation):
             branch=branch,
             id=str(data.id),
             include_source=True,
+            raise_on_error=True,
         )
         node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
         updated_fields = await node_profiles_applier.apply_profiles(node=obj)

--- a/backend/infrahub/graphql/queries/ipam.py
+++ b/backend/infrahub/graphql/queries/ipam.py
@@ -8,6 +8,7 @@ from netaddr import IPSet
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import BuiltinIPPrefix
 from infrahub.core.query.ipam import get_ip_addresses, get_subnets
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.pools.address import get_available
@@ -31,7 +32,9 @@ class IPAddressGetNextAvailable(ObjectType):
     ) -> dict[str, str]:
         graphql_context: GraphqlContext = info.context
 
-        prefix = await NodeManager.get_one(id=prefix_id, db=graphql_context.db, branch=graphql_context.branch)
+        prefix = await NodeManager.get_one(
+            id=prefix_id, kind=BuiltinIPPrefix, db=graphql_context.db, branch=graphql_context.branch
+        )
 
         if not prefix:
             raise NodeNotFoundError(
@@ -78,17 +81,19 @@ class IPPrefixGetNextAvailable(ObjectType):
     ) -> dict[str, str]:
         graphql_context: GraphqlContext = info.context
 
-        prefix = await NodeManager.get_one(id=prefix_id, db=graphql_context.db, branch=graphql_context.branch)
+        prefix = await NodeManager.get_one(
+            id=prefix_id, db=graphql_context.db, branch=graphql_context.branch, kind=BuiltinIPPrefix
+        )
 
         if not prefix:
             raise NodeNotFoundError(
                 branch_name=graphql_context.branch.name, node_type=InfrahubKind.IPPREFIX, identifier=prefix_id
             )
 
-        namespace = await prefix.ip_namespace.get_peer(db=graphql_context.db)  # type: ignore[attr-defined]
+        namespace = await prefix.ip_namespace.get_peer(db=graphql_context.db)
         subnets = await get_subnets(
             db=graphql_context.db,
-            ip_prefix=ipaddress.ip_network(prefix.prefix.value),  # type: ignore[attr-defined]
+            ip_prefix=ipaddress.ip_network(prefix.prefix.value),
             namespace=namespace,
             branch=graphql_context.branch,
         )

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
-    from infrahub.core.protocols import CoreNode
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
@@ -59,7 +58,7 @@ class PoolAllocatedEdge(ObjectType):
     node = Field(PoolAllocatedNode, required=True)
 
 
-def _validate_pool_type(pool_id: str, pool: CoreNode | None = None) -> CoreNode:
+def _validate_pool_type(pool_id: str, pool: Node | None = None) -> Node:
     if not pool or pool.get_kind() not in [
         InfrahubKind.IPADDRESSPOOL,
         InfrahubKind.IPPREFIXPOOL,
@@ -83,9 +82,7 @@ class PoolAllocated(ObjectType):
         limit: int = 10,
     ) -> dict:
         graphql_context: GraphqlContext = info.context
-        pool: CoreNode | None = await NodeManager.get_one(
-            id=pool_id, db=graphql_context.db, branch=graphql_context.branch
-        )
+        pool = await NodeManager.get_one(id=pool_id, db=graphql_context.db, branch=graphql_context.branch)
 
         fields = extract_graphql_fields(info=info)
 
@@ -190,7 +187,7 @@ class PoolUtilization(ObjectType):
     ) -> dict:
         graphql_context: GraphqlContext = info.context
         db: InfrahubDatabase = graphql_context.db
-        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=db, branch=graphql_context.branch)
+        pool = await NodeManager.get_one(id=pool_id, db=db, branch=graphql_context.branch)
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
         if pool.get_kind() == "CoreNumberPool":
             return await resolve_number_pool_utilization(
@@ -275,7 +272,7 @@ class PoolUtilization(ObjectType):
 
 
 async def resolve_number_pool_allocation(
-    db: InfrahubDatabase, graphql_context: GraphqlContext, pool: CoreNode, fields: dict, offset: int, limit: int
+    db: InfrahubDatabase, graphql_context: GraphqlContext, pool: Node, fields: dict, offset: int, limit: int
 ) -> dict:
     response: dict[str, Any] = {}
     query = await NumberPoolGetAllocated.init(
@@ -304,7 +301,7 @@ async def resolve_number_pool_allocation(
 
 
 async def resolve_number_pool_utilization(
-    db: InfrahubDatabase, pool: CoreNode, at: Timestamp | str | None, branch: Branch
+    db: InfrahubDatabase, pool: Node, at: Timestamp | str | None, branch: Branch
 ) -> dict:
     """
     Returns a mapping containg utilization info of a number pool.

--- a/backend/infrahub/graphql/queries/search.py
+++ b/backend/infrahub/graphql/queries/search.py
@@ -13,7 +13,7 @@ from infrahub.graphql.field_extractor import extract_graphql_fields
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
-    from infrahub.core.protocols import CoreNode
+    from infrahub.core.node import Node as InfrahubNode
     from infrahub.graphql.initialization import GraphqlContext
 
 
@@ -106,12 +106,12 @@ async def search_resolver(
 ) -> dict[str, Any]:
     graphql_context: GraphqlContext = info.context
     response: dict[str, Any] = {}
-    results: list[CoreNode] = []
+    results: list[InfrahubNode] = []
 
     fields = extract_graphql_fields(info=info)
 
     if is_valid_uuid(q):
-        matching: CoreNode | None = await NodeManager.get_one(
+        matching = await NodeManager.get_one(
             db=graphql_context.db, branch=graphql_context.branch, at=graphql_context.at, id=q
         )
         if matching:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,18 @@ disallow_untyped_defs = false
 [[tool.mypy.overrides]]
 module = "tests.functional.*"
 disallow_untyped_defs = false
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "attr-defined",
+]
+
+[[tool.mypy.overrides]]
+module = "tests.integration.*"
+disable_error_code = [
+    "assignment",
+    "attr-defined",
+]
 
 [[tool.mypy.overrides]]
 module = "infrahub.core.attribute"


### PR DESCRIPTION
When we introduced the `@overload` decorators within NodeManager we made the error of changing them from returning `Node` or `Node | None` to instead return `Any` provided that we didn't send in a SchemaProtocol. This PR changes this for the `.get_one()` method. This means that provided that we get a value back it will be either a SchemaProtocol or a Node, as a result some of the code requires updates. I've also added some mypy exceptions within the tests instead of fixing the issues that were already faulty but weren't noticed due to the fact that `Any` was returned previously. After this there are some additional methods within the NodeManager that we should update to avoid returning `Any` which can mask various errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved API consistency by standardizing object retrieval with explicit type parameters across the codebase.
  * Enhanced type safety with expanded method signatures and better type annotations.
  * Simplified event payload handling by passing objects directly instead of serialized representations.

* **Tests**
  * Updated type-checking configuration for test modules to improve code quality analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->