### PR TITLE
Fix relationship resolver for default filter

### DIFF
--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -452,8 +452,16 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
             return
 
         if self.peer_id and not is_valid_uuid(self.peer_id):
+            fields = {"display_label": None}
+            peer_schema = db.schema.get(
+                name=self.schema.peer, branch=self.get_branch_based_on_support_type(), duplicate=False
+            )
+            if peer_schema.default_filter:
+                default_filter = peer_schema.default_filter.split("__")[0]
+                fields[default_filter] = None
+
             peer = await registry.manager.get_one_by_default_filter(
-                db=db, id=self.peer_id, branch=self.branch, kind=self.schema.peer, fields={"display_label": None}
+                db=db, id=self.peer_id, branch=self.branch, kind=self.schema.peer, fields=fields
             )
             if peer:
                 self.set_peer(value=peer)


### PR DESCRIPTION
Ensures that the relationship resolver queries for get_one_by_default_filter() actually collects the attribute that's used to define the default filter.

I think some additional thought is required around this and we might need some additional changes but it would be good to merge it as the pipeline is currently failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relationship peer resolution to dynamically construct lookup criteria based on peer schema configuration, enhancing accuracy when resolving relationships using non-UUID identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->