### PR TITLE
Lookup relationship attributes for hfid and display_label

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -752,9 +752,34 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         return self
 
     async def resolve_relationships(self, db: InfrahubDatabase) -> None:
+        extra_filters: dict[str, set[str]] = {}
+
+        if not self._existing:
+            # If we are creating a new node, we need to resolve extra filters from HFID and Display Labels,
+            # if we don't do this the fields might be blank
+            schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)
+            try:
+                hfid_identifier = schema_branch.hfids.get_node_definition(kind=self._schema.kind)
+                for rel_name, attrs in hfid_identifier.relationship_fields.items():
+                    extra_filters.setdefault(rel_name, set()).update(attrs)
+            except KeyError:
+                # No HFID defined for this kind
+                ...
+            try:
+                display_label_identifier = schema_branch.display_labels.get_template_node(kind=self._schema.kind)
+                for rel_name, attrs in display_label_identifier.relationship_fields.items():
+                    extra_filters.setdefault(rel_name, set()).update(attrs)
+            except KeyError:
+                # No Display Label defined for this kind
+                ...
+
         for name in self._relationships:
             relm: RelationshipManager = getattr(self, name)
-            await relm.resolve(db=db)
+            query_filter = []
+            if name in extra_filters:
+                query_filter.extend(list(extra_filters[name]))
+
+            await relm.resolve(db=db, fields=query_filter)
 
     async def load(
         self,

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -445,23 +445,20 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         )
         await delete_query.execute(db=db)
 
-    async def resolve(self, db: InfrahubDatabase, at: Timestamp | None = None) -> None:
+    async def resolve(self, db: InfrahubDatabase, at: Timestamp | None = None, fields: list[str] | None = None) -> None:
         """Resolve the peer of the relationship."""
+
+        fields = fields or []
+        query_fields = dict.fromkeys(fields)
+        if "display_label" not in query_fields:
+            query_fields["display_label"] = None
 
         if self._peer is not None:
             return
 
         if self.peer_id and not is_valid_uuid(self.peer_id):
-            fields = {"display_label": None}
-            peer_schema = db.schema.get(
-                name=self.schema.peer, branch=self.get_branch_based_on_support_type(), duplicate=False
-            )
-            if peer_schema.default_filter:
-                default_filter = peer_schema.default_filter.split("__")[0]
-                fields[default_filter] = None
-
             peer = await registry.manager.get_one_by_default_filter(
-                db=db, id=self.peer_id, branch=self.branch, kind=self.schema.peer, fields=fields
+                db=db, id=self.peer_id, branch=self.branch, kind=self.schema.peer, fields=query_fields
             )
             if peer:
                 self.set_peer(value=peer)
@@ -478,7 +475,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
                 hfid=self.peer_hfid,
                 branch=self.branch,
                 kind=kind,
-                fields={"display_label": None},
+                fields=query_fields,
                 raise_on_error=True,
             )
             self.set_peer(value=peer)
@@ -1150,9 +1147,9 @@ class RelationshipManager:
 
         return True
 
-    async def resolve(self, db: InfrahubDatabase) -> None:
+    async def resolve(self, db: InfrahubDatabase, fields: list[str] | None = None) -> None:
         for rel in self._relationships:
-            await rel.resolve(db=db)
+            await rel.resolve(db=db, fields=fields)
 
     async def remove_locally(
         self,

--- a/backend/infrahub/core/schema/schema_branch_display.py
+++ b/backend/infrahub/core/schema/schema_branch_display.py
@@ -14,6 +14,7 @@ class TemplateLabel:
     template: str
     attributes: set[str] = field(default_factory=set)
     relationships: set[str] = field(default_factory=set)
+    relationship_fields: dict[str, set[str]] = field(default_factory=dict)
     filter_key: str = "ids"
 
     @property
@@ -76,6 +77,17 @@ class DisplayLabels:
             self._template_based_display_labels[kind].attributes.add(schema_path.active_attribute_schema.name)
         elif schema_path.is_type_relationship and schema_path.related_schema:
             self._template_based_display_labels[kind].relationships.add(schema_path.active_relationship_schema.name)
+            if (
+                schema_path.active_relationship_schema.name
+                not in self._template_based_display_labels[kind].relationship_fields
+            ):
+                self._template_based_display_labels[kind].relationship_fields[
+                    schema_path.active_relationship_schema.name
+                ] = set()
+            self._template_based_display_labels[kind].relationship_fields[
+                schema_path.active_relationship_schema.name
+            ].add(schema_path.active_attribute_schema.name)
+
             if schema_path.related_schema.kind not in self._template_relationship_triggers:
                 self._template_relationship_triggers[schema_path.related_schema.kind] = RelationshipTriggers()
             if (

--- a/backend/infrahub/core/schema/schema_branch_hfid.py
+++ b/backend/infrahub/core/schema/schema_branch_hfid.py
@@ -14,6 +14,7 @@ class HFIDDefinition:
     hfid: list[str]
     attributes: set[str] = field(default_factory=set)
     relationships: set[str] = field(default_factory=set)
+    relationship_fields: dict[str, set[str]] = field(default_factory=dict)
     filter_key: str = "ids"
 
     @property
@@ -67,6 +68,11 @@ class HFIDs:
             self._node_level_hfids[kind].attributes.add(schema_path.active_attribute_schema.name)
         elif schema_path.is_type_relationship and schema_path.related_schema:
             self._node_level_hfids[kind].relationships.add(schema_path.active_relationship_schema.name)
+            if schema_path.active_relationship_schema.name not in self._node_level_hfids[kind].relationship_fields:
+                self._node_level_hfids[kind].relationship_fields[schema_path.active_relationship_schema.name] = set()
+            self._node_level_hfids[kind].relationship_fields[schema_path.active_relationship_schema.name].add(
+                schema_path.active_attribute_schema.name
+            )
             if schema_path.related_schema.kind not in self._relationship_triggers:
                 self._relationship_triggers[schema_path.related_schema.kind] = RelationshipTriggers()
             if (

--- a/backend/tests/unit/core/schema/schema_branch/test_schema_convert_display_labels.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_schema_convert_display_labels.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
-from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
@@ -11,9 +12,10 @@ class DisplayLabelTestCase:
     name: str
     schema_root: SchemaRoot
     display_label: str
+    relationship_fields: dict[str, set[str]] = field(default_factory=dict)
 
 
-DISPLAY_LABEL_TEST_CASES: list[DisplayLabelTestCase] = [
+DISPLAY_LABEL_CONVERT_TEST_CASES: list[DisplayLabelTestCase] = [
     DisplayLabelTestCase(
         name="single_attribute_label_no_value",
         schema_root=SchemaRoot(
@@ -90,7 +92,7 @@ DISPLAY_LABEL_TEST_CASES: list[DisplayLabelTestCase] = [
 
 @pytest.mark.parametrize(
     "test_case",
-    [pytest.param(tc, id=tc.name) for tc in DISPLAY_LABEL_TEST_CASES],
+    [pytest.param(tc, id=tc.name) for tc in DISPLAY_LABEL_CONVERT_TEST_CASES],
 )
 async def test_expected_final_display_label(
     test_case: DisplayLabelTestCase,
@@ -101,3 +103,136 @@ async def test_expected_final_display_label(
     schema_branch.process()
     node = schema_branch.get_node(name="TestWidget", duplicate=False)
     assert node.display_label == test_case.display_label
+
+
+DISPLAY_LABEL_RELATIONSHIP_FIELDS_TEST_CASES: list[DisplayLabelTestCase] = [
+    DisplayLabelTestCase(
+        name="no_relationships",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    display_labels=["name__value", "status"],
+                    display_label="{{ name__value|upper }}: {{ status__value|lower }}",
+                ),
+            ]
+        ),
+        display_label="{{ name__value|upper }}: {{ status__value|lower }}",
+    ),
+    DisplayLabelTestCase(
+        name="single_relationship_single_field",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container", peer="TestContainer", cardinality=RelationshipCardinality.ONE
+                        )
+                    ],
+                    display_labels=["name__value", "status"],
+                    display_label="{{ name__value|upper }}: {{ status__value|lower }} - {{ container__storage_name__value }}",
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+            ]
+        ),
+        display_label="{{ name__value|upper }}: {{ status__value|lower }}",
+        relationship_fields={"container": {"storage_name"}},
+    ),
+    DisplayLabelTestCase(
+        name="single_relationship_dual_fields",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container", peer="TestContainer", cardinality=RelationshipCardinality.ONE
+                        )
+                    ],
+                    display_labels=["name__value", "status"],
+                    display_label="{{ name__value }}: {{ status__value }} - {{ container__storage_name__value }}. {{ container__status__value }}",
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+            ]
+        ),
+        display_label="{{ name__value }}: {{ status__value }} - {{ container__storage_name__value }}. {{ container__status__value }}",
+        relationship_fields={"container": {"storage_name", "status"}},
+    ),
+    DisplayLabelTestCase(
+        name="dual_relationship_dual_fields",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container", peer="TestContainer", cardinality=RelationshipCardinality.ONE
+                        ),
+                        RelationshipSchema(name="owner", peer="TestOwner", cardinality=RelationshipCardinality.ONE),
+                    ],
+                    display_label="{{ owner__family_name__value }}'s {{ name__value }}: - {{ container__storage_name__value }}. {{ container__status__value }}",  # noqa: E501
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+                NodeSchema(
+                    name="Owner",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="family_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="description", kind="Text", optional=True),
+                    ],
+                    display_label="family_name__value",
+                ),
+            ]
+        ),
+        display_label="{{ owner__family_name__value }}'s {{ name__value }}: - {{ container__storage_name__value }}. {{ container__status__value }}",
+        relationship_fields={"container": {"storage_name", "status"}, "owner": {"family_name"}},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in DISPLAY_LABEL_RELATIONSHIP_FIELDS_TEST_CASES],
+)
+async def test_expected_relationship_fields(
+    test_case: DisplayLabelTestCase,
+) -> None:
+    """Test that the registered relationship_fields matches the expected value."""
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=test_case.schema_root)
+    schema_branch.process()
+    node = schema_branch.display_labels.get_template_node(kind="TestWidget")
+    assert node.relationship_fields == test_case.relationship_fields

--- a/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
@@ -1,10 +1,22 @@
+from dataclasses import dataclass, field
+from typing import Any
+
 import pytest
 
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.exceptions import ValidationError
 
-_SCHEMA = {
+
+@dataclass
+class HFIDTestCase:
+    name: str
+    schema_root: SchemaRoot
+    relationship_fields: dict[str, set[str]] = field(default_factory=dict)
+
+
+_SCHEMA: dict[str, Any] = {
     "nodes": [
         {
             "name": "Car",
@@ -102,3 +114,158 @@ async def test_schema_constraints(human_friendly_id, uniqueness_constraints, sho
     else:
         schema_branch.load_schema(schema=schema_root)
         schema_branch.process()
+
+
+HFID_RELATIONSHIP_FIELDS_TEST_CASES: list[HFIDTestCase] = [
+    HFIDTestCase(
+        name="no_relationships",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    display_label="{{ name__value|upper }}: {{ status__value|lower }}",
+                    human_friendly_id=["name__value", "status__value"],
+                ),
+            ]
+        ),
+    ),
+    HFIDTestCase(
+        name="single_relationship_single_field",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container",
+                            peer="TestContainer",
+                            cardinality=RelationshipCardinality.ONE,
+                            optional=False,
+                        )
+                    ],
+                    display_label="{{ name__value|upper }}: {{ status__value|lower }} - {{ container__storage_name__value }}",
+                    human_friendly_id=["name__value", "status__value", "container__storage_name__value"],
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+            ]
+        ),
+        relationship_fields={"container": {"storage_name"}},
+    ),
+    HFIDTestCase(
+        name="single_relationship_dual_fields",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container",
+                            peer="TestContainer",
+                            cardinality=RelationshipCardinality.ONE,
+                            optional=False,
+                        )
+                    ],
+                    display_label="{{ name__value }}: {{ status__value }} - {{ container__storage_name__value }}. {{ container__status__value }}",
+                    human_friendly_id=[
+                        "name__value",
+                        "status__value",
+                        "container__storage_name__value",
+                        "container__status__value",
+                    ],
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+            ]
+        ),
+        relationship_fields={"container": {"storage_name", "status"}},
+    ),
+    HFIDTestCase(
+        name="dual_relationship_dual_fields",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Test",
+                    attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="container",
+                            peer="TestContainer",
+                            cardinality=RelationshipCardinality.ONE,
+                            optional=False,
+                        ),
+                        RelationshipSchema(
+                            name="owner",
+                            peer="TestOwner",
+                            cardinality=RelationshipCardinality.ONE,
+                            optional=False,
+                        ),
+                    ],
+                    display_label="{{ owner__family_name__value }}'s {{ name__value }}",
+                    human_friendly_id=[
+                        "name__value",
+                        "status__value",
+                        "container__storage_name__value",
+                        "container__status__value",
+                        "owner__family_name__value",
+                    ],
+                ),
+                NodeSchema(
+                    name="Container",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="status", kind="Text"),
+                    ],
+                    display_label="storage_name__value",
+                ),
+                NodeSchema(
+                    name="Owner",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="family_name", kind="Text", unique=True, optional=False),
+                        AttributeSchema(name="description", kind="Text", optional=True),
+                    ],
+                    display_label="family_name__value",
+                ),
+            ]
+        ),
+        relationship_fields={"container": {"storage_name", "status"}, "owner": {"family_name"}},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in HFID_RELATIONSHIP_FIELDS_TEST_CASES],
+)
+async def test_expected_relationship_fields(
+    test_case: HFIDTestCase,
+) -> None:
+    """Test that the registered relationship_fields matches the expected value."""
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=test_case.schema_root)
+    schema_branch.process()
+    node = schema_branch.hfids.get_node_definition(kind="TestWidget")
+    assert node.relationship_fields == test_case.relationship_fields

--- a/backend/tests/unit/graphql/mutations/test_display_label.py
+++ b/backend/tests/unit/graphql/mutations/test_display_label.py
@@ -5,10 +5,10 @@ from uuid import uuid4
 
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision, RelationshipCardinality
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
@@ -164,6 +164,100 @@ async def test_update_display_label_update(
     assert after_change.data
     assert after_change.data["TestingTShirt"]["count"] == 1
     assert after_change.data["TestingTShirt"]["edges"][0]["node"]["display_label"] == "very-new-label"
+
+
+async def test_create_nodes_with_display_labels(
+    db: InfrahubDatabase,
+    node_group_schema: None,
+    default_branch: Branch,
+) -> None:
+    """Validate that the correct display label is assigned when creating nodes."""
+    schema_root = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Widget",
+                namespace="Test",
+                attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                relationships=[
+                    RelationshipSchema(name="container", peer="TestContainer", cardinality=RelationshipCardinality.ONE)
+                ],
+                display_labels=["name__value", "status"],
+                display_label="{{ name__value|upper }}: {{ status__value|lower }} - {{ container__storage_name__value }}",
+            ),
+            NodeSchema(
+                name="Container",
+                namespace="Test",
+                attributes=[
+                    AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                    AttributeSchema(name="status", kind="Text"),
+                ],
+                display_label="storage_name__value",
+                default_filter="storage_name__value",
+            ),
+            NodeSchema(
+                name="Owner",
+                namespace="Test",
+                attributes=[
+                    AttributeSchema(name="family_name", kind="Text", unique=True, optional=False),
+                    AttributeSchema(name="description", kind="Text", optional=True),
+                ],
+                display_label="family_name__value",
+            ),
+        ]
+    )
+
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    container1 = await Node.init(db=db, schema="TestContainer")
+    await container1.new(db=db, storage_name="WarehouseA", status="Active")
+    await container1.save(db=db)
+
+    event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=event)
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+
+    create_widget = """
+    mutation TestWidgetCreate($name: String!, $container_id: String, $container_hfid: [String!]) {
+        TestWidgetCreate(data:
+        {
+            name: { value: $name},
+            status: { value: "NEW"},
+            container: {id: $container_id, hfid: $container_hfid}
+        }) {
+            ok
+            object {
+                id
+                display_label
+            }
+        }
+    }
+    """
+
+    widget1_default_filter = await graphql(
+        schema=gql_params.schema,
+        source=create_widget,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "Trinket1", "container_id": "WarehouseA"},
+    )
+    assert widget1_default_filter.errors is None
+    assert widget1_default_filter.data
+    assert widget1_default_filter.data["TestWidgetCreate"]["ok"] is True
+    assert widget1_default_filter.data["TestWidgetCreate"]["object"]["display_label"] == "TRINKET1: new - WarehouseA"
+
+    widget2_hfid = await graphql(
+        schema=gql_params.schema,
+        source=create_widget,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "Trinket2", "container_hfid": ["WarehouseA"]},
+    )
+    assert widget2_hfid.errors is None
+    assert widget2_hfid.data
+    assert widget2_hfid.data["TestWidgetCreate"]["ok"] is True
+    assert widget2_hfid.data["TestWidgetCreate"]["object"]["display_label"] == "TRINKET2: new - WarehouseA"
 
 
 UPDATE_DISPLAY_LABEL = """

--- a/backend/tests/unit/graphql/mutations/test_hfid.py
+++ b/backend/tests/unit/graphql/mutations/test_hfid.py
@@ -5,10 +5,10 @@ from uuid import uuid4
 
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision, RelationshipCardinality
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
@@ -175,3 +175,101 @@ query MyTShirt($id: ID!) {
     }
 }
 """
+
+
+async def test_create_nodes_with_relational_hfids(
+    db: InfrahubDatabase,
+    node_group_schema: None,
+    default_branch: Branch,
+) -> None:
+    """Validate that the correct display label is assigned when creating nodes."""
+    schema_root = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Widget",
+                namespace="Test",
+                attributes=[AttributeSchema(name="name", kind="Text"), AttributeSchema(name="status", kind="Text")],
+                relationships=[
+                    RelationshipSchema(
+                        name="container", peer="TestContainer", cardinality=RelationshipCardinality.ONE, optional=False
+                    )
+                ],
+                display_labels=["name__value", "status"],
+                display_label="{{ name__value|upper }}: {{ status__value|lower }} - {{ container__storage_name__value }}",
+                human_friendly_id=["name__value", "status__value", "container__storage_name__value"],
+            ),
+            NodeSchema(
+                name="Container",
+                namespace="Test",
+                default_filter="storage_name__value",
+                attributes=[
+                    AttributeSchema(name="storage_name", kind="Text", unique=True, optional=False),
+                    AttributeSchema(name="status", kind="Text"),
+                ],
+                display_label="storage_name__value",
+            ),
+            NodeSchema(
+                name="Owner",
+                namespace="Test",
+                attributes=[
+                    AttributeSchema(name="family_name", kind="Text", unique=True, optional=False),
+                    AttributeSchema(name="description", kind="Text", optional=True),
+                ],
+                display_label="family_name__value",
+            ),
+        ]
+    )
+
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    async with db.start_transaction() as dbt:
+        container1 = await Node.init(db=dbt, schema="TestContainer")
+        await container1.new(db=dbt, storage_name="WarehouseA", status="Active")
+        await container1.save(db=dbt)
+
+    event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=event)
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+
+    create_widget = """
+    mutation TestWidgetCreate($name: String!, $container_id: String, $container_hfid: [String!]) {
+        TestWidgetCreate(data:
+        {
+            name: { value: $name},
+            status: { value: "NEW"},
+            container: {id: $container_id, hfid: $container_hfid}
+        }) {
+            ok
+            object {
+                id
+                hfid
+            }
+        }
+    }
+    """
+
+    widget1 = await graphql(
+        schema=gql_params.schema,
+        source=create_widget,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "Trinket1", "container_id": "WarehouseA"},
+    )
+    assert widget1.errors is None
+    assert widget1.data
+    assert widget1.data["TestWidgetCreate"]["ok"] is True
+    assert widget1.data["TestWidgetCreate"]["object"]["hfid"] == ["Trinket1", "NEW", "WarehouseA"]
+
+    widget2 = await graphql(
+        schema=gql_params.schema,
+        source=create_widget,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "Trinket2", "container_hfid": ["WarehouseA"]},
+    )
+    assert widget2.errors is None
+    assert widget2.data
+    assert widget2.data["TestWidgetCreate"]["ok"] is True
+    assert widget2.data["TestWidgetCreate"]["object"]["hfid"] == ["Trinket2", "NEW", "WarehouseA"]


### PR DESCRIPTION
Reverts the naive approch of assuming that the default_filter will be used as a component for HFIDs for related nodes (from #7578). In order to have the display_labels and hfids correctly defined during node creation we have a check that determines what attributes we need to collect for the peers involved with hfid or display labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selective field fetching for relationship resolution, with display labels preserved by default.
  * Schema labels/HFIDs now track per-relationship attribute sets to inform resolution.

* **Tests**
  * Expanded test coverage validating relationship-field extraction, selective resolution, and display-label behavior across schema scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->