### PR TITLE
IFC-1904 Prevent merging branches with status `NEED_UPGRADE_REBASE`

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -9,6 +9,7 @@ from typing_extensions import Self
 from infrahub.branch.merge_mutation_checker import verify_branch_merge_mutation_allowed
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.database import retry_db_transaction
 from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
@@ -289,6 +290,10 @@ class BranchMerge(Mutation):
         await verify_branch_merge_mutation_allowed(
             db=graphql_context.db, account_session=graphql_context.active_account_session
         )
+
+        obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name)
+        if obj.status == BranchStatus.NEED_UPGRADE_REBASE:
+            raise ValidationError(f"Cannot merge branch '{branch_name}' with status '{obj.status.name}'")
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -8,6 +8,7 @@ from graphql import GraphQLResolveInfo
 from infrahub import lock
 from infrahub.core.account import GlobalPermission
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import (
     CheckType,
     GlobalPermissions,
@@ -156,6 +157,11 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         if updated_state == ProposedChangeState.MERGED:
             if will_be_draft:
                 raise ValidationError("A draft proposed change is not allowed to be merged")
+
+            source_branch = await Branch.get_by_name(db=graphql_context.db, name=obj.source_branch.value)
+            if source_branch.status == BranchStatus.NEED_UPGRADE_REBASE:
+                raise ValidationError("The branch must be upgraded and rebased prior to merging the proposed change")
+
             data["state"]["value"] = ProposedChangeState.MERGING.value
 
         proposed_change, result = await super().mutate_update(

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -3,6 +3,7 @@ from infrahub_sdk.client import InfrahubClient
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
@@ -407,6 +408,41 @@ async def test_branch_merge_wrong_branch(
     assert result.errors
     assert len(result.errors) == 1
     assert result.errors[0].message == "Branch: branch99 not found."
+
+
+async def test_branch_merge_need_upgrade_rebase(
+    db: InfrahubDatabase, base_dataset_02, register_core_models_schema, session_admin, local_services: InfrahubServices
+):
+    branch = await create_branch(db=db, branch_name="branch_to_upgrade")
+    branch.status = BranchStatus.NEED_UPGRADE_REBASE
+    await branch.save(db=db)
+
+    query = """
+    mutation {
+        BranchMerge(data: { name: "branch_to_upgrade" }) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=branch, account_session=session_admin, service=local_services
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "Cannot merge branch 'branch_to_upgrade' with status 'NEED_UPGRADE_REBASE'"
 
 
 async def test_branch_merge_with_conflict_fails(

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -428,7 +428,6 @@ async def test_branch_merge_need_upgrade_rebase(
     }
     """
 
-    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, branch=branch, account_session=session_admin, service=local_services
     )

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -7,6 +7,7 @@ from prefect.client.orchestration import get_client
 from infrahub.auth import AccountSession, AuthType
 from infrahub.components import ComponentType
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
@@ -380,6 +381,33 @@ async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_m
 
     assert update_status.errors
     assert "A draft proposed change is not allowed to be merged" in str(update_status.errors[0])
+
+
+async def test_merge_proposed_change_with_branch_upgrade_rebase_status(
+    db: InfrahubDatabase, register_core_models_schema: None
+):
+    branch_name = "upgrade-rebase-status-proposed-change"
+    source_branch = Branch(name=branch_name)
+    source_branch.status = BranchStatus.NEED_UPGRADE_REBASE
+    await source_branch.save(db=db)
+
+    proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    await proposed_change.new(db=db, name="pc-1234", destination_branch="main", source_branch=branch_name, state="open")
+    await proposed_change.save(db=db)
+
+    service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
+
+    update_status = await graphql_mutation(
+        query=UPDATE_PROPOSED_CHANGE,
+        db=db,
+        variables={"proposed_change": proposed_change.id, "state": "merged"},
+        service=service,
+    )
+
+    assert update_status.errors
+    assert "The branch must be upgraded and rebased prior to merging the proposed change" in str(
+        update_status.errors[0]
+    )
 
 
 class TestMergeProposedChangePermissionFailure(TestInfrahubApp):


### PR DESCRIPTION
This change adds the requiring logic to prevent a branch from being merged, either via a branch merge mutation or via a proposed change merge, when the branch has a status set to `NEED_UPGRADE_REBASE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-merge validation that prevents merging when a branch requires an upgrade and rebase, returning a clear error to stop the operation.

* **Tests**
  * Added unit tests covering merge attempts blocked by branches in the upgrade/rebase-required state to ensure the validation and error handling work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->