### PR TITLE
fix ProfileDataQuery to only get 1 value per attribute

### DIFF
--- a/backend/infrahub/profiles/queries/get_profile_data.py
+++ b/backend/infrahub/profiles/queries/get_profile_data.py
@@ -57,18 +57,17 @@ CALL (profile, attr) {
     ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
     RETURN r.status = "active" AS is_active
 }
-WITH profile, attr, is_active
+WITH profile, attr
 WHERE is_active = TRUE
 // --------------
 // get the attribute values
 // --------------
-MATCH (attr)-[:HAS_VALUE]->(av:AttributeValue)
-WITH DISTINCT profile, attr, av
-CALL (attr, av) {
+CALL (attr) {
     MATCH (attr)-[r:HAS_VALUE]->(av)
     WHERE %(branch_filter)s
     ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
-    RETURN r.status = "active" AS is_active
+    RETURN av, r.status = "active" AS is_active
+    LIMIT 1
 }
 WITH profile, attr, av
 WHERE is_active = TRUE


### PR DESCRIPTION
the `GetProfileDataQuery` used in our profiles applying logic had a bug in it that would cause it to return multiple values if it was run on a branch with a profile value update

basically, it would retrieve active values of a given attribute on the default branch and the user's branch and then usually return them in the right order such that that user-branch value would overwrite the default-branch value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the profile data retrieval process to streamline how attribute values are selected and filtered, improving efficiency in profile query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->