### PR TITLE
fix IP address self-parent edge case

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -450,12 +450,23 @@ class IPPrefixReconcileQuery(Query):
         // ------------------
         CALL (ip_node) {
             OPTIONAL MATCH parent_prefix_path = (ip_node)-[r1:IS_RELATED]->(:Relationship {name: "parent__child"})-[r2:IS_RELATED]->(current_parent:%(ip_prefix_kind)s)
-            WHERE all(r IN relationships(parent_prefix_path) WHERE (%(branch_filter)s))
+            WHERE $is_prefix = TRUE
+            AND all(r IN relationships(parent_prefix_path) WHERE (%(branch_filter)s))
             RETURN current_parent, (r1.status = "active" AND r2.status = "active") AS parent_is_active
             ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
             LIMIT 1
         }
-        WITH ip_namespace, ip_node, CASE WHEN parent_is_active THEN current_parent ELSE NULL END as current_parent
+        WITH ip_namespace, ip_node, CASE WHEN parent_is_active THEN current_parent ELSE NULL END as prefix_parent
+        CALL (ip_node) {
+            OPTIONAL MATCH parent_prefix_path = (ip_node)-[r1:IS_RELATED]->(:Relationship {name: "ip_prefix__ip_address"})<-[r2:IS_RELATED]-(current_parent:%(ip_prefix_kind)s)
+            WHERE $is_prefix = FALSE
+            AND all(r IN relationships(parent_prefix_path) WHERE (%(branch_filter)s))
+            RETURN current_parent, (r1.status = "active" AND r2.status = "active") AS parent_is_active
+            ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
+            LIMIT 1
+        }
+        WITH ip_namespace, ip_node, prefix_parent, CASE WHEN parent_is_active THEN current_parent ELSE NULL END as address_parent
+        WITH ip_namespace, ip_node, COALESCE(prefix_parent, address_parent) AS current_parent
         """ % {
             "branch_filter": branch_filter,
             "ip_prefix_kind": InfrahubKind.IPPREFIX,
@@ -467,7 +478,7 @@ class IPPrefixReconcileQuery(Query):
         // Get prefix node's current prefix children, if any exist
         // ------------------
         CALL (ip_node) {
-            OPTIONAL MATCH child_prefix_path = (ip_node)<-[r1:IS_RELATED]-(:Relationship {name: "parent__child"})<-[r2:IS_RELATED]-(current_prefix_child:%(ip_prefix_kind)s)
+            OPTIONAL MATCH child_prefix_path = (ip_node:%(ip_prefix_kind)s)<-[r1:IS_RELATED]-(:Relationship {name: "parent__child"})<-[r2:IS_RELATED]-(current_prefix_child:%(ip_prefix_kind)s)
             WHERE all(r IN relationships(child_prefix_path) WHERE (%(branch_filter)s))
             WITH current_prefix_child, (r1.status = "active" AND r2.status = "active") AS is_active
             ORDER BY current_prefix_child.uuid, r1.branch_level DESC, r1.from DESC, r2.branch_level DESC, r2.from DESC
@@ -479,7 +490,7 @@ class IPPrefixReconcileQuery(Query):
         // Get prefix node's current address children, if any exist
         // ------------------
         CALL (ip_node) {
-            OPTIONAL MATCH child_address_path = (ip_node)-[r1:IS_RELATED]-(:Relationship {name: "ip_prefix__ip_address"})-[r2:IS_RELATED]-(current_address_child:%(ip_address_kind)s)
+            OPTIONAL MATCH child_address_path = (ip_node:%(ip_prefix_kind)s)-[r1:IS_RELATED]->(:Relationship {name: "ip_prefix__ip_address"})<-[r2:IS_RELATED]-(current_address_child:%(ip_address_kind)s)
             WHERE all(r IN relationships(child_address_path) WHERE (%(branch_filter)s))
             WITH current_address_child, (r1.status = "active" AND r2.status = "active") AS is_active
             ORDER BY current_address_child.uuid, r1.branch_level DESC, r1.from DESC, r2.branch_level DESC, r2.from DESC

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -1,8 +1,11 @@
 import ipaddress
+from uuid import uuid4
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind, SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.initialization import create_branch, get_default_ipnamespace
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
@@ -10,7 +13,13 @@ from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.ipam import IPPrefixReconcileQuery
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+def randomized_branch_name(branch_name: str) -> str:
+    return f"{branch_name}_{uuid4().hex[:8]}"
 
 
 async def test_ipprefix_reconcile_query_simple(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
@@ -241,7 +250,7 @@ async def test_ipprefix_reconcile_query_get_deleted_node_by_uuid(
 async def test_ipprefix_reconcile_query_deleted_children_ignored_on_branch(
     db: InfrahubDatabase, ip_dataset_01: dict[str, Node]
 ):
-    branch = await create_branch(db=db, branch_name="branch2")
+    branch = await create_branch(db=db, branch_name=randomized_branch_name("branch2"))
 
     ns1_id = ip_dataset_01["ns1"].id
     net140_branch = await NodeManager.get_one(db=db, branch=branch, id=ip_dataset_01["net140"].id)
@@ -276,7 +285,7 @@ async def test_ipprefix_reconcile_query_deleted_children_ignored_on_branch(
 async def test_ipprefix_reconcile_query_deleted_parent_ignored_on_branch(
     db: InfrahubDatabase, ip_dataset_01: dict[str, Node]
 ):
-    branch = await create_branch(db=db, branch_name="branch2")
+    branch = await create_branch(db=db, branch_name=randomized_branch_name("branch2"))
 
     ns1_id = ip_dataset_01["ns1"].id
     net140_branch = await NodeManager.get_one(db=db, branch=branch, id=ip_dataset_01["net140"].id)
@@ -309,7 +318,7 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
-    branch2 = await create_branch(branch_name="branch2", db=db)
+    branch2 = await create_branch(branch_name=randomized_branch_name("branch2"), db=db)
 
     ns1_id = ip_dataset_01["ns1"].id
     net140 = ip_dataset_01["net140"]
@@ -343,6 +352,16 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
         new_address_branch.id,
     }
     assert set(query.get_calculated_children_uuids()) == expected_children
+    query = await IPPrefixReconcileQuery.init(
+        db=db, branch=branch2, ip_value=ipaddress.ip_interface("10.10.0.1"), namespace=ns1_id
+    )
+    await query.execute(db=db)
+
+    assert query.get_ip_node_uuid() == new_address_branch.id
+    assert query.get_current_parent_uuid() is None
+    assert query.get_current_children_uuids() == []
+    assert query.get_calculated_parent_uuid() == new_parent_branch.id
+    assert query.get_calculated_children_uuids() == []
 
     await branch2.rebase(db=db)
 
@@ -364,6 +383,16 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
         new_address_main.id,
     }
     assert set(query.get_calculated_children_uuids()) == expected_children_after_rebase
+    query = await IPPrefixReconcileQuery.init(
+        db=db, branch=branch2, ip_value=ipaddress.ip_interface("10.10.0.2"), namespace=ns1_id
+    )
+    await query.execute(db=db)
+
+    assert query.get_ip_node_uuid() == new_address_main.id
+    assert query.get_current_parent_uuid() is None
+    assert query.get_current_children_uuids() == []
+    assert query.get_calculated_parent_uuid() == new_parent_branch.id
+    assert query.get_calculated_children_uuids() == []
 
 
 async def test_reconcile_parent_child_identification(
@@ -615,7 +644,7 @@ async def test_reconcile_query_on_migrated_kind_node(db: InfrahubDatabase, defau
     prefix_140 = ip_dataset_01["net140"]
     namespace = ip_dataset_01["ns1"]
 
-    branch = await create_branch(db=db, branch_name="migrated-branch")
+    branch = await create_branch(db=db, branch_name=randomized_branch_name("migrated-branch"))
 
     # update IpamIPPrefix schema name
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch, duplicate=True)
@@ -657,3 +686,40 @@ async def test_reconcile_query_on_migrated_kind_node(db: InfrahubDatabase, defau
         ip_dataset_01["net145"].id,
         ip_dataset_01["address10"].id,
     }
+
+
+async def test_reconcile_query_for_address_with_prefix_added_on_branch_and_merged(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+):
+    """
+    Test for bug that could cause an IP address to be its own parent after an update on a branch was merged
+    """
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    address_10 = ip_dataset_01["address10"]
+    namespace = ip_dataset_01["ns1"]
+
+    branch = await create_branch(db=db, branch_name=randomized_branch_name("address-parent"))
+
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=branch)
+    new_prefix = await Node.init(db=db, branch=branch, schema=prefix_schema)
+    await new_prefix.new(db=db, prefix="10.10.0.0/28", ip_namespace=namespace, ip_addresses=[address_10.id])
+    await new_prefix.save(db=db)
+
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    await diff_merger.merge_graph(at=Timestamp())
+    # get branch to make sure branched_from is refreshed
+    branch = await Branch.get_by_name(db=db, name=branch.name)
+
+    ip_interface = ipaddress.ip_interface(address_10.address.value)
+    query = await IPPrefixReconcileQuery.init(db=db, branch=branch, ip_value=ip_interface, namespace=namespace)
+    await query.execute(db=db)
+
+    assert query.get_ip_node_uuid() == address_10.id
+    assert query.get_current_parent_uuid() == new_prefix.id
+    assert query.get_current_children_uuids() == []
+    assert query.get_calculated_parent_uuid() == new_prefix.id
+    assert query.get_calculated_children_uuids() == []

--- a/changelog/7319.fixed.md
+++ b/changelog/7319.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in IP address reconciliation that could cause an address to be set as its own parent if the address was created or updated on a branch that was previously merged.


### PR DESCRIPTION
fixes #7319 

fixes a bug that could allow an IP address to be set as its own parent. this would only be possible if the following happened
1. IP address has its prefix updated on a branch
2. that branch is merged
3. the IP address has is reconciled again, after the branch merge

also updates the `IPPrefixReconcileQuery` to correctly get the parent prefix of an IP address being reconciled. the current code never retrieved the parent for an address. this worked b/c the query would get the correct calculated prefix and then update it every time, but getting the current parent prefix allows us to skip updating it if it is not necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where IP addresses could be incorrectly set as their own parent when created or updated on a previously merged branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->