### PR TITLE
Fix flakiness on object-filters E2E tests

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table-schema-selector.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table-schema-selector.tsx
@@ -54,7 +54,11 @@ export function ObjectTableSchemaSelector() {
         <RenderItem schema={selectedSchema ?? baseSchema} />
       </ComboboxTrigger>
 
-      <ComboboxContent portal fitTriggerWidth={false}>
+      <ComboboxContent
+        portal
+        fitTriggerWidth={false}
+        data-testid="object-schema-schema-selector-popover"
+      >
         <ComboboxList shouldFilter>
           <ComboboxItem
             value={baseSchema.hash}

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -8,7 +8,7 @@ test.describe("Verifies the object creation", () => {
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
   test.describe.configure({ mode: "serial" });
 
-  const BRANCH_NAME = generateRandomBranchName();
+  const BRANCH_NAME = generateRandomBranchName("select-2-steps");
 
   test.beforeAll(async ({ request }) => {
     await createBranchAPI(request, BRANCH_NAME);
@@ -18,17 +18,9 @@ test.describe("Verifies the object creation", () => {
     await deleteBranchAPI(request, BRANCH_NAME);
   });
 
-  test.beforeEach(async function ({ page }) {
-    page.on("response", async (response) => {
-      if (response.status() === 500) {
-        await expect(response.url()).toBe("This URL responded with a 500 status");
-      }
-    });
-  });
-
   test("creates and verifies the nodes values", async ({ page }) => {
     await test.step("create the object", async () => {
-      await page.goto("/objects/InfraVLAN");
+      await page.goto(`/objects/InfraVLAN?branch=${BRANCH_NAME}`);
       await page.getByTestId("create-object-button").click();
       await page.getByRole("combobox", { name: "Site" }).click();
       await page.getByRole("option", { name: "atl1" }).click();

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -49,6 +49,8 @@ test.describe("Object filters", () => {
 
       await page.getByRole("button", { name: "Site" }).click();
       await expect(page.getByTestId("relationship-filter-form")).toContainText("atl1×");
+      await page.getByText("Filter by Site").press("Escape");
+      await expect(page.getByTestId("relationship-filter-form")).not.toBeVisible();
     });
 
     await test.step("remove an attribute filter", async () => {
@@ -99,6 +101,7 @@ test.describe("Object filters", () => {
 
     await test.step("filter target kind", async () => {
       await page.getByTestId("object-schema-schema-selector").click();
+      await expect(page.getByTestId("object-schema-schema-selector-popover")).toBeVisible();
       await expect(
         page.getByRole("option", { name: "Interface L2 Infra", exact: true })
       ).toBeVisible();
@@ -116,6 +119,7 @@ test.describe("Object filters", () => {
 
     await test.step("filter using kind", async () => {
       await page.getByRole("option", { name: "Interface L3 Infra", exact: true }).click();
+      await expect(page.getByTestId("object-schema-schema-selector-popover")).not.toBeVisible();
 
       await expect(page.getByTestId("object-schema-schema-selector")).toContainText(
         "Interface L3Infra"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for filter popover interactions (escape-key closure, visibility checks) and updated end-to-end test flows to use branch-scoped navigation and simplified setup by removing a prior response-assertion hook.
* **Style**
  * Minor formatting adjustments to component property declarations and addition of explicit test identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->