### PR TITLE
Ipam tree is now resizable

### DIFF
--- a/changelog/7262.added.md
+++ b/changelog/7262.added.md
@@ -1,0 +1,4 @@
+IPAM tree is now resizable:
+
+- Adjust the width of the IPAM tree panel by dragging the divider
+- Tree panel can be resized between 10% and 50% of the screen width

--- a/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
@@ -36,14 +36,14 @@ export default function IpNamespaceSelector({ className }: IpNamespaceSelectorPr
         data-testid="namespace-select"
         className={classNames(
           focusVisibleStyle,
-          "flex h-10 flex-col rounded px-1.5 py-0.5",
+          "flex flex-col justify-center rounded-lg px-2 py-1",
           "border border-transparent",
           "hover:bg-gray-100",
           className
         )}
       >
         <Row className="text-gray-600 text-xs">IP Namespace</Row>
-        <Row className="gap-1.5 text-sm">
+        <Row className="gap-1.5 text-sm leading-3.5">
           <span className="truncate">{getNodeLabel(currentIpNamespace)}</span>
           <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 text-gray-600" />
         </Row>

--- a/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
@@ -36,7 +36,7 @@ export default function IpNamespaceSelector({ className }: IpNamespaceSelectorPr
         data-testid="namespace-select"
         className={classNames(
           focusVisibleStyle,
-          "flex h-10 w-full flex-col rounded px-1.5 py-0.5",
+          "flex h-10 flex-col rounded px-1.5 py-0.5",
           "border border-transparent",
           "hover:bg-gray-100",
           className

--- a/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
@@ -42,7 +42,7 @@ export default function IpNamespaceSelector({ className }: IpNamespaceSelectorPr
           className
         )}
       >
-        <Row className="text-gray-600 text-xs">IP Namespace</Row>
+        <Row className="truncate text-gray-600 text-xs">IP Namespace</Row>
         <Row className="gap-1.5 text-sm leading-3.5">
           <span className="truncate">{getNodeLabel(currentIpNamespace)}</span>
           <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 text-gray-600" />

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -6,15 +6,19 @@ import { IPAM_TREE_KEY } from "@/config/localStorage";
 
 import { Separator } from "@/shared/components/aria/separator";
 import { Button } from "@/shared/components/buttons/button-primitive";
-import { Col, Row } from "@/shared/components/container";
+import { Row } from "@/shared/components/container";
 import ErrorScreen from "@/shared/components/errors/error-screen";
-import { Card } from "@/shared/components/ui/card";
+import Content from "@/shared/components/layout/content";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/shared/components/ui/resizable";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
 import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 
 import IpNamespaceSelector from "@/entities/ipam/ip-namespaces/ip-namespace-selector";
 import { IpNamespaceProvider } from "@/entities/ipam/ip-namespaces/ui/ip-namespace-provider";
-import { IpamBreadcrumb } from "@/entities/ipam/ipam-breadcrumb";
 import IpamTree from "@/entities/ipam/ipam-tree/ipam-tree";
 
 export const Component = () => {
@@ -24,43 +28,43 @@ export const Component = () => {
 
   return (
     <IpNamespaceProvider>
-      <Card className="flex size-full flex-col overflow-hidden p-0">
-        <Row className="h-11 gap-0 *:shrink-0">
-          <Button
-            variant="ghost"
-            size="square"
-            aria-label="toggle IPAM tree"
-            onClick={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
-            className="m-1 text-gray-400 hover:text-neutral-600"
-          >
-            <SidebarIcon className="size-4" />
-          </Button>
-          <Separator orientation="vertical" />
-          <IpNamespaceSelector className="m-0.75 w-47" />
-          <Separator orientation="vertical" />
-          <IpamBreadcrumb className="grow px-2" />
-        </Row>
-
-        <Separator />
-
-        <Row className="grow items-stretch gap-0 overflow-hidden">
-          {!booleanCollapsed && (
-            <Col className="w-60 shrink-0 gap-0 border-gray-200 border-r">
-              <ErrorBoundary
-                fallbackRender={({ error }) => <ErrorScreen message={error.message} />}
+      <ResizablePanelGroup direction="horizontal" className="items-stretch">
+        <ResizablePanel defaultSize={20} minSize={10} maxSize={50} className="flex grow flex-col">
+          <Content.Card className="flex grow flex-col">
+            <Row className="h-11 gap-0">
+              <Button
+                variant="ghost"
+                size="square"
+                aria-label="toggle IPAM tree"
+                onClick={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
+                className="m-1 text-gray-400 hover:text-neutral-600"
               >
-                <ScrollArea scrollX>
-                  <IpamTree className="w-full px-2" />
-                </ScrollArea>
-              </ErrorBoundary>
-            </Col>
-          )}
+                <SidebarIcon className="size-4" />
+              </Button>
 
-          <Col className="grow gap-0 overflow-hidden">
+              <Separator orientation="vertical" />
+
+              <IpNamespaceSelector className="m-0.75 grow" />
+            </Row>
+
+            <Separator />
+
+            <ErrorBoundary fallbackRender={({ error }) => <ErrorScreen message={error.message} />}>
+              <ScrollArea scrollX>
+                <IpamTree className="w-full px-2" />
+              </ScrollArea>
+            </ErrorBoundary>
+          </Content.Card>
+        </ResizablePanel>
+
+        <ResizableHandle />
+
+        <ResizablePanel className="flex grow flex-col">
+          <Content.Card className="flex grow flex-col">
             <Outlet />
-          </Col>
-        </Row>
-      </Card>
+          </Content.Card>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </IpNamespaceProvider>
   );
 };

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -1,3 +1,5 @@
+import { useAtom, useAtomValue } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { SidebarIcon } from "lucide-react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router";
@@ -15,52 +17,48 @@ import {
   ResizablePanelGroup,
 } from "@/shared/components/ui/resizable";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
-import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
+import { classNames } from "@/shared/utils/common";
 
 import IpNamespaceSelector from "@/entities/ipam/ip-namespaces/ip-namespace-selector";
 import { IpNamespaceProvider } from "@/entities/ipam/ip-namespaces/ui/ip-namespace-provider";
 import IpamTree from "@/entities/ipam/ipam-tree/ipam-tree";
 
-export const Component = () => {
-  const [collapsed, setCollapsed] = useLocalStorage(IPAM_TREE_KEY);
+const ipamTreeCollapsedAtom = atomWithStorage(IPAM_TREE_KEY, false);
 
-  const booleanCollapsed = collapsed === "true";
+export const Component = () => {
+  const ipamTreeCollapsed = useAtomValue(ipamTreeCollapsedAtom);
 
   return (
     <IpNamespaceProvider>
       <ResizablePanelGroup direction="horizontal" className="items-stretch">
-        <ResizablePanel defaultSize={20} minSize={10} maxSize={50} className="flex grow flex-col">
-          <Content.Card className="flex grow flex-col">
-            <Row className="h-11 gap-0">
-              <Button
-                variant="ghost"
-                size="square"
-                aria-label="toggle IPAM tree"
-                onClick={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
-                className="m-1 text-gray-400 hover:text-neutral-600"
-              >
-                <SidebarIcon className="size-4" />
-              </Button>
+        {!ipamTreeCollapsed && (
+          <>
+            <ResizablePanel
+              defaultSize={20}
+              minSize={10}
+              maxSize={50}
+              className="flex grow flex-col"
+            >
+              <Content.Card className="flex grow flex-col">
+                <IpamToolbar />
 
-              <Separator orientation="vertical" />
+                <ErrorBoundary
+                  fallbackRender={({ error }) => <ErrorScreen message={error.message} />}
+                >
+                  <ScrollArea scrollX>
+                    <IpamTree className="w-full px-2" />
+                  </ScrollArea>
+                </ErrorBoundary>
+              </Content.Card>
+            </ResizablePanel>
 
-              <IpNamespaceSelector className="m-0.75 grow" />
-            </Row>
-
-            <Separator />
-
-            <ErrorBoundary fallbackRender={({ error }) => <ErrorScreen message={error.message} />}>
-              <ScrollArea scrollX>
-                <IpamTree className="w-full px-2" />
-              </ScrollArea>
-            </ErrorBoundary>
-          </Content.Card>
-        </ResizablePanel>
-
-        <ResizableHandle />
+            <ResizableHandle />
+          </>
+        )}
 
         <ResizablePanel className="flex grow flex-col">
           <Content.Card className="flex grow flex-col">
+            {ipamTreeCollapsed && <IpamToolbar />}
             <Outlet />
           </Content.Card>
         </ResizablePanel>
@@ -68,3 +66,29 @@ export const Component = () => {
     </IpNamespaceProvider>
   );
 };
+
+function IpamToolbar() {
+  const [collapsed, setCollapsed] = useAtom(ipamTreeCollapsedAtom);
+
+  return (
+    <>
+      <Row className="h-11 gap-0">
+        <Button
+          variant="ghost"
+          size="square"
+          aria-label="toggle IPAM tree"
+          onClick={() => setCollapsed(!collapsed)}
+          className="m-1 text-gray-400 hover:text-neutral-600"
+        >
+          <SidebarIcon className="size-4" />
+        </Button>
+
+        <Separator orientation="vertical" />
+
+        <IpNamespaceSelector className={classNames("m-0.75 grow", collapsed && "max-w-[313px]")} />
+      </Row>
+
+      <Separator />
+    </>
+  );
+}

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -78,14 +78,14 @@ function IpamToolbar() {
           size="square"
           aria-label="toggle IPAM tree"
           onClick={() => setCollapsed(!collapsed)}
-          className="m-1 text-gray-400 hover:text-neutral-600"
+          className="m-1 rounded-lg text-gray-400 hover:text-neutral-600"
         >
           <SidebarIcon className="size-4" />
         </Button>
 
         <Separator orientation="vertical" />
 
-        <IpNamespaceSelector className={classNames("m-0.75 grow", collapsed && "max-w-[313px]")} />
+        <IpNamespaceSelector className={classNames("m-0.5 grow", collapsed && "max-w-[313px]")} />
       </Row>
 
       <Separator />

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -34,6 +34,8 @@ export const Component = () => {
         {!ipamTreeCollapsed && (
           <>
             <ResizablePanel
+              id="tree-panel"
+              order={0}
               defaultSize={20}
               minSize={10}
               maxSize={50}
@@ -56,7 +58,7 @@ export const Component = () => {
           </>
         )}
 
-        <ResizablePanel className="flex grow flex-col">
+        <ResizablePanel id="main-panel" order={1} className="flex grow flex-col">
           <Content.Card className="flex grow flex-col">
             {ipamTreeCollapsed && <IpamToolbar />}
             <Outlet />

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -80,14 +80,14 @@ function IpamToolbar() {
           size="square"
           aria-label="toggle IPAM tree"
           onClick={() => setCollapsed(!collapsed)}
-          className="m-1 rounded-lg text-gray-400 hover:text-neutral-600"
+          className="m-1 shrink-0 rounded-lg text-gray-400 hover:text-neutral-600"
         >
           <SidebarIcon className="size-4" />
         </Button>
 
         <Separator orientation="vertical" />
 
-        <IpNamespaceSelector className={classNames("m-0.5 grow", collapsed && "max-w-[313px]")} />
+        <IpNamespaceSelector className={classNames("m-0.5 grow", collapsed && "max-w-60")} />
       </Row>
 
       <Separator />

--- a/frontend/app/src/pages/objects/layout.tsx
+++ b/frontend/app/src/pages/objects/layout.tsx
@@ -58,7 +58,7 @@ const ObjectPageLayout = () => {
               </Content.Card>
             </ResizablePanel>
 
-            <ResizableHandle withHandle className="w-0.5 bg-transparent" />
+            <ResizableHandle />
           </>
         )}
 

--- a/frontend/app/src/shared/components/ui/resizable.tsx
+++ b/frontend/app/src/shared/components/ui/resizable.tsx
@@ -19,20 +19,14 @@ export const ResizablePanelGroup = ({
 export const ResizablePanel = ResizablePrimitive.Panel;
 
 export const ResizableHandle = ({
-  withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
-  withHandle?: boolean;
-}) => (
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle>) => (
   <ResizablePrimitive.PanelResizeHandle
     className={classNames(
-      "flex items-center justify-center",
-      "relative w-px bg-gray-200",
-      "after:-translate-x-1/2 after:absolute after:inset-y-0 after:left-1/2 after:w-1",
-      "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
-      "data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0",
+      "relative w-0.5 bg-transparent outline-hidden",
       "hover:bg-custom-blue-600",
+      "focus-visible:bg-custom-blue-600",
       className
     )}
     {...props}

--- a/frontend/app/tests/e2e/ipam/ip-address-list.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-address-list.spec.ts
@@ -34,7 +34,7 @@ test.describe("/ipam/ip_addresses - IP Address list", () => {
 
     await test.step("use breadcrumb to go back to parent prefix", async () => {
       await page
-        .getByLabel("IPAM navigation breadcrumb")
+        .getByTestId("breadcrumb-ipam")
         .getByRole("link", { name: "172.16.0.0/16" })
         .click();
 

--- a/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
@@ -34,7 +34,7 @@ test.describe("/ipam/ip_prefixes - Ip Prefix list", () => {
 
     await test.step("use breadcrumb to go back to parent prefix", async () => {
       await page
-        .getByLabel("IPAM navigation breadcrumb")
+        .getByTestId("breadcrumb-ipam")
         .getByRole("link", { name: "2001:db8::/100" })
         .click();
     });


### PR DESCRIPTION
issue #7262 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPAM tree panel is resizable—drag the divider to adjust width (constrained to ~10–50% of screen).
  * IPAM toolbar added with a toggle and namespace selector; toolbar appears in both expanded and collapsed states and tree collapse state is persisted.

* **UI/Style**
  * Simplified resizer handle styling for visual consistency.
  * Namespace selector button sizing adjusted to a compact, rounded layout.

* **Refactor**
  * IPAM layout restructured to a resizable two-panel composition.

* **Tests**
  * E2E tests updated to use stable test-id selectors for breadcrumb navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->