### PR TITLE
Fix typing for NodeManager.find_object

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -467,9 +467,6 @@ class NodeManager:
         id: str | None = None,
         hfid: list[str] | None = None,
     ) -> Any:
-        if not id and not hfid:
-            raise ProcessingError(message="either id or hfid must be provided.")
-
         if id and is_valid_uuid(id):
             return await cls.get_one(
                 db=db,
@@ -494,16 +491,19 @@ class NodeManager:
                 raise_on_error=True,
             )
 
-        return await cls.get_one_by_default_filter(
-            db=db,
-            kind=kind,
-            id=id,
-            branch=branch,
-            at=at,
-            include_owner=True,
-            include_source=True,
-            raise_on_error=True,
-        )
+        if id:
+            return await cls.get_one_by_default_filter(
+                db=db,
+                kind=kind,
+                id=id,
+                branch=branch,
+                at=at,
+                include_owner=True,
+                include_source=True,
+                raise_on_error=True,
+            )
+
+        raise ProcessingError(message="either id or hfid must be provided.")
 
     @overload
     @classmethod


### PR DESCRIPTION
Fixes a problem in NodeManager.find_object where the linter could think that we'd call NodeManager.get_one_by_default_filter() where the `id` parameter was set to `None`.

This is probably a limitation in the type checkers as it wouldn't be the case but the fix clears up this confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal control flow for object lookup and error handling, improving code maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->