### PR TITLE
Fix overloads for NodeManager.find_object

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -455,7 +455,7 @@ class NodeManager:
         branch: Branch | str | None = ...,
         id: str | None = ...,
         hfid: list[str] | None = ...,
-    ) -> Any: ...
+    ) -> Node: ...
 
     @classmethod
     async def find_object(
@@ -466,7 +466,7 @@ class NodeManager:
         branch: Branch | str | None = None,
         id: str | None = None,
         hfid: list[str] | None = None,
-    ) -> Any:
+    ) -> Node | SchemaProtocol:
         if id and is_valid_uuid(id):
             return await cls.get_one(
                 db=db,

--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -122,7 +122,7 @@ class IPAddressPoolGetResource(Mutation):
     ) -> Self:
         graphql_context: GraphqlContext = info.context
 
-        obj: CoreIPAddressPool = await registry.manager.find_object(
+        obj: CoreIPAddressPool = await registry.manager.find_object(  # type: ignore[assignment]
             db=graphql_context.db,
             kind=InfrahubKind.IPADDRESSPOOL,
             id=data.get("id"),


### PR DESCRIPTION
Avoid returning `Any` from `NodeManager.find_object()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations for enhanced code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->