### PR TITLE
Clarify documentation branching workflow in Git guide

### DIFF
--- a/docs/docs/development/git-best-practices.mdx
+++ b/docs/docs/development/git-best-practices.mdx
@@ -151,7 +151,7 @@ Infrahub follows a structured branching model designed for stable releases and c
 
 **Release branches**:
 
-- `release-x.y`: Cut from `develop` during release prep, merged into `stable` and then back into `develop`
+- `release-x.y`: Cut from `develop` during release prep, merged into `stable` and then back into `develop`; an automation bot keeps them in sync by continuously PR-ing `stable → release-x.y` and `release-x.y → develop` (or `stable → develop` when no release branch exists)
 
 **Feature branches**:
 
@@ -292,6 +292,12 @@ Use the branch that matches when the change must appear on https://docs.infrahub
 - Branch directly from `stable` (for example, `docs/stable-doc-workflow`) so the fix deploys as soon as the PR merges
 - If you already authored the fix on `develop`, rebase or cherry-pick it onto a `stable`-based branch before opening the PR
 - Target `stable` in the pull request
+
+### Docs for work on a release branch
+
+- When a feature (or its documentation) lives on an active `release-x.y` branch, create your docs branch from that same release branch (for example, `release-1.5`)
+- Target the release branch in your PR so the docs ship with the release and flow back into `develop` via the automated sync
+- Rebase on the release branch regularly to pick up stabilization commits
 
 ### Future or feature documentation
 

--- a/docs/docs/development/git-best-practices.mdx
+++ b/docs/docs/development/git-best-practices.mdx
@@ -149,6 +149,10 @@ Infrahub follows a structured branching model designed for stable releases and c
 - `stable`: Production-ready code, protected branch, only updated via PRs
 - `develop`: Integration branch for new features, default branch for development
 
+**Release branches**:
+
+- `release-x.y`: Cut from `develop` during release prep, merged into `stable` and then back into `develop`
+
 **Feature branches**:
 
 - `feature/description`: New features or enhancements
@@ -278,6 +282,21 @@ Follow these practices to ensure smooth code review and integration.
    - Rebase on target branch if requested
    - Squash commits if needed
    - Use merge commit for feature branches
+
+## Documentation branching workflow
+
+Use the branch that matches when the change must appear on https://docs.infrahub.app:
+
+### Minor fixes to published docs
+
+- Branch directly from `stable` (for example, `docs/stable-doc-workflow`) so the fix deploys as soon as the PR merges
+- If you already authored the fix on `develop`, rebase or cherry-pick it onto a `stable`-based branch before opening the PR
+- Target `stable` in the pull request
+
+### Future or feature documentation
+
+- Branch from `develop` for docs tied to unreleased features
+- This keeps upcoming content out of `stable` until the feature is available
 
 ## Bringing latest changes from stable into develop
 


### PR DESCRIPTION
Expanded the git workflow guide to clarify how documentation updates should branch and land docs/docs/development/git-best-practices.mdx.

Now calls out release branches alongside stable/develop, restores the original release checklist ordering, and adds a dedicated “Documentation branching workflow” section that explains when doc fixes should fork from stable versus develop.

@ogenstad @petercrocker Please let me know if I should add more. Please note, I kept it in develop branch, as I am not sure when this info should or should not become live for now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced Git best practices documentation with new Release branches section covering release flow and synchronization.
  * Added comprehensive Documentation branching workflow guidance for different documentation scenarios including minor fixes, release-specific docs, and upcoming features.
  * Included detailed sync process for merging latest changes between stable and development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->