### PR TITLE
fix(backend): database session usage

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, AsyncGenerator
 
 from fastapi import Depends, Query, Request
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
@@ -17,8 +17,6 @@ from infrahub.exceptions import AuthorizationError
 from infrahub.permissions import PermissionManager
 
 if TYPE_CHECKING:
-    from neo4j import AsyncSession
-
     from infrahub.models import RefreshTokenData
 
 jwt_scheme = HTTPBearer(auto_error=False)
@@ -36,16 +34,9 @@ class BranchParams(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-async def get_session(request: Request) -> AsyncIterator[AsyncSession]:
-    session = request.app.state.db.session(database=config.SETTINGS.database.database_name)
-    try:
-        yield session
-    finally:
-        await session.close()
-
-
-async def get_db(request: Request) -> InfrahubDatabase:
-    return request.app.state.db.start_session()
+async def get_db(request: Request) -> AsyncGenerator[InfrahubDatabase, None]:
+    async with request.app.state.db.start_session() as db:
+        yield db
 
 
 async def get_access_token(

--- a/backend/infrahub/api/transformation.py
+++ b/backend/infrahub/api/transformation.py
@@ -64,17 +64,18 @@ async def transform_python(
             message="Repository doesn't have a commit",
         )
 
-    gql_params = await prepare_graphql_params(
-        db=request.app.state.db, branch=branch_params.branch, at=branch_params.at, service=request.app.state.service
-    )
+    async with db.start_session(read_only=True) as dbs:
+        gql_params = await prepare_graphql_params(
+            db=dbs, branch=branch_params.branch, at=branch_params.at, service=request.app.state.service
+        )
 
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query.query.value,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values=params,
-    )
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query.query.value,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values=params,
+        )
 
     data = extract_data(query_name=query.name.value, result=result)
 
@@ -128,17 +129,18 @@ async def transform_jinja2(
             message="Repository doesn't have a commit",
         )
 
-    gql_params = await prepare_graphql_params(
-        db=request.app.state.db, branch=branch_params.branch, at=branch_params.at, service=request.app.state.service
-    )
+    async with db.start_session(read_only=True) as dbs:
+        gql_params = await prepare_graphql_params(
+            db=dbs, branch=branch_params.branch, at=branch_params.at, service=request.app.state.service
+        )
 
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query.query.value,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values=params,
-    )
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query.query.value,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values=params,
+        )
 
     data = extract_data(query_name=query.name.value, result=result)
 

--- a/backend/infrahub/core/validators/uniqueness/checker.py
+++ b/backend/infrahub/core/validators/uniqueness/checker.py
@@ -122,7 +122,8 @@ class UniquenessChecker(ConstraintCheckerInterface):
             db=self.db, branch=await self.get_branch(), query_request=query_request
         )
         async with self.semaphore:
-            query_results = await query.execute(db=self.db.start_session(read_only=True))
+            async with self.db.start_session(read_only=True) as db:
+                query_results = await query.execute(db=db)
 
         return await self._parse_results(schema=schema, query_results=query_results.results)
 

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -173,19 +173,6 @@ class InfrahubDatabase:
         else:
             self.db_type = config.SETTINGS.database.db_type
 
-    def __del__(self) -> None:
-        if not self._session or not self._is_session_local or self._session.closed():
-            return
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        if loop and loop.is_running():
-            loop.create_task(self._session.close())
-        else:
-            asyncio.run(self._session.close())
-
     @property
     def is_session(self) -> bool:
         if self._mode == InfrahubDatabaseMode.SESSION:

--- a/changelog/+197d6056.fixed.md
+++ b/changelog/+197d6056.fixed.md
@@ -1,0 +1,1 @@
+Backend database sessions are now handled consistently avoiding resource leakage.


### PR DESCRIPTION
Always wrap start_session with a context manager so that the session is properly closed.
This avoids the __del__ workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved database session handling across the backend for more consistent lifecycle control and explicit cleanup.
  * Read-only sessions are now used for GraphQL parameter preparation and validation checks to isolate queries.
  * Removed automatic destructor-based cleanup; resource closure must be explicit.
  * Added changelog entry documenting the session management changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->