### PR TITLE
Fix query key for object details to include attributes and relationships

### DIFF
--- a/frontend/app/src/entities/nodes/object/domain/get-object.ts
+++ b/frontend/app/src/entities/nodes/object/domain/get-object.ts
@@ -5,6 +5,7 @@ import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { addAttributesToRequest, addRelationshipsToRequest } from "@/shared/api/graphql/utils";
 import type { ContextParams } from "@/shared/api/types";
 
+import { getAttributesVisibleInDetailedView } from "@/entities/nodes/object/utils/get-attributes-visible-in-detailed-view";
 import { getRelationshipsVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import type { NodeObject } from "@/entities/nodes/types";
 import type { AttributeSchema, ModelSchema, RelationshipSchema } from "@/entities/schema/types";
@@ -24,7 +25,7 @@ export const getObject: GetObject = async ({
   atDate,
   objectSchema,
   objectId,
-  getAttributesVisible = (attributes) => attributes, // all attributes are visible by default on detailed view
+  getAttributesVisible = getAttributesVisibleInDetailedView,
   getRelationshipsVisible = getRelationshipsVisibleInDetailedView,
   relationshipFragment,
 }) => {

--- a/frontend/app/src/entities/nodes/object/domain/object.query-keys.ts
+++ b/frontend/app/src/entities/nodes/object/domain/object.query-keys.ts
@@ -1,6 +1,10 @@
 import type { ContextParams } from "@/shared/api/types";
 import type { Filter } from "@/shared/hooks/useFilters";
 
+import { getAttributesVisibleInDetailedView } from "@/entities/nodes/object/utils/get-attributes-visible-in-detailed-view";
+import { getRelationshipsVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
+import type { AttributeSchema, ModelSchema, RelationshipSchema } from "@/entities/schema/types";
+
 export interface ObjectKeysBaseParams extends ContextParams {
   objectKind: string;
 }
@@ -11,6 +15,9 @@ export interface ObjectListKeysParams extends ObjectKeysBaseParams {
 
 export interface ObjectDetailKeysParams extends ObjectKeysBaseParams {
   objectId: string;
+  objectSchema?: ModelSchema;
+  getAttributesVisible?: (attributes: AttributeSchema[]) => AttributeSchema[];
+  getRelationshipsVisible?: (relationships: RelationshipSchema[]) => RelationshipSchema[];
 }
 
 export interface ObjectConvertFieldsMappingKeysParams extends ContextParams {
@@ -38,9 +45,38 @@ export const objectQueryKeys = {
   list: (params: ObjectListKeysParams) =>
     [...objectQueryKeys.lists(params), params.filters] as const,
   detail: (params: ObjectDetailKeysParams) =>
-    [...objectQueryKeys.lists(params), params.objectId] as const,
+    [
+      ...objectQueryKeys.lists(params),
+      params.objectId,
+      ...getAttributesKey(params),
+      ...getRelationshipsKey(params),
+    ] as const,
   ancestors: (params: ObjectDetailKeysParams) =>
     [...objectQueryKeys.detail(params), "ancestors"] as const,
   tree: ({ parentObjectId, ...params }: ObjectTreeKeysParams) =>
     [...objectQueryKeys.lists(params), "tree", parentObjectId] as const,
+};
+
+const getAttributesKey = (params: ObjectDetailKeysParams) => {
+  if (!params?.objectSchema?.attributes) {
+    return [];
+  }
+
+  const getAttributes = params?.getAttributesVisible ?? getAttributesVisibleInDetailedView;
+
+  return getAttributes(params.objectSchema.attributes).map((attribute) => {
+    return attribute.name;
+  });
+};
+
+const getRelationshipsKey = (params: ObjectDetailKeysParams) => {
+  if (!params?.objectSchema?.relationships) {
+    return [];
+  }
+
+  const getRelationships = params?.getRelationshipsVisible ?? getRelationshipsVisibleInDetailedView;
+
+  return getRelationships(params.objectSchema.relationships).map((relationship) => {
+    return relationship.name;
+  });
 };

--- a/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-detailed-view.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-detailed-view.ts
@@ -1,0 +1,8 @@
+import type { AttributeSchema } from "@/entities/schema/types";
+
+// All attributes are visible by default on detailed view
+export function getAttributesVisibleInDetailedView(
+  attributes: AttributeSchema[]
+): AttributeSchema[] {
+  return attributes;
+}


### PR DESCRIPTION
This will avoid cache collision for queries on object details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced object detail query key generation to better support attribute and relationship visibility customization, improving cache handling for object detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->