### PR TITLE
Add filters to InfrahubBranch and add field for default_branch

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -179,7 +179,7 @@ class Branch(StandardNode):
         **kwargs: Any,
     ) -> int:
         query: Query = await BranchNodeGetListQuery.init(
-            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, **kwargs
+            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, exclude_global=True, **kwargs
         )
         return await query.count(db=db)
 

--- a/backend/infrahub/core/query/branch.py
+++ b/backend/infrahub/core/query/branch.py
@@ -151,4 +151,9 @@ class RebaseBranchDeleteRelationshipQuery(Query):
 
 
 class BranchNodeGetListQuery(StandardNodeGetListQuery):
-    raw_filter = f"n.status <> '{BranchStatus.DELETING.value}'"
+    def __init__(self, exclude_global: bool = False, **kwargs: Any) -> None:
+        self.raw_filter = f"n.status <> '{BranchStatus.DELETING.value}'"
+        if exclude_global:
+            self.raw_filter += f" AND n.name <> '{GLOBAL_BRANCH_NAME}'"
+
+        super().__init__(**kwargs)

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import ID, Field, Int, List, NonNull, String
 
+from infrahub.core.registry import registry
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types import BranchType, InfrahubBranch, InfrahubBranchType
@@ -18,7 +19,7 @@ async def branch_resolver(
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
     fields = extract_graphql_fields(info)
-    return await BranchType.get_list(graphql_context=info.context, fields=fields, **kwargs)
+    return await BranchType.get_list(graphql_context=info.context, fields=fields, exclude_global=True, **kwargs)
 
 
 BranchQueryList = Field(
@@ -36,6 +37,8 @@ async def infrahub_branch_resolver(
     info: GraphQLResolveInfo,
     limit: int | None = None,
     offset: int | None = None,
+    name__value: str | None = None,
+    ids: list[str] | None = None,
 ) -> dict[str, Any]:
     if isinstance(limit, int) and limit < 1:
         raise ValidationError("limit must be >= 1")
@@ -46,11 +49,27 @@ async def infrahub_branch_resolver(
     result: dict[str, Any] = {}
     if "edges" in fields:
         branches = await InfrahubBranch.get_list(
-            graphql_context=info.context, fields=fields.get("edges", {}).get("node", {}), limit=limit, offset=offset
+            graphql_context=info.context,
+            fields=fields.get("edges", {}).get("node", {}),
+            limit=limit,
+            offset=offset,
+            name=name__value,
+            ids=ids,
+            exclude_global=True,
         )
         result["edges"] = [{"node": branch} for branch in branches]
     if "count" in fields:
-        result["count"] = await InfrahubBranchType.get_list_count(graphql_context=info.context)
+        result["count"] = await InfrahubBranchType.get_list_count(
+            graphql_context=info.context, name=name__value, ids=ids
+        )
+
+    if "default_branch" in fields:
+        result["default_branch"] = await InfrahubBranch.get_by_name(
+            graphql_context=info.context,
+            fields=fields["default_branch"],
+            name=registry.default_branch,
+        )
+
     return result
 
 
@@ -58,6 +77,8 @@ InfrahubBranchQueryList = Field(
     InfrahubBranchType,
     offset=Int(),
     limit=Int(),
+    name__value=String(),
+    ids=List(ID),
     description="Retrieve paginated information about active branches.",
     resolver=infrahub_branch_resolver,
     required=True,

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -36,7 +36,7 @@ class BranchType(InfrahubObjectType):
 
     @staticmethod
     async def _map_fields_to_graphql(objs: list[Branch], fields: dict) -> list[dict[str, Any]]:
-        return [await obj.to_graphql(fields=fields) for obj in objs if obj.name != GLOBAL_BRANCH_NAME]
+        return [await obj.to_graphql(fields=fields) for obj in objs]
 
     @classmethod
     async def get_list(
@@ -52,6 +52,19 @@ class BranchType(InfrahubObjectType):
                 return []
 
             return await cls._map_fields_to_graphql(objs=objs, fields=fields)
+
+    @classmethod
+    async def get_by_name(
+        cls,
+        fields: dict,
+        graphql_context: GraphqlContext,
+        name: str,
+    ) -> dict[str, Any]:
+        branch_responses = await cls.get_list(fields=fields, graphql_context=graphql_context, name=name)
+
+        if branch_responses:
+            return branch_responses[0]
+        raise BranchNotFoundError(f"Branch with name '{name}' not found")
 
 
 class RequiredStringValueField(InfrahubObjectType):
@@ -120,13 +133,13 @@ class InfrahubBranchEdge(InfrahubObjectType):
 class InfrahubBranchType(InfrahubObjectType):
     count = Field(Int, description="Total number of items")
     edges = Field(NonNull(List(of_type=NonNull(InfrahubBranchEdge))))
+    default_branch = Field(
+        InfrahubBranch,
+        required=True,
+        description="The default branch of the Infrahub instance, provides a direct way to access the default branch regardless of filters.",
+    )
 
     @classmethod
     async def get_list_count(cls, graphql_context: GraphqlContext, **kwargs: Any) -> int:
         async with graphql_context.db.start_session(read_only=True) as db:
-            count = await Branch.get_list_count(db=db, **kwargs)
-            try:
-                await Branch.get_by_name(name=GLOBAL_BRANCH_NAME, db=db)
-                return count - 1
-            except BranchNotFoundError:
-                return count
+            return await Branch.get_list_count(db=db, **kwargs)

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -160,11 +160,12 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-    ):
+    ) -> None:
+        branch_map = {}
         for i in range(10):
             create_branch_query = """
-            mutation {
-                BranchCreate(data: { name: "%s", description: "%s" }) {
+            mutation($branch_name: String!, $branch_description: String!) {
+                BranchCreate(data: { name: $branch_name, description: $branch_description }) {
                     ok
                     object {
                         id
@@ -172,10 +173,7 @@ class TestBranchQuery(TestInfrahubApp):
                     }
                 }
             }
-            """ % (
-                f"sample-branch-{i}",
-                f"sample description {i}",
-            )
+            """
 
             gql_params = await prepare_graphql_params(
                 db=db,
@@ -183,19 +181,25 @@ class TestBranchQuery(TestInfrahubApp):
                 account_session=session_admin,
                 service=service,
             )
+
+            branch_name = f"sample-branch-{i}"
             branch_result = await graphql(
                 schema=gql_params.schema,
                 source=create_branch_query,
                 context_value=gql_params.context,
                 root_value=None,
-                variable_values={},
+                variable_values={"branch_name": branch_name, "branch_description": f"sample description {i}"},
             )
             assert branch_result.errors is None
             assert branch_result.data
+            branch_id = branch_result.data["BranchCreate"]["object"]["id"]
+            assert branch_result.data["BranchCreate"]["object"]["name"] == branch_name
+            assert branch_id
+            branch_map[branch_name] = branch_id
 
         query = """
-            query {
-                InfrahubBranch(offset: 2, limit: 5) {
+            query($offset: Int, $limit: Int, $name: String, $ids: [ID!]) {
+                InfrahubBranch(offset: $offset, limit: $limit, name__value: $name, ids: $ids) {
                     count
                     edges {
                         node {
@@ -207,6 +211,11 @@ class TestBranchQuery(TestInfrahubApp):
                             }
                         }
                     }
+                    default_branch {
+                        name {
+                            value
+                        }
+                    }
                 }
             }
         """
@@ -216,7 +225,7 @@ class TestBranchQuery(TestInfrahubApp):
             source=query,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={},
+            variable_values={"offset": 2, "limit": 5},
         )
         assert all_branches.errors is None
         assert all_branches.data
@@ -244,6 +253,36 @@ class TestBranchQuery(TestInfrahubApp):
             key=lambda x: x["name"]["value"]
         )
 
+        assert all_branches.data["InfrahubBranch"]["default_branch"]["name"]["value"] == "main"
+
+        name_branches = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "sample-branch-4"},
+        )
+        assert name_branches.errors is None
+        assert name_branches.data
+        assert name_branches.data["InfrahubBranch"]["count"] == 1
+        assert name_branches.data["InfrahubBranch"]["edges"][0]["node"]["name"]["value"] == "sample-branch-4"
+        assert name_branches.data["InfrahubBranch"]["default_branch"]["name"]["value"] == "main"
+
+        ids = [branch_map["sample-branch-3"], branch_map["sample-branch-7"]]
+        id_branches = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"ids": ids},
+        )
+        assert id_branches.errors is None
+        assert id_branches.data
+        assert id_branches.data["InfrahubBranch"]["count"] == 2
+        assert id_branches.data["InfrahubBranch"]["edges"][0]["node"]["name"]["value"] == "sample-branch-3"
+        assert id_branches.data["InfrahubBranch"]["edges"][1]["node"]["name"]["value"] == "sample-branch-7"
+        assert id_branches.data["InfrahubBranch"]["default_branch"]["name"]["value"] == "main"
+
     async def test_paginated_branch_query__returns_error_on_invalid_offset_or_limit(
         self,
         db: InfrahubDatabase,
@@ -252,7 +291,7 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-    ):
+    ) -> None:
         query = """
             query {
                 InfrahubBranch(offset: -1, limit: 5) {
@@ -275,6 +314,7 @@ class TestBranchQuery(TestInfrahubApp):
             root_value=None,
             variable_values={},
         )
+        assert all_branches.errors
         assert len(all_branches.errors)
         assert all_branches.errors[0].message == "offset must be >= 0"
 
@@ -299,5 +339,6 @@ class TestBranchQuery(TestInfrahubApp):
             root_value=None,
             variable_values={},
         )
+        assert all_branches.errors
         assert len(all_branches.errors)
         assert all_branches.errors[0].message == "limit must be >= 1"

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -7265,6 +7265,10 @@ type InfrahubBranchEdge {
 type InfrahubBranchType {
   """Total number of items"""
   count: Int
+  """
+  The default branch of the Infrahub instance, provides a direct way to access the default branch regardless of filters.
+  """
+  default_branch: InfrahubBranch!
   edges: [InfrahubBranchEdge!]!
 }
 
@@ -10794,7 +10798,7 @@ type Query {
   IPPrefixGetNextAvailable(prefix_id: String!, prefix_length: Int): IPPrefixGetNextAvailable! @deprecated(reason: "This query has been renamed to 'InfrahubIPPrefixGetNextAvailable'. It will be removed in the next version of Infrahub.")
   InfrahubAccountToken(limit: Int, offset: Int): AccountTokenEdges!
   """Retrieve paginated information about active branches."""
-  InfrahubBranch(limit: Int, offset: Int): InfrahubBranchType!
+  InfrahubBranch(ids: [ID], limit: Int, name__value: String, offset: Int): InfrahubBranchType!
   InfrahubEvent(
     """Filter the query to specific accounts"""
     account__ids: [String!]


### PR DESCRIPTION
Changes in this PR:

* Adds `name__value` and `ids` filter to `InfrahubBranch` query
* Adds response option for `default_branch` so that the Frontend can always have quick access to the default branch within a paginated result
* Some cleanup for `BranchNodeGetListQuery` and management of the default branch and updates to the count query, to avoid having to remove the default branch after querying for other branches within get_list_count().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch queries now support filtering by name and branch IDs
  * Default branch is now accessible and included in branch query results

* **Tests**
  * Expanded test coverage for branch filtering by name and IDs, with default branch verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->