### PR TITLE
prep release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.5.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.5.2) - 2025-11-17
+
+### Fixed
+
+- Fix migration that backfills display labels and human-friendly IDs to account for schema that only exist on the branch being migrated.
+  Add new migration to add display labels and human-friendly IDs to existing instances of templates and profiles. ([#7655](https://github.com/opsmill/infrahub/issues/7655))
+- Prevent attempting diff update on a deleted branch. Log a warning instead. ([#7666](https://github.com/opsmill/infrahub/issues/7666))
+
 ## [Infrahub - v1.5.1](https://github.com/opsmill/infrahub/tree/infrahub-v1.5.1) - 2025-11-13
 
 ### Security

--- a/changelog/7655.fixed.md
+++ b/changelog/7655.fixed.md
@@ -1,2 +1,0 @@
-Fix migration that backfills display labels and human-friendly IDs to account for schema that only exist on the branch being migrated.
-Add new migration to add display labels and human-friendly IDs to existing instances of templates and profiles.

--- a/changelog/7666.fixed.md
+++ b/changelog/7666.fixed.md
@@ -1,1 +1,0 @@
-Prevent attempting diff update on a deleted branch. Log a warning instead.

--- a/docs/docs/release-notes/infrahub/release-1_5_2.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_5_2.mdx
@@ -1,0 +1,27 @@
+---
+title: Release 1.5.2
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.5.2</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>November 18th, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.5.2](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.5.2)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+<!-- vale off -->
+- Fix migration that backfills display labels and human-friendly IDs to account for schema that only exist on the branch being migrated.
+  Add new migration to add display labels and human-friendly IDs to existing instances of templates and profiles. ([#7655](https://github.com/opsmill/infrahub/issues/7655))
+- Prevent attempting diff update on a deleted branch. Log a warning instead. ([#7666](https://github.com/opsmill/infrahub/issues/7666))
+<!-- vale on -->

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -417,6 +417,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_5_2',
             'release-notes/infrahub/release-1_5_1',
             'release-notes/infrahub/release-1_5_0',
             'release-notes/infrahub/release-1_4_13',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.5.1"
+version = "1.5.2"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.5.1"
+version = "1.5.2"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.5.1"
+version = "1.5.2"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backfilled display labels and human-friendly IDs for existing templates and profiles during migration
  * Prevented diff updates on deleted branches and log a warning instead

* **Documentation**
  * Added release notes for Infrahub v1.5.2

* **Chores**
  * Bumped package version to 1.5.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->