### PR TITLE
In PC data tabs, node's label are links to detail view

### DIFF
--- a/changelog/+link-on-PC-label.added.md
+++ b/changelog/+link-on-PC-label.added.md
@@ -1,0 +1,1 @@
+In the Proposed Changes data tabs, each node label is now a clickable link that takes you to the updated object’s detail page.

--- a/frontend/app/src/entities/diff/node-diff/node.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
-import {Link, useLocation, useParams} from "react-router";
+import { Link, useLocation, useParams } from "react-router";
 
 import { QSP } from "@/config/qsp";
 

--- a/frontend/app/src/entities/diff/node-diff/node.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node.tsx
@@ -1,7 +1,9 @@
 import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
-import { useLocation, useParams } from "react-router";
+import {Link, useLocation, useParams} from "react-router";
+
+import { QSP } from "@/config/qsp";
 
 import Accordion from "@/shared/components/display/accordion";
 import { Badge } from "@/shared/components/ui/badge";
@@ -10,6 +12,7 @@ import { classNames } from "@/shared/utils/common";
 
 import type { DiffNode as DiffNodeType, PropertyType } from "@/entities/diff/node-diff/types";
 import { DiffBadge } from "@/entities/diff/node-diff/utils";
+import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 
 import { DiffNodeAttribute } from "./node-attribute";
@@ -50,7 +53,15 @@ export const DiffNode = ({ sourceBranch, destinationBranch, node }: DiffNodeProp
             <div className="group flex items-center gap-2 py-2 pr-2 text-xs">
               <DiffBadge status={node.status} hasConflicts={node.contains_conflict} />
               <Badge variant="white">{schemaKindName[node.kind] ?? node.kind}</Badge>
-              <span className="px-2 py-1 font-medium text-gray-800">{node.label}</span>
+              <Link
+                to={getObjectDetailsUrl(node.kind, node.uuid, [
+                  { name: QSP.BRANCH, value: destinationBranch },
+                ])}
+                className="px-2 py-1 font-medium text-gray-800 hover:text-custom-blue-800 hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {node.label}
+              </Link>
 
               {!branchName && node.path_identifier && <DiffThread path={node.path_identifier} />}
             </div>

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
@@ -28,7 +28,7 @@ test.describe("/proposed-changes diff data", () => {
 
     await test.step("check diff data", async () => {
       await expect(page.getByText("UpdatedInterfaceL3Ethernet1")).toBeVisible();
-      await expect(page.getByRole('link', { name: 'Ethernet1' })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Ethernet1" })).toBeVisible();
       await expect(page.getByText("UpdatedDeviceden1-edge1")).toBeVisible();
       await expect(page.getByRole("link", { name: "den1-edge1" })).toBeVisible();
       await page.getByText("UpdatedInterfaceL3Ethernet1").click();

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
@@ -28,7 +28,9 @@ test.describe("/proposed-changes diff data", () => {
 
     await test.step("check diff data", async () => {
       await expect(page.getByText("UpdatedInterfaceL3Ethernet1")).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Ethernet1' })).toBeVisible();
       await expect(page.getByText("UpdatedDeviceden1-edge1")).toBeVisible();
+      await expect(page.getByRole("link", { name: "den1-edge1" })).toBeVisible();
       await page.getByText("UpdatedInterfaceL3Ethernet1").click();
       await expect(
         page.getByText("UpdatedInterfaceL3Ethernet1 main den1-maintenance-")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Node labels in Proposed Changes data tabs are now clickable links that navigate to the updated object's detail page.

* **Tests**
  * Added link visibility verification in diff data tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->