### PR TITLE
IFC-1961 Add ability to clear out profile relationships on updates

### DIFF
--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -32,6 +32,7 @@ from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
 from infrahub.groups.ancestors import collect_ancestors
 from infrahub.permissions import get_global_permission_for_kind
+from infrahub.profiles.node_applier import NodeProfilesApplier
 
 from ..types import RelatedNodeInput
 
@@ -91,7 +92,7 @@ class RelationshipAdd(Mutation):
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
         rel_schema = source.get_schema().get_relationship(name=relationship_name)
-        display_label: str = await source.get_display_label(db=graphql_context.db) or ""
+        display_label = await source.get_display_label(db=graphql_context.db)
         node_changelog = NodeChangelog(
             node_id=source.get_id(), node_kind=source.get_kind(), display_label=display_label
         )
@@ -116,6 +117,11 @@ class RelationshipAdd(Mutation):
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.create_relationship(relationship=rel)
                     await rel.save(db=db)
+
+            if relationship_name == "profiles":
+                node_profiles_applier = NodeProfilesApplier(db=db, branch=graphql_context.branch)
+                await node_profiles_applier.apply_profiles(node=source)
+                await source.save(db=db)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
@@ -238,6 +244,11 @@ class RelationshipRemove(Mutation):
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.delete_relationship(relationship=rel)
                     await rel.delete(db=db)
+
+            if relationship_name == "profiles":
+                node_profiles_applier = NodeProfilesApplier(db=db, branch=graphql_context.branch)
+                await node_profiles_applier.apply_profiles(node=source)
+                await source.save(db=db)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -22,7 +22,7 @@ from infrahub.core.query.relationship import (
     RelationshipPeerData,
 )
 from infrahub.core.relationship import Relationship
-from infrahub.database import retry_db_transaction
+from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.events import EventMeta
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from infrahub.events.models import EventNode
@@ -39,6 +39,7 @@ from ..types import RelatedNodeInput
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
+    from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.core.relationship import RelationshipManager
     from infrahub.core.schema.relationship_schema import RelationshipSchema
@@ -119,9 +120,11 @@ class RelationshipAdd(Mutation):
                     await rel.save(db=db)
 
             if relationship_name == "profiles":
-                node_profiles_applier = NodeProfilesApplier(db=db, branch=graphql_context.branch)
-                await node_profiles_applier.apply_profiles(node=source)
-                await source.save(db=db)
+                await _apply_profiles(node=source, db=db, branch=graphql_context.branch)
+
+            if source.get_schema().is_profile_schema and relationship_name == "related_nodes":
+                for node in nodes.values():
+                    await _apply_profiles(node=node, db=db, branch=graphql_context.branch)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
@@ -246,9 +249,11 @@ class RelationshipRemove(Mutation):
                     await rel.delete(db=db)
 
             if relationship_name == "profiles":
-                node_profiles_applier = NodeProfilesApplier(db=db, branch=graphql_context.branch)
-                await node_profiles_applier.apply_profiles(node=source)
-                await source.save(db=db)
+                await _apply_profiles(node=source, db=db, branch=graphql_context.branch)
+
+            if source.get_schema().is_profile_schema and relationship_name == "related_nodes":
+                for node in nodes.values():
+                    await _apply_profiles(node=node, db=db, branch=graphql_context.branch)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
@@ -485,3 +490,11 @@ def _get_group_event_type(
             # Modifying the membership of the current node
             group_event_type = GroupUpdateType.MEMBER_OF_GROUPS
     return group_event_type
+
+
+async def _apply_profiles(node: Node, db: InfrahubDatabase, branch: Branch) -> None:
+    refreshed_node = await NodeManager.get_one(db=db, id=node.get_id(), branch=branch)
+    node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
+    updated_fields = await node_profiles_applier.apply_profiles(node=refreshed_node)
+    if updated_fields:
+        await refreshed_node.save(db=db, fields=updated_fields)

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1395,3 +1395,214 @@ async def test_relationship_read_only(
 
     assert remove_result.errors
     assert "'devices' is a read-only relationship at LocationSite" in str(remove_result.errors)
+
+
+async def test_relationship_add_remove_profiles(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema: None
+) -> None:
+    """Validates that profiles are applied when adding/removing profiles to a node."""
+    person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person.new(db=db, name="John Doe")
+    await person.save(db=db)
+
+    person_initial = await NodeManager.get_one(db=db, id=person.id, branch=default_branch)
+    assert person_initial.height.value is None
+    assert person_initial.height.is_default is True
+    assert person_initial.height.is_from_profile is False
+
+    profile_schema = registry.schema.get("ProfileTestPerson", branch=default_branch)
+    profile = await Node.init(db=db, schema=profile_schema, branch=default_branch)
+    await profile.new(db=db, profile_name="tall-person", profile_priority=100, height=185)
+    await profile.save(db=db)
+
+    profile_check = await NodeManager.get_one(db=db, id=profile.id, branch=default_branch)
+    assert profile_check.height.value == 185
+
+    add_query = """
+    mutation RelationshipAdd(
+        $id: String!,
+        $relationship_name: String!,
+        $node: String!,
+        ) {
+        RelationshipAdd(
+            data: {id: $id, name: $relationship_name, nodes: [{id: $node}]}
+        ) {
+        ok
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=add_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person.id, "relationship_name": "profiles", "node": profile.id},
+    )
+
+    assert result.errors is None
+
+    person_check = await NodeManager.get_one(db=db, id=person.id, branch=default_branch)
+    profiles = await person_check.profiles.get(db=db)
+    assert len(profiles) == 1
+    assert profiles[0].peer_id == profile.id
+
+    person_updated = await NodeManager.get_one(db=db, id=person.id, branch=default_branch, include_source=True)
+    assert person_updated.height.value == 185
+    assert person_updated.height.is_default is False
+    assert person_updated.height.is_from_profile is True
+    source = await person_updated.height.get_source(db=db)
+    assert source is not None
+    assert source.id == profile.id
+
+    remove_query = """
+    mutation RelationshipRemove(
+        $id: String!,
+        $relationship_name: String!,
+        $node: String!,
+        ) {
+        RelationshipRemove(
+            data: {id: $id, name: $relationship_name, nodes: [{id: $node}]}
+        ) {
+        ok
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=remove_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person.id, "relationship_name": "profiles", "node": profile.id},
+    )
+
+    assert result.errors is None
+
+    person_final = await NodeManager.get_one(db=db, id=person.id, branch=default_branch, include_source=True)
+    assert person_final.height.value is None
+    assert person_final.height.is_default is True
+    assert person_final.height.is_from_profile is False
+    source = await person_final.height.get_source(db=db)
+    assert source is None
+
+
+async def test_relationship_add_remove_related_nodes(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema: None
+) -> None:
+    """Validates that profiles are applied to related nodes when adding/removing related_nodes to a profile."""
+    person1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person1.new(db=db, name="Alice")
+    await person1.save(db=db)
+
+    person2 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person2.new(db=db, name="Bob")
+    await person2.save(db=db)
+
+    person1_initial = await NodeManager.get_one(db=db, id=person1.id, branch=default_branch)
+    assert person1_initial.height.value is None
+    assert person1_initial.height.is_default is True
+    assert person1_initial.height.is_from_profile is False
+
+    person2_initial = await NodeManager.get_one(db=db, id=person2.id, branch=default_branch)
+    assert person2_initial.height.value is None
+    assert person2_initial.height.is_default is True
+    assert person2_initial.height.is_from_profile is False
+
+    profile_schema = registry.schema.get("ProfileTestPerson", branch=default_branch)
+    profile = await Node.init(db=db, schema=profile_schema, branch=default_branch)
+    await profile.new(db=db, profile_name="tall-people", profile_priority=100, height=185)
+    await profile.save(db=db)
+
+    add_query = """
+    mutation RelationshipAdd(
+        $id: String!,
+        $relationship_name: String!,
+        $node_1: String!,
+        $node_2: String!,
+        ) {
+        RelationshipAdd(
+            data: {id: $id, name: $relationship_name, nodes: [{id: $node_1}, {id: $node_2}]}
+        ) {
+        ok
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=add_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": profile.id,
+            "relationship_name": "related_nodes",
+            "node_1": person1.id,
+            "node_2": person2.id,
+        },
+    )
+
+    assert result.errors is None
+
+    person1_updated = await NodeManager.get_one(db=db, id=person1.id, branch=default_branch, include_source=True)
+    assert person1_updated.height.value == 185
+    assert person1_updated.height.is_default is False
+    assert person1_updated.height.is_from_profile is True
+    source1 = await person1_updated.height.get_source(db=db)
+    assert source1 is not None
+    assert source1.id == profile.id
+
+    person2_updated = await NodeManager.get_one(db=db, id=person2.id, branch=default_branch, include_source=True)
+    assert person2_updated.height.value == 185
+    assert person2_updated.height.is_default is False
+    assert person2_updated.height.is_from_profile is True
+    source2 = await person2_updated.height.get_source(db=db)
+    assert source2 is not None
+    assert source2.id == profile.id
+
+    remove_query = """
+    mutation RelationshipRemove(
+        $id: String!,
+        $relationship_name: String!,
+        $node: String!,
+        ) {
+        RelationshipRemove(
+            data: {id: $id, name: $relationship_name, nodes: [{id: $node}]}
+        ) {
+        ok
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=remove_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": profile.id, "relationship_name": "related_nodes", "node": person1.id},
+    )
+
+    assert result.errors is None
+
+    person1_final = await NodeManager.get_one(db=db, id=person1.id, branch=default_branch, include_source=True)
+    assert person1_final.height.value is None
+    assert person1_final.height.is_default is True
+    assert person1_final.height.is_from_profile is False
+    source1_final = await person1_final.height.get_source(db=db)
+    assert source1_final is None
+
+    person2_final = await NodeManager.get_one(db=db, id=person2.id, branch=default_branch, include_source=True)
+    assert person2_final.height.value == 185
+    assert person2_final.height.is_default is False
+    assert person2_final.height.is_from_profile is True
+    source2_final = await person2_final.height.get_source(db=db)
+    assert source2_final is not None
+    assert source2_final.id == profile.id


### PR DESCRIPTION
This change makes sure that we run the `NodeProfilesApplier` when we mutate a relationship of some nodes by using the `RelationshipAdd` or `RelationshipRemove` mutations.

Previously, when adding or removing a profile via these mutations, the values of attributes were not updated according to what was in the profiles. This change fix this behaviour. Combined with changes from IFC-1953, it will also take care of applying or un-applying peers to relationships coming from profiles.