### PR TITLE
Display node labels using the following priority: display_label, then hfid, then id

### DIFF
--- a/changelog/display-labels.fixed.md
+++ b/changelog/display-labels.fixed.md
@@ -1,0 +1,1 @@
+Display node labels using the following priority: display_label, then hfid, then id.

--- a/frontend/app/src/entities/artifacts/ui/artifact-details.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-details.tsx
@@ -12,6 +12,7 @@ import { ArtifactFile } from "@/entities/artifacts/ui/artifact-file";
 import { NodeEvents } from "@/entities/events/ui/node-details-events";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { NodeDescription } from "@/entities/nodes/object/ui/node-description";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { ModelSchema } from "@/entities/schema/types";
 
 import ArtifactHeader from "./artifact-header";
@@ -46,7 +47,7 @@ export function ArtifactsDetails({ artifactId, artifactSchema }: ArtifactsDetail
       <Content.Card className="flex grow flex-col">
         <Col className="gap-3 p-4 pb-2">
           <ArtifactHeader
-            name={objectDetailsData?.display_label}
+            name={objectDetailsData ? getNodeLabel(objectDetailsData) : ""}
             status={objectDetailsData?.status?.value}
             id={artifactId}
             hfid={objectDetailsData?.hfid && JSON.stringify(objectDetailsData?.hfid)}

--- a/frontend/app/src/entities/diff/artifact-diff/artifact-repo-diff.tsx
+++ b/frontend/app/src/entities/diff/artifact-diff/artifact-repo-diff.tsx
@@ -8,6 +8,7 @@ import ErrorScreen from "@/shared/components/errors/error-screen";
 import NoDataFound from "@/shared/components/errors/no-data-found";
 
 import { getArtifactDetails } from "@/entities/artifacts/api/getArtifacts";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
 import "react-diff-view/style/index.css";
 
@@ -48,11 +49,11 @@ export const ArtifactRepoDiff = (props: any) => {
     return <NoDataFound message="No artifact diff" />;
   }
 
-  const artifact = data?.CoreArtifact?.edges[0]?.node?.object?.node?.display_label;
+  const artifactNode = data?.CoreArtifact?.edges[0]?.node?.object?.node;
 
   const title = (
     <div className="flex">
-      {artifact && <Badge className="mr-2">{artifact?.object?.node?.display_label}</Badge>}
+      {artifactNode && <Badge className="mr-2">{getNodeLabel(artifactNode)}</Badge>}
 
       {diff?.display_label}
     </div>

--- a/frontend/app/src/entities/diff/utils.tsx
+++ b/frontend/app/src/entities/diff/utils.tsx
@@ -7,7 +7,8 @@ import { LinkButton } from "@/shared/components/buttons/button-primitive";
 import { Badge } from "@/shared/components/ui/badge";
 import { Tooltip } from "@/shared/components/ui/tooltip";
 
-import { NodeLabel } from "../nodes/object/ui/node-label";
+import { NodeLabel } from "@/entities/nodes/object/ui/node-label";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 function extractNodeId(path: string) {
   // Expect an ID immediately following "data/"; support optional leading slash
@@ -34,6 +35,10 @@ export const displayValue = (value: any) => {
 
   if (value === "NULL") {
     return "-";
+  }
+
+  if (value && typeof value === "object" && "__typename" in value && "id" in value) {
+    return getNodeLabel(value);
   }
 
   return value?.display_label || value || "-";

--- a/frontend/app/src/entities/events/ui/filters/global-filter-tag.tsx
+++ b/frontend/app/src/entities/events/ui/filters/global-filter-tag.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { Tag, type TagProps } from "react-aria-components";
 
 import { focusVisibleStyle } from "@/shared/components/style-rac";
@@ -6,7 +5,7 @@ import type { Filter } from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";
 
 type FilterTagProps = {
-  label: ReactNode;
+  label: string;
   currentFilter?: Filter;
 } & TagProps;
 

--- a/frontend/app/src/entities/events/ui/filters/global-filter-tag.tsx
+++ b/frontend/app/src/entities/events/ui/filters/global-filter-tag.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Tag, type TagProps } from "react-aria-components";
 
 import { focusVisibleStyle } from "@/shared/components/style-rac";
@@ -5,7 +6,7 @@ import type { Filter } from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";
 
 type FilterTagProps = {
-  label: string;
+  label: ReactNode;
   currentFilter?: Filter;
 } & TagProps;
 

--- a/frontend/app/src/entities/events/ui/filters/global-filter.tsx
+++ b/frontend/app/src/entities/events/ui/filters/global-filter.tsx
@@ -6,6 +6,7 @@ import type { TagProps } from "react-aria-components";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import useFilters from "@/shared/hooks/useFilters";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
 import { GlobalFilterForm } from "./global-filter-form";
@@ -41,7 +42,7 @@ export function GlobalFilter({ label, name, fieldSchema, ...props }: FilterTagPr
     if (Array.isArray(currentFilter?.value)) {
       return currentFilter?.value
         .map((value) => {
-          return value.display_label;
+          return getNodeLabel(value);
         })
         .join(", ");
     }

--- a/frontend/app/src/entities/events/ui/filters/global-kind-filter.tsx
+++ b/frontend/app/src/entities/events/ui/filters/global-kind-filter.tsx
@@ -6,6 +6,8 @@ import type { TagProps } from "react-aria-components";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import useFilters from "@/shared/hooks/useFilters";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
+import type { NodeCore } from "@/entities/nodes/types";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
 import { FilterTag } from "./global-filter-tag";
@@ -29,8 +31,8 @@ export function GlobalKindFilter({ label, name, fieldSchema, ...props }: FilterT
 
   const getFilterDisplayValue = () => {
     return currentFilter?.value
-      .map((value) => {
-        return value.display_label;
+      .map((value: NodeCore) => {
+        return getNodeLabel(value);
       })
       .join(", ");
   };

--- a/frontend/app/src/entities/events/ui/node-details-events.tsx
+++ b/frontend/app/src/entities/events/ui/node-details-events.tsx
@@ -9,6 +9,7 @@ import { LoadingIndicator } from "@/shared/components/loading/loading-indicator"
 import { Link } from "@/shared/components/ui/link";
 
 import { useNodeLabel } from "@/entities/nodes/object/api/get-display-label.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 import { useGetEvents } from "../domain/get-events.query";
 import { EventCard } from "./event-card";
@@ -60,7 +61,7 @@ export const NodeEvents = ({
 
   const filter = {
     name: "relatedNodeIds__value",
-    value: [{ id: objectId, display_label: displayLabelData.display_label }],
+    value: [{ id: objectId, display_label: getNodeLabel(displayLabelData) }],
   };
 
   return (

--- a/frontend/app/src/entities/graphql/ui/graphql-query-details-card.tsx
+++ b/frontend/app/src/entities/graphql/ui/graphql-query-details-card.tsx
@@ -16,6 +16,7 @@ import {
   type AttributeType,
   ObjectAttributeValue,
 } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { Permission } from "@/entities/permission/types";
 import type { ModelSchema } from "@/entities/schema/types";
@@ -64,7 +65,7 @@ const GraphqlQueryDetailsTitle = ({
         <Badge variant="blue">{schema.namespace}</Badge>
 
         <span>
-          {schema.name} - {data.display_label}
+          {schema.name} - {getNodeLabel(data)}
         </span>
 
         <ObjectEditSlideOverTrigger
@@ -144,7 +145,7 @@ const GraphqlQueryPropertyList = ({
             value: relationshipData?.map(({ node, properties }: any) => (
               <div key={node.id} className="flex items-center justify-between">
                 <Link to={getObjectDetailsUrl(node.__typename, node.id)}>
-                  {node?.display_label}
+                  {node ? getNodeLabel(node) : ""}
                 </Link>
 
                 {properties.is_protected && <ProtectedIcon />}
@@ -173,7 +174,7 @@ const GraphqlQueryPropertyList = ({
           value: relationshipData && (
             <div className="flex items-center justify-between">
               <Link to={getObjectDetailsUrl(relationshipData.__typename, relationshipData.id)}>
-                {relationshipData?.display_label}
+                {relationshipData ? getNodeLabel(relationshipData) : ""}
               </Link>
 
               <div className="flex items-center">

--- a/frontend/app/src/entities/groups/ui/add-group-trigger-button.tsx
+++ b/frontend/app/src/entities/groups/ui/add-group-trigger-button.tsx
@@ -8,6 +8,7 @@ import SlideOver, { SlideOverTitle } from "@/shared/components/display/slide-ove
 import type { GroupDataFromAPI } from "@/entities/groups/api/types";
 import AddGroupForm from "@/entities/groups/ui/add-group-form";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { Permission } from "@/entities/permission/types";
 import type { NodeSchema } from "@/entities/schema/types";
 
@@ -48,7 +49,7 @@ export default function AddGroupTriggerButton({
         title={
           <SlideOverTitle
             schema={schema}
-            currentObjectLabel={objectDetailsData?.display_label}
+            currentObjectLabel={objectDetailsData ? getNodeLabel(objectDetailsData) : ""}
             title="Select group(s)"
             subtitle="Select one or more groups to assign"
           />

--- a/frontend/app/src/entities/groups/ui/groups-manager-trigger-button.tsx
+++ b/frontend/app/src/entities/groups/ui/groups-manager-trigger-button.tsx
@@ -6,6 +6,7 @@ import SlideOver, { SlideOverTitle } from "@/shared/components/display/slide-ove
 
 import { GroupsManager, type GroupsManagerProps } from "@/entities/groups/ui/groups-manager";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { Permission } from "@/entities/permission/types";
 
 export interface GroupsManagerTriggerProps extends ButtonProps, GroupsManagerProps {
@@ -43,7 +44,7 @@ export const GroupsManagerTriggerButton = ({
         title={
           <SlideOverTitle
             schema={schema}
-            currentObjectLabel={objectDetailsData?.display_label}
+            currentObjectLabel={objectDetailsData ? getNodeLabel(objectDetailsData) : ""}
             title="Manage groups"
             subtitle="Add and unassign groups"
           />

--- a/frontend/app/src/entities/groups/ui/groups-manager.tsx
+++ b/frontend/app/src/entities/groups/ui/groups-manager.tsx
@@ -14,6 +14,7 @@ import { getGroupsQuery } from "@/entities/groups/api/getGroups";
 import type { GroupDataFromAPI } from "@/entities/groups/api/types";
 import AddGroupTriggerButton from "@/entities/groups/ui/add-group-trigger-button";
 import ObjectGroupsList from "@/entities/groups/ui/object-groups-list";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getPermission } from "@/entities/permission/utils";
 import type { ModelSchema } from "@/entities/schema/types";
 
@@ -77,7 +78,7 @@ export const GroupsManager = ({ className, schema, objectId }: GroupsManagerProp
     query === ""
       ? currentObjectGroups
       : currentObjectGroups.filter((group) =>
-          group.display_label.toLowerCase().includes(query.toLowerCase())
+          getNodeLabel(group).toLowerCase().includes(query.toLowerCase())
         );
 
   const filteredVisibleGroups = groupsFilteredBySearch.filter(

--- a/frontend/app/src/entities/groups/ui/object-groups-list.tsx
+++ b/frontend/app/src/entities/groups/ui/object-groups-list.tsx
@@ -14,6 +14,7 @@ import { Tooltip } from "@/shared/components/ui/tooltip";
 import { pluralize } from "@/shared/utils/string";
 
 import type { GroupDataFromAPI } from "@/entities/groups/api/types";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { useRemoveRelationships } from "@/entities/nodes/relationships/domain/remove-relationships/remove-relationships.mutation";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
@@ -54,7 +55,7 @@ const ObjectGroupItem = ({ objectId, group }: ObjectGroupProps) => {
           to={getObjectDetailsUrl(group.__typename, group.id)}
           className="block truncate font-semibold hover:underline"
         >
-          {group.display_label}
+          {getNodeLabel(group)}
         </Link>
 
         <div className="flex items-center gap-2">
@@ -118,7 +119,7 @@ const RemoveGroupButton = ({ objectId, group }: ObjectGroupProps) => {
 
       <ModalDelete
         title="Leave Group"
-        description={`Are you sure you want to leave group ${group.display_label}?`}
+        description={`Are you sure you want to leave group ${getNodeLabel(group)}?`}
         onCancel={() => setShowDeleteModal(false)}
         onDelete={handleRemoveGroup}
         open={showDeleteModal}

--- a/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-details.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-details.tsx
@@ -6,6 +6,7 @@ import { Link } from "@/shared/components/ui/link";
 import { IP_SUMMARY_RELATIONSHIPS_BLACKLIST } from "@/entities/ipam/constants";
 import { ObjectAttributeValue } from "@/entities/nodes/getObjectItemDisplayValue";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { isRelationshipVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import type { NodeRelationshipMany, NodeRelationshipOne } from "@/entities/nodes/types";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
@@ -70,7 +71,7 @@ export function IpAddressDetails({ ipAddressSchema, ipAddressId }: IpAddressDeta
             name,
             value: relationshipData ? (
               <Link to={getObjectDetailsUrl(relationshipData.__typename, relationshipData.id)}>
-                {relationshipData?.display_label}
+                {getNodeLabel(relationshipData)}
               </Link>
             ) : null,
           };
@@ -96,7 +97,7 @@ export function IpAddressDetails({ ipAddressSchema, ipAddressId }: IpAddressDeta
 
                 return (
                   <Link key={node?.id} to={getObjectDetailsUrl(node.__typename, node.id)}>
-                    {node.display_label}
+                    {getNodeLabel(node)}
                   </Link>
                 );
               })}

--- a/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
@@ -18,6 +18,7 @@ import { TableIdentifierHeader } from "@/entities/nodes/object/ui/object-table/c
 import { TableRelationshipCell } from "@/entities/nodes/object/ui/object-table/cells/table-relationship-cell";
 import { getObjectGenericColumns } from "@/entities/nodes/object/ui/object-table/utils/get-object-table-columns";
 import { getToggleSelectedRowHandler } from "@/entities/nodes/object/ui/object-table/utils/get-toggle-selected-row-handler";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeAttribute, NodeObject, NodeRelationship } from "@/entities/nodes/types";
 import type { ModelSchema } from "@/entities/schema/types";
 
@@ -43,11 +44,12 @@ export const getIpAddressTableColumns = (
           />
         );
       },
-      cell: ({ cell, row, table }) => {
-        const displayLabel: string = cell.getValue() ?? "-";
+      cell: ({ row, table }) => {
+        const value: string = getNodeLabel(row.original) ?? "-";
+        const ipAdressNode = row.original;
 
-        if (row.original.__typename === IP_ADDRESS_AVAILABLE_KIND) {
-          const ipAddressAvailableNode = row.original as IpAddressAvailableNode;
+        if (ipAdressNode.__typename === IP_ADDRESS_AVAILABLE_KIND) {
+          const ipAddressAvailableNode = ipAdressNode as IpAddressAvailableNode;
 
           return (
             <>
@@ -58,7 +60,7 @@ export const getIpAddressTableColumns = (
               </StickyLeftCell>
 
               <TableCell className={classNames(cellMutedStyle, "-col-end-2 col-start-2")}>
-                {displayLabel}
+                {ipAdressNode.display_label}
               </TableCell>
             </>
           );
@@ -66,9 +68,9 @@ export const getIpAddressTableColumns = (
 
         return (
           <TableIdentifierCell
-            objectKind={row.original.__typename as string}
-            objectId={row.original.id as string}
-            label={displayLabel}
+            objectKind={ipAdressNode.__typename as string}
+            objectId={ipAdressNode.id as string}
+            label={value}
             isSelected={row.getIsSelected()}
             onClickCheckbox={getToggleSelectedRowHandler({ row, table })}
           />

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
@@ -29,7 +29,6 @@ export function IpPrefixAvailableIdentifier({
   const parentNode = ipPrefixNode.parent?.node;
   const ancestorsCount: number = (parentNode?.ancestors?.count ?? 0) + 1;
   const isCreationAllowed = permission.create.isAllowed;
-  console.log("ipPrefixNode: ", ipPrefixNode);
 
   return (
     <>

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
@@ -12,7 +12,6 @@ import { classNames } from "@/shared/utils/common";
 import type { IpPrefixNode } from "@/entities/ipam/ip-prefixes/types";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
-import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 export interface IpPrefixAvailableIdentifierProps extends ButtonProps {
   ipPrefixNode: IpPrefixNode;
@@ -78,7 +77,7 @@ export function IpPrefixAvailableIdentifier({
             setIsCreateFormOpen(false);
             queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
           }}
-          currentObject={{ prefix: { value: getNodeLabel(ipPrefixNode) } }}
+          currentObject={{ prefix: { value: ipPrefixNode.display_label } }}
           onCancel={() => setIsCreateFormOpen(false)}
           kind={selectedSchema.kind!}
         />

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
@@ -29,6 +29,7 @@ export function IpPrefixAvailableIdentifier({
   const parentNode = ipPrefixNode.parent?.node;
   const ancestorsCount: number = (parentNode?.ancestors?.count ?? 0) + 1;
   const isCreationAllowed = permission.create.isAllowed;
+  console.log("ipPrefixNode: ", ipPrefixNode);
 
   return (
     <>
@@ -56,7 +57,7 @@ export function IpPrefixAvailableIdentifier({
             {[...Array(ancestorsCount)].map((_, i) => (
               <div className="size-1 rounded-full bg-gray-300" key={i} />
             ))}
-            {getNodeLabel(ipPrefixNode)}
+            {ipPrefixNode.display_label}
           </Row>
         </Button>
       </Tooltip>

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-available-identifier.tsx
@@ -12,6 +12,7 @@ import { classNames } from "@/shared/utils/common";
 import type { IpPrefixNode } from "@/entities/ipam/ip-prefixes/types";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 export interface IpPrefixAvailableIdentifierProps extends ButtonProps {
   ipPrefixNode: IpPrefixNode;
@@ -55,7 +56,7 @@ export function IpPrefixAvailableIdentifier({
             {[...Array(ancestorsCount)].map((_, i) => (
               <div className="size-1 rounded-full bg-gray-300" key={i} />
             ))}
-            {ipPrefixNode.display_label}
+            {getNodeLabel(ipPrefixNode)}
           </Row>
         </Button>
       </Tooltip>
@@ -77,7 +78,7 @@ export function IpPrefixAvailableIdentifier({
             setIsCreateFormOpen(false);
             queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
           }}
-          currentObject={{ prefix: { value: ipPrefixNode.display_label } }}
+          currentObject={{ prefix: { value: getNodeLabel(ipPrefixNode) } }}
           onCancel={() => setIsCreateFormOpen(false)}
           kind={selectedSchema.kind!}
         />

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-details.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-details.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/shared/components/ui/link";
 import { IP_SUMMARY_RELATIONSHIPS_BLACKLIST } from "@/entities/ipam/constants";
 import { ObjectAttributeValue } from "@/entities/nodes/getObjectItemDisplayValue";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { isRelationshipVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import type {
   NodeAttribute,
@@ -91,7 +92,7 @@ export function IpPrefixDetails({ prefixSchema, prefixId }: IpPrefixDetailsProps
             name,
             value: relationshipData ? (
               <Link to={getObjectDetailsUrl(relationshipData.__typename, relationshipData.id)}>
-                {relationshipData?.display_label}
+                {getNodeLabel(relationshipData)}
               </Link>
             ) : null,
           };
@@ -117,7 +118,7 @@ export function IpPrefixDetails({ prefixSchema, prefixId }: IpPrefixDetailsProps
 
                 return (
                   <Link key={node?.id} to={getObjectDetailsUrl(node.__typename, node.id)}>
-                    {node.display_label}
+                    {getNodeLabel(node)}
                   </Link>
                 );
               })}

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
@@ -10,6 +10,7 @@ import { IP_ADDRESS_GENERIC, IP_PREFIX_GENERIC } from "@/entities/ipam/constants
 import { useGetNextIpAddressAvailable } from "@/entities/ipam/ip-addresses/domain/get-next-ip-address-available.query";
 import { useGetNextIpPrefixAvailable } from "@/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.query";
 import { useCreateObjectMutation } from "@/entities/nodes/object/domain/create-object.mutation";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { useAllocateResourceMutation } from "@/entities/resource-manager/domain/allocate-resource.mutation";
 import { getAllocateMutationNameFromSchema } from "@/entities/resource-manager/utils/get-allocate-mutation-name-from-schema";
 import { isOfKind } from "@/entities/schema/utils/is-of-kind";

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
@@ -54,7 +54,7 @@ function IpamCreationForm(props: IpamCreationFormProps) {
       () => (
         <Alert
           type={ALERT_TYPES.SUCCESS}
-          message={`${props.schema.label} ${newNode.display_label} created`}
+          message={`${props.schema.label} ${getNodeLabel(newNode)} created`}
         />
       ),
       {

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
@@ -142,6 +142,6 @@ const RelationshipDisplay = ({ className, node, ...props }: RelationshipDisplayP
     className={classNames("inline-flex underline decoration-dotted", className)}
     {...props}
   >
-    {node.display_label}
+    {getNodeLabel(node)}
   </Link>
 );

--- a/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
@@ -19,6 +19,7 @@ import { TableIdentifierHeader } from "@/entities/nodes/object/ui/object-table/c
 import { TableRelationshipCell } from "@/entities/nodes/object/ui/object-table/cells/table-relationship-cell";
 import { getObjectGenericColumns } from "@/entities/nodes/object/ui/object-table/utils/get-object-table-columns";
 import { getToggleSelectedRowHandler } from "@/entities/nodes/object/ui/object-table/utils/get-toggle-selected-row-handler";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/utils/get-relationships-visible-in-list-view";
 import type { NodeAttribute, NodeObject, NodeRelationship } from "@/entities/nodes/types";
 import type { ModelSchema } from "@/entities/schema/types";
@@ -42,8 +43,8 @@ export const getIpPrefixTableColumns = (schema: ModelSchema): Array<ColumnDef<No
           />
         );
       },
-      cell: ({ cell, row, table }) => {
-        const value: string = cell.getValue() ?? "-";
+      cell: ({ row, table }) => {
+        const value: string = getNodeLabel(row.original) ?? "-";
         const ipPrefixNode = row.original;
 
         if (ipPrefixNode.__typename === IP_PREFIX_AVAILABLE_KIND) {

--- a/frontend/app/src/entities/ipam/ipam-breadcrumb.tsx
+++ b/frontend/app/src/entities/ipam/ipam-breadcrumb.tsx
@@ -10,6 +10,7 @@ import { IP_ADDRESS_GENERIC, IP_PREFIX_GENERIC } from "@/entities/ipam/constants
 import { constructPathForIpam } from "@/entities/ipam/utils";
 import { useGetObjectAncestors } from "@/entities/nodes/hierarchy/domain/get-object-ancestors.query";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { isRelationshipVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import type { NodeCoreWithParent, NodeRelationshipOne } from "@/entities/nodes/types";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
@@ -145,7 +146,7 @@ function RecursiveAncestorBreadcrumb({
       <IpamBreadcrumbSeparator />
 
       <IpamBreadcrumbLink to={getObjectDetailsUrl(currentObject.__typename, currentObject.id)}>
-        {currentObject.display_label}
+        {getNodeLabel(currentObject)}
       </IpamBreadcrumbLink>
     </>
   );
@@ -189,7 +190,7 @@ function IpAddressBreadcrumb({ objectSchema, objectId }: IpAddressBreadcrumbProp
       <IpamBreadcrumbSeparator />
 
       <IpamBreadcrumbLink to={getObjectDetailsUrl(data.__typename, data.id)}>
-        {data.display_label}
+        {getNodeLabel(data)}
       </IpamBreadcrumbLink>
     </>
   );

--- a/frontend/app/src/entities/nodes/convert/ui/convert-source-relationship-one-input.tsx
+++ b/frontend/app/src/entities/nodes/convert/ui/convert-source-relationship-one-input.tsx
@@ -18,6 +18,7 @@ import {
   SourceOptionValue,
 } from "@/entities/nodes/convert/ui/source-option-item";
 import type { Node } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 export const ConvertSourceRelationshipOneInput = ({
   sourceObject,
@@ -56,7 +57,7 @@ export const ConvertSourceRelationshipOneInput = ({
       <ComboboxTrigger className={className}>
         {currentOption && (
           <SourceOptionValue
-            optionLabel={currentOption?.value?.display_label || "-"}
+            optionLabel={currentOption?.value ? getNodeLabel(currentOption.value) : "-"}
             sourceFieldName={currentOption.source?.label}
           />
         )}
@@ -83,7 +84,7 @@ export const ConvertSourceRelationshipOneInput = ({
                 }}
               >
                 <SourceOptionItem
-                  optionLabel={option.value?.display_label || "-"}
+                  optionLabel={option.value ? getNodeLabel(option.value) : "-"}
                   isDefaultMatch={option.isDefaultMatch}
                   sourceFieldName={option.source?.label}
                 />

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -35,7 +35,6 @@ const getTextValue = (data: any) => {
   }
 
   return (
-    getNodeLabel(data) ??
     data?.label ??
     data?.display_label ??
     data?.value ??

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -90,7 +90,7 @@ export const getDisplayValue = (
 
   if (row[attribute?.name]?.edges) {
     const items = row[attribute?.name]?.edges
-      .map((edge: any) => edge?.node?.display_label ?? edge?.node?.value ?? "-")
+      .map((edge: any) => (edge?.node ? getNodeLabel(edge.node) : edge?.node?.value ?? "-"))
       .slice(0, 5);
 
     const rest = row[attribute?.name]?.edges?.slice(5)?.length;

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -24,6 +24,7 @@ import { CodeViewer } from "@/shared/components/editor/code/code-viewer";
 import { MarkdownRender } from "@/shared/components/editor/markdown/markdown-render";
 import { Link } from "@/shared/components/ui/link";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { ATTRIBUTE_KIND } from "@/entities/schema/constants";
 import type { iSchemaKindNameMap } from "@/entities/schema/stores/schemaKindName.atom";
 import type { AttributeKind, AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
@@ -34,6 +35,7 @@ const getTextValue = (data: any) => {
   }
 
   return (
+    getNodeLabel(data) ??
     data?.label ??
     data?.display_label ??
     data?.value ??

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -90,7 +90,7 @@ export const getDisplayValue = (
 
   if (row[attribute?.name]?.edges) {
     const items = row[attribute?.name]?.edges
-      .map((edge: any) => (edge?.node ? getNodeLabel(edge.node) : edge?.node?.value ?? "-"))
+      .map((edge: any) => (edge?.node ? getNodeLabel(edge.node) : (edge?.node?.value ?? "-")))
       .slice(0, 5);
 
     const rest = row[attribute?.name]?.edges?.slice(5)?.length;

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -30,8 +30,9 @@ import type { iSchemaKindNameMap } from "@/entities/schema/stores/schemaKindName
 import type { AttributeKind, AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
 const getTextValue = (data: any) => {
-  if (typeof data === "string" || typeof data === "number") {
-    return data;
+  // If data.node is a node object, use getNodeLabel
+  if (data?.node && "__typename" in data.node && "id" in data.node) {
+    return data?.label ?? getNodeLabel(data.node) ?? data?.value ?? "-";
   }
 
   return (

--- a/frontend/app/src/entities/nodes/object-header.tsx
+++ b/frontend/app/src/entities/nodes/object-header.tsx
@@ -9,6 +9,7 @@ import useFilters from "@/shared/hooks/useFilters";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeAttribute } from "@/entities/nodes/types";
 import type { ModelSchema } from "@/entities/schema/types";
 
@@ -69,7 +70,7 @@ export function ObjectDetailsHeader({ schema, objectId }: ObjectDetailsHeaderPro
     <Skeleton className="h-6 w-60" />
   ) : (
     <div className="flex items-center gap-3">
-      {objectDetailsData?.display_label ?? `${schema.label} not found`}
+      {objectDetailsData ? getNodeLabel(objectDetailsData) : `${schema.label} not found`}
 
       <ObjectDetailsButton
         id={objectId}

--- a/frontend/app/src/entities/nodes/object-item-details/action-buttons/details-buttons.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/action-buttons/details-buttons.tsx
@@ -19,6 +19,7 @@ import { GeneratorDefinitionRunButton } from "@/entities/generators/ui/generator
 import { GeneratorRunButton } from "@/entities/generators/ui/generator-run-button";
 import { GroupsManagerTriggerButton } from "@/entities/groups/ui/groups-manager-trigger-button";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import ObjectItemEditComponent from "@/entities/nodes/object-item-edit/object-item-edit-paginated";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { Permission } from "@/entities/permission/types";
@@ -100,8 +101,8 @@ export function DetailsButtons({ schema, objectDetailsData, permission }: Detail
         title={
           <SlideOverTitle
             schema={schema}
-            currentObjectLabel={objectDetailsData.display_label}
-            title={`Edit ${objectDetailsData.display_label}`}
+            currentObjectLabel={getNodeLabel(objectDetailsData)}
+            title={`Edit ${getNodeLabel(objectDetailsData)}`}
             subtitle={schema.description}
           />
         }

--- a/frontend/app/src/entities/nodes/object-item-details/object-item-details-paginated.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/object-item-details-paginated.tsx
@@ -23,6 +23,7 @@ import { NodeEvents } from "@/entities/events/ui/node-details-events";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 import { ObjectDetailsContent } from "@/entities/nodes/object/ui/object-details-content";
 import { ObjectDetailsTab, RelationshipTab } from "@/entities/nodes/object/ui/object-tabs";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getRelationshipsVisibleInTab } from "@/entities/nodes/object/utils/get-relationships-visible-in-tab";
 import { ActionButtons } from "@/entities/nodes/object-item-details/action-buttons";
 import ObjectItemMetaEdit from "@/entities/nodes/object-item-meta-edit/object-item-meta-edit";
@@ -87,8 +88,8 @@ export default function ObjectItemDetails({
   const relationshipsTabs = getRelationshipsVisibleInTab(schema.relationships ?? []);
 
   useTitle(
-    objectDetailsData?.display_label
-      ? `${objectDetailsData?.display_label} details`
+    objectDetailsData
+      ? `${getNodeLabel(objectDetailsData)} details`
       : `${schema.label} details`
   );
 

--- a/frontend/app/src/entities/nodes/object-item-details/object-item-details-paginated.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/object-item-details-paginated.tsx
@@ -88,9 +88,7 @@ export default function ObjectItemDetails({
   const relationshipsTabs = getRelationshipsVisibleInTab(schema.relationships ?? []);
 
   useTitle(
-    objectDetailsData
-      ? `${getNodeLabel(objectDetailsData)} details`
-      : `${schema.label} details`
+    objectDetailsData ? `${getNodeLabel(objectDetailsData)} details` : `${schema.label} details`
   );
 
   if (!objectDetailsData) {

--- a/frontend/app/src/entities/nodes/object-item-details/relationship-details-paginated.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/relationship-details-paginated.tsx
@@ -23,6 +23,7 @@ import { stringifyWithoutQuotes } from "@/shared/utils/string";
 
 import { currentBranchAtom } from "@/entities/branches/stores";
 import { updateObjectWithId } from "@/entities/nodes/api/updateObjectWithId";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import ObjectItemEditComponent from "@/entities/nodes/object-item-edit/object-item-edit-paginated";
 import { getSchemaObjectColumns } from "@/entities/nodes/object-items/getSchemaObjectColumns";
 import { ObjectItemsCell, TextCell } from "@/entities/nodes/object-items/object-items-cell";
@@ -180,7 +181,7 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                         relationshipsData.node?.id
                       )}
                     >
-                      {relationshipsData.node?.display_label}
+                      {relationshipsData.node ? getNodeLabel(relationshipsData.node) : "-"}
                     </StyledLink>
                   ) : (
                     "-"
@@ -324,7 +325,7 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                   {relationshipsData?.map(({ node, properties }: any) => (
                     <dd className="flex items-center text-gray-900 underline" key={node.id}>
                       <Link to={getObjectDetailsUrl(node.__typename, node.id)}>
-                        {node.display_label}
+                        {getNodeLabel(node)}
                       </Link>
 
                       {node && (
@@ -356,10 +357,10 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
           description={
             <>
               Are you sure you want to remove the association between{" "}
-              <b>`{props.parentNode.display_label}`</b> and{" "}
-              <b>`{relatedRowToDelete.display_label}`</b>? The{" "}
+              <b>`{getNodeLabel(props.parentNode)}`</b> and{" "}
+              <b>`{getNodeLabel(relatedRowToDelete)}`</b>? The{" "}
               <b>`{relatedRowToDelete.__typename.replace(regex, "")}`</b>{" "}
-              <b>`{relatedRowToDelete.display_label}`</b> won&apos;t be deleted in the process.
+              <b>`{getNodeLabel(relatedRowToDelete)}`</b> won&apos;t be deleted in the process.
             </>
           }
           onCancel={() => setRelatedRowToDelete(undefined)}
@@ -381,7 +382,7 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
               <SlideOverTitle
                 schema={parentSchema}
                 currentObjectLabel={relationshipSchema.label}
-                title={`Edit ${relatedObjectToEdit?.display_label}`}
+                title={`Edit ${relatedObjectToEdit ? getNodeLabel(relatedObjectToEdit) : ""}`}
                 subtitle="Update the details of the related object"
               />
             )

--- a/frontend/app/src/entities/nodes/object-items/object-items-cell.tsx
+++ b/frontend/app/src/entities/nodes/object-items/object-items-cell.tsx
@@ -9,6 +9,7 @@ import {
   type RelationshipManyType,
   type RelationshipOneType,
 } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
@@ -57,7 +58,7 @@ export const RelationshipOneCell = ({ data }: { data: RelationshipOneType }) => 
       to={getObjectDetailsUrl(data.node.__typename, data.node.id)}
       className="hover:underline"
     >
-      {data.node.display_label}
+      {getNodeLabel(data.node)}
     </LinkCell>
   );
 };
@@ -71,7 +72,7 @@ export const RelationshipManyCell = ({ data }: { data: RelationshipManyType }) =
         return (
           <Link key={node.id} to={getObjectDetailsUrl(node.__typename, node.id)}>
             <Badge className="font-medium hover:bg-gray-200 hover:underline">
-              {node.display_label}
+              {getNodeLabel(node)}
             </Badge>
           </Link>
         );

--- a/frontend/app/src/entities/nodes/object/ui/node-label.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/node-label.tsx
@@ -3,6 +3,8 @@ import { NODE_OBJECT } from "@/config/constants";
 import { Skeleton } from "@/shared/components/skeleton";
 import { classNames } from "@/shared/utils/common";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
+
 import { useNodeLabel } from "../api/get-display-label.query";
 
 type NodeLabelProps = {
@@ -23,9 +25,9 @@ export const NodeLabel = ({ id, kind = NODE_OBJECT, branch, className }: NodeLab
     return <div className="italic">No id provided</div>;
   }
 
-  if (error || !data?.display_label) {
+  if (error || !data) {
     return <div className={classNames("italic", className)}>{id}</div>;
   }
 
-  return <div className={className}>{data?.display_label}</div>;
+  return <div className={className}>{getNodeLabel(data)}</div>;
 };

--- a/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
@@ -7,6 +7,7 @@ import { ListBox, ListBoxItem, ListBoxLoadMoreItem } from "@/shared/components/a
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import { debounce } from "@/shared/utils/common";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
 import { useRelationships } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships.query";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
@@ -41,13 +42,17 @@ export function ObjectAutocomplete({
       >
         <ListBox className={className}>
           <Collection items={flatData}>
-            {({ id, display_label, __typename }) => {
-              const { schema } = getSchema(__typename);
+            {(node) => {
+              const { schema } = getSchema(node.__typename);
+              const nodeLabel = getNodeLabel(node);
 
               return (
-                <ListBoxItem textValue={display_label} href={getObjectDetailsUrl(__typename, id)}>
+                <ListBoxItem
+                  textValue={nodeLabel}
+                  href={getObjectDetailsUrl(node.__typename, node.id)}
+                >
                   <Icon icon={getSchemaIcon(schema)} />
-                  <span className="truncate">{display_label}</span>
+                  <span className="truncate">{nodeLabel}</span>
                 </ListBoxItem>
               );
             }}

--- a/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
@@ -54,7 +54,7 @@ describe("getNodeLabel", () => {
     expect(result).toBe("test-id");
   });
 
-  it("should prefer hfid over display_label when both are available", () => {
+  it("should prefer display_label over hfid when both are available", () => {
     // GIVEN
     const node: NodeCore = {
       ...baseNode,
@@ -66,7 +66,34 @@ describe("getNodeLabel", () => {
     const result = getNodeLabel(node);
 
     // THEN
+    expect(result).toBe("Display Label");
+  });
+
+  it("should prefer hfid when display_label is not available", () => {
+    // GIVEN
+    const node: NodeCore = {
+      ...baseNode,
+      hfid: ["hfid-1"],
+    };
+
+    // WHEN
+    const result = getNodeLabel(node);
+
+    // THEN
     expect(result).toBe("hfid-1");
+  });
+
+  it("should prefer id when hfid is not available", () => {
+    // GIVEN
+    const node: NodeCore = {
+      ...baseNode,
+    };
+
+    // WHEN
+    const result = getNodeLabel(node);
+
+    // THEN
+    expect(result).toBe("test-id");
   });
 
   it("should fallback to node.id when special labels are null", () => {

--- a/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeCore } from "@/entities/nodes/types";
 import { getSchema } from "@/entities/schema/domain/get-schema";
 
 import { generateNodeSchema } from "../../../../../tests/fake/schema";
-import { getNodeLabel } from "./get-node-label";
 
 vi.mock("@/entities/schema/domain/get-schema", () => ({
   getSchema: vi.fn(() => ({

--- a/frontend/app/src/entities/nodes/object/utils/get-node-label.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-node-label.ts
@@ -6,12 +6,12 @@ export function getNodeLabel(node: NodeCore): string {
 
   if (!schema) return node.id;
 
-  if (schema.human_friendly_id && node.hfid?.length) {
-    return node.hfid.join(", ");
-  }
-
   if ((schema.display_label || schema.display_labels) && node.display_label) {
     return node.display_label;
+  }
+
+  if (schema.human_friendly_id && node.hfid?.length) {
+    return node.hfid.join(", ");
   }
 
   return node.id;

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-combobox-list.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-combobox-list.tsx
@@ -10,6 +10,7 @@ import {
 import { Spinner } from "@/shared/components/ui/spinner";
 import { debounce } from "@/shared/utils/common";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { useRelationships } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships.query";
 import type { RelationshipNode } from "@/entities/nodes/relationships/domain/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -57,7 +58,7 @@ export const RelationshipComboboxList = forwardRef<HTMLDivElement, RelationshipC
                   selectedValue={value?.id}
                   onSelect={() => onSelect(node)}
                 >
-                  <span className="truncate">{node.display_label}</span>
+                  <span className="truncate">{getNodeLabel(node)}</span>
                 </ComboboxItem>
               ));
             })}

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-hierarchical-combobox-list.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-hierarchical-combobox-list.tsx
@@ -11,6 +11,7 @@ import { Spinner } from "@/shared/components/ui/spinner";
 import { debounce } from "@/shared/utils/common";
 
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getRelationshipsInfiniteQueryOptions } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships.query";
 import type { RelationshipNode } from "@/entities/nodes/relationships/domain/types";
 import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
@@ -107,7 +108,7 @@ const HierarchicalExplorer = ({
     return (
       <>
         <Badge className="mt-1 ml-2 cursor-pointer self-start" onClick={handleRemoveNode}>
-          {selectNode.display_label} &times;
+          {getNodeLabel(selectNode)} &times;
         </Badge>
 
         <HierarchicalExplorer
@@ -169,7 +170,7 @@ const HierarchicalExplorer = ({
                     selectedValue={value?.id}
                     onSelect={() => handleSelect(node)}
                   >
-                    <span className="truncate">{node.display_label}</span>
+                    <span className="truncate">{getNodeLabel(node)}</span>
                     <span className="ml-auto text-gray-500 text-xs">{schema?.label}</span>
                   </ComboboxItem>
                 );

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-hierarchical-input.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-hierarchical-input.tsx
@@ -20,6 +20,7 @@ import { inputStyle } from "@/shared/components/ui/style";
 import { classNames } from "@/shared/utils/common";
 
 import type { Node } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { RelationshipNode } from "@/entities/nodes/relationships/domain/types";
 import { AddRelationshipAction } from "@/entities/nodes/relationships/ui/add-relationship-action";
 import {
@@ -75,7 +76,7 @@ export const RelationshipHierarchicalInput = forwardRef<
   return (
     <Combobox open={open} onOpenChange={setOpen}>
       <ComboboxTrigger ref={ref} {...props}>
-        {value?.display_label}
+        {value ? getNodeLabel(value) : ""}
       </ComboboxTrigger>
 
       <RelationshipHierarchicalContent peer={peer} onSelect={handleSelect} value={value} />
@@ -112,19 +113,19 @@ export const RelationshipHierarchicalManyInput = forwardRef<
           )}
         >
           <div className="flex grow flex-wrap gap-2">
-            {value?.map(({ id, display_label }) => (
-              <Badge key={id} className="flex items-center gap-1 pr-0.5">
-                {display_label}
+            {value?.map((node) => (
+              <Badge key={node.id} className="flex items-center gap-1 pr-0.5">
+                {getNodeLabel(node)}
 
                 <Button
                   size="icon"
                   variant="ghost"
                   onClick={(e) => {
                     e.stopPropagation();
-                    onChange(value?.filter((item) => item.id !== id));
+                    onChange(value?.filter((item) => item.id !== node.id));
                   }}
                   className="h-4 w-4 text-gray-500 hover:text-gray-800"
-                  aria-label={`Remove ${display_label}`}
+                  aria-label={`Remove ${getNodeLabel(node)}`}
                   data-testid="remove-option"
                 >
                   &times;

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-properties.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-properties.tsx
@@ -5,6 +5,7 @@ import { PropertyList } from "@/shared/components/table/property-list";
 import { Link } from "@/shared/components/ui/link";
 import { formatFullDate } from "@/shared/utils/date";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import {
   type UseGetRelationshipPropertiesParams,
   useGetRelationshipProperties,
@@ -30,7 +31,7 @@ export function RelationshipProperties(props: RelationshipPropertiesProps) {
       name: "Source",
       value: source ? (
         <Link to={constructPath(`/objects/${source.__typename}/${source.id}`)}>
-          {source.display_label}
+          {getNodeLabel(source)}
         </Link>
       ) : (
         "-"
@@ -44,7 +45,7 @@ export function RelationshipProperties(props: RelationshipPropertiesProps) {
       name: "Owner",
       value: owner ? (
         <Link to={constructPath(`/objects/${owner.__typename}/${owner.id}`)}>
-          {owner.display_label}
+          {getNodeLabel(owner)}
         </Link>
       ) : (
         "-"

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
@@ -91,10 +91,21 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
     {
       name: "Created by",
       value: (
-        <Tooltip content={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""} enabled>
+        <Tooltip
+          content={
+            proposedChangesDetails?.created_by?.node
+              ? getNodeLabel(proposedChangesDetails.created_by.node)
+              : ""
+          }
+          enabled
+        >
           <Avatar
             size={"sm"}
-            name={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""}
+            name={
+              proposedChangesDetails?.created_by?.node
+                ? getNodeLabel(proposedChangesDetails.created_by.node)
+                : ""
+            }
             className="bg-custom-blue-green"
           />
         </Tooltip>
@@ -162,9 +173,18 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
           {proposedChangesDetails?.description?.value && (
             <CardWithBorder contentClassName="" data-testid="pc-description">
               <CardWithBorder.Title className="flex items-center gap-2">
-                <Avatar name={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""} size="sm" />
+                <Avatar
+                  name={
+                    proposedChangesDetails?.created_by?.node
+                      ? getNodeLabel(proposedChangesDetails.created_by.node)
+                      : ""
+                  }
+                  size="sm"
+                />
 
-                {proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""}
+                {proposedChangesDetails?.created_by?.node
+                  ? getNodeLabel(proposedChangesDetails.created_by.node)
+                  : ""}
 
                 <DateDisplay
                   date={proposedChangesDetails.description.updated_at}

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
@@ -17,6 +17,7 @@ import { Card, CardWithBorder } from "@/shared/components/ui/card";
 import { Tooltip } from "@/shared/components/ui/tooltip";
 import { classNames } from "@/shared/utils/common";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 import { PcActionButton } from "@/entities/proposed-changes/ui/action-button/pc-action-button";
 import { PcReviewButton } from "@/entities/proposed-changes/ui/action-button/pc-review-button";
@@ -90,10 +91,10 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
     {
       name: "Created by",
       value: (
-        <Tooltip content={proposedChangesDetails?.created_by?.node?.display_label} enabled>
+        <Tooltip content={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""} enabled>
           <Avatar
             size={"sm"}
-            name={proposedChangesDetails?.created_by?.node?.display_label}
+            name={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""}
             className="bg-custom-blue-green"
           />
         </Tooltip>
@@ -104,8 +105,8 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
       value: (
         <div className="flex flex-wrap gap-2">
           {approvedBy.map((user: any, index: number) => (
-            <Tooltip key={index} content={user.display_label} enabled>
-              <Avatar size={"sm"} name={user.display_label} />
+            <Tooltip key={index} content={getNodeLabel(user)} enabled>
+              <Avatar size={"sm"} name={getNodeLabel(user)} />
             </Tooltip>
           ))}
         </div>
@@ -116,8 +117,8 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
       value: (
         <div className="flex flex-wrap gap-2">
           {rejectedBy.map((user: any, index: number) => (
-            <Tooltip key={index} content={user.display_label} enabled>
-              <Avatar size={"sm"} name={user.display_label} />
+            <Tooltip key={index} content={getNodeLabel(user)} enabled>
+              <Avatar size={"sm"} name={getNodeLabel(user)} />
             </Tooltip>
           ))}
         </div>
@@ -128,8 +129,8 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
       value: (
         <div className="flex flex-wrap gap-2">
           {reviewers.map((reviewer: any, index: number) => (
-            <Tooltip key={index} content={reviewer.display_label} enabled>
-              <Avatar size={"sm"} name={reviewer.display_label} />
+            <Tooltip key={index} content={getNodeLabel(reviewer)} enabled>
+              <Avatar size={"sm"} name={getNodeLabel(reviewer)} />
             </Tooltip>
           ))}
         </div>
@@ -161,9 +162,9 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
           {proposedChangesDetails?.description?.value && (
             <CardWithBorder contentClassName="" data-testid="pc-description">
               <CardWithBorder.Title className="flex items-center gap-2">
-                <Avatar name={proposedChangesDetails?.created_by?.node?.display_label} size="sm" />
+                <Avatar name={proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""} size="sm" />
 
-                {proposedChangesDetails?.created_by?.node?.display_label}
+                {proposedChangesDetails?.created_by?.node ? getNodeLabel(proposedChangesDetails.created_by.node) : ""}
 
                 <DateDisplay
                   date={proposedChangesDetails.description.updated_at}

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-form.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-form.tsx
@@ -87,14 +87,14 @@ export const ProposedChangeEditForm = ({ initialData, onSuccess }: ProposedChang
           initialData?.reviewers?.edges
             .map((edge: any) => ({
               id: edge?.node?.id,
-              display_label: edge?.node?.display_label,
+              display_label: edge?.node ? getNodeLabel(edge.node) : undefined,
               __typename: edge?.node?.__typename,
             }))
             .filter(Boolean) ?? [],
       },
       options: initialData?.reviewers?.edges.map(({ node }) => ({
         id: node?.id,
-        name: node?.display_label,
+        name: node ? getNodeLabel(node) : undefined,
       })),
     },
   ];

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-form.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-form.tsx
@@ -16,6 +16,7 @@ import { branchesState } from "@/entities/branches/stores";
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
 import { updateObjectWithId } from "@/entities/nodes/api/updateObjectWithId";
 import type { AttributeType } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
 
 type ProposedChangeEditFormProps = {

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-trigger.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-trigger.tsx
@@ -54,7 +54,9 @@ export const ProposedChangeEditTrigger = ({
               <div className="flex grow items-center gap-2 truncate whitespace-nowrap text-sm">
                 <span>Proposed changes</span>
                 <Icon icon="mdi:chevron-right" />
-                <span className="truncate">{proposedChangesDetails ? getNodeLabel(proposedChangesDetails) : ""}</span>
+                <span className="truncate">
+                  {proposedChangesDetails ? getNodeLabel(proposedChangesDetails) : ""}
+                </span>
               </div>
 
               <ObjectHelpButton

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-trigger.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-edit-trigger.tsx
@@ -10,6 +10,7 @@ import { ButtonWithTooltip } from "@/shared/components/buttons/button-primitive"
 import SlideOver from "@/shared/components/display/slide-over";
 import { ObjectHelpButton } from "@/shared/components/menu/object-help-button";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { ProposedChangeEditForm } from "@/entities/proposed-changes/ui/proposed-change-edit-form";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
@@ -53,7 +54,7 @@ export const ProposedChangeEditTrigger = ({
               <div className="flex grow items-center gap-2 truncate whitespace-nowrap text-sm">
                 <span>Proposed changes</span>
                 <Icon icon="mdi:chevron-right" />
-                <span className="truncate">{proposedChangesDetails?.display_label}</span>
+                <span className="truncate">{proposedChangesDetails ? getNodeLabel(proposedChangesDetails) : ""}</span>
               </div>
 
               <ObjectHelpButton

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
@@ -12,6 +12,7 @@ import { classNames } from "@/shared/utils/common";
 
 import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { ProposedChangeItem } from "@/entities/proposed-changes/domain/get-proposed-changes";
 import { ProposedChangeDiffSummary } from "@/entities/proposed-changes/ui/diff-summary/proposed-change-diff-summary";
 import { ProposedChangesActionCell } from "@/entities/proposed-changes/ui/proposed-changes-actions-cell";
@@ -30,7 +31,7 @@ export const ProposedChangesItem = ({ node }: ProposedChangesItemProps) => {
         <ProposedChangesInfo
           id={node.id}
           name={node.name.value}
-          author={node.created_by.node?.display_label}
+          author={node.created_by.node ? getNodeLabel(node.created_by.node) : undefined}
           state={node.state?.value}
           isDraft={!!node.is_draft?.value}
           isApproved={!!node.approved_by.edges.length}
@@ -48,7 +49,7 @@ export const ProposedChangesItem = ({ node }: ProposedChangesItemProps) => {
 
       <ProposedChangesActionCell
         objectId={node.id}
-        objectLabel={node.display_label}
+        objectLabel={getNodeLabel(node)}
         permission={permission}
       />
     </ListBoxItem>

--- a/frontend/app/src/entities/role-manager/api/getAccounts.ts
+++ b/frontend/app/src/entities/role-manager/api/getAccounts.ts
@@ -16,6 +16,8 @@ export const GET_ROLE_MANAGEMENT_ACCOUNTS = gql`
       edges {
         node {
           id
+          display_label
+          hfid
           name {
             value
           }

--- a/frontend/app/src/entities/role-manager/api/getGlobalPermissions.ts
+++ b/frontend/app/src/entities/role-manager/api/getGlobalPermissions.ts
@@ -17,6 +17,7 @@ export const GET_ROLE_MANAGEMENT_GLOBAL_PERMISSIONS = gql`
         node {
           id
           display_label
+          hfid
           action {
             value
           }

--- a/frontend/app/src/entities/role-manager/api/getGroups.ts
+++ b/frontend/app/src/entities/role-manager/api/getGroups.ts
@@ -16,6 +16,8 @@ export const GET_ROLE_MANAGEMENT_GROUPS = gql`
       edges {
         node {
           id
+          display_label
+          hfid
           name {
             value
           }

--- a/frontend/app/src/entities/role-manager/api/getObjectPermissions.ts
+++ b/frontend/app/src/entities/role-manager/api/getObjectPermissions.ts
@@ -17,6 +17,7 @@ export const GET_ROLE_MANAGEMENT_OBJECT_PERMISSIONS = gql`
         node {
           id
           display_label
+          hfid
           name {
             value
           }

--- a/frontend/app/src/entities/role-manager/api/getRoles.ts
+++ b/frontend/app/src/entities/role-manager/api/getRoles.ts
@@ -16,6 +16,8 @@ export const GET_ROLE_MANAGEMENT_ROLES = gql`
       edges {
         node {
           id
+          display_label
+          hfid
           name {
             value
           }

--- a/frontend/app/src/entities/role-manager/ui/accounts.tsx
+++ b/frontend/app/src/entities/role-manager/ui/accounts.tsx
@@ -105,7 +105,7 @@ function Accounts() {
           value: { edges: edge?.node?.member_of_groups?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.member_of_groups?.edges?.map((edge) => edge?.node?.display_label)}
+              items={edge?.node?.member_of_groups?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/role-manager/ui/accounts.tsx
+++ b/frontend/app/src/entities/role-manager/ui/accounts.tsx
@@ -89,6 +89,8 @@ function Accounts() {
     data[ACCOUNT_GENERIC_OBJECT]?.edges.map((edge) => ({
       values: {
         id: edge?.node?.id,
+        display_label: edge?.node?.display_label,
+        hfid: edge?.node?.hfid,
         name: { value: edge?.node?.name?.value },
         description: { value: edge?.node?.description?.value },
         account_type: { value: edge?.node?.account_type?.value },

--- a/frontend/app/src/entities/role-manager/ui/accounts.tsx
+++ b/frontend/app/src/entities/role-manager/ui/accounts.tsx
@@ -22,6 +22,7 @@ import { SearchInput } from "@/shared/components/ui/search-input";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import usePagination from "@/shared/hooks/usePagination";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { GET_ROLE_MANAGEMENT_ACCOUNTS } from "@/entities/role-manager/api/getAccounts";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -105,7 +106,9 @@ function Accounts() {
           value: { edges: edge?.node?.member_of_groups?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.member_of_groups?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
+              items={edge?.node?.member_of_groups?.edges?.map((edge) =>
+                edge?.node ? getNodeLabel(edge.node) : ""
+              )}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
@@ -96,7 +96,9 @@ function GlobalPermissions() {
           roles: {
             display: (
               <InlineDisplay
-                items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
+                items={edge?.node?.roles?.edges?.map((edge) =>
+                  edge?.node ? getNodeLabel(edge.node) : ""
+                )}
                 render={(item) => <Badge>{item}</Badge>}
               />
             ),

--- a/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
@@ -86,7 +86,8 @@ function GlobalPermissions() {
       return {
         values: {
           id: edge?.node?.id,
-          display_label: { value: edge?.node ? getNodeLabel(edge.node) : undefined },
+          display_label: edge?.node?.display_label,
+          hfid: edge?.node?.hfid,
           action: { value: edge?.node?.action?.value },
           decision: {
             display: globalDecisionOptions.find(

--- a/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
@@ -22,6 +22,7 @@ import { SearchInput } from "@/shared/components/ui/search-input";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import usePagination from "@/shared/hooks/usePagination";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { GET_ROLE_MANAGEMENT_GLOBAL_PERMISSIONS } from "@/entities/role-manager/api/getGlobalPermissions";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";

--- a/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/global-permissions.tsx
@@ -85,7 +85,7 @@ function GlobalPermissions() {
       return {
         values: {
           id: edge?.node?.id,
-          display_label: { value: edge?.node?.display_label },
+          display_label: { value: edge?.node ? getNodeLabel(edge.node) : undefined },
           action: { value: edge?.node?.action?.value },
           decision: {
             display: globalDecisionOptions.find(
@@ -96,7 +96,7 @@ function GlobalPermissions() {
           roles: {
             display: (
               <InlineDisplay
-                items={edge?.node?.roles?.edges?.map((edge) => edge?.node?.display_label)}
+                items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
                 render={(item) => <Badge>{item}</Badge>}
               />
             ),

--- a/frontend/app/src/entities/role-manager/ui/groups.tsx
+++ b/frontend/app/src/entities/role-manager/ui/groups.tsx
@@ -93,6 +93,8 @@ function Groups() {
       id: edge?.node?.id,
       values: {
         id: edge?.node?.id,
+        display_label: edge?.node?.display_label,
+        hfid: edge?.node?.hfid,
         name: { value: edge?.node?.name?.value },
         description: { value: edge?.node?.description?.value },
         label: { value: edge?.node?.label?.value },

--- a/frontend/app/src/entities/role-manager/ui/groups.tsx
+++ b/frontend/app/src/entities/role-manager/ui/groups.tsx
@@ -21,6 +21,7 @@ import { SearchInput } from "@/shared/components/ui/search-input";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import usePagination from "@/shared/hooks/usePagination";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { GET_ROLE_MANAGEMENT_GROUPS } from "@/entities/role-manager/api/getGroups";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -100,7 +101,11 @@ function Groups() {
           value: { edges: edge?.node?.members?.edges },
           display: (
             <GroupMembers
-              members={edge?.node?.members?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "") ?? []}
+              members={
+                edge?.node?.members?.edges?.map((edge) =>
+                  edge?.node ? getNodeLabel(edge.node) : ""
+                ) ?? []
+              }
             />
           ),
         },
@@ -108,7 +113,9 @@ function Groups() {
           value: { edges: edge?.node?.roles?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
+              items={edge?.node?.roles?.edges?.map((edge) =>
+                edge?.node ? getNodeLabel(edge.node) : ""
+              )}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/role-manager/ui/groups.tsx
+++ b/frontend/app/src/entities/role-manager/ui/groups.tsx
@@ -100,7 +100,7 @@ function Groups() {
           value: { edges: edge?.node?.members?.edges },
           display: (
             <GroupMembers
-              members={edge?.node?.members?.edges?.map((edge) => edge?.node?.display_label) ?? []}
+              members={edge?.node?.members?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "") ?? []}
             />
           ),
         },
@@ -108,7 +108,7 @@ function Groups() {
           value: { edges: edge?.node?.roles?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.roles?.edges?.map((edge) => edge?.node?.display_label)}
+              items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
@@ -24,6 +24,7 @@ import { SearchInput } from "@/shared/components/ui/search-input";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import usePagination from "@/shared/hooks/usePagination";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { GET_ROLE_MANAGEMENT_OBJECT_PERMISSIONS } from "@/entities/role-manager/api/getObjectPermissions";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -139,7 +140,9 @@ function Permissions() {
             value: { edges: edge?.node?.roles?.edges },
             display: (
               <InlineDisplay
-                items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
+                items={edge?.node?.roles?.edges?.map((edge) =>
+                  edge?.node ? getNodeLabel(edge.node) : ""
+                )}
                 render={(item) => <Badge>{item}</Badge>}
               />
             ),

--- a/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
@@ -112,7 +112,8 @@ function Permissions() {
       return {
         values: {
           id: edge?.node?.id,
-          display_label: edge?.node ? getNodeLabel(edge.node) : undefined,
+          display_label: edge?.node?.display_label,
+          hfid: edge?.node?.hfid,
           display: {
             value: edge?.node ? getNodeLabel(edge.node) : undefined,
             display: (

--- a/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
+++ b/frontend/app/src/entities/role-manager/ui/object-permissions.tsx
@@ -111,12 +111,12 @@ function Permissions() {
       return {
         values: {
           id: edge?.node?.id,
-          display_label: edge?.node?.display_label,
+          display_label: edge?.node ? getNodeLabel(edge.node) : undefined,
           display: {
-            value: edge?.node?.display_label,
+            value: edge?.node ? getNodeLabel(edge.node) : undefined,
             display: (
               <div className="flex items-center gap-2">
-                {icon} {edge?.node?.display_label}
+                {icon} {edge?.node ? getNodeLabel(edge.node) : ""}
               </div>
             ),
           },
@@ -139,7 +139,7 @@ function Permissions() {
             value: { edges: edge?.node?.roles?.edges },
             display: (
               <InlineDisplay
-                items={edge?.node?.roles?.edges?.map((edge) => edge?.node?.display_label)}
+                items={edge?.node?.roles?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
                 render={(item) => <Badge>{item}</Badge>}
               />
             ),

--- a/frontend/app/src/entities/role-manager/ui/roles.tsx
+++ b/frontend/app/src/entities/role-manager/ui/roles.tsx
@@ -79,6 +79,8 @@ function Roles() {
     data[ACCOUNT_ROLE_OBJECT]?.edges.map((edge) => ({
       values: {
         id: edge?.node?.id,
+        display_label: edge?.node?.display_label,
+        hfid: edge?.node?.hfid,
         name: { value: edge?.node?.name.value },
         description: { value: edge?.node?.description?.value },
         groups: {

--- a/frontend/app/src/entities/role-manager/ui/roles.tsx
+++ b/frontend/app/src/entities/role-manager/ui/roles.tsx
@@ -21,6 +21,7 @@ import { SearchInput } from "@/shared/components/ui/search-input";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import usePagination from "@/shared/hooks/usePagination";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { GET_ROLE_MANAGEMENT_ROLES } from "@/entities/role-manager/api/getRoles";
 import { schemaKindNameState } from "@/entities/schema/stores/schemaKindName.atom";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -84,7 +85,9 @@ function Roles() {
           value: { edges: edge?.node?.groups?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.groups?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
+              items={edge?.node?.groups?.edges?.map((edge) =>
+                edge?.node ? getNodeLabel(edge.node) : ""
+              )}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/role-manager/ui/roles.tsx
+++ b/frontend/app/src/entities/role-manager/ui/roles.tsx
@@ -84,7 +84,7 @@ function Roles() {
           value: { edges: edge?.node?.groups?.edges },
           display: (
             <InlineDisplay
-              items={edge?.node?.groups?.edges?.map((edge) => edge?.node?.display_label)}
+              items={edge?.node?.groups?.edges?.map((edge) => edge?.node ? getNodeLabel(edge.node) : "")}
               render={(item) => <Badge>{item}</Badge>}
             />
           ),

--- a/frontend/app/src/entities/search-anywhere/ui/search-nodes.tsx
+++ b/frontend/app/src/entities/search-anywhere/ui/search-nodes.tsx
@@ -11,6 +11,7 @@ import { IP_ADDRESS_GENERIC, IP_PREFIX_GENERIC } from "@/entities/ipam/constants
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getSchemaObjectColumns } from "@/entities/nodes/object-items/getSchemaObjectColumns";
+import type { NodeCore } from "@/entities/nodes/types";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import { ATTRIBUTE_KIND } from "@/entities/schema/constants";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -144,18 +145,18 @@ type NodeAttributeProps = {
   value:
     | { value: string | number | boolean | null }
     | { value: string | null; label: string; color: string }
-    | { node: { display_label?: string } }
-    | { edges: Array<{ node: { display_label?: string } }> };
+    | { node: NodeCore }
+    | { edges: Array<{ node: NodeCore }> };
 };
 
 const NodeAttribute = ({ title, kind, value }: NodeAttributeProps) => {
   const formatValue = (): string | number | boolean | ReactElement | null => {
     if ("node" in value && value.node) {
-      return value.node.display_label ?? null;
+      return value.node ? getNodeLabel(value.node) : null;
     }
 
     if ("edges" in value && value.edges?.length > 0) {
-      return value.edges.map(({ node }) => node?.display_label).join(", ");
+      return value.edges.map(({ node }) => (node ? getNodeLabel(node) : "")).join(", ");
     }
 
     if ("value" in value && value.value) {

--- a/frontend/app/src/entities/search-anywhere/ui/search-nodes.tsx
+++ b/frontend/app/src/entities/search-anywhere/ui/search-nodes.tsx
@@ -119,7 +119,7 @@ const NodesOptions = ({ node }: NodesOptionsProps) => {
           {displayIpNamespace && (
             <NodeAttribute
               title={"IP Namespace"}
-              value={{ value: objectDetailsData?.ip_namespace?.node?.display_label }}
+              value={{ node: objectDetailsData?.ip_namespace?.node ?? undefined }}
             />
           )}
 

--- a/frontend/app/src/entities/user-profile/ui/user-profile.tsx
+++ b/frontend/app/src/entities/user-profile/ui/user-profile.tsx
@@ -13,6 +13,7 @@ import { LoadingIndicator } from "@/shared/components/loading/loading-indicator"
 import { Tabs } from "@/shared/components/tabs";
 import { useTitle } from "@/shared/hooks/useTitle";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { genericSchemasAtom } from "@/entities/schema/stores/schema.atom";
 import { getProfileDetails } from "@/entities/user-profile/api/getProfileDetails";
 
@@ -98,7 +99,7 @@ export function UserProfilePage() {
             <Avatar name={profile?.name?.value} />
 
             <div className="ml-2">
-              <h3>{profile?.display_label}</h3>
+              <h3>{profile ? getNodeLabel(profile) : ""}</h3>
 
               <p className="text-gray-500 text-sm">{profile?.description?.value ?? "-"}</p>
             </div>

--- a/frontend/app/src/pages/proposed-changes/details.tsx
+++ b/frontend/app/src/pages/proposed-changes/details.tsx
@@ -22,6 +22,7 @@ import { ArtifactsDiff } from "@/entities/diff/artifact-diff/artifacts-diff";
 import { Checks } from "@/entities/diff/checks/checks";
 import { FilesDiff } from "@/entities/diff/file-diff/files-diff";
 import { NodeDiff } from "@/entities/diff/node-diff";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import { useGetProposedChangeDetails } from "@/entities/proposed-changes/domain/get-proposed-change-details.query";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
@@ -46,7 +47,7 @@ const ProposedChangeDetailsContent = ({ proposedChangeData }: ProposedChangesDet
   const [proposedChange, setProposedChange] = useAtom(proposedChangedState);
   useTitle(
     `${
-      proposedChange.display_label ? `${proposedChange.display_label} - ` : ""
+      proposedChange ? `${getNodeLabel(proposedChange)} - ` : ""
     }Proposed change - Infrahub`
   );
 
@@ -181,7 +182,7 @@ export function Component() {
   return (
     <Content.Card className="flex flex-col">
       <Content.CardTitle
-        title={proposedChangeData.display_label}
+        title={getNodeLabel(proposedChangeData)}
         description={
           <div className="inline-flex items-center gap-1 text-xs">
             <Link
@@ -191,7 +192,7 @@ export function Component() {
               )}
               className="font-semibold text-custom-blue-green"
             >
-              {proposedChangeData?.created_by?.node?.display_label}
+              {proposedChangeData?.created_by?.node ? getNodeLabel(proposedChangeData.created_by.node) : ""}
             </Link>
             wants to merge
             <Link to={constructPath(`/branches/${proposedChangeData.source_branch?.value}`)}>

--- a/frontend/app/src/pages/proposed-changes/details.tsx
+++ b/frontend/app/src/pages/proposed-changes/details.tsx
@@ -46,9 +46,7 @@ const ProposedChangeDetailsContent = ({ proposedChangeData }: ProposedChangesDet
   const [qspTaskId] = useQueryState(QSP.TASK_ID);
   const [proposedChange, setProposedChange] = useAtom(proposedChangedState);
   useTitle(
-    `${
-      proposedChange ? `${getNodeLabel(proposedChange)} - ` : ""
-    }Proposed change - Infrahub`
+    `${proposedChange ? `${getNodeLabel(proposedChange)} - ` : ""}Proposed change - Infrahub`
   );
 
   if (proposedChangeData) setProposedChange(proposedChangeData);
@@ -192,7 +190,9 @@ export function Component() {
               )}
               className="font-semibold text-custom-blue-green"
             >
-              {proposedChangeData?.created_by?.node ? getNodeLabel(proposedChangeData.created_by.node) : ""}
+              {proposedChangeData?.created_by?.node
+                ? getNodeLabel(proposedChangeData.created_by.node)
+                : ""}
             </Link>
             wants to merge
             <Link to={constructPath(`/branches/${proposedChangeData.source_branch?.value}`)}>

--- a/frontend/app/src/pages/resource-manager/resource-pool-details.tsx
+++ b/frontend/app/src/pages/resource-manager/resource-pool-details.tsx
@@ -18,6 +18,7 @@ import {
   ObjectAttributeValue,
 } from "@/entities/nodes/getObjectItemDisplayValue";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { Permission } from "@/entities/permission/types";
 import { RequireObjectPermissions } from "@/entities/permission/ui/require-object-permissions";
@@ -149,7 +150,7 @@ const ResourcePoolContent = ({
           name: schemaRelationship.label || schemaRelationship.name,
           value: relationshipData && (
             <Link to={getObjectDetailsUrl(relationshipData.__typename, relationshipData.id)}>
-              {relationshipData?.display_label}
+              {relationshipData ? getNodeLabel(relationshipData) : ""}
             </Link>
           ),
         };
@@ -159,7 +160,7 @@ const ResourcePoolContent = ({
   return (
     <Content.Card>
       <Content.CardTitle
-        title={resourcePool.display_label}
+        title={getNodeLabel(resourcePool)}
         isReloadLoading={isRefetching}
         reload={handleRefetchAll}
         end={

--- a/frontend/app/src/shared/components/conversations/thread.tsx
+++ b/frontend/app/src/shared/components/conversations/thread.tsx
@@ -23,6 +23,7 @@ import { currentBranchAtom } from "@/entities/branches/stores";
 import { getThreadTitle } from "@/entities/diff/utils";
 import { updateObjectWithId } from "@/entities/nodes/api/updateObjectWithId";
 import { useCreateObjectMutation } from "@/entities/nodes/object/domain/create-object.mutation";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectPermissionsQuery } from "@/entities/permission/queries/getObjectPermissions";
 import { getPermission } from "@/entities/permission/utils";
 
@@ -200,7 +201,7 @@ export const Thread = (props: tThread) => {
       {sortedComments.map((comment: any, index: number) => (
         <Comment
           key={index}
-          author={comment?.created_by?.node?.display_label ?? "Anonymous"}
+          author={comment?.created_by?.node ? getNodeLabel(comment.created_by.node) : "Anonymous"}
           createdAt={comment?.created_at?.value}
           content={comment?.text?.value ?? ""}
           className={"border border-gray-200"}

--- a/frontend/app/src/shared/components/display/meta-details-tooltips.tsx
+++ b/frontend/app/src/shared/components/display/meta-details-tooltips.tsx
@@ -9,6 +9,7 @@ import { Link } from "@/shared/components/ui/link";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import { formatFullDate, formatRelativeTimeFromNow } from "@/shared/utils/date";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 
 interface MetaDetailsTooltipProps {
@@ -36,10 +37,10 @@ export default function MetaDetailsTooltip({
           {isFromProfile ? (
             <Badge variant="green" className="font-normal hover:underline">
               <Icon icon="mdi:shape-plus-outline" className="mr-1" />
-              {source.display_label}
+              {getNodeLabel(source)}
             </Badge>
           ) : (
-            source.display_label
+            getNodeLabel(source)
           )}
         </Link>
       ) : (
@@ -57,7 +58,7 @@ export default function MetaDetailsTooltip({
     {
       name: "Owner",
       value: owner ? (
-        <Link to={getObjectDetailsUrl(owner.__typename, owner.id)}>{owner.display_label}</Link>
+        <Link to={getObjectDetailsUrl(owner.__typename, owner.id)}>{getNodeLabel(owner)}</Link>
       ) : (
         "-"
       ),

--- a/frontend/app/src/shared/components/display/properties-popover.tsx
+++ b/frontend/app/src/shared/components/display/properties-popover.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { ButtonWithTooltip } from "@/shared/components/buttons/button-primitive";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import ObjectItemMetaEdit from "@/entities/nodes/object-item-meta-edit/object-item-meta-edit";
 import { metaEditFieldDetailsState } from "@/entities/nodes/stores/showMetaEdit.atom";
 import type { Permission } from "@/entities/permission/types";
@@ -76,7 +77,7 @@ const PropertiesPopover = ({
         title={
           <SlideOverTitle
             schema={schema}
-            currentObjectLabel={data?.display_label}
+            currentObjectLabel={data ? getNodeLabel(data) : ""}
             title={`${metaEditFieldDetails?.label} properties`}
             subtitle={`Update the properties of ${metaEditFieldDetails?.label}`}
           />

--- a/frontend/app/src/shared/components/form/object-edit-slide-over-trigger.tsx
+++ b/frontend/app/src/shared/components/form/object-edit-slide-over-trigger.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { type ButtonProps, ButtonWithTooltip } from "@/shared/components/buttons/button-primitive";
 import SlideOver, { SlideOverTitle } from "@/shared/components/display/slide-over";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import ObjectItemEditComponent from "@/entities/nodes/object-item-edit/object-item-edit-paginated";
 import type { Permission } from "@/entities/permission/types";
 import type { ModelSchema } from "@/entities/schema/types";
@@ -44,8 +45,8 @@ const ObjectEditSlideOverTrigger = ({
         title={
           <SlideOverTitle
             schema={schema}
-            currentObjectLabel={data.display_label}
-            title={`Edit ${data.display_label}`}
+            currentObjectLabel={getNodeLabel(data)}
+            title={`Edit ${getNodeLabel(data)}`}
             subtitle={data?.description?.value}
           />
         }

--- a/frontend/app/src/shared/components/form/profiles-selector.tsx
+++ b/frontend/app/src/shared/components/form/profiles-selector.tsx
@@ -23,6 +23,7 @@ import { inputStyle } from "@/shared/components/ui/style";
 import { classNames } from "@/shared/utils/common";
 
 import { getProfiles } from "@/entities/nodes/api/getProfiles";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectAttributes } from "@/entities/nodes/object-items/getSchemaObjectColumns";
 import { genericSchemasAtom, profileSchemasAtom } from "@/entities/schema/stores/schema.atom";
 import type { NodeSchema } from "@/entities/schema/types";
@@ -154,7 +155,7 @@ export const ProfilesSelector = ({
             <div className="flex grow flex-wrap gap-2">
               {selectedValues?.map((profile) => (
                 <Badge key={id} className="flex items-center gap-1 pr-0.5">
-                  {profile.display_label}
+                  {getNodeLabel(profile)}
 
                   <Button
                     size="icon"
@@ -189,10 +190,10 @@ export const ProfilesSelector = ({
               .map((item) => (
                 <ComboboxItem
                   key={item.id}
-                  value={item.display_label}
+                  value={getNodeLabel(item)}
                   onSelect={() => handleChange(item)}
                 >
-                  {item.display_label}
+                  {getNodeLabel(item)}
                 </ComboboxItem>
               ))}
           </ComboboxList>

--- a/frontend/app/src/shared/components/inputs/peer.tsx
+++ b/frontend/app/src/shared/components/inputs/peer.tsx
@@ -5,6 +5,7 @@ import { Combobox, ComboboxContent, ComboboxTrigger } from "@/shared/components/
 import { classNames } from "@/shared/utils/common";
 
 import type { Node } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { AddRelationshipAction } from "@/entities/nodes/relationships/ui/add-relationship-action";
 import { RelationshipComboboxList } from "@/entities/nodes/relationships/ui/relationship-combobox-list";
 
@@ -41,7 +42,7 @@ export const PeerInput = ({
           className
         )}
       >
-        {value?.display_label}
+        {value ? getNodeLabel(value) : ""}
       </ComboboxTrigger>
 
       <ComboboxContent>

--- a/frontend/app/src/shared/components/inputs/relationship-one.tsx
+++ b/frontend/app/src/shared/components/inputs/relationship-one.tsx
@@ -20,6 +20,7 @@ import { classNames } from "@/shared/utils/common";
 
 import { generateRelationshipListQuery } from "@/entities/nodes/api/generateRelationshipListQuery";
 import type { Node, RelationshipManyType } from "@/entities/nodes/getObjectItemDisplayValue";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { AddRelationshipAction } from "@/entities/nodes/relationships/ui/add-relationship-action";
 
 import { Badge } from "../ui/badge";
@@ -97,7 +98,7 @@ export const RelationshipInput = React.forwardRef<
       >
         {value && (
           <span data-testid="select-value">
-            {"from_pool" in value ? "Allocated by pool" : value.display_label}
+            {"from_pool" in value ? "Allocated by pool" : getNodeLabel(value)}
           </span>
         )}
 
@@ -132,7 +133,7 @@ export const RelationshipInput = React.forwardRef<
                   setOpen(false);
                 }}
               >
-                <span className="truncate">{relationship.display_label}</span>
+                <span className="truncate">{getNodeLabel(relationship)}</span>
               </ComboboxItem>
             );
           })}
@@ -148,7 +149,7 @@ export const RelationshipInput = React.forwardRef<
                     setOpen(false);
                   }}
                 >
-                  <span className="grow truncate">{option.display_label}</span>
+                  <span className="grow truncate">{getNodeLabel(option)}</span>
 
                   {option.badge && <Badge className="mr-2">{option.badge}</Badge>}
                 </ComboboxItem>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-proposed-changes.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-proposed-changes.tsx
@@ -17,6 +17,7 @@ import { BreadcrumbSelectorTrigger } from "@/shared/components/layout/breadcrumb
 
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { ObjectAutocomplete } from "@/entities/nodes/object/ui/object-autocomplete";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
 export function BreadcrumbProposedChanges() {
@@ -59,7 +60,7 @@ function BreadcrumbProposedChangeSelector({ proposedChangeId }: { proposedChange
   return (
     <Breadcrumb>
       <MenuTrigger>
-        <BreadcrumbSelectorTrigger>{data.display_label}</BreadcrumbSelectorTrigger>
+        <BreadcrumbSelectorTrigger>{getNodeLabel(data)}</BreadcrumbSelectorTrigger>
 
         <Popover className="bg-stone-100/50 backdrop-blur">
           <ObjectAutocomplete className="max-h-58" objectKind={PROPOSED_CHANGES_OBJECT} />

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-resource-manager.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-resource-manager.tsx
@@ -17,6 +17,7 @@ import { Popover, PopoverDialog } from "@/shared/components/aria/popover";
 import { Col, Row } from "@/shared/components/container";
 import { BreadcrumbObjectDetails } from "@/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { RESOURCE_GENERIC_KIND } from "@/entities/resource-manager/constants";
 import { useGetPoolUtilization } from "@/entities/resource-manager/domain/get-pool-utilization.query";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -77,7 +78,7 @@ function ResourceSelector({
             to={constructPath(`/resource-manager/${resourcePoolId}/resources/${resourceId}`)}
             className="truncate font-medium text-sm leading-4 hover:underline"
           >
-            {currentResource.display_label}
+            {getNodeLabel(currentResource)}
           </Link>
         </Col>
 
@@ -97,7 +98,7 @@ function ResourceSelector({
                           `/resource-manager/${resourcePoolId}/resources/${resource.id}`
                         )}
                       >
-                        {resource.display_label}
+                        {getNodeLabel(resource)}
                       </ListBoxItem>
                     )}
                   </ListBox>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
@@ -8,6 +8,7 @@ import { Popover } from "@/shared/components/aria/popover";
 import { Col, Row } from "@/shared/components/container";
 
 import { ObjectAutocomplete } from "@/entities/nodes/object/ui/object-autocomplete";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeCore } from "@/entities/nodes/types";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { RelationshipSchema } from "@/entities/schema/types";
@@ -59,7 +60,7 @@ export function BreadcrumbItemObject({
             to={getObjectDetailsUrl(node.__typename, node.id)}
             className="truncate font-medium text-sm leading-4 hover:underline"
           >
-            {node.display_label}
+            {getNodeLabel(node)}
           </Link>
         </Col>
 

--- a/frontend/app/src/shared/components/modals/modal-delete-object.tsx
+++ b/frontend/app/src/shared/components/modals/modal-delete-object.tsx
@@ -7,6 +7,7 @@ import { ACCOUNT_TOKEN_OBJECT } from "@/config/constants";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
 import { useDeleteObjectMutation } from "@/entities/nodes/object/domain/delete-object.mutation";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 import { ALERT_TYPES, Alert } from "../ui/alert";
 import ModalDelete from "./modal-delete";
@@ -26,6 +27,9 @@ export default function ModalDeleteObject({ label, rowToDelete, open, close, onD
   const deleteObject = useDeleteObjectMutation();
 
   const objectDisplay =
+    (rowToDelete && "__typename" in rowToDelete && "id" in rowToDelete
+      ? getNodeLabel(rowToDelete)
+      : null) ||
     rowToDelete?.display_label?.value ||
     rowToDelete?.display_label ||
     rowToDelete?.name?.value ||

--- a/frontend/app/src/shared/components/ui/id.tsx
+++ b/frontend/app/src/shared/components/ui/id.tsx
@@ -8,6 +8,7 @@ import { BadgeCircle, CIRCLE_BADGE_TYPES } from "@/shared/components/display/bad
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 
 import { getObjectDisplayLabel } from "@/entities/nodes/api/getObjectDisplayLabel";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 type tId = {
   id: string;
@@ -32,13 +33,13 @@ export const Id = (props: tId) => {
     return <LoadingIndicator />;
   }
 
-  if (error || !object?.display_label) {
+  if (error || !getNodeLabel(object)) {
     return <BadgeCircle type={CIRCLE_BADGE_TYPES.LIGHT}>Name not found</BadgeCircle>;
   }
 
   return (
     <BadgeCircle type={CIRCLE_BADGE_TYPES.LIGHT}>
-      {object?.display_label}
+      {getNodeLabel(object)}
 
       {!preventCopy && (
         <Clipboard

--- a/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-4_integration-with-git.spec.ts
+++ b/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-4_integration-with-git.spec.ts
@@ -35,7 +35,7 @@ test.describe("Getting started with Infrahub - Integration with Git", () => {
       await expect(page.getByText("Generic Device object")).toBeVisible();
       await page.getByRole("link", { name: "atl1-edge1" }).click();
       await page.getByText("Interfaces15").click();
-      await page.getByRole("link", { name: "atl1-edge1, Ethernet1", exact: true }).click();
+      await page.getByRole("link", { name: "Ethernet1", exact: true }).first().click();
     });
 
     await test.step("Update the interface Ethernet 1 for atl1-edge1", async () => {

--- a/frontend/app/tests/e2e/form/multi-select.spec.ts
+++ b/frontend/app/tests/e2e/form/multi-select.spec.ts
@@ -20,7 +20,7 @@ test.describe("Verify multi select behaviour", () => {
   test("select, remove and create tags using multi-select", async ({ page }) => {
     await test.step("Navigate to Ethernet11", async () => {
       await page.goto(`/objects/InfraInterfaceL2?branch=${BRANCH_NAME}`);
-      await page.getByRole("link", { name: "atl1-edge1, Ethernet11", exact: true }).click();
+      await page.getByRole("link", { name: "Ethernet11", exact: true }).first().click();
     });
 
     await page.getByTestId("edit-button").click();

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -63,7 +63,7 @@ test.describe("Verifies the object creation", () => {
       await page
         .getByTestId("identifier-cell")
         .getByRole("link", { name: "Ethernet1", exact: true })
-        .first()
+        .nth(2)
         .click();
       await page.getByTestId("edit-button").click();
     });

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -35,7 +35,7 @@ test.describe("Verifies the object creation", () => {
     });
 
     await test.step("verify object details", async () => {
-      await page.getByRole("link", { name: "vlan-test," }).click();
+      await page.getByRole("link", { name: "vlan-test" }).click();
       await expect(page.getByText("Namevlan-test")).toBeVisible();
       await expect(page.getByText("Vlan Id600")).toBeVisible();
       await expect(page.getByText("L3 GatewayMGMT")).toBeVisible();

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -62,7 +62,8 @@ test.describe("Verifies the object creation", () => {
       await page.goto(`/objects/InfraInterfaceL3?branch=${BRANCH_NAME}`);
       await page
         .getByTestId("identifier-cell")
-        .getByRole("link", { name: "dfw1-edge1, Ethernet1", exact: true })
+        .getByRole("link", { name: "Ethernet1", exact: true })
+        .first()
         .click();
       await page.getByTestId("edit-button").click();
     });

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -63,7 +63,7 @@ test.describe("Verifies the object creation", () => {
       await page
         .getByTestId("identifier-cell")
         .getByRole("link", { name: "Ethernet1", exact: true })
-        .nth(2)
+        .first()
         .click();
       await page.getByTestId("edit-button").click();
     });
@@ -71,7 +71,7 @@ test.describe("Verifies the object creation", () => {
     await test.step("check inputs values", async () => {
       await expect(page.getByLabel("Kind")).toContainText("Interface L3 Infra");
       await expect(page.locator('button[name="connected_endpoint_parent"]')).toContainText(
-        "dfw1-edge2"
+        "atl1-edge2"
       );
       await expect(
         page.getByTestId("side-panel-container").getByLabel("Interface L3")

--- a/frontend/app/tests/e2e/objects/convert/object-convert.spec.ts
+++ b/frontend/app/tests/e2e/objects/convert/object-convert.spec.ts
@@ -20,7 +20,7 @@ test.describe("Object details - convert", () => {
   test("should convert an Interface L3 to an Interface L2", async ({ page }) => {
     await test.step("access object details and convert page", async () => {
       await page.goto(`/objects/InfraInterface?branch=${BRANCH_NAME}`);
-      await page.getByRole("link", { name: "atl1-edge1, Ethernet1", exact: true }).click();
+      await page.getByRole("link", { name: "Ethernet1", exact: true }).first().click();
       await page.getByTestId("object-details-button").click();
       await saveScreenshotForDocs(page, "object_convert_button");
       await page.getByRole("menuitem", { name: "Convert object type" }).click();

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -74,7 +74,7 @@ test.describe("/objects/:objectKind/:objectId", () => {
       await expect(kindSelector).toContainText("Circuit Endpoint");
 
       const nodeSelector = page.getByLabel("Circuit Endpoint").getByTestId("select-value");
-      await expect(nodeSelector).not.toBeEmpty();
+      await expect(nodeSelector).not.toBeEmpty(); // ID is in the input but it's dynamic
     });
   });
 });

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -74,7 +74,7 @@ test.describe("/objects/:objectKind/:objectId", () => {
       await expect(kindSelector).toContainText("Circuit Endpoint");
 
       const nodeSelector = page.getByLabel("Circuit Endpoint").getByTestId("select-value");
-      await expect(nodeSelector).toContainText("InfraCircuitEndpoint");
+      await expect(nodeSelector).not.toBeEmpty();
     });
   });
 });

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -67,7 +67,7 @@ test.describe("/objects/:objectKind/:objectId", () => {
 
       await page.getByRole("link", { name: "atl1-edge1" }).click();
       await page.getByText("Interfaces15").click();
-      await page.getByRole("link", { name: "atl1-edge1, Ethernet4" }).click();
+      await page.getByRole("link", { name: "Ethernet4" }).first().click();
       await page.getByTestId("edit-button").click();
 
       const kindSelector = page.getByLabel("Kind").getByTestId("select-value");

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -96,7 +96,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
       await test.step("Edit a relationship", async () => {
         await page.getByRole("link", { name: "Loopback0", exact: true }).click();
 
-        await page.getByRole("menuitem", { name: "Edit" }).click();
+        await page.getByTestId("edit-button").click();
         await expect(page.getByText("Device *")).toBeVisible();
         await page.getByRole("textbox", { name: "Name *" }).fill("Loopback0-update");
         await page.getByRole("button", { name: "Save" }).click();

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -132,7 +132,8 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
       await page.goto(`/objects/InfraInterfaceL3?branch=${BRANCH_NAME}`);
       await page
         .getByTestId("identifier-cell")
-        .getByRole("link", { name: "den1-edge2, Ethernet1", exact: true })
+        .getByRole("link", { name: "Ethernet1", exact: true })
+        .nth(2)
         .click();
       await page.getByText("Ip Addresses1").click();
       await page.getByTestId("open-relationship-form-button").click();

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -94,7 +94,8 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
       });
 
       await test.step("Edit a relationship", async () => {
-        await page.getByTestId("Loopback0").click();
+        await page.getByRole("link", { name: "Loopback0", exact: true }).click();
+
         await page.getByRole("menuitem", { name: "Edit" }).click();
         await expect(page.getByText("Device *")).toBeVisible();
         await page.getByRole("textbox", { name: "Name *" }).fill("Loopback0-update");

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -104,7 +104,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
 
       await test.step("Verify relationship update", async () => {
         await expect(page.getByText("InterfaceL3 updated")).toBeVisible();
-        await expect(page.getByText("Loopback0-update", { exact: true })).toBeVisible();
+        await expect(page.getByText("NameLoopback0-update", { exact: true })).toBeVisible();
       });
     });
 

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -136,7 +136,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
         .getByRole("link", { name: "Ethernet1", exact: true })
         .nth(2)
         .click();
-      await page.getByText("Ip Addresses1").click();
+      await page.getByText("Ip Addresses0").click();
       await page.getByTestId("open-relationship-form-button").click();
       await page.getByTestId("select-open-pool-option-button").click();
       await expect(page.getByRole("option", { name: "Loopbacks pool" })).toBeVisible();

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -104,7 +104,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
 
       await test.step("Verify relationship update", async () => {
         await expect(page.getByText("InterfaceL3 updated")).toBeVisible();
-        await expect(page.getByText("NameLoopback0-update", { exact: true })).toBeVisible();
+        await expect(page.getByText("NameLoopback0-update")).toBeVisible();
       });
     });
 

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -94,7 +94,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
       });
 
       await test.step("Edit a relationship", async () => {
-        await page.getByTestId("actions-cell-atl1-core1, Loopback0").click();
+        await page.getByTestId("Loopback0").click();
         await page.getByRole("menuitem", { name: "Edit" }).click();
         await expect(page.getByText("Device *")).toBeVisible();
         await page.getByRole("textbox", { name: "Name *" }).fill("Loopback0-update");

--- a/frontend/app/tests/e2e/objects/profiles/profile-on-generic.spec.ts
+++ b/frontend/app/tests/e2e/objects/profiles/profile-on-generic.spec.ts
@@ -109,9 +109,7 @@ test.describe("/objects/CoreProfile - Profile for Interface L2 and fields verifi
 
   test("should verify the available profiles in the object form", async ({ page }) => {
     await page.goto(`/objects/InfraInterface?branch=${BRANCH_NAME}`);
-    await expect(
-      page.getByRole("link", { name: "atl1-edge1, Ethernet1", exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Ethernet1", exact: true }).first()).toBeVisible();
     await page.getByTestId("create-object-button").click();
     await page.getByLabel("Select an object type").click();
     await page.getByRole("option", { name: "Interface L2 Infra", exact: true }).click();

--- a/frontend/app/tests/e2e/resource-manager/number-pool.spec.ts
+++ b/frontend/app/tests/e2e/resource-manager/number-pool.spec.ts
@@ -117,7 +117,7 @@ test.describe("/resource-manager - Number Pool Tests", () => {
 
     await test.step("Verify pool assignment", async () => {
       await page.getByRole("searchbox", { name: "Search" }).fill("interface with pool");
-      await page.getByRole("link", { name: "atl1-core1, test interface" }).click();
+      await page.getByRole("link", { name: "test interface with pool" }).click();
       await page.getByText("Speed1").getByTestId("view-metadata-button").click();
       await expect(page.getByRole("link", { name: "number pool test for generic" })).toBeVisible();
     });

--- a/frontend/app/tests/e2e/search.spec.ts
+++ b/frontend/app/tests/e2e/search.spec.ts
@@ -98,7 +98,7 @@ test.describe("when searching an object", () => {
 
     await page.getByTestId("search-anywhere-input").fill(uuid);
     await expect(
-      page.getByRole("option", { name: "AS174, 174 Infra Autonomous System" })
+      page.getByRole("option", { name: "AS174 174 Infra Autonomous System" })
     ).toBeVisible();
   });
 });

--- a/frontend/app/tests/e2e/search.spec.ts
+++ b/frontend/app/tests/e2e/search.spec.ts
@@ -88,7 +88,7 @@ test.describe("when searching an object", () => {
   test("display result when searching by uuid", async ({ page }) => {
     await page.goto("/objects/InfraAutonomousSystem");
 
-    await page.getByRole("link", { name: "AS174, 174" }).click();
+    await page.getByRole("link", { name: "AS174 174" }).click();
     const uuid = (await page.locator("dd").first().textContent()) as string;
 
     await test.step("open search anywhere modal", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized object labels across the UI to use a centralized resolver that now prefers display_label, then human‑friendly ID (hfid), then object ID — ensuring consistent names and safer fallbacks.

* **Tests**
  * Updated end-to-end tests and selectors to match revised visible labels and link texts.

* **Chore**
  * Added changelog entry documenting the label display priority.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->