### PR TITLE
Ensure breadcrumb shows hierarchy when depth limit is reached + help tooltip

### DIFF
--- a/frontend/app/src/config/constants.ts
+++ b/frontend/app/src/config/constants.ts
@@ -155,8 +155,6 @@ export const PROPOSED_CHANGES_EDITABLE_STATE = ["open", "closed"];
 
 export const TASK_TAB = "tasks";
 
-export const SEARCH_QUERY_NAME = "InfrahubSearchAnywhere";
-
 export const SEARCH_ANY_FILTER = "any__value";
 
 export const SEARCH_PARTIAL_MATCH = "partial_match";

--- a/frontend/app/src/entities/nodes/hierarchy/domain/get-object-ancestors.test.ts
+++ b/frontend/app/src/entities/nodes/hierarchy/domain/get-object-ancestors.test.ts
@@ -324,6 +324,56 @@ describe("getObjectAncestors", () => {
     });
 
     // THEN: Should filter out null nodes and still maintain order
+    expect(result[1]!.id).toBe("child-id");
+  });
+
+  it("should return partial ancestors chain when root is missing from response", async () => {
+    // GIVEN
+    const child: NodeCoreWithParent = {
+      id: "child-id",
+      __typename: "LocationCity",
+      display_label: "Los Angeles",
+      parent: {
+        node: { id: "parent-id", __typename: "LocationState", display_label: "California" },
+      },
+    };
+    const parent: NodeCoreWithParent = {
+      id: "parent-id",
+      __typename: "LocationState",
+      display_label: "California",
+      parent: {
+        node: { id: "grandparent-id", __typename: "LocationCountry", display_label: "USA" },
+      },
+    };
+    const mockApiResponse = {
+      data: {
+        [objectKind]: {
+          edges: [
+            {
+              node: {
+                ...child,
+                ancestors: {
+                  edges: [{ node: parent }],
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    vi.mocked(getObjectAncestorsFromApiModule.getObjectAncestorsFromApi).mockResolvedValue(
+      mockApiResponse as any
+    );
+
+    // WHEN
+    const result = await getObjectAncestors({
+      branchName,
+      objectKind,
+      objectId,
+    });
+
+    // THEN
     expect(result).toHaveLength(2);
     expect(result[0]!.id).toBe("parent-id");
     expect(result[1]!.id).toBe("child-id");

--- a/frontend/app/src/entities/nodes/hierarchy/domain/get-object-ancestors.ts
+++ b/frontend/app/src/entities/nodes/hierarchy/domain/get-object-ancestors.ts
@@ -38,21 +38,17 @@ export const getObjectAncestors: GetObjectAncestors = async ({
   const { ancestors, ...currentObject } = result;
   const ancestorNodes = ancestors?.edges?.map((edge) => edge.node).filter((n) => !!n) ?? [];
 
-  // Build an ordered list from root (parent = null) to current object
+  // Build an ordered list from current object to root (or as far up as we can go)
   const allNodes = [...ancestorNodes, currentObject] as Array<NodeCoreWithParent>;
   const nodeMap = new Map(allNodes.map((node) => [node.id, node]));
 
-  // Start from the root (parent is null) and build the ordered chain
   const orderedNodes: Array<NodeCoreWithParent> = [];
-  const root = allNodes.find((node) => !node.parent?.node?.id);
+  let current: NodeCoreWithParent | undefined = currentObject;
 
-  if (root) {
-    let current: NodeCoreWithParent | undefined = root;
-    while (current) {
-      orderedNodes.push(current);
-      const nextId = allNodes.find((node) => node.parent?.node?.id === current?.id)?.id;
-      current = nextId ? nodeMap.get(nextId) : undefined;
-    }
+  while (current) {
+    orderedNodes.unshift(current);
+    const parentId: string | undefined = current.parent?.node?.id;
+    current = parentId ? nodeMap.get(parentId) : undefined;
   }
 
   return orderedNodes;

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -65,7 +65,7 @@ export function BreadcrumbObjectDetailsHierarchy({
             href={`${INFRAHUB_DOC_LOCAL}/reference/configuration#database`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-amber-600"
+            className="text-amber-600 gap-1"
           >
             <TriangleAlertIcon className="size-4" /> Depth limit reached
           </BreadcrumbItem>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -48,30 +48,28 @@ export function BreadcrumbObjectDetailsHierarchy({
   return (
     <>
       {!hasTopLevelNode && (
-        <BreadcrumbItem>
-          <Tooltip
-            enabled
-            content={
-              <div className="max-w-xs">
-                <p className="mb-2 font-semibold">Hierarchy depth limit reached</p>
-                <p>
-                  The complete hierarchy cannot be displayed because the maximum search depth has
-                  been reached. Click to learn more about configuring{" "}
-                  <code className="bg-gray-700">INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY</code>.
-                </p>
-              </div>
-            }
+        <Tooltip
+          enabled
+          content={
+            <div className="max-w-xs">
+              <p className="mb-2 font-semibold">Hierarchy depth limit reached</p>
+              <p>
+                The complete hierarchy cannot be displayed because the maximum search depth has
+                been reached. Click to learn more about configuring{" "}
+                <code className="bg-gray-700">INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY</code>.
+              </p>
+            </div>
+          }
+        >
+          <BreadcrumbItem
+            href={`${INFRAHUB_DOC_LOCAL}/reference/configuration#database`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-amber-600"
           >
-            <a
-              href={`${INFRAHUB_DOC_LOCAL}/reference/configuration#database`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-amber-600 hover:underline"
-            >
-              <TriangleAlertIcon className="size-4" /> Depth limit reached
-            </a>
-          </Tooltip>
-        </BreadcrumbItem>
+            <TriangleAlertIcon className="size-4" /> Depth limit reached
+          </BreadcrumbItem>
+        </Tooltip>
       )}
 
       {data.map((ancestor) => (

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -1,7 +1,15 @@
 import { keepPreviousData } from "@tanstack/react-query";
+import { TriangleAlertIcon } from "lucide-react";
 
-import { BreadcrumbItemError, BreadcrumbItemLoading } from "@/shared/components/aria/breadcrumbs";
+import { INFRAHUB_DOC_LOCAL } from "@/config/config";
+
+import {
+  BreadcrumbItem,
+  BreadcrumbItemError,
+  BreadcrumbItemLoading,
+} from "@/shared/components/aria/breadcrumbs";
 import { BreadcrumbItemObject } from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object";
+import { Tooltip } from "@/shared/components/ui/tooltip";
 
 import { useGetObjectAncestors } from "@/entities/nodes/hierarchy/domain/get-object-ancestors.query";
 import type { NodeCoreWithParent } from "@/entities/nodes/types";
@@ -35,9 +43,42 @@ export function BreadcrumbObjectDetailsHierarchy({
     return <BreadcrumbItemError error={error} />;
   }
 
-  return data.map((ancestor) => (
-    <BreadcrumbItemObjectHierarchy key={ancestor.id} node={ancestor} />
-  ));
+  const hasTopLevelNode = data.some((node) => !node.parent.node);
+
+  return (
+    <>
+      {!hasTopLevelNode && (
+        <BreadcrumbItem>
+          <Tooltip
+            enabled
+            content={
+              <div className="max-w-xs">
+                <p className="mb-2 font-semibold">Hierarchy depth limit reached</p>
+                <p>
+                  The complete hierarchy cannot be displayed because the maximum search depth has
+                  been reached. Click to learn more about configuring{" "}
+                  <code className="bg-gray-700">INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY</code>.
+                </p>
+              </div>
+            }
+          >
+            <a
+              href={`${INFRAHUB_DOC_LOCAL}/reference/configuration#database`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-amber-600 hover:underline"
+            >
+              <TriangleAlertIcon className="size-4" /> Depth limit reached
+            </a>
+          </Tooltip>
+        </BreadcrumbItem>
+      )}
+
+      {data.map((ancestor) => (
+        <BreadcrumbItemObjectHierarchy key={ancestor.id} node={ancestor} />
+      ))}
+    </>
+  );
 }
 
 function BreadcrumbItemObjectHierarchy({ node }: { node: NodeCoreWithParent }) {

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -65,7 +65,7 @@ export function BreadcrumbObjectDetailsHierarchy({
             href={`${INFRAHUB_DOC_LOCAL}/reference/configuration#database`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-amber-600 gap-1"
+            className="gap-1 text-amber-600"
           >
             <TriangleAlertIcon className="size-4" /> Depth limit reached
           </BreadcrumbItem>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -54,8 +54,8 @@ export function BreadcrumbObjectDetailsHierarchy({
             <div className="max-w-xs">
               <p className="mb-2 font-semibold">Hierarchy depth limit reached</p>
               <p>
-                The complete hierarchy cannot be displayed because the maximum search depth has
-                been reached. Click to learn more about configuring{" "}
+                The complete hierarchy cannot be displayed because the maximum search depth has been
+                reached. Click to learn more about configuring{" "}
                 <code className="bg-gray-700">INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY</code>.
               </p>
             </div>


### PR DESCRIPTION
Issue:
- https://github.com/opsmill/infrahub/issues/7677
<img width="1224" height="159" alt="image" src="https://github.com/user-attachments/assets/04542800-0e16-49e1-a329-0beb8549af41" />
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ancestor chain retrieval more reliably handles missing or partial ancestor data and preserves correct ordering.

* **New Features**
  * Breadcrumbs display a "Depth limit reached" warning with a help link when the top-level ancestor is unavailable.

* **Tests**
  * Added coverage for partial-ancestor responses and ordering when some ancestors are missing.

* **Chores**
  * Removed a legacy search-related constant from configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->