### PR TITLE
Fixed sidebar collapsing when a link existed at the top level

### DIFF
--- a/changelog/+sidebar-collapse.fixed.md
+++ b/changelog/+sidebar-collapse.fixed.md
@@ -1,0 +1,1 @@
+Fixed a UI issue that prevented the sidebar from fully collapsing when a link existed at the top level.

--- a/frontend/app/src/shared/components/layout/menu-navigation/components/menu-section-object.tsx
+++ b/frontend/app/src/shared/components/layout/menu-navigation/components/menu-section-object.tsx
@@ -90,7 +90,7 @@ const TopLevelMenuItem: React.FC<{
     return (
       <Link
         to={constructPath(item.path)}
-        className={classNames(menuNavigationItemStyle, "w-[224px]")}
+        className={classNames(menuNavigationItemStyle, isCollapsed ? "p-2" : "w-[224px]")}
       >
         <MenuItemIcon item={item} />
         <span className={classNames("text-sm", isCollapsed && "hidden")}>{item.label}</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar collapse behavior when top-level navigation links are present. The sidebar now fully collapses with consistent styling throughout the navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->