### PR TITLE
Add quotes to git config safe directory and --replace-all

### DIFF
--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -221,7 +221,7 @@ class InfrahubWorkerAsync(BaseWorker):
 
         await self._run_git_config_global(config.SETTINGS.git.user_name, setting_name="user.name")
         await self._run_git_config_global(config.SETTINGS.git.user_email, setting_name="user.email")
-        await self._run_git_config_global("*", "--add", setting_name="safe.directory")
+        await self._run_git_config_global("'*'", "--add", setting_name="safe.directory")
         await self._run_git_config_global("true", setting_name="credential.usehttppath")
         await self._run_git_config_global(config.SETTINGS.dev.git_credential_helper, setting_name="credential.helper")
 

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -221,7 +221,7 @@ class InfrahubWorkerAsync(BaseWorker):
 
         await self._run_git_config_global(config.SETTINGS.git.user_name, setting_name="user.name")
         await self._run_git_config_global(config.SETTINGS.git.user_email, setting_name="user.email")
-        await self._run_git_config_global("'*'", "--add", setting_name="safe.directory")
+        await self._run_git_config_global("'*'", "--replace-all", setting_name="safe.directory")
         await self._run_git_config_global("true", setting_name="credential.usehttppath")
         await self._run_git_config_global(config.SETTINGS.dev.git_credential_helper, setting_name="credential.helper")
 


### PR DESCRIPTION
Adds quotes to the `'*'` wildcard and `--replace-all` to the git config for safe directory to avoid appending another identical entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git configuration handling for secure directory settings to avoid misconfiguration and improve compatibility across environments, reducing potential failures when performing repository operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->