### PR TITLE
fix(backend): IFC-2040 cache task count results

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -402,6 +402,11 @@ class WorkflowSettings(BaseSettings):
     worker_polling_interval: int = Field(
         default=2, ge=1, le=30, description="Specify how often the worker should poll the server for tasks (sec)"
     )
+    flow_run_count_cache_threshold: int = Field(
+        default=100_000,
+        ge=0,
+        description="Threshold for caching flow run counts (0 to always cache, higher values to disable)",
+    )
 
     @property
     def api_endpoint(self) -> str:

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -1,5 +1,6 @@
 import asyncio
-import uuid
+import hashlib
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
@@ -27,11 +28,14 @@ from prefect.client.schemas.sorting import (
     FlowRunSort,
 )
 
+from infrahub import config
 from infrahub.core.constants import TaskConclusion
 from infrahub.core.query.node import NodeGetKindQuery
 from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
+from infrahub.message_bus.types import KVTTL
 from infrahub.utils import get_nested_dict
+from infrahub.workers.dependencies import get_cache
 from infrahub.workflows.constants import TAG_NAMESPACE, WorkflowTag
 
 from .constants import CONCLUSION_STATE_MAPPING
@@ -44,6 +48,12 @@ PREFECT_MAX_LOGS_PER_CALL = 200
 
 
 class PrefectTask:
+    @staticmethod
+    def _build_flow_run_count_cache_key(body: dict[str, Any]) -> str:
+        serialized = json.dumps(body, sort_keys=True, separators=(",", ":"))
+        hashed = hashlib.sha256(serialized.encode()).hexdigest()
+        return f"task_manager:flow_run_count:{hashed}"
+
     @classmethod
     async def count_flow_runs(
         cls,
@@ -59,10 +69,24 @@ class PrefectTask:
             "flows": flow_filter.model_dump(mode="json") if flow_filter else None,
             "flow_runs": (flow_run_filter.model_dump(mode="json", exclude_unset=True) if flow_run_filter else None),
         }
+        cache_key = cls._build_flow_run_count_cache_key(body)
+
+        cache = await get_cache()
+        cached_value_raw = await cache.get(key=cache_key)
+        if cached_value_raw is not None:
+            try:
+                return int(cached_value_raw)
+            except (TypeError, ValueError):
+                await cache.delete(key=cache_key)
 
         response = await client._client.post("/flow_runs/count", json=body)
         response.raise_for_status()
-        return response.json()
+        count_value = int(response.json())
+
+        if count_value >= config.SETTINGS.workflow.flow_run_count_cache_threshold:
+            await cache.set(key=cache_key, value=str(count_value), expires=KVTTL.ONE_MINUTE)
+
+        return count_value
 
     @classmethod
     async def _get_related_nodes(cls, db: InfrahubDatabase, flows: list[FlowRun]) -> RelatedNodesInfo:
@@ -204,7 +228,7 @@ class PrefectTask:
             tags=FlowRunFilterTags(all_=filter_tags),
         )
         if ids:
-            flow_run_filter.id = FlowRunFilterId(any_=[uuid.UUID(id) for id in ids])
+            flow_run_filter.id = FlowRunFilterId(any_=[UUID(id) for id in ids])
 
         if statuses:
             flow_run_filter.state = FlowRunFilterState(type=FlowRunFilterStateType(any_=statuses))

--- a/changelog/7568.fixed.md
+++ b/changelog/7568.fixed.md
@@ -1,0 +1,1 @@
+Enable caching of the task count in order to avoid performance issues when having a long task history.

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -89,7 +89,8 @@ RUN mkdir -p /opt/infrahub/git /opt/infrahub/storage /opt/infrahub/source /opt/i
 WORKDIR /source
 
 ENV PREFECT_WORKER_QUERY_SECONDS="2" \
-    PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES=500
+    PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES=500 \
+    PREFECT_API_DATABASE_TIMEOUT=60
 
 # --------------------------------------------
 # Import Frontend Build

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -143,6 +143,7 @@ Configuration settings for the message bus.
 | `INFRAHUB_WORKFLOW_EXTRA_LOGGERS` | A list of additional logger that will be captured during task execution. | array[string] | None |
 | `INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL` | Log level applied to all extra loggers. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | INFO |
 | `INFRAHUB_WORKFLOW_WORKER_POLLING_INTERVAL` | Specify how often the worker should poll the server for tasks (sec) | integer | 2 |
+| `INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD` | Threshold for caching flow run counts (0 to always cache, higher values to disable) | integer | 100000 |
 
 ## Miscellaneous
 


### PR DESCRIPTION
When the task history is large, the count query can take a few seconds to complete due to how the Prefect database is handling the query (it will scan each row in the table).
We can cache the count result when the history is larger than a statically defined 100k entries.

Also update the default db timeout value for Prefect since the count query can sometimes take more time than the default 10 seconds value.

Related to https://github.com/opsmill/infrahub/issues/7568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented flow run count caching with configurable threshold (default: 100,000)
  * Cache entries expire after one minute

* **Configuration**
  * New setting: INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD to control caching
  * New environment variable: PREFECT_API_DATABASE_TIMEOUT=60 for backend DB operations

* **Documentation**
  * Updated configuration reference with the new cache threshold

* **Changelog**
  * Added entry noting task count caching to mitigate long-history performance issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->