### PR TITLE
fix: allow List attributes to use regex parameter

### DIFF
--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -16,7 +16,7 @@ def get_attribute_parameters_class_for_kind(kind: str) -> type[AttributeParamete
         "NumberPool": NumberPoolParameters,
         "Text": TextAttributeParameters,
         "TextArea": TextAttributeParameters,
-        "List": TextAttributeParameters,
+        "List": ListAttributeParameters,
         "Number": NumberAttributeParameters,
     }
     return param_classes.get(kind, AttributeParameters)
@@ -51,6 +51,16 @@ class AttributeParameters(HashableModel):
         target_fields = set(cls.model_fields.keys())
         filtered_data = {k: v for k, v in source_data.items() if k in target_fields}
         return cls(**filtered_data)
+
+
+class ListAttributeParameters(AttributeParameters):
+    """Parameters for List attributes supporting regex validation on list items."""
+
+    regex: str | None = Field(
+        default=None,
+        description="Regular expression that each list item value must match if defined",
+        json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
+    )
 
 
 class TextAttributeParameters(AttributeParameters):

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -16,6 +16,7 @@ def get_attribute_parameters_class_for_kind(kind: str) -> type[AttributeParamete
         "NumberPool": NumberPoolParameters,
         "Text": TextAttributeParameters,
         "TextArea": TextAttributeParameters,
+        "List": TextAttributeParameters,
         "Number": NumberAttributeParameters,
     }
     return param_classes.get(kind, AttributeParameters)

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -280,13 +280,6 @@ class ListAttributeSchema(AttributeSchema):
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )
 
-    @model_validator(mode="after")
-    def reconcile_parameters(self) -> Self:
-        if self.regex != self.parameters.regex:
-            final_regex = self.parameters.regex if self.parameters.regex is not None else self.regex
-            self.regex = self.parameters.regex = final_regex
-        return self
-
     def get_regex(self) -> str | None:
         return self.parameters.regex
 

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -15,6 +15,7 @@ from infrahub.types import ATTRIBUTE_KIND_LABELS, ATTRIBUTE_TYPES
 
 from .attribute_parameters import (
     AttributeParameters,
+    ListAttributeParameters,
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
@@ -135,8 +136,11 @@ class AttributeSchema(GeneratedAttributeSchema):
         if isinstance(self.parameters, NumberPoolParameters) and not self.kind == "NumberPool":
             raise ValueError(f"NumberPoolParameters can't be used as parameters for {self.kind}")
 
-        if isinstance(self.parameters, TextAttributeParameters) and self.kind not in ["Text", "TextArea", "List"]:
+        if isinstance(self.parameters, TextAttributeParameters) and self.kind not in ["Text", "TextArea"]:
             raise ValueError(f"TextAttributeParameters can't be used as parameters for {self.kind}")
+
+        if isinstance(self.parameters, ListAttributeParameters) and self.kind != "List":
+            raise ValueError(f"ListAttributeParameters can't be used as parameters for {self.kind}")
 
         return self
 
@@ -264,8 +268,14 @@ class NumberAttributeSchema(AttributeSchema):
 
 
 class ListAttributeSchema(AttributeSchema):
-    parameters: TextAttributeParameters = Field(
-        default_factory=TextAttributeParameters,
+    """Schema for List attributes with regex validation support.
+
+    Note: Only regex validation is supported for List attributes.
+    Unlike Text/TextArea attributes, min_length and max_length are not supported.
+    """
+
+    parameters: ListAttributeParameters = Field(
+        default_factory=ListAttributeParameters,
         description="Extra parameters specific to list attributes",
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -135,7 +135,7 @@ class AttributeSchema(GeneratedAttributeSchema):
         if isinstance(self.parameters, NumberPoolParameters) and not self.kind == "NumberPool":
             raise ValueError(f"NumberPoolParameters can't be used as parameters for {self.kind}")
 
-        if isinstance(self.parameters, TextAttributeParameters) and self.kind not in ["Text", "TextArea"]:
+        if isinstance(self.parameters, TextAttributeParameters) and self.kind not in ["Text", "TextArea", "List"]:
             raise ValueError(f"TextAttributeParameters can't be used as parameters for {self.kind}")
 
         return self
@@ -263,9 +263,28 @@ class NumberAttributeSchema(AttributeSchema):
     )
 
 
+class ListAttributeSchema(AttributeSchema):
+    parameters: TextAttributeParameters = Field(
+        default_factory=TextAttributeParameters,
+        description="Extra parameters specific to list attributes",
+        json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
+    )
+
+    @model_validator(mode="after")
+    def reconcile_parameters(self) -> Self:
+        if self.regex != self.parameters.regex:
+            final_regex = self.parameters.regex if self.parameters.regex is not None else self.regex
+            self.regex = self.parameters.regex = final_regex
+        return self
+
+    def get_regex(self) -> str | None:
+        return self.parameters.regex
+
+
 attribute_schema_class_by_kind: dict[str, type[AttributeSchema]] = {
     "NumberPool": NumberPoolSchema,
     "Text": TextAttributeSchema,
     "TextArea": TextAttributeSchema,
+    "List": ListAttributeSchema,
     "Number": NumberAttributeSchema,
 }

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -33,6 +33,7 @@ from infrahub.core.constants import (
 )
 from infrahub.core.schema.attribute_parameters import (
     AttributeParameters,
+    ListAttributeParameters,
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
@@ -643,6 +644,7 @@ attribute_schema = SchemaNode(
             kind="JSON",
             internal_kind=[
                 AttributeParameters,
+                ListAttributeParameters,
                 TextAttributeParameters,
                 NumberAttributeParameters,
                 NumberPoolParameters,

--- a/backend/infrahub/core/schema/generated/attribute_schema.py
+++ b/backend/infrahub/core/schema/generated/attribute_schema.py
@@ -10,6 +10,7 @@ from infrahub.core.constants import AllowOverrideType, BranchSupportType, Hashab
 from infrahub.core.models import HashableModel
 from infrahub.core.schema.attribute_parameters import (
     AttributeParameters,
+    ListAttributeParameters,
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
@@ -118,12 +119,16 @@ class GeneratedAttributeSchema(HashableModel):
         description="Type of allowed override for the attribute.",
         json_schema_extra={"update": "allowed"},
     )
-    parameters: AttributeParameters | TextAttributeParameters | NumberAttributeParameters | NumberPoolParameters = (
-        Field(
-            default_factory=AttributeParameters,
-            description="Extra parameters specific to this kind of attribute",
-            json_schema_extra={"update": "validate_constraint"},
-        )
+    parameters: (
+        AttributeParameters
+        | ListAttributeParameters
+        | TextAttributeParameters
+        | NumberAttributeParameters
+        | NumberPoolParameters
+    ) = Field(
+        default_factory=AttributeParameters,
+        description="Extra parameters specific to this kind of attribute",
+        json_schema_extra={"update": "validate_constraint"},
     )
     deprecation: str | None = Field(
         default=None,

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -54,7 +54,11 @@ from infrahub.core.schema import (
     SchemaRoot,
     TemplateSchema,
 )
-from infrahub.core.schema.attribute_parameters import NumberPoolParameters, TextAttributeParameters
+from infrahub.core.schema.attribute_parameters import (
+    ListAttributeParameters,
+    NumberPoolParameters,
+    TextAttributeParameters,
+)
 from infrahub.core.schema.attribute_schema import get_attribute_schema_class_for_kind
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
@@ -509,44 +513,53 @@ class SchemaBranch:
 
         return fields or None
 
-    def _text_attr_needs_reconciliation(self, attr: AttributeSchema) -> bool:
-        """Check if a Text attribute needs reconciliation between deprecated fields and parameters."""
-        if not isinstance(attr.parameters, TextAttributeParameters):
-            return False
-        return (
-            attr.regex != attr.parameters.regex
-            or attr.min_length != attr.parameters.min_length
-            or attr.max_length != attr.parameters.max_length
-        )
+    def _attr_needs_legacy_param_reconciliation(self, attr: AttributeSchema) -> bool:
+        """Check if an attribute needs reconciliation between deprecated fields and parameters.
 
-    def _reconcile_text_attr(self, attr: AttributeSchema) -> None:
-        """Reconcile a single Text attribute's deprecated fields with parameters.
+        Supports Text/TextArea attributes (regex, min_length, max_length) and List attributes (regex).
+        """
+        if isinstance(attr.parameters, TextAttributeParameters):
+            return (
+                attr.regex != attr.parameters.regex
+                or attr.min_length != attr.parameters.min_length
+                or attr.max_length != attr.parameters.max_length
+            )
+        if isinstance(attr.parameters, ListAttributeParameters):
+            return attr.regex != attr.parameters.regex
+        return False
+
+    def _reconcile_legacy_attr_params(self, attr: AttributeSchema) -> None:
+        """Reconcile an attribute's deprecated fields with parameters.
 
         Parameters take precedence over deprecated top-level fields when both are set.
+        Supports Text/TextArea attributes (regex, min_length, max_length) and List attributes (regex).
         """
-        if not isinstance(attr.parameters, TextAttributeParameters):
-            return
+        if isinstance(attr.parameters, (TextAttributeParameters, ListAttributeParameters)):
+            # Sync regex: parameters takes precedence
+            if attr.parameters.regex is not None:
+                attr.regex = attr.parameters.regex
+            elif attr.regex is not None:
+                attr.parameters.regex = attr.regex
 
-        # Sync regex: parameters takes precedence
-        if attr.parameters.regex is not None:
-            attr.regex = attr.parameters.regex
-        elif attr.regex is not None:
-            attr.parameters.regex = attr.regex
+        if isinstance(attr.parameters, TextAttributeParameters):
+            # Sync min_length: parameters takes precedence
+            if attr.parameters.min_length is not None:
+                attr.min_length = attr.parameters.min_length
+            elif attr.min_length is not None:
+                attr.parameters.min_length = attr.min_length
 
-        # Sync min_length: parameters takes precedence
-        if attr.parameters.min_length is not None:
-            attr.min_length = attr.parameters.min_length
-        elif attr.min_length is not None:
-            attr.parameters.min_length = attr.min_length
+            # Sync max_length: parameters takes precedence
+            if attr.parameters.max_length is not None:
+                attr.max_length = attr.parameters.max_length
+            elif attr.max_length is not None:
+                attr.parameters.max_length = attr.max_length
 
-        # Sync max_length: parameters takes precedence
-        if attr.parameters.max_length is not None:
-            attr.max_length = attr.parameters.max_length
-        elif attr.max_length is not None:
-            attr.parameters.max_length = attr.max_length
+    def _reconcile_legacy_attribute_parameters(self, schema: SchemaRoot | None = None) -> None:
+        """Reconcile deprecated fields and parameters for attributes with legacy parameter support.
 
-    def _reconcile_text_attribute_parameters(self, schema: SchemaRoot | None = None) -> None:
-        """Reconcile regex, min_length, max_length between deprecated fields and parameters for Text attributes.
+        This handles the transition of validation parameters (regex, min_length, max_length)
+        from top-level attribute fields to the nested parameters object. Supports Text/TextArea
+        and List attributes.
 
         Args:
             schema: If provided, reconcile incoming schema data before merging.
@@ -556,19 +569,19 @@ class SchemaBranch:
             # Incoming schema: modify in place
             for item in schema.nodes + schema.generics:
                 for attr in item.attributes:
-                    self._reconcile_text_attr(attr)
+                    self._reconcile_legacy_attr_params(attr)
             return
 
         # Loaded schemas: need to duplicate before modifying
         for name in self.all_names:
             node = self.get(name=name, duplicate=False)
 
-            if not any(self._text_attr_needs_reconciliation(attr) for attr in node.attributes):
+            if not any(self._attr_needs_legacy_param_reconciliation(attr) for attr in node.attributes):
                 continue
 
             node = node.duplicate()
             for attr in node.attributes:
-                self._reconcile_text_attr(attr)
+                self._reconcile_legacy_attr_params(attr)
             self.set(name=name, schema=node)
 
     def load_schema(self, schema: SchemaRoot) -> None:
@@ -576,8 +589,8 @@ class SchemaBranch:
 
         In the current implementation, if a schema object present in the SchemaRoot already exist, it will be overwritten.
         """
-        # Reconcile deprecated text attribute parameters before merging
-        self._reconcile_text_attribute_parameters(schema)
+        # Reconcile deprecated attribute parameters before merging
+        self._reconcile_legacy_attribute_parameters(schema)
 
         for item in schema.nodes + schema.generics:
             try:
@@ -618,7 +631,7 @@ class SchemaBranch:
         self.generate_identifiers()
         self.process_default_values()
         self.process_deprecations()
-        self._reconcile_text_attribute_parameters()
+        self._reconcile_legacy_attribute_parameters()
         self.process_cardinality_counts()
         self.process_inheritance()
         self.process_hierarchy()

--- a/backend/templates/attributeschema_imports.j2
+++ b/backend/templates/attributeschema_imports.j2
@@ -5,6 +5,7 @@ from typing import Any
 from infrahub.core.models import HashableModel
 from infrahub.core.constants import AllowOverrideType, BranchSupportType, HashableModelState
 from infrahub.core.schema.attribute_parameters import AttributeParameters
+from infrahub.core.schema.attribute_parameters import ListAttributeParameters
 from infrahub.core.schema.attribute_parameters import NumberAttributeParameters
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.attribute_parameters import TextAttributeParameters

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -12,7 +12,11 @@ from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.registry import registry
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import (
+<<<<<<< HEAD:backend/tests/component/core/schema/test_attribute_parameters.py
     AttributeParameters,
+=======
+    ListAttributeParameters,
+>>>>>>> 13a243097 (Use ListAttributeParameters for List):backend/tests/unit/core/schema/test_attribute_parameters.py
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
@@ -396,7 +400,7 @@ def test_list_attribute_with_regex_parameter() -> None:
 
     node = NodeSchema(**node_schema)
     protocols_attribute = node.get_attribute("protocols")
-    assert isinstance(protocols_attribute.parameters, TextAttributeParameters)
+    assert isinstance(protocols_attribute.parameters, ListAttributeParameters)
     assert protocols_attribute.parameters.regex == "ssh|ping|telnet"
     assert protocols_attribute.get_regex() == "ssh|ping|telnet"
 
@@ -419,7 +423,7 @@ def test_list_attribute_regex_reconciliation() -> None:
 
     node = NodeSchema(**node_schema)
     protocols_attribute = node.get_attribute("protocols")
-    assert isinstance(protocols_attribute.parameters, TextAttributeParameters)
+    assert isinstance(protocols_attribute.parameters, ListAttributeParameters)
     assert protocols_attribute.regex == "ssh|ping|telnet"
     assert protocols_attribute.parameters.regex == "ssh|ping|telnet"
 

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -422,3 +422,39 @@ def test_list_attribute_regex_reconciliation() -> None:
     assert isinstance(protocols_attribute.parameters, TextAttributeParameters)
     assert protocols_attribute.regex == "ssh|ping|telnet"
     assert protocols_attribute.parameters.regex == "ssh|ping|telnet"
+
+
+async def test_list_attribute_regex_parameter_validation(
+    db: InfrahubDatabase, default_branch, register_core_models_schema
+) -> None:
+    """Test that list values are validated against regex defined in parameters."""
+    node_schema: dict[str, Any] = {
+        "name": "Node",
+        "namespace": "Testing",
+        "attributes": [
+            {"name": "name", "kind": "Text"},
+            {
+                "name": "protocols",
+                "kind": "List",
+                "optional": True,
+                "parameters": {"regex": "^(ssh|ping|telnet)$"},
+            },
+        ],
+    }
+
+    schema = NodeSchema(**node_schema)
+
+    # Valid values should work
+    node = await Node.init(db=db, schema=schema)
+    await node.new(db=db, name="test-node", protocols=["ssh", "ping"])
+    assert node.protocols.value == ["ssh", "ping"]
+
+    # Invalid value should raise ValidationError
+    invalid_node = await Node.init(db=db, schema=schema)
+    with pytest.raises(ValidationError, match=r"http must conform with the regex"):
+        await invalid_node.new(db=db, name="test-invalid", protocols=["ssh", "http"])
+
+    # Single invalid value should also fail
+    another_node = await Node.init(db=db, schema=schema)
+    with pytest.raises(ValidationError, match=r"ftp must conform with the regex"):
+        await another_node.new(db=db, name="test-single", protocols=["ftp"])

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -380,6 +380,7 @@ def test_attribute_schema_kind_change_with_parameters_object() -> None:
     assert number_attr.kind == "Number"
     assert isinstance(number_attr.parameters, NumberAttributeParameters)
 
+
 def test_list_attribute_with_regex_parameter() -> None:
     node_schema: dict[str, Any] = {
         "name": "Node",

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -378,3 +378,47 @@ def test_attribute_schema_kind_change_with_parameters_object() -> None:
 
     assert number_attr.kind == "Number"
     assert isinstance(number_attr.parameters, NumberAttributeParameters)
+
+def test_list_attribute_with_regex_parameter() -> None:
+    node_schema: dict[str, Any] = {
+        "name": "Node",
+        "namespace": "Testing",
+        "attributes": [
+            {"name": "name", "kind": "Text"},
+            {
+                "name": "protocols",
+                "kind": "List",
+                "optional": True,
+                "parameters": {"regex": "ssh|ping|telnet"},
+            },
+        ],
+    }
+
+    node = NodeSchema(**node_schema)
+    protocols_attribute = node.get_attribute("protocols")
+    assert isinstance(protocols_attribute.parameters, TextAttributeParameters)
+    assert protocols_attribute.parameters.regex == "ssh|ping|telnet"
+    assert protocols_attribute.get_regex() == "ssh|ping|telnet"
+
+
+def test_list_attribute_regex_reconciliation() -> None:
+    """Test that regex in parameters and at schema level are reconciled."""
+    node_schema: dict[str, Any] = {
+        "name": "Node",
+        "namespace": "Testing",
+        "attributes": [
+            {
+                "name": "protocols",
+                "kind": "List",
+                "optional": True,
+                "parameters": {"regex": "ssh|ping|telnet"},
+                "regex": None,
+            },
+        ],
+    }
+
+    node = NodeSchema(**node_schema)
+    protocols_attribute = node.get_attribute("protocols")
+    assert isinstance(protocols_attribute.parameters, TextAttributeParameters)
+    assert protocols_attribute.regex == "ssh|ping|telnet"
+    assert protocols_attribute.parameters.regex == "ssh|ping|telnet"

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -12,11 +12,8 @@ from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.registry import registry
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import (
-<<<<<<< HEAD:backend/tests/component/core/schema/test_attribute_parameters.py
     AttributeParameters,
-=======
     ListAttributeParameters,
->>>>>>> 13a243097 (Use ListAttributeParameters for List):backend/tests/unit/core/schema/test_attribute_parameters.py
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -405,29 +405,6 @@ def test_list_attribute_with_regex_parameter() -> None:
     assert protocols_attribute.get_regex() == "ssh|ping|telnet"
 
 
-def test_list_attribute_regex_reconciliation() -> None:
-    """Test that regex in parameters and at schema level are reconciled."""
-    node_schema: dict[str, Any] = {
-        "name": "Node",
-        "namespace": "Testing",
-        "attributes": [
-            {
-                "name": "protocols",
-                "kind": "List",
-                "optional": True,
-                "parameters": {"regex": "ssh|ping|telnet"},
-                "regex": None,
-            },
-        ],
-    }
-
-    node = NodeSchema(**node_schema)
-    protocols_attribute = node.get_attribute("protocols")
-    assert isinstance(protocols_attribute.parameters, ListAttributeParameters)
-    assert protocols_attribute.regex == "ssh|ping|telnet"
-    assert protocols_attribute.parameters.regex == "ssh|ping|telnet"
-
-
 async def test_list_attribute_regex_parameter_validation(
     db: InfrahubDatabase, default_branch, register_core_models_schema
 ) -> None:

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -388,11 +388,12 @@ async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
     assert criticality.get_attribute(name="color").optional is True
 
 
-async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
-    """Test that SchemaBranch.load_schema() syncs top-level and parameters fields for Text attributes."""
+async def test_schema_branch_reconcile_legacy_attribute_parameters() -> None:
+    """Test that SchemaBranch.load_schema() syncs top-level and parameters fields for attributes with legacy parameters."""
     regex = "abc"
     min_length = 3
     max_length = 5
+    list_regex = "^(ssh|telnet|https)$"
 
     # Test reconciliation when parameters are set (new style)
     SCHEMA_WITH_PARAMS: dict[str, Any] = {
@@ -409,6 +410,12 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
                         "kind": "Text",
                         "parameters": {"regex": regex, "min_length": min_length, "max_length": max_length},
                     },
+                    {
+                        "name": "protocols",
+                        "kind": "List",
+                        "optional": True,
+                        "parameters": {"regex": list_regex},
+                    },
                 ],
             }
         ]
@@ -424,6 +431,9 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
     assert desc_attr.parameters.regex == desc_attr.regex == regex
     assert desc_attr.parameters.min_length == desc_attr.min_length == min_length
     assert desc_attr.parameters.max_length == desc_attr.max_length == max_length
+
+    protocols_attr = node.get_attribute(name="protocols")
+    assert protocols_attr.parameters.regex == protocols_attr.regex == list_regex
 
     # Test reconciliation when top-level fields are set (deprecated style)
     SCHEMA_WITH_TOP_LEVEL: dict[str, Any] = {
@@ -442,6 +452,12 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
                         "min_length": min_length,
                         "max_length": max_length,
                     },
+                    {
+                        "name": "protocols",
+                        "kind": "List",
+                        "optional": True,
+                        "regex": list_regex,
+                    },
                 ],
             }
         ]
@@ -457,6 +473,9 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
     assert hostname_attr.parameters.regex == hostname_attr.regex == regex
     assert hostname_attr.parameters.min_length == hostname_attr.min_length == min_length
     assert hostname_attr.parameters.max_length == hostname_attr.max_length == max_length
+
+    protocols_attr = node.get_attribute(name="protocols")
+    assert protocols_attr.parameters.regex == protocols_attr.regex == list_regex
 
 
 async def test_schema_branch_add_groups(schema_all_in_one) -> None:

--- a/changelog/7717.fixed.md
+++ b/changelog/7717.fixed.md
@@ -1,0 +1,1 @@
+Allow List attributes to use the regex parameter for validating list item values

--- a/frontend/app/src/shared/api/rest/types.generated.ts
+++ b/frontend/app/src/shared/api/rest/types.generated.ts
@@ -1111,7 +1111,7 @@ export interface components {
              * Parameters
              * @description Extra parameters specific to this kind of attribute
              */
-            parameters?: components["schemas"]["AttributeParameters"] | components["schemas"]["TextAttributeParameters"] | components["schemas"]["NumberAttributeParameters"] | components["schemas"]["NumberPoolParameters"];
+            parameters?: components["schemas"]["AttributeParameters"] | components["schemas"]["ListAttributeParameters"] | components["schemas"]["TextAttributeParameters"] | components["schemas"]["NumberAttributeParameters"] | components["schemas"]["NumberPoolParameters"];
             /**
              * Deprecation
              * @description Mark attribute as deprecated and provide a user-friendly message to display
@@ -1222,7 +1222,7 @@ export interface components {
              * Parameters
              * @description Extra parameters specific to this kind of attribute
              */
-            parameters?: components["schemas"]["AttributeParameters"] | components["schemas"]["TextAttributeParameters"] | components["schemas"]["NumberAttributeParameters"] | components["schemas"]["NumberPoolParameters"];
+            parameters?: components["schemas"]["AttributeParameters"] | components["schemas"]["ListAttributeParameters"] | components["schemas"]["TextAttributeParameters"] | components["schemas"]["NumberAttributeParameters"] | components["schemas"]["NumberPoolParameters"];
             /**
              * Deprecation
              * @description Mark attribute as deprecated and provide a user-friendly message to display
@@ -1562,6 +1562,21 @@ export interface components {
             additionalProperties?: boolean | {
                 [key: string]: unknown;
             } | null;
+        };
+        /**
+         * ListAttributeParameters
+         * @description Parameters for List attributes supporting regex validation on list items.
+         */
+        ListAttributeParameters: {
+            /** Id */
+            id?: string | null;
+            /** @default present */
+            state: components["schemas"]["HashableModelState"];
+            /**
+             * Regex
+             * @description Regular expression that each list item value must match if defined
+             */
+            regex?: string | null;
         };
         /** LoggingSettings */
         LoggingSettings: {

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -3409,6 +3409,9 @@
                                 "$ref": "#/components/schemas/AttributeParameters"
                             },
                             {
+                                "$ref": "#/components/schemas/ListAttributeParameters"
+                            },
+                            {
                                 "$ref": "#/components/schemas/TextAttributeParameters"
                             },
                             {
@@ -3664,6 +3667,9 @@
                         "anyOf": [
                             {
                                 "$ref": "#/components/schemas/AttributeParameters"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ListAttributeParameters"
                             },
                             {
                                 "$ref": "#/components/schemas/TextAttributeParameters"
@@ -4587,6 +4593,42 @@
                     "type"
                 ],
                 "title": "JSONSchema"
+            },
+            "ListAttributeParameters": {
+                "properties": {
+                    "id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Id"
+                    },
+                    "state": {
+                        "$ref": "#/components/schemas/HashableModelState",
+                        "default": "present"
+                    },
+                    "regex": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Regex",
+                        "description": "Regular expression that each list item value must match if defined",
+                        "update": "validate_constraint"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "ListAttributeParameters",
+                "description": "Parameters for List attributes supporting regex validation on list items."
             },
             "LoggingSettings": {
                 "properties": {


### PR DESCRIPTION
Add support for List attributes to accept regex validation via parameters.regex syntax. List attributes can now use TextAttributeParameters which includes regex support.

Changes:
- Added List to parameter class mapping
- Created ListAttributeSchema with regex reconciliation
- Updated validation to allow TextAttributeParameters for List
- Added tests for List with regex parameter

Fixes #7717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List attributes now support regex validation for individual list items across the platform.

* **Tests**
  * Added coverage to validate list regex behavior and ensure invalid list items are rejected.

* **Schema / API**
  * Public schemas and API types updated to include the new list-parameter shape so UIs and integrations can use the new validation option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->