### PR TITLE
IFC-2043: Remove is_visible property from attribute and relationships metadata - frontend

### DIFF
--- a/frontend/app/src/entities/diff/node-diff/types.ts
+++ b/frontend/app/src/entities/diff/node-diff/types.ts
@@ -10,12 +10,7 @@ export const DIFF_STATUS = {
 
 export type DiffStatus = (typeof DIFF_STATUS)[keyof typeof DIFF_STATUS];
 
-export type PropertyType =
-  | "HAS_VALUE"
-  | "HAS_OWNER"
-  | "HAS_SOURCE"
-  | "IS_PROTECTED"
-  | "IS_RELATED";
+export type PropertyType = "HAS_VALUE" | "HAS_OWNER" | "HAS_SOURCE" | "IS_PROTECTED" | "IS_RELATED";
 
 export type DiffConflict = {
   base_branch_action: DiffStatus;

--- a/frontend/app/src/entities/diff/node-diff/types.ts
+++ b/frontend/app/src/entities/diff/node-diff/types.ts
@@ -14,7 +14,6 @@ export type PropertyType =
   | "HAS_VALUE"
   | "HAS_OWNER"
   | "HAS_SOURCE"
-  | "IS_VISIBLE"
   | "IS_PROTECTED"
   | "IS_RELATED";
 

--- a/frontend/app/src/entities/diff/node-diff/utils.tsx
+++ b/frontend/app/src/entities/diff/node-diff/utils.tsx
@@ -137,8 +137,6 @@ export const formatPropertyName = (name: DiffProperty["property_type"]) => {
       return "value";
     case "IS_PROTECTED":
       return "protected";
-    case "IS_VISIBLE":
-      return "visible";
     case "IS_RELATED":
       return "ID";
     default: {

--- a/frontend/app/src/entities/nodes/api/getObjectDetails.ts
+++ b/frontend/app/src/entities/nodes/api/getObjectDetails.ts
@@ -36,7 +36,6 @@ query {{kind}} {
               is_default
               is_from_profile
               is_protected
-              is_visible
               source {
                 id
                 display_label
@@ -70,7 +69,6 @@ query {{kind}} {
               properties {
                 updated_at
                 is_protected
-                is_visible
                 source {
                   id
                   display_label

--- a/frontend/app/src/entities/nodes/object-item-details/relationship-details-paginated.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/relationship-details-paginated.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { EyeSlashIcon, LockClosedIcon } from "@heroicons/react/24/outline";
+import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify-icon/react";
 import { useAtom, useAtomValue } from "jotai";
 import { Fragment, useState } from "react";
@@ -100,10 +100,6 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
 
   if (loading) {
     return <LoadingIndicator className="h-12" />;
-  }
-
-  if (relationshipsData && relationshipsData?.properties?.is_visible === false) {
-    return null;
   }
 
   if (relationshipSchema?.cardinality === "many" && !Array.isArray(relationshipsData)) {
@@ -224,10 +220,6 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                   {relationshipsData.properties?.is_protected && (
                     <LockClosedIcon className="h-4 w-4" />
                   )}
-
-                  {relationshipsData.properties?.is_visible === false && (
-                    <EyeSlashIcon className="h-4 w-4" />
-                  )}
                 </>
               }
             />
@@ -339,8 +331,6 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                       )}
 
                       {properties.is_protected && <LockClosedIcon className="h-4 w-4" />}
-
-                      {properties.is_visible === false && <EyeSlashIcon className="h-4 w-4" />}
                     </dd>
                   ))}
                 </dl>

--- a/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.test.ts
+++ b/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.test.ts
@@ -17,7 +17,6 @@ const nodeData = {
     value: "atl1-edge1",
     updated_at: "2023-07-10T15:01:29.806543+00:00",
     is_protected: true,
-    is_visible: true,
     source: {
       id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
       display_label: "Pop-Builder",
@@ -30,7 +29,6 @@ const nodeData = {
     value: null,
     updated_at: "2023-07-10T15:01:29.806543+00:00",
     is_protected: false,
-    is_visible: true,
     source: null,
     owner: null,
     __typename: "TextAttribute",
@@ -39,7 +37,6 @@ const nodeData = {
     value: "7280R3",
     updated_at: "2023-07-10T15:01:29.806543+00:00",
     is_protected: false,
-    is_visible: true,
     source: {
       id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
       display_label: "Pop-Builder",
@@ -57,7 +54,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:29.806543+00:00",
       is_protected: true,
-      is_visible: true,
       source: {
         id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
         display_label: "Pop-Builder",
@@ -77,7 +73,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:29.806543+00:00",
       is_protected: null,
-      is_visible: true,
       source: null,
       owner: {
         id: "9622f4c6-2a61-4e71-8d78-36dcab0d219c",
@@ -97,7 +92,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:29.806543+00:00",
       is_protected: true,
-      is_visible: true,
       source: {
         id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
         display_label: "Pop-Builder",
@@ -121,7 +115,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:29.806543+00:00",
       is_protected: true,
-      is_visible: true,
       source: {
         id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
         display_label: "Pop-Builder",
@@ -147,7 +140,6 @@ const nodeData = {
         properties: {
           updated_at: "2023-07-10T15:01:29.806543+00:00",
           is_protected: null,
-          is_visible: true,
           source: null,
           owner: null,
           __typename: "RelationshipProperty",
@@ -163,7 +155,6 @@ const nodeData = {
         properties: {
           updated_at: "2023-07-10T15:01:29.806543+00:00",
           is_protected: null,
-          is_visible: true,
           source: null,
           owner: null,
           __typename: "RelationshipProperty",
@@ -182,7 +173,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:30.985897+00:00",
       is_protected: null,
-      is_visible: true,
       source: null,
       owner: null,
       __typename: "RelationshipProperty",
@@ -198,7 +188,6 @@ const nodeData = {
     properties: {
       updated_at: "2023-07-10T15:01:29.806543+00:00",
       is_protected: true,
-      is_visible: true,
       source: {
         id: "bf26a7e3-db46-40f3-b02b-40c6ef362d13",
         display_label: "Pop-Builder",
@@ -216,7 +205,6 @@ const nodeData = {
 const newDataForMetaEdit = {
   owner: "owner-id",
   source: "source-id",
-  is_visible: true,
   is_protected: true,
 };
 
@@ -237,7 +225,6 @@ describe("Mutation details from object data", () => {
         id: nodeData.site.node.id,
         _relation__owner: newDataForMetaEdit.owner,
         _relation__source: newDataForMetaEdit.source,
-        _relation__is_visible: newDataForMetaEdit.is_visible,
         _relation__is_protected: newDataForMetaEdit.is_protected,
       },
     });
@@ -257,7 +244,6 @@ mutation ${nodeSchema.kind}Update {
         id: "${nodeData.site.node.id}",
         _relation__owner: "${newDataForMetaEdit.owner}",
         _relation__source: "${newDataForMetaEdit.source}",
-        _relation__is_visible: ${newDataForMetaEdit.is_visible},
         _relation__is_protected: ${newDataForMetaEdit.is_protected}
     }
 }) {

--- a/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.ts
+++ b/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.ts
@@ -1,6 +1,6 @@
 import type { NodeSchema } from "@/entities/schema/types";
 
-const metadataFields = ["source", "owner", "is_visible", "is_protected"];
+const metadataFields = ["source", "owner", "is_protected"];
 
 const isValueValid = (value: any) => {
   if (value === undefined) {

--- a/frontend/app/src/entities/nodes/object-item-meta-edit/object-item-meta-edit.tsx
+++ b/frontend/app/src/entities/nodes/object-item-meta-edit/object-item-meta-edit.tsx
@@ -104,18 +104,6 @@ export default function ObjectItemMetaEdit(props: Props) {
             parent: attributeOrRelationshipToEdit.source?.__typename,
           },
           {
-            name: "is_visible",
-            label: "is visible",
-            type: "Checkbox",
-            defaultValue: {
-              source: { type: "user" },
-              value: attributeOrRelationshipToEdit.is_visible,
-            },
-            rules: {
-              required: true,
-            },
-          },
-          {
             name: "is_protected",
             label: "is protected",
             type: "Checkbox",

--- a/frontend/app/src/entities/nodes/relationships/api/get-relationship-properties-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-relationship-properties-from-api.ts
@@ -31,7 +31,6 @@ const generateRelationshipPropertiesQuery = ({
               },
               edges: {
                 properties: {
-                  is_visible: true,
                   is_protected: true,
                   updated_at: true,
                   source: {

--- a/frontend/app/src/entities/nodes/relationships/domain/types.ts
+++ b/frontend/app/src/entities/nodes/relationships/domain/types.ts
@@ -7,7 +7,6 @@ export type RelationshipNode = {
 };
 
 export type RelationshipProperties = {
-  is_visible: boolean;
   is_protected: boolean;
   updated_at: Date;
   source: NodeCore | null;

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-properties.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-properties.tsx
@@ -23,7 +23,7 @@ export function RelationshipProperties(props: RelationshipPropertiesProps) {
     return <ErrorScreen message="Something went wrong when fetching relationship properties" />;
   }
 
-  const { source, owner, updated_at, is_protected, is_visible } = data;
+  const { source, owner, updated_at, is_protected } = data;
 
   const items = [
     {
@@ -49,10 +49,6 @@ export function RelationshipProperties(props: RelationshipPropertiesProps) {
       ) : (
         "-"
       ),
-    },
-    {
-      name: "Is visible",
-      value: is_visible ? "True" : "False",
     },
     {
       name: "Is protected",

--- a/frontend/app/src/entities/user-profile/api/getProfileDetails.ts
+++ b/frontend/app/src/entities/user-profile/api/getProfileDetails.ts
@@ -10,7 +10,6 @@ query GET_PROFILE_DETAILS {
           value
           updated_at
           is_protected
-          is_visible
           source {
             id
             display_label

--- a/frontend/app/src/shared/api/graphql/utils.test.ts
+++ b/frontend/app/src/shared/api/graphql/utils.test.ts
@@ -65,7 +65,6 @@ describe("addAttributesToRequest", () => {
         is_default: true,
         is_from_profile: true,
         is_protected: true,
-        is_visible: true,
         source: {
           id: true,
           hfid: true,
@@ -124,7 +123,6 @@ describe("addAttributesToRequest", () => {
         is_default: true,
         is_from_profile: true,
         is_protected: true,
-        is_visible: true,
         source: {
           id: true,
           hfid: true,
@@ -208,7 +206,6 @@ describe("addRelationshipsToRequest", () => {
           display_label: true,
         },
         properties: {
-          is_visible: true,
           is_protected: true,
           updated_at: true,
           source: {

--- a/frontend/app/src/shared/api/graphql/utils.ts
+++ b/frontend/app/src/shared/api/graphql/utils.ts
@@ -35,7 +35,6 @@ export const addAttributesToRequest = (
         is_default: true,
         is_from_profile: true,
         is_protected: true,
-        is_visible: true,
         source: {
           id: true,
           hfid: true,
@@ -80,7 +79,6 @@ export const addRelationshipsToRequest = (
     },
     ...(withMetadata && {
       properties: {
-        is_visible: true,
         is_protected: true,
         updated_at: true,
         source: {

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
@@ -305,7 +305,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -365,7 +364,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "1",
           display_label: "Architecture Team",
@@ -425,7 +423,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -474,7 +471,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -523,7 +519,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -585,7 +580,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -647,7 +641,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",
@@ -709,7 +702,6 @@ describe("getFormFieldsFromSchema", () => {
       name: {
         is_from_profile: false,
         is_protected: true,
-        is_visible: true,
         owner: {
           id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
           display_label: "Architecture Team",

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -23,7 +23,6 @@ const buildRelationshipOneData = (override: Partial<RelationshipOneType>): Relat
   properties: {
     updated_at: "2024-07-17T17:59:05.309135+00:00",
     is_protected: null,
-    is_visible: true,
     source: null,
     owner: null,
     __typename: "RelationshipProperty",

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -20,9 +20,6 @@ test.describe("Object metadata", () => {
     // Owner should be empty
     await expect(page.getByLabel("Kind").first().getByTestId("select-value")).not.toBeVisible();
 
-    // Is visible should be checked
-    await expect(page.getByLabel("is visible *")).toBeChecked();
-
     // Is protected should not be checked
     await expect(page.getByLabel("is protected *")).not.toBeChecked();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the visibility property and all related UI indicators across objects, relationships, metadata editors, and detail views.
  * Updated queries and data shapes to stop requesting visibility information.

* **Tests**
  * Updated tests and fixtures to reflect removal of visibility fields and related assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->