### PR TITLE
Fix in IPAM breadcrumb, switching only display current namespace IPs

### DIFF
--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-ipam.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-ipam.tsx
@@ -1,4 +1,5 @@
 import { keepPreviousData } from "@tanstack/react-query";
+import { useQueryState } from "nuqs";
 import type React from "react";
 import { useParams } from "react-router";
 
@@ -15,9 +16,11 @@ import {
   IP_ADDRESS_GENERIC,
   IP_PREFIX_GENERIC,
   IP_PREFIX_RELATIONSHIP_NAME,
+  IPAM_QSP,
 } from "@/entities/ipam/constants";
 import { constructPathForIpam } from "@/entities/ipam/utils";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
 import type { NodeRelationshipOne } from "@/entities/nodes/types";
 import type { ModelSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -51,12 +54,27 @@ interface BreadcrumbIpamContentProps {
 }
 
 function BreadcrumbIpamContent({ objectSchema, objectId }: BreadcrumbIpamContentProps) {
+  const [namespaceQSP] = useQueryState(IPAM_QSP.NAMESPACE);
+  const filterQuery = namespaceQSP ? { ip_namespace__ids: [namespaceQSP] } : undefined;
+
   if (isOfKind(IP_PREFIX_GENERIC, objectSchema)) {
-    return <BreadcrumbObjectDetailsHierarchy objectSchema={objectSchema} objectId={objectId} />;
+    return (
+      <BreadcrumbObjectDetailsHierarchy
+        objectSchema={objectSchema}
+        objectId={objectId}
+        filterQuery={filterQuery}
+      />
+    );
   }
 
   if (isOfKind(IP_ADDRESS_GENERIC, objectSchema)) {
-    return <BreadcrumbIpAddress ipAddressSchema={objectSchema} ipAddressId={objectId} />;
+    return (
+      <BreadcrumbIpAddress
+        ipAddressSchema={objectSchema}
+        ipAddressId={objectId}
+        filterQuery={filterQuery}
+      />
+    );
   }
 
   return null;
@@ -65,9 +83,14 @@ function BreadcrumbIpamContent({ objectSchema, objectId }: BreadcrumbIpamContent
 interface BreadcrumbIpAddressProps {
   ipAddressSchema: ModelSchema;
   ipAddressId: string;
+  filterQuery?: GetRelationshipsParams["filterQuery"];
 }
 
-export function BreadcrumbIpAddress({ ipAddressSchema, ipAddressId }: BreadcrumbIpAddressProps) {
+export function BreadcrumbIpAddress({
+  ipAddressSchema,
+  ipAddressId,
+  filterQuery,
+}: BreadcrumbIpAddressProps) {
   const { schema: ipPrefixSchema } = useSchema(IP_PREFIX_GENERIC);
   const { data, isPending, error } = useGetObject(
     {
@@ -98,12 +121,14 @@ export function BreadcrumbIpAddress({ ipAddressSchema, ipAddressId }: Breadcrumb
         <BreadcrumbObjectDetailsHierarchy
           objectSchema={ipPrefixSchema}
           objectId={ipPrefixNode.id}
+          filterQuery={filterQuery}
         />
       )}
       <BreadcrumbItemObject
         node={data}
         parentId={ipPrefixNode?.id}
         parentRelationshipSchema={ipPrefixRelationshipSchema}
+        filterQuery={filterQuery}
       />
     </>
   );

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -13,17 +13,20 @@ import { Tooltip } from "@/shared/components/ui/tooltip";
 
 import { useGetObjectAncestors } from "@/entities/nodes/hierarchy/domain/get-object-ancestors.query";
 import type { NodeCoreWithParent } from "@/entities/nodes/types";
+import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
 import type { ModelSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
 interface BreadcrumbObjectDetailsHierarchyProps {
   objectSchema: ModelSchema;
   objectId: string;
+  filterQuery?: GetRelationshipsParams["filterQuery"];
 }
 
 export function BreadcrumbObjectDetailsHierarchy({
   objectSchema,
   objectId,
+  filterQuery,
 }: BreadcrumbObjectDetailsHierarchyProps) {
   const { data, isPending, error } = useGetObjectAncestors(
     {
@@ -73,13 +76,23 @@ export function BreadcrumbObjectDetailsHierarchy({
       )}
 
       {data.map((ancestor) => (
-        <BreadcrumbItemObjectHierarchy key={ancestor.id} node={ancestor} />
+        <BreadcrumbItemObjectHierarchy
+          key={ancestor.id}
+          node={ancestor}
+          filterQuery={filterQuery}
+        />
       ))}
     </>
   );
 }
 
-function BreadcrumbItemObjectHierarchy({ node }: { node: NodeCoreWithParent }) {
+function BreadcrumbItemObjectHierarchy({
+  node,
+  filterQuery,
+}: {
+  node: NodeCoreWithParent;
+  filterQuery?: GetRelationshipsParams["filterQuery"];
+}) {
   const { schema } = useSchema(node.__typename);
   const parentRelationshipSchema = schema?.relationships?.find(
     (rel) => rel.kind === "Hierarchy" && rel.name === "parent"
@@ -90,6 +103,7 @@ function BreadcrumbItemObjectHierarchy({ node }: { node: NodeCoreWithParent }) {
       node={node}
       parentId={node.parent.node?.id}
       parentRelationshipSchema={parentRelationshipSchema}
+      filterQuery={filterQuery}
     />
   );
 }

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-object-details-hierarchy.tsx
@@ -12,8 +12,8 @@ import { BreadcrumbItemObject } from "@/shared/components/layout/breadcrumb-navi
 import { Tooltip } from "@/shared/components/ui/tooltip";
 
 import { useGetObjectAncestors } from "@/entities/nodes/hierarchy/domain/get-object-ancestors.query";
-import type { NodeCoreWithParent } from "@/entities/nodes/types";
 import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
+import type { NodeCoreWithParent } from "@/entities/nodes/types";
 import type { ModelSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
@@ -9,8 +9,8 @@ import { Col, Row } from "@/shared/components/container";
 
 import { ObjectAutocomplete } from "@/entities/nodes/object/ui/object-autocomplete";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
-import type { NodeCore } from "@/entities/nodes/types";
 import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
+import type { NodeCore } from "@/entities/nodes/types";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { RelationshipSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -89,7 +89,7 @@ export function BreadcrumbItemObject({
                   }
                 : {
                     objectKind: autocompleteObjectKind ?? node.__typename,
-                    filterQuery: filterQuery,
+                    filterQuery,
                   })}
             />
           </Popover>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
@@ -10,6 +10,7 @@ import { Col, Row } from "@/shared/components/container";
 import { ObjectAutocomplete } from "@/entities/nodes/object/ui/object-autocomplete";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeCore } from "@/entities/nodes/types";
+import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import type { RelationshipSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -19,11 +20,13 @@ export function BreadcrumbItemObject({
   autocompleteObjectKind,
   parentRelationshipSchema,
   parentId,
+  filterQuery,
 }: {
   node: NodeCore;
   autocompleteObjectKind?: string;
   parentId?: string;
   parentRelationshipSchema?: RelationshipSchema;
+  filterQuery?: GetRelationshipsParams["filterQuery"];
 }) {
   const { schema } = useSchema(node.__typename);
 
@@ -81,9 +84,13 @@ export function BreadcrumbItemObject({
                     objectKind: parentToChildRelationshipSchema.peer,
                     filterQuery: {
                       [`${parentRelationshipSchema.name}__ids`]: [parentId],
+                      ...filterQuery,
                     },
                   }
-                : { objectKind: autocompleteObjectKind ?? node.__typename })}
+                : {
+                    objectKind: autocompleteObjectKind ?? node.__typename,
+                    filterQuery: filterQuery,
+                  })}
             />
           </Popover>
         </MenuTrigger>

--- a/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
@@ -4,7 +4,7 @@ import { ACCOUNT_STATE_PATH } from "../../constants";
 import { generateRandomBranchName } from "../../utils";
 import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
 
-test.describe("/ipam - IP Namespace", () => {
+test.describe.only("/ipam - IP Namespace", () => {
   test.describe.configure({ mode: "serial" });
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
 
@@ -145,6 +145,14 @@ test.describe("/ipam - IP Namespace", () => {
 
     await test.step("create a prefix between a parent and its children", async () => {
       await ipamTree.getByText("11.0.0.0/8").click();
+
+      // validate breadcrumb
+      const breadcrumb = page.getByTestId("breadcrumb-navigation");
+      await expect(breadcrumb.getByRole('link', { name: '11.0.0.0/8' })).toBeVisible();
+      await breadcrumb.getByRole('button', { name: 'Select a different IP Prefix' }).click();
+      await expect(page.getByRole("option")).toHaveCount(2);
+      await page.getByPlaceholder('Search...').press('Escape');
+
       await page.getByRole("link", { name: "Children" }).click();
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/10");
@@ -163,6 +171,14 @@ test.describe("/ipam - IP Namespace", () => {
 
     await test.step("delete a prefix between 2 other prefixes", async () => {
       await ipamTree.getByText("11.0.0.0/10").click();
+
+      // validate breadcrumb
+      const breadcrumb = page.getByTestId("breadcrumb-navigation");
+      await expect(breadcrumb.getByRole('link', { name: '11.0.0.0/10' })).toBeVisible();
+      await breadcrumb.getByRole('button', { name: 'Select a different IP Prefix' }).last().click();
+      await expect(page.getByRole("option")).toHaveCount(1);
+      await page.getByPlaceholder('Search...').press('Escape');
+
       await page.getByTestId("object-details-menu").click();
       await page.getByRole("menuitem", { name: "Delete" }).click();
       await expect(page.getByTestId("modal-delete")).toContainText(

--- a/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
@@ -4,7 +4,7 @@ import { ACCOUNT_STATE_PATH } from "../../constants";
 import { generateRandomBranchName } from "../../utils";
 import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
 
-test.describe.only("/ipam - IP Namespace", () => {
+test.describe("/ipam - IP Namespace", () => {
   test.describe.configure({ mode: "serial" });
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
 
@@ -148,10 +148,10 @@ test.describe.only("/ipam - IP Namespace", () => {
 
       // validate breadcrumb
       const breadcrumb = page.getByTestId("breadcrumb-navigation");
-      await expect(breadcrumb.getByRole('link', { name: '11.0.0.0/8' })).toBeVisible();
-      await breadcrumb.getByRole('button', { name: 'Select a different IP Prefix' }).click();
+      await expect(breadcrumb.getByRole("link", { name: "11.0.0.0/8" })).toBeVisible();
+      await breadcrumb.getByRole("button", { name: "Select a different IP Prefix" }).click();
       await expect(page.getByRole("option")).toHaveCount(2);
-      await page.getByPlaceholder('Search...').press('Escape');
+      await page.getByPlaceholder("Search...").press("Escape");
 
       await page.getByRole("link", { name: "Children" }).click();
       await page.getByTestId("create-object-button").click();
@@ -174,10 +174,10 @@ test.describe.only("/ipam - IP Namespace", () => {
 
       // validate breadcrumb
       const breadcrumb = page.getByTestId("breadcrumb-navigation");
-      await expect(breadcrumb.getByRole('link', { name: '11.0.0.0/10' })).toBeVisible();
-      await breadcrumb.getByRole('button', { name: 'Select a different IP Prefix' }).last().click();
+      await expect(breadcrumb.getByRole("link", { name: "11.0.0.0/10" })).toBeVisible();
+      await breadcrumb.getByRole("button", { name: "Select a different IP Prefix" }).last().click();
       await expect(page.getByRole("option")).toHaveCount(1);
-      await page.getByPlaceholder('Search...').press('Escape');
+      await page.getByPlaceholder("Search...").press("Escape");
 
       await page.getByTestId("object-details-menu").click();
       await page.getByRole("menuitem", { name: "Delete" }).click();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation now threads filtering criteria through IP address and object hierarchies, improving contextual filtering and autocomplete results when navigating related items.

* **Tests**
  * Added end-to-end checks validating breadcrumb behavior and option counts during IP prefix selection workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->