### PR TITLE
Use yamllint from uv.lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,12 @@ jobs:
 
   # ------------------------------------------ All Linter  ------------------------------------------
   yaml-lint:
-    if: needs.files-changed.outputs.yaml == 'true'
-    needs: ["files-changed"]
+    if: |
+      needs.files-changed.outputs.yaml == 'true' ||
+      needs.files-changed.outputs.infrahub_uv_files == 'true'
+    needs:
+      - files-changed
+      - prepare-environment
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
@@ -74,10 +78,19 @@ jobs:
         uses: "actions/checkout@v6"
         with:
           submodules: true
-      - name: "Setup environment"
-        run: "pip install yamllint==1.35.1"
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
+      - name: Install dependencies
+        run: "uv sync --all-groups"
       - name: "Linting: yamllint"
-        run: "yamllint -s ."
+        run: "uv run yamllint -s ."
 
   javascript-lint:
     defaults:


### PR DESCRIPTION
The version of yamllint that we used in the pipeline was different from the one in the lock file uv.lock. Updating the CI job to instead install the one we have for uv to ensure that the versions always align.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve build environment setup and linting processes.

---

**Note:** This release contains only internal development infrastructure updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->