### PR TITLE
Add source and owner to GraphQL queries to dataset04

### DIFF
--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -11,6 +11,7 @@ from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.field_extractor import extract_graphql_fields
+from infrahub.utils import has_any_key
 
 from ..loaders.peers import PeerRelationshipsDataLoader, QueryPeerParams
 from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
@@ -194,6 +195,9 @@ class ManyRelationshipResolver:
         offset: int | None = None,
         limit: int | None = None,
     ) -> list[dict[str, Any]] | None:
+        include_source = has_any_key(data=node_fields, keys=["_relation__source", "source"])
+        include_owner = has_any_key(data=node_fields, keys=["_relation__owner", "owner"])
+
         async with db.start_session(read_only=True) as dbs:
             objs = await NodeManager.query_peers(
                 db=dbs,
@@ -208,8 +212,8 @@ class ManyRelationshipResolver:
                 branch=branch,
                 branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
                 fetch_peers=True,
-                include_source=True,
-                include_owner=True,
+                include_source=include_source,
+                include_owner=include_owner,
             )
             if not objs:
                 return None
@@ -230,6 +234,9 @@ class ManyRelationshipResolver:
         if node_fields and "hfid" in node_fields:
             node_fields["human_friendly_id"] = None
 
+        include_source = has_any_key(data=node_fields, keys=["_relation__source", "source"])
+        include_owner = has_any_key(data=node_fields, keys=["_relation__owner", "owner"])
+
         query_params = QueryPeerParams(
             branch=branch,
             source_kind=source_kind,
@@ -238,8 +245,8 @@ class ManyRelationshipResolver:
             fields=node_fields,
             at=at,
             branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
-            include_source=True,
-            include_owner=True,
+            include_source=include_source,
+            include_owner=include_owner,
         )
         if query_params in self._data_loader_instances:
             loader = self._data_loader_instances[query_params]

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -9,6 +9,7 @@ from infrahub.core.constants import BranchSupportType, InfrahubKind, Relationshi
 from infrahub.core.manager import NodeManager
 from infrahub.exceptions import NodeNotFoundError
 from infrahub.graphql.field_extractor import extract_graphql_fields
+from infrahub.utils import has_any_key
 
 from ..models import OrderModel
 from ..parser import extract_selection
@@ -185,6 +186,9 @@ async def default_paginated_list_resolver(
 
         objs = []
         if edges or "hfid" in filters:
+            include_source = has_any_key(data=node_fields, keys=["_relation__source", "source"])
+            include_owner = has_any_key(data=node_fields, keys=["_relation__owner", "owner"])
+
             objs = await NodeManager.query(
                 db=db,
                 schema=schema,
@@ -195,8 +199,8 @@ async def default_paginated_list_resolver(
                 limit=limit,
                 offset=offset,
                 account=graphql_context.account_session,
-                include_source=True,
-                include_owner=True,
+                include_source=include_source,
+                include_owner=include_owner,
                 partial_match=partial_match,
                 order=order,
             )

--- a/backend/infrahub/utils.py
+++ b/backend/infrahub/utils.py
@@ -83,3 +83,21 @@ def get_all_subclasses[AnyClass: type](cls: AnyClass) -> list[AnyClass]:
         subclasses.append(subclass)
         subclasses.extend(get_all_subclasses(subclass))
     return subclasses
+
+
+def has_any_key(data: dict[str, Any], keys: list[str]) -> bool:
+    """Recursively check if any of the specified keys exist in the dictionary at any level.
+
+    Args:
+        data: The dictionary to search through
+        keys: List of key names to search for
+
+    Returns:
+        True if any of the keys are found at any level of the dictionary, False otherwise
+    """
+    for key, value in data.items():
+        if key in keys:
+            return True
+        if isinstance(value, dict) and has_any_key(data=value, keys=keys):
+            return True
+    return False

--- a/backend/tests/test_data/dataset04.py
+++ b/backend/tests/test_data/dataset04.py
@@ -65,9 +65,9 @@ async def load_data(
 
     start_time = time.time()
 
-    tags = {}
-    repository = {}
-    gqlquery = {}
+    tags: dict[str, Node] = {}
+    repository: dict[str, Node] = {}
+    gqlquery: dict[str, Node] = {}
 
     tag_schema = registry.schema.get_node_schema(name=InfrahubKind.TAG, branch=default_branch)
     repository_schema = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
@@ -103,11 +103,21 @@ async def load_data(
     for _idx in range(nbr_query):
         random_tags = [tags[tag] for tag in random.choices(TAGS, k=3)]
         random_repo = repository[random.choice(list(repository.keys()))]
+        random_repo_tags = [
+            {"id": tags[tag].id, "_relation__owner": random_repo.id, "_relation__source": random_repo.id}
+            for tag in random.choices(TAGS, k=3)
+        ]
 
         name = f"query-{nbr_query:04}"
         query_str = "query CoreQuery%s { tag { name { value }}}" % f"{nbr_query:04}"
         obj = await Node.init(db=db, schema=gqlquery_schema, branch=default_branch)
-        await obj.new(db=db, name=name, query=query_str, tags=random_tags, repository=random_repo)
+        await obj.new(
+            db=db,
+            name={"value": name, "source": random_repo.id, "owner": random_repo.id},
+            query=query_str,
+            tags=random_repo_tags,
+            repository={"id": random_repo.id, "_relation__owner": random_repo.id, "_relation__source": random_repo.id},
+        )
         await obj.save(db=db)
         gqlquery[name] = obj
 

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -1,5 +1,116 @@
-from infrahub.utils import get_fixtures_dir
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from infrahub.utils import get_fixtures_dir, has_any_key
 
 
 def test_get_fixtures_dir() -> None:
     assert get_fixtures_dir().exists()
+
+
+@dataclass
+class HasAnyKeyTestCase:
+    name: str
+    data: dict[str, Any]
+    keys: list[str]
+    expected: bool
+
+
+HAS_ANY_KEY_TEST_CASES: list[HasAnyKeyTestCase] = [
+    HasAnyKeyTestCase(
+        name="empty_dict_returns_false",
+        data={},
+        keys=["foo"],
+        expected=False,
+    ),
+    HasAnyKeyTestCase(
+        name="empty_keys_returns_false",
+        data={"foo": "bar"},
+        keys=[],
+        expected=False,
+    ),
+    HasAnyKeyTestCase(
+        name="simple_dict_key_found",
+        data={"foo": "bar", "baz": "qux"},
+        keys=["foo"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="simple_dict_key_not_found",
+        data={"foo": "bar", "baz": "qux"},
+        keys=["missing"],
+        expected=False,
+    ),
+    HasAnyKeyTestCase(
+        name="simple_dict_multiple_keys_one_found",
+        data={"foo": "bar", "baz": "qux"},
+        keys=["missing", "baz"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="nested_dict_key_at_top_level",
+        data={"foo": {"nested": "value"}, "bar": "baz"},
+        keys=["foo"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="nested_dict_key_at_second_level",
+        data={"foo": {"nested": "value"}, "bar": "baz"},
+        keys=["nested"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="nested_dict_key_not_found",
+        data={"foo": {"nested": "value"}, "bar": "baz"},
+        keys=["missing"],
+        expected=False,
+    ),
+    HasAnyKeyTestCase(
+        name="deeply_nested_dict_key_found",
+        data={"level1": {"level2": {"level3": {"target": "value"}}}},
+        keys=["target"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="deeply_nested_dict_key_not_found",
+        data={"level1": {"level2": {"level3": {"target": "value"}}}},
+        keys=["missing"],
+        expected=False,
+    ),
+    HasAnyKeyTestCase(
+        name="mixed_nested_dict_multiple_keys",
+        data={"a": {"b": {"c": "value"}}, "d": "value"},
+        keys=["c", "x", "y"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="dict_with_non_dict_values",
+        data={"foo": [1, 2, 3], "bar": 42, "baz": "string"},
+        keys=["foo"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="nested_dict_with_list_value_key_in_dict",
+        data={"foo": {"bar": [1, 2, 3]}, "baz": "qux"},
+        keys=["bar"],
+        expected=True,
+    ),
+    HasAnyKeyTestCase(
+        name="search_key_matches_value_not_key",
+        data={"foo": "target"},
+        keys=["target"],
+        expected=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in HAS_ANY_KEY_TEST_CASES],
+)
+def test_has_any_key(test_case: HasAnyKeyTestCase) -> None:
+    """Test that has_any_key correctly identifies if any key exists in the dictionary."""
+    result = has_any_key(data=test_case.data, keys=test_case.keys)
+    assert result == test_case.expected


### PR DESCRIPTION
This PR addresses a comment that came up here: https://github.com/opsmill/infrahub/pull/7698#discussion_r2555536486

Where we hardcode include_source and include_owner to True in a few places.

The changes in this PR reverts this behaviour from where it was implemented in the PR along with in some other places. The goal is to currently only lookup the source and owner informations if actually requested by the GraphQL query. For this we analyze the user submitted fields by parsing that dictionary with the new `has_any_key()` method. This approach is a bit simplistic as we'd request the source or owner information for everything regardless of if this information was only requested for a single attribute. However this is still an improvement to what we had and the use of the parameter itself indicates that it wasn't meant to work in any other way. At some point we should refactor this completely to have better granularity (at that point we'd remove the include_source and include_owner parameters).

Other changes to this PR include setting the source and owner info within the dataset04 query so that the benchmark tests have something to validate against.

There are some improvements reported by codspeed for this (https://codspeed.io/opsmill/infrahub/branches/pog-source-owner-dataset04?utm_source=github&utm_medium=comment&utm_content=header), however the improvment in performance is to small to be reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized GraphQL query resolution to fetch only requested fields, reducing unnecessary data retrieval and improving response times.

* **Tests**
  * Added comprehensive unit tests for utility functions to ensure reliability of query optimization logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->