### PR TITLE
IFC-1896 Don't query fields to compute display label/HFID 

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from copy import copy
 from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
-from infrahub_sdk.utils import is_valid_uuid
+from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
 
-from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import InfrahubKind, RelationshipCardinality, RelationshipDirection
 from infrahub.core.node import Node
 from infrahub.core.node.delete_validator import NodeDeleteValidator
 from infrahub.core.query.node import (
@@ -187,6 +187,17 @@ class NodeManager:
         )
         await query.execute(db=db)
         node_ids = query.get_node_ids()
+
+        if node_schema.kind in [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS]:
+            if fields and "display_label" in fields:
+                schema_branch = db.schema.get_schema_branch(name=branch.name)
+                display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
+                if display_label_fields:
+                    fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
+            if fields and "hfid" in fields and node_schema.human_friendly_id:
+                hfid_fields = node_schema.generate_fields_for_hfid()
+                if hfid_fields:
+                    fields = deep_merge_dict(dicta=fields, dictb=hfid_fields)
 
         response = await cls.get_many(
             ids=node_ids,

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from copy import copy
 from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
-from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
+from infrahub_sdk.utils import is_valid_uuid
 
 from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
 from infrahub.core.node import Node
@@ -188,18 +188,6 @@ class NodeManager:
         await query.execute(db=db)
         node_ids = query.get_node_ids()
 
-        # if display_label or hfid has been requested we need to ensure we are querying the right fields
-        if fields and "display_label" in fields:
-            schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
-            if display_label_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
-
-        if fields and "hfid" in fields and node_schema.human_friendly_id:
-            hfid_fields = node_schema.generate_fields_for_hfid()
-            if hfid_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=hfid_fields)
-
         response = await cls.get_many(
             ids=node_ids,
             fields=fields,
@@ -324,20 +312,6 @@ class NodeManager:
         if not peers_info:
             return []
 
-        # if display_label has been requested we need to ensure we are querying the right fields
-        if fields and "display_label" in fields:
-            peer_schema = schema.get_peer_schema(db=db, branch=branch)
-            schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=peer_schema.kind)
-            if display_label_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
-
-        if fields and "hfid" in fields:
-            peer_schema = schema.get_peer_schema(db=db, branch=branch)
-            hfid_fields = peer_schema.generate_fields_for_hfid()
-            if hfid_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=hfid_fields)
-
         if fetch_peers:
             peer_ids = [peer.peer_id for peer in peers_info]
             peer_nodes = await cls.get_many(
@@ -419,15 +393,6 @@ class NodeManager:
 
         if not peers_ids:
             return {}
-
-        hierarchy_schema = node_schema.get_hierarchy_schema(db=db, branch=branch)
-
-        # if display_label has been requested we need to ensure we are querying the right fields
-        if fields and "display_label" in fields:
-            schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=hierarchy_schema.kind)
-            if display_label_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
         return await cls.get_many(
             db=db, ids=peers_ids, fields=fields, at=at, branch=branch, include_owner=True, include_source=True

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from copy import copy
 from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
-from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
+from infrahub_sdk.utils import is_valid_uuid
 
-from infrahub.core.constants import InfrahubKind, RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
 from infrahub.core.node import Node
 from infrahub.core.node.delete_validator import NodeDeleteValidator
 from infrahub.core.query.node import (
@@ -187,17 +187,6 @@ class NodeManager:
         )
         await query.execute(db=db)
         node_ids = query.get_node_ids()
-
-        if node_schema.kind in [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS]:
-            if fields and "display_label" in fields:
-                schema_branch = db.schema.get_schema_branch(name=branch.name)
-                display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
-                if display_label_fields:
-                    fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
-            if fields and "hfid" in fields and node_schema.human_friendly_id:
-                hfid_fields = node_schema.generate_fields_for_hfid()
-                if hfid_fields:
-                    fields = deep_merge_dict(dicta=fields, dictb=hfid_fields)
 
         response = await cls.get_many(
             ids=node_ids,

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from copy import copy
 from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
-from infrahub_sdk.utils import is_valid_uuid
+from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
 
-from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import InfrahubKind, RelationshipCardinality, RelationshipDirection
 from infrahub.core.node import Node
 from infrahub.core.node.delete_validator import NodeDeleteValidator
 from infrahub.core.query.node import (
@@ -188,6 +188,23 @@ class NodeManager:
         await query.execute(db=db)
         node_ids = query.get_node_ids()
 
+        if (
+            fields
+            and "identifier" in fields
+            and node_schema.kind
+            in [
+                InfrahubKind.BASEPERMISSION,
+                InfrahubKind.GLOBALPERMISSION,
+                InfrahubKind.OBJECTPERMISSION,
+            ]
+        ):
+            # This is a workaround to ensure we are querying the right fields for permissions
+            # The identifier for permissions needs the same fields as the display label
+            schema_branch = db.schema.get_schema_branch(name=branch.name)
+            display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
+            if display_label_fields:
+                fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
+
         response = await cls.get_many(
             ids=node_ids,
             fields=fields,
@@ -311,6 +328,20 @@ class NodeManager:
         peers_info = list(query.get_peers())
         if not peers_info:
             return []
+
+        if fields and "identifier" in fields:
+            # This is a workaround to ensure we are querying the right fields for permissions
+            # The identifier for permissions needs the same fields as the display label
+            peer_schema = schema.get_peer_schema(db=db, branch=branch)
+            if peer_schema.kind in [
+                InfrahubKind.BASEPERMISSION,
+                InfrahubKind.GLOBALPERMISSION,
+                InfrahubKind.OBJECTPERMISSION,
+            ]:
+                schema_branch = db.schema.get_schema_branch(name=branch.name)
+                display_label_fields = schema_branch.generate_fields_for_display_label(name=peer_schema.kind)
+                if display_label_fields:
+                    fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
         if fetch_peers:
             peer_ids = [peer.peer_id for peer in peers_info]

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -4,6 +4,7 @@ import ipaddress
 from typing import TYPE_CHECKING, Any
 
 from graphql.type.definition import GraphQLNonNull
+from infrahub_sdk.utils import deep_merge_dict
 from netaddr import IPSet
 from opentelemetry import trace
 
@@ -233,6 +234,23 @@ async def _resolve_available_prefix_nodes(
     return available_nodes
 
 
+def _ensure_display_label_fields(
+    db: InfrahubDatabase, branch: Branch, schema: NodeSchema | GenericSchema, node_fields: dict[str, Any]
+) -> None:
+    """Ensure fields needed to compute display_label are included in node_fields.
+
+    This is mostly for virtual nodes (InternalIPPrefixAvailable, InternalIPRangeAvailable) that are not stored in the
+    database.
+    """
+    if "display_label" not in node_fields or schema.kind not in [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS]:
+        return
+
+    schema_branch = db.schema.get_schema_branch(name=branch.name)
+    display_label_fields = schema_branch.generate_fields_for_display_label(name=schema.kind)
+    if display_label_fields:
+        node_fields = deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
+
+
 def _filter_kinds(nodes: list[Node], kinds: list[str], limit: int | None) -> list[Node]:
     filtered: list[Node] = []
     available_node_kinds = [InfrahubKind.IPPREFIXAVAILABLE, InfrahubKind.IPRANGEAVAILABLE]
@@ -323,6 +341,8 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
 
         edges = fields.get("edges", {})
         node_fields = edges.get("node", {})
+
+        _ensure_display_label_fields(db=db, branch=graphql_context.branch, schema=schema, node_fields=node_fields)
 
         permission_set: dict[str, Any] | None = None
         permissions = (

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
 from graphql import GraphQLResolveInfo
-from infrahub_sdk.utils import deep_merge_dict
 
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType, RelationshipHierarchyDirection
@@ -227,16 +226,10 @@ class ManyRelationshipResolver:
         node_fields: dict[str, Any],
     ) -> list[dict[str, Any]] | None:
         if node_fields and "display_label" in node_fields:
-            schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=rel_schema.peer)
-            if display_label_fields:
-                node_fields = deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
+            node_fields["display_label"] = None
 
         if node_fields and "hfid" in node_fields:
-            peer_schema = db.schema.get(name=rel_schema.peer, branch=branch, duplicate=False)
-            hfid_fields = peer_schema.generate_fields_for_hfid()
-            if hfid_fields:
-                node_fields = deep_merge_dict(dicta=node_fields, dictb=hfid_fields)
+            node_fields["human_friendly_id"] = None
 
         query_params = QueryPeerParams(
             branch=branch,

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -225,9 +225,6 @@ class ManyRelationshipResolver:
         filters: dict[str, Any],
         node_fields: dict[str, Any],
     ) -> list[dict[str, Any]] | None:
-        if node_fields and "display_label" in node_fields:
-            node_fields["display_label"] = None
-
         if node_fields and "hfid" in node_fields:
             node_fields["human_friendly_id"] = None
 

--- a/backend/infrahub/graphql/resolvers/single_relationship.py
+++ b/backend/infrahub/graphql/resolvers/single_relationship.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any
 
 from graphql import GraphQLResolveInfo
 from graphql.type.definition import GraphQLNonNull
-from infrahub_sdk.utils import deep_merge_dict
 
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType
@@ -143,16 +142,10 @@ class SingleRelationshipResolver:
             return None
 
         if node_fields and "display_label" in node_fields:
-            schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=rel_schema.peer)
-            if display_label_fields:
-                node_fields = deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
+            node_fields["display_label"] = None
 
         if node_fields and "hfid" in node_fields:
-            peer_schema = db.schema.get(name=rel_schema.peer, branch=branch, duplicate=False)
-            hfid_fields = peer_schema.generate_fields_for_hfid()
-            if hfid_fields:
-                node_fields = deep_merge_dict(dicta=node_fields, dictb=hfid_fields)
+            node_fields["human_friendly_id"] = None
 
         query_params = GetManyParams(
             fields=node_fields,

--- a/backend/infrahub/graphql/resolvers/single_relationship.py
+++ b/backend/infrahub/graphql/resolvers/single_relationship.py
@@ -141,9 +141,6 @@ class SingleRelationshipResolver:
         except (KeyError, IndexError):
             return None
 
-        if node_fields and "display_label" in node_fields:
-            node_fields["display_label"] = None
-
         if node_fields and "hfid" in node_fields:
             node_fields["human_friendly_id"] = None
 

--- a/changelog/+hfid-displaylabel-graphql.fixed.md
+++ b/changelog/+hfid-displaylabel-graphql.fixed.md
@@ -1,1 +1,1 @@
-Fix retriveing human friendly ID and display label for relationship nodes via GraphQL, incorrect values could be returned instead of the ones stored in the database
+Fix retrieving human friendly ID and display label for relationship nodes via GraphQL, incorrect values could be returned instead of the ones stored in the database

--- a/changelog/+hfid-displaylabel-graphql.fixed.md
+++ b/changelog/+hfid-displaylabel-graphql.fixed.md
@@ -1,0 +1,1 @@
+Fix retriveing human friendly ID and display label for relationship nodes via GraphQL, incorrect values could be returned instead of the ones stored in the database


### PR DESCRIPTION
After the HFID and display label refactoring work, we started storing the values for these properties as attributes in the database. We therefore do not require any logic to try to compute them on the fly and so we do not need to find out which fields to query for alongside those that the user requested.

This change fixes cases where HFID and display label may not be retrieved from the database when trying to access them for relationships via GraphQL queries.

There are workarounds in this PR to make IPAM and permissions responses correct. For IPAM, the issue is that we do not store some of the "context" nodes in the database, so we therefore have to query for fields to reconstruct their display labels (they do not have HFIDs). For permissions, the `identifier` field is computed on the fly too so we need to query for the fields to reconstruct it (which are the same as the one used in the display label). Ideally, we'd need to move the permission `identifier` field to a read-only computed attribute and maybe move the display label to be Jinja2 computed too (could be we'll end up with identifier == display label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GraphQL retrieval of human-friendly ID and display label for relationship nodes so stored values are returned correctly.
  * Ensured display labels for available IP prefix/range nodes are computed and returned properly in GraphQL listings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->