### PR TITLE
Fix graphiql autocompletion in production mode

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -25,9 +25,10 @@ export default defineConfig({
       customWorkers: [
         {
           label: "graphql",
-          entry: "monaco-graphql/esm/graphql.worker",
+          entry: "monaco-graphql/esm/graphql.worker.js",
         },
       ],
+      publicPath: "assets/monaco-editor",
     }),
   ],
 });


### PR DESCRIPTION
Fastapi server only /assets and /favicons and index.html. This PR moved monaco editor code within /assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced GraphQL editor resource loading and asset path configuration for improved editor stability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->