### PR TITLE
Update path to the git credential helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
               git config --global user.email 'infrahub@opsmill.com' && \
               git config --global --add safe.directory '*' && \
               git config --global credential.usehttppath true && \
-              git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+              git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -340,7 +340,7 @@ jobs:
               git config --global user.email 'infrahub@opsmill.com' && \
               git config --global --add safe.directory '*' && \
               git config --global credential.usehttppath true && \
-              git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+              git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -387,7 +387,7 @@ jobs:
               git config --global user.email 'infrahub@opsmill.com' && \
               git config --global --add safe.directory '*' && \
               git config --global credential.usehttppath true && \
-              git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+              git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -439,7 +439,7 @@ jobs:
               git config --global user.email 'infrahub@opsmill.com' && \
               git config --global --add safe.directory '*' && \
               git config --global credential.usehttppath true && \
-              git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+              git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: "Set environment variables"
         run: echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }}>> $GITHUB_ENV
       - name: "Set environment variables"
@@ -504,7 +504,7 @@ jobs:
   #             git config --global user.email 'infrahub@opsmill.com' && \
   #             git config --global --add safe.directory '*' && \
   #             git config --global credential.usehttppath true && \
-  #             git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+  #             git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
   #     - name: Install uv
   #       uses: astral-sh/setup-uv@v7
   #       with:
@@ -1085,7 +1085,7 @@ jobs:
               git config --global user.email 'infrahub@opsmill.com' && \
               git config --global --add safe.directory '*' && \
               git config --global credential.usehttppath true && \
-              git config --global credential.helper /usr/local/bin/infrahub-git-credential"
+              git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -327,7 +327,7 @@ class DevelopmentSettings(BaseSettings):
         description="Allow enterprise configuration in development mode, this will not enable the features just allow the configuration.",
     )
     git_credential_helper: str = Field(
-        default="/usr/local/bin/infrahub-git-credential",
+        default="infrahub-git-credential",
         description="Location of git credential helper",
     )
 

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -221,9 +221,11 @@ class InfrahubWorkerAsync(BaseWorker):
 
         await self._run_git_config_global(config.SETTINGS.git.user_name, setting_name="user.name")
         await self._run_git_config_global(config.SETTINGS.git.user_email, setting_name="user.email")
-        await self._run_git_config_global("'*'", "--replace-all", setting_name="safe.directory")
+        await self._run_git_config_global("*", "--replace-all", setting_name="safe.directory")
         await self._run_git_config_global("true", setting_name="credential.usehttppath")
-        await self._run_git_config_global(config.SETTINGS.dev.git_credential_helper, setting_name="credential.helper")
+        await self._run_git_config_global(
+            f"/usr/bin/env {config.SETTINGS.dev.git_credential_helper}", setting_name="credential.helper"
+        )
 
     async def _run_git_config_global(self, *args: str, setting_name: str) -> None:
         proc = await asyncio.create_subprocess_exec(

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -78,7 +78,7 @@ RUN git config --global user.name "Infrahub" && \
     git config --global user.email "infrahub@opsmill.com" && \
     git config --global --add safe.directory '*' && \
     git config --global credential.usehttppath true && \
-    git config --global credential.helper /usr/local/bin/infrahub-git-credential
+    git config --global credential.helper "/usr/bin/env infrahub-git-credential"
 
 RUN mkdir -p /opt/infrahub/git /opt/infrahub/storage /opt/infrahub/source /opt/infrahub/frontend/app/dist /opt/infrahub/workflow
 

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -66,7 +66,7 @@ The development settings are only relevant for local development
 |------|-------------|------|---------|
 | `INFRAHUB_DEV_FRONTEND_REDIRECT_SSO` | Indicates of the frontend should be responsible for the SSO redirection | boolean | False |
 | `INFRAHUB_DEV_ALLOW_ENTERPRISE_CONFIGURATION` | Allow enterprise configuration in development mode, this will not enable the features just allow the configuration. | boolean | False |
-| `INFRAHUB_DEV_GIT_CREDENTIAL_HELPER` | Location of git credential helper | string | /usr/local/bin/infrahub-git-credential |
+| `INFRAHUB_DEV_GIT_CREDENTIAL_HELPER` | Location of git credential helper | string | infrahub-git-credential |
 
 ## Http
 


### PR DESCRIPTION
When we migrated to uv from Poetry some issues arose with regards to how we find the git credential helper as the path changed from /usr/local/bin/infrahub-git-credential to /.venv/bin/infrahub-git-credential

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved git credential helper resolution mechanism across CI workflows, build processes, and configuration to use environment-based path resolution for better portability across environments.
  * Updated documentation to reflect configuration defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->