### PR TITLE
Add quotes to type expression in `typing.cast()`

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional, Self, Union, cast
 
-from neo4j.graph import Node as Neo4jNode
 from pydantic import Field, field_validator
 
 from infrahub.core.branch.enums import BranchStatus
@@ -24,6 +23,8 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, InitializationError, ValidationError
 
 if TYPE_CHECKING:
+    from neo4j.graph import Node as Neo4jNode
+
     from infrahub.database import InfrahubDatabase
 
 
@@ -168,7 +169,7 @@ class Branch(StandardNode):
         )
         await query.execute(db=db)
 
-        return [cls.from_db(node=cast(Neo4jNode, result.get("n"))) for result in query.get_results()]
+        return [cls.from_db(node=cast("Neo4jNode", result.get("n"))) for result in query.get_results()]
 
     @classmethod
     async def get_list_count(

--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -290,7 +290,7 @@ class NodeChangelog(BaseModel):
                     name=relationship.schema.name
                 )
             relationship_container = cast(
-                RelationshipCardinalityManyChangelog, self.relationships[relationship.schema.name]
+                "RelationshipCardinalityManyChangelog", self.relationships[relationship.schema.name]
             )
 
             relationship_container.add_new_peer(relationship=relationship)
@@ -311,7 +311,7 @@ class NodeChangelog(BaseModel):
                     name=relationship.schema.name
                 )
             relationship_container = cast(
-                RelationshipCardinalityManyChangelog, self.relationships[relationship.schema.name]
+                "RelationshipCardinalityManyChangelog", self.relationships[relationship.schema.name]
             )
             relationship_container.remove_peer(
                 peer_id=relationship.get_peer_id(), peer_kind=relationship.get_peer_kind()

--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -24,7 +24,7 @@ class ObjectConflictValidatorRecorder:
             )
         except NodeNotFoundError:
             return []
-        proposed_change = cast(CoreProposedChange, proposed_change)
+        proposed_change = cast("CoreProposedChange", proposed_change)
         validator = await self.get_or_create_validator(proposed_change)
         await self.initialize_validator(validator)
 

--- a/backend/infrahub/core/node/proposed_change.py
+++ b/backend/infrahub/core/node/proposed_change.py
@@ -1,10 +1,12 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from infrahub.core.constants.infrahubkind import THREADCOMMENT
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.core.protocols import CoreProposedChange as CoreProposedChangeProtocol
 from infrahub.database import InfrahubDatabase
+
+if TYPE_CHECKING:
+    from infrahub.core.protocols import CoreProposedChange as CoreProposedChangeProtocol
 
 
 class CoreProposedChange(Node):
@@ -29,7 +31,7 @@ class CoreProposedChange(Node):
         if fields:
             if "total_comments" in fields:
                 total_comments = 0
-                proposed_change = cast(CoreProposedChangeProtocol, self)
+                proposed_change = cast("CoreProposedChangeProtocol", self)
                 change_comments = await proposed_change.comments.get_relationships(db=db)
                 total_comments += len(change_comments)
 

--- a/backend/infrahub/core/validators/attribute/choices.py
+++ b/backend/infrahub/core/validators/attribute/choices.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, Any, cast
 
 from infrahub.core.constants import NULL_VALUE, PathType
 from infrahub.core.path import DataPath, GroupedDataPaths
-from infrahub.core.schema.generic_schema import GenericSchema
 
 from ..interface import ConstraintCheckerInterface
 from ..shared import AttributeSchemaValidatorQuery
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
+    from infrahub.core.schema.generic_schema import GenericSchema
     from infrahub.database import InfrahubDatabase
 
     from ..model import SchemaConstraintValidatorRequest
@@ -106,7 +106,7 @@ class AttributeChoicesChecker(ConstraintCheckerInterface):
         # skip inheriting schemas that override the attribute being checked
         excluded_kinds: list[str] = []
         if request.node_schema.is_generic_schema:
-            request.node_schema = cast(GenericSchema, request.node_schema)
+            request.node_schema = cast("GenericSchema", request.node_schema)
             for inheriting_kind in request.node_schema.used_by:
                 inheriting_schema = request.schema_branch.get_node(name=inheriting_kind, duplicate=False)
                 inheriting_schema_attribute = inheriting_schema.get_attribute(name=request.schema_path.field_name)

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -172,9 +172,9 @@ class InfrahubGraphQLApp:
 
         response = handler(request)
         if isawaitable(response):
-            return await cast(Awaitable[Response], response)
+            return await cast("Awaitable[Response]", response)
 
-        return cast(Response, response)
+        return cast("Response", response)
 
     async def _handle_http_request(
         self, request: Request, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
@@ -350,8 +350,8 @@ class InfrahubGraphQLApp:
         websocket: WebSocket,
         subscriptions: dict[str, AsyncGenerator[Any, None]],
     ) -> None:
-        operation_id = cast(str, message.get("id"))
-        message_type = cast(str, message.get("type"))
+        operation_id = cast("str", message.get("id"))
+        message_type = cast("str", message.get("type"))
 
         if message_type == GQL_CONNECTION_INIT:
             websocket.scope["connection_params"] = message.get("payload")
@@ -445,7 +445,7 @@ class InfrahubGraphQLApp:
         if isinstance(result, ExecutionResult) and result.errors:
             return result.errors
 
-        asyncgen = cast(AsyncGenerator[Any, None], result)
+        asyncgen = cast("AsyncGenerator[Any, None]", result)
         subscriptions[operation_id] = asyncgen
         task = asyncio.create_task(self._observe_subscription(asyncgen, operation_id, websocket))
         subscription_tasks.add(task)
@@ -479,7 +479,7 @@ async def _get_operation_from_request(request: Request) -> dict[str, Any] | list
     content_type = request.headers.get("Content-Type", "").split(";")[0]
     if content_type == "application/json":
         try:
-            return cast(dict[str, Any] | list[Any], await request.json())
+            return cast("dict[str, Any] | list[Any]", await request.json())
         except (TypeError, ValueError) as err:
             raise ValueError("Request body is not a valid JSON") from err
     elif content_type == "multipart/form-data":

--- a/backend/infrahub/graphql/mutations/action.py
+++ b/backend/infrahub/graphql/mutations/action.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, cast
 from graphene import InputObjectType, Mutation
 from typing_extensions import Self
 
-from infrahub.core.protocols import CoreNodeTriggerAttributeMatch, CoreNodeTriggerRelationshipMatch, CoreNodeTriggerRule
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from infrahub.log import get_logger
 
@@ -16,6 +15,11 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.protocols import (
+        CoreNodeTriggerAttributeMatch,
+        CoreNodeTriggerRelationshipMatch,
+        CoreNodeTriggerRule,
+    )
     from infrahub.core.schema import NodeSchema
     from infrahub.database import InfrahubDatabase
 
@@ -104,9 +108,11 @@ class InfrahubTriggerRuleMatchMutation(InfrahubMutationMixin, Mutation):
             trigger_match, result = await super().mutate_create(
                 info=info, data=data, branch=branch, database=dbt, override_data=override_data
             )
-            trigger_match_model = cast(CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch, trigger_match)
+            trigger_match_model = cast(
+                "CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch", trigger_match
+            )
             node_trigger_rule = await trigger_match_model.trigger.get_peer(db=dbt, raise_on_error=True)
-            node_trigger_rule_model = cast(CoreNodeTriggerRule, node_trigger_rule)
+            node_trigger_rule_model = cast("CoreNodeTriggerRule", node_trigger_rule)
             node_schema = dbt.schema.get_node_schema(name=node_trigger_rule_model.node_kind.value, duplicate=False)
             _validate_node_kind_field(data=data, node_schema=node_schema)
 
@@ -124,9 +130,11 @@ class InfrahubTriggerRuleMatchMutation(InfrahubMutationMixin, Mutation):
         graphql_context: GraphqlContext = info.context
         async with graphql_context.db.start_transaction() as dbt:
             trigger_match, result = await super().mutate_update(info=info, data=data, branch=branch, database=dbt)
-            trigger_match_model = cast(CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch, trigger_match)
+            trigger_match_model = cast(
+                "CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch", trigger_match
+            )
             node_trigger_rule = await trigger_match_model.trigger.get_peer(db=dbt, raise_on_error=True)
-            node_trigger_rule_model = cast(CoreNodeTriggerRule, node_trigger_rule)
+            node_trigger_rule_model = cast("CoreNodeTriggerRule", node_trigger_rule)
             node_schema = dbt.schema.get_node_schema(name=node_trigger_rule_model.node_kind.value, duplicate=False)
             _validate_node_kind_field(data=data, node_schema=node_schema)
 
@@ -134,7 +142,7 @@ class InfrahubTriggerRuleMatchMutation(InfrahubMutationMixin, Mutation):
 
 
 def _validate_node_kind(data: InputObjectType, db: InfrahubDatabase) -> None:
-    input_data = cast(dict[str, dict[str, Any]], data)
+    input_data = cast("dict[str, dict[str, Any]]", data)
     if node_kind := input_data.get("node_kind"):
         value = node_kind.get("value")
         if isinstance(value, str):
@@ -149,7 +157,7 @@ def _validate_node_kind(data: InputObjectType, db: InfrahubDatabase) -> None:
 
 
 def _validate_node_kind_field(data: InputObjectType, node_schema: NodeSchema) -> None:
-    input_data = cast(dict[str, dict[str, Any]], data)
+    input_data = cast("dict[str, dict[str, Any]]", data)
     if attribute_name := input_data.get("attribute_name"):
         value = attribute_name.get("value")
         if isinstance(value, str):

--- a/backend/infrahub/graphql/mutations/hfid.py
+++ b/backend/infrahub/graphql/mutations/hfid.py
@@ -55,7 +55,7 @@ class UpdateHFID(Mutation):
                 input_value=f"{node_schema.kind}.human_friendly_id has not been defined for this kind."
             )
 
-        updated_hfid = cast(list[str], data.value)
+        updated_hfid = cast("list[str]", data.value)
 
         if len(node_schema.human_friendly_id) != len(updated_hfid):
             raise ValidationError(

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -9,7 +9,6 @@ from graphene import Boolean, Field, InputObjectType, Mutation, String
 from infrahub import config
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
-from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
 from infrahub.core.schema import NodeSchema
 from infrahub.git.models import (
     GitRepositoryImportObjects,
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
 
@@ -107,7 +107,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         if node.get_kind() != InfrahubKind.READONLYREPOSITORY:
             return await super().mutate_update(info, data, branch, database=graphql_context.db, node=node)
 
-        node = cast(CoreReadOnlyRepository, node)
+        node = cast("CoreReadOnlyRepository", node)
         current_commit = node.commit.value
         current_ref = node.ref.value
         new_commit = None
@@ -118,7 +118,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             new_ref = data.ref.value
 
         obj, result = await super().mutate_update(info, data, branch, database=graphql_context.db, node=node)
-        obj = cast(CoreReadOnlyRepository, obj)
+        obj = cast("CoreReadOnlyRepository", obj)
 
         send_update_message = (new_commit and new_commit != current_commit) or (new_ref and new_ref != current_ref)
         if not send_update_message:

--- a/backend/infrahub/graphql/mutations/webhook.py
+++ b/backend/infrahub/graphql/mutations/webhook.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Self, cast
 from graphene import InputObjectType, Mutation
 
 from infrahub.core.manager import NodeManager
-from infrahub.core.protocols import CoreWebhook
 from infrahub.core.schema import NodeSchema
 from infrahub.database import retry_db_transaction
 from infrahub.events.utils import get_all_infrahub_node_kind_events
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.protocols import CoreWebhook
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
 
@@ -107,7 +107,7 @@ class InfrahubWebhookMutation(InfrahubMutationMixin, Mutation):
             branch=branch,
         )
 
-        webhook = cast(CoreWebhook, obj)
+        webhook = cast("CoreWebhook", obj)
 
         event_type = input_data.event_type.value if input_data.event_type else webhook.event_type.value.value
         node_kind = input_data.node_kind.value if input_data.node_kind else webhook.node_kind.value

--- a/backend/infrahub/proposed_change/branch_diff.py
+++ b/backend/infrahub/proposed_change/branch_diff.py
@@ -64,4 +64,4 @@ async def get_diff_summary_cache(pipeline_id: UUID) -> list[NodeDiff]:
     if not summary_payload:
         raise ResourceNotFoundError(message=f"Diff summary for pipeline {pipeline_id} was not found in the cache")
 
-    return cast(list["NodeDiff"], json.loads(summary_payload))
+    return cast("list[NodeDiff]", json.loads(summary_payload))

--- a/backend/infrahub/repositories/create_repository.py
+++ b/backend/infrahub/repositories/create_repository.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, cast
 
 from infrahub.core.constants import RepositoryInternalStatus
 from infrahub.core.constants.infrahubkind import READONLYREPOSITORY, REPOSITORY
-from infrahub.core.protocols import CoreGenericRepository, CoreReadOnlyRepository, CoreRepository
 from infrahub.exceptions import ValidationError
 from infrahub.git.models import GitRepositoryAdd, GitRepositoryAddReadOnly
 from infrahub.log import get_logger
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
     from infrahub.auth import AccountSession
     from infrahub.context import InfrahubContext
     from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreGenericRepository, CoreReadOnlyRepository, CoreRepository
     from infrahub.database import InfrahubDatabase
     from infrahub.services import InfrahubServices
 
@@ -74,7 +74,7 @@ class RepositoryFinalizer:
             authenticated_user = self.account_session.account_id
 
         if obj.get_kind() == READONLYREPOSITORY:
-            obj = cast(CoreReadOnlyRepository, obj)
+            obj = cast("CoreReadOnlyRepository", obj)
             model = GitRepositoryAddReadOnly(
                 repository_id=obj.id,
                 repository_name=obj.name.value,
@@ -92,7 +92,7 @@ class RepositoryFinalizer:
             )
 
         elif obj.get_kind() == REPOSITORY:
-            obj = cast(CoreRepository, obj)
+            obj = cast("CoreRepository", obj)
             git_repo_add_model = GitRepositoryAdd(
                 repository_id=obj.id,
                 repository_name=obj.name.value,

--- a/backend/infrahub/validators/tasks.py
+++ b/backend/infrahub/validators/tasks.py
@@ -26,7 +26,7 @@ async def start_validator[ValidatorType: CoreValidator](
         validator.started_at.value = ""
         validator.completed_at.value = ""
         await validator.save()
-        validator = cast(ValidatorType, validator)
+        validator = cast("ValidatorType", validator)
     else:
         data["proposed_change"] = proposed_change
         validator = await client.create(kind=validator_type, data=data)

--- a/backend/tests/db_snapshot.py
+++ b/backend/tests/db_snapshot.py
@@ -527,7 +527,7 @@ CALL (n_uuid, vertex_element_ids) {
                     deduplicated_attr.branch_properties_map[branch] = {}
                 for property_type_map in attr_branch_dict["property_type_maps"]:
                     property_type = DatabaseEdgeType(property_type_map["property_type"])
-                    property_type = cast(PropertyTypes, property_type)
+                    property_type = cast("PropertyTypes", property_type)
                     if property_type not in deduplicated_attr.branch_properties_map[branch]:
                         deduplicated_attr.branch_properties_map[branch][property_type] = set()
                     for property_value_statuses in property_type_map["property_value_maps"]:
@@ -561,7 +561,7 @@ CALL (n_uuid, vertex_element_ids) {
                     dedup_rel.branch_properties_map[branch] = {}
                 for property_type_map in rel_branch_details["property_type_maps"]:
                     property_type = DatabaseEdgeType(property_type_map["property_type"])
-                    property_type = cast(PropertyTypes, property_type)
+                    property_type = cast("PropertyTypes", property_type)
                     if property_type not in dedup_rel.branch_properties_map[branch]:
                         dedup_rel.branch_properties_map[branch][property_type] = set()
                     for property_value_statuses in property_type_map["property_value_maps"]:

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -1520,7 +1520,7 @@ async def generate_site(
         management_ip = await client.allocate_next_ip_address(
             resource_pool=management_pool, identifier=device_name, data={"interface": intf.id}, branch=branch
         )
-        management_ip = cast(IpamIPAddress, management_ip)
+        management_ip = cast("IpamIPAddress", management_ip)
 
         # set the IP address of the device to the management interface IP address
         obj.primary_address = management_ip  # type: ignore[assignment]
@@ -1903,7 +1903,7 @@ async def branch_scenario_add_upstream(
     subnet = await client.allocate_next_ip_prefix(
         resource_pool=external_pool, identifier=device_name, branch=new_branch_name
     )
-    subnet = cast(IpamIPPrefix, subnet)
+    subnet = cast("IpamIPPrefix", subnet)
     subnet_hosts = subnet.prefix.value.hosts()
     address = f"{str(next(subnet_hosts))}/29"
     peer_address = f"{str(next(subnet_hosts))}/29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -578,7 +578,6 @@ ignore = [
     "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
     "SIM401",  # Use `property["items"].get("format", None)` instead of an `if` block
-    "TC006",   # [*] Add quotes to type expression in `typing.cast()`
     "UP018",   # Unnecessary {literal_type} call (rewrite as a literal)
     "UP031",   # Use format specifiers instead of percent format
     "UP035",   # `typing.List` is deprecated, use `list` instead


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal typing and import organization across the backend and tests, standardizing forward-referenced type annotations.
  * Re-enabled a lint rule enforcing quoted type expressions.
  * No functional or user-visible behavior changes; existing APIs and workflows remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->