### PR TITLE
Fix: get-relationships returns hfid correctly

### DIFF
--- a/frontend/app/src/entities/nodes/relationships/domain/get-relationships/get-relationships.test.ts
+++ b/frontend/app/src/entities/nodes/relationships/domain/get-relationships/get-relationships.test.ts
@@ -25,6 +25,7 @@ describe("getRelationships", () => {
             {
               node: {
                 id: "1",
+                hfid: ["test", "hfid", "1"],
                 display_label: "Test Label",
                 __typename: "TestType",
               },
@@ -65,6 +66,7 @@ describe("getRelationships", () => {
     expect(result).toEqual([
       {
         id: "1",
+        hfid: ["test", "hfid", "1"],
         display_label: "Test Label",
         __typename: "TestType",
       },

--- a/frontend/app/src/entities/nodes/relationships/domain/get-relationships/get-relationships.ts
+++ b/frontend/app/src/entities/nodes/relationships/domain/get-relationships/get-relationships.ts
@@ -2,7 +2,7 @@ import {
   getRelationshipsFromApi,
   type getRelationshipsFromApiParams,
 } from "@/entities/nodes/relationships/api/get-relationships-from-api";
-import type { RelationshipNode } from "@/entities/nodes/relationships/domain/types";
+import type { NodeCore } from "@/entities/nodes/types";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -12,7 +12,7 @@ export const RELATIONSHIPS_PER_PAGE = 20;
 
 export type GetRelationshipsParams = getRelationshipsFromApiParams;
 
-export type GetRelationships = (params: GetRelationshipsParams) => Promise<Array<RelationshipNode>>;
+export type GetRelationships = (params: GetRelationshipsParams) => Promise<Array<NodeCore>>;
 
 export const getRelationships: GetRelationships = async ({
   branchName,
@@ -35,9 +35,5 @@ export const getRelationships: GetRelationships = async ({
 
   const relationshipsData = data[peer];
 
-  return relationshipsData.edges.map(({ node }: { node: any }) => ({
-    id: node.id,
-    display_label: node.display_label,
-    __typename: node.__typename,
-  }));
+  return relationshipsData.edges.map(({ node }: { node: NodeCore }) => node);
 };

--- a/frontend/app/tests/e2e/login.spec.ts
+++ b/frontend/app/tests/e2e/login.spec.ts
@@ -144,7 +144,7 @@ test.describe("/login", () => {
     test("redirect to homepage if user is already logged in", async ({ page }) => {
       await page.goto("/login");
 
-      await expect(page.getByText("Open Proposed changes")).toBeVisible();
+      await expect(page.getByText("Open Proposed changes", { exact: true })).toBeVisible();
     });
 
     test("should refresh access token and retry failed request", async ({ page }) => {

--- a/frontend/app/tests/e2e/profile/account-tokens.spec.ts
+++ b/frontend/app/tests/e2e/profile/account-tokens.spec.ts
@@ -7,7 +7,7 @@ test.describe("/profile?tab=tokens", () => {
   test.describe("when not logged in as admin account", () => {
     test("should not access profile tokens", async ({ page }) => {
       await page.goto("/profile?tab=tokens");
-      await expect(page.getByText("Open Proposed changes")).toBeVisible();
+      await expect(page.getByText("Open Proposed changes", { exact: true })).toBeVisible();
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relationships endpoint now returns complete node objects with full properties instead of a limited subset.

* **Tests**
  * Updated unit test data and assertions to match the expanded node shape.
  * Tightened end-to-end assertions to use exact text matching where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->