### PR TITLE
Fix breadcrumb for hierarchical object when its schema is a generic without parent__ids filter

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
@@ -40,7 +40,7 @@ export function ObjectAutocomplete({
         layout={ListLayout}
         layoutOptions={{ rowHeight: 30, loaderHeight: 30, padding: 4 }}
       >
-        <ListBox className={className}>
+        <ListBox className={className} emptyMessage="No result found">
           <Collection items={flatData}>
             {(node) => {
               const { schema } = getSchema(node.__typename);

--- a/frontend/app/src/entities/nodes/object/ui/object-relationship-list.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-relationship-list.tsx
@@ -1,0 +1,70 @@
+import { Icon } from "@iconify-icon/react";
+import { Collection } from "react-aria-components";
+
+import { ListBox, ListBoxItem, ListBoxLoadMoreItem } from "@/shared/components/aria/list-box";
+import ErrorScreen from "@/shared/components/errors/error-screen";
+import { classNames } from "@/shared/utils/common";
+
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
+import {
+  type UseObjectRelationshipsParams,
+  useObjectRelationships,
+} from "@/entities/nodes/relationships/domain/get-object-relationships/get-object-relationships.query";
+import { getObjectDetailsUrl } from "@/entities/nodes/utils";
+import { getSchema } from "@/entities/schema/domain/get-schema";
+import { getSchemaIcon } from "@/entities/schema/utils/get-schema-icon";
+
+interface ObjectRelationshipListProps extends UseObjectRelationshipsParams {
+  className?: string;
+}
+
+export function ObjectRelationshipList({
+  parentKind,
+  parentId,
+  relationshipName,
+  relationshipSchema,
+  filters,
+  className,
+}: ObjectRelationshipListProps) {
+  const { isPending, data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useObjectRelationships({
+      parentKind,
+      parentId,
+      relationshipName,
+      relationshipSchema,
+      filters,
+    });
+
+  if (error) return <ErrorScreen message={error.message} />;
+
+  const flatData = data?.pages.flat() ?? [];
+
+  return (
+    <ListBox
+      aria-label="object relationship list"
+      className={classNames("p-1", className)}
+      emptyMessage="No result found"
+    >
+      <Collection items={flatData}>
+        {(node) => {
+          const { schema } = getSchema(node.__typename);
+          const nodeLabel = getNodeLabel(node);
+
+          return (
+            <ListBoxItem textValue={nodeLabel} href={getObjectDetailsUrl(node.__typename, node.id)}>
+              <Icon icon={getSchemaIcon(schema)} />
+              <span className="truncate">{nodeLabel}</span>
+            </ListBoxItem>
+          );
+        }}
+      </Collection>
+
+      {(isPending || hasNextPage) && (
+        <ListBoxLoadMoreItem
+          isLoading={isPending || isFetchingNextPage}
+          onLoadMore={fetchNextPage}
+        />
+      )}
+    </ListBox>
+  );
+}

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-item-object.tsx
@@ -8,6 +8,7 @@ import { Popover } from "@/shared/components/aria/popover";
 import { Col, Row } from "@/shared/components/container";
 
 import { ObjectAutocomplete } from "@/entities/nodes/object/ui/object-autocomplete";
+import { ObjectRelationshipList } from "@/entities/nodes/object/ui/object-relationship-list";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { GetRelationshipsParams } from "@/entities/nodes/relationships/domain/get-relationships/get-relationships";
 import type { NodeCore } from "@/entities/nodes/types";
@@ -47,6 +48,9 @@ export function BreadcrumbItemObject({
         }
       })
     : null;
+  const { schema: parentToChildSchema, isGeneric: isGenericParentToChild } = useSchema(
+    parentToChildRelationshipSchema?.peer
+  ); // TO FIX: https://github.com/opsmill/infrahub/issues/7748, generic on hierarchy do not have parent__ids filter
 
   return (
     <Breadcrumb>
@@ -77,21 +81,35 @@ export function BreadcrumbItemObject({
           </Button>
 
           <Popover className="bg-stone-100/50 backdrop-blur">
-            <ObjectAutocomplete
-              className="max-h-58"
-              {...(parentRelationshipSchema && parentToChildRelationshipSchema && parentId
-                ? {
-                    objectKind: parentToChildRelationshipSchema.peer,
-                    filterQuery: {
-                      [`${parentRelationshipSchema.name}__ids`]: [parentId],
-                      ...filterQuery,
-                    },
-                  }
-                : {
-                    objectKind: autocompleteObjectKind ?? node.__typename,
-                    filterQuery,
-                  })}
-            />
+            {parentRelationshipSchema &&
+            parentId &&
+            parentToChildRelationshipSchema?.kind === "Hierarchy" &&
+            isGenericParentToChild &&
+            !parentToChildSchema.hierarchical ? (
+              <ObjectRelationshipList
+                className="max-h-58"
+                parentKind={parentRelationshipSchema.peer}
+                parentId={parentId}
+                relationshipName={parentToChildRelationshipSchema.name}
+                relationshipSchema={parentToChildSchema}
+              />
+            ) : (
+              <ObjectAutocomplete
+                className="max-h-58"
+                {...(parentRelationshipSchema && parentToChildRelationshipSchema && parentId
+                  ? {
+                      objectKind: parentToChildRelationshipSchema.peer,
+                      filterQuery: {
+                        [`${parentRelationshipSchema.name}__ids`]: [parentId],
+                        ...filterQuery,
+                      },
+                    }
+                  : {
+                      objectKind: autocompleteObjectKind ?? node.__typename,
+                      filterQuery,
+                    })}
+              />
+            )}
           </Popover>
         </MenuTrigger>
       </Row>


### PR DESCRIPTION
Patch for: https://github.com/opsmill/infrahub/issues/7748

Breadcrumb won't display search input in this case because it's not possible through API