### PR TITLE
Remove deprecated messages from RabbitMQ priority

### DIFF
--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -22,20 +22,8 @@ RESPONSE_MAP: dict[str, type[InfrahubResponse]] = {
 }
 
 PRIORITY_MAP = {
-    "check.artifact.create": 2,
-    "check.repository.check_definition": 2,
-    "check.repository.merge_conflicts": 2,
     "send.echo.request": 5,  # Currently only for testing purposes, will be removed once all message bus have been migrated to prefect
-    "event.branch.delete": 5,
-    "event.branch.merge": 5,
-    "event.schema.update": 5,
-    "git.diff.names_only": 4,
     "git.file.get": 4,
-    "request.artifact.generate": 2,
-    "request.git.sync": 4,
-    "request.proposed_change.pipeline": 5,
-    "transform.jinja.template": 4,
-    "transform.python.data": 4,
 }
 
 


### PR DESCRIPTION
The entire priority component for RabbitMQ will be removed. For now just starting off with some housekeeping and removing messages that have been migrated to Prefect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined message routing configuration by consolidating priority mappings to improve system efficiency and reduce operational complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->