### PR TITLE
Remove assigned as `deep_merge_dict` mutates its first parameter

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -203,7 +203,7 @@ class NodeManager:
             schema_branch = db.schema.get_schema_branch(name=branch.name)
             display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
             if display_label_fields:
-                fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
+                deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
         response = await cls.get_many(
             ids=node_ids,
@@ -341,7 +341,7 @@ class NodeManager:
                 schema_branch = db.schema.get_schema_branch(name=branch.name)
                 display_label_fields = schema_branch.generate_fields_for_display_label(name=peer_schema.kind)
                 if display_label_fields:
-                    fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
+                    deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
         if fetch_peers:
             peer_ids = [peer.peer_id for peer in peers_info]

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -248,7 +248,7 @@ def _ensure_display_label_fields(
     schema_branch = db.schema.get_schema_branch(name=branch.name)
     display_label_fields = schema_branch.generate_fields_for_display_label(name=schema.kind)
     if display_label_fields:
-        node_fields = deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
+        deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
 
 
 def _filter_kinds(nodes: list[Node], kinds: list[str], limit: int | None) -> list[Node]:


### PR DESCRIPTION
The `deep_merge_dict` function from the SDK mutates the dict passed as a first parameter. So it is useless to assign its return value to the variable that is passed as its first parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed display label field merging in query and peer query operations to ensure all display label-related fields are properly augmented and included in query results across branch handling and peer query processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->