### PR TITLE
Fix ruff violation for RUF043 

### DIFF
--- a/backend/tests/unit/api/diff/test_diff_query_validation.py
+++ b/backend/tests/unit/api/diff/test_diff_query_validation.py
@@ -39,5 +39,5 @@ class TestDiffQueryValidation:
     def test_time_from_required_for_default_branch(self) -> None:
         self.branch.is_default = True
 
-        with pytest.raises(ValidationError, match="time_from is mandatory when diffing on the default branch `abc`."):
+        with pytest.raises(ValidationError, match=r"time_from is mandatory when diffing on the default branch `abc`."):
             DiffQueryValidated(branch=self.branch, branch_only=True)

--- a/backend/tests/unit/core/schema/test_attribute_parameters.py
+++ b/backend/tests/unit/core/schema/test_attribute_parameters.py
@@ -92,7 +92,7 @@ def test_number_pool_optional() -> None:
     schema_branch = SchemaBranch(cache={})
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
-        ValidationError, match="TestNumberAttribute.assigned_number is a NumberPool it can't be optional"
+        ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it can't be optional"
     ):
         schema_branch.process()
 
@@ -119,7 +119,7 @@ def test_number_pool_read_only() -> None:
     schema_branch = SchemaBranch(cache={})
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
-        ValidationError, match="TestNumberAttribute.assigned_number is a NumberPool it has to be a read_only attribute"
+        ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it has to be a read_only attribute"
     ):
         schema_branch.process()
 
@@ -164,7 +164,7 @@ def test_number_pool_override_generic() -> None:
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError,
-        match="Overriding 'TestNumberAttribute.number' NumberPool attribute from generic 'BaseNumberAttribute' is not supported",
+        match=r"Overriding 'TestNumberAttribute.number' NumberPool attribute from generic 'BaseNumberAttribute' is not supported",
     ):
         schema_branch.process()
 
@@ -201,7 +201,7 @@ def test_number_pool_fail_on_multiple_generics() -> None:
     schema_branch = SchemaBranch(cache={})
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
-        ValidationError, match="SnowIncident.number is a NumberPool inherited from more than one generic"
+        ValidationError, match=r"SnowIncident.number is a NumberPool inherited from more than one generic"
     ):
         schema_branch.process()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -561,7 +561,6 @@ ignore = [
     "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",  # Prefer `next(...)` over single element slice
     "RUF029",  # Function is declared `async`, but doesn't `await` or use `async` features.
-    "RUF043",  # Pattern passed to `match=` contains metacharacters but is neither escaped nor raw
     "RUF052",  # Local dummy variable `_meta` is accessed
     "S101",    # Use of `assert` detected
     "S105",    # Possible hardcoded password assigned to: "REGEX_PASSWORD"


### PR DESCRIPTION
Pattern passed to `match=` contains meta characters but is neither escaped nor raw.

PR to test command introduced in #7792 