### PR TITLE
Add support for PKCE

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -12,10 +12,12 @@ from opentelemetry import trace
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
 from infrahub.auth import (
+    SSOStateCache,
     get_groups_from_provider,
     signin_sso_account,
     validate_auth_response,
 )
+from infrahub.auth_pkce import compute_code_challenge, generate_code_verifier
 from infrahub.exceptions import ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -42,6 +44,7 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     with trace.get_tracer(__name__).start_as_current_span("sso_oauth2_client_configuration") as span:
         span.set_attribute("provider_name", provider_name)
         span.set_attribute("scopes", provider.scopes)
+        span.set_attribute("pkce_enabled", provider.pkce_enabled)
 
         client = AsyncOAuth2Client(
             client_id=provider.client_id,
@@ -52,14 +55,32 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     redirect_uri = _get_redirect_url(request=request, provider_name=provider_name)
     final_url = final_url or config.SETTINGS.main.public_url or str(request.base_url)
 
+    # Generate PKCE parameters if enabled
+    code_verifier = None
+    pkce_params: dict[str, str] = {}
+    if provider.pkce_enabled:
+        code_verifier = generate_code_verifier()
+        code_challenge = compute_code_challenge(code_verifier)
+        pkce_params = {
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+
     authorization_uri, state = client.create_authorization_url(
-        url=provider.authorization_url, redirect_uri=redirect_uri, scope=provider.scopes, final_url=final_url
+        url=provider.authorization_url,
+        redirect_uri=redirect_uri,
+        scope=provider.scopes,
+        final_url=final_url,
+        **pkce_params,
     )
 
     service: InfrahubServices = request.app.state.service
 
+    cache_data = SSOStateCache(final_url=final_url, code_verifier=code_verifier)
     await service.cache.set(
-        key=f"security:oauth2:provider:{provider_name}:state:{state}", value=final_url, expires=KVTTL.TWO_HOURS
+        key=f"security:oauth2:provider:{provider_name}:state:{state}",
+        value=cache_data.model_dump_json(),
+        expires=KVTTL.TWO_HOURS,
     )
 
     if config.SETTINGS.dev.frontend_redirect_sso:
@@ -82,19 +103,25 @@ async def token(
     service: InfrahubServices = request.app.state.service
 
     cache_key = f"security:oauth2:provider:{provider_name}:state:{state}"
-    stored_final_url = await service.cache.get(key=cache_key)
+    cached_data = await service.cache.get(key=cache_key)
     await service.cache.delete(key=cache_key)
 
-    if not stored_final_url:
+    if not cached_data:
         raise ProcessingError(message="Invalid 'state' parameter")
 
-    token_data = {
+    sso_state = SSOStateCache.model_validate_json(cached_data)
+
+    token_data: dict[str, str | None] = {
         "code": code,
         "client_id": provider.client_id,
         "client_secret": provider.client_secret,
         "redirect_uri": _get_redirect_url(request=request, provider_name=provider_name),
         "grant_type": "authorization_code",
     }
+
+    # Add code_verifier if PKCE was used
+    if sso_state.code_verifier:
+        token_data["code_verifier"] = sso_state.code_verifier
 
     token_response = await service.http.post(provider.token_url, data=token_data)
     validate_auth_response(response=token_response, provider_type="OAuth 2.0")
@@ -139,5 +166,5 @@ async def token(
     )
 
     return models.UserTokenWithUrl(
-        access_token=user_token.access_token, refresh_token=user_token.refresh_token, final_url=stored_final_url
+        access_token=user_token.access_token, refresh_token=user_token.refresh_token, final_url=sso_state.final_url
     )

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -14,10 +14,12 @@ from pydantic import BaseModel, HttpUrl
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
 from infrahub.auth import (
+    SSOStateCache,
     get_groups_from_provider,
     signin_sso_account,
     validate_auth_response,
 )
+from infrahub.auth_pkce import compute_code_challenge, generate_code_verifier
 from infrahub.exceptions import ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -58,6 +60,10 @@ class OIDCDiscoveryConfig(BaseModel):
     tls_client_certificate_bound_access_tokens: bool | None = None
     mtls_endpoint_aliases: dict[str, HttpUrl] | None = None
 
+    @property
+    def supports_pkce(self) -> bool:
+        return "S256" in (self.code_challenge_methods_supported or [])
+
 
 def _get_redirect_url(request: Request, provider_name: str) -> str:
     """Return public redirect URL."""
@@ -74,10 +80,14 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     validate_auth_response(response=response, provider_type="OIDC")
     oidc_config = OIDCDiscoveryConfig(**response.json())
 
+    pkce_supported = oidc_config.supports_pkce
+
     with trace.get_tracer(__name__).start_as_current_span("sso_oauth2_client_configuration") as span:
         span.set_attribute("provider_name", provider_name)
         span.set_attribute("scopes", provider.scopes)
         span.set_attribute("discovery_url", provider.discovery_url)
+        span.set_attribute("pkce_enabled", provider.pkce_enabled)
+        span.set_attribute("pkce_supported", pkce_supported)
 
         client = AsyncOAuth2Client(
             client_id=provider.client_id,
@@ -88,12 +98,26 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     redirect_uri = _get_redirect_url(request=request, provider_name=provider_name)
     final_url = final_url or config.SETTINGS.main.public_url or str(request.base_url)
 
+    # Generate PKCE parameters if enabled and supported by provider
+    code_verifier = None
+    pkce_params: dict[str, str] = {}
+    if provider.pkce_enabled and pkce_supported:
+        code_verifier = generate_code_verifier()
+        code_challenge = compute_code_challenge(code_verifier)
+        pkce_params = {
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+
     authorization_uri, state = client.create_authorization_url(
-        url=str(oidc_config.authorization_endpoint), redirect_uri=redirect_uri, scope=provider.scopes
+        url=str(oidc_config.authorization_endpoint), redirect_uri=redirect_uri, scope=provider.scopes, **pkce_params
     )
 
+    cache_data = SSOStateCache(final_url=final_url, code_verifier=code_verifier)
     await service.cache.set(
-        key=f"security:oidc:provider:{provider_name}:state:{state}", value=final_url, expires=KVTTL.TWO_HOURS
+        key=f"security:oidc:provider:{provider_name}:state:{state}",
+        value=cache_data.model_dump_json(),
+        expires=KVTTL.TWO_HOURS,
     )
 
     if config.SETTINGS.dev.frontend_redirect_sso:
@@ -116,19 +140,25 @@ async def token(
     service: InfrahubServices = request.app.state.service
 
     cache_key = f"security:oidc:provider:{provider_name}:state:{state}"
-    stored_final_url = await service.cache.get(key=cache_key)
+    cached_data = await service.cache.get(key=cache_key)
     await service.cache.delete(key=cache_key)
 
-    if not stored_final_url:
+    if not cached_data:
         raise ProcessingError(message="Invalid 'state' parameter")
 
-    token_data = {
+    sso_state = SSOStateCache.model_validate_json(cached_data)
+
+    token_data: dict[str, str | None] = {
         "code": code,
         "client_id": provider.client_id,
         "client_secret": provider.client_secret,
         "redirect_uri": _get_redirect_url(request=request, provider_name=provider_name),
         "grant_type": "authorization_code",
     }
+
+    # Add code_verifier if PKCE was used
+    if sso_state.code_verifier:
+        token_data["code_verifier"] = sso_state.code_verifier
 
     discovery_response = await service.http.get(url=provider.discovery_url)
     validate_auth_response(response=discovery_response, provider_type="OIDC")
@@ -183,7 +213,7 @@ async def token(
     )
 
     return models.UserTokenWithUrl(
-        access_token=user_token.access_token, refresh_token=user_token.refresh_token, final_url=stored_final_url
+        access_token=user_token.access_token, refresh_token=user_token.refresh_token, final_url=sso_state.final_url
     )
 
 

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -51,6 +51,17 @@ class AccountSession(BaseModel):
         return self.auth_type == AuthType.JWT
 
 
+class SSOStateCache(BaseModel):
+    """Cache data stored during OAuth2/OIDC authorization flow.
+
+    This model is used to store state information between the authorization
+    request and the token exchange, including PKCE code_verifier when enabled.
+    """
+
+    final_url: str
+    code_verifier: str | None = None
+
+
 async def validate_active_account(db: InfrahubDatabase, account_id: str) -> None:
     account = await NodeManager.get_one(db=db, kind=CoreGenericAccount, id=account_id, raise_on_error=True)
     if account.status.value != AccountStatus.ACTIVE.value:

--- a/backend/infrahub/auth_pkce.py
+++ b/backend/infrahub/auth_pkce.py
@@ -1,0 +1,41 @@
+"""PKCE (RFC 7636) utilities for OAuth2/OIDC authentication.
+
+This module provides functions to generate code verifiers and compute
+code challenges for the Proof Key for Code Exchange (PKCE) extension.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+
+def generate_code_verifier() -> str:
+    """Generate a cryptographically random code verifier.
+
+    The code verifier is a high-entropy cryptographic random string using
+    the unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~",
+    with a minimum length of 43 characters and a maximum length of 128
+    characters.
+
+    Returns:
+        A 43-character URL-safe string (256 bits of entropy).
+    """
+    return secrets.token_urlsafe(32)
+
+
+def compute_code_challenge(code_verifier: str) -> str:
+    """Compute S256 code challenge from verifier.
+
+    Implements the S256 code challenge method as defined in RFC 7636:
+    code_challenge = BASE64URL(SHA256(code_verifier))
+
+    Args:
+        code_verifier: The code verifier string.
+
+    Returns:
+        Base64URL-encoded SHA256 hash without padding.
+    """
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -585,11 +585,14 @@ class SecurityOIDCBaseSettings(BaseSettings):
     icon: str = Field(default="mdi:account-key")
     display_label: str = Field(default="Single Sign on")
     userinfo_method: UserInfoMethod = Field(default=UserInfoMethod.GET)
+    pkce_enabled: bool = Field(
+        default=True, description="Enable PKCE (RFC 7636) with S256 method for authorization code flow"
+    )
 
 
 class SecurityOIDCSettings(SecurityOIDCBaseSettings):
     client_id: str = Field(..., description="Client ID of the application created in the auth provider")
-    client_secret: str = Field(..., description="Client secret as defined in auth provider")
+    client_secret: str | None = Field(default=None, description="Client secret as defined in auth provider")
     discovery_url: str = Field(..., description="The OIDC discovery URL xyz/.well-known/openid-configuration")
     scopes: list[str] = Field(default_factory=_default_scopes)
 
@@ -637,13 +640,16 @@ class SecurityOAuth2BaseSettings(BaseSettings):
 
     icon: str = Field(default="mdi:account-key")
     userinfo_method: UserInfoMethod = Field(default=UserInfoMethod.GET)
+    pkce_enabled: bool = Field(
+        default=True, description="Enable PKCE (RFC 7636) with S256 method for authorization code flow"
+    )
 
 
 class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):
     """Common base for Oauth2 providers"""
 
     client_id: str = Field(..., description="Client ID of the application created in the auth provider")
-    client_secret: str = Field(..., description="Client secret as defined in auth provider")
+    client_secret: str | None = Field(default=None, description="Client secret as defined in auth provider")
     authorization_url: str = Field(...)
     token_url: str = Field(...)
     userinfo_url: str = Field(...)

--- a/backend/tests/unit/test_auth_pkce.py
+++ b/backend/tests/unit/test_auth_pkce.py
@@ -1,0 +1,66 @@
+"""Tests for PKCE (RFC 7636) utility functions."""
+
+import base64
+import hashlib
+import re
+
+from infrahub.auth_pkce import compute_code_challenge, generate_code_verifier
+
+
+def test_generate_code_verifier_length() -> None:
+    """Code verifier should be 43 characters (256 bits of entropy from token_urlsafe(32))."""
+    verifier = generate_code_verifier()
+    assert len(verifier) == 43
+
+
+def test_generate_code_verifier_valid_characters() -> None:
+    """Code verifier should only contain URL-safe base64 characters."""
+    verifier = generate_code_verifier()
+    # URL-safe base64 uses A-Z, a-z, 0-9, -, _
+    assert re.match(r"^[A-Za-z0-9_-]+$", verifier)
+
+
+def test_generate_code_verifier_uniqueness() -> None:
+    """Each call should generate a unique verifier."""
+    verifiers = {generate_code_verifier() for _ in range(100)}
+    assert len(verifiers) == 100
+
+
+def test_compute_code_challenge_s256_computation() -> None:
+    """Code challenge should be BASE64URL(SHA256(code_verifier)) without padding."""
+    verifier = "test_verifier_string"
+    challenge = compute_code_challenge(verifier)
+
+    # Manually compute expected challenge
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+    assert challenge == expected
+
+
+def test_compute_code_challenge_no_padding() -> None:
+    """Code challenge should not have base64 padding characters."""
+    verifier = generate_code_verifier()
+    challenge = compute_code_challenge(verifier)
+    assert "=" not in challenge
+
+
+def test_compute_code_challenge_rfc_7636_appendix_b_test_vector() -> None:
+    """Test against RFC 7636 Appendix B test vector.
+
+    From RFC 7636:
+    code_verifier = dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+    code_challenge = E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+    """
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    challenge = compute_code_challenge(verifier)
+    expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    assert challenge == expected
+
+
+def test_compute_code_challenge_deterministic() -> None:
+    """Same verifier should always produce the same challenge."""
+    verifier = generate_code_verifier()
+    challenge1 = compute_code_challenge(verifier)
+    challenge2 = compute_code_challenge(verifier)
+    assert challenge1 == challenge2

--- a/changelog/7400.added.md
+++ b/changelog/7400.added.md
@@ -1,0 +1,1 @@
+Add support for PKCE within Oauth2 and OIDC authentications. With this change the client_secret for Oauth2 and OIDC have been switched to being optional. PKCE is enabled by default but can be switched off in the configuration if required.

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -205,8 +205,9 @@ Configuration settings for the message bus.
 |------|-------------|------|---------|
 | `INFRAHUB_OAUTH2_GOOGLE_ICON` | None | string | mdi:google |
 | `INFRAHUB_OAUTH2_GOOGLE_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OAUTH2_GOOGLE_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OAUTH2_GOOGLE_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OAUTH2_GOOGLE_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OAUTH2_GOOGLE_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OAUTH2_GOOGLE_AUTHORIZATION_URL` | None | string | https://accounts.google.com/o/oauth2/auth |
 | `INFRAHUB_OAUTH2_GOOGLE_TOKEN_URL` | None | string | https://oauth2.googleapis.com/token |
 | `INFRAHUB_OAUTH2_GOOGLE_USERINFO_URL` | None | string | https://www.googleapis.com/oauth2/v3/userinfo |
@@ -216,8 +217,9 @@ Configuration settings for the message bus.
 | `INFRAHUB_OAUTH2_GOOGLE_CLOUDIDENTITY_URL` | Google Cloud endpoint for Cloud Identity. Using searchDirectGroups by default because it is available for the Free plan | string | https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups |
 | `INFRAHUB_OAUTH2_PROVIDER1_ICON` | None | string | mdi:account-key |
 | `INFRAHUB_OAUTH2_PROVIDER1_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OAUTH2_PROVIDER1_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OAUTH2_PROVIDER1_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OAUTH2_PROVIDER1_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OAUTH2_PROVIDER1_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OAUTH2_PROVIDER1_AUTHORIZATION_URL` | None | string | None |
 | `INFRAHUB_OAUTH2_PROVIDER1_TOKEN_URL` | None | string | None |
 | `INFRAHUB_OAUTH2_PROVIDER1_USERINFO_URL` | None | string | None |
@@ -225,8 +227,9 @@ Configuration settings for the message bus.
 | `INFRAHUB_OAUTH2_PROVIDER1_DISPLAY_LABEL` | None | string | Single Sign on |
 | `INFRAHUB_OAUTH2_PROVIDER2_ICON` | None | string | mdi:account-key |
 | `INFRAHUB_OAUTH2_PROVIDER2_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OAUTH2_PROVIDER2_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OAUTH2_PROVIDER2_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OAUTH2_PROVIDER2_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OAUTH2_PROVIDER2_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OAUTH2_PROVIDER2_AUTHORIZATION_URL` | None | string | None |
 | `INFRAHUB_OAUTH2_PROVIDER2_TOKEN_URL` | None | string | None |
 | `INFRAHUB_OAUTH2_PROVIDER2_USERINFO_URL` | None | string | None |
@@ -240,8 +243,9 @@ Configuration settings for the message bus.
 | `INFRAHUB_OIDC_GOOGLE_ICON` | None | string | mdi:google |
 | `INFRAHUB_OIDC_GOOGLE_DISPLAY_LABEL` | None | string | Google |
 | `INFRAHUB_OIDC_GOOGLE_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OIDC_GOOGLE_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OIDC_GOOGLE_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OIDC_GOOGLE_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OIDC_GOOGLE_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OIDC_GOOGLE_DISCOVERY_URL` | None | string | https://accounts.google.com/.well-known/openid-configuration |
 | `INFRAHUB_OIDC_GOOGLE_SCOPES` | None | array[string] | None |
 | `INFRAHUB_OIDC_GOOGLE_FETCH_GROUPS` | Whether to use Cloud Identity API to fetch user groups. Note: requires additional scope: https://www.googleapis.com/auth/cloud-identity.groups.readonly | boolean | False |
@@ -249,15 +253,17 @@ Configuration settings for the message bus.
 | `INFRAHUB_OIDC_PROVIDER1_ICON` | None | string | mdi:account-key |
 | `INFRAHUB_OIDC_PROVIDER1_DISPLAY_LABEL` | None | string | Single Sign on |
 | `INFRAHUB_OIDC_PROVIDER1_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OIDC_PROVIDER1_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OIDC_PROVIDER1_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OIDC_PROVIDER1_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OIDC_PROVIDER1_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OIDC_PROVIDER1_DISCOVERY_URL` | The OIDC discovery URL xyz/.well-known/openid-configuration | string | None |
 | `INFRAHUB_OIDC_PROVIDER1_SCOPES` | None | array[string] | None |
 | `INFRAHUB_OIDC_PROVIDER2_ICON` | None | string | mdi:account-key |
 | `INFRAHUB_OIDC_PROVIDER2_DISPLAY_LABEL` | None | string | Single Sign on |
 | `INFRAHUB_OIDC_PROVIDER2_USERINFO_METHOD` | None | string (post, get) | get |
+| `INFRAHUB_OIDC_PROVIDER2_PKCE_ENABLED` | Enable PKCE (RFC 7636) with S256 method for authorization code flow | boolean | True |
 | `INFRAHUB_OIDC_PROVIDER2_CLIENT_ID` | Client ID of the application created in the auth provider | string | None |
-| `INFRAHUB_OIDC_PROVIDER2_CLIENT_SECRET` | Client secret as defined in auth provider | string | None |
+| `INFRAHUB_OIDC_PROVIDER2_CLIENT_SECRET` | Client secret as defined in auth provider | None | None |
 | `INFRAHUB_OIDC_PROVIDER2_DISCOVERY_URL` | The OIDC discovery URL xyz/.well-known/openid-configuration | string | None |
 | `INFRAHUB_OIDC_PROVIDER2_SCOPES` | None | array[string] | None |
 

--- a/docs/docs/reference/sso.mdx
+++ b/docs/docs/reference/sso.mdx
@@ -38,8 +38,9 @@ The Google provider configuration is simplified compared to standard providers. 
 | Parameter | Environment Variable | TOML Path | Description | Required |
 |-----------|---------------------|-----------|-------------|----------|
 | Client ID | `INFRAHUB_OIDC_<SLOT>_CLIENT_ID` | `security.oidc_provider_settings.<slot>.client_id` | The client identifier issued to the client by the identity provider | Yes |
-| Client Secret | `INFRAHUB_OIDC_<SLOT>_CLIENT_SECRET` | `security.oidc_provider_settings.<slot>.client_secret` | The client secret issued to the client by the identity provider | Yes |
+| Client Secret | `INFRAHUB_OIDC_<SLOT>_CLIENT_SECRET` | `security.oidc_provider_settings.<slot>.client_secret` | The client secret issued to the client by the identity provider | No |
 | Discovery URL | `INFRAHUB_OIDC_<SLOT>_DISCOVERY_URL` | `security.oidc_provider_settings.<slot>.discovery_url` | The URL of the OIDC discovery document | Yes |
+| PKCE | `INFRAHUB_OIDC_<SLOT>_PKCE_ENABLED` | `security.oidc_provider_settings.<slot>.pkce_enabled` | Indicates if PKCE is enabled | No |
 | Display Label | `INFRAHUB_OIDC_<SLOT>_DISPLAY_LABEL` | `security.oidc_provider_settings.<slot>.display_label` | The label displayed on the login button | No |
 | Icon | `INFRAHUB_OIDC_<SLOT>_ICON` | `security.oidc_provider_settings.<slot>.icon` | The Material Design icon name to display on the login button | No |
 | Enabled Providers | `INFRAHUB_SECURITY_OIDC_PROVIDERS` | `security.oidc_providers` | Array of enabled OIDC provider slots | Yes* |
@@ -51,10 +52,11 @@ The Google provider configuration is simplified compared to standard providers. 
 | Parameter | Environment Variable | TOML Path | Description | Required |
 |-----------|---------------------|-----------|-------------|----------|
 | Client ID | `INFRAHUB_OAUTH2_<SLOT>_CLIENT_ID` | `security.oauth2_provider_settings.<slot>.client_id` | The client identifier issued to the client by the identity provider | Yes |
-| Client Secret | `INFRAHUB_OAUTH2_<SLOT>_CLIENT_SECRET` | `security.oauth2_provider_settings.<slot>.client_secret` | The client secret issued to the client by the identity provider | Yes |
+| Client Secret | `INFRAHUB_OAUTH2_<SLOT>_CLIENT_SECRET` | `security.oauth2_provider_settings.<slot>.client_secret` | The client secret issued to the client by the identity provider | No |
 | Authorization URL | `INFRAHUB_OAUTH2_<SLOT>_AUTHORIZATION_URL` | `security.oauth2_provider_settings.<slot>.authorization_url` | The authorization endpoint URL | Yes |
 | Token URL | `INFRAHUB_OAUTH2_<SLOT>_TOKEN_URL` | `security.oauth2_provider_settings.<slot>.token_url` | The token endpoint URL | Yes |
 | Userinfo URL | `INFRAHUB_OAUTH2_<SLOT>_USERINFO_URL` | `security.oauth2_provider_settings.<slot>.userinfo_url` | The userinfo endpoint URL | Yes |
+| PKCE | `INFRAHUB_OAUTH2_<SLOT>_PKCE_ENABLED` | `security.oauth2_provider_settings.<slot>.pkce_enabled` | Indicates if PKCE is enabled | No |
 | Display Label | `INFRAHUB_OAUTH2_<SLOT>_DISPLAY_LABEL` | `security.oauth2_provider_settings.<slot>.display_label` | The label displayed on the login button | No |
 | Icon | `INFRAHUB_OAUTH2_<SLOT>_ICON` | `security.oauth2_provider_settings.<slot>.icon` | The Material Design icon name to display on the login button | No |
 | Enabled Providers | `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` | `security.oauth2_providers` | Array of enabled OAuth 2.0 provider slots | Yes* |


### PR DESCRIPTION
Add supports for PKCE, also changes the client_secret parameters to be optional as this is not always required when using PKCE. Targets ´stable` to allow for inclusion in Infrahub 1.6.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PKCE (Proof Key for Code Exchange) support for OAuth2 and OIDC authentication, enabled by default for enhanced security.
  * Client secret is now optional for OAuth2 and OIDC providers when using PKCE.

* **Configuration**
  * New `PKCE_ENABLED` configuration toggle available for all OAuth2 and OIDC providers to enable or disable PKCE flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->