### PR TITLE
use local OpenAPI schema for type generation + add CI validation

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -28,6 +28,7 @@ frontend_files: &frontend_files
 
 openapi_schema_files: &openapi_schema_files
   - "schema/openapi.json"
+  - "frontend/app/src/shared/api/rest/types.generated.ts"
 
 e2e_test_files:
   - "frontend/app/tests/e2e/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -26,6 +26,9 @@ infrahub_uv_files: &infrahub_uv_files
 frontend_files: &frontend_files
   - "frontend/app/**"
 
+openapi_schema_files: &openapi_schema_files
+  - "schema/openapi.json"
+
 e2e_test_files:
   - "frontend/app/tests/e2e/**"
 
@@ -85,8 +88,12 @@ release_all:
 
 frontend_all:
   - *frontend_files
+  - *openapi_schema_files
   - *ci_config
   - *development_files
+
+openapi_schema_all:
+  - *openapi_schema_files
 
 e2e_all:
   - *backend_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       github_workflows: ${{ steps.changes.outputs.github_workflows }}
       e2e_tests: ${{ steps.changes.outputs.e2e_test_files }}
       testcontainers: ${{ steps.changes.outputs.testcontainers_files }}
+      openapi_schema: ${{ steps.changes.outputs.openapi_schema_all }}
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"
@@ -112,6 +113,45 @@ jobs:
         run: npm ci
       - name: Run Biome
         run: npx biome ci .
+
+  frontend-validate-openapi-types:
+    if: |
+      needs.files-changed.outputs.openapi_schema == 'true'
+    needs: ["files-changed"]
+    defaults:
+      run:
+        working-directory: ./frontend/app
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v6"
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: frontend/app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate OpenAPI types
+        run: npm run codegen:openapi
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code src/shared/api/rest/types.generated.ts; then
+            echo "❌ Error: Generated OpenAPI types are out of sync with schema/openapi.json"
+            echo ""
+            echo "The OpenAPI schema has been updated, but the generated TypeScript types haven't been regenerated."
+            echo ""
+            echo "To fix this, run the following commands from the repository root:"
+            echo "  cd frontend/app"
+            echo "  npm run codegen:openapi"
+            echo "  git add src/shared/api/rest/types.generated.ts"
+            echo "  git commit -m 'chore: regenerate OpenAPI types'"
+            exit 1
+          fi
 
   python-lint:
     if: |

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -10,7 +10,7 @@
     "serve": "vite preview",
     "build-serve": "npm run build && npm run serve",
     "codegen": "graphql-codegen --config graphql.config.ts",
-    "codegen:openapi": "npx openapi-typescript http://localhost:8000/api/openapi.json --output src/shared/api/rest/types.generated.ts",
+    "codegen:openapi": "npx openapi-typescript ../../schema/openapi.json --output src/shared/api/rest/types.generated.ts",
     "ci:test:e2e": "CI=1 DEBUG=pw:browser npm run test:e2e 2>/dev/null",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/frontend/app/src/shared/api/rest/types.generated.ts
+++ b/frontend/app/src/shared/api/rest/types.generated.ts
@@ -467,6 +467,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/schema.graphql": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Graphql Schema */
+        get: operations["get_graphql_schema_schema_graphql_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1538,9 +1555,11 @@ export interface components {
         };
         /** LoggingSettings */
         LoggingSettings: {
-            /** @default {
+            /**
+             * @default {
              *       "enable": false
-             *     } */
+             *     }
+             */
             remote: components["schemas"]["RemoteLoggingSettings"];
         };
         /** MainSettings */
@@ -2119,10 +2138,12 @@ export interface components {
             generics?: components["schemas"]["GenericSchema"][];
             /** Nodes */
             nodes?: components["schemas"]["NodeSchema"][];
-            /** @default {
+            /**
+             * @default {
              *       "state": "present",
              *       "nodes": []
-             *     } */
+             *     }
+             */
             extensions: components["schemas"]["SchemaExtension"];
         };
         /** SchemaNamespace */
@@ -2165,11 +2186,49 @@ export interface components {
             /** @description The modifications to the schema */
             diff: components["schemas"]["SchemaDiff"];
             /**
+             * Warnings
+             * @description Warnings encountered while loading the schema
+             */
+            warnings?: components["schemas"]["SchemaWarning"][];
+            /**
              * Schema Updated
              * @description Indicates if the loading of the schema changed the existing schema
              */
             readonly schema_updated: boolean;
         };
+        /** SchemaWarning */
+        SchemaWarning: {
+            /** @description The type of warning */
+            type: components["schemas"]["SchemaWarningType"];
+            /**
+             * Kinds
+             * @description The kinds impacted by the warning
+             */
+            kinds?: components["schemas"]["SchemaWarningKind"][];
+            /**
+             * Message
+             * @description The message that describes the warning
+             */
+            message: string;
+        };
+        /** SchemaWarningKind */
+        SchemaWarningKind: {
+            /**
+             * Kind
+             * @description The kind impacted by the warning
+             */
+            kind: string;
+            /**
+             * Field
+             * @description The attribute or relationship impacted by the warning
+             */
+            field?: string | null;
+        };
+        /**
+         * SchemaWarningType
+         * @enum {string}
+         */
+        SchemaWarningType: "deprecation";
         /** SchemasLoadAPI */
         SchemasLoadAPI: {
             /** Schemas */
@@ -2320,7 +2379,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": null;
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -2402,7 +2461,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": null;
+                    "application/json": unknown;
                 };
             };
         };
@@ -3176,6 +3235,40 @@ export interface operations {
                 };
                 content: {
                     "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_graphql_schema_schema_graphql_get: {
+        parameters: {
+            query?: {
+                /** @description Whether to sort the schema alphabetically. */
+                sorted?: boolean;
+                /** @description Name of the branch to use for the query */
+                branch?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GraphQL schema endpoint and new schema warning types; schema updates can now include warnings.
  * Adjusted some API responses to explicitly return JSON where previously none was specified.

* **Chores**
  * Local tooling now generates types from a checked-in OpenAPI schema file.
  * CI workflow added validation to fail when generated OpenAPI types are out of sync.
  * Repository file filters updated to include the OpenAPI schema.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->