### PR TITLE
IFC-1954 Add events to apply profiles on attr/rel change

### DIFF
--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -128,16 +128,14 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         # Handle nodes removed from related_nodes - these need explicit refresh
         # since the async automation won't find them in the profile's related_nodes after the change.
         # Attribute changes and added nodes are handled by the Prefect automation
-        if updated_related_node_ids != original_related_node_ids:
-            removed_node_ids = original_related_node_ids - updated_related_node_ids
-            if removed_node_ids:
-                await cls._send_profile_refresh_workflows(
-                    db=db,
-                    workflow_service=workflow_service,
-                    branch_name=branch.name,
-                    obj=obj,
-                    node_ids=list(removed_node_ids),
-                )
+        if removed_node_ids := original_related_node_ids - updated_related_node_ids:
+            await cls._send_profile_refresh_workflows(
+                db=db,
+                workflow_service=workflow_service,
+                branch_name=branch.name,
+                obj=obj,
+                node_ids=list(removed_node_ids),
+            )
 
         return obj, mutation
 

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -71,16 +71,6 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
             )
 
     @classmethod
-    def _get_profile_attr_values_map(cls, obj: Node) -> dict[str, Any]:
-        attr_values_map = {}
-        for attr_schema in obj.get_schema().attributes:
-            # profile name update can be ignored
-            if attr_schema.name == "profile_name":
-                continue
-            attr_values_map[attr_schema.name] = getattr(obj, attr_schema.name).value
-        return attr_values_map
-
-    @classmethod
     async def _get_profile_related_node_ids(cls, db: InfrahubDatabase, obj: Node) -> set[str]:
         related_nodes = []
         related_nodes.extend(await obj.related_nodes.get_relationships(db=db))  # type: ignore[attr-defined]
@@ -127,30 +117,27 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         skip_uniqueness_check: bool = False,
     ) -> tuple[Node, Self]:
         workflow_service = info.context.active_service.workflow
-        original_attr_values = cls._get_profile_attr_values_map(obj=obj)
         original_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
 
         obj, mutation = await super()._call_mutate_update(
             info=info, data=data, branch=branch, db=db, obj=obj, skip_uniqueness_check=skip_uniqueness_check
         )
 
-        updated_attr_values = cls._get_profile_attr_values_map(obj=obj)
         updated_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
 
-        if original_attr_values != updated_attr_values:
-            await cls._send_profile_refresh_workflows(
-                db=db, workflow_service=workflow_service, branch_name=branch.name, obj=obj
-            )
-        elif updated_related_node_ids != original_related_node_ids:
+        # Handle nodes removed from related_nodes - these need explicit refresh
+        # since the async automation won't find them in the profile's related_nodes after the change.
+        # Attribute changes and added nodes are handled by the Prefect automation
+        if updated_related_node_ids != original_related_node_ids:
             removed_node_ids = original_related_node_ids - updated_related_node_ids
-            added_node_ids = updated_related_node_ids - original_related_node_ids
-            await cls._send_profile_refresh_workflows(
-                db=db,
-                workflow_service=workflow_service,
-                branch_name=branch.name,
-                obj=obj,
-                node_ids=list(removed_node_ids) + list(added_node_ids),
-            )
+            if removed_node_ids:
+                await cls._send_profile_refresh_workflows(
+                    db=db,
+                    workflow_service=workflow_service,
+                    branch_name=branch.name,
+                    obj=obj,
+                    node_ids=list(removed_node_ids),
+                )
 
         return obj, mutation
 

--- a/backend/infrahub/profiles/gather.py
+++ b/backend/infrahub/profiles/gather.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from prefect import task
+from prefect.cache_policies import NONE
+
+from infrahub.core.constants import RelationshipKind
+from infrahub.core.registry import registry
+from infrahub.database import InfrahubDatabase  # noqa: TC001  needed for prefect flow
+from infrahub.workflows.catalogue import PROFILE_REFRESH_PROCESS
+
+from .models import ProfileRefreshTriggerDefinition
+
+
+@task(name="gather-trigger-profile-refresh", cache_policy=NONE)
+async def gather_trigger_profile_refresh(
+    db: InfrahubDatabase | None = None,  # noqa: ARG001 Needed to have a common function signature for gathering functions
+) -> list[ProfileRefreshTriggerDefinition]:
+    """Gather profile refresh triggers for all profile schemas.
+
+    This function creates trigger definitions for each profile schema that will
+    listen for `NodeUpdatedEvent` on profiles. When a profile's attributes or
+    relationships change, the trigger will fire and execute the profile refresh
+    workflow to re-apply profiles to all related nodes.
+    """
+    branches_with_diff_from_main = registry.get_altered_schema_branches()
+    branches_to_process: list[tuple[str, list[str]]] = [(branch, []) for branch in branches_with_diff_from_main]
+    branches_to_process.append((registry.default_branch, branches_with_diff_from_main))
+
+    triggers: list[ProfileRefreshTriggerDefinition] = []
+
+    for branch_scope, branches_out_of_scope in branches_to_process:
+        schema_branch = registry.schema.get_schema_branch(name=branch_scope)
+
+        for profile_name in schema_branch.profile_names:
+            profile_schema = schema_branch.get_profile(name=profile_name, duplicate=False)
+
+            trigger_attr = [
+                attr.name for attr in profile_schema.attributes if attr.name not in ("profile_name", "profile_priority")
+            ]
+            trigger_rels = [
+                rel.name
+                for rel in profile_schema.relationships
+                if rel.kind in (RelationshipKind.GENERIC, RelationshipKind.ATTRIBUTE) and rel.name != "related_nodes"
+            ]
+            trigger_fields = trigger_attr + trigger_rels
+
+            if trigger_fields:
+                triggers.append(
+                    ProfileRefreshTriggerDefinition.from_profile_schema(
+                        branch=branch_scope,
+                        profile_kind=profile_schema.kind,
+                        trigger_fields=trigger_fields,
+                        workflow=PROFILE_REFRESH_PROCESS,
+                        branches_out_of_scope=branches_out_of_scope,
+                    )
+                )
+
+    return triggers

--- a/backend/infrahub/profiles/gather.py
+++ b/backend/infrahub/profiles/gather.py
@@ -42,7 +42,7 @@ async def gather_trigger_profile_refresh(
                 for rel in profile_schema.relationships
                 if rel.kind in (RelationshipKind.GENERIC, RelationshipKind.ATTRIBUTE) and rel.name != "related_nodes"
             ]
-            trigger_fields = trigger_attr + trigger_rels
+            trigger_fields = sorted(trigger_attr + trigger_rels)
 
             if trigger_fields:
                 triggers.append(

--- a/backend/infrahub/profiles/models.py
+++ b/backend/infrahub/profiles/models.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Self
+
+from infrahub.core.registry import registry
+from infrahub.events import NodeUpdatedEvent
+from infrahub.trigger.constants import NAME_SEPARATOR
+from infrahub.trigger.models import EventTrigger, ExecuteWorkflow, TriggerBranchDefinition, TriggerType
+
+if TYPE_CHECKING:
+    from infrahub.workflows.models import WorkflowDefinition
+
+
+class ProfileRefreshTriggerDefinition(TriggerBranchDefinition):
+    """Trigger definition for profile refresh when profile attributes/relationships change."""
+
+    type: TriggerType = TriggerType.PROFILE
+    profile_kind: str
+
+    @classmethod
+    def from_profile_schema(
+        cls,
+        branch: str,
+        profile_kind: str,
+        trigger_fields: list[str],
+        workflow: WorkflowDefinition,
+        branches_out_of_scope: list[str] | None = None,
+    ) -> Self:
+        """Create a trigger definition for profile refresh when profile attributes/relationships change."""
+        event_trigger = EventTrigger()
+        event_trigger.events.add(NodeUpdatedEvent.event_name)
+        event_trigger.match = {"infrahub.node.kind": profile_kind}
+
+        if branches_out_of_scope:
+            event_trigger.match["infrahub.branch.name"] = [f"!{b}" for b in branches_out_of_scope]
+        elif branch != registry.default_branch:
+            event_trigger.match["infrahub.branch.name"] = branch
+
+        event_trigger.match_related = {
+            "prefect.resource.role": ["infrahub.node.attribute_update", "infrahub.node.relationship_update"],
+            "infrahub.field.name": trigger_fields,
+        }
+
+        workflow_action = ExecuteWorkflow(
+            workflow=workflow,
+            parameters={
+                "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                "profile_kind": profile_kind,
+                "profile_id": "{{ event.resource['infrahub.node.id'] }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {
+                        "__prefect_kind": "jinja",
+                        "template": "{{ event.payload['context'] | tojson }}",
+                    },
+                },
+            },
+        )
+
+        return cls(
+            name=f"{profile_kind}{NAME_SEPARATOR}refresh",
+            branch=branch,
+            profile_kind=profile_kind,
+            trigger=event_trigger,
+            actions=[workflow_action],
+        )

--- a/backend/infrahub/profiles/tasks.py
+++ b/backend/infrahub/profiles/tasks.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from prefect import flow
 from prefect.logging import get_run_logger
 
-from infrahub.workers.dependencies import get_client, get_workflow
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
+from infrahub.trigger.models import TriggerSetupReport, TriggerType
+from infrahub.trigger.setup import setup_triggers_specific
+from infrahub.workers.dependencies import get_client, get_component, get_database, get_workflow
 from infrahub.workflows.catalogue import PROFILE_REFRESH
-from infrahub.workflows.utils import add_tags
+from infrahub.workflows.utils import add_tags, wait_for_schema_to_converge
+
+from .gather import gather_trigger_profile_refresh
+
+if TYPE_CHECKING:
+    from infrahub_sdk.node.relationship import RelationshipManager
 
 REFRESH_PROFILES_MUTATION = """
 mutation RefreshProfiles(
@@ -20,34 +30,18 @@ mutation RefreshProfiles(
 """
 
 
-@flow(
-    name="object-profiles-refresh",
-    flow_run_name="Refresh profiles for {node_id}",
-)
-async def object_profiles_refresh(
-    branch_name: str,
-    node_id: str,
-) -> None:
+@flow(name="object-profiles-refresh", flow_run_name="Refresh profiles for {node_id}")
+async def object_profiles_refresh(branch_name: str, node_id: str) -> None:
     log = get_run_logger()
     client = get_client()
 
     await add_tags(branches=[branch_name], nodes=[node_id], db_change=True)
-    await client.execute_graphql(
-        query=REFRESH_PROFILES_MUTATION,
-        variables={"id": node_id},
-        branch_name=branch_name,
-    )
+    await client.execute_graphql(query=REFRESH_PROFILES_MUTATION, variables={"id": node_id}, branch_name=branch_name)
     log.info(f"Profiles refreshed for {node_id}")
 
 
-@flow(
-    name="objects-profiles-refresh-multiple",
-    flow_run_name="Refresh profiles for multiple objects",
-)
-async def objects_profiles_refresh_multiple(
-    branch_name: str,
-    node_ids: list[str],
-) -> None:
+@flow(name="objects-profiles-refresh-multiple", flow_run_name="Refresh profiles for multiple objects")
+async def objects_profiles_refresh_multiple(branch_name: str, node_ids: list[str]) -> None:
     log = get_run_logger()
 
     await add_tags(branches=[branch_name])
@@ -55,9 +49,68 @@ async def objects_profiles_refresh_multiple(
     for node_id in node_ids:
         log.info(f"Requesting profile refresh for {node_id}")
         await get_workflow().submit_workflow(
-            workflow=PROFILE_REFRESH,
-            parameters={
-                "branch_name": branch_name,
-                "node_id": node_id,
-            },
+            workflow=PROFILE_REFRESH, parameters={"branch_name": branch_name, "node_id": node_id}
+        )
+
+
+@flow(name="profile-refresh-setup", flow_run_name="Setup profile refresh triggers")
+async def profile_refresh_setup(
+    context: InfrahubContext,  # noqa: ARG001
+    branch_name: str | None = None,
+    event_name: str | None = None,  # noqa: ARG001
+) -> None:
+    """Setup Prefect automations for profile refresh triggers.
+
+    This flow is triggered by schema changes and sets up automations that will
+    listen for profile updates. When a profile's attributes or relationships
+    change, the corresponding automation will trigger profile refresh for all
+    related nodes.
+    """
+    database = await get_database()
+    async with database.start_session() as db:
+        log = get_run_logger()
+
+        if branch_name:
+            await add_tags(branches=[branch_name])
+            component = await get_component()
+            await wait_for_schema_to_converge(branch_name=branch_name, component=component, db=db, log=log)
+
+        report: TriggerSetupReport = await setup_triggers_specific(
+            gatherer=gather_trigger_profile_refresh, trigger_type=TriggerType.PROFILE
+        )  # type: ignore[misc]
+
+        log.info(f"{report.in_use_count} Profile refresh automation configuration completed")
+
+
+@flow(name="profile-refresh-process", flow_run_name="Process profile refresh for {profile_kind}")
+async def profile_refresh_process(
+    branch_name: str,
+    profile_kind: str,
+    profile_id: str,
+    context: InfrahubContext,  # noqa: ARG001
+) -> None:
+    """Process profile refresh when a profile's attributes or relationships change.
+
+    This flow fetches all nodes related to the profile via the `related_nodes`
+    relationship and submits profile refresh workflows for each of them.
+    """
+    log = get_run_logger()
+    client = get_client()
+
+    await add_tags(branches=[branch_name])
+
+    profile = await client.get(kind=profile_kind, ids=[profile_id], branch=branch_name)
+    related_nodes: RelationshipManager = profile.related_nodes  # type: ignore
+    await related_nodes.fetch()
+
+    if not related_nodes.peer_ids:
+        log.info(f"No related nodes found for profile {profile_id}")
+        return
+
+    log.info(f"Found {len(related_nodes.peer_ids)} related nodes for profile {profile_id}")
+
+    for node_id in related_nodes.peer_ids:
+        log.info(f"Requesting profile refresh for {node_id}")
+        await get_workflow().submit_workflow(
+            workflow=PROFILE_REFRESH, parameters={"branch_name": branch_name, "node_id": node_id}
         )

--- a/backend/infrahub/profiles/triggers.py
+++ b/backend/infrahub/profiles/triggers.py
@@ -1,0 +1,22 @@
+from infrahub.events.branch_action import BranchDeletedEvent
+from infrahub.events.schema_action import SchemaUpdatedEvent
+from infrahub.trigger.models import BuiltinTriggerDefinition, EventTrigger, ExecuteWorkflow
+from infrahub.workflows.catalogue import PROFILE_REFRESH_SETUP
+
+TRIGGER_PROFILE_REFRESH_SETUP = BuiltinTriggerDefinition(
+    name="profile-refresh-setup-all",
+    trigger=EventTrigger(events={SchemaUpdatedEvent.event_name, BranchDeletedEvent.event_name}),
+    actions=[
+        ExecuteWorkflow(
+            workflow=PROFILE_REFRESH_SETUP,
+            parameters={
+                "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                "event_name": "{{ event.event }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
+            },
+        ),
+    ],
+)

--- a/backend/infrahub/trigger/catalogue.py
+++ b/backend/infrahub/trigger/catalogue.py
@@ -6,6 +6,7 @@ from infrahub.computed_attribute.triggers import (
 )
 from infrahub.display_labels.triggers import TRIGGER_DISPLAY_LABELS_ALL_SCHEMA
 from infrahub.hfid.triggers import TRIGGER_HFID_ALL_SCHEMA
+from infrahub.profiles.triggers import TRIGGER_PROFILE_REFRESH_SETUP
 from infrahub.schema.triggers import TRIGGER_SCHEMA_UPDATED
 from infrahub.trigger.models import TriggerDefinition
 from infrahub.webhook.triggers import TRIGGER_WEBHOOK_DELETE, TRIGGER_WEBHOOK_SETUP_UPDATE
@@ -17,6 +18,7 @@ builtin_triggers: list[TriggerDefinition] = [
     TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT,
     TRIGGER_DISPLAY_LABELS_ALL_SCHEMA,
     TRIGGER_HFID_ALL_SCHEMA,
+    TRIGGER_PROFILE_REFRESH_SETUP,
     TRIGGER_SCHEMA_UPDATED,
     TRIGGER_WEBHOOK_DELETE,
     TRIGGER_WEBHOOK_SETUP_UPDATE,

--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -101,6 +101,7 @@ class TriggerType(StrEnum):
     COMPUTED_ATTR_PYTHON_QUERY = "computed_attr_python_query"
     DISPLAY_LABEL_JINJA2 = "display_label_jinja2"
     HUMAN_FRIENDLY_ID = "human_friendly_id"
+    PROFILE = "profile"
     # OBJECT = "object"
 
     @property

--- a/backend/infrahub/trigger/tasks.py
+++ b/backend/infrahub/trigger/tasks.py
@@ -8,6 +8,7 @@ from infrahub.computed_attribute.gather import (
 )
 from infrahub.display_labels.gather import gather_trigger_display_labels_jinja2
 from infrahub.hfid.gather import gather_trigger_hfid
+from infrahub.profiles.gather import gather_trigger_profile_refresh
 from infrahub.trigger.catalogue import builtin_triggers
 from infrahub.webhook.gather import gather_trigger_webhook
 from infrahub.workers.dependencies import get_database
@@ -28,6 +29,7 @@ async def trigger_configure_all() -> None:
             computed_attribute_python_query_triggers,
         ) = await gather_trigger_computed_attribute_python(db=db)
         action_rules = await gather_trigger_action_rules(db=db)
+        profile_refresh_triggers = await gather_trigger_profile_refresh()
         triggers = (
             computed_attribute_j2_triggers
             + computed_attribute_python_triggers
@@ -35,6 +37,7 @@ async def trigger_configure_all() -> None:
             + display_label_triggers
             + human_friendly_id_triggers
             + builtin_triggers
+            + profile_refresh_triggers
             + webhook_trigger
             + action_rules
         )

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -623,6 +623,23 @@ PROFILE_REFRESH = WorkflowDefinition(
 )
 
 
+PROFILE_REFRESH_SETUP = WorkflowDefinition(
+    name="profile-refresh-setup",
+    type=WorkflowType.CORE,
+    module="infrahub.profiles.tasks",
+    function="profile_refresh_setup",
+)
+
+
+PROFILE_REFRESH_PROCESS = WorkflowDefinition(
+    name="profile-refresh-process",
+    type=WorkflowType.CORE,
+    module="infrahub.profiles.tasks",
+    function="profile_refresh_process",
+    tags=[WorkflowTag.DATABASE_CHANGE],
+)
+
+
 CLEAN_UP_DEADLOCKS = WorkflowDefinition(
     name="clean-up-deadlocks",
     type=WorkflowType.INTERNAL,
@@ -685,6 +702,8 @@ WORKFLOWS = [
     IPAM_RECONCILIATION,
     PROFILE_REFRESH,
     PROFILE_REFRESH_MULTIPLE,
+    PROFILE_REFRESH_PROCESS,
+    PROFILE_REFRESH_SETUP,
     PROPOSED_CHANGE_MERGE,
     QUERY_COMPUTED_ATTRIBUTE_TRANSFORM_TARGETS,
     REMOVE_ADD_NODE_FROM_GROUP,

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -276,7 +276,7 @@ class TestProfiles(TestInfrahubApp):
         client: InfrahubClient,
         branch: BranchData,
     ) -> None:
-        await self.refresh_profiles(client, branch.name, device_2_empty_attribute.id)
+        await self.refresh_profiles(client=client, branch_name=branch.name, node_id=device_2_empty_attribute.id)
 
         updated_device_2 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
@@ -413,9 +413,9 @@ class TestProfiles(TestInfrahubApp):
         device_profile_3.profile_priority.value = 999
         await device_profile_3.save()
 
-        await self.refresh_profiles(client, branch.name, device_1_full_attributes.id)
-        await self.refresh_profiles(client, branch.name, device_2_empty_attribute.id)
-        await self.refresh_profiles(client, branch.name, device_3.id)
+        await self.refresh_profiles(client=client, branch_name=branch.name, node_id=device_1_full_attributes.id)
+        await self.refresh_profiles(client=client, branch_name=branch.name, node_id=device_2_empty_attribute.id)
+        await self.refresh_profiles(client=client, branch_name=branch.name, node_id=device_3.id)
 
         updated_device_1 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -1,18 +1,31 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from attr import dataclass
-from infrahub_sdk.branch import BranchData
-from infrahub_sdk.client import InfrahubClient
 from infrahub_sdk.exceptions import BranchNotFoundError, NodeNotFoundError
-from infrahub_sdk.node.node import InfrahubNode
 
-from infrahub.core.branch import Branch
 from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA
 from tests.helpers.test_app import TestInfrahubApp
 
+if TYPE_CHECKING:
+    from infrahub_sdk.branch import BranchData
+    from infrahub_sdk.client import InfrahubClient
+    from infrahub_sdk.node.node import InfrahubNode
+
+    from infrahub.core.branch import Branch
+
 BRANCH_NAMES = ["main", "branch2"]
+
+REFRESH_PROFILES_MUTATION = """
+mutation RefreshProfiles($id: String!) {
+  InfrahubProfilesRefresh(data: {id: $id}) {
+    ok
+  }
+}
+"""
 
 
 @dataclass
@@ -33,13 +46,20 @@ class AttributeProfileDetails:
 
 
 class TestProfiles(TestInfrahubApp):
+    async def refresh_profiles(self, client: InfrahubClient, branch_name: str, node_id: str) -> None:
+        # This should be done using a trigger but for test purpose we do it manually
+        response = await client.execute_graphql(
+            query=REFRESH_PROFILES_MUTATION, variables={"id": node_id}, branch_name=branch_name
+        )
+        assert response["InfrahubProfilesRefresh"]["ok"]
+
     @pytest.fixture(params=BRANCH_NAMES)
     async def branch(self, request, client: InfrahubClient) -> BranchData:
         branch_name = request.param
         try:
             return await client.branch.get(branch_name=branch_name)
         except BranchNotFoundError:
-            return await client.branch.create(branch_name=branch_name)
+            return await client.branch.create(branch_name=branch_name, background_execution=None)
 
     @pytest.fixture(scope="class")
     async def load_schema(self, client: InfrahubClient, default_branch: Branch) -> None:
@@ -256,6 +276,8 @@ class TestProfiles(TestInfrahubApp):
         client: InfrahubClient,
         branch: BranchData,
     ) -> None:
+        await self.refresh_profiles(client, branch.name, device_2_empty_attribute.id)
+
         updated_device_2 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
         )
@@ -390,6 +412,10 @@ class TestProfiles(TestInfrahubApp):
         )
         device_profile_3.profile_priority.value = 999
         await device_profile_3.save()
+
+        await self.refresh_profiles(client, branch.name, device_1_full_attributes.id)
+        await self.refresh_profiles(client, branch.name, device_2_empty_attribute.id)
+        await self.refresh_profiles(client, branch.name, device_3.id)
 
         updated_device_1 = await client.get(
             branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -98,8 +98,23 @@ mutation ($update_data: PretendPersonUpdateInput!) {
 }
 """ % {"person_values": PERSON_VALUES}
 
+REFRESH_PROFILES_MUTATION = """
+mutation RefreshProfiles($id: String!) {
+  InfrahubProfilesRefresh(data: {id: $id}) {
+    ok
+  }
+}
+"""
+
 
 class TestProfileLifecycle(TestInfrahubApp):
+    async def refresh_profiles(self, client: InfrahubClient, branch_name: str, node_id: str) -> None:
+        # This should be done using a trigger but for test purpose we do it manually
+        response = await client.execute_graphql(
+            query=REFRESH_PROFILES_MUTATION, variables={"id": node_id}, branch_name=branch_name
+        )
+        assert response["InfrahubProfilesRefresh"]["ok"]
+
     @pytest.fixture(scope="class")
     def generic_schema_base(self) -> GenericSchema:
         return GenericSchema(
@@ -985,6 +1000,8 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert len(updated_person_profile_1.related_nodes.peers) == 1
         assert updated_person_profile_1.related_nodes.peers[0].id == person_1.id
 
+        await self.refresh_profiles(client=client, branch_name=default_branch.name, node_id=person_1.id)
+
     async def test_step_12_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ) -> None:
@@ -1048,6 +1065,8 @@ class TestProfileLifecycle(TestInfrahubApp):
         await updated_person_profile_1.related_nodes.fetch()
         assert len(updated_person_profile_1.related_nodes.peers) == 1
         assert updated_person_profile_1.related_nodes.peers[0].id == person_2.id
+
+        await self.refresh_profiles(client=client, branch_name=default_branch.name, node_id=person_2.id)
 
     async def test_step_14_check_persons_again(
         self, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient

--- a/backend/tests/unit/profiles/conftest.py
+++ b/backend/tests/unit/profiles/conftest.py
@@ -1,0 +1,131 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import BranchSupportType, RelationshipCardinality, RelationshipKind
+from infrahub.core.schema import (
+    AttributeSchema,
+    GenericSchema,
+    NodeSchema,
+    RelationshipSchema,
+    SchemaRoot,
+)
+from infrahub.database import InfrahubDatabase
+
+
+@pytest.fixture
+async def profile_schema_with_attributes(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
+) -> SchemaRoot:
+    """Create a schema with a node that has attributes that can be set via profiles."""
+    SCHEMA = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Device",
+                namespace="Test",
+                branch=BranchSupportType.AWARE.value,
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                    AttributeSchema(name="description", kind="Text", optional=True),
+                    AttributeSchema(name="status", kind="Text", optional=True),
+                ],
+            ),
+        ]
+    )
+
+    registry.schema.register_schema(schema=SCHEMA, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    return SCHEMA
+
+
+@pytest.fixture
+async def profile_schema_with_generic_relationship(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
+) -> SchemaRoot:
+    """Create a schema with a node that has a generic relationship that can be set via profiles."""
+    generic_schema = GenericSchema(
+        name="GenericRole",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        attributes=[AttributeSchema(name="role_name", kind="Text")],
+    )
+
+    role_schema = NodeSchema(
+        name="Role",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        inherit_from=["TestGenericRole"],
+        attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+    )
+
+    device_schema = NodeSchema(
+        name="Device",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text", optional=True),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="role",
+                peer="TestGenericRole",
+                kind=RelationshipKind.GENERIC,
+                optional=True,
+                cardinality=RelationshipCardinality.ONE,
+            ),
+        ],
+    )
+
+    SCHEMA = SchemaRoot(nodes=[role_schema, device_schema], generics=[generic_schema])
+
+    registry.schema.register_schema(schema=SCHEMA, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    return SCHEMA
+
+
+@pytest.fixture
+async def profile_schema_with_attribute_relationship(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
+) -> SchemaRoot:
+    """Create a schema with a node that has an attribute relationship that can be set via profiles."""
+    location_schema = NodeSchema(
+        name="Location",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+    )
+
+    device_schema = NodeSchema(
+        name="Device",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text", optional=True),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="location",
+                peer="TestLocation",
+                kind=RelationshipKind.ATTRIBUTE,
+                optional=True,
+                cardinality=RelationshipCardinality.ONE,
+            ),
+        ],
+    )
+
+    SCHEMA = SchemaRoot(nodes=[location_schema, device_schema])
+
+    registry.schema.register_schema(schema=SCHEMA, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    return SCHEMA

--- a/backend/tests/unit/profiles/conftest.py
+++ b/backend/tests/unit/profiles/conftest.py
@@ -16,7 +16,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.fixture
 async def profile_schema_with_attributes(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
-) -> SchemaRoot:
+) -> None:
     """Create a schema with a node that has attributes that can be set via profiles."""
     SCHEMA = SchemaRoot(
         nodes=[
@@ -38,13 +38,11 @@ async def profile_schema_with_attributes(
     default_branch.update_schema_hash()
     await default_branch.save(db=db)
 
-    return SCHEMA
-
 
 @pytest.fixture
 async def profile_schema_with_generic_relationship(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
-) -> SchemaRoot:
+) -> None:
     """Create a schema with a node that has a generic relationship that can be set via profiles."""
     generic_schema = GenericSchema(
         name="GenericRole",
@@ -87,13 +85,11 @@ async def profile_schema_with_generic_relationship(
     default_branch.update_schema_hash()
     await default_branch.save(db=db)
 
-    return SCHEMA
-
 
 @pytest.fixture
 async def profile_schema_with_attribute_relationship(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
-) -> SchemaRoot:
+) -> None:
     """Create a schema with a node that has an attribute relationship that can be set via profiles."""
     location_schema = NodeSchema(
         name="Location",
@@ -127,5 +123,3 @@ async def profile_schema_with_attribute_relationship(
     registry.schema.process_schema_branch(name=default_branch.name)
     default_branch.update_schema_hash()
     await default_branch.save(db=db)
-
-    return SCHEMA

--- a/backend/tests/unit/profiles/test_gather.py
+++ b/backend/tests/unit/profiles/test_gather.py
@@ -27,7 +27,7 @@ async def test_gather_trigger_profile_refresh_core_models(register_core_models_s
 
 
 async def test_gather_trigger_profile_refresh_with_attributes(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: None
 ) -> None:
     """Test that triggers are created for profile schemas with attributes."""
     triggers = await gather_trigger_profile_refresh()
@@ -57,7 +57,7 @@ async def test_gather_trigger_profile_refresh_with_attributes(
 
 
 async def test_gather_trigger_profile_refresh_with_generic_relationship(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_generic_relationship: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_generic_relationship: None
 ) -> None:
     """Test that triggers include generic relationships."""
     triggers = await gather_trigger_profile_refresh()
@@ -74,7 +74,7 @@ async def test_gather_trigger_profile_refresh_with_generic_relationship(
 
 
 async def test_gather_trigger_profile_refresh_with_attribute_relationship(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attribute_relationship: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attribute_relationship: None
 ) -> None:
     """Test that triggers include attribute relationships."""
     triggers = await gather_trigger_profile_refresh()

--- a/backend/tests/unit/profiles/test_gather.py
+++ b/backend/tests/unit/profiles/test_gather.py
@@ -1,0 +1,142 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import BranchSupportType
+from infrahub.core.initialization import create_branch
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.database import InfrahubDatabase
+from infrahub.events.node_action import NodeUpdatedEvent
+from infrahub.profiles.gather import gather_trigger_profile_refresh
+
+
+async def test_gather_trigger_profile_refresh_core_models(register_core_models_schema, default_branch: Branch) -> None:
+    """Test that triggers are created for core model profiles that have trigger fields."""
+    triggers = await gather_trigger_profile_refresh()
+
+    # We have builtin kinds that have corresponding profiles
+    assert [t.profile_kind for t in triggers] == [
+        "ProfileBuiltinTag",
+        "ProfileIpamNamespace",
+        "ProfileBuiltinIPPrefix",
+        "ProfileBuiltinIPAddress",
+    ]
+
+    trigger_events: set[str] = set()
+    for trigger in triggers:
+        trigger_events.update(trigger.trigger.events)
+    assert trigger_events == {NodeUpdatedEvent.event_name}
+
+
+async def test_gather_trigger_profile_refresh_with_attributes(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+) -> None:
+    """Test that triggers are created for profile schemas with attributes."""
+    triggers = await gather_trigger_profile_refresh()
+
+    profile_triggers = [t for t in triggers if t.profile_kind == "ProfileTestDevice"]
+    assert len(profile_triggers) == 1
+
+    trigger = profile_triggers[0]
+    assert trigger.name == "ProfileTestDevice::refresh"
+    assert trigger.generate_name() == "profile::main::ProfileTestDevice::refresh"
+    assert trigger.trigger.events == {NodeUpdatedEvent.event_name}
+    assert trigger.trigger.match == {"infrahub.node.kind": "ProfileTestDevice"}
+
+    assert "infrahub.field.name" in trigger.trigger.match_related
+    trigger_fields = trigger.trigger.match_related["infrahub.field.name"]
+    assert "description" in trigger_fields
+    assert "status" in trigger_fields
+    assert "profile_name" not in trigger_fields
+    assert "profile_priority" not in trigger_fields
+    assert "related_nodes" not in trigger_fields
+
+    assert "prefect.resource.role" in trigger.trigger.match_related
+    assert "infrahub.node.attribute_update" in trigger.trigger.match_related["prefect.resource.role"]
+    assert "infrahub.node.relationship_update" in trigger.trigger.match_related["prefect.resource.role"]
+
+    assert "infrahub.branch.name" not in trigger.trigger.match
+
+
+async def test_gather_trigger_profile_refresh_with_generic_relationship(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_generic_relationship: SchemaRoot
+) -> None:
+    """Test that triggers include generic relationships."""
+    triggers = await gather_trigger_profile_refresh()
+
+    profile_triggers = [t for t in triggers if t.profile_kind == "ProfileTestDevice"]
+    assert len(profile_triggers) == 1
+
+    trigger = profile_triggers[0]
+    trigger_fields = trigger.trigger.match_related["infrahub.field.name"]
+
+    assert "role" in trigger_fields
+    assert "description" in trigger_fields
+    assert "related_nodes" not in trigger_fields
+
+
+async def test_gather_trigger_profile_refresh_with_attribute_relationship(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attribute_relationship: SchemaRoot
+) -> None:
+    """Test that triggers include attribute relationships."""
+    triggers = await gather_trigger_profile_refresh()
+
+    profile_triggers = [t for t in triggers if t.profile_kind == "ProfileTestDevice"]
+    assert len(profile_triggers) == 1
+
+    trigger = profile_triggers[0]
+    trigger_fields = trigger.trigger.match_related["infrahub.field.name"]
+
+    assert "location" in trigger_fields
+    assert "description" in trigger_fields
+
+
+async def test_gather_trigger_profile_refresh_different_branch(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema, node_group_schema
+) -> None:
+    """Test that branch-specific triggers are created when schema differs across branches."""
+    SCHEMA = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Device",
+                namespace="Test",
+                branch=BranchSupportType.AWARE.value,
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                    AttributeSchema(name="description", kind="Text", optional=True),
+                ],
+            ),
+        ]
+    )
+
+    registry.schema.register_schema(schema=SCHEMA, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    branch = await create_branch(branch_name="branch2", db=db)
+
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    device_schema = schema_branch.get_node("TestDevice")
+
+    device_schema.attributes.append(AttributeSchema(name="status", kind="Text", optional=True))
+    schema_branch.set(name="TestDevice", schema=device_schema)
+    registry.schema.set_schema_branch(name=branch.name, schema=schema_branch)
+    branch.update_schema_hash()
+    schema_branch.process()
+    await branch.save(db=db)
+
+    name_main = "profile::main::ProfileTestDevice::refresh"
+    name_branch = "profile::branch2::ProfileTestDevice::refresh"
+
+    triggers = await gather_trigger_profile_refresh()
+    triggers_by_name = {trigger.generate_name(): trigger for trigger in triggers}
+
+    assert name_main in triggers_by_name
+    assert name_branch in triggers_by_name
+
+    trigger_main = triggers_by_name[name_main]
+    assert "infrahub.branch.name" in trigger_main.trigger.match
+    assert trigger_main.trigger.match["infrahub.branch.name"] == ["!branch2"]
+
+    trigger_branch = triggers_by_name[name_branch]
+    assert "infrahub.branch.name" in trigger_branch.trigger.match
+    assert trigger_branch.trigger.match["infrahub.branch.name"] == "branch2"

--- a/backend/tests/unit/profiles/test_models.py
+++ b/backend/tests/unit/profiles/test_models.py
@@ -1,5 +1,4 @@
 from infrahub.core.branch import Branch
-from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.profiles.models import ProfileRefreshTriggerDefinition
@@ -8,7 +7,7 @@ from infrahub.workflows.catalogue import PROFILE_REFRESH_PROCESS
 
 
 async def test_profile_refresh_trigger_definition_from_profile_schema(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: None
 ) -> None:
     """Test creating a ProfileRefreshTriggerDefinition from a profile schema."""
     trigger_fields = ["description", "status"]
@@ -42,7 +41,7 @@ async def test_profile_refresh_trigger_definition_from_profile_schema(
 
 
 async def test_profile_refresh_trigger_definition_with_branch_scoping(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: None
 ) -> None:
     """Test creating a trigger with branch scoping for non-default branch."""
     trigger_fields = ["description", "status"]
@@ -62,7 +61,7 @@ async def test_profile_refresh_trigger_definition_with_branch_scoping(
 
 
 async def test_profile_refresh_trigger_definition_with_branches_out_of_scope(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: None
 ) -> None:
     """Test creating a trigger with branches out of scope."""
     trigger_fields = ["description", "status"]
@@ -80,7 +79,7 @@ async def test_profile_refresh_trigger_definition_with_branches_out_of_scope(
 
 
 async def test_profile_refresh_trigger_definition_actions(
-    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: None
 ) -> None:
     """Test that the trigger has the correct workflow action."""
     trigger_fields = ["description", "status"]

--- a/backend/tests/unit/profiles/test_models.py
+++ b/backend/tests/unit/profiles/test_models.py
@@ -1,0 +1,107 @@
+from infrahub.core.branch import Branch
+from infrahub.core.schema import SchemaRoot
+from infrahub.database import InfrahubDatabase
+from infrahub.events.node_action import NodeUpdatedEvent
+from infrahub.profiles.models import ProfileRefreshTriggerDefinition
+from infrahub.trigger.models import TriggerType
+from infrahub.workflows.catalogue import PROFILE_REFRESH_PROCESS
+
+
+async def test_profile_refresh_trigger_definition_from_profile_schema(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+) -> None:
+    """Test creating a ProfileRefreshTriggerDefinition from a profile schema."""
+    trigger_fields = ["description", "status"]
+
+    trigger = ProfileRefreshTriggerDefinition.from_profile_schema(
+        branch=default_branch.name,
+        profile_kind="ProfileTestDevice",
+        trigger_fields=trigger_fields,
+        workflow=PROFILE_REFRESH_PROCESS,
+    )
+
+    assert trigger.name == "ProfileTestDevice::refresh"
+    assert trigger.branch == default_branch.name
+    assert trigger.profile_kind == "ProfileTestDevice"
+    assert trigger.type == TriggerType.PROFILE
+
+    assert trigger.generate_name() == "profile::main::ProfileTestDevice::refresh"
+
+    assert trigger.trigger.events == {NodeUpdatedEvent.event_name}
+    assert trigger.trigger.match == {"infrahub.node.kind": "ProfileTestDevice"}
+
+    assert "prefect.resource.role" in trigger.trigger.match_related
+    assert trigger.trigger.match_related["prefect.resource.role"] == [
+        "infrahub.node.attribute_update",
+        "infrahub.node.relationship_update",
+    ]
+    assert "infrahub.field.name" in trigger.trigger.match_related
+    assert trigger.trigger.match_related["infrahub.field.name"] == trigger_fields
+
+    assert "infrahub.branch.name" not in trigger.trigger.match
+
+
+async def test_profile_refresh_trigger_definition_with_branch_scoping(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+) -> None:
+    """Test creating a trigger with branch scoping for non-default branch."""
+    trigger_fields = ["description", "status"]
+
+    trigger = ProfileRefreshTriggerDefinition.from_profile_schema(
+        branch="feature-branch",
+        profile_kind="ProfileTestDevice",
+        trigger_fields=trigger_fields,
+        workflow=PROFILE_REFRESH_PROCESS,
+    )
+
+    assert trigger.branch == "feature-branch"
+    assert trigger.generate_name() == "profile::feature-branch::ProfileTestDevice::refresh"
+
+    assert "infrahub.branch.name" in trigger.trigger.match
+    assert trigger.trigger.match["infrahub.branch.name"] == "feature-branch"
+
+
+async def test_profile_refresh_trigger_definition_with_branches_out_of_scope(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+) -> None:
+    """Test creating a trigger with branches out of scope."""
+    trigger_fields = ["description", "status"]
+
+    trigger = ProfileRefreshTriggerDefinition.from_profile_schema(
+        branch=default_branch.name,
+        profile_kind="ProfileTestDevice",
+        trigger_fields=trigger_fields,
+        workflow=PROFILE_REFRESH_PROCESS,
+        branches_out_of_scope=["branch1", "branch2"],
+    )
+
+    assert "infrahub.branch.name" in trigger.trigger.match
+    assert trigger.trigger.match["infrahub.branch.name"] == ["!branch1", "!branch2"]
+
+
+async def test_profile_refresh_trigger_definition_actions(
+    db: InfrahubDatabase, default_branch: Branch, profile_schema_with_attributes: SchemaRoot
+) -> None:
+    """Test that the trigger has the correct workflow action."""
+    trigger_fields = ["description", "status"]
+
+    trigger = ProfileRefreshTriggerDefinition.from_profile_schema(
+        branch=default_branch.name,
+        profile_kind="ProfileTestDevice",
+        trigger_fields=trigger_fields,
+        workflow=PROFILE_REFRESH_PROCESS,
+    )
+
+    assert len(trigger.actions) == 1
+
+    action = trigger.actions[0]
+    assert action.workflow == PROFILE_REFRESH_PROCESS
+
+    assert "branch_name" in action.parameters
+    assert "profile_kind" in action.parameters
+    assert "profile_id" in action.parameters
+    assert "context" in action.parameters
+
+    assert action.parameters["profile_kind"] == "ProfileTestDevice"
+    assert action.parameters["branch_name"] == "{{ event.resource['infrahub.branch.name'] }}"
+    assert action.parameters["profile_id"] == "{{ event.resource['infrahub.node.id'] }}"


### PR DESCRIPTION
This change adds the required prefect automation mechanisms to trigger re-applying a profile on its related nodes when an attribute or a relationship changes on the profile.