### PR TITLE
Fix breadcrumb of CoreArtifactDefinition details page

### DIFF
--- a/changelog/+fix-artifact-definition-breadcrumb.fixed.md
+++ b/changelog/+fix-artifact-definition-breadcrumb.fixed.md
@@ -1,0 +1,1 @@
+Fix breadcrumb display on CoreArtifactDefinition details page.

--- a/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-objects.tsx
+++ b/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-objects.tsx
@@ -16,7 +16,7 @@ export function BreadcrumbObjects() {
   const { pathname } = useLocation();
 
   // For CoreArtifact route, objectKind is hardcoded in the path
-  const isArtifactRoute = pathname.includes(`/objects/${ARTIFACT_OBJECT}`);
+  const isArtifactRoute = pathname.includes(`/objects/${ARTIFACT_OBJECT}/`);
   const actualObjectKind = isArtifactRoute ? ARTIFACT_OBJECT : objectKind;
 
   const { schema, isProfile, isTemplate } = useSchema(actualObjectKind);

--- a/frontend/app/tests/e2e/breadcrumb.spec.ts
+++ b/frontend/app/tests/e2e/breadcrumb.spec.ts
@@ -85,6 +85,17 @@ test.describe("Breadcrumb Navigation", () => {
       await expect(breadcrumb.getByRole("link", { name: "atl1-core2" })).toBeVisible();
       await expect(page.getByTestId("object-header").getByText("atl1-core2")).toBeVisible();
     });
+
+    test("should display object kind in breadcrumb on artifact pages", async ({ page }) => {
+      await page.goto("/objects/CoreArtifact");
+      const breadcrumb = page.getByTestId("breadcrumb-navigation");
+      await expect(breadcrumb.getByRole("link", { name: "Artifact" })).toBeVisible();
+
+      await page.getByRole("link", { name: "openconfig-interfaces" }).first().click();
+
+      await expect(breadcrumb.getByRole("link", { name: "Artifact" })).toBeVisible();
+      await expect(breadcrumb.getByRole("link", { name: "openconfig-interfaces" })).toBeVisible();
+    });
   });
 
   test.describe("/profile - Account Profile breadcrumb", () => {

--- a/frontend/app/tests/e2e/objects/artifact-definition.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact-definition.spec.ts
@@ -2,13 +2,20 @@ import { expect, test } from "@playwright/test";
 
 import { ACCOUNT_STATE_PATH } from "../../constants";
 
-test.describe.fixme("/objects/CoreArtifactDefinition - Artifact Definition page", () => {
+test.describe("/objects/CoreArtifactDefinition - Artifact Definition page", () => {
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
-  test.slow();
 
   test("should generate artifacts successfully", async ({ page }) => {
     await page.goto("/objects/CoreArtifactDefinition");
+    const breadcrumb = page.getByTestId("breadcrumb-navigation");
+    await expect(breadcrumb.getByRole("link", { name: "Artifact Definition" })).toBeVisible();
+
     await page.getByRole("link", { name: "Startup Config for Edge devices" }).click();
+    await expect(breadcrumb.getByRole("link", { name: "Artifact Definition" })).toBeVisible();
+    await expect(
+      breadcrumb.getByRole("link", { name: "Startup Config for Edge devices" })
+    ).toBeVisible();
+
     await expect(page.getByRole("button", { name: "Generate" })).not.toBeDisabled();
     await page.getByRole("button", { name: "Generate" }).click();
     await expect(page.getByText("Artifacts generated")).toBeVisible();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed breadcrumb navigation display on CoreArtifactDefinition details page to properly show object kind information.

* **Tests**
  * Added end-to-end tests to verify breadcrumb visibility and navigation functionality on artifact pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->