### PR TITLE
Fix schema cache issue after adding/removing enums or dropdowns

### DIFF
--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -81,7 +81,7 @@ class SchemaDropdownAdd(Mutation):
         _validate_schema_permission(graphql_context=graphql_context)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
-        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=False)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=True)
         attribute = str(data.attribute)
         validate_kind_dropdown(kind=kind, attribute=attribute)
         dropdown = str(data.dropdown)
@@ -141,7 +141,7 @@ class SchemaDropdownRemove(Mutation):
         graphql_context: GraphqlContext = info.context
 
         _validate_schema_permission(graphql_context=graphql_context)
-        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=False)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=True)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
         attribute = str(data.attribute)
@@ -197,7 +197,7 @@ class SchemaEnumAdd(Mutation):
         graphql_context: GraphqlContext = info.context
 
         _validate_schema_permission(graphql_context=graphql_context)
-        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=False)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=True)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
         attribute = str(data.attribute)
@@ -243,7 +243,7 @@ class SchemaEnumRemove(Mutation):
         graphql_context: GraphqlContext = info.context
 
         _validate_schema_permission(graphql_context=graphql_context)
-        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=False)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name, duplicate=True)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
         attribute = str(data.attribute)

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -1,11 +1,18 @@
 import pytest
 
+from infrahub.auth import AccountSession
+from infrahub.components import ComponentType
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.graphql.mutations.schema import validate_kind, validate_kind_dropdown, validate_kind_enum
+from infrahub.services import InfrahubServices
+from infrahub.services.component import InfrahubComponent
+from tests.adapters.cache import MemoryCache
+from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql
 
 
@@ -221,3 +228,100 @@ async def test_validate_kind_enum_exceptions(db: InfrahubDatabase, choices_schem
         validate_kind_enum(kind=node._schema, attribute="comment")
 
     assert "Attribute comment on TestChoice is not an enum" in str(exc.value)
+
+
+async def test_add_dropdown_option_does_not_corrupt_schema_cache(
+    db: InfrahubDatabase,
+    default_permission_backend: None,
+    default_branch: Branch,
+    choices_schema: None,
+    session_admin: AccountSession,
+) -> None:
+    """Test that adding a dropdown option does not corrupt the schema cache.
+
+    This test reproduces issue #7780 where adding a dropdown option via the UI
+    would modify the cached schema object directly, causing hash mismatches when
+    other code paths tried to retrieve the schema.
+
+    The bug occurs when:
+    1. Schema is fetched with duplicate=False (returns cached object)
+    2. The cached object is mutated (e.g., adding a dropdown option)
+    3. The mutated object's hash changes, but old hash key remains in cache (stale)
+    4. When purge_inactive_branches runs, it computes hashes to keep using get_hash()
+       which returns the NEW hash, so the OLD hash entry gets deleted
+    5. Any code with a reference to a SchemaBranch using the old hash fails
+    """
+    cache = MemoryCache()
+    bus = BusRecorder()
+    service = await InfrahubServices.new(
+        database=db,
+        message_bus=bus,
+        cache=cache,
+        component_type=ComponentType.API_SERVER,
+        component=InfrahubComponent(cache=cache, db=db, message_bus=bus, component_type=ComponentType.API_SERVER),
+    )
+
+    # Get the schema branch BEFORE the mutation - this simulates another process
+    # that cached the schema branch (e.g., another API request in flight).
+    # We use duplicate() to get a separate SchemaBranch instance that shares the cache.
+    schema_before = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+
+    # Verify the schema is retrievable with the original hash
+    test_choice_schema = schema_before.get(name="TestChoice", duplicate=False)
+    assert test_choice_schema is not None
+
+    # Get the original choices BEFORE mutation
+    original_temp_attr = test_choice_schema.get_attribute("temperature_scale")
+    assert original_temp_attr.choices
+    original_choices = [c.name for c in original_temp_attr.choices]
+    assert original_choices == ["celsius"]
+
+    query = """
+    mutation {
+        SchemaDropdownAdd(data: {kind: "TestChoice", attribute: "temperature_scale", dropdown: "fahrenheit"}) {
+            ok
+            object {
+                value
+            }
+        }
+    }
+    """
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, account_session=session_admin, service=service
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors is None
+    assert result.data
+    assert result.data["SchemaDropdownAdd"]["ok"] is True
+    assert result.data["SchemaDropdownAdd"]["object"]["value"] == "fahrenheit"
+
+    # Verify that the new dropdown was actually saved by checking the registry
+    schema_after = registry.schema.get_schema_branch(name=default_branch.name)
+    test_choice_after = schema_after.get(name="TestChoice", duplicate=False)
+    temp_attr_after = test_choice_after.get_attribute("temperature_scale")
+    assert temp_attr_after.choices
+    choices_after = [c.name for c in temp_attr_after.choices]
+    assert "fahrenheit" in choices_after, f"Dropdown 'fahrenheit' not found in choices: {choices_after}"
+    assert "celsius" in choices_after
+
+    # The bug: The mutation modified the cached schema object in-place (with duplicate=False),
+    # so test_choice_schema (which we got before the mutation) now has the new dropdown too.
+    # This proves the cached object was mutated rather than a copy being modified.
+    mutated_temp_attr = test_choice_schema.get_attribute("temperature_scale")
+    assert mutated_temp_attr.choices
+    mutated_choices = [c.name for c in mutated_temp_attr.choices]
+
+    # If the fix is NOT in place, the original object was mutated:
+    # mutated_choices will contain "fahrenheit" even though we got it before the mutation
+    if "fahrenheit" in mutated_choices:
+        pytest.fail(
+            f"Bug #7780: Cached schema object was mutated in-place. "
+            f"Original object now has choices {mutated_choices} instead of ['celsius']"
+        )

--- a/changelog/7780.fixed.md
+++ b/changelog/7780.fixed.md
@@ -1,0 +1,1 @@
+Fixed schema cache issue when adding or removing dropdown/enum options via the UI, which causes intermittent "incorrect hash" errors after page refreshes.


### PR DESCRIPTION
Some previous optimizations to avoid duplicating the schema was causing issues for the mutations where we actually want to duplicate the schema node, i.e. when we are modifying them.

(the codspeed issue is not related to anything within this PR)

Fixes #7780.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent "incorrect hash" errors after adding or removing dropdown or enum options in the UI; schema cache now preserves correct state across page refreshes.

* **Tests**
  * Added a unit test that verifies schema cache integrity when dropdown options are added, preventing in-place corruption of cached schema objects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->