### PR TITLE
Add changelog instructions for coding agents

### DIFF
--- a/.claude/commands/fix-github-issue.md
+++ b/.claude/commands/fix-github-issue.md
@@ -11,7 +11,6 @@ Follow these steps:
 7. Implement the necessary changes to fix the issue
 8. Write and run tests to verify the fix
 9. Ensure code passes linting and type checking
-10. Create a short user-facing changelog entry using towncrier, describing the fixed issue. Reference the GitHub issue in the changelog. Do not focus on the technical aspects of the implemented solution.
-11.Create a descriptive commit message, do not mention CLAUDE in the commit message or as co-author
+10. Create a short user-facing changelog entry using towncrier
 
 Remember to use the GitHub CLI (gh) for all GitHub-related tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,23 @@ When editing markdown files (enforced by markdownlint):
 - No trailing spaces or multiple consecutive blank lines
 - No bare URLs (use `[text](url)` format)
 
+## Towncrier for changelog
+
+Towncrier is used to manage the changelog which is being published with every release.
+Every issue that is being fixed, or new feature that gets implemented should be accompanied by a proper changelog entry.
+
+The changelog message should be a short and user-facing. It should describe what has been fixed or implemented without focusing on the technical aspects of the implementation.
+
+To create a new changelog entry use the following command.
+The filename should be in the format `${ISSUE}.{ACTION}.md`:
+
+- ${ISSUE}: the id of the GitHub issue or feature request, if you are not working on an issue or feature request use `+`.
+- ${ACTION}: one of added, fixed, housekeeping
+
+```bash
+uv run towncrier -c "content of changelog entry" ${ISSUE}.{ACTION}.md
+```
+
 ## Git Workflow
 
 - **Main branches:** `stable` (production), `develop` (development), `release-*` (releases)


### PR DESCRIPTION
Add changelog instructions for coding agents and remove instruction to create a git commit from the Claude Code /fix-github-issue command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Towncrier-style changelog guidance to contributor docs.

* **Chores**
  * Simplified the contributor checklist by merging two changelog steps into a single user-facing entry step.

* **Bug Fixes**
  * Diff summary counts now always return values (added/updated/removed/conflicts) to ensure consistent reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->