### PR TITLE
Add missing types for benchmark tests

### DIFF
--- a/backend/tests/benchmark/conftest.py
+++ b/backend/tests/benchmark/conftest.py
@@ -1,14 +1,17 @@
 import asyncio
+from collections.abc import Callable
+from typing import Any
 
 import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
 
 
 @pytest.fixture
-async def exec_async(event_loop):
-    def _wrapper(func, *args, **kwargs):
+async def exec_async(event_loop: asyncio.AbstractEventLoop) -> Callable[..., Any]:
+    def _wrapper(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         if asyncio.iscoroutinefunction(func):
 
-            def _():
+            def _() -> Any:
                 return event_loop.run_until_complete(func(*args, **kwargs))
 
             return _()
@@ -19,12 +22,12 @@ async def exec_async(event_loop):
 
 
 @pytest.fixture
-async def aio_benchmark(benchmark, event_loop):
-    def _wrapper(func, *args, **kwargs):
+async def aio_benchmark(benchmark: BenchmarkFixture, event_loop: asyncio.AbstractEventLoop) -> Callable[..., Any]:
+    def _wrapper(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         if asyncio.iscoroutinefunction(func):
 
             @benchmark
-            def _():
+            def _() -> Any:
                 return event_loop.run_until_complete(func(*args, **kwargs))
         else:
             return benchmark(func, *args, **kwargs)

--- a/backend/tests/benchmark/intensive/test_batch_create.py
+++ b/backend/tests/benchmark/intensive/test_batch_create.py
@@ -1,4 +1,6 @@
 import uuid
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -48,12 +50,14 @@ class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
         DETACH DELETE n
         """
 
-        params: dict = {"kinds": kinds}
+        params: dict[str, Any] = {"kinds": kinds}
 
         await db.execute_query(query=query, params=params, name="delete_nodes")
 
     @pytest.fixture
-    async def load_schema(self, client, branch, car_person_schema_unique_owner) -> None:
+    async def load_schema(
+        self, client: InfrahubClient, branch: Branch, car_person_schema_unique_owner: dict[str, Any]
+    ) -> None:
         res = await client.schema.load([car_person_schema_unique_owner], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 
@@ -63,12 +67,12 @@ class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
         self,
         client: InfrahubClient,
         db: InfrahubDatabase,
-        load_schema,
+        load_schema: None,
         branch: Branch,
         allow_upsert: bool,
         batch_size: int,
-        aio_benchmark,
-        exec_async,
+        aio_benchmark: Callable[..., Any],
+        exec_async: Callable[..., Any],
     ) -> None:
         batch = exec_async(
             self.create_car_batch,
@@ -85,6 +89,6 @@ class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
         )
 
 
-async def execute_batch(infrahub_batch) -> None:
+async def execute_batch(infrahub_batch: InfrahubBatch) -> None:
     async for _, _ in infrahub_batch.execute():
         pass

--- a/backend/tests/benchmark/test_get_menu.py
+++ b/backend/tests/benchmark/test_get_menu.py
@@ -1,14 +1,25 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 
 from infrahub.api.menu import get_menu
+from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_default_menu
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
 @pytest.fixture
-async def init_menu(db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
+async def init_menu(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch) -> None:
     await create_default_menu(db=db)
 
 
-def test_get_menu(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema, init_menu) -> None:
+def test_get_menu(
+    aio_benchmark: Callable[..., Any],
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_menu: None,
+) -> None:
     aio_benchmark(get_menu, db=db, branch=default_branch, permission_manager=None)

--- a/backend/tests/benchmark/test_get_schema.py
+++ b/backend/tests/benchmark/test_get_schema.py
@@ -1,6 +1,16 @@
+from collections.abc import Callable
+from typing import Any
+
 from infrahub.api.schema import get_schema
+from infrahub.core.branch import Branch
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
-def test_get_schema(aio_benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
+def test_get_schema(
+    aio_benchmark: Callable[..., Any],
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+) -> None:
     aio_benchmark(get_schema, branch=default_branch, namespaces=None)

--- a/backend/tests/benchmark/test_graphql_generate_schema.py
+++ b/backend/tests/benchmark/test_graphql_generate_schema.py
@@ -1,13 +1,19 @@
 from graphql import GraphQLSchema
+from pytest_benchmark.fixture import BenchmarkFixture
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.manager import GraphQLSchemaManager
 
 
 def test_graphql_generate_schema(
-    benchmark, db: InfrahubDatabase, default_branch: Branch, data_schema, car_person_schema
+    benchmark: BenchmarkFixture,
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    data_schema: None,
+    car_person_schema: SchemaBranch,
 ) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     gqlm = GraphQLSchemaManager(schema=schema)

--- a/backend/tests/benchmark/test_graphql_query.py
+++ b/backend/tests/benchmark/test_graphql_query.py
@@ -1,4 +1,6 @@
 import os
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
@@ -33,7 +35,7 @@ async def reset_environment(db: InfrahubDatabase) -> None:
 
 
 @pytest.fixture(scope="module")
-async def default_branch(reset_environment, db: InfrahubDatabase) -> Branch:
+async def default_branch(reset_environment: None, db: InfrahubDatabase) -> Branch:
     branch = await create_default_branch(db=db)
     await create_global_branch(db=db)
     registry.schema = SchemaManager()
@@ -52,11 +54,17 @@ async def register_default_schema(db: InfrahubDatabase, default_branch: Branch) 
 
 
 @pytest.fixture(scope="module")
-async def dataset04(db: InfrahubDatabase, default_branch, register_default_schema) -> None:
+async def dataset04(db: InfrahubDatabase, default_branch: Branch, register_default_schema: SchemaBranch) -> None:
     await load_data(db=db, nbr_query=250)
 
 
-def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04) -> None:
+def test_query_one_model(
+    exec_async: Callable[..., Any],
+    aio_benchmark: Callable[..., Any],
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    dataset04: None,
+) -> None:
     query = """
     query {
         CoreGraphQLQuery {
@@ -97,7 +105,11 @@ def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, defaul
 
 
 def test_query_rel_many(
-    exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04: None
+    exec_async: Callable[..., Any],
+    aio_benchmark: Callable[..., Any],
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    dataset04: None,
 ) -> None:
     query = """
     query {
@@ -146,7 +158,13 @@ def test_query_rel_many(
     )
 
 
-def test_query_rel_one(exec_async, aio_benchmark, db: InfrahubDatabase, default_branch: Branch, dataset04) -> None:
+def test_query_rel_one(
+    exec_async: Callable[..., Any],
+    aio_benchmark: Callable[..., Any],
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    dataset04: None,
+) -> None:
     query = """
     query {
         CoreGraphQLQuery {

--- a/backend/tests/benchmark/test_load_node_to_db.py
+++ b/backend/tests/benchmark/test_load_node_to_db.py
@@ -1,4 +1,8 @@
+from collections.abc import Callable
+from typing import Any
+
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.schema import (
     NodeSchema,
     SchemaRoot,
@@ -8,11 +12,13 @@ from infrahub.core.schema.manager import SchemaManager
 from infrahub.database import InfrahubDatabase
 
 
-def test_load_node_to_db_node_schema(aio_benchmark, db: InfrahubDatabase, default_branch) -> None:
+def test_load_node_to_db_node_schema(
+    aio_benchmark: Callable[..., Any], db: InfrahubDatabase, default_branch: Branch
+) -> None:
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
 
-    SCHEMA = {
+    SCHEMA: dict[str, Any] = {
         "name": "Criticality",
         "namespace": "Builtin",
         "default_filter": "name__value",
@@ -26,6 +32,6 @@ def test_load_node_to_db_node_schema(aio_benchmark, db: InfrahubDatabase, defaul
             {"name": "others", "peer": "BuiltinCriticality", "optional": True, "cardinality": "many"},
         ],
     }
-    node = NodeSchema(**SCHEMA)  # type: ignore[arg-type]
+    node = NodeSchema(**SCHEMA)
 
     aio_benchmark(registry.schema.load_node_to_db, node=node, db=db, branch=default_branch)

--- a/backend/tests/benchmark/test_nodemanager_peers.py
+++ b/backend/tests/benchmark/test_nodemanager_peers.py
@@ -1,14 +1,20 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 
 from infrahub.core import registry
-from infrahub.core.manager import Node, NodeManager
+from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
 from infrahub.core.relationship import RelationshipManager
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
 @pytest.fixture
-async def test_account(db: InfrahubDatabase, default_branch, register_core_models_schema) -> Node:
+async def test_account(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch) -> Node:
     node = await Node.init(db=db, schema="CoreAccount", branch=default_branch)
     await node.new(db=db, name="test_account", password="")
     await node.save(db=db)
@@ -17,7 +23,9 @@ async def test_account(db: InfrahubDatabase, default_branch, register_core_model
 
 
 @pytest.fixture
-async def relm(db: InfrahubDatabase, default_branch, register_core_models_schema, test_account) -> RelationshipManager:
+async def relm(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, test_account: Node
+) -> RelationshipManager:
     model = registry.schema.get(name="CoreAccount")
     rel_schema = model.get_relationship("member_of_groups")
 
@@ -28,7 +36,9 @@ async def relm(db: InfrahubDatabase, default_branch, register_core_models_schema
     return relm
 
 
-def test_nodemanager_querypeers(aio_benchmark, db: InfrahubDatabase, default_branch, test_account) -> None:
+def test_nodemanager_querypeers(
+    aio_benchmark: Callable[..., Any], db: InfrahubDatabase, default_branch: Branch, test_account: Node
+) -> None:
     model = registry.schema.get(name="CoreAccount")
     aio_benchmark(
         NodeManager().query_peers,
@@ -40,5 +50,7 @@ def test_nodemanager_querypeers(aio_benchmark, db: InfrahubDatabase, default_bra
     )
 
 
-def test_relationshipmanager_getpeer(aio_benchmark, db: InfrahubDatabase, default_branch, relm) -> None:
+def test_relationshipmanager_getpeer(
+    aio_benchmark: Callable[..., Any], db: InfrahubDatabase, default_branch: Branch, relm: RelationshipManager
+) -> None:
     aio_benchmark(relm.get_peers, db=db)

--- a/backend/tests/benchmark/test_nodeschema_duplicate.py
+++ b/backend/tests/benchmark/test_nodeschema_duplicate.py
@@ -1,9 +1,13 @@
+from pytest_benchmark.fixture import BenchmarkFixture
+
 from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
 def test_base_schema_duplicate_CoreProposedChange(
-    benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema
+    benchmark: BenchmarkFixture, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     model = registry.schema.get(name="CoreProposedChange")
     new_node = benchmark(model.duplicate)

--- a/backend/tests/benchmark/test_schemabranch_duplicate.py
+++ b/backend/tests/benchmark/test_schemabranch_duplicate.py
@@ -1,8 +1,14 @@
+from pytest_benchmark.fixture import BenchmarkFixture
+
 from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
-def test_schemabranch_duplicate(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
+def test_schemabranch_duplicate(
+    benchmark: BenchmarkFixture, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     new_schema = benchmark(schema.duplicate)
     assert new_schema.get_hash() == schema.get_hash()

--- a/backend/tests/benchmark/test_schemabranch_process.py
+++ b/backend/tests/benchmark/test_schemabranch_process.py
@@ -1,7 +1,13 @@
+from pytest_benchmark.fixture import BenchmarkFixture
+
 from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
-def test_schemabranch_process(benchmark, db: InfrahubDatabase, default_branch, register_core_models_schema) -> None:
+def test_schemabranch_process(
+    benchmark: BenchmarkFixture, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     benchmark(schema.process)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,10 +174,6 @@ module = "infrahub.*"
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = "tests.benchmark.*"
-disallow_untyped_defs = false
-
-[[tool.mypy.overrides]]
 module = "tests.conftest"
 disallow_untyped_defs = false
 


### PR DESCRIPTION
Just adding type hints and removing an ignore line. Started to look at this when I noticed some weird reports from codespeed. The degradation reported for this PR is incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test suite infrastructure with improved type annotations
  * Fixed test fixture control flow issue
  * Strengthened type checking for internal test suite

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->