### PR TITLE
add fix-ci-failed claude code custom command

### DIFF
--- a/.claude/commands/fix-ci-failed.md
+++ b/.claude/commands/fix-ci-failed.md
@@ -1,0 +1,22 @@
+Please analyze and fix the GitHub CI job issue for a given branch.
+
+Follow these steps:
+
+1. Use this shell script to pull the failed logs from the Github CI job. The first argument to the script should be the current checked out branch, which you can retrieve using the shell command `git rev-parse --abbrev-ref HEAD`.
+
+```bash
+BRANCH=$1
+RUN_ID=$(gh run list --branch $BRANCH -w CI --json databaseId,conclusion,status --jq '.[0] | select(.conclusion=="failure") | .databaseId')
+
+JOB_ID=$( gh run view $RUN_ID --json jobs --jq '.jobs[] | select(.conclusion=="failure") | .databaseId')
+
+gh run view -v --log-failed --job $JOB_ID
+```
+2. Understand the problem described in the logs
+3. Search the codebase for relevant files
+4. Come up with a plan first and ask for my review
+5. Implement the necessary changes to fix the issue
+6. Run tests to verify the fix
+7. Ensure code passes linting and type checking
+
+Remember to use the GitHub CLI (gh) for all GitHub-related tasks.

--- a/.claude/commands/fix-ci-failed.md
+++ b/.claude/commands/fix-ci-failed.md
@@ -2,7 +2,7 @@ Please analyze and fix the GitHub CI job issue for a given branch.
 
 Follow these steps:
 
-1. Use this shell script to pull the failed logs from the Github CI job. The first argument to the script should be the current checked out branch, which you can retrieve using the shell command `git rev-parse --abbrev-ref HEAD`.
+1. Use this shell script to pull the failed logs from the Github CI job. The first argument to the script should be the current checked-out branch, which you can retrieve using the shell command `git rev-parse --abbrev-ref HEAD`.
 
 ```bash
 BRANCH=$1

--- a/.claude/commands/fix-ci-failed.md
+++ b/.claude/commands/fix-ci-failed.md
@@ -12,6 +12,7 @@ JOB_ID=$( gh run view $RUN_ID --json jobs --jq '.jobs[] | select(.conclusion=="f
 
 gh run view -v --log-failed --job $JOB_ID
 ```
+
 2. Understand the problem described in the logs
 3. Search the codebase for relevant files
 4. Come up with a plan first and ask for my review


### PR DESCRIPTION
This custom command can be used with Claude code to fix issues that cause the GitHub CI to fail for the current checked out branch.

It will pull the logs for the failed tasks of the CI job, analyzes them and tries to implement a fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added procedural guide for analyzing and resolving continuous integration failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->