### PR TITLE
Pass user context back to mutation layer for background tasks

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -42,8 +42,10 @@ mutation UpdateAttribute(
     $kind: String!,
     $attribute: String!,
     $value: String!
+    $context_account_id: String!
   ) {
   InfrahubUpdateComputedAttribute(
+    context: {account: {id: $context_account_id}},
     data: {id: $id, attribute: $attribute, value: $value, kind: $kind}
   ) {
     ok
@@ -62,7 +64,7 @@ async def process_transform(
     object_id: str,
     computed_attribute_name: str,  # noqa: ARG001
     computed_attribute_kind: str,  # noqa: ARG001
-    context: InfrahubContext,  # noqa: ARG001
+    context: InfrahubContext,
     updated_fields: list[str] | None = None,  # noqa: ARG001
 ) -> None:
     await add_tags(branches=[branch_name], nodes=[object_id])
@@ -124,7 +126,13 @@ async def process_transform(
 
         await client.execute_graphql(
             query=UPDATE_ATTRIBUTE,
-            variables={"id": object_id, "kind": node_kind, "attribute": attribute_name, "value": transformed_data},
+            variables={
+                "id": object_id,
+                "kind": node_kind,
+                "attribute": attribute_name,
+                "value": transformed_data,
+                "context_account_id": context.account.account_id,
+            },
             branch_name=branch_name,
         )
 
@@ -168,6 +176,7 @@ async def computed_attribute_jinja2_update_value(
     node_kind: str,
     attribute_name: str,
     template: Jinja2Template,
+    context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
     client = get_client()
@@ -182,7 +191,13 @@ async def computed_attribute_jinja2_update_value(
     try:
         await client.execute_graphql(
             query=UPDATE_ATTRIBUTE,
-            variables={"id": obj.node_id, "kind": node_kind, "attribute": attribute_name, "value": value},
+            variables={
+                "id": obj.node_id,
+                "kind": node_kind,
+                "attribute": attribute_name,
+                "value": value,
+                "context_account_id": context.account.account_id,
+            },
             branch_name=branch_name,
         )
         log.info(f"Updating computed attribute {node_kind}.{attribute_name}='{value}' ({obj.node_id})")
@@ -202,7 +217,7 @@ async def process_jinja2(
     object_id: str,
     computed_attribute_name: str,
     computed_attribute_kind: str,
-    context: InfrahubContext,  # noqa: ARG001
+    context: InfrahubContext,
     updated_fields: list[str] | None = None,
 ) -> None:
     log = get_run_logger()
@@ -258,6 +273,7 @@ async def process_jinja2(
                 node_kind=node_schema.kind,
                 attribute_name=computed_macro.attribute.name,
                 template=jinja_template,
+                context=context,
             )
 
         _ = [response async for _, response in batch.execute()]
@@ -462,6 +478,7 @@ async def query_transform_targets(
                         "object_id": subscriber.object_id,
                         "computed_attribute_name": computed_attribute.name,
                         "computed_attribute_kind": subscriber.kind,
+                        "context": context,
                     },
                 )
 

--- a/backend/infrahub/display_labels/tasks.py
+++ b/backend/infrahub/display_labels/tasks.py
@@ -21,9 +21,11 @@ UPDATE_DISPLAY_LABEL = """
 mutation UpdateDisplayLabel(
     $id: String!,
     $kind: String!,
-    $value: String!
+    $value: String!,
+    $context_account_id: String!
   ) {
   InfrahubUpdateDisplayLabel(
+    context: {account: {id: $context_account_id}},
     data: {id: $id, value: $value, kind: $kind}
   ) {
     ok
@@ -41,6 +43,7 @@ async def display_label_jinja2_update_value(
     obj: DisplayLabelJinja2GraphQLResponse,
     node_kind: str,
     template: Jinja2Template,
+    context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
     client = get_client()
@@ -55,7 +58,12 @@ async def display_label_jinja2_update_value(
     try:
         await client.execute_graphql(
             query=UPDATE_DISPLAY_LABEL,
-            variables={"id": obj.node_id, "kind": node_kind, "value": value},
+            variables={
+                "id": obj.node_id,
+                "kind": node_kind,
+                "value": value,
+                "context_account_id": context.account.account_id,
+            },
             branch_name=branch_name,
         )
         log.info(f"Updating {node_kind}.display_label='{value}' ({obj.node_id})")
@@ -74,7 +82,7 @@ async def process_display_label(
     node_kind: str,
     object_id: str,
     target_kind: str,
-    context: InfrahubContext,  # noqa: ARG001
+    context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
     client = get_client()
@@ -114,6 +122,7 @@ async def process_display_label(
             obj=node,
             node_kind=node_schema.kind,
             template=jinja_template,
+            context=context,
         )
 
     _ = [response async for _, response in batch.execute()]

--- a/backend/infrahub/graphql/context.py
+++ b/backend/infrahub/graphql/context.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 async def apply_external_context(graphql_context: GraphqlContext, context_input: ContextInput | None) -> None:
     """Applies context provided by an external mutation to the GraphQL context"""
-    if not context_input or not context_input.account:
+    if not context_input or not context_input.account or not context_input.account.id:
         return
 
     if graphql_context.active_account_session.account_id == context_input.account.id:

--- a/backend/infrahub/hfid/tasks.py
+++ b/backend/infrahub/hfid/tasks.py
@@ -20,9 +20,11 @@ UPDATE_HFID = """
 mutation UpdateHFID(
     $id: String!,
     $kind: String!,
-    $value: [String!]!
+    $value: [String!]!,
+    $context_account_id: String!
   ) {
   InfrahubUpdateHFID(
+    context: {account: {id: $context_account_id}},
     data: {id: $id, value: $value, kind: $kind}
   ) {
     ok
@@ -40,6 +42,7 @@ async def hfid_update_value(
     obj: HFIDGraphQLResponse,
     node_kind: str,
     hfid_definition: list[str],
+    context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
     client = get_client()
@@ -58,7 +61,12 @@ async def hfid_update_value(
     try:
         await client.execute_graphql(
             query=UPDATE_HFID,
-            variables={"id": obj.node_id, "kind": node_kind, "value": rendered_hfid},
+            variables={
+                "id": obj.node_id,
+                "kind": node_kind,
+                "value": rendered_hfid,
+                "context_account_id": context.account.account_id,
+            },
             branch_name=branch_name,
         )
         log.info(f"Updating {node_kind}.human_friendly_id='{rendered_hfid}' ({obj.node_id})")
@@ -77,7 +85,7 @@ async def process_hfid(
     node_kind: str,
     object_id: str,
     target_kind: str,
-    context: InfrahubContext,  # noqa: ARG001
+    context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
     client = get_client()
@@ -115,6 +123,7 @@ async def process_hfid(
             obj=node,
             node_kind=node_schema.kind,
             hfid_definition=hfid_definition.hfid,
+            context=context,
         )
 
     _ = [response async for _, response in batch.execute()]

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -5,9 +5,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.computed_attribute.tasks import gather_trigger_computed_attribute_python, query_transform_targets
+from infrahub.computed_attribute.gather import gather_trigger_computed_attribute_python
+from infrahub.computed_attribute.tasks import query_transform_targets
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from tests.helpers.file_repo import FileRepo
@@ -35,10 +37,13 @@ mutation Recompute($kind: String!, $attribute: String!, $node_ids: [String!]) {
 
 class TestComputedAttribute(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def context(self, client: InfrahubClient, default_branch: Branch) -> InfrahubContext:
-        """Placeholder context for now, would be good to implement some auth and permissions here"""
+    async def context(self, db: InfrahubDatabase, initialize_registry: None, default_branch: Branch) -> InfrahubContext:
+        """Context with a real account from the database for computed attribute workflows"""
+        admin_account = await NodeManager.get_one_by_hfid(
+            db=db, kind=InfrahubKind.ACCOUNT, hfid=["admin"], raise_on_error=True
+        )
         return InfrahubContext(
-            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            account=AccountSession(authenticated=True, account_id=admin_account.id, auth_type=AuthType.API),
             branch=BranchContext(name=default_branch.name, id=str(default_branch.uuid)),
         )
 


### PR DESCRIPTION
This PR passes along the InfrahubContext to the Prefect tasks that updates computed attributes, display_labels and HFIDs, then sends these contexts to the server within the mutation.

This is done to preserve the original user of a request. I.e. if a user mutates a node which triggers a computed attribute to be recalculated that task will run in the background on one of the Prefect workers. This lead to the user running the Prefect worker as being the one who changed the computed attributes / display_labels or HFIDs. When we pass along the context the original user is instead preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account context is now properly tracked and associated with computed attribute, display label, and HFID updates across the system.

* **Bug Fixes**
  * Added validation to ensure account context information is present and correctly processed in GraphQL operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->