### PR TITLE
update node-level metadata on default branch when updating attrs/rels

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -974,10 +974,11 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         return self
 
     async def _save_metadata(self, db: InfrahubDatabase, branch: Branch) -> None:
-        update_metadata_query = await NodeUpdateMetadataQuery.init(
-            db=db, branch=branch, node_id=self.get_id(), user_id=self._get_updated_by(), at=self._get_updated_at()
-        )
-        await update_metadata_query.execute(db=db)
+        if user_id := self._get_updated_by():
+            update_metadata_query = await NodeUpdateMetadataQuery.init(
+                db=db, branch=branch, node_id=self.get_id(), user_id=user_id, at=self._get_updated_at()
+            )
+            await update_metadata_query.execute(db=db)
 
     async def delete(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None) -> None:
         """Delete the Node in the database."""

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -26,7 +26,7 @@ from infrahub.core.constants.schema import SchemaElementPathType
 from infrahub.core.metadata.interface import MetadataInterface
 from infrahub.core.metadata.model import MetadataInfo
 from infrahub.core.protocols import CoreNumberPool, CoreObjectTemplate
-from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery
+from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery, NodeUpdateMetadataQuery
 from infrahub.core.schema import (
     AttributeSchema,
     GenericSchema,
@@ -951,7 +951,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if node_changelog.has_changes:
             self._set_updated_at(update_at)
             self._set_updated_by(user_id)
-
+            update_branch = self.get_branch_based_on_support_type()
+            if update_branch.is_default or update_branch.is_global:
+                await self._save_metadata(db=db, branch=update_branch)
         return node_changelog
 
     async def save(
@@ -970,6 +972,12 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             self._node_changelog = await self._create(db=db, user_id=user_id, at=save_at)
 
         return self
+
+    async def _save_metadata(self, db: InfrahubDatabase, branch: Branch) -> None:
+        update_metadata_query = await NodeUpdateMetadataQuery.init(
+            db=db, branch=branch, node_id=self.get_id(), user_id=self._get_updated_by(), at=self._get_updated_at()
+        )
+        await update_metadata_query.execute(db=db)
 
     async def delete(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None) -> None:
         """Delete the Node in the database."""

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -635,6 +635,32 @@ SET r.to_user_id = $user_id
         self.add_to_query(query)
 
 
+class NodeUpdateMetadataQuery(NodeQuery):
+    name = "node_update_metadata"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+    raise_error_if_empty = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
+        if not self.branch.is_default and not self.branch.is_global:
+            raise ValueError("NodeUpdateMetadataQuery can only be used on the default or global branch")
+        self.params["uuid"] = self.node_id
+        self.params["branch"] = self.branch.name
+        self.params["at"] = self.at.to_string()
+        self.params["user_id"] = self.user_id
+
+        query = """
+MATCH (n:Node { uuid: $uuid })-[r:IS_PART_OF { branch_level: 1, status: "active" }]->(:Root)
+WHERE r.to IS NULL
+OPTIONAL MATCH (n)-[delete_edge:IS_PART_OF {status: "deleted", branch: $branch}]->(:Root)
+WHERE delete_edge.from <= $at
+WITH n, r
+WHERE delete_edge IS NULL
+SET n.updated_at = $at, n.updated_by = $user_id
+        """
+        self.add_to_query(query)
+
+
 class NodeCheckIDQuery(Query):
     name = "node_check_id"
 
@@ -1300,7 +1326,8 @@ CALL (field) {
     RETURN updated_at, updated_by
 }
 WITH n, r_is_part_of, updated_at, updated_by
-ORDER BY elementId(n), updated_at DESC
+// updated_by ordering preferences non "__system__" users
+ORDER BY elementId(n), updated_at DESC, updated_by DESC
 WITH n, r_is_part_of, head(collect(updated_at)) AS updated_at, head(collect(updated_by)) AS updated_by
             """ % {"branch_filter": branch_filter_str}
         self.add_to_query(last_update_query)

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -475,6 +475,19 @@ async def test_node_property_getter(db: InfrahubDatabase, default_branch: Branch
     assert attr.owner_id == "yetotheruuid"
 
 
+async def _validate_node_metadata(
+    db: InfrahubDatabase,
+    branch: Branch,
+    node_id: str,
+    update_time_range: tuple[Timestamp, Timestamp],
+    updated_by: str,
+) -> None:
+    """Validate Node-level _get_updated_at and _get_updated_by metadata."""
+    node = await NodeManager.get_one(db=db, branch=branch, id=node_id, include_metadata=MetadataOptions.USER_TIMESTAMPS)
+    assert update_time_range[0] < node._get_updated_at() < update_time_range[1]
+    assert node._get_updated_by() == updated_by
+
+
 async def test_attribute_properties_and_metadata_on_branch(
     db: InfrahubDatabase,
     default_branch: Branch,
@@ -488,12 +501,20 @@ async def test_attribute_properties_and_metadata_on_branch(
     before_create = Timestamp()
     await crit_low.save(db=db)
     after_create = Timestamp()
+    # validate initial node-level metadata
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_create, after_create),
+        updated_by=SYSTEM_USER_ID,
+    )
 
     # Set the source and owner properties on the object on the default branch
     crit_low.name.source = first_account
     crit_low.name.owner = second_account
     before_default_update = Timestamp()
-    await crit_low.name.save(db=db, user_id="first-update")
+    await crit_low.save(db=db, user_id="first-update")
     after_default_update = Timestamp()
 
     # Retrieve the object from the database and validate that the source and owner properties are correct
@@ -512,6 +533,14 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_created_by() == SYSTEM_USER_ID
     assert before_default_update < refreshed_crit_low.name._get_updated_at() < after_default_update
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
+    # validate node-level metadata after first update on default branch
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Create a branch
     branch1 = await create_branch(branch_name="branch1", db=db)
@@ -535,7 +564,7 @@ async def test_attribute_properties_and_metadata_on_branch(
     crit_low_branch.name.source = second_account
     crit_low_branch.name.owner = first_account
     before_branch_update = Timestamp()
-    await crit_low_branch.name.save(db=db, user_id="second-update")
+    await crit_low_branch.save(db=db, user_id="second-update")
     after_branch_update = Timestamp()
 
     # Retrieve the object on the branch and validate the source and owner properties
@@ -554,6 +583,14 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "second-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on branch after branch update
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_update, after_branch_update),
+        updated_by="second-update",
+    )
 
     # retrieve and verify the properties and metadata on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -571,12 +608,20 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Delete the source and owner properties on the object on the branch
     refreshed_crit_low_branch.name.clear_source()
     refreshed_crit_low_branch.name.clear_owner()
     before_branch_clear = Timestamp()
-    await refreshed_crit_low_branch.name.save(db=db, user_id="third-update")
+    await refreshed_crit_low_branch.save(db=db, user_id="third-update")
     after_branch_clear = Timestamp()
 
     # Retrieve the object on the branch and validate the source and owner properties
@@ -593,6 +638,14 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "third-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on branch after clearing source/owner
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_clear, after_branch_clear),
+        updated_by="third-update",
+    )
 
     # retrieve and verify the properties and metadata on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -610,6 +663,14 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Delete the source and owner properties on the object on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -623,7 +684,7 @@ async def test_attribute_properties_and_metadata_on_branch(
     refreshed_crit_low.name.clear_source()
     refreshed_crit_low.name.clear_owner()
     before_default_clear = Timestamp()
-    await refreshed_crit_low.name.save(db=db, user_id="fourth-update")
+    await refreshed_crit_low.save(db=db, user_id="fourth-update")
     after_default_clear = Timestamp()
 
     # Retrieve the object on the default branch and validate the source and owner properties
@@ -642,6 +703,14 @@ async def test_attribute_properties_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "fourth-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch after clearing source/owner
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_clear, after_default_clear),
+        updated_by="fourth-update",
+    )
 
     await verify_no_duplicate_paths(db=db)
 
@@ -659,11 +728,19 @@ async def test_attribute_value_and_metadata_on_branch(
     before_create = Timestamp()
     await crit_low.save(db=db)
     after_create = Timestamp()
+    # validate initial node-level metadata
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_create, after_create),
+        updated_by=SYSTEM_USER_ID,
+    )
 
     # Set the value property on the object on the default branch
     crit_low.name.value = "name1"
     before_default_update = Timestamp()
-    await crit_low.name.save(db=db, user_id="first-update")
+    await crit_low.save(db=db, user_id="first-update")
     after_default_update = Timestamp()
 
     # Retrieve the object from the database and validate that the value property is correct
@@ -680,6 +757,14 @@ async def test_attribute_value_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_created_by() == SYSTEM_USER_ID
     assert before_default_update < refreshed_crit_low.name._get_updated_at() < after_default_update
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
+    # validate node-level metadata after first update on default branch
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Create a branch
     branch1 = await create_branch(branch_name="branch1", db=db)
@@ -701,7 +786,7 @@ async def test_attribute_value_and_metadata_on_branch(
 
     crit_low_branch.name.value = "name2"
     before_branch_update = Timestamp()
-    await crit_low_branch.name.save(db=db, user_id="second-update")
+    await crit_low_branch.save(db=db, user_id="second-update")
     after_branch_update = Timestamp()
 
     # Retrieve the object on the branch and validate the value property
@@ -718,6 +803,13 @@ async def test_attribute_value_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "second-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_update, after_branch_update),
+        updated_by="second-update",
+    )
 
     # retrieve and verify the properties and metadata on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -733,6 +825,14 @@ async def test_attribute_value_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Update the value property on the object on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -745,7 +845,7 @@ async def test_attribute_value_and_metadata_on_branch(
     )
     refreshed_crit_low.name.value = "name4"
     before_default_update2 = Timestamp()
-    await refreshed_crit_low.name.save(db=db, user_id="fourth-update")
+    await refreshed_crit_low.save(db=db, user_id="fourth-update")
     after_default_update2 = Timestamp()
 
     # Retrieve the object on the default branch and validate the value property
@@ -762,6 +862,14 @@ async def test_attribute_value_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "fourth-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch after second update
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update2, after_default_update2),
+        updated_by="fourth-update",
+    )
 
     # Retrieve the object on the branch and validate the value property
     refreshed_crit_low_branch = await NodeManager.get_one(
@@ -775,6 +883,14 @@ async def test_attribute_value_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "second-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    # validate that the node-level metadata on the branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_update, after_branch_update),
+        updated_by="second-update",
+    )
 
     await verify_no_duplicate_paths(db=db)
 
@@ -792,11 +908,19 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     before_create = Timestamp()
     await crit_low.save(db=db)
     after_create = Timestamp()
+    # validate initial node-level metadata
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_create, after_create),
+        updated_by=SYSTEM_USER_ID,
+    )
 
     # Set the is_protected flag on the object on the default branch
     crit_low.name.is_protected = True
     before_default_update = Timestamp()
-    await crit_low.name.save(db=db, user_id="first-update")
+    await crit_low.save(db=db, user_id="first-update")
     after_default_update = Timestamp()
 
     # Retrieve the object from the database and validate that the is_protected flag is correct
@@ -814,6 +938,14 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_created_by() == SYSTEM_USER_ID
     assert before_default_update < refreshed_crit_low.name._get_updated_at() < after_default_update
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
+    # validate node-level metadata after first update on default branch
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Create a branch
     branch1 = await create_branch(branch_name="branch1", db=db)
@@ -835,7 +967,7 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
 
     crit_low_branch.name.is_protected = False
     before_branch_update = Timestamp()
-    await crit_low_branch.name.save(db=db, user_id="second-update")
+    await crit_low_branch.save(db=db, user_id="second-update")
     after_branch_update = Timestamp()
 
     # Retrieve the object on the branch and validate the is_protected flag
@@ -853,6 +985,14 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "second-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on branch after branch update
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_update, after_branch_update),
+        updated_by="second-update",
+    )
 
     # retrieve and verify the properties and metadata on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -869,6 +1009,14 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "first-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update, after_default_update),
+        updated_by="first-update",
+    )
 
     # Update the is_protected flag on the object on the default branch
     refreshed_crit_low = await NodeManager.get_one(
@@ -881,7 +1029,7 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     )
     refreshed_crit_low.name.is_protected = False
     before_default_update2 = Timestamp()
-    await refreshed_crit_low.name.save(db=db, user_id="fourth-update")
+    await refreshed_crit_low.save(db=db, user_id="fourth-update")
     after_default_update2 = Timestamp()
 
     # Retrieve the object on the default branch and validate the is_protected flag
@@ -899,6 +1047,14 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     assert refreshed_crit_low.name._get_updated_by() == "fourth-update"
     assert refreshed_crit_low.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on default branch after second update
+    await _validate_node_metadata(
+        db=db,
+        branch=default_branch,
+        node_id=crit_low.id,
+        update_time_range=(before_default_update2, after_default_update2),
+        updated_by="fourth-update",
+    )
 
     # Retrieve the object on the branch and validate the is_protected flag
     refreshed_crit_low_branch = await NodeManager.get_one(
@@ -913,6 +1069,14 @@ async def test_attribute_is_protected_flag_and_metadata_on_branch(
     assert refreshed_crit_low_branch.name._get_updated_by() == "second-update"
     assert refreshed_crit_low_branch.name._get_created_at() == crit_low.name._get_created_at()
     assert refreshed_crit_low_branch.name._get_created_by() == crit_low.name._get_created_by()
+    # validate node-level metadata on branch remains unchanged
+    await _validate_node_metadata(
+        db=db,
+        branch=branch1,
+        node_id=crit_low.id,
+        update_time_range=(before_branch_update, after_branch_update),
+        updated_by="second-update",
+    )
 
     await verify_no_duplicate_paths(db=db)
 

--- a/backend/tests/unit/core/test_relationship_metadata.py
+++ b/backend/tests/unit/core/test_relationship_metadata.py
@@ -73,6 +73,21 @@ class TestRelationshipMetadata:
         )
         return {rel.get_peer_id(): rel for rel in relationships}
 
+    async def _validate_node_metadata(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        node_id: str,
+        update_time_range: tuple[Timestamp, Timestamp],
+        updated_by: str,
+    ) -> None:
+        """Validate Node-level _get_updated_at and _get_updated_by metadata."""
+        node = await NodeManager.get_one(
+            db=db, branch=branch, id=node_id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        assert update_time_range[0] < node._get_updated_at() < update_time_range[1]
+        assert node._get_updated_by() == updated_by
+
     async def _validate_relationship_metadata(
         self,
         db: InfrahubDatabase,
@@ -191,6 +206,14 @@ class TestRelationshipMetadata:
         assert len(tags_rels_map) == 2
         for tag_rel in tags_rels_map.values():
             self._validate_rel_metadata(tag_rel, (self.before_create, self.after_create), SYSTEM_USER_ID, None, None)
+        # validate initial node-level metadata
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(self.before_create, self.after_create),
+            updated_by=SYSTEM_USER_ID,
+        )
 
         # Set the source and owner properties on both relationships on the default branch
         fresh_person = await NodeManager.get_one(db=db, branch=default_branch, id=self.person_id)
@@ -213,6 +236,14 @@ class TestRelationshipMetadata:
             updated_by="first-update",
             source_id=first_account.id,
             owner_id=second_account.id,
+        )
+        # validate node-level metadata after first update
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_first_update, after_first_update),
+            updated_by="first-update",
         )
 
         branch = await create_branch(db=db, branch_name="branch2")
@@ -239,6 +270,14 @@ class TestRelationshipMetadata:
             source_id=second_account.id,
             owner_id=first_account.id,
         )
+        # validate node-level metadata after second update on default branch
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="second-update",
+        )
         # validate that properties and metadata on branch remain the same
         await self._validate_relationship_metadata(
             db=db,
@@ -248,6 +287,14 @@ class TestRelationshipMetadata:
             updated_by="first-update",
             source_id=first_account.id,
             owner_id=second_account.id,
+        )
+        # validate node-level metadata on branch remains the same as first update
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_first_update, after_first_update),
+            updated_by="first-update",
         )
 
         # Update the source and owner properties on the branch
@@ -273,6 +320,14 @@ class TestRelationshipMetadata:
             source_id=second_account.id,
             owner_id=first_account.id,
         )
+        # validate node-level metadata on default branch remains unchanged
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="second-update",
+        )
         # Validate that branch now has the updated source and owner and metadata
         await self._validate_relationship_metadata(
             db=db,
@@ -282,6 +337,14 @@ class TestRelationshipMetadata:
             updated_by="first-branch-update",
             source_id=second_account.id,
             owner_id=first_account.id,
+        )
+        # validate node-level metadata on branch reflects the branch update
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_branch_update, after_branch_update),
+            updated_by="first-branch-update",
         )
 
         # clear the source and owner properties on both relationships on the default branch
@@ -306,6 +369,14 @@ class TestRelationshipMetadata:
             source_id=None,
             owner_id=None,
         )
+        # validate node-level metadata on default branch after third update
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="third-update",
+        )
         # Validate that branch keeps the same metadata
         await self._validate_relationship_metadata(
             db=db,
@@ -315,6 +386,14 @@ class TestRelationshipMetadata:
             updated_by="first-branch-update",
             source_id=second_account.id,
             owner_id=first_account.id,
+        )
+        # validate node-level metadata on branch remains unchanged
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_branch_update, after_branch_update),
+            updated_by="first-branch-update",
         )
 
         # clear the source and owner on the branch
@@ -340,6 +419,14 @@ class TestRelationshipMetadata:
             source_id=None,
             owner_id=None,
         )
+        # validate node-level metadata on branch after second branch update
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_branch_update_2, after_branch_update_2),
+            updated_by="second-branch-update",
+        )
         # validate that default_branch still has cleared source and owner from before
         await self._validate_relationship_metadata(
             db=db,
@@ -349,6 +436,14 @@ class TestRelationshipMetadata:
             updated_by="third-update",
             source_id=None,
             owner_id=None,
+        )
+        # validate node-level metadata on default branch remains unchanged
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="third-update",
         )
 
     def _validate_rel_metadata_peer_and_protected(
@@ -424,6 +519,14 @@ class TestRelationshipMetadata:
             for tag_rel in tag_rels
         ]
         self._validate_rel_metadata_peer_and_protected(tag_rels, tag_metadatas)
+        # validate initial node-level metadata
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(self.before_create, self.after_create),
+            updated_by=SYSTEM_USER_ID,
+        )
 
         # Set is_protected on both relationships on the default branch
         fresh_person = await NodeManager.get_one(db=db, branch=default_branch, id=self.person_id)
@@ -465,6 +568,14 @@ class TestRelationshipMetadata:
             ),
         ]
         self._validate_rel_metadata_peer_and_protected(list(tags_rels_map.values()), tags_metadata_main_1)
+        # validate node-level metadata after first update
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_first_update, after_first_update),
+            updated_by="first-update",
+        )
 
         branch = await create_branch(db=db, branch_name="branch2")
 
@@ -507,12 +618,28 @@ class TestRelationshipMetadata:
             ),
         ]
         self._validate_rel_metadata_peer_and_protected(list(tags_rels_map.values()), tags_metadata_main_2)
+        # validate node-level metadata on default branch after second update
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="second-update",
+        )
         # validate primary_tag relationship remains unchanged on branch
         primary_tag_rel = await self._get_primary_tag_rel(db=db, branch=branch)
         self._validate_rel_metadata_peer_and_protected([primary_tag_rel], [primary_tag_metadata_main_1])
         # validate tags relationships remain unchanged on branch
         tags_rels_map = await self._get_tags_rels(db=db, branch=branch)
         self._validate_rel_metadata_peer_and_protected(list(tags_rels_map.values()), tags_metadata_main_1)
+        # validate node-level metadata on branch remains unchanged
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_first_update, after_first_update),
+            updated_by="first-update",
+        )
 
         # Update is_protected status on the primary_tag relationship and one of the peers in the tags relationship on branch
         fresh_person_branch = await NodeManager.get_one(db=db, branch=branch, id=self.person_id)
@@ -553,8 +680,24 @@ class TestRelationshipMetadata:
             ),
         ]
         self._validate_rel_metadata_peer_and_protected(list(tags_rels_map.values()), tags_metadata_branch)
+        # validate node-level metadata on branch after branch update
+        await self._validate_node_metadata(
+            db=db,
+            branch=branch,
+            node_id=self.person_id,
+            update_time_range=(before_branch_update, after_branch_update),
+            updated_by="branch-update-1",
+        )
         # Validate that no changes were made on the default branch
         primary_tag_rel = await self._get_primary_tag_rel(db=db, branch=default_branch)
         self._validate_rel_metadata_peer_and_protected([primary_tag_rel], [primary_tag_metadata_main_2])
         tags_rels_map = await self._get_tags_rels(db=db, branch=default_branch)
         self._validate_rel_metadata_peer_and_protected(list(tags_rels_map.values()), tags_metadata_main_2)
+        # validate node-level metadata on default branch remains unchanged
+        await self._validate_node_metadata(
+            db=db,
+            branch=default_branch,
+            node_id=self.person_id,
+            update_time_range=(before_update, after_update),
+            updated_by="second-update",
+        )


### PR DESCRIPTION
new simple query to update node-level metadata on the default branch (`created/updated_by/at` properties on the `Node` vertex) when attributes or relationships on the node are updated during a save

we weren't making this update before, so the node might not correctly reflect the time and user of the actual last update on the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node metadata (updated_at and updated_by) are now reliably persisted when nodes are modified on default/global branches.
  * Node listing in non-default branches now orders by recent updates and modifier to surface the most relevant changes.

* **Tests**
  * Expanded test coverage to validate node-level metadata across creation, updates, branching, and metadata-clearing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->