### PR TITLE
Fix typing violations in Prefect worker

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -207,6 +207,14 @@ class MainSettings(BaseSettings):
     def convert_to_path(cls, value: Path | str) -> Path:
         return Path(value) if isinstance(value, str) else value
 
+    @property
+    def infrahub_address(self) -> str:
+        """This is the address that the Prefect worker will use to connect to Infrahub API."""
+        if self.internal_address:
+            return self.internal_address
+
+        raise InitializationError()
+
 
 class FileSystemStorageSettings(BaseSettings):
     # Make variable lookup case-sensitive to avoid fetching $PATH value

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -24,6 +24,7 @@ from infrahub.core import registry
 from infrahub.core.initialization import initialization
 from infrahub.database.graph import validate_graph_version
 from infrahub.dependencies.registry import build_component_registry
+from infrahub.exceptions import InitializationError
 from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
 from infrahub.services import InfrahubServices
@@ -182,9 +183,17 @@ class InfrahubWorkerAsync(BaseWorker):
     async def _init_infrahub_client(self, client: InfrahubClient | None = None) -> InfrahubClient:
         if not client:
             self._logger.debug(f"Using Infrahub API at {config.SETTINGS.main.internal_address}")
-            client = InfrahubClient(
-                config=Config(address=config.SETTINGS.main.internal_address, retry_on_failure=True, log=self._logger)
-            )
+            try:
+                client = InfrahubClient(
+                    config=Config(
+                        address=config.SETTINGS.main.infrahub_address, retry_on_failure=True, log=self._logger
+                    )
+                )
+            except InitializationError as err:
+                self._logger.error(
+                    "Infrahub client initialization failed due to missing configuration for internal_address."
+                )
+                raise typer.Exit(1) from err
 
         try:
             await client.branch.all()
@@ -194,7 +203,7 @@ class InfrahubWorkerAsync(BaseWorker):
 
         return client
 
-    async def _init_services(self, client: InfrahubClient) -> None:
+    async def _init_services(self, client: InfrahubClient | None) -> None:
         client = await self._init_infrahub_client(client=client)
 
         service = await InfrahubServices.new(


### PR DESCRIPTION
This PR fixes some typing violations within the Prefect worker and at the same type provides a more user friendly error if the configuration for the internal address is missing from the Prefect workers. The config is a bit weird now as that value is required on the Prefect workers but not in the server.

These are were marked with warnings in the IDE but not by mypy as the SDK is still missing a `py.typed` file (#7205)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging during API client initialization with improved failure messaging

* **Chores**
  * Strengthened configuration validation for API address resolution, added retry logic for failed initialization attempts, and improved overall system startup robustness

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->