### PR TITLE
Pass along request context for artifacts & generators in pipeline

### DIFF
--- a/backend/infrahub/artifacts/tasks.py
+++ b/backend/infrahub/artifacts/tasks.py
@@ -14,6 +14,7 @@ async def create(model: CheckArtifactCreate) -> ValidatorConclusion:
     await add_tags(branches=[model.branch_name], nodes=[model.target_id])
 
     client = get_client()
+    client.request_context = model.context.to_request_context()
 
     validator = await client.get(kind=InfrahubKind.ARTIFACTVALIDATOR, id=model.validator_id, include=["checks"])
 

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -1421,7 +1421,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         artifact.status.value = ArtifactStatus.READY.value
         if artifact.name.value != message.artifact_name:
             artifact.name.value = message.artifact_name
-        await artifact.save()
+        await artifact.save(request_context=message.context.to_request_context())
 
         event_class = ArtifactCreatedEvent if artifact_created else ArtifactUpdatedEvent
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -622,6 +622,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
 
     log = get_run_logger()
     client = get_client()
+    client.request_context = context.to_request_context()
 
     artifact_definition = await client.get(
         kind=CoreArtifactDefinition,
@@ -781,6 +782,7 @@ async def run_generator_as_check(model: RunGeneratorAsCheckModel, context: Infra
     await add_tags(branches=[model.branch_name], nodes=[model.proposed_change], db_change=True)
 
     client = get_client()
+    client.request_context = context.to_request_context()
     log = get_run_logger()
 
     repository = await get_initialized_repo(
@@ -859,7 +861,7 @@ async def run_generator_as_check(model: RunGeneratorAsCheckModel, context: Infra
     if check:
         check.created_at.value = Timestamp().to_string()
         check.conclusion.value = conclusion.value
-        await check.save()
+        await check.save(request_context=context.to_request_context())
     else:
         check = await client.create(
             kind=InfrahubKind.GENERATORCHECK,
@@ -925,6 +927,7 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
 
     log = get_run_logger()
     client = get_client()
+    client.request_context = context.to_request_context()
 
     proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -13,6 +13,7 @@ from infrahub.workers.dependencies import get_client
 async def define_artifact(model: CheckArtifactCreate | RequestArtifactGenerate) -> tuple[InfrahubNode, bool]:
     """Return an artifact together with a flag to indicate if the artifact is created now or already existed."""
     client = get_client()
+    client.request_context = model.context.to_request_context()
     created = False
     if model.artifact_id:
         artifact = await client.get(kind=InfrahubKind.ARTIFACT, id=model.artifact_id, branch=model.branch_name)

--- a/backend/infrahub/validators/tasks.py
+++ b/backend/infrahub/validators/tasks.py
@@ -29,6 +29,7 @@ async def start_validator[ValidatorType: CoreValidator](
         validator = cast("ValidatorType", validator)
     else:
         data["proposed_change"] = proposed_change
+        client.request_context = context.to_request_context()
         validator = await client.create(kind=validator_type, data=data)
         await validator.save()
 

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -48,10 +48,14 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         await load_schema(db=db, schema=CAR_SCHEMA)
 
     @pytest.fixture(scope="class")
-    async def context(self) -> InfrahubContext:
+    async def context(self, db: InfrahubDatabase) -> InfrahubContext:
         """Placeholder context for now, would be good to implement some auth and permissions here"""
+        admin_account = await NodeManager.get_one_by_hfid(
+            db=db, kind=InfrahubKind.ACCOUNT, hfid=["admin"], raise_on_error=True
+        )
+
         return InfrahubContext(
-            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            account=AccountSession(authenticated=True, account_id=admin_account.id, auth_type=AuthType.API),
             branch=BranchContext(name="main", id="d18808fe-70c8-4782-bd55-144d6980036f"),
         )
 

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -377,7 +377,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         pr_account_events = await client.execute_graphql(
             query=QUERY_EVENT,
-            variables={"account__ids": [proposed_change_user.id]},
+            variables={"account__ids": [proposed_change_user.id], "limit": 50},
         )
         pr_account_events_types = {event["node"]["event"] for event in pr_account_events["InfrahubEvent"]["edges"]}
         assert "infrahub.validator.passed" in pr_account_events_types
@@ -427,6 +427,7 @@ query(
     $account__ids: [String!],
     $related_node__ids: [String!],
     $event_type_filter: EventTypeFilter
+    $limit: Int
 ) {
   InfrahubEvent(
     branches: $branch,
@@ -435,6 +436,7 @@ query(
     event_type_filter: $event_type_filter
     account__ids: $account__ids
     related_node__ids: $related_node__ids
+    limit: $limit
   ) {
     count
     edges {


### PR DESCRIPTION
Pass along the existing context to artifacts & generators within the pipeline so that created objects maintain the id of the user that triggered the pipeline.

Updated tests where required to align with new requirements and number or generated events from a given user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved request context propagation throughout async operations for consistent and reliable behavior across system components.

* **Tests**
  * Enhanced test infrastructure to use authenticated contexts for improved test reliability and accuracy.
  * Updated GraphQL queries to support result limiting for better test control and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->