### PR TITLE
fix RelationshipGetPeerQuery branch-agnostic metadata logic

### DIFF
--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -788,38 +788,51 @@ CALL (rels) {
     def _add_updated_metadata_to_query(self, branch_filter_str: str) -> None:
         if not (self.include_metadata & (MetadataOptions.UPDATED_AT | MetadataOptions.UPDATED_BY)):
             return
+        self.update_return_labels(["updated_at", "updated_by"])
         if self.branch.is_default or self.branch.is_global:
             last_updated_query = """
 WITH *, rl.updated_at AS updated_at, rl.updated_by AS updated_by
             """
+            self.add_to_query(last_updated_query)
+            return
+
+        # query for non-default, non-global branches
+        if self.branch_agnostic:
+            time_details = """
+WITH [r.from, r.from_user_id] AS from_details, [r.to, r.to_user_id] AS to_details
+            """
         else:
-            last_updated_query = """
+            time_details = """
+WITH CASE
+    WHEN $is_branch_agnostic THEN [r.from, r.from_user_id]
+    WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
+    WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
+    ELSE [NULL, NULL]
+END AS from_details,
+CASE
+    WHEN $is_branch_agnostic THEN [r.to, r.to_user_id]
+    WHEN r.branch IN $branch0 AND r.to < $time0 THEN [r.to, r.to_user_id]
+    WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
+    ELSE [NULL, NULL]
+END AS to_details
+            """
+        last_updated_query = """
 CALL (rl) {
-    MATCH (rl)-[r]-(property)
-    WHERE %(branch_filter)s
-    WITH CASE
-        WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
-        WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
-        ELSE [NULL, NULL]
-    END AS from_details,
-    CASE
-        WHEN r.branch IN $branch0 AND r.to < $time0 THEN [r.to, r.to_user_id]
-        WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
-        ELSE [NULL, NULL]
-    END AS to_details
-    WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
-    WITH from_details_list + to_details_list AS details_list
-    UNWIND details_list AS one_details
-    WITH one_details[0] AS updated_at, one_details[1] AS updated_by
-    WHERE updated_at IS NOT NULL
-    WITH updated_at, updated_by
-    ORDER BY updated_at DESC
-    LIMIT 1
-    RETURN updated_at, updated_by
+MATCH (rl)-[r]-(property)
+WHERE %(branch_filter)s
+%(time_details)s
+WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
+WITH from_details_list + to_details_list AS details_list
+UNWIND details_list AS one_details
+WITH one_details[0] AS updated_at, one_details[1] AS updated_by
+WHERE updated_at IS NOT NULL
+WITH updated_at, updated_by
+ORDER BY updated_at DESC
+LIMIT 1
+RETURN updated_at, updated_by
 }
-            """ % {"branch_filter": branch_filter_str}
+        """ % {"branch_filter": branch_filter_str, "time_details": time_details}
         self.add_to_query(last_updated_query)
-        self.update_return_labels(["updated_at", "updated_by"])
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(
@@ -830,6 +843,7 @@ CALL (rl) {
 
         peer_schema = self.schema.get_peer_schema(db=db, branch=self.branch)
 
+        self.params["is_branch_agnostic"] = self.branch_agnostic
         self.params["source_ids"] = self.source_ids
         self.params["rel_identifier"] = self.schema.identifier
         self.params["peer_kind"] = self.schema.peer

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -5,7 +5,12 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import MetadataOptions, RelationshipDirection, SchemaPathType
+from infrahub.core.constants import (
+    SYSTEM_USER_ID,
+    MetadataOptions,
+    RelationshipDirection,
+    SchemaPathType,
+)
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
@@ -1170,3 +1175,89 @@ async def test_query_RelationshipGetByIdentifierQuery(
     )
     await query.execute(db=db)
     assert await query.count(db=db) == 4
+
+
+async def test_query_RelationshipGetPeerQuery_branch_agnostic(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+) -> None:
+    """Test that RelationshipGetPeerQuery works correctly with branch_agnostic=True"""
+    # Create a new branch
+    branch = await create_branch(branch_name="test_agnostic_branch", db=db)
+
+    branch_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await branch_accord.owner.update(db=db, data=person_jane_main.id)
+    before_branch_update = Timestamp()
+    await branch_accord.save(db=db, user_id="user1")
+    after_branch_update = Timestamp()
+
+    person_schema = registry.schema.get(name="TestCar", branch=branch)
+    rel_schema = person_schema.get_relationship("owner")
+
+    # validate query on branch gets correct times
+    query = await RelationshipGetPeerQuery.init(
+        db=db,
+        source_ids=[car_accord_main.id],
+        schema=rel_schema,
+        rel=Relationship,
+        branch=branch,
+        at=Timestamp(),
+        include_metadata=MetadataOptions.IS_PROTECTED | MetadataOptions.IS_VISIBLE | MetadataOptions.USER_TIMESTAMPS,
+    )
+    await query.execute(db=db)
+
+    # validate the peer timestamp metadata
+    peer_by_id_map = {peer.peer_id: peer for peer in query.get_peers()}
+    assert set(peer_by_id_map.keys()) == {person_jane_main.id}
+    jane_peer = peer_by_id_map[person_jane_main.id]
+    assert before_branch_update < jane_peer.created_at < after_branch_update
+    assert before_branch_update < jane_peer.updated_at < after_branch_update
+    assert jane_peer.created_by == "user1"
+    assert jane_peer.updated_by == "user1"
+
+    # validate the query on the default branch
+    query = await RelationshipGetPeerQuery.init(
+        db=db,
+        source_ids=[car_accord_main.id],
+        schema=rel_schema,
+        rel=Relationship,
+        branch=default_branch,
+        at=Timestamp(),
+        include_metadata=MetadataOptions.IS_PROTECTED | MetadataOptions.IS_VISIBLE | MetadataOptions.USER_TIMESTAMPS,
+    )
+    await query.execute(db=db)
+
+    # validate the peer timestamp metadata
+    peer_by_id_map = {peer.peer_id: peer for peer in query.get_peers()}
+    assert set(peer_by_id_map.keys()) == {person_john_main.id}
+    john_peer = peer_by_id_map[person_john_main.id]
+    assert john_peer.created_at < before_branch_update
+    assert john_peer.updated_at < before_branch_update
+    assert john_peer.created_by == SYSTEM_USER_ID
+    assert john_peer.updated_by == SYSTEM_USER_ID
+
+    # validate query when branch-agnostic gets correct times
+    query = await RelationshipGetPeerQuery.init(
+        db=db,
+        source_ids=[car_accord_main.id],
+        schema=rel_schema,
+        rel=Relationship,
+        branch=branch,
+        branch_agnostic=True,
+        at=Timestamp(),
+        include_metadata=MetadataOptions.IS_PROTECTED | MetadataOptions.IS_VISIBLE | MetadataOptions.USER_TIMESTAMPS,
+    )
+    await query.execute(db=db)
+
+    # validate the peer timestamp metadata
+    # john is not included because he is deleted on a branch
+    peer_by_id_map = {peer.peer_id: peer for peer in query.get_peers()}
+    assert set(peer_by_id_map.keys()) == {person_jane_main.id}
+    jane_peer = peer_by_id_map[person_jane_main.id]
+    assert before_branch_update < jane_peer.created_at < after_branch_update
+    assert before_branch_update < jane_peer.updated_at < after_branch_update
+    assert jane_peer.created_by == "user1"
+    assert jane_peer.updated_by == "user1"


### PR DESCRIPTION
a bug in the cypher logic in `RelationshipGetPeerQuery` for `branch_agnostic=True` caused it to crash if retrieving metadata b/c the query included params that do not exist (`branch0`, `branch1`, and `time0`) if the query is running in branch-agnostic mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced relationship query metadata handling to better support multi-branch scenarios with improved timestamp and authorship tracking.

* **Tests**
  * Added comprehensive testing for branch-aware relationship metadata retrieval and timestamp resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->