### PR TITLE
include created/updated_at/by metadata in merge logic

### DIFF
--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -10,6 +10,7 @@ from infrahub.core.diff.query.merge import (
     DiffMergePropertiesQuery,
     DiffMergeQuery,
     DiffMergeRollbackQuery,
+    MergeMetadataQuery,
 )
 from infrahub.log import get_logger
 
@@ -39,6 +40,7 @@ class DiffMerger:
         self.db = db
         self.diff_repository = diff_repository
         self.serializer = serializer
+        self._affected_node_uuids: list[str] = []
 
     async def merge_graph(self, at: Timestamp) -> EnrichedDiffRoot:
         tracking_id = BranchTrackingId(name=self.source_branch.name)
@@ -69,6 +71,7 @@ class DiffMerger:
                 # make sure that we use the ADDED db_id if it exists
                 # it will not if a node was migrated and then deleted
                 migrated_kinds_id_map[n.uuid] = n.identifier.db_id
+
         async for node_diff_dicts, property_diff_dicts in self.serializer.serialize_diff(diff=enriched_diff):
             if node_diff_dicts:
                 log.info(f"Merging batch of nodes #{batch_num}")
@@ -105,13 +108,31 @@ class DiffMerger:
             )
             await migrated_merge_query.execute(db=self.db)
 
+        affected_node_uuids = [n.uuid for n in enriched_diff.nodes]
+        self._affected_node_uuids = affected_node_uuids
+        if affected_node_uuids:
+            finalize_query = await MergeMetadataQuery.init(
+                db=self.db,
+                branch=self.source_branch,
+                at=at,
+                target_branch=self.destination_branch,
+                node_uuids=affected_node_uuids,
+            )
+            await finalize_query.execute(db=self.db)
+
         self.source_branch.branched_from = at.to_string()
         await self.source_branch.save(db=self.db)
         registry.branch[self.source_branch.name] = self.source_branch
         return enriched_diff
 
     async def rollback(self, at: Timestamp) -> None:
+        if not self._affected_node_uuids:
+            return
         rollback_query = await DiffMergeRollbackQuery.init(
-            db=self.db, branch=self.source_branch, target_branch=self.destination_branch, at=at
+            db=self.db,
+            branch=self.source_branch,
+            target_branch=self.destination_branch,
+            at=at,
+            node_uuids=self._affected_node_uuids,
         )
         await rollback_query.execute(db=self.db)

--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -116,14 +116,14 @@ class DiffMerger:
             for i in range(0, len(affected_node_uuids), self.metadata_batch_size):
                 batch_uuids = affected_node_uuids[i : i + self.metadata_batch_size]
                 log.info(f"Updating metadata for batch {i // self.metadata_batch_size + 1} ({len(batch_uuids)} nodes)")
-                finalize_query = await DiffMergeMetadataQuery.init(
+                metadata_query = await DiffMergeMetadataQuery.init(
                     db=self.db,
                     branch=self.source_branch,
                     at=at,
                     target_branch=self.destination_branch,
                     node_uuids=batch_uuids,
                 )
-                await finalize_query.execute(db=self.db)
+                await metadata_query.execute(db=self.db)
 
         self.source_branch.branched_from = at.to_string()
         await self.source_branch.save(db=self.db)

--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -6,11 +6,11 @@ from infrahub.core import registry
 from infrahub.core.constants import DiffAction
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.query.merge import (
+    DiffMergeMetadataQuery,
     DiffMergeMigratedKindsQuery,
     DiffMergePropertiesQuery,
     DiffMergeQuery,
     DiffMergeRollbackQuery,
-    MergeMetadataQuery,
 )
 from infrahub.log import get_logger
 
@@ -27,6 +27,8 @@ log = get_logger()
 
 
 class DiffMerger:
+    metadata_batch_size = 500
+
     def __init__(
         self,
         db: InfrahubDatabase,
@@ -111,14 +113,17 @@ class DiffMerger:
         affected_node_uuids = [n.uuid for n in enriched_diff.nodes]
         self._affected_node_uuids = affected_node_uuids
         if affected_node_uuids:
-            finalize_query = await MergeMetadataQuery.init(
-                db=self.db,
-                branch=self.source_branch,
-                at=at,
-                target_branch=self.destination_branch,
-                node_uuids=affected_node_uuids,
-            )
-            await finalize_query.execute(db=self.db)
+            for i in range(0, len(affected_node_uuids), self.metadata_batch_size):
+                batch_uuids = affected_node_uuids[i : i + self.metadata_batch_size]
+                log.info(f"Updating metadata for batch {i // self.metadata_batch_size + 1} ({len(batch_uuids)} nodes)")
+                finalize_query = await DiffMergeMetadataQuery.init(
+                    db=self.db,
+                    branch=self.source_branch,
+                    at=at,
+                    target_branch=self.destination_branch,
+                    node_uuids=batch_uuids,
+                )
+                await finalize_query.execute(db=self.db)
 
         self.source_branch.branched_from = at.to_string()
         await self.source_branch.save(db=self.db)

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -14,6 +14,7 @@ class DiffMergeQuery(Query):
     name = "diff_merge"
     type = QueryType.WRITE
     insert_return = False
+    raise_error_if_empty = False
 
     def __init__(
         self,
@@ -56,7 +57,7 @@ END AS node_db_id
 // ------------------------------
 CALL (node_diff_map, node_db_id) {
     MATCH (n:Node {uuid: node_diff_map.uuid})-[n_is_part_of:IS_PART_OF]->(:Root)
-    WHERE node_db_id IS NULL OR %(id_func)s(n) = node_db_id
+    WHERE node_db_id IS NULL OR elementId(n) = node_db_id
     AND n_is_part_of.branch IN [$source_branch, $target_branch]
     RETURN n
     ORDER BY n_is_part_of.branch_level DESC, n_is_part_of.from DESC, n_is_part_of.status ASC
@@ -79,65 +80,79 @@ CALL (n, node_diff_map, is_node_kind_migration) {
         AND is_node_kind_migration = FALSE
         MATCH (root:Root)
         // ------------------------------
+        // get from_user_id from source branch edge for creating new edges
+        // and to_user_id from source branch deleted edge for closing edges
+        // ------------------------------
+        CALL (n, root, node_rel_status) {
+            OPTIONAL MATCH (n)-[source_is_part_of:IS_PART_OF {branch: $source_branch, status: node_rel_status}]->(root)
+            WHERE source_is_part_of.from <= $at AND source_is_part_of.to IS NULL
+            RETURN source_is_part_of.from_user_id AS source_from_user_id
+            ORDER BY source_is_part_of.from DESC
+            LIMIT 1
+        }
+        // ------------------------------
         // set IS_PART_OF.to, optionally, target branch
         // ------------------------------
-        WITH root, n, node_rel_status
-        CALL (root, n, node_rel_status) {
+        WITH root, n, node_rel_status, source_from_user_id
+        CALL (root, n, node_rel_status, source_from_user_id) {
             OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(n)
             WHERE node_rel_status = "deleted"
             AND target_r_root.from <= $at AND target_r_root.to IS NULL
-            SET target_r_root.to = $at
+            SET target_r_root.to = $at, target_r_root.to_user_id = source_from_user_id
         }
         // ------------------------------
         // create new IS_PART_OF relationship on target_branch
+        // also set created_at/created_by on Node vertex when adding
         // ------------------------------
-        WITH root, n, node_rel_status
-        CALL (root, n, node_rel_status) {
+        WITH root, n, node_rel_status, source_from_user_id
+        CALL (root, n, node_rel_status, source_from_user_id) {
             OPTIONAL MATCH (root)<-[r_root:IS_PART_OF {branch: $target_branch}]-(n)
             WHERE r_root.status = node_rel_status
             AND r_root.from <= $at
             AND (r_root.to >= $at OR r_root.to IS NULL)
-            WITH r_root
+            WITH n, r_root, source_from_user_id
             WHERE r_root IS NULL
             CREATE (root)
-                <-[:IS_PART_OF { branch: $target_branch, branch_level: $branch_level, from: $at, status: node_rel_status }]
+                <-[:IS_PART_OF { branch: $target_branch, branch_level: $branch_level, from: $at, status: node_rel_status, from_user_id: source_from_user_id }]
                 -(n)
+            SET n.created_at = $at, n.created_by = source_from_user_id
         }
         // ------------------------------
         // shortcut to delete all attributes and relationships for this node if the node is deleted
         // ------------------------------
-        CALL (n, node_rel_status) {
-            WITH n, node_rel_status
+        CALL (n, node_rel_status, source_from_user_id) {
+            WITH n, node_rel_status, source_from_user_id
             WHERE node_rel_status = "deleted"
             CALL (n) {
-                OPTIONAL MATCH (n)-[rel1:IS_RELATED]-(:Relationship)-[rel2]-(p)
+                OPTIONAL MATCH (n)-[rel1:IS_RELATED]-(attr_rel:Relationship)-[rel2]-(p)
                 WHERE (p.uuid IS NULL OR n.uuid <> p.uuid)
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
                 AND rel1.status = "active"
                 AND rel2.status = "active"
-                RETURN rel1, rel2
+                RETURN rel1, rel2, attr_rel
                 UNION
-                OPTIONAL MATCH (n)-[rel1:HAS_ATTRIBUTE]->(:Attribute)-[rel2]->()
+                OPTIONAL MATCH (n)-[rel1:HAS_ATTRIBUTE]->(attr_rel:Attribute)-[rel2]->()
                 WHERE type(rel2) <> "HAS_ATTRIBUTE"
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
                 AND rel1.status = "active"
                 AND rel2.status = "active"
-                RETURN rel1, rel2
+                RETURN rel1, rel2, attr_rel
             }
-            WITH rel1, rel2
+            WITH rel1, rel2, attr_rel, source_from_user_id
             WHERE rel1.to IS NULL
             AND rel2.to IS NULL
             AND rel1.from <= $at
             AND rel2.from <= $at
-            SET rel1.to = $at
-            SET rel2.to = $at
+            SET rel1.to = $at, rel1.to_user_id = source_from_user_id
+            SET rel2.to = $at, rel2.to_user_id = source_from_user_id
+            SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = source_from_user_id
             // ------------------------------
             // and delete HAS_OWNER and HAS_SOURCE edges to this node if the node is deleted
             // ------------------------------
-            WITH n
-            CALL (n) {
+            WITH n, source_from_user_id
+            CALL (n, source_from_user_id) {
                 CALL (n) {
                     MATCH (n)<-[rel:HAS_OWNER]-()
                     WHERE rel.branch = $target_branch
@@ -153,7 +168,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                     AND rel.to IS NULL
                     RETURN rel
                 }
-                SET rel.to = $at
+                SET rel.to = $at, rel.to_user_id = source_from_user_id
             }
         }
     }
@@ -180,32 +195,47 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 ORDER BY has_attr.from DESC
                 LIMIT 1
             }
-            WITH n, attr_rel_status, a
+            // ------------------------------
+            // get from_user_id from source branch edge
+            // ------------------------------
+            CALL (n, a, attr_rel_status) {
+                OPTIONAL MATCH (n)-[source_has_attr:HAS_ATTRIBUTE {branch: $source_branch, status: attr_rel_status}]->(a)
+                WHERE source_has_attr.from <= $at AND source_has_attr.to IS NULL
+                RETURN source_has_attr.from_user_id AS attr_source_from_user_id
+                ORDER BY source_has_attr.from DESC
+                LIMIT 1
+            }
+            WITH n, attr_rel_status, a, attr_source_from_user_id
             // ------------------------------
             // set HAS_ATTRIBUTE.to on target branch if necessary
+            // set Attribute.new_updated_at/by if deleting
+            // set Attribute.created_at/by vertex when adding
             // ------------------------------
-            CALL (n, attr_rel_status, a) {
+            CALL (n, attr_rel_status, a, attr_source_from_user_id) {
                 OPTIONAL MATCH (n)
                     -[target_r_attr:HAS_ATTRIBUTE {branch: $target_branch, status: "active"}]
                     ->(a)
                 WHERE attr_rel_status = "deleted"
                 AND target_r_attr.from <= $at AND target_r_attr.to IS NULL
-                SET target_r_attr.to = $at
+                SET target_r_attr.to = $at, target_r_attr.to_user_id = attr_source_from_user_id
+                SET a.new_updated_at = $at, a.new_updated_by = attr_source_from_user_id
             }
-            WITH n, attr_rel_status, a
+            WITH n, attr_rel_status, a, attr_source_from_user_id
             // ------------------------------
             // conditionally create new HAS_ATTRIBUTE relationship on target_branch, if necessary
+            // also set created_at/created_by and new_updated_at/updated_by on Attribute vertex when adding
             // ------------------------------
-            CALL (n, attr_rel_status, a) {
-                WITH n, attr_rel_status, a
+            CALL (n, attr_rel_status, a, attr_source_from_user_id) {
+                WITH n, attr_rel_status, a, attr_source_from_user_id
                 WHERE a IS NOT NULL
                 OPTIONAL MATCH (n)-[r_attr:HAS_ATTRIBUTE {branch: $target_branch}]->(a)
                 WHERE r_attr.status = attr_rel_status
                 AND r_attr.from <= $at
                 AND (r_attr.to >= $at OR r_attr.to IS NULL)
-                WITH r_attr
+                WITH a, r_attr, attr_source_from_user_id
                 WHERE r_attr IS NULL
-                CREATE (n)-[:HAS_ATTRIBUTE { branch: $target_branch, branch_level: $branch_level, from: $at, status: attr_rel_status }]->(a)
+                CREATE (n)-[:HAS_ATTRIBUTE { branch: $target_branch, branch_level: $branch_level, from: $at, status: attr_rel_status, from_user_id: attr_source_from_user_id }]->(a)
+                SET a.created_at = $at, a.created_by = attr_source_from_user_id, a.new_updated_at = $at, a.new_updated_by = attr_source_from_user_id
             }
             RETURN 1 AS done
         }
@@ -236,7 +266,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             // ------------------------------
             CALL (rel_peer_id, rel_peer_db_id) {
                 MATCH (rel_peer:Node {uuid: rel_peer_id})-[target_is_part_of:IS_PART_OF]->(:Root)
-                WHERE (rel_peer_db_id IS NULL OR %(id_func)s(rel_peer) = rel_peer_db_id)
+                WHERE (rel_peer_db_id IS NULL OR elementId(rel_peer) = rel_peer_db_id)
                 AND target_is_part_of.branch IN [$source_branch, $target_branch]
                 RETURN rel_peer
                 ORDER BY target_is_part_of.branch_level DESC, target_is_part_of.from DESC, target_is_part_of.status ASC
@@ -244,7 +274,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             }
             WITH rel_name, related_rel_status, rel_peer
             // ------------------------------
-            // determine the directions of each IS_RELATED
+            // determine the directions of each IS_RELATED and get from_user_id from source branch
             // ------------------------------
             CALL (n, rel_name, rel_peer, related_rel_status) {
                 MATCH (n)
@@ -268,26 +298,34 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                     ELSE "l"
                 END AS r2_dir,
                 source_r_rel_1.hierarchy AS r1_hierarchy,
-                source_r_rel_2.hierarchy AS r2_hierarchy
+                source_r_rel_2.hierarchy AS r2_hierarchy,
+                source_r_rel_1.from_user_id AS r1_from_user_id,
+                source_r_rel_2.from_user_id AS r2_from_user_id
             }
-            WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, rel_name, rel_peer, related_rel_status
-            CALL (n, rel_name, rel_peer, related_rel_status) {
+            WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status
+            // ------------------------------
+            // set IS_RELATED.to on target branch when deleting relationship
+            // also set new_updated_at/updated_by on Relationship vertex
+            // ------------------------------
+            CALL (n, r, rel_name, rel_peer, related_rel_status, r1_from_user_id, r2_from_user_id) {
                 OPTIONAL MATCH (n)
                     -[target_r_rel_1:IS_RELATED {branch: $target_branch, status: "active"}]
-                    -(:Relationship {name: rel_name})
+                    -(r:Relationship {name: rel_name})
                     -[target_r_rel_2:IS_RELATED {branch: $target_branch, status: "active"}]
                     -(rel_peer)
                 WHERE related_rel_status = "deleted"
                 AND target_r_rel_1.from <= $at AND target_r_rel_1.to IS NULL
                 AND target_r_rel_2.from <= $at AND target_r_rel_2.to IS NULL
-                SET target_r_rel_1.to = $at
-                SET target_r_rel_2.to = $at
+                SET target_r_rel_1.to = $at, target_r_rel_1.to_user_id = r1_from_user_id
+                SET target_r_rel_2.to = $at, target_r_rel_2.to_user_id = r2_from_user_id
+                SET r.new_updated_at = $at, r.new_updated_by = r1_from_user_id
             }
-            WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, rel_name, rel_peer, related_rel_status
+            WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status
             // ------------------------------
             // conditionally create new IS_RELATED relationships on target_branch, if necessary
+            // also set created_at/created_by and new_updated_at/updated_by on Relationship vertex when adding
             // ------------------------------
-            CALL (n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, rel_name, rel_peer, related_rel_status) {
+            CALL (n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status) {
                 OPTIONAL MATCH (n)
                     -[r_rel_1:IS_RELATED {branch: $target_branch, status: related_rel_status}]
                     -(:Relationship {name: rel_name})
@@ -297,46 +335,48 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 AND (r_rel_1.to >= $at OR r_rel_1.to IS NULL)
                 AND r_rel_2.from <= $at
                 AND (r_rel_2.to >= $at OR r_rel_2.to IS NULL)
-                WITH rel_peer, r_rel_1, r_rel_2
+                WITH r, rel_peer, r_rel_1, r_rel_2, r1_from_user_id, r2_from_user_id
                 WHERE r_rel_1 IS NULL
                 AND r_rel_2 IS NULL
+                // set Relationship vertex metadata when adding
+                SET r.created_at = $at, r.created_by = r1_from_user_id, r.new_updated_at = $at, r.new_updated_by = r1_from_user_id
+                WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, related_rel_status, r1_from_user_id, r2_from_user_id
                 // ------------------------------
                 // create IS_RELATED relationships with directions maintained from source
                 // ------------------------------
-                CALL (n, r, r1_dir, r1_hierarchy, related_rel_status) {
-                    WITH n, r, r1_dir, r1_hierarchy, related_rel_status
+                CALL (n, r, r1_dir, r1_hierarchy, related_rel_status, r1_from_user_id) {
+                    WITH n, r, r1_dir, r1_hierarchy, related_rel_status, r1_from_user_id
                     WHERE r1_dir = "r"
                     CREATE (n)
-                        -[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r1_hierarchy}]
+                        -[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r1_hierarchy, from_user_id: r1_from_user_id}]
                         ->(r)
                 }
-                CALL (n, r, r1_dir, r1_hierarchy, related_rel_status) {
-                    WITH n, r, r1_dir, r1_hierarchy, related_rel_status
+                CALL (n, r, r1_dir, r1_hierarchy, related_rel_status, r1_from_user_id) {
+                    WITH n, r, r1_dir, r1_hierarchy, related_rel_status, r1_from_user_id
                     WHERE r1_dir = "l"
                     CREATE (n)
-                        <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r1_hierarchy}]
+                        <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r1_hierarchy, from_user_id: r1_from_user_id}]
                         -(r)
                 }
-                CALL (r, rel_peer, r2_dir, r2_hierarchy, related_rel_status) {
-                    WITH r, rel_peer, r2_dir, r2_hierarchy, related_rel_status
+                CALL (r, rel_peer, r2_dir, r2_hierarchy, related_rel_status, r2_from_user_id) {
+                    WITH r, rel_peer, r2_dir, r2_hierarchy, related_rel_status, r2_from_user_id
                     WHERE r2_dir = "r"
                     CREATE (r)
-                        -[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r2_hierarchy}]
+                        -[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r2_hierarchy, from_user_id: r2_from_user_id}]
                         ->(rel_peer)
                 }
-                CALL (r, rel_peer, r2_dir, r2_hierarchy, related_rel_status) {
-                    WITH r, rel_peer, r2_dir, r2_hierarchy, related_rel_status
+                CALL (r, rel_peer, r2_dir, r2_hierarchy, related_rel_status, r2_from_user_id) {
+                    WITH r, rel_peer, r2_dir, r2_hierarchy, related_rel_status, r2_from_user_id
                     WHERE r2_dir = "l"
                     CREATE (r)
-                        <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r2_hierarchy}]
+                        <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r2_hierarchy, from_user_id: r2_from_user_id}]
                         -(rel_peer)
                 }
             }
         }
     }
 }
-RETURN 1 AS done
-        """ % {"id_func": db.get_id_function_name()}
+        """
         self.add_to_query(query=query)
 
 
@@ -391,7 +431,7 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
             -[has_attr:HAS_ATTRIBUTE]
             ->(attr:Attribute {name: attr_rel_prop_diff.attribute_name})
         WHERE attr_rel_prop_diff.attribute_name IS NOT NULL
-        AND (node_db_id IS NULL OR %(id_func)s(n) = node_db_id)
+        AND (node_db_id IS NULL OR elementId(n) = node_db_id)
         AND has_attr.branch IN [$source_branch, $target_branch]
         RETURN attr
         ORDER BY has_attr.from DESC
@@ -404,8 +444,8 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
             -[r2:IS_RELATED]
             -(rel_peer:Node {uuid: attr_rel_prop_diff.peer_uuid})
         WHERE attr_rel_prop_diff.relationship_id IS NOT NULL
-        AND (node_db_id IS NULL OR %(id_func)s(n) = node_db_id)
-        AND (peer_db_id IS NULL OR %(id_func)s(rel_peer) = peer_db_id)
+        AND (node_db_id IS NULL OR elementId(n) = node_db_id)
+        AND (peer_db_id IS NULL OR elementId(rel_peer) = peer_db_id)
         AND r1.branch IN [$source_branch, $target_branch]
         AND r2.branch IN [$source_branch, $target_branch]
         RETURN rel
@@ -425,7 +465,7 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
         CALL (attr_rel, property_diff, peer_db_id) {
             OPTIONAL MATCH (peer:Node {uuid: property_diff.value})
             WHERE property_diff.property_type IN ["HAS_SOURCE", "HAS_OWNER"]
-            AND (peer_db_id IS NULL OR %(id_func)s(peer) = peer_db_id)
+            AND (peer_db_id IS NULL OR elementId(peer) = peer_db_id)
             // ------------------------------
             // the serialized diff might not include the values for IS_PROTECTED in
             // some cases, so we need to figure them out here
@@ -464,15 +504,27 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
             ELSE NULL
         END as prop_rel_status
         // ------------------------------
-        // set property edge.to, optionally, on target branch
+        // get from_user_id from source branch property edge
         // ------------------------------
-        CALL (attr_rel, prop_rel_status, prop_type) {
-            OPTIONAL MATCH (attr_rel)
-                -[target_r_prop {branch: $target_branch}]
-                ->()
+        CALL (attr_rel, prop_type) {
+            OPTIONAL MATCH (attr_rel)-[source_prop_edge {branch: $source_branch}]->()
+            WHERE type(source_prop_edge) = prop_type
+            AND source_prop_edge.from <= $at AND source_prop_edge.to IS NULL
+            RETURN source_prop_edge.from_user_id AS prop_source_from_user_id
+            ORDER BY source_prop_edge.from DESC
+            LIMIT 1
+        }
+        // ------------------------------
+        // set property edge.to, optionally, on target branch
+        // also set new_updated_at/updated_by on Attribute/Relationship vertex
+        // ------------------------------
+        CALL (attr_rel, prop_type, prop_node, prop_source_from_user_id) {
+            MATCH (attr_rel)-[target_r_prop {branch: $target_branch}]->(target_prop)
             WHERE type(target_r_prop) = prop_type
+            AND target_prop <> prop_node
             AND target_r_prop.from < $at AND target_r_prop.to IS NULL
-            SET target_r_prop.to = $at
+            SET target_r_prop.to = $at, target_r_prop.to_user_id = prop_source_from_user_id
+            SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = prop_source_from_user_id
         }
         // ------------------------------
         // check for existing edge on target_branch
@@ -485,35 +537,38 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
             AND (r_prop.to > $at OR r_prop.to IS NULL)
             RETURN r_prop
         }
-        WITH attr_rel,prop_rel_status, prop_type, prop_node, r_prop
+        WITH attr_rel, prop_rel_status, prop_type, prop_node, r_prop, prop_source_from_user_id
         WHERE r_prop IS NULL
+        // set updated_at/updated_by on Attribute/Relationship vertex when creating property edges
+        SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = prop_source_from_user_id
+        WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
         // ------------------------------
         // create new edge to prop_node on target_branch, if necessary
         // one subquery per possible edge type b/c edge type cannot be a variable
         // ------------------------------
-        CALL (attr_rel, prop_rel_status, prop_type, prop_node) {
-            WITH attr_rel, prop_rel_status, prop_type, prop_node
+        CALL (attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id) {
+            WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
             WHERE prop_type = "HAS_VALUE"
-            CREATE (attr_rel)-[:HAS_VALUE { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status }]->(prop_node)
+            CREATE (attr_rel)-[:HAS_VALUE { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status, from_user_id: prop_source_from_user_id }]->(prop_node)
         }
-        CALL (attr_rel, prop_rel_status, prop_type, prop_node) {
-            WITH attr_rel, prop_rel_status, prop_type, prop_node
+        CALL (attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id) {
+            WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
             WHERE prop_type = "HAS_SOURCE"
-            CREATE (attr_rel)-[:HAS_SOURCE { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status }]->(prop_node)
+            CREATE (attr_rel)-[:HAS_SOURCE { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status, from_user_id: prop_source_from_user_id }]->(prop_node)
         }
-        CALL (attr_rel, prop_rel_status, prop_type, prop_node) {
-            WITH attr_rel, prop_rel_status, prop_type, prop_node
+        CALL (attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id) {
+            WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
             WHERE prop_type = "HAS_OWNER"
-            CREATE (attr_rel)-[:HAS_OWNER { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status }]->(prop_node)
+            CREATE (attr_rel)-[:HAS_OWNER { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status, from_user_id: prop_source_from_user_id }]->(prop_node)
         }
-        CALL (attr_rel, prop_rel_status, prop_type, prop_node) {
-            WITH attr_rel, prop_rel_status, prop_type, prop_node
+        CALL (attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id) {
+            WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
             WHERE prop_type = "IS_PROTECTED"
-            CREATE (attr_rel)-[:IS_PROTECTED { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status }]->(prop_node)
+            CREATE (attr_rel)-[:IS_PROTECTED { branch: $target_branch, branch_level: $branch_level, from: $at, status: prop_rel_status, from_user_id: prop_source_from_user_id }]->(prop_node)
         }
     }
 }
-        """ % {"id_func": db.get_id_function_name()}
+        """
         self.add_to_query(query=query)
 
 
@@ -577,47 +632,46 @@ CALL (n) {
     // --------------
     // ignore edges of this type that already have the correct status on the target branch
     // --------------
-    WITH n, peer, edge_type, latest_source_edge, latest_target_edge
+    WITH n, peer, edge_type, latest_source_edge, latest_target_edge, latest_source_edge.from_user_id AS user_id
     WHERE (latest_target_edge IS NULL AND latest_source_edge.status = "active")
     OR latest_source_edge.status <> latest_target_edge.status
-    CALL (latest_source_edge, latest_target_edge) {
+    CALL (n, latest_source_edge, latest_target_edge, user_id) {
         // --------------
         // set the to time on active target branch edges that we are setting to deleted
+        // to_user_id comes from the source edge's from_user_id (user who deleted it on source branch)
         // --------------
-        WITH latest_target_edge WHERE latest_target_edge IS NOT NULL
+        WITH n, latest_target_edge, user_id WHERE latest_target_edge IS NOT NULL
         AND latest_source_edge.status = "deleted"
         AND latest_target_edge.status = "active"
         AND latest_target_edge.to IS NULL
-        SET latest_target_edge.to = $at
+        SET latest_target_edge.to = $at, latest_target_edge.to_user_id = user_id
     }
     // --------------
     // create the outbound edges on the target branch, one subquery per possible type
+    // from_user_id is copied from source edge via properties(latest_source_edge)
     // --------------
-    CALL (n, latest_source_edge, peer, edge_type) {
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
         WITH edge_type WHERE edge_type = "IS_PART_OF"
         CREATE (n)-[new_edge:IS_PART_OF]->(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET n.created_at = $at, n.created_by = user_id
     }
-    CALL (n, latest_source_edge, peer, edge_type) {
-        WITH edge_type
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+        WITH peer, user_id, edge_type
         WHERE edge_type = "IS_RELATED"
         CREATE (n)-[new_edge:IS_RELATED]->(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
-    CALL (n, latest_source_edge, peer, edge_type) {
-        WITH edge_type
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+        WITH peer, user_id, edge_type
         WHERE edge_type = "HAS_ATTRIBUTE"
         CREATE (n)-[new_edge:HAS_ATTRIBUTE]->(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
     // --------------
     // do all of this again for inbound edges
@@ -647,52 +701,126 @@ CALL (n) {
     // --------------
     // ignore edges of this type that already have the correct status on the target branch
     // --------------
-    WITH n, peer, edge_type, latest_source_edge, latest_target_edge
+    WITH n, peer, edge_type, latest_source_edge, latest_target_edge, latest_source_edge.from_user_id AS user_id
     WHERE latest_target_edge IS NULL OR latest_source_edge.status <> latest_target_edge.status
-    CALL (latest_source_edge, latest_target_edge) {
+    CALL (latest_source_edge, latest_target_edge, user_id, peer) {
         // --------------
         // set the to time on active target branch edges that we are setting to deleted
+        // to_user_id comes from the source edge's from_user_id (user who deleted it on source branch)
         // --------------
-        WITH latest_target_edge
+        WITH latest_target_edge, user_id, peer
         WHERE latest_target_edge IS NOT NULL
         AND latest_source_edge.status = "deleted"
         AND latest_target_edge.status = "active"
         AND latest_target_edge.to IS NULL
-        SET latest_target_edge.to = $at
+        SET latest_target_edge.to = $at, latest_target_edge.to_user_id = user_id
+        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
     // --------------
-    // create the outbound edges on the target branch, one subquery per possible type
+    // create the inbound edges on the target branch, one subquery per possible type
+    // from_user_id is copied from source edge via properties(latest_source_edge)
     // --------------
-    CALL (n, latest_source_edge, peer, edge_type) {
-        WITH edge_type
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+        WITH peer, user_id, edge_type
         WHERE edge_type = "IS_RELATED"
         CREATE (n)<-[new_edge:IS_RELATED]-(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
-    CALL (n, latest_source_edge, peer, edge_type) {
-        WITH edge_type
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+        WITH peer, user_id, edge_type
         WHERE edge_type = "HAS_OWNER"
         CREATE (n)<-[new_edge:HAS_OWNER]-(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
-    CALL (n, latest_source_edge, peer, edge_type) {
-        WITH edge_type
+    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+        WITH peer, user_id, edge_type
         WHERE edge_type = "HAS_SOURCE"
         CREATE (n)<-[new_edge:HAS_SOURCE]-(peer)
         SET new_edge = properties(latest_source_edge)
-        SET new_edge.from = $at
-        SET new_edge.branch_level = $branch_level
-        SET new_edge.branch = $target_branch
+        SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
 }
         """
         self.add_to_query(query)
+
+
+class MergeMetadataQuery(Query):
+    """Finalize metadata on affected nodes after merge.
+
+    For all Node, Attribute, and Relationship vertices, set the updated_at/by metadata properties in the following order
+        1. previous_updated_at/by = updated_at/by
+        2. updated_at/by = new_updated_at/by
+        3. new_updated_at/by = NULL
+    For all Nodes affected by this merge, set updated_at/by to the latest updated_at/by pair from the linked Attributes and Relationships
+    """
+
+    name = "merge_metadata"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(
+        self,
+        node_uuids: list[str],
+        at: Timestamp,
+        target_branch: Branch,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.node_uuids = node_uuids
+        self.at = at
+        self.target_branch = target_branch
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params = {
+            "node_uuids": self.node_uuids,
+            "at": self.at.to_string(),
+            "target_branch": self.target_branch.name,
+        }
+        query = """
+// Match all affected nodes
+MATCH (n:Node)
+WHERE n.uuid IN $node_uuids
+// ------------------------------------
+// set latest updated at and by for Node using its Attribute and Relationship vertices
+// Save current values to previous_updated_at/by for rollback support
+// ------------------------------------
+CALL (n) {
+    MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
+    WHERE attr_rel.new_updated_at IS NOT NULL
+    RETURN
+        attr_rel.new_updated_at AS latest_updated_at,
+        attr_rel.new_updated_by AS latest_updated_by,
+        attr_rel.new_updated_by STARTS WITH "__" AS is_system
+    ORDER BY latest_updated_at DESC, is_system ASC
+    LIMIT 1
+}
+SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+SET n.updated_at = latest_updated_at, n.updated_by = latest_updated_by
+// ------------------------------------
+// Find all connected Attribute and Relationship vertices with new_* properties
+// Save current values to previous_* for rollback support
+// Set previous_* = *, * = new_*, new_* = NULL
+// ------------------------------------
+WITH n
+CALL (n) {
+    MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
+    WHERE (attr_rel.new_updated_at IS NOT NULL)
+    WITH DISTINCT attr_rel
+    // Save current values for rollback
+    SET attr_rel.previous_updated_at = attr_rel.updated_at, attr_rel.previous_updated_by = attr_rel.updated_by
+    // Finalize Attribute vertex metadata
+    SET attr_rel.updated_at = COALESCE(attr_rel.new_updated_at, attr_rel.updated_at)
+    SET attr_rel.updated_by = COALESCE(attr_rel.new_updated_by, attr_rel.updated_by)
+    // Clear new_* properties
+    SET attr_rel.new_updated_at = NULL, attr_rel.new_updated_by = NULL
+}
+        """
+        self.add_to_query(query=query)
 
 
 class DiffMergeRollbackQuery(Query):
@@ -704,33 +832,62 @@ class DiffMergeRollbackQuery(Query):
         self,
         at: Timestamp,
         target_branch: Branch,
+        node_uuids: list[str],
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.at = at
         self.target_branch = target_branch
         self.source_branch_name = self.branch.name
+        self.node_uuids = node_uuids
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params = {
             "at": self.at.to_string(),
             "target_branch": self.target_branch.name,
             "source_branch": self.source_branch_name,
+            "node_uuids": self.node_uuids,
         }
         query = """
-        // ---------------------------
-        // reset to times on target branch
-        // ---------------------------
-        CALL () {
-            OPTIONAL MATCH ()-[r_to {to: $at, branch: $target_branch}]-()
-            SET r_to.to = NULL
-        }
-        // ---------------------------
-        // reset from times on target branch
-        // ---------------------------
-        CALL () {
-            OPTIONAL MATCH ()-[r_from {from: $at, branch: $target_branch}]-()
-            DELETE r_from
-        }
+// ---------------------------
+// Restore updated_at/by from previous_* on affected Node vertices
+// ---------------------------
+MATCH (n:Node)
+WHERE n.uuid IN $node_uuids
+CALL (n) {
+    WITH n
+    WHERE n.previous_updated_at IS NOT NULL
+    SET n.updated_at = n.previous_updated_at, n.updated_by = n.previous_updated_by
+    SET n.previous_updated_at = NULL, n.previous_updated_by = NULL
+}
+// ---------------------------
+// Restore updated_at/by from previous_* on affected Attribute/Relationship vertices
+// ---------------------------
+CALL (n) {
+    MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
+    WHERE attr_rel.previous_updated_at IS NOT NULL
+    WITH DISTINCT attr_rel
+    SET attr_rel.updated_at = attr_rel.previous_updated_at, attr_rel.updated_by = attr_rel.previous_updated_by
+    SET attr_rel.previous_updated_at = NULL, attr_rel.previous_updated_by = NULL
+}
+// ---------------------------
+// Limit results to 1 row
+// ---------------------------
+WITH 1 AS one
+LIMIT 1
+// ---------------------------
+// reset to times on target branch
+// ---------------------------
+CALL () {
+    OPTIONAL MATCH (v)-[r_to {to: $at, branch: $target_branch}]-()
+    SET r_to.to = NULL, r_to.to_user_id = NULL
+}
+// ---------------------------
+// reset from times on target branch
+// ---------------------------
+CALL () {
+    OPTIONAL MATCH (v)-[r_from {from: $at, branch: $target_branch}]-()
+    DELETE r_from
+}
         """
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
@@ -115,6 +116,8 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             CREATE (root)
                 <-[:IS_PART_OF { branch: $target_branch, branch_level: $branch_level, from: $at, status: node_rel_status, from_user_id: source_from_user_id }]
                 -(n)
+            WITH node_rel_status
+            WHERE node_rel_status = "active"
             SET n.created_at = $at, n.created_by = source_from_user_id
         }
         // ------------------------------
@@ -147,7 +150,6 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             AND rel2.from <= $at
             SET rel1.to = $at, rel1.to_user_id = source_from_user_id
             SET rel2.to = $at, rel2.to_user_id = source_from_user_id
-            SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = source_from_user_id
             // ------------------------------
             // and delete HAS_OWNER and HAS_SOURCE edges to this node if the node is deleted
             // ------------------------------
@@ -208,7 +210,6 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             WITH n, attr_rel_status, a, attr_source_from_user_id
             // ------------------------------
             // set HAS_ATTRIBUTE.to on target branch if necessary
-            // set Attribute.new_updated_at/by if deleting
             // set Attribute.created_at/by vertex when adding
             // ------------------------------
             CALL (n, attr_rel_status, a, attr_source_from_user_id) {
@@ -218,12 +219,11 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 WHERE attr_rel_status = "deleted"
                 AND target_r_attr.from <= $at AND target_r_attr.to IS NULL
                 SET target_r_attr.to = $at, target_r_attr.to_user_id = attr_source_from_user_id
-                SET a.new_updated_at = $at, a.new_updated_by = attr_source_from_user_id
             }
             WITH n, attr_rel_status, a, attr_source_from_user_id
             // ------------------------------
             // conditionally create new HAS_ATTRIBUTE relationship on target_branch, if necessary
-            // also set created_at/created_by and new_updated_at/updated_by on Attribute vertex when adding
+            // also set created_at/created_by on Attribute vertex when adding
             // ------------------------------
             CALL (n, attr_rel_status, a, attr_source_from_user_id) {
                 WITH n, attr_rel_status, a, attr_source_from_user_id
@@ -235,7 +235,9 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 WITH a, r_attr, attr_source_from_user_id
                 WHERE r_attr IS NULL
                 CREATE (n)-[:HAS_ATTRIBUTE { branch: $target_branch, branch_level: $branch_level, from: $at, status: attr_rel_status, from_user_id: attr_source_from_user_id }]->(a)
-                SET a.created_at = $at, a.created_by = attr_source_from_user_id, a.new_updated_at = $at, a.new_updated_by = attr_source_from_user_id
+                WITH attr_rel_status
+                WHERE attr_rel_status = "active"
+                SET a.created_at = $at, a.created_by = attr_source_from_user_id
             }
             RETURN 1 AS done
         }
@@ -305,7 +307,6 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status
             // ------------------------------
             // set IS_RELATED.to on target branch when deleting relationship
-            // also set new_updated_at/updated_by on Relationship vertex
             // ------------------------------
             CALL (n, r, rel_name, rel_peer, related_rel_status, r1_from_user_id, r2_from_user_id) {
                 OPTIONAL MATCH (n)
@@ -318,12 +319,11 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 AND target_r_rel_2.from <= $at AND target_r_rel_2.to IS NULL
                 SET target_r_rel_1.to = $at, target_r_rel_1.to_user_id = r1_from_user_id
                 SET target_r_rel_2.to = $at, target_r_rel_2.to_user_id = r2_from_user_id
-                SET r.new_updated_at = $at, r.new_updated_by = r1_from_user_id
             }
             WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status
             // ------------------------------
             // conditionally create new IS_RELATED relationships on target_branch, if necessary
-            // also set created_at/created_by and new_updated_at/updated_by on Relationship vertex when adding
+            // also set created_at/created_by on Relationship vertex when adding
             // ------------------------------
             CALL (n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, r1_from_user_id, r2_from_user_id, rel_name, rel_peer, related_rel_status) {
                 OPTIONAL MATCH (n)
@@ -338,8 +338,6 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 WITH r, rel_peer, r_rel_1, r_rel_2, r1_from_user_id, r2_from_user_id
                 WHERE r_rel_1 IS NULL
                 AND r_rel_2 IS NULL
-                // set Relationship vertex metadata when adding
-                SET r.created_at = $at, r.created_by = r1_from_user_id, r.new_updated_at = $at, r.new_updated_by = r1_from_user_id
                 WITH n, r, r1_dir, r2_dir, r1_hierarchy, r2_hierarchy, related_rel_status, r1_from_user_id, r2_from_user_id
                 // ------------------------------
                 // create IS_RELATED relationships with directions maintained from source
@@ -372,6 +370,10 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                         <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status, hierarchy: r2_hierarchy, from_user_id: r2_from_user_id}]
                         -(rel_peer)
                 }
+                // set Relationship vertex metadata when adding
+                WITH r
+                WHERE r.created_at IS NULL
+                SET r.created_at = $at, r.created_by = r1_from_user_id
             }
         }
     }
@@ -516,7 +518,6 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
         }
         // ------------------------------
         // set property edge.to, optionally, on target branch
-        // also set new_updated_at/updated_by on Attribute/Relationship vertex
         // ------------------------------
         CALL (attr_rel, prop_type, prop_node, prop_source_from_user_id) {
             MATCH (attr_rel)-[target_r_prop {branch: $target_branch}]->(target_prop)
@@ -524,7 +525,6 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
             AND target_prop <> prop_node
             AND target_r_prop.from < $at AND target_r_prop.to IS NULL
             SET target_r_prop.to = $at, target_r_prop.to_user_id = prop_source_from_user_id
-            SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = prop_source_from_user_id
         }
         // ------------------------------
         // check for existing edge on target_branch
@@ -539,8 +539,6 @@ CALL (attr_rel_prop_diff, node_db_id, peer_db_id) {
         }
         WITH attr_rel, prop_rel_status, prop_type, prop_node, r_prop, prop_source_from_user_id
         WHERE r_prop IS NULL
-        // set updated_at/updated_by on Attribute/Relationship vertex when creating property edges
-        SET attr_rel.new_updated_at = $at, attr_rel.new_updated_by = prop_source_from_user_id
         WITH attr_rel, prop_rel_status, prop_type, prop_node, prop_source_from_user_id
         // ------------------------------
         // create new edge to prop_node on target_branch, if necessary
@@ -663,7 +661,7 @@ CALL (n) {
         CREATE (n)-[new_edge:IS_RELATED]->(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
+        SET peer.created_at = $at, peer.created_by = user_id
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
         WITH peer, user_id, edge_type
@@ -671,7 +669,7 @@ CALL (n) {
         CREATE (n)-[new_edge:HAS_ATTRIBUTE]->(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
+        SET peer.created_at = $at, peer.created_by = user_id
     }
     // --------------
     // do all of this again for inbound edges
@@ -714,7 +712,6 @@ CALL (n) {
         AND latest_target_edge.status = "active"
         AND latest_target_edge.to IS NULL
         SET latest_target_edge.to = $at, latest_target_edge.to_user_id = user_id
-        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
     // --------------
     // create the inbound edges on the target branch, one subquery per possible type
@@ -726,7 +723,7 @@ CALL (n) {
         CREATE (n)<-[new_edge:IS_RELATED]-(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET peer.created_at = $at, peer.created_by = user_id, peer.new_updated_at = $at, peer.new_updated_by = user_id
+        SET peer.created_at = $at, peer.created_by = user_id
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
         WITH peer, user_id, edge_type
@@ -734,7 +731,6 @@ CALL (n) {
         CREATE (n)<-[new_edge:HAS_OWNER]-(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
         WITH peer, user_id, edge_type
@@ -742,21 +738,31 @@ CALL (n) {
         CREATE (n)<-[new_edge:HAS_SOURCE]-(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET peer.new_updated_at = $at, peer.new_updated_by = user_id
     }
 }
         """
         self.add_to_query(query)
 
 
-class MergeMetadataQuery(Query):
-    """Finalize metadata on affected nodes after merge.
+class DiffMergeMetadataQuery(Query):
+    """Set metadata properties on Nodes, Attributes, and Relationships included in this merge
 
-    For all Node, Attribute, and Relationship vertices, set the updated_at/by metadata properties in the following order
-        1. previous_updated_at/by = updated_at/by
-        2. updated_at/by = new_updated_at/by
-        3. new_updated_at/by = NULL
-    For all Nodes affected by this merge, set updated_at/by to the latest updated_at/by pair from the linked Attributes and Relationships
+    Each Node, Attribute, and Relationship should have its current updated_at/by (if it exists) saved in the
+    previous_updated_at/by properties to support a rollback.
+    For Attributes and Relationships (let's call them fields), set updated_by to the user_id of the latest change on
+        the field on the branch being merged
+    For Nodes, set the updated_by to the user_id of the latest change on any associated fields on this branch
+    For Nodes, Attributes, and Relationships, set updated_at to the merge time.
+
+    The logic in pseudocode
+        For each Node we care about:
+        a. For each Attribute/Relationship (let's call them "fields") linked to the Node
+            i. filter to only fields updated on the source branch
+            ii. previous_updated_at/by = updated_at/by
+            iii. identify the latest update and set updated_by = the associated user_id
+            iv. set updated_at = $at
+        b. set Node.updated_by to the user_id associated with the latest change of ALL the Node's fields
+        c. set Node.updated_at = $at
     """
 
     name = "merge_metadata"
@@ -780,45 +786,98 @@ class MergeMetadataQuery(Query):
             "node_uuids": self.node_uuids,
             "at": self.at.to_string(),
             "target_branch": self.target_branch.name,
+            "source_branch": self.branch.name,
+            "global_branch": GLOBAL_BRANCH_NAME,
+            "branched_from": self.branch.get_branched_from(),
         }
+        # ruff: noqa: E501
         query = """
-// Match all affected nodes
-MATCH (n:Node)
-WHERE n.uuid IN $node_uuids
-// ------------------------------------
-// set latest updated at and by for Node using its Attribute and Relationship vertices
-// Save current values to previous_updated_at/by for rollback support
-// ------------------------------------
-CALL (n) {
-    MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
-    WHERE attr_rel.new_updated_at IS NOT NULL
-    RETURN
-        attr_rel.new_updated_at AS latest_updated_at,
-        attr_rel.new_updated_by AS latest_updated_by,
-        attr_rel.new_updated_by STARTS WITH "__" AS is_system
-    ORDER BY latest_updated_at DESC, is_system ASC
+// --------------------
+// Match all affected nodes, accounting for nodes with migrated kind
+// for each UUID, get the latest Node that was active on this branch
+// --------------------
+UNWIND $node_uuids AS node_uuid
+CALL (node_uuid) {
+    MATCH (n:Node {uuid: node_uuid})-[e:IS_PART_OF]->(:Root)
+    WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
+    AND (
+        (e.branch = $target_branch AND e.from <= $branched_from)
+        OR (e.branch IN [$source_branch, $global_branch] AND e.from <= $at)
+    )
+    RETURN n
+    ORDER BY e.from DESC
     LIMIT 1
 }
-SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
-SET n.updated_at = latest_updated_at, n.updated_by = latest_updated_by
-// ------------------------------------
-// Find all connected Attribute and Relationship vertices with new_* properties
-// Save current values to previous_* for rollback support
-// Set previous_* = *, * = new_*, new_* = NULL
-// ------------------------------------
-WITH n
-CALL (n) {
-    MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
-    WHERE (attr_rel.new_updated_at IS NOT NULL)
-    WITH DISTINCT attr_rel
-    // Save current values for rollback
-    SET attr_rel.previous_updated_at = attr_rel.updated_at, attr_rel.previous_updated_by = attr_rel.updated_by
-    // Finalize Attribute vertex metadata
-    SET attr_rel.updated_at = COALESCE(attr_rel.new_updated_at, attr_rel.updated_at)
-    SET attr_rel.updated_by = COALESCE(attr_rel.new_updated_by, attr_rel.updated_by)
-    // Clear new_* properties
-    SET attr_rel.new_updated_at = NULL, attr_rel.new_updated_by = NULL
+// --------------------
+// Get all the Attributes and Relationships for this Node that were active on this branch at some point
+// --------------------
+MATCH (n)-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
+AND (
+    (e.branch = $target_branch AND e.from <= $branched_from)
+    OR (e.branch IN [$source_branch, $global_branch] AND e.from <= $at)
+)
+
+// --------------------
+// For each field, only include it if it has an update at $at on the target branch
+// to prevent updating metadata for conflicts in which the base branch version was accepted
+// --------------------
+WITH DISTINCT n, field
+WHERE exists((field)-[{branch: $target_branch, from: $at}]-())
+OR exists((field)-[{branch: $target_branch, to: $at}]-())
+
+// --------------------
+// For each changed field, find the latest time and user_id that updated it on the source branch
+// Check both from (creation) and to (deletion) timestamps
+// Prefer non-system users (those not starting with "__")
+// --------------------
+CALL (field) {
+    MATCH ()-[edge {branch: $source_branch}]-(field)
+    WHERE edge.from <= $at
+    // Collect both from and to timestamps as potential "change times"
+    WITH edge,
+         edge.from AS from_time,
+         edge.from_user_id AS from_user,
+         edge.to AS to_time,
+         edge.to_user_id AS to_user
+    // Create rows for each type of change
+    UNWIND [
+        CASE WHEN from_time <= $at THEN {time: from_time, user_id: from_user} ELSE NULL END,
+        CASE WHEN to_time IS NOT NULL AND to_time <= $at THEN {time: to_time, user_id: to_user} ELSE NULL END
+    ] AS change
+    WITH change WHERE change IS NOT NULL AND change.user_id IS NOT NULL
+    // Sort by time DESC, then prefer non-system users (is_system ASC puts false before true)
+    WITH change.user_id AS change_user_id, change.time AS change_time, change.user_id STARTS WITH "__" AS is_system
+    RETURN change_user_id, change_time
+    ORDER BY change_time DESC, is_system ASC
+    LIMIT 1
 }
+
+// Save current field values for rollback, then update field metadata
+WITH n, field, change_user_id, change_time
+WHERE change_user_id IS NOT NULL
+// --------------------
+// make sure not to set the previous_updated_at multiple times
+// --------------------
+CALL (field, change_user_id) {
+    WITH field
+    WHERE field.updated_at <> $at
+    SET field.previous_updated_at = field.updated_at, field.previous_updated_by = field.updated_by
+    SET field.updated_at = $at, field.updated_by = change_user_id
+}
+
+// Aggregate to find the latest change across all fields for Node-level metadata
+WITH n, change_user_id, change_time, change_user_id STARTS WITH "__" AS is_system
+ORDER BY change_time DESC, is_system ASC
+WITH n, collect(change_user_id)[0] AS node_updated_by
+
+// ------------------------------------
+// Update Node metadata with latest change across all its fields
+// ------------------------------------
+WITH n, node_updated_by
+WHERE node_updated_by IS NOT NULL
+SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+SET n.updated_at = $at, n.updated_by = node_updated_by
         """
         self.add_to_query(query=query)
 

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -861,7 +861,7 @@ WHERE change_user_id IS NOT NULL
 // --------------------
 CALL (field, change_user_id) {
     WITH field
-    WHERE field.updated_at <> $at
+    WHERE field.updated_at <> $at OR field.updated_at IS NULL
     SET field.previous_updated_at = field.updated_at, field.previous_updated_by = field.updated_by
     SET field.updated_at = $at, field.updated_by = change_user_id
 }

--- a/backend/infrahub/core/metadata/determiner.py
+++ b/backend/infrahub/core/metadata/determiner.py
@@ -47,11 +47,11 @@ class MetadataDeterminer:
             if not (field_metadata_options & MetadataOptions.CREATED_BY) and "created_by" in metadata_properties_dict:
                 field_metadata_options |= MetadataOptions.CREATED_BY
             if not (field_metadata_options & MetadataOptions.SOURCE) and (
-                "source" in metadata_properties_dict or "_relation__owner" in metadata_properties_dict
+                "source" in metadata_properties_dict or "_relation__source" in metadata_properties_dict
             ):
                 field_metadata_options |= MetadataOptions.SOURCE
             if not (field_metadata_options & MetadataOptions.OWNER) and (
-                "owner" in metadata_properties_dict or "_relation__source" in metadata_properties_dict
+                "owner" in metadata_properties_dict or "_relation__owner" in metadata_properties_dict
             ):
                 field_metadata_options |= MetadataOptions.OWNER
             if is_relationship:

--- a/backend/infrahub/core/metadata/query/node_metadata.py
+++ b/backend/infrahub/core/metadata/query/node_metadata.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.query import Query, QueryType
+
+if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
+
+
+class RelationshipDirection(Enum):
+    OUTBOUND = "outbound"
+    INBOUND = "inbound"
+    BIDIRECTIONAL = "bidirectional"
+
+
+@dataclass
+class AttributeMetadata:
+    uuid: str
+    name: str
+    is_deleted: bool
+    created_at: Timestamp | None = None
+    created_by: str | None = None
+    updated_at: Timestamp | None = None
+    updated_by: str | None = None
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.uuid,
+                self.name,
+                self.is_deleted,
+                self.created_at,
+                self.created_by,
+                self.updated_at,
+                self.updated_by,
+            )
+        )
+
+
+@dataclass
+class RelationshipMetadata:
+    uuid: str
+    identifier: str  # Relationship.name in DB (e.g., "testcar__testperson")
+    peer_uuid: str
+    direction: RelationshipDirection
+    is_deleted: bool
+    created_at: Timestamp | None = None
+    created_by: str | None = None
+    updated_at: Timestamp | None = None
+    updated_by: str | None = None
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.uuid,
+                self.identifier,
+                self.peer_uuid,
+                self.direction,
+                self.is_deleted,
+                self.created_at,
+                self.created_by,
+                self.updated_at,
+                self.updated_by,
+            )
+        )
+
+
+@dataclass
+class NodeMetadata:
+    uuid: str
+    kind: str
+    is_deleted: bool
+    created_at: Timestamp | None = None
+    created_by: str | None = None
+    updated_at: Timestamp | None = None
+    updated_by: str | None = None
+    attributes: list[AttributeMetadata] = field(default_factory=list)
+    relationships: list[RelationshipMetadata] = field(default_factory=list)
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.uuid,
+                self.kind,
+                self.is_deleted,
+                self.created_at,
+                self.created_by,
+                self.updated_at,
+                self.updated_by,
+                tuple(self.attributes),
+                tuple(self.relationships),
+            )
+        )
+
+
+class NodeMetadataDefaultBranchQuery(Query):
+    """Query to retrieve metadata for nodes and their attributes/relationships.
+
+    This query only works on the default branch and reads metadata directly from
+    vertex properties. It supports retrieving deleted nodes, attributes, and
+    relationships.
+    """
+
+    name = "node_metadata"
+    type = QueryType.READ
+    insert_return = False
+
+    def __init__(self, node_uuids: list[str], **kwargs: Any) -> None:
+        self.node_uuids = node_uuids
+        super().__init__(**kwargs)
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        if not self.branch.is_default:
+            raise ValueError("NodeMetadataQuery only runs on the default branch")
+
+        self.params["node_uuids"] = self.node_uuids
+        self.params["branch"] = self.branch.name
+
+        # Query nodes with their metadata and deletion status
+        # Then query attributes and relationships
+        query = """
+// ------------------
+// Part 1: Get node metadata with deletion status
+// ------------------
+MATCH (n:Node)
+WHERE n.uuid IN $node_uuids
+CALL (n) {
+    MATCH (n)-[r_ipo:IS_PART_OF]->(root:Root)
+    WHERE r_ipo.branch = $branch
+    RETURN r_ipo
+    ORDER BY r_ipo.from DESC
+    LIMIT 1
+}
+WITH n,
+    CASE
+        WHEN r_ipo.status = "deleted" THEN true
+        WHEN r_ipo.to IS NOT NULL THEN true
+        ELSE false
+    END AS node_is_deleted
+
+// ------------------
+// Part 2: Get attribute details
+// ------------------
+OPTIONAL MATCH (n)-[:HAS_ATTRIBUTE {branch: $branch}]->(attr:Attribute)
+WITH DISTINCT n, node_is_deleted, attr
+CALL (n, attr) {
+    OPTIONAL MATCH (n)-[r_attr:HAS_ATTRIBUTE]->(attr)
+    WHERE r_attr.branch = $branch
+    WITH r_attr, attr
+    ORDER BY r_attr.from DESC
+    LIMIT 1
+    RETURN {
+        uuid: attr.uuid,
+        name: attr.name,
+        is_deleted: CASE
+            WHEN r_attr.status = "deleted" THEN true
+            WHEN r_attr.to IS NOT NULL THEN true
+            ELSE false
+        END,
+        created_at: attr.created_at,
+        created_by: attr.created_by,
+        updated_at: attr.updated_at,
+        updated_by: attr.updated_by
+    } AS attribute_details
+}
+WITH n, node_is_deleted, COALESCE(collect(attribute_details), []) AS attributes
+
+// ------------------
+// Part 3: Get relationship details
+// ------------------
+OPTIONAL MATCH (n)-[:IS_RELATED {branch: $branch}]-(rel:Relationship)-[:IS_RELATED {branch: $branch}]-(peer:Node)
+WHERE n <> peer
+WITH DISTINCT n, node_is_deleted, attributes, rel, peer
+CALL (n, rel, peer) {
+    OPTIONAL MATCH (n)-[r1:IS_RELATED]-(rel:Relationship)-[r2:IS_RELATED]-(peer:Node)
+    WHERE r1.branch = $branch AND r2.branch = $branch
+    WITH r1, r2
+    ORDER BY r1.from DESC, r2.from DESC
+    LIMIT 1
+    RETURN {
+        uuid: rel.uuid,
+        identifier: rel.name,
+        peer_uuid: peer.uuid,
+        direction: CASE
+            WHEN startNode(r1) = n AND startNode(r2) = rel THEN "outbound"
+            WHEN startNode(r1) = rel AND startNode(r2) = peer THEN "inbound"
+            ELSE "bidirectional"
+        END,
+        is_deleted: CASE
+            WHEN (r1.status = "deleted" OR r1.to IS NOT NULL) AND (r2.status = "deleted" OR r2.to IS NOT NULL) THEN true
+            ELSE false
+        END,
+        created_at: rel.created_at,
+        created_by: rel.created_by,
+        updated_at: rel.updated_at,
+        updated_by: rel.updated_by
+    } AS relationship_details
+}
+WITH n, node_is_deleted, attributes, COALESCE(collect(relationship_details), []) AS relationships
+
+RETURN n.uuid AS node_uuid, n.kind AS node_kind, node_is_deleted,
+       n.created_at AS node_created_at, n.created_by AS node_created_by,
+       n.updated_at AS node_updated_at, n.updated_by AS node_updated_by,
+       attributes, relationships
+        """
+        self.return_labels = [
+            "node_uuid",
+            "node_kind",
+            "node_is_deleted",
+            "node_created_at",
+            "node_created_by",
+            "node_updated_at",
+            "node_updated_by",
+            "attributes",
+            "relationships",
+        ]
+        self.add_to_query(query)
+
+    def get_metadatas(self) -> list[NodeMetadata]:
+        """Process query results into NodeMetadata dataclasses."""
+        from infrahub.core.timestamp import Timestamp
+
+        nodes: list[NodeMetadata] = []
+
+        for result in self.get_results():
+            node_uuid = result.get_as_type("node_uuid", return_type=str)
+            node_kind = result.get_as_type("node_kind", return_type=str)
+            node_is_deleted = result.get_as_type("node_is_deleted", bool)
+
+            node_created_at_str = result.get_as_str("node_created_at")
+            node_created_at = Timestamp(node_created_at_str) if node_created_at_str else None
+            node_created_by = result.get_as_str("node_created_by")
+            node_updated_at_str = result.get_as_str("node_updated_at")
+            node_updated_at = Timestamp(node_updated_at_str) if node_updated_at_str else None
+            node_updated_by = result.get_as_str("node_updated_by")
+
+            # Parse attributes
+            attributes_data: list[dict[str, Any]] = result.get_as_type("attributes", list)
+            attributes: list[AttributeMetadata] = []
+            for attr_data in attributes_data:
+                attr_created_at_str = attr_data.get("created_at")
+                attr_created_at = Timestamp(attr_created_at_str) if attr_created_at_str else None
+                attr_updated_at_str = attr_data.get("updated_at")
+                attr_updated_at = Timestamp(attr_updated_at_str) if attr_updated_at_str else None
+
+                attributes.append(
+                    AttributeMetadata(
+                        uuid=attr_data["uuid"],
+                        name=attr_data["name"],
+                        is_deleted=attr_data["is_deleted"],
+                        created_at=attr_created_at,
+                        created_by=attr_data.get("created_by"),
+                        updated_at=attr_updated_at,
+                        updated_by=attr_data.get("updated_by"),
+                    )
+                )
+
+            # Parse relationships
+            relationships_data: list[dict[str, Any]] = result.get_as_type("relationships", list)
+            relationships: list[RelationshipMetadata] = []
+            for rel_data in relationships_data:
+                rel_created_at_str = rel_data.get("created_at")
+                rel_created_at = Timestamp(rel_created_at_str) if rel_created_at_str else None
+                rel_updated_at_str = rel_data.get("updated_at")
+                rel_updated_at = Timestamp(rel_updated_at_str) if rel_updated_at_str else None
+
+                direction_str = rel_data["direction"]
+                direction = RelationshipDirection(direction_str)
+
+                relationships.append(
+                    RelationshipMetadata(
+                        uuid=rel_data["uuid"],
+                        identifier=rel_data["identifier"],
+                        peer_uuid=rel_data["peer_uuid"],
+                        direction=direction,
+                        is_deleted=rel_data["is_deleted"],
+                        created_at=rel_created_at,
+                        created_by=rel_data.get("created_by"),
+                        updated_at=rel_updated_at,
+                        updated_by=rel_data.get("updated_by"),
+                    )
+                )
+
+            nodes.append(
+                NodeMetadata(
+                    uuid=node_uuid,
+                    kind=node_kind,
+                    is_deleted=node_is_deleted,
+                    created_at=node_created_at,
+                    created_by=node_created_by,
+                    updated_at=node_updated_at,
+                    updated_by=node_updated_by,
+                    attributes=attributes,
+                    relationships=relationships,
+                )
+            )
+
+        return nodes

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -993,7 +993,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         if self._human_friendly_id:
             if deleted_attribute := await self._human_friendly_id.get_node_attribute(node=self, at=delete_at).delete(
-                 db=db, user_id=user_id, at=delete_at,
+                db=db,
+                user_id=user_id,
+                at=delete_at,
             ):
                 node_changelog.add_attribute(attribute=deleted_attribute)
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -988,18 +988,18 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         # Go over the list of Attribute and update them one by one
         for name in self._attributes:
             attr: BaseAttribute = getattr(self, name)
-            if deleted_attribute := await attr.delete(at=delete_at, db=db):
+            if deleted_attribute := await attr.delete(db=db, at=delete_at, user_id=user_id):
                 node_changelog.add_attribute(attribute=deleted_attribute)
 
         if self._human_friendly_id:
             if deleted_attribute := await self._human_friendly_id.get_node_attribute(node=self, at=delete_at).delete(
-                at=delete_at, db=db
+                 db=db, user_id=user_id, at=delete_at,
             ):
                 node_changelog.add_attribute(attribute=deleted_attribute)
 
         if self._display_label:
             if deleted_attribute := await self._display_label.get_node_attribute(node=self, at=delete_at).delete(
-                at=delete_at, db=db
+                db=db, at=delete_at, user_id=user_id
             ):
                 node_changelog.add_attribute(attribute=deleted_attribute)
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -768,10 +768,12 @@ WITH *, r1.from AS created_at, r1.from_user_id AS created_by
 WITH *, a.updated_at AS updated_at, a.updated_by AS updated_by
             """
         else:
-            last_updated_query = """
-CALL (a) {
-    MATCH (a)-[r]-(property)
-    WHERE %(branch_filter)s
+            if self.branch_agnostic:
+                time_details = """
+    WITH [r.from, r.from_user_id] AS from_details, [r.to, r.to_user_id] AS to_details
+                """
+            else:
+                time_details = """
     WITH CASE
         WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
         WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
@@ -782,6 +784,12 @@ CALL (a) {
         WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
         ELSE [NULL, NULL]
     END AS to_details
+                """
+            last_updated_query = """
+CALL (a) {
+    MATCH (a)-[r]-(property)
+    WHERE %(branch_filter)s
+    %(time_details)s
     WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
     WITH from_details_list + to_details_list AS details_list
     UNWIND details_list AS one_details
@@ -792,7 +800,7 @@ CALL (a) {
     LIMIT 1
     RETURN updated_at, updated_by
 }
-            """ % {"branch_filter": branch_filter_str}
+            """ % {"branch_filter": branch_filter_str, "time_details": time_details}
         self.add_to_query(last_updated_query)
         self.return_labels.extend(["updated_at", "updated_by"])
 
@@ -1045,10 +1053,12 @@ WITH *, created_details[0] AS created_at, created_details[1] AS created_by
 WITH *, rel.updated_at AS updated_at, rel.updated_by AS updated_by
             """
         else:
-            last_updated_query = """
-CALL (rel) {
-    MATCH (rel)-[r]-(property)
-    WHERE %(branch_filter)s
+            if self.branch_agnostic:
+                time_details = """
+    WITH [r.from, r.from_user_id] AS from_details, [r.to, r.to_user_id] AS to_details
+                """
+            else:
+                time_details = """
     WITH CASE
         WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
         WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
@@ -1059,6 +1069,12 @@ CALL (rel) {
         WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
         ELSE [NULL, NULL]
     END AS to_details
+                """
+            last_updated_query = """
+CALL (rel) {
+    MATCH (rel)-[r]-(property)
+    WHERE %(branch_filter)s
+    %(time_details)s
     WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
     WITH from_details_list + to_details_list AS details_list
     UNWIND details_list AS one_details
@@ -1069,7 +1085,7 @@ CALL (rel) {
     LIMIT 1
     RETURN updated_at, updated_by
 }
-            """ % {"branch_filter": branch_filter_str}
+            """ % {"branch_filter": branch_filter_str, "time_details": time_details}
         self.add_to_query(last_updated_query)
         self.return_labels.extend(["updated_at", "updated_by"])
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -1266,6 +1266,23 @@ class NodeListGetInfoQuery(Query):
 WITH *, n.updated_at AS updated_at, n.updated_by AS updated_by
             """
         else:
+            if self.branch_agnostic:
+                time_details = """
+    WITH [r.from, r.from_user_id] AS from_details, [r.to, r.to_user_id] AS to_details
+                """
+            else:
+                time_details = """
+    WITH CASE
+        WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
+        WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
+        ELSE [NULL, NULL]
+    END AS from_details,
+    CASE
+        WHEN r.branch IN $branch0 AND r.to < $time0 THEN [r.to, r.to_user_id]
+        WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
+        ELSE [NULL, NULL]
+    END AS to_details
+                """
             last_update_query = """
 MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
 WHERE %(branch_filter)s
@@ -1282,16 +1299,7 @@ WHERE is_active = TRUE
 CALL (field) {
     MATCH (field)-[r]-(property)
     WHERE %(branch_filter)s
-    WITH CASE
-        WHEN r.branch IN $branch0 AND r.from < $time0 THEN [r.from, r.from_user_id]
-        WHEN r.branch IN $branch1 AND r.from < $time1 THEN [r.from, r.from_user_id]
-        ELSE [NULL, NULL]
-    END AS from_details,
-    CASE
-        WHEN r.branch IN $branch0 AND r.to < $time0 THEN [r.to, r.to_user_id]
-        WHEN r.branch IN $branch1 AND r.to < $time1 THEN [r.to, r.to_user_id]
-        ELSE [NULL, NULL]
-    END AS to_details
+    %(time_details)s
     WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
     WITH from_details_list + to_details_list AS details_list
     UNWIND details_list AS one_details
@@ -1306,7 +1314,7 @@ WITH n, r_is_part_of, updated_at, updated_by
 // updated_by ordering preferences non "__system__" users
 ORDER BY elementId(n), updated_at DESC, updated_by DESC
 WITH n, r_is_part_of, head(collect(updated_at)) AS updated_at, head(collect(updated_by)) AS updated_by
-            """ % {"branch_filter": branch_filter_str}
+            """ % {"branch_filter": branch_filter_str, "time_details": time_details}
         self.add_to_query(last_update_query)
         self.return_labels.extend(["updated_at", "updated_by"])
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1159,6 +1159,7 @@ class RelationshipManager:
         | None,
         db: InfrahubDatabase,
         process_delete: bool = True,
+        user_id: str = SYSTEM_USER_ID,
     ) -> bool:
         """Replace and Update the list of relationships with this one."""
         if not isinstance(data, list):
@@ -1189,7 +1190,7 @@ class RelationshipManager:
                 if previous_relationships:
                     if process_delete:
                         for rel in previous_relationships.values():
-                            await rel.delete(db=db)
+                            await rel.delete(db=db, user_id=user_id)
                     changed = True
                 continue
 

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -19,6 +19,7 @@ from infrahub.core.diff.model.path import ConflictSelection
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.query.node_metadata import NodeMetadataDefaultBranchQuery
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
@@ -144,6 +145,113 @@ class TestDiffAndMerge:
         assert "num_cupholders" not in attribute_names
         assert "is_cool" not in attribute_names
         assert "nickname" not in attribute_names
+        await verify_no_duplicate_paths(db=db)
+
+    @pytest.mark.parametrize(
+        "base_action,diff_action,selection,expect_deleted",
+        [
+            # DELETE on base + UPDATE on diff: selecting BASE_BRANCH keeps the node deleted
+            ("delete", "update", ConflictSelection.BASE_BRANCH, True),
+            # UPDATE on base + DELETE on diff: selecting BASE_BRANCH keeps the node with base value
+            ("update", "delete", ConflictSelection.BASE_BRANCH, False),
+            # Note: DIFF_BRANCH selection for node-level conflicts involving deletion is not tested here
+            # because un-deleting an object on the default branch is not supported
+        ],
+    )
+    async def test_node_delete_update_conflict(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        person_john_main: Node,
+        base_action: str,
+        diff_action: str,
+        selection: ConflictSelection,
+        expect_deleted: bool,
+    ) -> None:
+        """Test node-level conflicts between delete and update operations.
+
+        This test covers scenarios where BASE_BRANCH is selected to resolve the conflict:
+        1. DELETE on base + UPDATE on diff + select BASE_BRANCH = Node deleted
+        2. UPDATE on base + DELETE on diff + select BASE_BRANCH = Node exists with base value
+
+        Note: Selecting DIFF_BRANCH for node-level delete conflicts is not supported because
+        un-deleting an object on the default branch is not allowed.
+        """
+        # Capture initial metadata
+        person_before = await NodeManager.get_one(
+            db=db, id=person_john_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        person_created_at = person_before._get_created_at()
+        person_created_by = person_before._get_created_by()
+
+        branch2 = await create_branch(db=db, branch_name="branch2")
+
+        # Perform actions based on test parameters
+        before_base_update = Timestamp()
+        if base_action == "delete":
+            person_main = await NodeManager.get_one(db=db, id=person_john_main.id)
+            await person_main.delete(db=db, user_id="main-user")
+        else:  # base_action == "update"
+            person_main = await NodeManager.get_one(db=db, id=person_john_main.id)
+            person_main.height.value = 200
+            await person_main.save(db=db, user_id="main-user")
+        after_base_update = Timestamp()
+
+        if diff_action == "delete":
+            person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
+            await person_branch.delete(db=db, user_id="branch-user")
+        else:  # diff_action == "update"
+            person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
+            person_branch.height.value = 150
+            await person_branch.save(db=db, user_id="branch-user")
+
+        # Run diff coordinator to detect conflicts
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
+        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+
+        # Assert a node-level conflict is detected
+        conflicts_map = enriched_diff.get_all_conflicts()
+        assert len(conflicts_map) >= 1
+        conflict_node = get_one_diff_node(diff_root=enriched_diff, node_uuid=person_john_main.id)
+        assert conflict_node.conflict is not None
+        if base_action == "delete":
+            assert conflict_node.conflict.base_branch_action is DiffAction.REMOVED
+            assert conflict_node.conflict.diff_branch_action is DiffAction.UPDATED
+        else:  # base_action == "update"
+            assert conflict_node.conflict.base_branch_action is DiffAction.UPDATED
+            assert conflict_node.conflict.diff_branch_action is DiffAction.REMOVED
+
+        # Set conflict resolution
+        await diff_repository.update_conflict_by_id(conflict_id=conflict_node.conflict.uuid, selection=selection)
+
+        # Merge the branch
+        merge_at = Timestamp()
+        diff_merger = await self._get_diff_merger(db=db, branch=branch2)
+        await diff_merger.merge_graph(at=merge_at)
+
+        # Validate outcome
+        if expect_deleted:
+            # Node should be deleted
+            with pytest.raises(NodeNotFoundError):
+                await NodeManager.get_one(db=db, id=person_john_main.id, raise_on_error=True)
+        else:
+            # Node should exist
+            updated_person = await NodeManager.get_one(
+                db=db, id=person_john_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+            )
+            assert updated_person is not None
+
+            # base_action must be "update" (since expect_deleted is False and selection is BASE_BRANCH)
+            assert updated_person.height.value == 200
+            # Metadata should reflect main-user's update
+            assert before_base_update < updated_person._get_updated_at() < after_base_update
+            assert updated_person._get_updated_by() == "main-user"
+
+            # created_at/created_by should remain unchanged
+            assert updated_person._get_created_at() == person_created_at
+            assert updated_person._get_created_by() == person_created_by
+
         await verify_no_duplicate_paths(db=db)
 
     @pytest.mark.parametrize(
@@ -712,10 +820,47 @@ class TestDiffAndMerge:
         )
         best_friend_rels = await updated_friend.best_friends.get_relationships(db=db)
         assert len(best_friend_rels) == 0
+
         assert before_friend_create < updated_friend._get_created_at() < after_friend_create
         assert updated_friend._get_created_by() == "main-user-friend"
         assert updated_friend._get_updated_at() == merge_at
         assert updated_friend._get_updated_by() == "branch-user"
+
+        # Verify metadata on deleted relationships using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[dog_main.id, friend_main.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 2
+
+        metadata_by_uuid = {m.uuid: m for m in node_metadatas}
+
+        # Validate dog's relationship to friend (deleted)
+        dog_meta = metadata_by_uuid[dog_main.id]
+        assert dog_meta.is_deleted is False
+        dog_rels_to_friend = [r for r in dog_meta.relationships if r.peer_uuid == friend_main.id]
+        assert len(dog_rels_to_friend) == 1
+        dog_rel_to_friend = dog_rels_to_friend[0]
+        assert dog_rel_to_friend.is_deleted is True
+        assert before_dog_create < dog_rel_to_friend.created_at < after_dog_create
+        assert dog_rel_to_friend.created_by == "main-user-dog"
+        assert dog_rel_to_friend.updated_at == merge_at
+        assert dog_rel_to_friend.updated_by == "branch-user"
+
+        # Validate friend's relationship to dog (deleted)
+        friend_meta = metadata_by_uuid[friend_main.id]
+        assert friend_meta.is_deleted is False
+        friend_rels_to_dog = [r for r in friend_meta.relationships if r.peer_uuid == dog_main.id]
+        assert len(friend_rels_to_dog) == 1
+        friend_rel_to_dog = friend_rels_to_dog[0]
+        assert friend_rel_to_dog.is_deleted is True
+        assert before_dog_create < friend_rel_to_dog.created_at < after_dog_create
+        assert friend_rel_to_dog.created_by == "main-user-dog"
+        assert friend_rel_to_dog.updated_at == merge_at
+        assert friend_rel_to_dog.updated_by == "branch-user"
 
         await verify_no_duplicate_paths(db=db)
 
@@ -1092,12 +1237,15 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ) -> None:
+        car_created_at = car_accord_main._get_created_at()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
-        await car_main.save(db=db)
+        before_alfred_update = Timestamp()
+        await car_main.save(db=db, user_id="main-user")
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
-        await car_branch.delete(db=db)
+        await car_branch.delete(db=db, user_id="branch-user")
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
@@ -1112,7 +1260,9 @@ class TestDiffAndMerge:
         # manually resolve the conflict
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
-        await car_main.save(db=db)
+        before_owner_rel_resolved = Timestamp()
+        await car_main.save(db=db, user_id="main-user-2")
+        after_owner_rel_resolved = Timestamp()
 
         # check that the conflict is removed
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -1124,9 +1274,9 @@ class TestDiffAndMerge:
         conflicts_map = enriched_diff.get_all_conflicts()
         assert len(conflicts_map) == 0
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         # validate that the car was deleted
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
@@ -1139,7 +1289,87 @@ class TestDiffAndMerge:
         cars_rels = await john_main.cars.get(db=db)
         assert len(cars_rels) == 0
 
-        await diff_merger.rollback(at=at)
+        # Validate metadata using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[car_accord_main.id, person_john_main.id, person_alfred_main.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 3
+
+        metadata_by_uuid = {m.uuid: m for m in node_metadatas}
+
+        # Validate car_accord_main (deleted)
+        car_meta = metadata_by_uuid[car_accord_main.id]
+        assert car_meta.is_deleted is True
+        assert car_meta.created_at == car_created_at
+        assert car_meta.created_by == SYSTEM_USER_ID
+        assert car_meta.updated_at == merge_at
+        assert car_meta.updated_by == "branch-user"
+
+        # Validate car's attributes (all deleted)
+        for attr in car_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_at == car_created_at
+            assert attr.created_by == SYSTEM_USER_ID
+            assert attr.updated_at == merge_at
+            assert attr.updated_by == "branch-user"
+
+        # Validate car's relationship to john (deleted)
+        # two relationships, both deleted
+        car_rels_to_john = sorted(
+            [r for r in car_meta.relationships if r.peer_uuid == person_john_main.id], key=lambda r: r.updated_at
+        )
+        assert len(car_rels_to_john) == 2
+        resolved_conflict_rel_to_john = car_rels_to_john[0]
+        assert resolved_conflict_rel_to_john.is_deleted is True
+        assert resolved_conflict_rel_to_john.created_by == "main-user-2"
+        assert before_owner_rel_resolved < resolved_conflict_rel_to_john.created_at < after_owner_rel_resolved
+        assert resolved_conflict_rel_to_john.updated_by == "main-user-2"
+        assert before_owner_rel_resolved < resolved_conflict_rel_to_john.updated_at < after_owner_rel_resolved
+        # original is actually updated later b/c it happens durign the merge
+        original_rel_to_john = car_rels_to_john[1]
+        assert original_rel_to_john.is_deleted is True
+        assert original_rel_to_john.created_by == SYSTEM_USER_ID
+        assert original_rel_to_john.created_at == car_created_at
+        assert original_rel_to_john.updated_by == "branch-user"
+        assert original_rel_to_john.updated_at == merge_at
+
+        # Validate person_john_main (has deleted relationship to car)
+        john_meta = metadata_by_uuid[person_john_main.id]
+        assert john_meta.is_deleted is False
+        # John's relationship to car should be deleted (via cascade from car deletion)
+        john_rels_to_car = sorted(
+            [r for r in john_meta.relationships if r.peer_uuid == car_accord_main.id], key=lambda r: r.updated_at
+        )
+        assert len(john_rels_to_car) == 2
+        resolved_conflict_rel_to_car = john_rels_to_car[0]
+        assert resolved_conflict_rel_to_car.is_deleted is True
+        assert resolved_conflict_rel_to_car.created_by == "main-user-2"
+        assert before_owner_rel_resolved < resolved_conflict_rel_to_car.created_at < after_owner_rel_resolved
+        assert resolved_conflict_rel_to_car.updated_by == "main-user-2"
+        assert before_owner_rel_resolved < resolved_conflict_rel_to_car.updated_at < after_owner_rel_resolved
+        # original is actually updated later b/c it happens durign the merge
+        original_rel_to_car = john_rels_to_car[1]
+        assert original_rel_to_car.is_deleted is True
+        assert original_rel_to_car.created_by == SYSTEM_USER_ID
+        assert original_rel_to_car.created_at == car_created_at
+        assert original_rel_to_car.updated_by == "branch-user"
+        assert original_rel_to_car.updated_at == merge_at
+
+        # Validate person_alfred_main (should have no relationship to car since it was
+        # added after branch creation and then reverted before merge)
+        alfred_meta = metadata_by_uuid[person_alfred_main.id]
+        assert alfred_meta.is_deleted is False
+        assert alfred_meta.created_by == SYSTEM_USER_ID
+        assert alfred_meta.created_at < before_alfred_update
+        # the car-alfred relationship is deleted by main-user-2
+        assert alfred_meta.updated_by == "main-user-2"
+        assert before_owner_rel_resolved < alfred_meta.updated_at < after_owner_rel_resolved
+
+        await diff_merger.rollback(at=merge_at)
 
         rolled_back_car = await NodeManager.get_one(
             db=db, id=car_accord_main.id, include_metadata=MetadataOptions.OWNER
@@ -1147,6 +1377,22 @@ class TestDiffAndMerge:
         owner_rel = await rolled_back_car.owner.get(db=db)
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is False
+<<<<<<< HEAD
+=======
+        assert owner_rel.is_visible is True
+
+        # Validate metadata after rollback - car should have metadata from before merge
+        # The car was modified on main (twice: first to alfred, then back to john)
+        # After rollback, the metadata should reflect the main-user-2 changes (the last main branch change)
+        rolled_back_car_with_metadata = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        # The car Node metadata should reflect the main-user-2 changes since that was the last change on main
+        assert rolled_back_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata._get_created_at() == car_created_at
+        assert rolled_back_car_with_metadata._get_updated_by() == "main-user-2"
+        assert before_owner_rel_resolved < rolled_back_car_with_metadata._get_updated_at() < after_owner_rel_resolved
+>>>>>>> d0b4d3025 (update unit tests some more)
         await verify_no_duplicate_paths(db=db)
 
     async def test_base_delete_with_added_branch_relationship(
@@ -1160,12 +1406,17 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ) -> None:
+        car_created_at = car_accord_main._get_created_at()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
-        await car_branch.save(db=db)
+        before_branch_update = Timestamp()
+        await car_branch.save(db=db, user_id="branch-user")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
-        await car_main.delete(db=db)
+        before_main_delete = Timestamp()
+        await car_main.delete(db=db, user_id="main-user")
+        after_main_delete = Timestamp()
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
@@ -1180,16 +1431,21 @@ class TestDiffAndMerge:
         # manually resolve the conflict
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
-        await car_branch.save(db=db)
+        await car_branch.save(db=db, user_id="branch-user-2")
 
         # check that the conflict is removed
-        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch2
+        )
+        enriched_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
+        )
         conflicts_map = enriched_diff.get_all_conflicts()
         assert len(conflicts_map) == 0
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         # validate that the car remains deleted
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
@@ -1202,11 +1458,110 @@ class TestDiffAndMerge:
         cars_rels = await john_main.cars.get(db=db)
         assert len(cars_rels) == 0
 
-        await diff_merger.rollback(at=at)
+        # Validate metadata using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[car_accord_main.id, person_john_main.id, person_alfred_main.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 3
 
-        # validate that car remains deleted after rollback
+        metadata_by_uuid = {m.uuid: m for m in node_metadatas}
+
+        # Validate car_accord_main (deleted on main, remains deleted after merge)
+        car_meta = metadata_by_uuid[car_accord_main.id]
+        assert car_meta.is_deleted is True
+        assert car_meta.created_at == car_created_at
+        assert car_meta.created_by == SYSTEM_USER_ID
+        # Car was deleted on main, so updated_at/by should reflect main-user's delete
+        assert before_main_delete < car_meta.updated_at < after_main_delete
+        assert car_meta.updated_by == "main-user"
+
+        # Validate car's attributes (all deleted)
+        for attr in car_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_at == car_created_at
+            assert attr.created_by == SYSTEM_USER_ID
+            assert before_main_delete < attr.updated_at < after_main_delete
+            assert attr.updated_by == "main-user"
+
+        # Validate car's relationship to john (deleted)
+        # The original relationship to john was deleted when car was deleted on main
+        car_rels_to_john = [r for r in car_meta.relationships if r.peer_uuid == person_john_main.id]
+        assert len(car_rels_to_john) == 1
+        original_rel_to_john = car_rels_to_john[0]
+        assert original_rel_to_john.is_deleted is True
+        assert original_rel_to_john.created_by == SYSTEM_USER_ID
+        assert original_rel_to_john.created_at == car_created_at
+        assert original_rel_to_john.updated_by == "main-user"
+        assert before_main_delete < original_rel_to_john.updated_at < after_main_delete
+
+        # Validate person_john_main (has deleted relationship to car)
+        john_meta = metadata_by_uuid[person_john_main.id]
+        assert john_meta.is_deleted is False
+        # John's relationship to car should be deleted (car was deleted on main)
+        john_rels_to_car = [r for r in john_meta.relationships if r.peer_uuid == car_accord_main.id]
+        assert len(john_rels_to_car) == 1
+        john_rel_to_car = john_rels_to_car[0]
+        assert john_rel_to_car.is_deleted is True
+        assert john_rel_to_car.created_by == SYSTEM_USER_ID
+        assert john_rel_to_car.created_at == car_created_at
+        assert john_rel_to_car.updated_by == "main-user"
+        assert before_main_delete < john_rel_to_car.updated_at < after_main_delete
+
+        # Validate person_alfred_main (should have no relationship to car since the branch
+        # changes are discarded when the car remains deleted)
+        alfred_meta = metadata_by_uuid[person_alfred_main.id]
+        assert alfred_meta.is_deleted is False
+        assert alfred_meta.created_by == SYSTEM_USER_ID
+        assert alfred_meta.created_at < before_branch_update
+        #  Alfred remains unchanged on main
+        assert alfred_meta.updated_by == SYSTEM_USER_ID
+        assert alfred_meta.updated_at < before_branch_update
+        # Alfred should not have been updated by this merge since branch changes were discarded
+        alfred_rels_to_car = [r for r in alfred_meta.relationships if r.peer_uuid == car_accord_main.id]
+        assert len(alfred_rels_to_car) == 0
+
+        await diff_merger.rollback(at=merge_at)
+
+        # validate that car remains deleted after rollback (no change expected)
         rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
         assert rolled_back_car is None
+
+        # Validate metadata after rollback - car should still be deleted with same metadata
+        node_metadata_query_after_rollback = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[car_accord_main.id, person_john_main.id, person_alfred_main.id],
+        )
+        await node_metadata_query_after_rollback.execute(db=db)
+        node_metadatas_after_rollback = node_metadata_query_after_rollback.get_metadatas()
+        assert len(node_metadatas_after_rollback) == 3
+
+        metadata_by_uuid_after_rollback = {m.uuid: m for m in node_metadatas_after_rollback}
+
+        # Validate car metadata after rollback - should be same as after merge
+        car_meta_after_rollback = metadata_by_uuid_after_rollback[car_accord_main.id]
+        assert car_meta_after_rollback.is_deleted is True
+        assert car_meta_after_rollback.created_at == car_created_at
+        assert car_meta_after_rollback.created_by == SYSTEM_USER_ID
+        assert before_main_delete < car_meta_after_rollback.updated_at < after_main_delete
+        assert car_meta_after_rollback.updated_by == "main-user"
+
+        # Validate john metadata after rollback
+        john_meta_after_rollback = metadata_by_uuid_after_rollback[person_john_main.id]
+        assert john_meta_after_rollback.is_deleted is False
+        john_rels_to_car_after_rollback = [
+            r for r in john_meta_after_rollback.relationships if r.peer_uuid == car_accord_main.id
+        ]
+        assert len(john_rels_to_car_after_rollback) == 1
+        john_rel_to_car_after_rollback = john_rels_to_car_after_rollback[0]
+        assert john_rel_to_car_after_rollback.is_deleted is True
+        assert john_rel_to_car_after_rollback.updated_by == "main-user"
+        assert before_main_delete < john_rel_to_car_after_rollback.updated_at < after_main_delete
+
         await verify_no_duplicate_paths(db=db)
 
     async def test_delete_with_many_relationship_added(
@@ -1216,29 +1571,44 @@ class TestDiffAndMerge:
         car_schema = car_person_schema_unregistered.get(name="TestCar")
         car_schema.relationships = []
         registry.schema.register_schema(schema=car_person_schema_unregistered, branch=default_branch.name)
-        # initial data
+
+        # initial data - track creation timestamps
+        before_person_1_create = Timestamp()
         person_1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
         await person_1.new(db=db, name="Alice", height=160)
-        await person_1.save(db=db)
+        await person_1.save(db=db, user_id="setup-user")
+        after_person_1_create = Timestamp()
+
+        before_person_2_create = Timestamp()
         person_2 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
         await person_2.new(db=db, name="Bob", height=161)
-        await person_2.save(db=db)
+        await person_2.save(db=db, user_id="setup-user")
+        after_person_2_create = Timestamp()
+
+        before_car_1_create = Timestamp()
         car_1 = await Node.init(db=db, schema="TestCar", branch=default_branch)
         await car_1.new(db=db, name="smart", nbr_seats=2, is_electric=True)
-        await car_1.save(db=db)
+        await car_1.save(db=db, user_id="setup-user")
+        after_car_1_create = Timestamp()
+
+        before_car_2_create = Timestamp()
         car_2 = await Node.init(db=db, schema="TestCar", branch=default_branch)
         await car_2.new(db=db, name="big", nbr_seats=12, is_electric=False)
-        await car_2.save(db=db)
+        await car_2.save(db=db, user_id="setup-user")
+        after_car_2_create = Timestamp()
+
         # make the branch
         branch2 = await create_branch(db=db, branch_name="branch2")
 
         # add relationship on main
+        before_rel_create = Timestamp()
         person_1_main = await NodeManager.get_one(db=db, id=person_1.id)
         await person_1_main.cars.update(db=db, data=[car_1, car_2])
-        await person_1_main.save(db=db)
+        await person_1_main.save(db=db, user_id="main-user")
+        after_rel_create = Timestamp()
         # delete node on branch
         person_1_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_1.id)
-        await person_1_branch.delete(db=db)
+        await person_1_branch.delete(db=db, user_id="branch-user")
 
         # check that there are no conflicts
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
@@ -1247,9 +1617,9 @@ class TestDiffAndMerge:
         assert len(conflicts_map) == 0
 
         # merge the branch
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         # validate that person_1 is deleted
         deleted_person = await NodeManager.get_one(db=db, id=person_1.id)
@@ -1260,6 +1630,102 @@ class TestDiffAndMerge:
         await verify_all_linked_edges_deleted(db=db, node_uuid=person_1.id, branch_name=default_branch.name)
         await verify_no_duplicate_paths(db=db)
 
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[person_1.get_id(), person_2.get_id(), car_1.get_id(), car_2.get_id()],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 4
+
+        # Get metadata by node UUID for easier assertions
+        metadata_by_uuid = {m.uuid: m for m in node_metadatas}
+
+        # Validate person_1 (deleted)
+        person_1_meta = metadata_by_uuid[person_1.id]
+        assert person_1_meta.is_deleted is True
+        assert person_1_meta.created_by == "setup-user"
+        assert before_person_1_create < person_1_meta.created_at < after_person_1_create
+        assert person_1_meta.updated_by == "branch-user"
+        assert person_1_meta.updated_at == merge_at
+
+        # Validate person_1's attributes (all deleted)
+        for attr in person_1_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_by == "setup-user"
+            assert before_person_1_create < attr.created_at < after_person_1_create
+            assert attr.updated_by == "branch-user"
+            assert attr.updated_at == merge_at
+
+        # Validate person_1's relationships to car_1 and car_2 (all deleted)
+        # NOTE: metadata is not set to "branch-user" because the relationships were
+        # added on the default branch after branch2 was created. The car node's metadata
+        # remains unchanged as "main-user".
+        person_1_rel_to_car_1 = next((r for r in person_1_meta.relationships if r.peer_uuid == car_1.id), None)
+        assert person_1_rel_to_car_1 is not None
+        assert person_1_rel_to_car_1.is_deleted is True
+        assert person_1_rel_to_car_1.created_by == "main-user"
+        assert before_rel_create < person_1_rel_to_car_1.created_at < after_rel_create
+        assert person_1_rel_to_car_1.updated_by == "main-user"
+        assert person_1_rel_to_car_1.updated_at == person_1_rel_to_car_1.created_at
+
+        person_1_rel_to_car_2 = next((r for r in person_1_meta.relationships if r.peer_uuid == car_2.id), None)
+        assert person_1_rel_to_car_2 is not None
+        assert person_1_rel_to_car_2.is_deleted is True
+        assert person_1_rel_to_car_2.created_by == "main-user"
+        assert before_rel_create < person_1_rel_to_car_2.created_at < after_rel_create
+        assert person_1_rel_to_car_2.updated_by == "main-user"
+        assert person_1_rel_to_car_2.updated_at == person_1_rel_to_car_2.created_at
+
+        # Validate person_2 (unaffected)
+        person_2_meta = metadata_by_uuid[person_2.id]
+        assert person_2_meta.is_deleted is False
+        assert person_2_meta.created_by == "setup-user"
+        assert before_person_2_create < person_2_meta.created_at < after_person_2_create
+        assert person_2_meta.updated_by == "setup-user"
+        assert person_2_meta.updated_at == person_2_meta.created_at
+        for attr in person_2_meta.attributes:
+            assert attr.is_deleted is False
+            assert before_person_2_create < attr.created_at < after_person_2_create
+
+        # Validate car_1 (relationship deleted)
+        # NOTE: Same edge case as person_1's relationships - updated_by remains "main-user"
+        car_1_meta = metadata_by_uuid[car_1.id]
+        assert car_1_meta.is_deleted is False
+        assert car_1_meta.created_by == "setup-user"
+        assert before_car_1_create < car_1_meta.created_at < after_car_1_create
+        assert car_1_meta.updated_by == "main-user"
+        assert before_rel_create < car_1_meta.updated_at < after_rel_create
+
+        # Validate car_1's relationship to person_1 (deleted)
+        # NOTE: Same edge case as person_1's relationships - updated_by remains "main-user"
+        car_1_rel_to_person_1 = next((r for r in car_1_meta.relationships if r.peer_uuid == person_1.id), None)
+        assert car_1_rel_to_person_1 is not None
+        assert car_1_rel_to_person_1.is_deleted is True
+        assert car_1_rel_to_person_1.created_by == "main-user"
+        assert before_rel_create < car_1_rel_to_person_1.created_at < after_rel_create
+        assert car_1_rel_to_person_1.updated_by == "main-user"
+        assert car_1_rel_to_person_1.updated_at == car_1_rel_to_person_1.created_at
+
+        # Validate car_2 (relationship deleted)
+        # NOTE: Same edge case as car_1 - car_2's metadata is not updated
+        car_2_meta = metadata_by_uuid[car_2.id]
+        assert car_2_meta.is_deleted is False
+        assert car_2_meta.created_by == "setup-user"
+        assert before_car_2_create < car_2_meta.created_at < after_car_2_create
+        assert car_2_meta.updated_by == "main-user"
+        assert before_rel_create < car_2_meta.updated_at < after_rel_create
+
+        # Validate car_2's relationship to person_1 (deleted)
+        # NOTE: Same edge case as person_1's relationships - updated_by remains "main-user"
+        car_2_rel_to_person_1 = next((r for r in car_2_meta.relationships if r.peer_uuid == person_1.id), None)
+        assert car_2_rel_to_person_1 is not None
+        assert car_2_rel_to_person_1.is_deleted is True
+        assert car_2_rel_to_person_1.created_by == "main-user"
+        assert before_rel_create < car_2_rel_to_person_1.created_at < after_rel_create
+        assert car_2_rel_to_person_1.updated_by == "main-user"
+
     @pytest.mark.parametrize("selection", [ConflictSelection.BASE_BRANCH, ConflictSelection.DIFF_BRANCH])
     async def test_attribute_update_with_conflict(
         self,
@@ -1269,15 +1735,19 @@ class TestDiffAndMerge:
         person_john_main: Node,
         selection: ConflictSelection,
     ) -> None:
+        person_created_at = person_john_main._get_created_at()
+
         main_value = 200
         branch_value = 150
         branch2 = await create_branch(db=db, branch_name="branch2")
         person_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
         person_main.height.value = main_value
-        await person_main.save(db=db)
+        before_main_update = Timestamp()
+        await person_main.save(db=db, user_id="main-user")
+        after_main_update = Timestamp()
         person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
         person_branch.height.value = branch_value
-        await person_branch.save(db=db)
+        await person_branch.save(db=db, user_id="branch-user")
 
         # set the conflict resolution
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
@@ -1290,9 +1760,9 @@ class TestDiffAndMerge:
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=selection)
 
         # merge the branch
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         # validate that person has correct age
         updated_person = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
@@ -1300,6 +1770,29 @@ class TestDiffAndMerge:
             assert updated_person.height.value == branch_value
         else:
             assert updated_person.height.value == main_value
+
+        # Validate metadata - when DIFF_BRANCH is selected, merge should update metadata
+        # When BASE_BRANCH is selected, main's value is kept so merge may still update metadata
+        updated_person_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=person_john_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        assert updated_person_with_metadata._get_created_at() == person_created_at
+        assert updated_person_with_metadata._get_created_by() == SYSTEM_USER_ID
+        if selection is ConflictSelection.DIFF_BRANCH:
+            # Branch value was merged, so metadata should be updated to merge time with branch-user
+            assert updated_person_with_metadata._get_updated_at() == merge_at
+            assert updated_person_with_metadata._get_updated_by() == "branch-user"
+            # Check height attribute metadata
+            assert updated_person_with_metadata.height._get_updated_at() == merge_at
+            assert updated_person_with_metadata.height._get_updated_by() == "branch-user"
+        else:
+            # Branch value was merged, so metadata should be updated to merge time with branch-user
+            assert before_main_update < updated_person_with_metadata._get_updated_at() < after_main_update
+            assert updated_person_with_metadata._get_updated_by() == "main-user"
+            # Check height attribute metadata
+            assert before_main_update < updated_person_with_metadata.height._get_updated_at() < after_main_update
+            assert updated_person_with_metadata.height._get_updated_by() == "main-user"
+
         await verify_no_duplicate_paths(db=db)
 
     async def test_hierarchy_preserved(
@@ -1354,8 +1847,17 @@ class TestDiffAndMerge:
             filters={},
         )
         assert set(retrieved_ancestors_map.keys()) == {d.id for d in site_ancestors}
+
+        # Validate metadata on merged nodes - europe region was created on branch and merged
+        europe_with_metadata = await NodeManager.get_one(
+            db=db, id=region.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        # Merged nodes should have updated_at set to merge time
+        assert europe_with_metadata._get_updated_at() == at
+
         await verify_no_duplicate_paths(db=db)
 
+    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
     async def test_diff_and_merge_with_migrated_node_kind(
         self,
         db: InfrahubDatabase,
@@ -1368,6 +1870,9 @@ class TestDiffAndMerge:
         person_jane_main: Node,
         person_john_main: Node,
     ) -> None:
+        car_accord_created_at = car_accord_main._get_created_at()
+        car_camry_created_at = car_camry_main._get_created_at()
+
         schema_main = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.update_schema_branch(db=db, branch=default_branch, schema=schema_main, update_db=True)
         original_car_owner = person_john_main
@@ -1405,17 +1910,17 @@ class TestDiffAndMerge:
         await migrated_car.owner.update(db=db, data=person_jane_main.id)
         new_color = "#654321"
         migrated_car.color.value = new_color
-        await migrated_car.save(db=db)
+        await migrated_car.save(db=db, user_id="branch-user-update")
 
         # delete a car
         migrated_car_to_delete = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
-        await migrated_car_to_delete.delete(db=db)
+        await migrated_car_to_delete.delete(db=db, user_id="branch-user-delete")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         updated_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         registry.schema.set_schema_branch(name=default_branch.name, schema=updated_schema_branch)
@@ -1445,9 +1950,66 @@ class TestDiffAndMerge:
         # try to get deleted node
         with pytest.raises(NodeNotFoundError):
             await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id, raise_on_error=True)
+
+        # Validate node-level metadata on migrated car after merge
+        migrated_car_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        # Node was created at merge time (migrated kind)
+        assert migrated_car_with_metadata._get_created_at() == merge_at
+        assert migrated_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        # Node was updated by branch-user-update (the last user to modify this node on branch)
+        assert migrated_car_with_metadata._get_updated_at() == merge_at
+        assert migrated_car_with_metadata._get_updated_by() == "branch-user-update"
+
+        # Validate attribute-level metadata on migrated car after merge
+        # Color attribute was updated by branch-user-update
+        assert migrated_car_with_metadata.color._get_created_at() == merge_at
+        assert migrated_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert migrated_car_with_metadata.color._get_updated_at() == merge_at
+        assert migrated_car_with_metadata.color._get_updated_by() == "branch-user-update"
+
+        # Other attributes should have been migrated but not updated by user
+        assert migrated_car_with_metadata.name._get_created_at() == merge_at
+        assert migrated_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert migrated_car_with_metadata.name._get_updated_at() == merge_at
+        assert migrated_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        assert migrated_car_with_metadata.nbr_seats._get_created_at() == merge_at
+        assert migrated_car_with_metadata.nbr_seats._get_created_by() == SYSTEM_USER_ID
+        assert migrated_car_with_metadata.nbr_seats._get_updated_at() == merge_at
+        assert migrated_car_with_metadata.nbr_seats._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate metadata on deleted car using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[car_camry_main.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 1
+
+        deleted_car_meta = node_metadatas[0]
+        assert deleted_car_meta.uuid == car_camry_main.id
+        assert deleted_car_meta.is_deleted is True
+        # Deleted car should have merge_at timestamp and branch-user-delete as updater
+        assert deleted_car_meta.created_at == merge_at
+        assert deleted_car_meta.created_by == SYSTEM_USER_ID
+        assert deleted_car_meta.updated_at == merge_at
+        assert deleted_car_meta.updated_by == "branch-user-delete"
+
+        # Validate deleted car's attributes metadata
+        for attr in deleted_car_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_at == merge_at
+            assert attr.created_by == SYSTEM_USER_ID
+            assert attr.updated_at == merge_at
+            assert attr.updated_by == "branch-user-delete"
+
         await verify_no_duplicate_paths(db=db)
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         rolled_back_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         registry.schema.set_schema_branch(name=default_branch.name, schema=rolled_back_schema_branch)
@@ -1470,6 +2032,44 @@ class TestDiffAndMerge:
         undeleted_car = await NodeManager.get_one(db=db, branch=default_branch, id=car_camry_main.id)
         assert undeleted_car.get_kind() == "TestCar"
 
+        # Validate node-level metadata after rollback for car_accord
+        rolled_back_car_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        # After rollback, should have original created_at and no user updates
+        assert rolled_back_car_with_metadata._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata._get_updated_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate attribute-level metadata after rollback
+        assert rolled_back_car_with_metadata.color._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.color._get_updated_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+        assert rolled_back_car_with_metadata.name._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.name._get_updated_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate undeleted car (car_camry) metadata after rollback
+        undeleted_car_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=car_camry_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        # Should have original timestamps restored
+        assert undeleted_car_with_metadata._get_created_at() == car_camry_created_at
+        assert undeleted_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata._get_updated_at() == car_camry_created_at
+        assert undeleted_car_with_metadata._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate attribute metadata on undeleted car
+        assert undeleted_car_with_metadata.color._get_created_at() == car_camry_created_at
+        assert undeleted_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata.color._get_updated_at() == car_camry_created_at
+        assert undeleted_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
     async def test_diff_and_merge_with_migrated_node_kind_and_migrated_inheritance(
         self,
         db: InfrahubDatabase,
@@ -1553,7 +2153,7 @@ class TestDiffAndMerge:
         await migrated_car.owner.update(db=db, data=person_1.id)
         new_color = "#654321"
         migrated_car.color.value = new_color
-        await migrated_car.save(db=db)
+        await migrated_car.save(db=db, user_id="branch-user")
 
         # migrate Test2NewElectricCar to inherit from TestVehicle
         schema_branch = registry.schema.get_schema_branch(name=branch2.name)
@@ -1576,7 +2176,7 @@ class TestDiffAndMerge:
 
         # delete a car
         migrated_car_to_delete = await NodeManager.get_one(db=db, branch=branch2, id=e_car_2.id)
-        await migrated_car_to_delete.delete(db=db)
+        await migrated_car_to_delete.delete(db=db, user_id="branch-user")
 
         at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
@@ -1609,6 +2209,14 @@ class TestDiffAndMerge:
         # try to get deleted node
         with pytest.raises(NodeNotFoundError):
             await NodeManager.get_one(db=db, branch=branch2, id=e_car_2.id, raise_on_error=True)
+
+        # Validate metadata on migrated car - should have updated_at from merge
+        migrated_car_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=e_car_1.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        assert migrated_car_with_metadata._get_updated_at() == at
+        assert migrated_car_with_metadata._get_updated_by() == "branch-user"
+
         await verify_no_duplicate_paths(db=db)
 
         await diff_merger.rollback(at=at)
@@ -1630,6 +2238,7 @@ class TestDiffAndMerge:
         undeleted_car = await NodeManager.get_one(db=db, branch=default_branch, id=e_car_2.id)
         assert undeleted_car.get_kind() == "TestElectricCar"
 
+    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
     async def test_diff_and_merge_with_migrated_node_kind_peer(
         self,
         db: InfrahubDatabase,
@@ -1693,11 +2302,11 @@ class TestDiffAndMerge:
         await migrated_car.owner.update(db=db, data=person_jane_main.id)
         new_color = "#654321"
         migrated_car.color.value = new_color
-        await migrated_car.save(db=db)
+        await migrated_car.save(db=db, user_id="branch-user")
 
         # delete a car
         migrated_car_to_delete = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
-        await migrated_car_to_delete.delete(db=db)
+        await migrated_car_to_delete.delete(db=db, user_id="branch-user")
 
         at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
@@ -1725,6 +2334,14 @@ class TestDiffAndMerge:
         # try to get deleted node
         with pytest.raises(NodeNotFoundError):
             await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id, raise_on_error=True)
+
+        # Validate metadata on merged car - should have updated_at from merge
+        merged_car_with_metadata = await NodeManager.get_one(
+            db=db, branch=default_branch, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        assert merged_car_with_metadata._get_updated_at() == at
+        assert merged_car_with_metadata._get_updated_by() == "branch-user"
+
         await verify_no_duplicate_paths(db=db)
 
         await diff_merger.rollback(at=at)

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -1092,12 +1092,6 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ) -> None:
-        # Capture initial metadata before any changes
-        car_before = await NodeManager.get_one(
-            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
-        )
-        car_created_at = car_before._get_created_at()
-
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -5,7 +5,13 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction, MetadataOptions, RelationshipHierarchyDirection, SchemaPathType
+from infrahub.core.constants import (
+    SYSTEM_USER_ID,
+    DiffAction,
+    MetadataOptions,
+    RelationshipHierarchyDirection,
+    SchemaPathType,
+)
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
 from infrahub.core.diff.merger.merger import DiffMerger
@@ -54,18 +60,41 @@ class TestDiffAndMerge:
     ) -> None:
         new_node = await Node.init(db=db, schema=all_attribute_types_schema.kind)
         await new_node.new(db=db, mylist=["a", "b", 1, 2])
-        await new_node.save(db=db)
+        before_create = Timestamp()
+        await new_node.save(db=db, user_id="main-user")
+        after_create = Timestamp()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         branch_node = await NodeManager.get_one(db=db, branch=branch2, id=new_node.id)
         branch_node.mylist.value = ["c", "d", 3, 4]
-        await branch_node.save(db=db)
+        await branch_node.save(db=db, user_id="branch-user")
+
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_node = await NodeManager.get_one(db=db, branch=default_branch, id=new_node.id)
+        updated_node = await NodeManager.get_one(
+            db=db, branch=default_branch, id=new_node.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
         assert updated_node.mylist.value == ["c", "d", 3, 4]
+
+        # Verify Node vertex metadata
+        # created_at/created_by should reflect the original creation on main
+        assert before_create < updated_node._get_created_at() < after_create
+        assert updated_node._get_created_by() == "main-user"
+        assert updated_node._get_updated_at() == merge_at
+        assert updated_node._get_updated_by() == "branch-user"
+
+        # Verify Attribute vertex metadata
+        mylist_attr = updated_node.mylist
+        # created_at/created_by should reflect original creation on main
+        assert before_create < mylist_attr._get_created_at() < after_create
+        assert mylist_attr._get_created_by() == "main-user"
+        # updated_at/updated_by should reflect the merge
+        assert mylist_attr._get_updated_at() == merge_at
+        assert mylist_attr._get_updated_by() == "branch-user"
         await verify_no_duplicate_paths(db=db)
 
     async def test_diff_and_merge_schema_with_default_values(
@@ -139,12 +168,14 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.value = "John-main"
-        await john_main.save(db=db)
+        before_main_update = Timestamp()
+        await john_main.save(db=db, user_id="main-user")
+        after_main_update = Timestamp()
         john_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
         john_branch.name.value = "John-branch"
-        await john_branch.save(db=db)
+        await john_branch.save(db=db, user_id="branch-user")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
             base_branch=default_branch, diff_branch=branch2
@@ -157,16 +188,45 @@ class TestDiffAndMerge:
         for conflict in conflicts_map.values():
             await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_john = await NodeManager.get_one(db=db, id=person_john_main.id)
+        updated_john = await NodeManager.get_one(
+            db=db, id=person_john_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
         assert updated_john.name.value == expected_value["name"]
         assert await updated_john.get_hfid(db=db) == expected_value["hfid"]
+        assert updated_john._get_created_at() < before_main_update
+        assert updated_john._get_created_by() == SYSTEM_USER_ID
+        assert updated_john.name._get_created_at() < before_main_update
+        assert updated_john.name._get_created_by() == SYSTEM_USER_ID
 
-        await diff_merger.rollback(at=at)
+        # Verify Node and Attribute metadata
+        if conflict_selection == ConflictSelection.DIFF_BRANCH:
+            # Branch changes were merged
+            assert updated_john._get_updated_at() == merge_at
+            assert updated_john._get_updated_by() == "branch-user"
+            # Attribute metadata should reflect the merge
+            assert updated_john.name._get_updated_at() == merge_at
+            assert updated_john.name._get_updated_by() == "branch-user"
+        else:
+            # Base branch was kept, no changes merged
+            assert before_main_update < updated_john._get_updated_at() < after_main_update
+            # Attribute metadata should reflect main branch update
+            assert before_main_update < updated_john.name._get_updated_at() < after_main_update
+            assert updated_john.name._get_updated_by() == "main-user"
 
-        rolled_back_john = await NodeManager.get_one(db=db, id=person_john_main.id)
+        await diff_merger.rollback(at=merge_at)
+
+        rolled_back_john = await NodeManager.get_one(
+            db=db, id=person_john_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
         assert rolled_back_john.name.value == "John-main"
+        # After rollback, Node metadata should be restored
+        assert before_main_update < rolled_back_john._get_updated_at() < after_main_update
+        assert rolled_back_john._get_updated_by() == "main-user"
+        # After rollback, Attribute metadata should be restored
+        assert before_main_update < rolled_back_john.name._get_updated_at() < after_main_update
+        assert rolled_back_john.name._get_updated_by() == "main-user"
         await verify_no_duplicate_paths(db=db)
 
     @pytest.mark.parametrize(
@@ -188,12 +248,14 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data=person_alfred_main)
-        await car_main.save(db=db)
+        before_main_update = Timestamp()
+        await car_main.save(db=db, user_id="main-user")
+        after_main_update = Timestamp()
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data=person_jane_main)
-        await car_branch.save(db=db)
+        await car_branch.save(db=db, user_id="branch-user")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
             base_branch=default_branch, diff_branch=branch2
@@ -206,20 +268,46 @@ class TestDiffAndMerge:
         conflict = next(iter(conflicts_map.values()))
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        updated_car = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         owner_rel = await updated_car.owner.get(db=db)
         if conflict_selection is ConflictSelection.BASE_BRANCH:
             assert owner_rel.peer_id == person_alfred_main.id
+            # Base branch was kept, no changes merged - Node metadata should reflect main update
+            assert before_main_update < updated_car._get_updated_at() < after_main_update
+            assert updated_car._get_updated_by() == "main-user"
+            # Relationship metadata should reflect main branch update
+            assert before_main_update < owner_rel._get_updated_at() < after_main_update
+            assert owner_rel._get_updated_by() == "main-user"
+            assert before_main_update < owner_rel._get_created_at() < after_main_update
+            assert owner_rel._get_created_by() == "main-user"
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert owner_rel.peer_id == person_jane_main.id
+            # Branch changes were merged - Node metadata should reflect the merge
+            assert updated_car._get_updated_at() == merge_at
+            assert updated_car._get_updated_by() == "branch-user"
+            # Relationship metadata should reflect the merge
+            assert owner_rel._get_created_at() == merge_at
+            assert owner_rel._get_created_by() == "branch-user"
+            assert owner_rel._get_updated_at() == merge_at
+            assert owner_rel._get_updated_by() == "branch-user"
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
-        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        rolled_back_car = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         owner_rel = await rolled_back_car.owner.get(db=db)
         assert owner_rel.peer_id == person_alfred_main.id
+        # After rollback, Node metadata should be restored to pre-merge state
+        assert before_main_update < rolled_back_car._get_updated_at() < after_main_update
+        assert rolled_back_car._get_updated_by() == "main-user"
+        # After rollback, Relationship metadata should be restored
+        assert before_main_update < owner_rel._get_updated_at() < after_main_update
+        assert owner_rel._get_updated_by() == "main-user"
         await verify_no_duplicate_paths(db=db)
 
     @pytest.mark.parametrize(
@@ -240,12 +328,14 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
         john_main.name.source = person_alfred_main
-        await john_main.save(db=db)
+        before_main_update = Timestamp()
+        await john_main.save(db=db, user_id="main-user")
+        after_main_update = Timestamp()
         john_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
         john_branch.name.source = person_jane_main
-        await john_branch.save(db=db)
+        await john_branch.save(db=db, user_id="branch-user")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
             base_branch=default_branch, diff_branch=branch2
@@ -258,23 +348,47 @@ class TestDiffAndMerge:
         conflict = next(iter(conflicts_map.values()))
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_john = await NodeManager.get_one(db=db, id=person_john_main.id, include_metadata=MetadataOptions.SOURCE)
+        updated_john = await NodeManager.get_one(
+            db=db, id=person_john_main.id, include_metadata=MetadataOptions.SOURCE | MetadataOptions.USER_TIMESTAMPS
+        )
+        assert updated_john._get_created_at() < before_main_update
+        assert updated_john._get_created_by() == SYSTEM_USER_ID
+        assert updated_john.name._get_created_at() < before_main_update
+        assert updated_john.name._get_created_by() == SYSTEM_USER_ID
 
         attr_source = await updated_john.name.get_source(db=db)
         if conflict_selection is ConflictSelection.BASE_BRANCH:
             assert attr_source.id == person_alfred_main.id
+            # Base branch was kept, no changes merged - Node metadata
+            assert before_main_update < updated_john._get_updated_at() < after_main_update
+            assert updated_john._get_updated_by() == "main-user"
+            # Attribute metadata should reflect main branch update
+            assert before_main_update < updated_john.name._get_updated_at() < after_main_update
+            assert updated_john.name._get_updated_by() == "main-user"
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert attr_source.id == person_jane_main.id
+            # Branch changes were merged - Node metadata
+            assert updated_john._get_updated_at() == merge_at
+            assert updated_john._get_updated_by() == "branch-user"
+            # Attribute metadata should reflect the merge
+            assert updated_john.name._get_updated_at() == merge_at
+            assert updated_john.name._get_updated_by() == "branch-user"
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         rolled_back_john = await NodeManager.get_one(
-            db=db, id=person_john_main.id, include_metadata=MetadataOptions.SOURCE
+            db=db, id=person_john_main.id, include_metadata=MetadataOptions.SOURCE | MetadataOptions.USER_TIMESTAMPS
         )
         attr_source = await rolled_back_john.name.get_source(db=db)
         assert attr_source.id == person_alfred_main.id
+        # After rollback, Node metadata should be restored to pre-merge state
+        assert before_main_update < rolled_back_john._get_updated_at() < after_main_update
+        assert rolled_back_john._get_updated_by() == "main-user"
+        # After rollback, Attribute metadata should be restored
+        assert before_main_update < rolled_back_john.name._get_updated_at() < after_main_update
+        assert rolled_back_john.name._get_updated_by() == "main-user"
         await verify_no_duplicate_paths(db=db)
 
     @pytest.mark.parametrize(
@@ -298,12 +412,14 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_john_main.id, "_relation__owner": person_alfred_main.id})
-        await car_main.save(db=db)
+        before_main_update = Timestamp()
+        await car_main.save(db=db, user_id="main-user")
+        after_main_update = Timestamp()
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__owner": person_jane_main.id})
-        await car_branch.save(db=db)
+        await car_branch.save(db=db, user_id="branch-user")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
             base_branch=default_branch, diff_branch=branch2
@@ -317,15 +433,39 @@ class TestDiffAndMerge:
         for conflict in conflicts_map.values():
             await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id, include_metadata=MetadataOptions.OWNER)
+        updated_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            id=car_accord_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
+            prefetch_relationships=True,
+        )
+        owner_rel_with_metadata = await updated_car_with_metadata.owner.get(db=db)
+        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
         owner_rel = await updated_car.owner.get(db=db)
         owner_prop = await owner_rel.get_owner(db=db)
+
+        assert updated_car_with_metadata._get_created_at() < before_main_update
+        assert updated_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel_with_metadata._get_created_at() < before_main_update
+        assert owner_rel_with_metadata._get_created_by() == SYSTEM_USER_ID
         if conflict_selection is ConflictSelection.BASE_BRANCH:
             assert owner_prop.id == person_alfred_main.id
+            # Base branch was kept, no changes merged - Node metadata should reflect main update
+            assert before_main_update < updated_car_with_metadata._get_updated_at() < after_main_update
+            assert updated_car_with_metadata._get_updated_by() == "main-user"
+            # Relationship metadata should reflect main branch update
+            assert before_main_update < owner_rel_with_metadata._get_updated_at() < after_main_update
+            assert owner_rel_with_metadata._get_updated_by() == "main-user"
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert owner_prop.id == person_jane_main.id
+            # Branch changes were merged - Node metadata should reflect the merge
+            assert updated_car_with_metadata._get_updated_at() == merge_at
+            assert updated_car_with_metadata._get_updated_by() == "branch-user"
+            # Relationship metadata should reflect the merge
+            assert owner_rel_with_metadata._get_updated_at() == merge_at
+            assert owner_rel_with_metadata._get_updated_by() == "branch-user"
 
         john_car_count = await NodeManager.count_peers(
             db=db,
@@ -337,14 +477,17 @@ class TestDiffAndMerge:
         )
         assert john_car_count == 1
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         rolled_back_car = await NodeManager.get_one(
-            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.OWNER
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.OWNER | MetadataOptions.USER_TIMESTAMPS
         )
         owner_rel = await rolled_back_car.owner.get(db=db)
         owner_prop = await owner_rel.get_owner(db=db)
         assert owner_prop.id == person_alfred_main.id
+        # After rollback, Node metadata should be restored to pre-merge state
+        assert before_main_update < rolled_back_car._get_updated_at() < after_main_update
+        assert rolled_back_car._get_updated_by() == "main-user"
         await verify_no_duplicate_paths(db=db)
 
     @pytest.mark.parametrize("new_height", (0, 1000, None))
@@ -357,10 +500,17 @@ class TestDiffAndMerge:
         person_jane_main,
         new_height,
     ) -> None:
+        # Capture initial metadata before any changes
+        person_before = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        person_created_at = person_before._get_created_at()
+        person_created_by = person_before._get_created_by()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_jane_main.id)
         person_branch.height.value = new_height
-        await person_branch.save(db=db)
+        await person_branch.save(db=db, user_id="branch-user")
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -373,10 +523,37 @@ class TestDiffAndMerge:
         assert node.action is DiffAction.UPDATED
 
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        at = Timestamp()
+        await diff_merger.merge_graph(at=at)
 
-        updated_person = await NodeManager.get_one(db=db, id=person_jane_main.id)
+        updated_person = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
         assert updated_person.height.value == new_height
+
+        # Validate Node metadata
+        # created_at/created_by should be unchanged (from fixture creation)
+        assert updated_person._get_created_at() == person_created_at
+        assert updated_person._get_created_by() == person_created_by
+        # updated_at/updated_by should reflect the merge
+        assert updated_person._get_updated_at() == at
+        assert updated_person._get_updated_by() == "branch-user"
+
+        # Validate the height attribute metadata
+        height_attr = updated_person.height
+        assert height_attr._get_created_at() == person_created_at
+        assert height_attr._get_created_by() == person_created_by
+        assert height_attr._get_updated_at() == at
+        assert height_attr._get_updated_by() == "branch-user"
+
+        # Validate other attributes were NOT updated (name attribute)
+        name_attr = updated_person.name
+        assert name_attr._get_created_at() == person_created_at
+        assert name_attr._get_created_by() == person_created_by
+        # name attribute should not have been updated by the merge
+        assert name_attr._get_updated_at() == person_created_at
+        assert name_attr._get_updated_by() == person_created_by
+
         await verify_no_duplicate_paths(db=db)
 
     async def test_one_many_relationship_added(
@@ -388,10 +565,17 @@ class TestDiffAndMerge:
         person_jane_main,
         car_camry_main,
     ) -> None:
+        # Capture person_jane's updated_at before adding the relationship
+        person_jane_before = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        person_jane_updated_at_before = person_jane_before._get_updated_at()
+        person_jane_updated_by_before = person_jane_before._get_updated_by()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         branch_car = await Node.init(db=db, schema="TestCar", branch=branch2)
         await branch_car.new(db=db, name="new camry", nbr_seats=5, is_electric=False, owner=person_jane_main.id)
-        await branch_car.save(db=db)
+        await branch_car.save(db=db, user_id="branch-user")
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -406,14 +590,71 @@ class TestDiffAndMerge:
         assert person_node.action is DiffAction.UPDATED
 
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_car = await NodeManager.get_one(db=db, id=branch_car.id)
+        # Verify car node and owner relationship metadata
+        updated_car = await NodeManager.get_one(
+            db=db, id=branch_car.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         assert updated_car.name.value == "new camry"
         assert updated_car.nbr_seats.value == 5
         assert updated_car.is_electric.value is False
         owner_rel = await updated_car.owner.get(db=db)
         assert owner_rel.peer_id == person_jane_main.id
+
+        # Car Node metadata - created on branch, merged to main
+        assert updated_car._get_created_at() == merge_at
+        assert updated_car._get_created_by() == "branch-user"
+        assert updated_car._get_updated_at() == merge_at
+        assert updated_car._get_updated_by() == "branch-user"
+        # Car owner relationship metadata
+        assert owner_rel._get_created_at() == merge_at
+        assert owner_rel._get_created_by() == "branch-user"
+        assert owner_rel._get_updated_at() == merge_at
+        assert owner_rel._get_updated_by() == "branch-user"
+
+        # Verify person_jane node and cars relationship metadata
+        updated_person = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        cars_rels = await updated_person.cars.get_relationships(db=db)
+        # Find the relationship to the new car
+        new_car_rel = next((r for r in cars_rels if r.peer_id == branch_car.id), None)
+        assert new_car_rel is not None
+
+        # Person Node metadata - updated_at should reflect the merge (rollup from new relationship)
+        assert updated_person._get_created_at() == person_jane_updated_at_before
+        assert updated_person._get_created_by() == SYSTEM_USER_ID
+        assert updated_person._get_updated_at() == merge_at
+        assert updated_person._get_updated_by() == "branch-user"
+        # Person cars relationship metadata (the new relationship to branch_car)
+        assert new_car_rel._get_created_at() == merge_at
+        assert new_car_rel._get_created_by() == "branch-user"
+        assert new_car_rel._get_updated_at() == merge_at
+        assert new_car_rel._get_updated_by() == "branch-user"
+
+        await verify_no_duplicate_paths(db=db)
+
+        # Rollback the merge
+        await diff_merger.rollback(at=merge_at)
+
+        # Car should no longer exist on main after rollback
+        rolled_back_car = await NodeManager.get_one(db=db, id=branch_car.id)
+        assert rolled_back_car is None
+
+        # Person should be restored to pre-merge state
+        rolled_back_person = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        # Person Node metadata should be restored
+        assert rolled_back_person._get_updated_at() == person_jane_updated_at_before
+        assert rolled_back_person._get_updated_by() == person_jane_updated_by_before
+        # The cars relationship to the new car should no longer exist
+        rolled_back_cars_rels = await rolled_back_person.cars.get_relationships(db=db)
+        rolled_back_new_car_rel = next((r for r in rolled_back_cars_rels if r.peer_id == branch_car.id), None)
+        assert rolled_back_new_car_rel is None
+
         await verify_no_duplicate_paths(db=db)
 
     async def test_relationship_set_to_null(
@@ -421,18 +662,22 @@ class TestDiffAndMerge:
     ) -> None:
         person_main = await Node.init(db=db, schema="TestPerson")
         await person_main.new(db=db, name="Dude")
-        await person_main.save(db=db)
+        await person_main.save(db=db, user_id="main-user-person")
         friend_main = await Node.init(db=db, schema="TestPerson")
         await friend_main.new(db=db, name="Friend")
-        await friend_main.save(db=db)
+        before_friend_create = Timestamp()
+        await friend_main.save(db=db, user_id="main-user-friend")
+        after_friend_create = Timestamp()
         dog_main = await Node.init(db=db, schema="TestDog")
         await dog_main.new(db=db, name="good dog", breed="mixed", owner=person_main, best_friend=friend_main)
-        await dog_main.save(db=db)
+        before_dog_create = Timestamp()
+        await dog_main.save(db=db, user_id="main-user-dog")
+        after_dog_create = Timestamp()
 
         branch2 = await create_branch(db=db, branch_name="branch2")
         dog_branch = await NodeManager.get_one(db=db, branch=branch2, id=dog_main.id)
-        await dog_branch.best_friend.update(db=db, data=None)
-        await dog_branch.save(db=db)
+        await dog_branch.best_friend.update(db=db, data=None, user_id="branch-user")
+        await dog_branch.save(db=db, user_id="branch-user")
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -447,14 +692,62 @@ class TestDiffAndMerge:
         assert friend_node.action is DiffAction.UPDATED
 
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
 
-        updated_dog = await NodeManager.get_one(db=db, id=dog_main.id)
+        # Verify dog node metadata - relationship was removed, so dog should be updated
+        updated_dog = await NodeManager.get_one(
+            db=db, id=dog_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         best_friend_rels = await updated_dog.best_friend.get_relationships(db=db)
         assert len(best_friend_rels) == 0
-        updated_friend = await NodeManager.get_one(db=db, id=friend_main.id)
+        assert before_dog_create < updated_dog._get_created_at() < after_dog_create
+        assert updated_dog._get_created_by() == "main-user-dog"
+        assert updated_dog._get_updated_at() == merge_at
+        assert updated_dog._get_updated_by() == "branch-user"
+
+        # Verify friend node metadata - relationship was removed from their side too
+        updated_friend = await NodeManager.get_one(
+            db=db, id=friend_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         best_friend_rels = await updated_friend.best_friends.get_relationships(db=db)
         assert len(best_friend_rels) == 0
+        assert before_friend_create < updated_friend._get_created_at() < after_friend_create
+        assert updated_friend._get_created_by() == "main-user-friend"
+        assert updated_friend._get_updated_at() == merge_at
+        assert updated_friend._get_updated_by() == "branch-user"
+
+        await verify_no_duplicate_paths(db=db)
+
+        # Rollback the merge
+        await diff_merger.rollback(at=merge_at)
+
+        # Verify dog metadata after rollback
+        rolled_back_dog = await NodeManager.get_one(
+            db=db, id=dog_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        # Dog's best_friend relationship should be restored
+        rolled_back_best_friend_rels = await rolled_back_dog.best_friend.get_relationships(db=db)
+        assert len(rolled_back_best_friend_rels) == 1
+        assert rolled_back_best_friend_rels[0].peer_id == friend_main.id
+        # Dog Node metadata should be restored to pre-merge state
+        assert before_dog_create < rolled_back_dog._get_updated_at() < after_dog_create
+        assert rolled_back_dog._get_updated_by() == "main-user-dog"
+
+        # Verify friend metadata after rollback
+        rolled_back_friend = await NodeManager.get_one(
+            db=db, id=friend_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        # Friend's best_friends relationship should be restored
+        rolled_back_best_friends_rels = await rolled_back_friend.best_friends.get_relationships(db=db)
+        assert len(rolled_back_best_friends_rels) == 1
+        assert rolled_back_best_friends_rels[0].peer_id == dog_main.id
+        # Friend Node metadata should be restored to pre-merge state
+        assert before_friend_create < rolled_back_friend._get_created_at() < after_friend_create
+        assert rolled_back_friend._get_created_by() == "main-user-friend"
+        assert before_friend_create < rolled_back_friend._get_updated_at() < after_friend_create
+        assert rolled_back_friend._get_updated_by() == "main-user-friend"
+
         await verify_no_duplicate_paths(db=db)
 
     async def test_local_and_aware_nodes_added_on_branch(
@@ -467,10 +760,12 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
         await person.new(db=db, name="Guy", height=180)
-        await person.save(db=db)
+        await person.save(db=db, user_id="branch-user-person")
         car = await Node.init(db=db, schema="TestCar", branch=branch2)
         await car.new(db=db, name="camry", owner=person.id)
-        await car.save(db=db)
+        before_car_create = Timestamp()
+        await car.save(db=db, user_id="branch-user-car")
+        after_car_create = Timestamp()
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -486,12 +781,29 @@ class TestDiffAndMerge:
             get_one_diff_node(diff_root=enriched_diff, node_uuid=car.id)
 
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
 
-        # validate person update on main
-        updated_person = await NodeManager.get_one(db=db, id=person.id)
+        # validate person update on main with metadata
+        updated_person = await NodeManager.get_one(
+            db=db, id=person.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
         assert updated_person.height.value == 180
         assert updated_person.name.value == "Guy"
+        # Person Node metadata - created on branch, merged to main
+        assert updated_person._get_created_at() == merge_at
+        assert updated_person._get_created_by() == "branch-user-person"
+        assert updated_person._get_updated_at() == merge_at
+        assert updated_person._get_updated_by() == "branch-user-person"
+        # Person Attribute metadata
+        assert updated_person.name._get_created_at() == merge_at
+        assert updated_person.name._get_created_by() == "branch-user-person"
+        assert updated_person.name._get_updated_at() == merge_at
+        assert updated_person.name._get_updated_by() == "branch-user-person"
+        assert updated_person.height._get_created_at() == merge_at
+        assert updated_person.height._get_created_by() == "branch-user-person"
+        assert updated_person.height._get_updated_at() == merge_at
+        assert updated_person.height._get_updated_by() == "branch-user-person"
         # validate car (branch=local) not merged to main
         updated_car = await NodeManager.get_one(db=db, id=car.id)
         assert updated_car is None
@@ -527,9 +839,14 @@ class TestDiffAndMerge:
             schema=owner_rel_schema,
             filters={},
             fetch_peers=True,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
         )
         assert len(owner_rels) == 1
         assert owner_rels[0].peer_id == person.id
+        assert before_car_create < owner_rels[0]._get_created_at() < after_car_create
+        assert owner_rels[0]._get_created_by() == "branch-user-car"
+        assert before_car_create < owner_rels[0]._get_updated_at() < after_car_create
+        assert owner_rels[0]._get_updated_by() == "branch-user-car"
         await verify_no_duplicate_paths(db=db)
 
     async def test_agnostic_and_aware_nodes_added_on_branch(
@@ -538,10 +855,14 @@ class TestDiffAndMerge:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
         await person.new(db=db, name="Guy", height=180)
-        await person.save(db=db)
+        before_person_create = Timestamp()
+        await person.save(db=db, user_id="branch-user-person")
+        after_person_create = Timestamp()
         car = await Node.init(db=db, schema="TestCar", branch=branch2)
         await car.new(db=db, name="camry", nbr_seats=3, is_electric=False, owner=person.id)
-        await car.save(db=db)
+        before_car_create = Timestamp()
+        await car.save(db=db, user_id="branch-user-car")
+        after_car_create = Timestamp()
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
@@ -556,37 +877,90 @@ class TestDiffAndMerge:
         assert diff_car.action is DiffAction.ADDED
 
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
 
-        # validate person (agnostic) exists on main
-        updated_person = await NodeManager.get_one(db=db, id=person.id)
+        # validate person (agnostic) exists on main with metadata
+        updated_person = await NodeManager.get_one(
+            db=db, id=person.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         assert updated_person.height.value == 180
         assert updated_person.name.value == "Guy"
-        cars_rels = await updated_person.cars.get(db=db)
+        # Person Node metadata - updated_at reflects merge (relationship added)
+        assert before_person_create < updated_person._get_created_at() < after_person_create
+        assert updated_person._get_created_by() == "branch-user-person"
+        assert updated_person._get_updated_at() == merge_at
+        assert updated_person._get_updated_by() == "branch-user-car"
+
+        cars_rels = await updated_person.cars.get_relationships(db=db)
         assert len(cars_rels) == 1
         assert cars_rels[0].peer_id == car.id
-        # validate car merged to main
-        updated_car = await NodeManager.get_one(db=db, id=car.id)
+        # Person cars relationship metadata
+        assert cars_rels[0]._get_created_at() == merge_at
+        assert cars_rels[0]._get_created_by() == "branch-user-car"
+        assert cars_rels[0]._get_updated_at() == merge_at
+        assert cars_rels[0]._get_updated_by() == "branch-user-car"
+
+        # validate car merged to main with metadata
+        updated_car = await NodeManager.get_one(
+            db=db, id=car.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
         assert updated_car.name.value == "camry"
         assert updated_car.nbr_seats.value == 3
         assert updated_car.is_electric.value is False
         owner_rel = await updated_car.owner.get(db=db)
         assert owner_rel.peer_id == person.id
+        # Car Node metadata - created on branch, merged to main
+        assert updated_car._get_created_at() == merge_at
+        assert updated_car._get_created_by() == "branch-user-car"
+        assert updated_car._get_updated_at() == merge_at
+        assert updated_car._get_updated_by() == "branch-user-car"
+        # Car owner relationship metadata
+        assert owner_rel._get_created_at() == merge_at
+        assert owner_rel._get_created_by() == "branch-user-car"
+        assert owner_rel._get_updated_at() == merge_at
+        assert owner_rel._get_updated_by() == "branch-user-car"
+        # Car Attribute metadata
+        assert updated_car.name._get_created_at() == merge_at
+        assert updated_car.name._get_created_by() == "branch-user-car"
 
+        # validate relationships on default branch
         person_schema = registry.schema.get(name="TestPerson", duplicate=False)
         cars_rel_schema = person_schema.get_relationship(name="cars")
         cars_rels = await NodeManager.query_peers(
-            db=db, ids=[person.id], source_kind="TestPerson", schema=cars_rel_schema, filters={}, fetch_peers=True
+            db=db,
+            ids=[person.id],
+            source_kind="TestPerson",
+            schema=cars_rel_schema,
+            filters={},
+            fetch_peers=True,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
         )
         assert len(cars_rels) == 1
         assert cars_rels[0].peer_id == car.id
+        assert cars_rels[0]._get_created_at() == merge_at
+        assert cars_rels[0]._get_created_by() == "branch-user-car"
+        assert cars_rels[0]._get_updated_at() == merge_at
+        assert cars_rels[0]._get_updated_by() == "branch-user-car"
+
         car_schema = registry.schema.get(name="TestCar", duplicate=False)
         owner_rel_schema = car_schema.get_relationship(name="owner")
         owner_rels = await NodeManager.query_peers(
-            db=db, ids=[car.id], source_kind="TestCar", schema=owner_rel_schema, filters={}, fetch_peers=True
+            db=db,
+            ids=[car.id],
+            source_kind="TestCar",
+            schema=owner_rel_schema,
+            filters={},
+            fetch_peers=True,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
         )
         assert len(owner_rels) == 1
         assert owner_rels[0].peer_id == person.id
+        assert owner_rels[0]._get_created_at() == merge_at
+        assert owner_rels[0]._get_created_by() == "branch-user-car"
+        assert owner_rels[0]._get_updated_at() == merge_at
+        assert owner_rels[0]._get_updated_by() == "branch-user-car"
+
         # validate relationship still exists on branch
         cars_rels = await NodeManager.query_peers(
             db=db,
@@ -596,9 +970,15 @@ class TestDiffAndMerge:
             schema=cars_rel_schema,
             filters={},
             fetch_peers=True,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
         )
         assert len(cars_rels) == 1
         assert cars_rels[0].peer_id == car.id
+        assert before_car_create < cars_rels[0]._get_created_at() < after_car_create
+        assert cars_rels[0]._get_created_by() == "branch-user-car"
+        assert before_car_create < cars_rels[0]._get_updated_at() < after_car_create
+        assert cars_rels[0]._get_updated_by() == "branch-user-car"
+
         owner_rels = await NodeManager.query_peers(
             db=db,
             branch=branch2,
@@ -607,9 +987,14 @@ class TestDiffAndMerge:
             schema=owner_rel_schema,
             filters={},
             fetch_peers=True,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
         )
         assert len(owner_rels) == 1
         assert owner_rels[0].peer_id == person.id
+        assert before_car_create < owner_rels[0]._get_created_at() < after_car_create
+        assert owner_rels[0]._get_created_by() == "branch-user-car"
+        assert before_car_create < owner_rels[0]._get_updated_at() < after_car_create
+        assert owner_rels[0]._get_updated_by() == "branch-user-car"
         await verify_no_duplicate_paths(db=db)
 
     async def test_update_individual_relationship_properties_one_at_a_time(
@@ -621,31 +1006,46 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ) -> None:
+        before_test_start = Timestamp()
         person_schema = db.schema.get(name="TestPerson", duplicate=False)
         cars_rel_schema = person_schema.get_relationship(name="cars")
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": True})
-        await car_branch.save(db=db)
+        await car_branch.save(db=db, user_id="branch-user-one")
 
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
 
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
-        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": True})
-        await car_branch.save(db=db)
+        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
+        await car_branch.save(db=db, user_id="branch-user-two")
 
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         # validate that the properties were correctly updated
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
         owner_rel = await updated_car.owner.get(db=db)
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is True
+
+        # validate metadata separately
+        updated_car_with_metadata = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        owner_rel_with_metadata = await updated_car_with_metadata.owner.get(db=db)
+        assert updated_car_with_metadata._get_created_at() < before_test_start
+        assert updated_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert updated_car_with_metadata._get_updated_at() == merge_at
+        assert updated_car_with_metadata._get_updated_by() == "branch-user-two"
+        assert owner_rel_with_metadata._get_created_at() < before_test_start
+        assert owner_rel_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel_with_metadata._get_updated_at() == merge_at
+        assert owner_rel_with_metadata._get_updated_by() == "branch-user-two"
 
         john_car_count = await NodeManager.count_peers(
             db=db,
@@ -657,13 +1057,28 @@ class TestDiffAndMerge:
         )
         assert john_car_count == 1
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         # validate that the properties were correctly rolled back
-        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
-        owner_rel = await updated_car.owner.get(db=db)
+        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        owner_rel = await rolled_back_car.owner.get(db=db)
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is False
+
+        # validate metadata separately
+        rolled_back_car_with_metadata = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        # Car Node metadata should be restored
+        assert rolled_back_car_with_metadata._get_created_at() < before_test_start
+        assert rolled_back_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata._get_updated_at() < before_test_start
+        assert rolled_back_car_with_metadata._get_updated_by() == SYSTEM_USER_ID
+        owner_rel_with_metadata = await rolled_back_car_with_metadata.owner.get(db=db)
+        assert owner_rel_with_metadata._get_created_at() < before_test_start
+        assert owner_rel_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel_with_metadata._get_updated_at() < before_test_start
+        assert owner_rel_with_metadata._get_updated_by() == SYSTEM_USER_ID
         await verify_no_duplicate_paths(db=db)
 
     async def test_branch_delete_with_added_base_relationship(
@@ -677,6 +1092,12 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ) -> None:
+        # Capture initial metadata before any changes
+        car_before = await NodeManager.get_one(
+            db=db, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        car_created_at = car_before._get_created_at()
+
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -1331,7 +1331,7 @@ class TestDiffAndMerge:
         assert before_owner_rel_resolved < resolved_conflict_rel_to_john.created_at < after_owner_rel_resolved
         assert resolved_conflict_rel_to_john.updated_by == "main-user-2"
         assert before_owner_rel_resolved < resolved_conflict_rel_to_john.updated_at < after_owner_rel_resolved
-        # original is actually updated later b/c it happens durign the merge
+        # original is actually updated later b/c it happens during the merge
         original_rel_to_john = car_rels_to_john[1]
         assert original_rel_to_john.is_deleted is True
         assert original_rel_to_john.created_by == SYSTEM_USER_ID
@@ -1353,7 +1353,7 @@ class TestDiffAndMerge:
         assert before_owner_rel_resolved < resolved_conflict_rel_to_car.created_at < after_owner_rel_resolved
         assert resolved_conflict_rel_to_car.updated_by == "main-user-2"
         assert before_owner_rel_resolved < resolved_conflict_rel_to_car.updated_at < after_owner_rel_resolved
-        # original is actually updated later b/c it happens durign the merge
+        # original is actually updated later b/c it happens during the merge
         original_rel_to_car = john_rels_to_car[1]
         assert original_rel_to_car.is_deleted is True
         assert original_rel_to_car.created_by == SYSTEM_USER_ID

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -1163,7 +1163,7 @@ class TestDiffAndMerge:
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
 
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
-        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
+        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__source": car_camry_main.id})
         await car_branch.save(db=db, user_id="branch-user-two")
 
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
@@ -1177,6 +1177,8 @@ class TestDiffAndMerge:
         owner_rel = await updated_car.owner.get(db=db)
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is True
+        owner_rel_source = await owner_rel.get_source(db=db)
+        assert owner_rel_source.id == car_camry_main.id
 
         # validate metadata separately
         updated_car_with_metadata = await NodeManager.get_one(
@@ -1377,9 +1379,6 @@ class TestDiffAndMerge:
         owner_rel = await rolled_back_car.owner.get(db=db)
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is False
-<<<<<<< HEAD
-=======
-        assert owner_rel.is_visible is True
 
         # Validate metadata after rollback - car should have metadata from before merge
         # The car was modified on main (twice: first to alfred, then back to john)
@@ -1392,7 +1391,6 @@ class TestDiffAndMerge:
         assert rolled_back_car_with_metadata._get_created_at() == car_created_at
         assert rolled_back_car_with_metadata._get_updated_by() == "main-user-2"
         assert before_owner_rel_resolved < rolled_back_car_with_metadata._get_updated_at() < after_owner_rel_resolved
->>>>>>> d0b4d3025 (update unit tests some more)
         await verify_no_duplicate_paths(db=db)
 
     async def test_base_delete_with_added_branch_relationship(

--- a/backend/tests/unit/core/diff/test_diff_merger.py
+++ b/backend/tests/unit/core/diff/test_diff_merger.py
@@ -648,7 +648,8 @@ class TestMergeDiff:
             id=person_node_main.id,
             include_metadata=MetadataOptions.OWNER | MetadataOptions.UPDATED_AT,
         )
-        assert updated_person._get_updated_at() < at
+        # Node's updated_at is rolled up to the latest updated_at of its Attribute/Relationship children
+        assert updated_person._get_updated_at() == at
         assert updated_person.height.value == person_node_main.height.value + 1
         owner_node = await updated_person.height.get_owner(db=db)
         assert owner_node.id == person_node_main.id

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -262,6 +262,38 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
     assert len(list(query.get_results())) == 2
 
 
+async def test_query_NodeListGetAttributeQuery_branch_agnostic(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_john_main,
+    person_jim_main,
+) -> None:
+    right_now = Timestamp()
+    ids = [person_john_main.id, person_jim_main.id]
+
+    # Test without metadata first
+    query = await NodeListGetAttributeQuery.init(db=db, ids=ids, branch=default_branch, branch_agnostic=True)
+    await query.execute(db=db)
+    assert sorted(query.get_attributes_group_by_node().keys()) == sorted(ids)
+
+    # Test with updated metadata
+    query_with_metadata = await NodeListGetAttributeQuery.init(
+        db=db,
+        ids=ids,
+        branch=default_branch,
+        branch_agnostic=True,
+        include_metadata=MetadataOptions.UPDATED_AT | MetadataOptions.UPDATED_BY,
+    )
+    await query_with_metadata.execute(db=db)
+    attrs_by_node = query_with_metadata.get_attributes_group_by_node()
+    for node_id in ids:
+        assert node_id in attrs_by_node
+        for attr in attrs_by_node[node_id].attrs.values():
+            assert attr.updated_at is not None
+            assert attr.updated_at < right_now
+            assert attr.updated_by == SYSTEM_USER_ID
+
+
 async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, base_dataset_02) -> None:
     default_branch = await registry.get_branch(db=db, branch="main")
     branch1 = await registry.get_branch(db=db, branch="branch1")
@@ -323,6 +355,50 @@ async def test_query_NodeListGetRelationshipsQuery(
         node_id=person_jack_tags_main.id, rel_name="builtintag__testperson", direction=RelationshipDirection.INBOUND
     )
     assert peer_ids == {tag_blue_main.id, tag_red_main.id}
+
+
+async def test_query_NodeListGetRelationshipsQuery_branch_agnostic(
+    db: InfrahubDatabase, default_branch: Branch, person_jack_tags_main, tag_blue_main, tag_red_main
+) -> None:
+    right_now = Timestamp()
+
+    # Test without metadata first
+    query = await NodeListGetRelationshipsQuery.init(
+        db=db,
+        ids=[person_jack_tags_main.id],
+        branch=default_branch,
+        branch_agnostic=True,
+    )
+    await query.execute(db=db)
+    grouped_peer_nodes = query.get_peers_group_by_node()
+    assert grouped_peer_nodes.has_node(person_jack_tags_main.id)
+    peer_ids = grouped_peer_nodes.get_peer_ids(
+        node_id=person_jack_tags_main.id, rel_name="builtintag__testperson", direction=RelationshipDirection.INBOUND
+    )
+    assert peer_ids == {tag_blue_main.id, tag_red_main.id}
+
+    # Test with updated metadata
+    query_with_metadata = await NodeListGetRelationshipsQuery.init(
+        db=db,
+        ids=[person_jack_tags_main.id],
+        branch=default_branch,
+        branch_agnostic=True,
+        include_metadata=MetadataOptions.UPDATED_AT | MetadataOptions.UPDATED_BY,
+    )
+    await query_with_metadata.execute(db=db)
+    grouped_peer_nodes = query_with_metadata.get_peers_group_by_node()
+    assert grouped_peer_nodes.has_node(person_jack_tags_main.id)
+    for tag in [tag_blue_main, tag_red_main]:
+        metadata_map = grouped_peer_nodes.get_metadata_map(
+            node_id=person_jack_tags_main.id,
+            rel_name="builtintag__testperson",
+            direction=RelationshipDirection.INBOUND,
+            peer_id=tag.id,
+        )
+        assert MetadataOptions.UPDATED_AT in metadata_map
+        assert metadata_map[MetadataOptions.UPDATED_AT] < right_now
+        assert MetadataOptions.UPDATED_BY in metadata_map
+        assert metadata_map[MetadataOptions.UPDATED_BY] == SYSTEM_USER_ID
 
 
 async def test_query_NodeListGetRelationshipsQuery_hierarchical(

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -122,6 +122,17 @@ async def test_query_NodeListGetInfoQuery(
         assert node.updated_at == node.created_at
         assert node.updated_by == SYSTEM_USER_ID
 
+    query_with_metadata = await NodeListGetInfoQuery.init(
+        db=db, branch=branch, branch_agnostic=True, ids=ids, include_metadata=MetadataOptions.USER_TIMESTAMPS
+    )
+    await query_with_metadata.execute(db=db)
+    async for node in query_with_metadata.get_nodes(db=db, duplicate=False):
+        assert node.node_uuid in ids
+        assert node.created_at < right_now
+        assert node.created_by == SYSTEM_USER_ID
+        assert node.updated_at == node.created_at
+        assert node.updated_by == SYSTEM_USER_ID
+
 
 async def test_query_NodeListGetInfoQuery_renamed(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch


### PR DESCRIPTION
IFC-1945

Adds support for updating created/updated_at/by metadata during a merge.

- the existing merge-related queries needed to be updated to include the correct from_user_id and to_user_id as taken from the corresponding edge on the branch being merged.
- needed a new query (`DiffMergeMetadataQuery`) to handle updating the updated_at/by properties on Node, Relationship, and Attribute vertices affected by the merge as well as setting the `previous_updated_by/at` property in case the merge needs to be rolled back before it completes. on the default and global branches, we store the metadata as properties directly on these vertices so that querying is faster as it does not require checking every edge connected to the vertex
- the DiffMergeRollbackQuery needed to be updated to handle rolling back updated_at/by properties
- had to update a whole of tests to cover these changes effectively

there is an existing edge case that we do not handle and I'm not sure if it is important enough to figure out.
consider the following:
- create `NodeA` and `NodeB`
- create branch `br2`
- on `main`, add a relationship from `NodeA` to `NodeB`
- on `br2`, delete `NodeA`
- merge `br2`. the merge logic will handle deleting all relationships touching `NodeA`, including the relationship to `NodeB` that does not exist on `br2`
- the metadata for this relationship and `NodeB` will not be updated as part of the merge, which is technically incorrect I think


TODO:
 - test performance on very big branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced metadata tracking: created/updated timestamps and user attribution for nodes, attributes, and relationships.
  * Batch-applied metadata updates during merges and branch-agnostic metadata retrieval across queries.
  * Merge now propagates user/timestamp info through relationship and node operations and tracks affected nodes for more accurate rollback.

* **Bug Fixes**
  * Corrected relationship metadata detection and improved migrated-kind handling.
  * Adjusted time-tracking semantics for updated timestamps.

* **Tests**
  * Expanded tests covering metadata propagation, branch-agnostic queries, merge/rollback, and conflict scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->