### PR TITLE
fix(utilities): use uv within collect script

### DIFF
--- a/utilities/collect
+++ b/utilities/collect
@@ -161,7 +161,7 @@ fi
 
 # Complete the command
 DOCKER_CMD="$DOCKER_CMD \
-  registry.opsmill.io/opsmill/infrahub:${VERSION} invoke bundle.collect $EXTRA_OPTS"
+  registry.opsmill.io/opsmill/infrahub:${VERSION} uv run invoke bundle.collect $EXTRA_OPTS"
 
 if [ $RUN_BENCHMARK -eq 1 ]; then
     echo "Performance benchmark will be run (use --no-benchmark to skip)"


### PR DESCRIPTION
invoke is not installed in the default image since it's a dev dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the execution method for the bundle collection process within the container environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->