### PR TITLE
Prevent macros running if pool has not been processed yet

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -708,30 +708,32 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                         variables[variable] = None
 
                 elif attribute_path.is_type_attribute:
-                    attribute = getattr(
-                        getattr(self, attribute_path.active_attribute_schema.name),
-                        attribute_path.active_attribute_property_name,
-                    )
+                    attr_obj: BaseAttribute = getattr(self, attribute_path.active_attribute_schema.name)
+                    # Skip macro if the referenced attribute is from a pool but hasn't been allocated yet
+                    if attr_obj.from_pool and attr_obj.value is None:
+                        break
+                    attribute = getattr(attr_obj, attribute_path.active_attribute_property_name)
                     variables[variable] = attribute
+            else:
+                # Only render if the inner loop completed without breaking (all variables resolved)
+                content = await jinja_template.render(variables=variables)
 
-            content = await jinja_template.render(variables=variables)
+                generator_method_name = "_generate_attribute_default"
+                if hasattr(self, f"generate_{attr_schema.name}"):
+                    generator_method_name = f"generate_{attr_schema.name}"
 
-            generator_method_name = "_generate_attribute_default"
-            if hasattr(self, f"generate_{attr_schema.name}"):
-                generator_method_name = f"generate_{attr_schema.name}"
+                generator_method = getattr(self, generator_method_name)
+                try:
+                    setattr(
+                        self,
+                        attr_schema.name,
+                        await generator_method(db=db, name=attr_schema.name, schema=attr_schema, data=content),
+                    )
+                    attribute = getattr(self, attr_schema.name)
 
-            generator_method = getattr(self, generator_method_name)
-            try:
-                setattr(
-                    self,
-                    attr_schema.name,
-                    await generator_method(db=db, name=attr_schema.name, schema=attr_schema, data=content),
-                )
-                attribute = getattr(self, attr_schema.name)
-
-                attribute.validate(value=attribute.value, name=attribute.name, schema=attribute.schema)
-            except ValidationError as exc:
-                errors.append(exc)
+                    attribute.validate(value=attribute.value, name=attribute.name, schema=attribute.schema)
+                except ValidationError as exc:
+                    errors.append(exc)
 
         if errors:
             raise ValidationError(errors)
@@ -799,6 +801,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         self.id = id or str(UUIDT())
 
         await self._process_fields(db=db, fields=kwargs, process_pools=process_pools)
+        print(f"Processed fields for new node {self}")
         await self._process_macros(db=db)
 
         return self

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -801,7 +801,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         self.id = id or str(UUIDT())
 
         await self._process_fields(db=db, fields=kwargs, process_pools=process_pools)
-        print(f"Processed fields for new node {self}")
         await self._process_macros(db=db)
 
         return self

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -752,7 +752,6 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         self.id = id or str(UUIDT())
 
         await self._process_fields(db=db, fields=kwargs, process_pools=process_pools)
-        print(f"Processed fields for new node {self}")
         await self._process_macros(db=db)
 
         return self

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -665,30 +665,32 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                         variables[variable] = None
 
                 elif attribute_path.is_type_attribute:
-                    attribute = getattr(
-                        getattr(self, attribute_path.active_attribute_schema.name),
-                        attribute_path.active_attribute_property_name,
-                    )
+                    attr_obj: BaseAttribute = getattr(self, attribute_path.active_attribute_schema.name)
+                    # Skip macro if the referenced attribute is from a pool but hasn't been allocated yet
+                    if attr_obj.from_pool and attr_obj.value is None:
+                        break
+                    attribute = getattr(attr_obj, attribute_path.active_attribute_property_name)
                     variables[variable] = attribute
+            else:
+                # Only render if the inner loop completed without breaking (all variables resolved)
+                content = await jinja_template.render(variables=variables)
 
-            content = await jinja_template.render(variables=variables)
+                generator_method_name = "_generate_attribute_default"
+                if hasattr(self, f"generate_{attr_schema.name}"):
+                    generator_method_name = f"generate_{attr_schema.name}"
 
-            generator_method_name = "_generate_attribute_default"
-            if hasattr(self, f"generate_{attr_schema.name}"):
-                generator_method_name = f"generate_{attr_schema.name}"
+                generator_method = getattr(self, generator_method_name)
+                try:
+                    setattr(
+                        self,
+                        attr_schema.name,
+                        await generator_method(db=db, name=attr_schema.name, schema=attr_schema, data=content),
+                    )
+                    attribute = getattr(self, attr_schema.name)
 
-            generator_method = getattr(self, generator_method_name)
-            try:
-                setattr(
-                    self,
-                    attr_schema.name,
-                    await generator_method(db=db, name=attr_schema.name, schema=attr_schema, data=content),
-                )
-                attribute = getattr(self, attr_schema.name)
-
-                attribute.validate(value=attribute.value, name=attribute.name, schema=attribute.schema)
-            except ValidationError as exc:
-                errors.append(exc)
+                    attribute.validate(value=attribute.value, name=attribute.name, schema=attribute.schema)
+                except ValidationError as exc:
+                    errors.append(exc)
 
         if errors:
             raise ValidationError(errors)
@@ -750,6 +752,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         self.id = id or str(UUIDT())
 
         await self._process_fields(db=db, fields=kwargs, process_pools=process_pools)
+        print(f"Processed fields for new node {self}")
         await self._process_macros(db=db)
 
         return self

--- a/backend/tests/component/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/component/graphql/test_mutation_create_jinja2_attributes.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core import registry
+from infrahub.core.constants import ComputedAttributeKind
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot, internal_schema
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot, internal_schema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
@@ -219,3 +221,83 @@ async def test_create_with_jinja2_with_generics(
     assert site_result.data
     assert site_result.data["TestingSiteCreate"]["ok"] is True
     assert site_result.data["TestingSiteCreate"]["object"]["code"]["value"] == "st"
+
+
+async def test_create_with_jinja2_format_filter_on_number_pool(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    node_group_schema: None,
+    data_schema: None,
+    register_core_models_schema: None,
+    branch: Branch,
+) -> None:
+    """Test that Jinja2 computed attributes using format filter on NumberPool values work correctly.
+
+    This is a regression test for GitHub issue #7836 where using the format filter
+    (e.g., "{{ '%09d' | format(number__value) }}") on a NumberPool attribute would fail
+    with "%d format: a real number is required, not NoneType" because the preview object
+    created during node creation had process_pools=False, leaving the pool value as None.
+    """
+    from infrahub.core.constants import InfrahubKind
+    from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+
+    schema = SchemaRoot(**internal_schema)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+    branch.update_schema_hash()
+    await branch.save(db=db)
+
+    # Schema with NumberPool attribute and Jinja2 computed attribute using format filter
+    ticket_schema = NodeSchema(
+        name="Ticket",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="title", kind="Text", optional=False),
+            AttributeSchema(name="sequence_number", kind="NumberPool", optional=False, read_only=True, unique=True),
+            AttributeSchema(
+                name="serial_number",
+                kind="Text",
+                optional=False,
+                read_only=True,
+                computed_attribute=ComputedAttribute(
+                    kind=ComputedAttributeKind.JINJA2,
+                    jinja2_template="TKT{{ '%09d' | format(sequence_number__value) }}",
+                ),
+            ),
+        ],
+    )
+
+    await load_schema(db, branch_name=branch.name, schema=SchemaRoot(nodes=[ticket_schema]))
+
+    query = """
+    mutation {
+        TestingTicketCreate(data: {
+            title: { value: "Test Ticket" }
+        }) {
+            ok
+            object {
+                id
+                title { value }
+                sequence_number { value }
+                serial_number { value }
+            }
+        }
+    }
+    """
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["TestingTicketCreate"]["ok"] is True
+    # The sequence_number should be allocated from the pool (starting at 1)
+    assert result.data["TestingTicketCreate"]["object"]["sequence_number"]["value"] == 1
+    # The serial_number should be formatted with leading zeros
+    assert result.data["TestingTicketCreate"]["object"]["serial_number"]["value"] == "TKT000000001"

--- a/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core import registry
+from infrahub.core.constants import ComputedAttributeKind
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot, internal_schema
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot, internal_schema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
@@ -219,3 +221,83 @@ async def test_create_with_jinja2_with_generics(
     assert site_result.data
     assert site_result.data["TestingSiteCreate"]["ok"] is True
     assert site_result.data["TestingSiteCreate"]["object"]["code"]["value"] == "st"
+
+
+async def test_create_with_jinja2_format_filter_on_number_pool(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    node_group_schema: None,
+    data_schema: None,
+    register_core_models_schema: None,
+    branch: Branch,
+) -> None:
+    """Test that Jinja2 computed attributes using format filter on NumberPool values work correctly.
+
+    This is a regression test for GitHub issue #7836 where using the format filter
+    (e.g., "{{ '%09d' | format(number__value) }}") on a NumberPool attribute would fail
+    with "%d format: a real number is required, not NoneType" because the preview object
+    created during node creation had process_pools=False, leaving the pool value as None.
+    """
+    from infrahub.core.constants import InfrahubKind
+    from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+
+    schema = SchemaRoot(**internal_schema)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+    branch.update_schema_hash()
+    await branch.save(db=db)
+
+    # Schema with NumberPool attribute and Jinja2 computed attribute using format filter
+    ticket_schema = NodeSchema(
+        name="Ticket",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="title", kind="Text", optional=False),
+            AttributeSchema(name="sequence_number", kind="NumberPool", optional=False, read_only=True, unique=True),
+            AttributeSchema(
+                name="serial_number",
+                kind="Text",
+                optional=False,
+                read_only=True,
+                computed_attribute=ComputedAttribute(
+                    kind=ComputedAttributeKind.JINJA2,
+                    jinja2_template="TKT{{ '%09d' | format(sequence_number__value) }}",
+                ),
+            ),
+        ],
+    )
+
+    await load_schema(db, branch_name=branch.name, schema=SchemaRoot(nodes=[ticket_schema]))
+
+    query = """
+    mutation {
+        TestingTicketCreate(data: {
+            title: { value: "Test Ticket" }
+        }) {
+            ok
+            object {
+                id
+                title { value }
+                sequence_number { value }
+                serial_number { value }
+            }
+        }
+    }
+    """
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["TestingTicketCreate"]["ok"] is True
+    # The sequence_number should be allocated from the pool (starting at 1)
+    assert result.data["TestingTicketCreate"]["object"]["sequence_number"]["value"] == 1
+    # The serial_number should be formatted with leading zeros
+    assert result.data["TestingTicketCreate"]["object"]["serial_number"]["value"] == "TKT000000001"

--- a/changelog/7836.fixed.md
+++ b/changelog/7836.fixed.md
@@ -1,0 +1,1 @@
+Skip Jinja2 macro processing when a referenced attribute is from a pool but hasn't been allocated yet.


### PR DESCRIPTION
Fixes: #7836 

Logic Implemented: 

  1. For each variable in the Jinja2 template:
    - If it's from a relationship, handle it as before
    - If it's a local attribute:
        - Get the attribute object
      - Check if it's a pool attribute (from_pool is set) with an unallocated value (value is None)
      - If so, break out of the inner variable loop
      - Otherwise, get the property value and add to variables
  2. The for...else construct means:
    - If the inner loop completes normally (no break), execute the else block which renders the template and creates the attribute
    - If the inner loop breaks (pool value not allocated), skip the else block entirely, moving to the next macro in the outer loop
    
 I added a new regression test in backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py:

  - Test name: test_create_with_jinja2_format_filter_on_number_pool
  - Purpose: Tests that Jinja2 computed attributes using the format filter on NumberPool values work correctly
  - Specifically tests the GitHub issue #7836 scenario: A template like "TKT{{ '%09d' | format(sequence_number__value) }}" that formats a NumberPool value with leading zeros
  - The test passes (both for main branch and branch2 parametrized cases)

  The test creates:
  1. A TestingTicket schema with:
    - title - text field
    - sequence_number - NumberPool field
    - serial_number - Text field computed via Jinja2 using format filter on the NumberPool value
  2. Creates a ticket via GraphQL mutation
  3. Verifies the sequence_number gets allocated (value=1)
  4. Verifies the serial_number is correctly formatted as "TKT000000001"
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip Jinja2 macro rendering and validation when a referenced attribute comes from a pool but hasn’t been allocated yet, preventing erroneous errors during attribute generation.

* **Tests**
  * Added a unit test validating Jinja2 computed attributes that format values allocated from a number pool (verifies zero-padded serial formatting).

* **Chores**
  * Added a changelog entry documenting the macro-processing skip behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->