### PR TITLE
fix(backend): HFID upsert no longer conflicts with sibling types

### DIFF
--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -110,8 +110,17 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                 continue
 
             # Create the valued query request for this constraint
+            # For HFID constraints, use the actual node's kind to ensure the query
+            # only matches nodes of the exact same type. This is important when
+            # node_schema is a parent/generic schema - sibling types that inherit
+            # from the same parent should be allowed to have the same HFID values.
+            # For STANDARD uniqueness constraints, use the schema's kind to enforce
+            # cross-type uniqueness as intended by generic constraints.
+            query_kind = (
+                node.get_kind() if uniqueness_constraint_path.typ == UniquenessConstraintType.HFID else node_schema.kind
+            )
             valued_query_request = NodeUniquenessQueryRequestValued(
-                kind=node_schema.kind,
+                kind=query_kind,
                 unique_valued_paths=valued_paths,
             )
 

--- a/backend/tests/unit/core/constraint_validators/conftest.py
+++ b/backend/tests/unit/core/constraint_validators/conftest.py
@@ -119,6 +119,53 @@ async def car_person_generics_data_simple(db: InfrahubDatabase, car_person_schem
 
 
 @pytest.fixture
+async def location_schema_hfid_on_generic(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+    """Schema with HFID defined on a generic (parent) with multiple concrete children.
+
+    This tests that HFID uniqueness is properly scoped to the specific child type,
+    not the parent generic type.
+    """
+    SCHEMA = {
+        "generics": [
+            {
+                "name": "Location",
+                "namespace": "Test",
+                "human_friendly_id": ["name__value"],
+                "display_labels": ["name__value"],
+                "order_by": ["name__value"],
+                "attributes": [
+                    {"name": "name", "kind": "Text"},
+                ],
+            },
+        ],
+        "nodes": [
+            {
+                "name": "LocationState",
+                "namespace": "Test",
+                "inherit_from": ["TestLocation"],
+                "display_labels": ["name__value"],
+                "attributes": [
+                    {"name": "state_code", "kind": "Text", "optional": True},
+                ],
+            },
+            {
+                "name": "LocationCountry",
+                "namespace": "Test",
+                "inherit_from": ["TestLocation"],
+                "display_labels": ["name__value"],
+                "attributes": [
+                    {"name": "country_code", "kind": "Text", "optional": True},
+                ],
+            },
+        ],
+    }
+
+    schema = SchemaRoot(**SCHEMA)
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    return schema
+
+
+@pytest.fixture
 async def car_person_schema_hfid(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
     SCHEMA = {
         "nodes": [

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -343,3 +343,42 @@ class TestNodeGroupedUniquenessConstraint:
         with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name'") as exc_info:
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_mercedes_of_maria)
         assert not isinstance(exc_info.value, HFIDViolatedError), "HFIDViolatedError should not be raised here"
+
+    async def test_hfid_on_generic_sibling_types_no_conflict(
+        self, db: InfrahubDatabase, default_branch: Branch, location_schema_hfid_on_generic
+    ) -> None:
+        """Test that sibling types with same HFID value don't conflict.
+
+        When HFID is defined on a parent generic (e.g., TestLocation), two different
+        child types (e.g., TestLocationState and TestLocationCountry) should be able to
+        have the same HFID value without conflict, since they are different types.
+
+        This tests the fix for the issue where:
+        ["LocationStateUpsert"] Node with id <uuid> exists, but it is a LocationCountry, not LocationState
+        """
+        # Create a LocationCountry with name "Georgia"
+        await create_and_save(db=db, schema="TestLocationCountry", name="Georgia", country_code="GE")
+
+        # Create a LocationState with the same name "Georgia" - this should NOT conflict
+        # because they are different types, even though they share the same parent HFID
+        location_state = await create_and_save(db=db, schema="TestLocationState", name="Georgia", state_code="GA")
+
+        # The uniqueness check should pass - no exception should be raised
+        await self.__call_system_under_test(db=db, branch=default_branch, node=location_state)
+
+    async def test_hfid_on_generic_same_type_does_conflict(
+        self, db: InfrahubDatabase, default_branch: Branch, location_schema_hfid_on_generic
+    ) -> None:
+        """Test that same types with same HFID value DO conflict.
+
+        Two nodes of the same type (e.g., both TestLocationState) should still conflict
+        if they have the same HFID value.
+        """
+        # Create first LocationState with name "Georgia"
+        _ = await create_and_save(db=db, schema="TestLocationState", name="Georgia", state_code="GA")
+
+        # Create second LocationState with same name - this SHOULD conflict
+        location_state_2 = await create_and_save(db=db, schema="TestLocationState", name="Georgia", state_code="GA2")
+
+        with pytest.raises(HFIDViolatedError, match="Violates uniqueness constraint 'name'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=location_state_2)

--- a/changelog/7841.fixed.md
+++ b/changelog/7841.fixed.md
@@ -1,0 +1,1 @@
+Fixed HFID upsert incorrectly conflicting with sibling types when HFID is defined on parent generic


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HFID uniqueness constraint validation to correctly handle scenarios where HFID constraints are defined on parent generic types. Different child types can now properly share identical HFID values without triggering false uniqueness violations, enabling correct upsert behavior in hierarchical data models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Fixed HFID upsert incorrectly conflicting with sibling types when HFID is defined on a parent generic
- Added tests to verify sibling types can have the same HFID values
- Added tests to verify same types still conflict as expected

## Root Cause

When HFID is defined on a parent generic schema (e.g., `Location`), the uniqueness query was using `node_schema.kind` (the parent's kind) instead of the actual node's specific kind. This caused the Cypher query to match nodes of any child type, leading to false HFID violations when sibling types had the same HFID value.

## Fix

The fix differentiates between HFID constraints and standard uniqueness constraints:
- **HFID constraints**: Use the actual node's kind (`node.get_kind()`) to scope uniqueness to the specific type
- **Standard uniqueness constraints**: Continue using the schema's kind to enforce cross-type uniqueness as intended by generic constraints

## Test plan

- [x] Added `test_hfid_on_generic_sibling_types_no_conflict` - verifies sibling types (e.g., LocationState and LocationCountry) can have the same HFID value ("Georgia")
- [x] Added `test_hfid_on_generic_same_type_does_conflict` - verifies same types still conflict as expected
- [x] All existing grouped uniqueness tests pass (26 tests)
- [x] Linting passes

Fixes #7841

🤖 Generated with [Claude Code](https://claude.com/claude-code)