### PR TITLE
Restructure metadata query and response format

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -552,6 +552,12 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                     )
                 continue
 
+            if field_name == "meta" and isinstance(fields.get("meta"), dict):
+                response[field_name] = {
+                    meta_field: getattr(self, meta_field, None) for meta_field in fields.get(field_name).keys()
+                }
+                continue
+
             if field_name.startswith("_"):
                 field = getattr(self, field_name[1:])
             else:

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -527,6 +527,10 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                 response[field_name] = updated_at.to_graphql() if updated_at else None
                 continue
 
+            if field_name == "updated_by":
+                response[field_name] = self._get_updated_by()
+                continue
+
             if field_name == "__typename":
                 response[field_name] = self.get_kind()
                 continue
@@ -550,12 +554,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                         fields={"id": None, "display_label": None, "__typename": None},
                         related_node_ids=related_node_ids,
                     )
-                continue
-
-            if field_name == "meta" and isinstance(fields.get("meta"), dict):
-                response[field_name] = {
-                    meta_field: getattr(self, meta_field, None) for meta_field in fields.get(field_name).keys()
-                }
                 continue
 
             if field_name.startswith("_"):

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -20,6 +20,7 @@ from infrahub.core.constants import (
     SYSTEM_USER_ID,
     AttributeDBNodeType,
     BranchSupportType,
+    InfrahubKind,
     MetadataOptions,
 )
 from infrahub.core.metadata.interface import MetadataInterface
@@ -524,11 +525,18 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         for field_name in field_names:
             if field_name == "updated_at":
                 updated_at = self._get_updated_at()
-                response[field_name] = updated_at.to_graphql() if updated_at else None
+                response[field_name] = await updated_at.to_graphql() if updated_at else None
                 continue
 
             if field_name == "updated_by":
-                response[field_name] = self._get_updated_by()
+                response[field_name] = (
+                    {
+                        "id": self._get_updated_by(),
+                        "__kind__": InfrahubKind.ACCOUNT,
+                    }
+                    if self._get_updated_by()
+                    else None
+                )
                 continue
 
             if field_name == "__typename":

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -37,7 +37,6 @@ class Branch(StandardNode):
     origin_branch: str = "main"
     branched_from: Optional[str] = Field(default=None, validate_default=True)
     hierarchy_level: int = 2
-    created_at: Optional[str] = Field(default=None, validate_default=True)
     is_default: bool = False
     is_global: bool = False
     is_protected: bool = False
@@ -92,11 +91,6 @@ class Branch(StandardNode):
         if not self.branched_from:
             raise RuntimeError(f"branched_from not set for branch {self.name}")
         return self.branched_from
-
-    @field_validator("created_at", mode="before")
-    @classmethod
-    def set_created_at(cls, value: str) -> str:
-        return Timestamp(value).to_string()
 
     def get_created_at(self) -> str:
         if not self.created_at:

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -75,13 +75,8 @@ def get_schema[SchemaProtocol](
 ) -> MainSchemaTypes:
     if isinstance(node_schema, str):
         return db.schema.get(name=node_schema, branch=branch.name, duplicate=duplicate)
-    if (
-        hasattr(node_schema, "_is_runtime_protocol")
-        and node_schema._is_runtime_protocol
-    ):
-        return db.schema.get(
-            name=node_schema.__name__, branch=branch.name, duplicate=duplicate
-        )
+    if hasattr(node_schema, "_is_runtime_protocol") and node_schema._is_runtime_protocol:
+        return db.schema.get(name=node_schema.__name__, branch=branch.name, duplicate=duplicate)
     if not isinstance(node_schema, (MainSchemaTypes)):
         raise ValueError(f"Invalid schema provided {node_schema}")
 
@@ -213,9 +208,7 @@ class NodeManager:
             # This is a workaround to ensure we are querying the right fields for permissions
             # The identifier for permissions needs the same fields as the display label
             schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(
-                name=node_schema.kind
-            )
+            display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
             if display_label_fields:
                 deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
@@ -237,12 +230,7 @@ class NodeManager:
     async def count(
         cls,
         db: InfrahubDatabase,
-        schema: type[SchemaProtocol]
-        | NodeSchema
-        | GenericSchema
-        | ProfileSchema
-        | TemplateSchema
-        | str,
+        schema: type[SchemaProtocol] | NodeSchema | GenericSchema | ProfileSchema | TemplateSchema | str,
         filters: dict | None = None,
         at: Timestamp | str | None = None,
         branch: Branch | str | None = None,
@@ -358,9 +346,7 @@ class NodeManager:
                 InfrahubKind.OBJECTPERMISSION,
             ]:
                 schema_branch = db.schema.get_schema_branch(name=branch.name)
-                display_label_fields = schema_branch.generate_fields_for_display_label(
-                    name=peer_schema.kind
-                )
+                display_label_fields = schema_branch.generate_fields_for_display_label(name=peer_schema.kind)
                 if display_label_fields:
                     deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
@@ -660,9 +646,7 @@ class NodeManager:
         kind_str = node_schema.kind
 
         if not node_schema.default_filter:
-            raise NodeNotFoundError(
-                branch_name=branch.name, node_type=kind_str, identifier=id
-            )
+            raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
 
         items = await NodeManager.query(
             db=db,
@@ -839,9 +823,7 @@ class NodeManager:
 
         filters = {}
         for key, item in zip(node_schema.human_friendly_id, hfid, strict=False):
-            path = node_schema.parse_schema_path(
-                path=key, schema=registry.schema.get_schema_branch(name=branch.name)
-            )
+            path = node_schema.parse_schema_path(path=key, schema=registry.schema.get_schema_branch(name=branch.name))
 
             if path.is_type_relationship and path.related_schema:
                 rel_schema = path.related_schema
@@ -851,9 +833,7 @@ class NodeManager:
                     schema=registry.schema.get_schema_branch(name=branch.name),
                 )
 
-            filters[key] = (
-                path.active_attribute_schema.get_class().deserialize_from_string(item)
-            )
+            filters[key] = path.active_attribute_schema.get_class().deserialize_from_string(item)
 
         items = await NodeManager.query(
             db=db,
@@ -872,9 +852,7 @@ class NodeManager:
 
         if len(items) < 1:
             if raise_on_error:
-                raise NodeNotFoundError(
-                    branch_name=branch.name, node_type=kind_str, identifier=hfid_str
-                )
+                raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=hfid_str)
             return None
 
         if len(items) > 1:
@@ -962,9 +940,7 @@ class NodeManager:
             branch_agnostic=branch_agnostic,
         )
         if not node:
-            raise NodeNotFoundError(
-                branch_name=branch.name, node_type=kind, identifier=id
-            )
+            raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
         return node
 
     @overload
@@ -1141,9 +1117,7 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                raise NodeNotFoundError(
-                    branch_name=branch.name, node_type=kind, identifier=id
-                )
+                raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
             return None
 
         node = result[id]
@@ -1160,8 +1134,7 @@ class NodeManager:
         ]
 
         if kind_validation and (
-            node_schema.kind != kind_validation
-            and kind_validation not in node_schema.inherit_from
+            node_schema.kind != kind_validation and kind_validation not in node_schema.inherit_from
         ):
             for item in kind_validation_exceptions:
                 if item[0] == kind_validation and item[1] == node.get_kind():
@@ -1199,10 +1172,8 @@ class NodeManager:
 
         if fields or metadata_fields:
             metadata_determiner = MetadataDeterminer()
-            include_metadata_for_fields = (
-                await metadata_determiner.determine_metadata_for_fields(
-                    node_fields=fields or {}, metadata_fields=metadata_fields
-                )
+            include_metadata_for_fields = await metadata_determiner.determine_metadata_for_fields(
+                node_fields=fields or {}, metadata_fields=metadata_fields
             )
             if isinstance(include_metadata, MetadataQueryOptions):
                 include_metadata |= include_metadata_for_fields
@@ -1212,9 +1183,7 @@ class NodeManager:
 
         # Query all nodes
         node_metadata_options = (
-            include_metadata.node_level
-            if isinstance(include_metadata, MetadataQueryOptions)
-            else include_metadata
+            include_metadata.node_level if isinstance(include_metadata, MetadataQueryOptions) else include_metadata
         )
         query = await NodeListGetInfoQuery.init(
             db=db,
@@ -1225,15 +1194,11 @@ class NodeManager:
             include_metadata=node_metadata_options,
         )
         await query.execute(db=db)
-        nodes_info_by_id: dict[str, NodeToProcess] = {
-            node.node_uuid: node async for node in query.get_nodes(db=db)
-        }
+        nodes_info_by_id: dict[str, NodeToProcess] = {node.node_uuid: node async for node in query.get_nodes(db=db)}
 
         # Query list of all Attributes
         attribute_metadata_options = (
-            include_metadata.attribute_level
-            if isinstance(include_metadata, MetadataQueryOptions)
-            else include_metadata
+            include_metadata.attribute_level if isinstance(include_metadata, MetadataQueryOptions) else include_metadata
         )
         query = await NodeListGetAttributeQuery.init(
             db=db,
@@ -1275,9 +1240,7 @@ class NodeManager:
 
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)
-            item = await node_class.init(
-                schema=node.schema, branch=node_branch, at=at, db=db
-            )
+            item = await node_class.init(schema=node.schema, branch=node_branch, at=at, db=db)
             await item.load(**new_node_data, db=db)
             item._set_created_at(node.created_at)
             item._set_created_by(node.created_by)
@@ -1319,24 +1282,18 @@ class NodeManager:
     ) -> None:
         if not prefetch_relationships and not fields:
             return
-        cardinality_one_identifiers_by_kind: (
-            dict[str, dict[str, RelationshipDirection]] | None
-        ) = None
+        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]] | None = None
         outbound_identifiers: set[str] | None = None
         inbound_identifiers: set[str] | None = None
         bidirectional_identifiers: set[str] | None = None
         if not prefetch_relationships:
-            cardinality_one_identifiers_by_kind = (
-                _get_cardinality_one_identifiers_by_kind(
-                    nodes=nodes_by_id.values(), fields=fields or {}
-                )
+            cardinality_one_identifiers_by_kind = _get_cardinality_one_identifiers_by_kind(
+                nodes=nodes_by_id.values(), fields=fields or {}
             )
             outbound_identifiers = set()
             inbound_identifiers = set()
             bidirectional_identifiers = set()
-            for (
-                identifier_direction_map
-            ) in cardinality_one_identifiers_by_kind.values():
+            for identifier_direction_map in cardinality_one_identifiers_by_kind.values():
                 for identifier, direction in identifier_direction_map.items():
                     if direction is RelationshipDirection.OUTBOUND:
                         outbound_identifiers.add(identifier)
@@ -1348,15 +1305,9 @@ class NodeManager:
         query = await NodeListGetRelationshipsQuery.init(
             db=db,
             ids=list(nodes_by_id.keys()),
-            outbound_identifiers=None
-            if outbound_identifiers is None
-            else list(outbound_identifiers),
-            inbound_identifiers=None
-            if inbound_identifiers is None
-            else list(inbound_identifiers),
-            bidirectional_identifiers=None
-            if bidirectional_identifiers is None
-            else list(bidirectional_identifiers),
+            outbound_identifiers=None if outbound_identifiers is None else list(outbound_identifiers),
+            inbound_identifiers=None if inbound_identifiers is None else list(inbound_identifiers),
+            bidirectional_identifiers=None if bidirectional_identifiers is None else list(bidirectional_identifiers),
             branch=branch,
             at=at,
             branch_agnostic=branch_agnostic,
@@ -1398,8 +1349,7 @@ class NodeManager:
         node: Node,
         grouped_peer_nodes: GroupedPeerNodes,
         nodes_by_id: dict[str, Node],
-        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]]
-        | None,
+        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]] | None,
         insert_peer_node: bool,
     ) -> None:
         if not grouped_peer_nodes.has_node(node_id=node.get_id()):
@@ -1424,18 +1374,15 @@ class NodeManager:
                         rel_peers.append(peer)
             # if only getting some relationships, make sure we want THIS relationship for THIS node schema
             elif cardinality_one_identifiers_by_kind:
-                required_direction = cardinality_one_identifiers_by_kind.get(
-                    node_schema.kind, {}
-                ).get(rel_schema.get_identifier())
+                required_direction = cardinality_one_identifiers_by_kind.get(node_schema.kind, {}).get(
+                    rel_schema.get_identifier()
+                )
                 if required_direction is not rel_schema.direction:
                     continue
                 rel_peers = list(peer_ids)
             else:
                 continue
-            if (
-                rel_schema.cardinality is RelationshipCardinality.ONE
-                and len(rel_peers) > 1
-            ):
+            if rel_schema.cardinality is RelationshipCardinality.ONE and len(rel_peers) > 1:
                 raise ValueError("At most, one relationship expected")
 
             rel_peers_with_metadata: list[PeerWithRelationshipMetadata] = []
@@ -1451,18 +1398,10 @@ class NodeManager:
                 if not metadata_map:
                     rel_peers_with_metadata.append(peer_with_metadata)
                     continue
-                peer_with_metadata.created_at = metadata_map.get(
-                    MetadataOptions.CREATED_AT
-                )
-                peer_with_metadata.created_by = metadata_map.get(
-                    MetadataOptions.CREATED_BY
-                )
-                peer_with_metadata.updated_at = metadata_map.get(
-                    MetadataOptions.UPDATED_AT
-                )
-                peer_with_metadata.updated_by = metadata_map.get(
-                    MetadataOptions.UPDATED_BY
-                )
+                peer_with_metadata.created_at = metadata_map.get(MetadataOptions.CREATED_AT)
+                peer_with_metadata.created_by = metadata_map.get(MetadataOptions.CREATED_BY)
+                peer_with_metadata.updated_at = metadata_map.get(MetadataOptions.UPDATED_AT)
+                peer_with_metadata.updated_by = metadata_map.get(MetadataOptions.UPDATED_BY)
                 rel_peers_with_metadata.append(peer_with_metadata)
 
             rel_manager.has_fetched_relationships = True
@@ -1482,15 +1421,11 @@ class NodeManager:
         nodes_to_delete = copy(nodes)
         if cascade_delete:
             node_delete_validator = NodeDeleteValidator(db=db, branch=branch)
-            ids_to_delete = await node_delete_validator.get_ids_to_delete(
-                nodes=nodes, at=at
-            )
+            ids_to_delete = await node_delete_validator.get_ids_to_delete(nodes=nodes, at=at)
             node_ids = {node.get_id() for node in nodes}
             missing_ids_to_delete = ids_to_delete - node_ids
             if missing_ids_to_delete:
-                node_map = await cls.get_many(
-                    db=db, ids=list(missing_ids_to_delete), branch=branch, at=at
-                )
+                node_map = await cls.get_many(db=db, ids=list(missing_ids_to_delete), branch=branch, at=at)
                 nodes_to_delete += list(node_map.values())
 
         for node in nodes_to_delete:
@@ -1516,12 +1451,9 @@ def _get_cardinality_one_identifiers_by_kind(
         cardinality_one_rel_identifiers_in_fields = {
             rel_schema.identifier: rel_schema.direction
             for rel_schema in node_schema.relationships
-            if rel_schema.cardinality is RelationshipCardinality.ONE
-            and rel_schema.name in field_names_set
+            if rel_schema.cardinality is RelationshipCardinality.ONE and rel_schema.name in field_names_set
         }
-        cardinality_one_fields_by_kind[node_schema.kind] = (
-            cardinality_one_rel_identifiers_in_fields
-        )
+        cardinality_one_fields_by_kind[node_schema.kind] = cardinality_one_rel_identifiers_in_fields
     return cardinality_one_fields_by_kind
 
 

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
 from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
 
-from infrahub.core.constants import InfrahubKind, MetadataOptions, RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import (
+    InfrahubKind,
+    MetadataOptions,
+    RelationshipCardinality,
+    RelationshipDirection,
+)
 from infrahub.core.metadata.determiner import MetadataDeterminer
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.node import Node
@@ -70,8 +75,13 @@ def get_schema[SchemaProtocol](
 ) -> MainSchemaTypes:
     if isinstance(node_schema, str):
         return db.schema.get(name=node_schema, branch=branch.name, duplicate=duplicate)
-    if hasattr(node_schema, "_is_runtime_protocol") and node_schema._is_runtime_protocol:
-        return db.schema.get(name=node_schema.__name__, branch=branch.name, duplicate=duplicate)
+    if (
+        hasattr(node_schema, "_is_runtime_protocol")
+        and node_schema._is_runtime_protocol
+    ):
+        return db.schema.get(
+            name=node_schema.__name__, branch=branch.name, duplicate=duplicate
+        )
     if not isinstance(node_schema, (MainSchemaTypes)):
         raise ValueError(f"Invalid schema provided {node_schema}")
 
@@ -87,6 +97,7 @@ class NodeManager:
         schema: NodeSchema | GenericSchema | ProfileSchema | TemplateSchema | str,
         filters: dict | None = ...,
         fields: dict | None = ...,
+        metadata_fields: dict | None = ...,
         offset: int | None = ...,
         limit: int | None = ...,
         at: Timestamp | str | None = ...,
@@ -107,6 +118,7 @@ class NodeManager:
         schema: type[SchemaProtocol],
         filters: dict | None = ...,
         fields: dict | None = ...,
+        metadata_fields: dict | None = ...,
         offset: int | None = ...,
         limit: int | None = ...,
         at: Timestamp | str | None = ...,
@@ -126,6 +138,7 @@ class NodeManager:
         schema: type[SchemaProtocol] | MainSchemaTypes | str,
         filters: dict | None = None,
         fields: dict | None = None,
+        metadata_fields: dict | None = None,
         offset: int | None = None,
         limit: int | None = None,
         at: Timestamp | str | None = None,
@@ -200,13 +213,16 @@ class NodeManager:
             # This is a workaround to ensure we are querying the right fields for permissions
             # The identifier for permissions needs the same fields as the display label
             schema_branch = db.schema.get_schema_branch(name=branch.name)
-            display_label_fields = schema_branch.generate_fields_for_display_label(name=node_schema.kind)
+            display_label_fields = schema_branch.generate_fields_for_display_label(
+                name=node_schema.kind
+            )
             if display_label_fields:
                 deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
         response = await cls.get_many(
             ids=node_ids,
             fields=fields,
+            metadata_fields=metadata_fields,
             branch=branch,
             at=at,
             include_metadata=include_metadata,
@@ -221,7 +237,12 @@ class NodeManager:
     async def count(
         cls,
         db: InfrahubDatabase,
-        schema: type[SchemaProtocol] | NodeSchema | GenericSchema | ProfileSchema | TemplateSchema | str,
+        schema: type[SchemaProtocol]
+        | NodeSchema
+        | GenericSchema
+        | ProfileSchema
+        | TemplateSchema
+        | str,
         filters: dict | None = None,
         at: Timestamp | str | None = None,
         branch: Branch | str | None = None,
@@ -295,6 +316,7 @@ class NodeManager:
         schema: RelationshipSchema,
         filters: dict,
         fields: dict | None = None,
+        metadata_fields: dict | None = None,
         offset: int | None = None,
         limit: int | None = None,
         at: Timestamp | str | None = None,
@@ -336,7 +358,9 @@ class NodeManager:
                 InfrahubKind.OBJECTPERMISSION,
             ]:
                 schema_branch = db.schema.get_schema_branch(name=branch.name)
-                display_label_fields = schema_branch.generate_fields_for_display_label(name=peer_schema.kind)
+                display_label_fields = schema_branch.generate_fields_for_display_label(
+                    name=peer_schema.kind
+                )
                 if display_label_fields:
                     deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
@@ -350,12 +374,17 @@ class NodeManager:
                 branch=branch,
                 branch_agnostic=branch_agnostic,
                 include_metadata=include_metadata,
+                metadata_fields=metadata_fields,
             )
 
         results = []
         for peer in peers_info:
             result = Relationship(
-                schema=schema, branch=branch, source_kind=peer.source_kind, at=at, node_id=peer.source_id
+                schema=schema,
+                branch=branch,
+                source_kind=peer.source_kind,
+                at=at,
+                node_id=peer.source_id,
             ).load(
                 db=db,
                 id=peer.rel_node_id,
@@ -430,7 +459,12 @@ class NodeManager:
             return {}
 
         return await cls.get_many(
-            db=db, ids=peers_ids, fields=fields, at=at, branch=branch, include_metadata=MetadataOptions.LINKED_NODES
+            db=db,
+            ids=peers_ids,
+            fields=fields,
+            at=at,
+            branch=branch,
+            include_metadata=MetadataOptions.LINKED_NODES,
         )
 
     @overload
@@ -626,7 +660,9 @@ class NodeManager:
         kind_str = node_schema.kind
 
         if not node_schema.default_filter:
-            raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
+            raise NodeNotFoundError(
+                branch_name=branch.name, node_type=kind_str, identifier=id
+            )
 
         items = await NodeManager.query(
             db=db,
@@ -803,16 +839,21 @@ class NodeManager:
 
         filters = {}
         for key, item in zip(node_schema.human_friendly_id, hfid, strict=False):
-            path = node_schema.parse_schema_path(path=key, schema=registry.schema.get_schema_branch(name=branch.name))
+            path = node_schema.parse_schema_path(
+                path=key, schema=registry.schema.get_schema_branch(name=branch.name)
+            )
 
             if path.is_type_relationship and path.related_schema:
                 rel_schema = path.related_schema
                 # Keep the relationship attribute path and parse it
                 path = rel_schema.parse_schema_path(
-                    path=key.split("__", maxsplit=1)[1], schema=registry.schema.get_schema_branch(name=branch.name)
+                    path=key.split("__", maxsplit=1)[1],
+                    schema=registry.schema.get_schema_branch(name=branch.name),
                 )
 
-            filters[key] = path.active_attribute_schema.get_class().deserialize_from_string(item)
+            filters[key] = (
+                path.active_attribute_schema.get_class().deserialize_from_string(item)
+            )
 
         items = await NodeManager.query(
             db=db,
@@ -831,7 +872,9 @@ class NodeManager:
 
         if len(items) < 1:
             if raise_on_error:
-                raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=hfid_str)
+                raise NodeNotFoundError(
+                    branch_name=branch.name, node_type=kind_str, identifier=hfid_str
+                )
             return None
 
         if len(items) > 1:
@@ -919,7 +962,9 @@ class NodeManager:
             branch_agnostic=branch_agnostic,
         )
         if not node:
-            raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
+            raise NodeNotFoundError(
+                branch_name=branch.name, node_type=kind, identifier=id
+            )
         return node
 
     @overload
@@ -1096,7 +1141,9 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
+                raise NodeNotFoundError(
+                    branch_name=branch.name, node_type=kind, identifier=id
+                )
             return None
 
         node = result[id]
@@ -1113,7 +1160,8 @@ class NodeManager:
         ]
 
         if kind_validation and (
-            node_schema.kind != kind_validation and kind_validation not in node_schema.inherit_from
+            node_schema.kind != kind_validation
+            and kind_validation not in node_schema.inherit_from
         ):
             for item in kind_validation_exceptions:
                 if item[0] == kind_validation and item[1] == node.get_kind():
@@ -1134,6 +1182,7 @@ class NodeManager:
         db: InfrahubDatabase,
         ids: list[str],
         fields: dict | None = None,
+        metadata_fields: dict | None = None,
         at: Timestamp | str | None = None,
         branch: Branch | str | None = None,
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
@@ -1148,9 +1197,13 @@ class NodeManager:
         if not ids:
             return {}
 
-        if fields:
+        if fields or metadata_fields:
             metadata_determiner = MetadataDeterminer()
-            include_metadata_for_fields = await metadata_determiner.determine_metadata_for_fields(node_fields=fields)
+            include_metadata_for_fields = (
+                await metadata_determiner.determine_metadata_for_fields(
+                    node_fields=fields or {}, metadata_fields=metadata_fields
+                )
+            )
             if isinstance(include_metadata, MetadataQueryOptions):
                 include_metadata |= include_metadata_for_fields
             else:
@@ -1159,7 +1212,9 @@ class NodeManager:
 
         # Query all nodes
         node_metadata_options = (
-            include_metadata.node_level if isinstance(include_metadata, MetadataQueryOptions) else include_metadata
+            include_metadata.node_level
+            if isinstance(include_metadata, MetadataQueryOptions)
+            else include_metadata
         )
         query = await NodeListGetInfoQuery.init(
             db=db,
@@ -1170,11 +1225,15 @@ class NodeManager:
             include_metadata=node_metadata_options,
         )
         await query.execute(db=db)
-        nodes_info_by_id: dict[str, NodeToProcess] = {node.node_uuid: node async for node in query.get_nodes(db=db)}
+        nodes_info_by_id: dict[str, NodeToProcess] = {
+            node.node_uuid: node async for node in query.get_nodes(db=db)
+        }
 
         # Query list of all Attributes
         attribute_metadata_options = (
-            include_metadata.attribute_level if isinstance(include_metadata, MetadataQueryOptions) else include_metadata
+            include_metadata.attribute_level
+            if isinstance(include_metadata, MetadataQueryOptions)
+            else include_metadata
         )
         query = await NodeListGetAttributeQuery.init(
             db=db,
@@ -1216,7 +1275,9 @@ class NodeManager:
 
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)
-            item = await node_class.init(schema=node.schema, branch=node_branch, at=at, db=db)
+            item = await node_class.init(
+                schema=node.schema, branch=node_branch, at=at, db=db
+            )
             await item.load(**new_node_data, db=db)
             item._set_created_at(node.created_at)
             item._set_created_by(node.created_by)
@@ -1258,18 +1319,24 @@ class NodeManager:
     ) -> None:
         if not prefetch_relationships and not fields:
             return
-        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]] | None = None
+        cardinality_one_identifiers_by_kind: (
+            dict[str, dict[str, RelationshipDirection]] | None
+        ) = None
         outbound_identifiers: set[str] | None = None
         inbound_identifiers: set[str] | None = None
         bidirectional_identifiers: set[str] | None = None
         if not prefetch_relationships:
-            cardinality_one_identifiers_by_kind = _get_cardinality_one_identifiers_by_kind(
-                nodes=nodes_by_id.values(), fields=fields or {}
+            cardinality_one_identifiers_by_kind = (
+                _get_cardinality_one_identifiers_by_kind(
+                    nodes=nodes_by_id.values(), fields=fields or {}
+                )
             )
             outbound_identifiers = set()
             inbound_identifiers = set()
             bidirectional_identifiers = set()
-            for identifier_direction_map in cardinality_one_identifiers_by_kind.values():
+            for (
+                identifier_direction_map
+            ) in cardinality_one_identifiers_by_kind.values():
                 for identifier, direction in identifier_direction_map.items():
                     if direction is RelationshipDirection.OUTBOUND:
                         outbound_identifiers.add(identifier)
@@ -1281,9 +1348,15 @@ class NodeManager:
         query = await NodeListGetRelationshipsQuery.init(
             db=db,
             ids=list(nodes_by_id.keys()),
-            outbound_identifiers=None if outbound_identifiers is None else list(outbound_identifiers),
-            inbound_identifiers=None if inbound_identifiers is None else list(inbound_identifiers),
-            bidirectional_identifiers=None if bidirectional_identifiers is None else list(bidirectional_identifiers),
+            outbound_identifiers=None
+            if outbound_identifiers is None
+            else list(outbound_identifiers),
+            inbound_identifiers=None
+            if inbound_identifiers is None
+            else list(inbound_identifiers),
+            bidirectional_identifiers=None
+            if bidirectional_identifiers is None
+            else list(bidirectional_identifiers),
             branch=branch,
             at=at,
             branch_agnostic=branch_agnostic,
@@ -1325,7 +1398,8 @@ class NodeManager:
         node: Node,
         grouped_peer_nodes: GroupedPeerNodes,
         nodes_by_id: dict[str, Node],
-        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]] | None,
+        cardinality_one_identifiers_by_kind: dict[str, dict[str, RelationshipDirection]]
+        | None,
         insert_peer_node: bool,
     ) -> None:
         if not grouped_peer_nodes.has_node(node_id=node.get_id()):
@@ -1334,7 +1408,9 @@ class NodeManager:
         node_schema = node.get_schema()
         for rel_schema in node_schema.relationships:
             peer_ids = grouped_peer_nodes.get_peer_ids(
-                node_id=node.get_id(), rel_name=rel_schema.get_identifier(), direction=rel_schema.direction
+                node_id=node.get_id(),
+                rel_name=rel_schema.get_identifier(),
+                direction=rel_schema.direction,
             )
             if not peer_ids:
                 continue
@@ -1348,15 +1424,18 @@ class NodeManager:
                         rel_peers.append(peer)
             # if only getting some relationships, make sure we want THIS relationship for THIS node schema
             elif cardinality_one_identifiers_by_kind:
-                required_direction = cardinality_one_identifiers_by_kind.get(node_schema.kind, {}).get(
-                    rel_schema.get_identifier()
-                )
+                required_direction = cardinality_one_identifiers_by_kind.get(
+                    node_schema.kind, {}
+                ).get(rel_schema.get_identifier())
                 if required_direction is not rel_schema.direction:
                     continue
                 rel_peers = list(peer_ids)
             else:
                 continue
-            if rel_schema.cardinality is RelationshipCardinality.ONE and len(rel_peers) > 1:
+            if (
+                rel_schema.cardinality is RelationshipCardinality.ONE
+                and len(rel_peers) > 1
+            ):
                 raise ValueError("At most, one relationship expected")
 
             rel_peers_with_metadata: list[PeerWithRelationshipMetadata] = []
@@ -1372,10 +1451,18 @@ class NodeManager:
                 if not metadata_map:
                     rel_peers_with_metadata.append(peer_with_metadata)
                     continue
-                peer_with_metadata.created_at = metadata_map.get(MetadataOptions.CREATED_AT)
-                peer_with_metadata.created_by = metadata_map.get(MetadataOptions.CREATED_BY)
-                peer_with_metadata.updated_at = metadata_map.get(MetadataOptions.UPDATED_AT)
-                peer_with_metadata.updated_by = metadata_map.get(MetadataOptions.UPDATED_BY)
+                peer_with_metadata.created_at = metadata_map.get(
+                    MetadataOptions.CREATED_AT
+                )
+                peer_with_metadata.created_by = metadata_map.get(
+                    MetadataOptions.CREATED_BY
+                )
+                peer_with_metadata.updated_at = metadata_map.get(
+                    MetadataOptions.UPDATED_AT
+                )
+                peer_with_metadata.updated_by = metadata_map.get(
+                    MetadataOptions.UPDATED_BY
+                )
                 rel_peers_with_metadata.append(peer_with_metadata)
 
             rel_manager.has_fetched_relationships = True
@@ -1395,11 +1482,15 @@ class NodeManager:
         nodes_to_delete = copy(nodes)
         if cascade_delete:
             node_delete_validator = NodeDeleteValidator(db=db, branch=branch)
-            ids_to_delete = await node_delete_validator.get_ids_to_delete(nodes=nodes, at=at)
+            ids_to_delete = await node_delete_validator.get_ids_to_delete(
+                nodes=nodes, at=at
+            )
             node_ids = {node.get_id() for node in nodes}
             missing_ids_to_delete = ids_to_delete - node_ids
             if missing_ids_to_delete:
-                node_map = await cls.get_many(db=db, ids=list(missing_ids_to_delete), branch=branch, at=at)
+                node_map = await cls.get_many(
+                    db=db, ids=list(missing_ids_to_delete), branch=branch, at=at
+                )
                 nodes_to_delete += list(node_map.values())
 
         for node in nodes_to_delete:
@@ -1425,9 +1516,12 @@ def _get_cardinality_one_identifiers_by_kind(
         cardinality_one_rel_identifiers_in_fields = {
             rel_schema.identifier: rel_schema.direction
             for rel_schema in node_schema.relationships
-            if rel_schema.cardinality is RelationshipCardinality.ONE and rel_schema.name in field_names_set
+            if rel_schema.cardinality is RelationshipCardinality.ONE
+            and rel_schema.name in field_names_set
         }
-        cardinality_one_fields_by_kind[node_schema.kind] = cardinality_one_rel_identifiers_in_fields
+        cardinality_one_fields_by_kind[node_schema.kind] = (
+            cardinality_one_rel_identifiers_in_fields
+        )
     return cardinality_one_fields_by_kind
 
 

--- a/backend/infrahub/core/metadata/determiner.py
+++ b/backend/infrahub/core/metadata/determiner.py
@@ -12,13 +12,14 @@ class MetadataDeterminer:
         All attribute-level metadata is combined and all relationship-level metadata is combined
         """
         node_metadata_options = MetadataOptions.NONE
-        if "_updated_at" in node_fields or "updated_at" in node_fields:
+        metadata_fields = node_fields.get("node_metadata", {})
+        if "_updated_at" in metadata_fields or "updated_at" in metadata_fields:
             node_metadata_options |= MetadataOptions.UPDATED_AT
-        if "updated_by" in node_fields:
+        if "updated_by" in metadata_fields:
             node_metadata_options |= MetadataOptions.UPDATED_BY
-        if "created_at" in node_fields:
+        if "created_at" in metadata_fields:
             node_metadata_options |= MetadataOptions.CREATED_AT
-        if "created_by" in node_fields:
+        if "created_by" in metadata_fields:
             node_metadata_options |= MetadataOptions.CREATED_BY
 
         attribute_metadata_options = MetadataOptions.NONE

--- a/backend/infrahub/core/metadata/determiner.py
+++ b/backend/infrahub/core/metadata/determiner.py
@@ -14,8 +14,6 @@ class MetadataDeterminer:
         Args:
             node_fields: The node fields requested in the query.
             metadata_fields: The metadata fields requested for the node (e.g., created_at, updated_at).
-
-        All attribute-level metadata is combined and all relationship-level metadata is combined.
         """
         node_metadata_options = MetadataOptions.NONE
         metadata_fields = metadata_fields or {}

--- a/backend/infrahub/core/metadata/determiner.py
+++ b/backend/infrahub/core/metadata/determiner.py
@@ -6,13 +6,19 @@ from infrahub.core.metadata.model import MetadataQueryOptions
 
 
 class MetadataDeterminer:
-    async def determine_metadata_for_fields(self, node_fields: dict[str, Any]) -> MetadataQueryOptions:
-        """Determine metadata required based on fields requested
+    async def determine_metadata_for_fields(
+        self, node_fields: dict[str, Any], metadata_fields: dict[str, Any] | None = None
+    ) -> MetadataQueryOptions:
+        """Determine metadata required based on fields requested.
 
-        All attribute-level metadata is combined and all relationship-level metadata is combined
+        Args:
+            node_fields: The node fields requested in the query.
+            metadata_fields: The metadata fields requested for the node (e.g., created_at, updated_at).
+
+        All attribute-level metadata is combined and all relationship-level metadata is combined.
         """
         node_metadata_options = MetadataOptions.NONE
-        metadata_fields = node_fields.get("node_metadata", {})
+        metadata_fields = metadata_fields or {}
         if "_updated_at" in metadata_fields or "updated_at" in metadata_fields:
             node_metadata_options |= MetadataOptions.UPDATED_AT
         if "updated_by" in metadata_fields:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1074,7 +1074,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 continue
 
             if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
-                response[field_name] = await self._build_meta_response(db, field_name, fields)
+                response[field_name] = await self._build_meta_response(field_name, fields)
                 continue
 
             field: BaseAttribute | None = getattr(self, field_name, None)
@@ -1123,7 +1123,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         return response
 
-    async def _build_meta_response(self, db: InfrahubDatabase, field_name: str, fields: dict) -> dict:
+    async def _build_meta_response(self, field_name: str, fields: dict) -> dict:
         data = {}
         for meta_field in fields.get(field_name, {}).keys():
             if meta_field == "created_at":
@@ -1143,19 +1143,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 updated_at = self._get_updated_at()
                 data["updated_at"] = updated_at.to_datetime() if updated_at else None
                 continue
-
-            meta_field_data: RelationshipManager | str | None = getattr(self, meta_field, None)
-
-            if isinstance(meta_field_data, RelationshipManager):
-                peer = await meta_field_data.get_peer(db=db)
-                data[meta_field] = peer.id if peer else None
-                continue
-
-            if isinstance(meta_field_data, str):
-                data[meta_field] = meta_field_data
-                continue
-
-            data[meta_field] = None
         return data
 
     async def from_graphql(self, data: dict, db: InfrahubDatabase, process_pools: bool = True) -> bool:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1073,10 +1073,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     response[field_name] = None
                 continue
 
-            if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
-                response[field_name] = await self._build_meta_response(field_name, fields)
-                continue
-
             field: BaseAttribute | None = getattr(self, field_name, None)
 
             if not field:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1125,15 +1125,15 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def _build_meta_response(self, db: InfrahubDatabase, field_name: str, fields: dict) -> dict:
         data = {}
-        for meta_field in fields.get(field_name).keys():
+        for meta_field in fields.get(field_name, {}).keys():
             meta_field_data: RelationshipManager | str | None = getattr(self, meta_field, None)
 
-            if meta_field_data is not None and isinstance(meta_field_data, RelationshipManager):
+            if isinstance(meta_field_data, RelationshipManager):
                 peer = await meta_field_data.get_peer(db=db)
                 data[meta_field] = peer.id if peer else None
                 continue
 
-            if meta_field_data is not None and isinstance(meta_field_data, str):
+            if isinstance(meta_field_data, str):
                 data[meta_field] = meta_field_data
                 continue
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1129,20 +1129,20 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             if meta_field == "created_at":
                 created_at = self._get_created_at()
                 data["created_at"] = created_at.to_datetime() if created_at else None
-                continue
 
             if meta_field == "created_by":
-                data["created_by"] = self._get_created_by()
-                continue
+                data["created_by"] = (
+                    {"id": self._get_created_by(), "__kind__": "CoreAccount"} if self._get_created_by() else None
+                )
 
             if meta_field == "updated_by":
-                data["updated_by"] = self._get_updated_by()
-                continue
+                data["updated_by"] = (
+                    {"id": self._get_updated_by(), "__kind__": "CoreAccount"} if self._get_updated_by() else None
+                )
 
             if meta_field == "updated_at":
                 updated_at = self._get_updated_at()
                 data["updated_at"] = updated_at.to_datetime() if updated_at else None
-                continue
         return data
 
     async def from_graphql(self, data: dict, db: InfrahubDatabase, process_pools: bool = True) -> bool:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1073,7 +1073,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     response[field_name] = None
                 continue
 
-            if field_name == "meta" and isinstance(fields.get("meta"), dict):
+            if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
                 response[field_name] = await self._build_meta_response(db, field_name, fields)
                 continue
 
@@ -1126,6 +1126,24 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
     async def _build_meta_response(self, db: InfrahubDatabase, field_name: str, fields: dict) -> dict:
         data = {}
         for meta_field in fields.get(field_name, {}).keys():
+            if meta_field == "created_at":
+                created_at = self._get_created_at()
+                data["created_at"] = created_at.to_datetime() if created_at else None
+                continue
+
+            if meta_field == "created_by":
+                data["created_by"] = self._get_created_by()
+                continue
+
+            if meta_field == "updated_by":
+                data["updated_by"] = self._get_updated_by()
+                continue
+
+            if meta_field == "updated_at":
+                updated_at = self._get_updated_at()
+                data["updated_at"] = updated_at.to_datetime() if updated_at else None
+                continue
+
             meta_field_data: RelationshipManager | str | None = getattr(self, meta_field, None)
 
             if isinstance(meta_field_data, RelationshipManager):

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1046,10 +1046,11 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         FIELD_NAME_TO_EXCLUDE = ["id"] + self._schema.relationship_names
 
-        if fields and isinstance(fields, dict):
-            field_names = [field_name for field_name in fields.keys() if field_name not in FIELD_NAME_TO_EXCLUDE]
-        else:
-            field_names = self._schema.attribute_names + ["__typename", "display_label"]
+        field_names = (
+            [field_name for field_name in fields.keys() if field_name not in FIELD_NAME_TO_EXCLUDE]
+            if fields and isinstance(fields, dict)
+            else self._schema.attribute_names + ["__typename", "display_label"]
+        )
 
         for field_name in field_names:
             if field_name == "__typename":
@@ -1070,6 +1071,10 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     response[field_name] = await updated_at.to_graphql()
                 else:
                     response[field_name] = None
+                continue
+
+            if field_name == "meta" and isinstance(fields.get("meta"), dict):
+                response[field_name] = await self._build_meta_response(db, field_name, fields)
                 continue
 
             field: BaseAttribute | None = getattr(self, field_name, None)
@@ -1117,6 +1122,23 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 continue
 
         return response
+
+    async def _build_meta_response(self, db: InfrahubDatabase, field_name: str, fields: dict) -> dict:
+        data = {}
+        for meta_field in fields.get(field_name).keys():
+            meta_field_data: RelationshipManager | str | None = getattr(self, meta_field, None)
+
+            if meta_field_data is not None and isinstance(meta_field_data, RelationshipManager):
+                peer = await meta_field_data.get_peer(db=db)
+                data[meta_field] = peer.id if peer else None
+                continue
+
+            if meta_field_data is not None and isinstance(meta_field_data, str):
+                data[meta_field] = meta_field_data
+                continue
+
+            data[meta_field] = None
+        return data
 
     async def from_graphql(self, data: dict, db: InfrahubDatabase, process_pools: bool = True) -> bool:
         """Update object from a GraphQL payload."""

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -18,7 +18,7 @@ from infrahub.core.query.standard_node import (
     StandardNodeQuery,
     StandardNodeUpdateQuery,
 )
-from infrahub.core.timestamp import current_timestamp
+from infrahub.core.timestamp import Timestamp, current_timestamp
 from infrahub.exceptions import Error, InitializationError
 
 if TYPE_CHECKING:
@@ -73,6 +73,7 @@ class StandardNode(BaseModel):
         raise InitializationError("The root node has not been initialized with a uuid")
 
     async def to_graphql(self, fields: dict) -> dict:
+        print(fields)
         response: dict[str, Any] = {"id": self.uuid}
 
         for field_name in fields.keys():
@@ -81,10 +82,14 @@ class StandardNode(BaseModel):
             if field_name == "__typename":
                 response[field_name] = self.get_type()
                 continue
-            if field_name == "meta" and isinstance(fields.get("meta"), dict):
-                response[field_name] = {
-                    meta_field: getattr(self, meta_field, None) for meta_field in fields.get(field_name).keys()
-                }
+            if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
+                _result = {}
+                for meta_field in fields.get(field_name).keys():
+                    if meta_field == "created_at":
+                        _result[meta_field] = Timestamp(self.created_at).to_datetime()
+                        continue
+                    _result[meta_field] = getattr(self, meta_field, None)
+                response[field_name] = _result
                 continue
             field = getattr(self, field_name, None)
             if field is None:
@@ -96,10 +101,6 @@ class StandardNode(BaseModel):
                     if nested_field == "value":
                         result[nested_field] = field
                         continue
-                    if nested_field == "meta":
-                        result[nested_field] = dict.fromkeys(fields.get(field_name).get("meta").keys())
-                        continue
-                    result[nested_field] = field
                 response[field_name] = result
                 continue
 

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -84,9 +84,9 @@ class StandardNode(BaseModel):
                 continue
             if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
                 _result = {}
-                for meta_field in fields.get(field_name).keys():
+                for meta_field in fields.get(field_name, {}).keys():
                     if meta_field == "created_at":
-                        _result[meta_field] = Timestamp(self.created_at).to_datetime()
+                        _result[meta_field] = Timestamp(self.created_at).to_datetime() if self.created_at else None  # type: ignore[attr-defined]
                         continue
                     _result[meta_field] = getattr(self, meta_field, None)
                 response[field_name] = _result
@@ -97,7 +97,7 @@ class StandardNode(BaseModel):
                 continue
             if isinstance(fields.get(field_name), dict):
                 result = {}
-                for nested_field in fields.get(field_name).keys():
+                for nested_field in fields.get(field_name, {}).keys():
                     if nested_field == "value":
                         result[nested_field] = field
                         continue

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Union, get_args, get_origin
 from uuid import UUID
 
 import ujson
 from infrahub_sdk.uuidt import UUIDT
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from infrahub.core.constants import NULL_VALUE, SYSTEM_USER_ID
 from infrahub.core.query.standard_node import (
@@ -30,9 +31,16 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
+@dataclass(slots=True)
+class StandardNodeQueryFields:
+    node: dict[str, Any] = field(default_factory=dict)
+    node_metadata: dict[str, Any] = field(default_factory=dict)
+
+
 class StandardNode(BaseModel):
     id: Optional[str] = None
     uuid: Optional[UUID] = None
+    created_at: Optional[str] = Field(default=None, validate_default=True)
     created_by: str = Field(default=SYSTEM_USER_ID)
     updated_by: Optional[str] = Field(default=None)
     updated_at: Optional[str] = Field(default=None, validate_default=True)
@@ -48,6 +56,11 @@ class StandardNode(BaseModel):
         if not self.id:
             raise ValueError("id isn't defined yet")
         return self.id
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def set_created_at(cls, value: str) -> str:
+        return Timestamp(value).to_string()
 
     @staticmethod
     def guess_field_type(field: FieldInfo) -> Any:
@@ -72,7 +85,14 @@ class StandardNode(BaseModel):
 
         raise InitializationError("The root node has not been initialized with a uuid")
 
-    async def to_graphql(self, fields: dict) -> dict:
+    async def to_graphql_flat(self, fields: dict) -> dict:
+        """Returns the GraphQL representation of the object with only top-level fields.
+
+        This method does not handle nested fields and is only used for the old `Branch` query which
+        will be deprecated in the future and replaced by the `InfrahubBranch` query.
+        It's also used for the old style of Branch mutations that will be deprecated in the future,
+        when we introduce InfrahubBranch muations for consistency.
+        """
         response: dict[str, Any] = {"id": self.uuid}
 
         for field_name in fields.keys():
@@ -80,15 +100,6 @@ class StandardNode(BaseModel):
                 continue
             if field_name == "__typename":
                 response[field_name] = self.get_type()
-                continue
-            if field_name == "node_metadata" and isinstance(fields.get("node_metadata"), dict):
-                _result = {}
-                for meta_field in fields.get(field_name, {}).keys():
-                    if meta_field == "created_at":
-                        _result[meta_field] = Timestamp(self.created_at).to_datetime() if self.created_at else None  # type: ignore[attr-defined]
-                        continue
-                    _result[meta_field] = getattr(self, meta_field, None)
-                response[field_name] = _result
                 continue
             field = getattr(self, field_name, None)
             if field is None:
@@ -106,6 +117,47 @@ class StandardNode(BaseModel):
             response[field_name] = field
 
         return response
+
+    async def to_graphql(self, fields: StandardNodeQueryFields) -> dict:
+        node_response: dict[str, Any] = {}
+        meta_response: dict[str, Any] = {}
+
+        for field_name in fields.node.keys():
+            if field_name == "id":
+                node_response["id"] = self.uuid
+                continue
+            if field_name == "__typename":
+                node_response[field_name] = self.get_type()
+                continue
+            field = getattr(self, field_name, None)
+            if field is None:
+                node_response[field_name] = None
+                continue
+            if isinstance(fields.node.get(field_name), dict):
+                result = {}
+                for nested_field in fields.node.get(field_name, {}).keys():
+                    if nested_field == "value":
+                        result[nested_field] = field
+                        continue
+                node_response[field_name] = result
+                continue
+
+            node_response[field_name] = field
+
+        for field_name in fields.node_metadata.keys():
+            match field_name:
+                case "created_at":
+                    meta_response["created_at"] = Timestamp(self.created_at).to_datetime() if self.created_at else None
+                case "updated_at":
+                    meta_response["updated_at"] = Timestamp(self.updated_at).to_datetime() if self.updated_at else None
+                case "created_by":
+                    if self.created_by and self.created_by != SYSTEM_USER_ID:
+                        meta_response["created_by"] = {"id": self.created_by}
+                case "updated_by":
+                    if self.updated_by and self.updated_by != SYSTEM_USER_ID:
+                        meta_response["updated_by"] = {"id": self.updated_by}
+
+        return {"node": node_response, "node_metadata": meta_response}
 
     async def save(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Create or Update the Node in the database."""
@@ -210,7 +262,7 @@ class StandardNode(BaseModel):
         else:
             data["uuid"] = str(self.uuid)
 
-        for attr_name, field in self.model_fields.items():
+        for attr_name, field_info in self.model_fields.items():
             if attr_name in self._exclude_attrs:
                 continue
 
@@ -218,7 +270,7 @@ class StandardNode(BaseModel):
             if isinstance(attr_value, Enum):
                 attr_value = attr_value.value
 
-            field_type = self.guess_field_type(field)
+            field_type = self.guess_field_type(field_info)
 
             if attr_value is None:
                 data[attr_name] = NULL_VALUE

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -81,10 +81,28 @@ class StandardNode(BaseModel):
             if field_name == "__typename":
                 response[field_name] = self.get_type()
                 continue
-            field = getattr(self, field_name)
+            if field_name == "meta" and isinstance(fields.get("meta"), dict):
+                response[field_name] = {
+                    meta_field: getattr(self, meta_field, None) for meta_field in fields.get(field_name).keys()
+                }
+                continue
+            field = getattr(self, field_name, None)
             if field is None:
                 response[field_name] = None
                 continue
+            if isinstance(fields.get(field_name), dict):
+                result = {}
+                for nested_field in fields.get(field_name).keys():
+                    if nested_field == "value":
+                        result[nested_field] = field
+                        continue
+                    if nested_field == "meta":
+                        result[nested_field] = dict.fromkeys(fields.get(field_name).get("meta").keys())
+                        continue
+                    result[nested_field] = field
+                response[field_name] = result
+                continue
+
             response[field_name] = field
 
         return response

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -73,7 +73,6 @@ class StandardNode(BaseModel):
         raise InitializationError("The root node has not been initialized with a uuid")
 
     async def to_graphql(self, fields: dict) -> dict:
-        print(fields)
         response: dict[str, Any] = {"id": self.uuid}
 
         for field_name in fields.keys():

--- a/backend/infrahub/core/task/task.py
+++ b/backend/infrahub/core/task/task.py
@@ -1,9 +1,11 @@
+# This entire file and possibly everything in this module should be deleted. - Patrick (2025-12-11)
+
 from typing import Any
 
 from pydantic import ConfigDict, Field
 
 from infrahub.core.constants import TaskConclusion
-from infrahub.core.node.standard import StandardNode
+from infrahub.core.node.standard import StandardNode, StandardNodeQueryFields
 from infrahub.core.protocols import CoreNode
 from infrahub.core.query.standard_node import StandardNodeQuery
 from infrahub.core.query.task import TaskNodeCreateQuery, TaskNodeQuery, TaskNodeQueryWithLogs
@@ -70,7 +72,7 @@ class Task(StandardNode):
                 logs = [
                     {
                         "node": await TaskLog.from_db(result, extras={"task_id": task_result.get("uuid")}).to_graphql(
-                            fields=log_fields
+                            fields=StandardNodeQueryFields(node=log_fields)
                         )
                     }
                     for result in logs_results

--- a/backend/infrahub/graphql/constants.py
+++ b/backend/infrahub/graphql/constants.py
@@ -1,1 +1,4 @@
 KIND_GRAPHQL_FIELD_NAME = "__kind__"
+
+NODE_METADATA_TYPE = "InfrahubNodeMetadata"
+RELATIONSHIP_METADATA_TYPE = "InfrahubRelationshipMetadata"

--- a/backend/infrahub/graphql/loaders/node.py
+++ b/backend/infrahub/graphql/loaders/node.py
@@ -17,6 +17,7 @@ from .shared import to_frozen_set
 class GetManyParams:
     branch: Branch | str
     fields: dict | None = None
+    metadata_fields: dict | None = None
     at: Timestamp | str | None = None
     include_metadata: MetadataOptions = MetadataOptions.NONE
     prefetch_relationships: bool = False
@@ -26,11 +27,15 @@ class GetManyParams:
         frozen_fields: frozenset | None = None
         if self.fields:
             frozen_fields = to_frozen_set(self.fields)
+        frozen_metadata_fields: frozenset | None = None
+        if self.metadata_fields:
+            frozen_metadata_fields = to_frozen_set(self.metadata_fields)
         timestamp = Timestamp(self.at)
         branch = self.branch.name if isinstance(self.branch, Branch) else self.branch
         hash_str = "|".join(
             [
                 str(hash(frozen_fields)),
+                str(hash(frozen_metadata_fields)),
                 timestamp.to_string(),
                 branch,
                 str(self.include_metadata.value),
@@ -53,6 +58,7 @@ class NodeDataLoader(DataLoader[str, Node | None]):
                 db=db,
                 ids=keys,
                 fields=self.query_params.fields,
+                metadata_fields=self.query_params.metadata_fields,
                 at=self.query_params.at,
                 branch=self.query_params.branch,
                 include_metadata=self.query_params.include_metadata,

--- a/backend/infrahub/graphql/loaders/peers.py
+++ b/backend/infrahub/graphql/loaders/peers.py
@@ -21,6 +21,7 @@ class QueryPeerParams:
     schema: RelationshipSchema
     filters: dict[str, Any]
     fields: dict | None = None
+    metadata_fields: dict | None = None
     at: Timestamp | str | None = None
     branch_agnostic: bool = False
     include_metadata: MetadataOptions = MetadataOptions.NONE
@@ -29,12 +30,16 @@ class QueryPeerParams:
         frozen_fields: frozenset | None = None
         if self.fields:
             frozen_fields = to_frozen_set(self.fields)
+        frozen_metadata_fields: frozenset | None = None
+        if self.metadata_fields:
+            frozen_metadata_fields = to_frozen_set(self.metadata_fields)
         frozen_filters = to_frozen_set(self.filters)
         timestamp = Timestamp(self.at)
         branch = self.branch.name if isinstance(self.branch, Branch) else self.branch
         hash_str = "|".join(
             [
                 str(hash(frozen_fields)),
+                str(hash(frozen_metadata_fields)),
                 str(hash(frozen_filters)),
                 timestamp.to_string(),
                 branch,
@@ -62,6 +67,7 @@ class PeerRelationshipsDataLoader(DataLoader[str, list[Relationship]]):
                 schema=self.query_params.schema,
                 filters=self.query_params.filters,
                 fields=self.query_params.fields,
+                metadata_fields=self.query_params.metadata_fields,
                 at=self.query_params.at,
                 branch=self.query_params.branch,
                 branch_agnostic=self.query_params.branch_agnostic,

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -67,6 +67,7 @@ from .types.attribute import BaseAttribute as BaseAttributeType
 from .types.attribute import TextAttributeType
 from .types.context import ContextInput
 from .types.event import EVENT_TYPES
+from .types.node import InfrahubObjectWithoutMeta
 
 if TYPE_CHECKING:
     from graphql import GraphQLSchema
@@ -994,7 +995,7 @@ class GraphQLSchemaManager:
 
         graphql_edged_object = registry.get_edge_type(reference_hash=edge_hash, schema_hash=self.schema_hash)
         if not graphql_edged_object:
-            graphql_edged_object = type(object_name, (InfrahubObject,), main_attrs)
+            graphql_edged_object = type(object_name, (InfrahubObjectWithoutMeta,), main_attrs)
             registry.set_edge_type(
                 reference=graphql_edged_object, reference_hash=edge_hash, schema_hash=self.schema_hash
             )
@@ -1038,7 +1039,7 @@ class GraphQLSchemaManager:
         )
         if not graphql_paginated_object:
             main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
-            graphql_paginated_object = type(object_name, (InfrahubObject,), main_attrs)
+            graphql_paginated_object = type(object_name, (InfrahubObjectWithoutMeta,), main_attrs)
             registry.set_paginated_type(
                 reference=graphql_paginated_object, reference_hash=paginated_hash, schema_hash=self.schema_hash
             )

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -244,12 +244,21 @@ class GraphQLSchemaManager:
             self.set_type(name=event._meta.name, graphql_type=event)
 
     def _load_node_interface(self) -> None:
+        """Load the base CoreNode interface. Edged/paginated objects are created later in generate_object_types."""
         node_interface_schema = GenericSchema(
             name="Node", namespace="Core", description="Interface for all nodes in Infrahub"
         )
-        interface = self.generate_interface_object(schema=node_interface_schema, populate_cache=True)
+        self.generate_interface_object(schema=node_interface_schema, populate_cache=True)
+
+    def _complete_node_interface(self, node_metadata: type[InfrahubObject]) -> None:
+        """Complete the CoreNode interface by creating its edged and paginated objects."""
+        node_interface_schema = GenericSchema(
+            name="Node", namespace="Core", description="Interface for all nodes in Infrahub"
+        )
+        # Re-call generate_interface_object to get the InterfaceReference (will use cached version)
+        interface = self.generate_interface_object(schema=node_interface_schema, populate_cache=False)
         edged_interface = self.generate_graphql_edged_object(
-            schema=node_interface_schema, node=interface, populate_cache=True
+            schema=node_interface_schema, node=interface, node_metadata=node_metadata, populate_cache=True
         )
         self.generate_graphql_paginated_object(schema=node_interface_schema, edge=edged_interface, populate_cache=True)
 
@@ -312,25 +321,43 @@ class GraphQLSchemaManager:
 
         full_schema = self.schema.get_all(duplicate=False)
 
-        # Generate all GraphQL Interface  Object first and store them in the registry
+        # Pass 1: Generate all GraphQL Interface objects first (without edged/paginated)
+        # This ensures GENERICACCOUNT exists before we create node_metadata
         for node_schema in full_schema.values():
-            if not isinstance(node_schema, GenericSchema):
-                continue
-            interface = self.generate_interface_object(schema=node_schema, populate_cache=True)
-            edged_interface = self.generate_graphql_edged_object(
-                schema=node_schema, node=interface, populate_cache=True
-            )
-            self.generate_graphql_paginated_object(schema=node_schema, edge=edged_interface, populate_cache=True)
+            if isinstance(node_schema, GenericSchema):
+                self.generate_interface_object(schema=node_schema, populate_cache=True)
 
         # Define LineageSource and LineageOwner
         data_source = self.get_type(name=InfrahubKind.LINEAGESOURCE)
         data_owner = self.get_type(name=InfrahubKind.LINEAGEOWNER)
         self.define_relationship_property(data_source=data_source, data_owner=data_owner)
+
+        # Now that GENERICACCOUNT exists, create node_metadata and relationship_metadata
+        account_type = self.get_type(name=InfrahubKind.GENERICACCOUNT)
+        self.define_node_metadata(account_type=account_type)
+        self.define_relationship_metadata(account_type=account_type)
+        node_metadata = self.get_type(name="InfrahubNodeMetadata")
+        relationship_metadata = self.get_type(name="InfrahubRelationshipMetadata")
+
+        # Complete the CoreNode interface (edged/paginated) now that node_metadata exists
+        self._complete_node_interface(node_metadata=node_metadata)
+
         relationship_property = self.get_type(name="RelationshipProperty")
         for data_type in ATTRIBUTE_TYPES.values():
             gql_type = self.get_type(name=data_type.get_graphql_type_name())
             gql_type._meta.fields["source"] = graphene.Field(data_source)
             gql_type._meta.fields["owner"] = graphene.Field(data_owner)
+
+        # Pass 2: Generate edged/paginated objects for all GenericSchema interfaces
+        for node_schema in full_schema.values():
+            if not isinstance(node_schema, GenericSchema):
+                continue
+            # Re-call generate_interface_object to get the InterfaceReference (will use cached version)
+            interface = self.generate_interface_object(schema=node_schema, populate_cache=False)
+            edged_interface = self.generate_graphql_edged_object(
+                schema=node_schema, node=interface, node_metadata=node_metadata, populate_cache=True
+            )
+            self.generate_graphql_paginated_object(schema=node_schema, edge=edged_interface, populate_cache=True)
 
         # Generate all Nested, Edged and NestedEdged Interfaces and store them in the registry
         for node_name, node_schema in full_schema.items():
@@ -341,7 +368,9 @@ class GraphQLSchemaManager:
             nested_edged_interface = self.generate_nested_interface_object(
                 schema=node_schema,
                 base_interface=node_interface,
+                node_metadata=node_metadata,
                 relation_property=relationship_property,
+                relationship_metadata=relationship_metadata,
             )
 
             nested_interface = self.generate_paginated_interface_object(
@@ -357,11 +386,13 @@ class GraphQLSchemaManager:
             if isinstance(node_schema, NodeSchema | ProfileSchema | TemplateSchema):
                 node_object_type = self.generate_graphql_object(schema=node_schema, populate_cache=True)
                 node_type_edged = self.generate_graphql_edged_object(
-                    schema=node_schema, node=node_object_type, populate_cache=True
+                    schema=node_schema, node=node_object_type, node_metadata=node_metadata, populate_cache=True
                 )
                 nested_node_type_edged = self.generate_graphql_edged_object(
                     schema=node_schema,
                     node=node_object_type,
+                    node_metadata=node_metadata,
+                    relationship_metadata=relationship_metadata,
                     relation_property=relationship_property,
                     populate_cache=True,
                 )
@@ -626,6 +657,46 @@ class GraphQLSchemaManager:
         relationship_property = type(type_name, (graphene.ObjectType,), main_attrs)
 
         self.set_type(name=type_name, graphql_type=relationship_property)
+
+    def define_node_metadata(self, account_type: type[InfrahubObject]) -> None:
+        type_name = "InfrahubNodeMetadata"
+
+        meta_attrs = {
+            "name": type_name,
+            "description": "Defines node metadata information",
+        }
+
+        main_attrs = {
+            "created_at": graphene.DateTime(required=False),
+            "created_by": graphene.Field(account_type, required=False),
+            "updated_at": graphene.DateTime(required=False),
+            "updated_by": graphene.Field(account_type, required=False),
+            "Meta": type("Meta", (object,), meta_attrs),
+        }
+
+        node_metadata = type(type_name, (graphene.ObjectType,), main_attrs)
+
+        self.set_type(name=type_name, graphql_type=node_metadata)
+
+    def define_relationship_metadata(self, account_type: type[InfrahubObject]) -> None:
+        type_name = "InfrahubRelationshipMetadata"
+
+        meta_attrs = {
+            "name": type_name,
+            "description": "Defines relationship metadata information",
+        }
+
+        main_attrs = {
+            "created_at": graphene.DateTime(required=False),
+            "created_by": graphene.Field(account_type, required=False),
+            "updated_at": graphene.DateTime(required=False),
+            "updated_by": graphene.Field(account_type, required=False),
+            "Meta": type("Meta", (object,), meta_attrs),
+        }
+
+        relationship_metadata = type(type_name, (graphene.ObjectType,), main_attrs)
+
+        self.set_type(name=type_name, graphql_type=relationship_metadata)
 
     def generate_graphql_mutations(
         self,
@@ -965,6 +1036,8 @@ class GraphQLSchemaManager:
         self,
         schema: MainSchemaTypes,
         node: InterfaceReference | InfrahubObjectReference,
+        node_metadata: type[InfrahubObject],
+        relationship_metadata: type[InfrahubObject] | None = None,
         relation_property: type[InfrahubObject] | None = None,
         populate_cache: bool = False,
     ) -> InfrahubEdgedReference:
@@ -987,11 +1060,14 @@ class GraphQLSchemaManager:
 
         main_attrs: dict[str, Any] = {
             "node": graphene.Field(node.reference, required=False),
+            "node_metadata": graphene.Field(node_metadata, required=True),
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
         if relation_property:
             main_attrs["properties"] = graphene.Field(relation_property, required=False)
+        if relationship_metadata:
+            main_attrs["relationship_metadata"] = graphene.Field(relationship_metadata, required=True)
 
         graphql_edged_object = registry.get_edge_type(reference_hash=edge_hash, schema_hash=self.schema_hash)
         if not graphql_edged_object:
@@ -1054,6 +1130,8 @@ class GraphQLSchemaManager:
         schema: GenericSchema,
         relation_property: graphene.ObjectType,
         base_interface: graphene.ObjectType,
+        node_metadata: type[InfrahubObject],
+        relationship_metadata: type[InfrahubObject] | None = None,
         populate_cache: bool = False,
     ) -> type[InfrahubObject]:
         meta_attrs: dict[str, Any] = {
@@ -1065,11 +1143,14 @@ class GraphQLSchemaManager:
         main_attrs: dict[str, Any] = {
             "node": graphene.Field(base_interface, required=False),
             "_updated_at": graphene.DateTime(required=False),
+            "node_metadata": graphene.Field(node_metadata, required=True),
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
         if relation_property:
             main_attrs["properties"] = graphene.Field(relation_property, required=False)
+        if relationship_metadata:
+            main_attrs["relationship_metadata"] = graphene.Field(relationship_metadata, required=True)
 
         object_name = f"NestedEdged{schema.kind}"
         md5hash = hashlib.md5(usedforsecurity=False)

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -23,6 +23,7 @@ from infrahub.graphql.mutations.graphql_query import InfrahubGraphQLQueryMutatio
 from infrahub.graphql.mutations.profile import InfrahubProfileMutation
 from infrahub.types import ATTRIBUTE_TYPES, InfrahubDataType, get_attribute_type
 
+from .constants import NODE_METADATA_TYPE, RELATIONSHIP_METADATA_TYPE
 from .directives import DIRECTIVES
 from .enums import generate_graphql_enum, get_enum_attribute_type_name
 from .metrics import SCHEMA_GENERATE_GRAPHQL_METRICS
@@ -336,8 +337,8 @@ class GraphQLSchemaManager:
         account_type = self.get_type(name=InfrahubKind.GENERICACCOUNT)
         self.define_node_metadata(account_type=account_type)
         self.define_relationship_metadata(account_type=account_type)
-        node_metadata = self.get_type(name="InfrahubNodeMetadata")
-        relationship_metadata = self.get_type(name="InfrahubRelationshipMetadata")
+        node_metadata = self.get_type(name=NODE_METADATA_TYPE)
+        relationship_metadata = self.get_type(name=RELATIONSHIP_METADATA_TYPE)
 
         # Complete the CoreNode interface (edged/paginated) now that node_metadata exists
         self._complete_node_interface(node_metadata=node_metadata)
@@ -347,6 +348,7 @@ class GraphQLSchemaManager:
             gql_type = self.get_type(name=data_type.get_graphql_type_name())
             gql_type._meta.fields["source"] = graphene.Field(data_source)
             gql_type._meta.fields["owner"] = graphene.Field(data_owner)
+            gql_type._meta.fields["updated_by"] = graphene.Field(account_type, required=False)
 
         # Pass 2: Generate edged/paginated objects for all GenericSchema interfaces
         for node_schema in full_schema.values():
@@ -659,10 +661,8 @@ class GraphQLSchemaManager:
         self.set_type(name=type_name, graphql_type=relationship_property)
 
     def define_node_metadata(self, account_type: type[InfrahubObject]) -> None:
-        type_name = "InfrahubNodeMetadata"
-
         meta_attrs = {
-            "name": type_name,
+            "name": NODE_METADATA_TYPE,
             "description": "Defines node metadata information",
         }
 
@@ -674,15 +674,13 @@ class GraphQLSchemaManager:
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
-        node_metadata = type(type_name, (graphene.ObjectType,), main_attrs)
+        node_metadata = type(NODE_METADATA_TYPE, (graphene.ObjectType,), main_attrs)
 
-        self.set_type(name=type_name, graphql_type=node_metadata)
+        self.set_type(name=NODE_METADATA_TYPE, graphql_type=node_metadata)
 
     def define_relationship_metadata(self, account_type: type[InfrahubObject]) -> None:
-        type_name = "InfrahubRelationshipMetadata"
-
         meta_attrs = {
-            "name": type_name,
+            "name": RELATIONSHIP_METADATA_TYPE,
             "description": "Defines relationship metadata information",
         }
 
@@ -694,9 +692,9 @@ class GraphQLSchemaManager:
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
-        relationship_metadata = type(type_name, (graphene.ObjectType,), main_attrs)
+        relationship_metadata = type(RELATIONSHIP_METADATA_TYPE, (graphene.ObjectType,), main_attrs)
 
-        self.set_type(name=type_name, graphql_type=relationship_metadata)
+        self.set_type(name=RELATIONSHIP_METADATA_TYPE, graphql_type=relationship_metadata)
 
     def generate_graphql_mutations(
         self,

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, Field, InputField, InputObjectType, Mutation, String
+from graphene import Boolean, Field, InputField, InputObjectType, Mutation, ObjectType, String
 from graphql import GraphQLResolveInfo
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
@@ -36,7 +36,7 @@ class InfrahubAccountUpdateSelfInput(InputObjectType):
     description = InputField(String(required=False), description="Description to use instead of the current one")
 
 
-class ValueType(InfrahubObjectType):
+class ValueType(ObjectType):
     value = String(required=True)
 
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -98,7 +98,11 @@ class BranchCreate(Mutation):
         # Retrieve created branch
         obj = await Branch.get_by_name(db=graphql_context.db, name=model.name)
         fields = extract_graphql_fields(info=info)
-        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=True, task=task)
+        return cls(
+            object=await obj.to_graphql_flat(fields=fields.get("object", {})),
+            ok=True,
+            task=task,
+        )
 
 
 class BranchNameInput(InputObjectType):
@@ -218,7 +222,7 @@ class BranchRebase(Mutation):
         fields = extract_graphql_fields(info=info)
         ok = True
 
-        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)
+        return cls(object=await obj.to_graphql_flat(fields=fields.get("object", {})), ok=ok, task=task)
 
 
 class BranchValidate(Mutation):
@@ -260,7 +264,7 @@ class BranchValidate(Mutation):
 
         fields = extract_graphql_fields(info=info)
 
-        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)
+        return cls(object=await obj.to_graphql_flat(fields=fields.get("object", {})), ok=ok, task=task)
 
 
 class BranchMerge(Mutation):
@@ -315,4 +319,4 @@ class BranchMerge(Mutation):
         fields = extract_graphql_fields(info=info)
         ok = True
 
-        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)
+        return cls(object=await obj.to_graphql_flat(fields=fields.get("object", {})), ok=ok, task=task)

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import ID, Field, Int, List, NonNull, String
 
+from infrahub.core.node.standard import StandardNodeQueryFields
 from infrahub.core.registry import registry
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
@@ -19,7 +20,9 @@ async def branch_resolver(
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
     fields = extract_graphql_fields(info)
-    return await BranchType.get_list(graphql_context=info.context, fields=fields, exclude_global=True, **kwargs)
+    return await BranchType.get_list(
+        graphql_context=info.context, fields=StandardNodeQueryFields(node=fields), exclude_global=True, **kwargs
+    )
 
 
 BranchQueryList = Field(
@@ -48,27 +51,32 @@ async def infrahub_branch_resolver(
     fields = extract_graphql_fields(info)
     result: dict[str, Any] = {}
     if "edges" in fields:
+        query_fields = StandardNodeQueryFields(
+            node=fields.get("edges", {}).get("node", {}),
+            node_metadata=fields.get("edges", {}).get("node_metadata", {}),
+        )
         branches = await InfrahubBranch.get_list(
             graphql_context=info.context,
-            fields=fields.get("edges", {}).get("node", {}),
+            fields=query_fields,
             limit=limit,
             offset=offset,
             name=name__value,
             ids=ids,
             exclude_global=True,
         )
-        result["edges"] = [{"node": branch} for branch in branches]
+        result["edges"] = branches
     if "count" in fields:
         result["count"] = await InfrahubBranchType.get_list_count(
             graphql_context=info.context, name=name__value, ids=ids
         )
 
     if "default_branch" in fields:
-        result["default_branch"] = await InfrahubBranch.get_by_name(
+        default_branch = await InfrahubBranch.get_by_name(
             graphql_context=info.context,
             fields=fields["default_branch"],
             name=registry.default_branch,
         )
+        result["default_branch"] = default_branch["node"]
 
     return result
 

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -3,9 +3,14 @@ from typing import TYPE_CHECKING, Any
 from graphql import GraphQLResolveInfo
 
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import BranchSupportType, MetadataOptions, RelationshipHierarchyDirection
+from infrahub.core.constants import (
+    BranchSupportType,
+    MetadataOptions,
+    RelationshipHierarchyDirection,
+)
 from infrahub.core.manager import NodeManager
 from infrahub.core.query.node import NodeGetHierarchyQuery
+from infrahub.core.relationship import Relationship
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.timestamp import Timestamp
@@ -23,7 +28,9 @@ if TYPE_CHECKING:
 
 class ManyRelationshipResolver:
     def __init__(self) -> None:
-        self._data_loader_instances: dict[QueryPeerParams, PeerRelationshipsDataLoader] = {}
+        self._data_loader_instances: dict[
+            QueryPeerParams, PeerRelationshipsDataLoader
+        ] = {}
 
     async def get_descendant_ids(
         self,
@@ -67,7 +74,9 @@ class ManyRelationshipResolver:
                 branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
             )
 
-    def _get_metadata_to_include(self, property_fields: dict[str, Any]) -> MetadataOptions:
+    def _get_metadata_to_include(
+        self, property_fields: dict[str, Any]
+    ) -> MetadataOptions:
         include_metadata = MetadataOptions.NONE
         if "created_at" in property_fields:
             include_metadata |= MetadataOptions.CREATED_AT
@@ -84,6 +93,23 @@ class ManyRelationshipResolver:
         if "is_protected" in property_fields:
             include_metadata |= MetadataOptions.IS_PROTECTED
         return include_metadata
+
+    def _build_relationship_meta_response(
+        self, relationship: Relationship, metadata_fields: dict[str, Any]
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        for meta_field in metadata_fields.keys():
+            if meta_field == "created_at":
+                created_at = relationship._get_created_at()
+                data["created_at"] = created_at.to_datetime() if created_at else None
+            elif meta_field == "created_by":
+                data["created_by"] = relationship._get_created_by()
+            elif meta_field == "updated_at":
+                updated_at = relationship._get_updated_at()
+                data["updated_at"] = updated_at.to_datetime() if updated_at else None
+            elif meta_field == "updated_by":
+                data["updated_by"] = relationship._get_updated_by()
+        return data
 
     async def resolve(
         self,
@@ -110,6 +136,10 @@ class ManyRelationshipResolver:
         edges = fields.get("edges", {})
         node_fields = edges.get("node", {})
         property_fields = edges.get("properties", {})
+        metadata_fields = {
+            "node_metadata": edges.get("node_metadata", {}),
+            "relationship_metadata": edges.get("relationship_metadata", {}),
+        }
         for key, value in property_fields.items():
             mapped_name = RELATIONS_PROPERTY_MAP[key]
             node_fields[mapped_name] = value
@@ -155,49 +185,77 @@ class ManyRelationshipResolver:
         if not node_fields:
             return response
 
-        relationships_include_metadata = self._get_metadata_to_include(property_fields=property_fields)
+        relationships_include_metadata = self._get_metadata_to_include(
+            property_fields=property_fields
+        )
+        if metadata_fields.get("relationship_metadata"):
+            relationships_include_metadata |= self._get_metadata_to_include(
+                property_fields=metadata_fields["relationship_metadata"]
+            )
 
         if offset or limit:
-            node_graph = await self._get_entities_simple(
+            relationships = await self._get_entities_simple(
                 db=graphql_context.db,
                 branch=graphql_context.branch,
                 ids=ids,
                 at=graphql_context.at,
-                related_node_ids=graphql_context.related_node_ids,
                 source_kind=source_kind,
                 rel_schema=node_rel,
                 filters=filters,
                 node_fields=node_fields,
+                metadata_fields=metadata_fields,
                 include_metadata=relationships_include_metadata,
                 offset=offset,
                 limit=limit,
             )
         else:
-            node_graph = await self._get_entities_with_data_loader(
+            relationships = await self._get_entities_with_data_loader(
                 db=graphql_context.db,
                 branch=graphql_context.branch,
                 ids=ids,
                 at=graphql_context.at,
-                related_node_ids=graphql_context.related_node_ids,
                 source_kind=source_kind,
                 rel_schema=node_rel,
                 filters=filters,
                 node_fields=node_fields,
+                metadata_fields=metadata_fields,
                 include_metadata=relationships_include_metadata,
             )
 
-        if not node_graph:
+        if not relationships:
             return response
 
         entries = []
-        for node in node_graph:
-            entry: dict[str, dict[str, Any]] = {"node": {}, "properties": {}}
-            for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
-                value = node.pop(key, None)
-                if value:
-                    entry["properties"][mapped] = value
-            entry["node"] = node
-            entries.append(entry)
+        async with graphql_context.db.start_session(read_only=True) as db:
+            for rel in relationships:
+                node = await rel.to_graphql(
+                    db=db,
+                    fields=node_fields,
+                    related_node_ids=graphql_context.related_node_ids,
+                )
+                entry: dict[str, dict[str, Any]] = {"node": {}, "properties": {}}
+                for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
+                    value = node.pop(key, None)
+                    if value:
+                        entry["properties"][mapped] = value
+                entry["node"] = node
+
+                if metadata_fields.get("node_metadata"):
+                    peer = await rel.get_peer(db=db)
+                    if peer:
+                        entry["node_metadata"] = await peer._build_meta_response(
+                            "node_metadata", edges
+                        )
+
+                if metadata_fields.get("relationship_metadata"):
+                    entry["relationship_metadata"] = (
+                        self._build_relationship_meta_response(
+                            relationship=rel,
+                            metadata_fields=metadata_fields["relationship_metadata"],
+                        )
+                    )
+
+                entries.append(entry)
 
         response["edges"] = entries
         return response
@@ -208,15 +266,15 @@ class ManyRelationshipResolver:
         branch: Branch,
         ids: list[str],
         at: Timestamp | None,
-        related_node_ids: set[str] | None,
         source_kind: str,
         rel_schema: RelationshipSchema,
         filters: dict[str, Any],
         node_fields: dict[str, Any],
+        metadata_fields: dict[str, dict[str, Any]],
         include_metadata: MetadataOptions,
         offset: int | None = None,
         limit: int | None = None,
-    ) -> list[dict[str, Any]] | None:
+    ) -> list[Relationship] | None:
         async with db.start_session(read_only=True) as dbs:
             objs = await NodeManager.query_peers(
                 db=dbs,
@@ -225,6 +283,7 @@ class ManyRelationshipResolver:
                 schema=rel_schema,
                 filters=filters,
                 fields=node_fields,
+                metadata_fields=metadata_fields.get("node_metadata"),
                 offset=offset,
                 limit=limit,
                 at=at,
@@ -235,7 +294,7 @@ class ManyRelationshipResolver:
             )
             if not objs:
                 return None
-            return [await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids) for obj in objs]
+            return objs
 
     async def _get_entities_with_data_loader(
         self,
@@ -243,13 +302,13 @@ class ManyRelationshipResolver:
         branch: Branch,
         ids: list[str],
         at: Timestamp | None,
-        related_node_ids: set[str] | None,
         source_kind: str,
         rel_schema: RelationshipSchema,
         filters: dict[str, Any],
         node_fields: dict[str, Any],
+        metadata_fields: dict[str, dict[str, Any]],
         include_metadata: MetadataOptions,
-    ) -> list[dict[str, Any]] | None:
+    ) -> list[Relationship] | None:
         if node_fields and "hfid" in node_fields:
             node_fields["human_friendly_id"] = None
 
@@ -259,6 +318,7 @@ class ManyRelationshipResolver:
             schema=rel_schema,
             filters=filters,
             fields=node_fields,
+            metadata_fields=metadata_fields.get("node_metadata"),
             at=at,
             branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
             include_metadata=include_metadata,
@@ -274,8 +334,4 @@ class ManyRelationshipResolver:
             all_peer_rels.extend(node_peer_rels)
         if not all_peer_rels:
             return None
-        async with db.start_session(read_only=True) as dbs:
-            return [
-                await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids)
-                for obj in all_peer_rels
-            ]
+        return all_peer_rels

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -28,9 +28,7 @@ if TYPE_CHECKING:
 
 class ManyRelationshipResolver:
     def __init__(self) -> None:
-        self._data_loader_instances: dict[
-            QueryPeerParams, PeerRelationshipsDataLoader
-        ] = {}
+        self._data_loader_instances: dict[QueryPeerParams, PeerRelationshipsDataLoader] = {}
 
     async def get_descendant_ids(
         self,
@@ -74,9 +72,7 @@ class ManyRelationshipResolver:
                 branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
             )
 
-    def _get_metadata_to_include(
-        self, property_fields: dict[str, Any]
-    ) -> MetadataOptions:
+    def _get_metadata_to_include(self, property_fields: dict[str, Any]) -> MetadataOptions:
         include_metadata = MetadataOptions.NONE
         if "created_at" in property_fields:
             include_metadata |= MetadataOptions.CREATED_AT
@@ -185,9 +181,7 @@ class ManyRelationshipResolver:
         if not node_fields:
             return response
 
-        relationships_include_metadata = self._get_metadata_to_include(
-            property_fields=property_fields
-        )
+        relationships_include_metadata = self._get_metadata_to_include(property_fields=property_fields)
         if metadata_fields.get("relationship_metadata"):
             relationships_include_metadata |= self._get_metadata_to_include(
                 property_fields=metadata_fields["relationship_metadata"]
@@ -243,16 +237,12 @@ class ManyRelationshipResolver:
                 if metadata_fields.get("node_metadata"):
                     peer = await rel.get_peer(db=db)
                     if peer:
-                        entry["node_metadata"] = await peer._build_meta_response(
-                            "node_metadata", edges
-                        )
+                        entry["node_metadata"] = await peer._build_meta_response("node_metadata", edges)
 
                 if metadata_fields.get("relationship_metadata"):
-                    entry["relationship_metadata"] = (
-                        self._build_relationship_meta_response(
-                            relationship=rel,
-                            metadata_fields=metadata_fields["relationship_metadata"],
-                        )
+                    entry["relationship_metadata"] = self._build_relationship_meta_response(
+                        relationship=rel,
+                        metadata_fields=metadata_fields["relationship_metadata"],
                     )
 
                 entries.append(entry)

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -164,8 +164,9 @@ async def default_paginated_list_resolver(
             key: value for key, value in kwargs.items() if ("__" in key and value is not None) or key in ("ids", "hfid")
         }
 
-        edges = fields.get("edges", {})
+        edges: dict[str, Any] = fields.get("edges", {})
         node_fields = edges.get("node", {})
+        metadata_fields: dict[str, Any] = edges.get("node_metadata", {})
         if "hfid" in node_fields:
             node_fields["human_friendly_id"] = None
 
@@ -190,6 +191,7 @@ async def default_paginated_list_resolver(
                 schema=schema,
                 filters=filters or None,
                 fields=node_fields,
+                metadata_fields=metadata_fields,
                 at=graphql_context.at,
                 branch=graphql_context.branch,
                 limit=limit,
@@ -221,7 +223,8 @@ async def default_paginated_list_resolver(
                         fields=node_fields,
                         related_node_ids=graphql_context.related_node_ids,
                         permissions=permission_set,
-                    )
+                    ),
+                    "node_metadata": await obj._build_meta_response("node_metadata", edges),
                 }
                 for obj in objs
             ]

--- a/backend/infrahub/graphql/resolvers/single_relationship.py
+++ b/backend/infrahub/graphql/resolvers/single_relationship.py
@@ -6,6 +6,8 @@ from graphql.type.definition import GraphQLNonNull
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType, MetadataOptions
 from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.relationship import Relationship
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -42,6 +44,23 @@ class SingleRelationshipResolver:
             include_metadata |= MetadataOptions.IS_PROTECTED
         return include_metadata
 
+    def _build_relationship_meta_response(
+        self, relationship: Relationship, metadata_fields: dict[str, Any]
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        for meta_field in metadata_fields.keys():
+            if meta_field == "created_at":
+                created_at = relationship._get_created_at()
+                data["created_at"] = created_at.to_datetime() if created_at else None
+            elif meta_field == "created_by":
+                data["created_by"] = relationship._get_created_by()
+            elif meta_field == "updated_at":
+                updated_at = relationship._get_updated_at()
+                data["updated_at"] = updated_at.to_datetime() if updated_at else None
+            elif meta_field == "updated_by":
+                data["updated_by"] = relationship._get_updated_by()
+        return data
+
     async def resolve(self, parent: dict, info: GraphQLResolveInfo, **kwargs: Any) -> dict[str, Any]:
         """Resolver for relationships of cardinality=one for Edged responses
 
@@ -63,52 +82,85 @@ class SingleRelationshipResolver:
         fields = extract_graphql_fields(info=info)
         node_fields = fields.get("node", {})
         property_fields = fields.get("properties", {})
+        metadata_fields = {
+            "node_metadata": fields.get("node_metadata", {}),
+            "relationship_metadata": fields.get("relationship_metadata", {}),
+        }
         for key, value in property_fields.items():
             mapped_name = RELATIONS_PROPERTY_MAP[key]
             node_fields[mapped_name] = value
 
         metadata_field_names = {prop_name for prop_name in RELATIONS_PROPERTY_MAP if prop_name != "__typename"}
-        requires_relationship_metadata = bool(set(property_fields.keys()) & metadata_field_names)
+        requires_relationship_properties = bool(set(property_fields.keys()) & metadata_field_names)
+        requires_relationship_metadata = bool(metadata_fields["relationship_metadata"])
 
         # Extract the schema of the node on the other end of the relationship from the GQL Schema
         node_rel = node_schema.get_relationship(info.field_name)
 
         response: dict[str, Any] = {"node": None, "properties": {}}
 
-        if requires_relationship_metadata:
+        relationship: Relationship | None = None
+        peer_node: Node | None = None
+
+        if requires_relationship_properties or requires_relationship_metadata:
             include_metadata = self._get_metadata_to_include(property_fields=property_fields)
-            node_graph = await self._get_entities_simple(
+            if requires_relationship_metadata:
+                include_metadata |= self._get_metadata_to_include(
+                    property_fields=metadata_fields["relationship_metadata"]
+                )
+            relationship = await self._get_entities_simple(
                 db=graphql_context.db,
                 branch=graphql_context.branch,
                 at=graphql_context.at,
-                related_node_ids=graphql_context.related_node_ids,
                 field_name=info.field_name,
                 parent_id=parent["id"],
                 source_kind=node_schema.kind,
                 rel_schema=node_rel,
                 node_fields=node_fields,
+                metadata_fields=metadata_fields,
                 include_metadata=include_metadata,
                 **kwargs,
             )
         else:
-            node_graph = await self._get_entities_with_data_loader(
+            peer_node = await self._get_entities_with_data_loader(
                 db=graphql_context.db,
                 branch=graphql_context.branch,
                 at=graphql_context.at,
-                related_node_ids=graphql_context.related_node_ids,
                 rel_schema=node_rel,
                 parent=parent,
                 node_fields=node_fields,
+                metadata_fields=metadata_fields,
             )
 
-        if not node_graph:
+        if not relationship and not peer_node:
             return response
-        response["node"] = node_graph
 
-        for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
-            value = node_graph.pop(key, None)
-            if value:
-                response["properties"][mapped] = value
+        async with graphql_context.db.start_session(read_only=True) as db:
+            if relationship:
+                node_graph = await relationship.to_graphql(
+                    db=db, fields=node_fields, related_node_ids=graphql_context.related_node_ids
+                )
+                peer_node = await relationship.get_peer(db=db)
+            elif peer_node:
+                node_graph = await peer_node.to_graphql(
+                    db=db, fields=node_fields, related_node_ids=graphql_context.related_node_ids
+                )
+
+            response["node"] = node_graph
+
+            for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
+                value = node_graph.pop(key, None)
+                if value:
+                    response["properties"][mapped] = value
+
+            if metadata_fields.get("node_metadata") and peer_node:
+                response["node_metadata"] = await peer_node._build_meta_response("node_metadata", fields)
+
+            if metadata_fields.get("relationship_metadata") and relationship:
+                response["relationship_metadata"] = self._build_relationship_meta_response(
+                    relationship=relationship, metadata_fields=metadata_fields["relationship_metadata"]
+                )
+
         return response
 
     async def _get_entities_simple(
@@ -116,15 +168,15 @@ class SingleRelationshipResolver:
         db: InfrahubDatabase,
         branch: Branch,
         at: Timestamp | None,
-        related_node_ids: set[str] | None,
         field_name: str,
         parent_id: str,
         source_kind: str,
         rel_schema: RelationshipSchema,
         node_fields: dict[str, Any],
+        metadata_fields: dict[str, dict[str, Any]],
         include_metadata: MetadataOptions,
         **kwargs: Any,
-    ) -> dict[str, Any] | None:
+    ) -> Relationship | None:
         filters = {
             f"{field_name}__{key}": value
             for key, value in kwargs.items()
@@ -138,6 +190,7 @@ class SingleRelationshipResolver:
                 schema=rel_schema,
                 filters=filters,
                 fields=node_fields,
+                metadata_fields=metadata_fields.get("node_metadata"),
                 at=at,
                 branch=branch,
                 branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
@@ -146,18 +199,18 @@ class SingleRelationshipResolver:
             )
             if not objs:
                 return None
-            return await objs[0].to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids)
+            return objs[0]
 
     async def _get_entities_with_data_loader(
         self,
         db: InfrahubDatabase,
         branch: Branch,
         at: Timestamp | None,
-        related_node_ids: set[str] | None,
         rel_schema: RelationshipSchema,
         parent: dict[str, Any],
         node_fields: dict[str, Any],
-    ) -> dict[str, Any] | None:
+        metadata_fields: dict[str, dict[str, Any]],
+    ) -> Node | None:
         try:
             peer_id: str = parent[rel_schema.name][0]["node"]["id"]
         except (KeyError, IndexError):
@@ -168,6 +221,7 @@ class SingleRelationshipResolver:
 
         query_params = GetManyParams(
             fields=node_fields,
+            metadata_fields=metadata_fields.get("node_metadata"),
             at=at,
             branch=branch,
             include_metadata=MetadataOptions.LINKED_NODES,
@@ -182,5 +236,4 @@ class SingleRelationshipResolver:
         node = await loader.load(key=peer_id)
         if not node:
             return None
-        async with db.start_session(read_only=True) as dbs:
-            return await node.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids)
+        return node

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -69,7 +69,19 @@ class AttributeInterface(InfrahubInterface):
     # owner = Field("DataOwner")
 
 
-class BaseAttribute(ObjectType):
+class InfrahubAttributeMetaObject(ObjectType):
+    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_at = String(
+        required=False,
+        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
+    )
+
+
+class InfrahubAttributeMeta(ObjectType):
+    meta = Field(InfrahubAttributeMetaObject, required=False)
+
+
+class BaseAttribute(InfrahubAttributeMeta):
     id = Field(String)
     is_from_profile = Field(Boolean)
     permissions = Field(PermissionType, required=False)

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -70,7 +70,8 @@ class AttributeInterface(InfrahubInterface):
 
 
 class InfrahubAttributeMetaObject(ObjectType):
-    updated_by = String(required=False, description="User that last modified the attribute")
+    # updated_by is dynamically added in GraphQLSchemaManager.generate_object_types()
+    # to use the account_type (CoreGenericAccount) instead of a plain String
     updated_at = DateTime(
         required=False,
         description="Date/Time when the attribute was last modified by a user or a system task",

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -70,10 +70,10 @@ class AttributeInterface(InfrahubInterface):
 
 
 class InfrahubAttributeMetaObject(ObjectType):
-    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_by = String(required=False, description="User that last modified the attribute")
     updated_at = DateTime(
         required=False,
-        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
+        description="Date/Time when the attribute was last modified by a user or a system task",
     )
 
 

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -71,17 +71,13 @@ class AttributeInterface(InfrahubInterface):
 
 class InfrahubAttributeMetaObject(ObjectType):
     updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
-    updated_at = String(
+    updated_at = DateTime(
         required=False,
         description="Date/Time when the attribute or relationship was last modified by a user or a system task",
     )
 
 
-class InfrahubAttributeMeta(ObjectType):
-    meta = Field(InfrahubAttributeMetaObject, required=False)
-
-
-class BaseAttribute(InfrahubAttributeMeta):
+class BaseAttribute(InfrahubAttributeMetaObject):
     id = Field(String)
     is_from_profile = Field(Boolean)
     permissions = Field(PermissionType, required=False)

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, Field, Int, List, NonNull, ObjectType, String
+from graphene import Boolean, DateTime, Field, Int, List, NonNull, ObjectType, String
 
 from infrahub.core.branch import Branch
 
@@ -68,33 +68,29 @@ class BranchType(InfrahubObjectType):
 
 class InfrahubBranchMetaObject(ObjectType):
     updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
-    updated_at = String(
+    updated_at = DateTime(
         required=False,
         description="Date/Time when the attribute or relationship was last modified by a user or a system task",
     )
 
 
-class InfrahubBranchMeta(ObjectType):
-    meta = Field(InfrahubBranchMetaObject, required=False)
-
-
-class RequiredStringValueField(InfrahubBranchMeta):
+class RequiredStringValueField(InfrahubBranchMetaObject):
     value = String(required=True)
 
 
-class NonRequiredStringValueField(InfrahubBranchMeta):
+class NonRequiredStringValueField(InfrahubBranchMetaObject):
     value = String(required=False)
 
 
-class NonRequiredIntValueField(InfrahubBranchMeta):
+class NonRequiredIntValueField(InfrahubBranchMetaObject):
     value = Int(required=False)
 
 
-class NonRequiredBooleanValueField(InfrahubBranchMeta):
+class NonRequiredBooleanValueField(InfrahubBranchMetaObject):
     value = Boolean(required=False)
 
 
-class StatusField(InfrahubBranchMeta):
+class StatusField(InfrahubBranchMetaObject):
     value = InfrahubBranchStatus(required=True)
 
 

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -67,7 +67,7 @@ class BranchType(InfrahubObjectType):
 
 
 class InfrahubBranchMetaObject(ObjectType):
-    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_by = String(required=False, description="User that last modified the attribute or relationship")
     updated_at = DateTime(
         required=False,
         description="Date/Time when the attribute or relationship was last modified by a user or a system task",

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, Field, Int, List, NonNull, String
+from graphene import Boolean, Field, Int, List, NonNull, ObjectType, String
 
 from infrahub.core.branch import Branch
-from infrahub.core.constants import GLOBAL_BRANCH_NAME
 
 from ...exceptions import BranchNotFoundError
 from .enums import InfrahubBranchStatus
@@ -67,23 +66,35 @@ class BranchType(InfrahubObjectType):
         raise BranchNotFoundError(f"Branch with name '{name}' not found")
 
 
-class RequiredStringValueField(InfrahubObjectType):
+class InfrahubBranchMetaObject(ObjectType):
+    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_at = String(
+        required=False,
+        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
+    )
+
+
+class InfrahubBranchMeta(ObjectType):
+    meta = Field(InfrahubBranchMetaObject, required=False)
+
+
+class RequiredStringValueField(InfrahubBranchMeta):
     value = String(required=True)
 
 
-class NonRequiredStringValueField(InfrahubObjectType):
+class NonRequiredStringValueField(InfrahubBranchMeta):
     value = String(required=False)
 
 
-class NonRequiredIntValueField(InfrahubObjectType):
+class NonRequiredIntValueField(InfrahubBranchMeta):
     value = Int(required=False)
 
 
-class NonRequiredBooleanValueField(InfrahubObjectType):
+class NonRequiredBooleanValueField(InfrahubBranchMeta):
     value = Boolean(required=False)
 
 
-class StatusField(InfrahubObjectType):
+class StatusField(InfrahubBranchMeta):
     value = InfrahubBranchStatus(required=True)
 
 
@@ -105,32 +116,12 @@ class InfrahubBranch(BranchType):
         description = "InfrahubBranch"
         name = "InfrahubBranch"
 
-    @staticmethod
-    async def _map_fields_to_graphql(objs: list[Branch], fields: dict) -> list[dict[str, Any]]:
-        field_keys = fields.keys()
-        result: list[dict[str, Any]] = []
-        for obj in objs:
-            if obj.name == GLOBAL_BRANCH_NAME:
-                continue
-            data: dict[str, Any] = {}
-            for field in field_keys:
-                if field == "id":
-                    data["id"] = obj.uuid
-                    continue
-                value = getattr(obj, field, None)
-                if isinstance(fields.get(field), dict):
-                    data[field] = {"value": value}
-                else:
-                    data[field] = value
-            result.append(data)
-        return result
 
-
-class InfrahubBranchEdge(InfrahubObjectType):
+class InfrahubBranchEdge(ObjectType):
     node = Field(InfrahubBranch, required=True)
 
 
-class InfrahubBranchType(InfrahubObjectType):
+class InfrahubBranchType(ObjectType):
     count = Field(Int, description="Total number of items")
     edges = Field(NonNull(List(of_type=NonNull(InfrahubBranchEdge))))
     default_branch = Field(

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, DateTime, Field, Int, List, NonNull, ObjectType, String
+from graphene import Boolean, Field, Int, List, NonNull, ObjectType, String
 
 from infrahub.core.branch import Branch
+from infrahub.core.node.standard import StandardNodeQueryFields
 
 from ...exceptions import BranchNotFoundError
 from .enums import InfrahubBranchStatus
+from .metadata import InfrahubStandardNodeMetaData
 from .standard_node import InfrahubObjectType
 
 if TYPE_CHECKING:
@@ -33,64 +35,35 @@ class BranchType(InfrahubObjectType):
         name = "Branch"
         model = Branch
 
-    @staticmethod
-    async def _map_fields_to_graphql(objs: list[Branch], fields: dict) -> list[dict[str, Any]]:
-        return [await obj.to_graphql(fields=fields) for obj in objs]
-
     @classmethod
     async def get_list(
         cls,
-        fields: dict,
+        fields: StandardNodeQueryFields,
         graphql_context: GraphqlContext,
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         async with graphql_context.db.start_session(read_only=True) as db:
             objs = await Branch.get_list(db=db, **kwargs)
-
-            if not objs:
-                return []
-
-            return await cls._map_fields_to_graphql(objs=objs, fields=fields)
-
-    @classmethod
-    async def get_by_name(
-        cls,
-        fields: dict,
-        graphql_context: GraphqlContext,
-        name: str,
-    ) -> dict[str, Any]:
-        branch_responses = await cls.get_list(fields=fields, graphql_context=graphql_context, name=name)
-
-        if branch_responses:
-            return branch_responses[0]
-        raise BranchNotFoundError(f"Branch with name '{name}' not found")
+            return [await obj.to_graphql_flat(fields=fields.node) for obj in objs]
 
 
-class InfrahubBranchMetaObject(ObjectType):
-    updated_by = String(required=False, description="User that last modified the attribute or relationship")
-    updated_at = DateTime(
-        required=False,
-        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
-    )
-
-
-class RequiredStringValueField(InfrahubBranchMetaObject):
+class RequiredStringValueField(ObjectType):
     value = String(required=True)
 
 
-class NonRequiredStringValueField(InfrahubBranchMetaObject):
+class NonRequiredStringValueField(ObjectType):
     value = String(required=False)
 
 
-class NonRequiredIntValueField(InfrahubBranchMetaObject):
+class NonRequiredIntValueField(ObjectType):
     value = Int(required=False)
 
 
-class NonRequiredBooleanValueField(InfrahubBranchMetaObject):
+class NonRequiredBooleanValueField(ObjectType):
     value = Boolean(required=False)
 
 
-class StatusField(InfrahubBranchMetaObject):
+class StatusField(ObjectType):
     value = InfrahubBranchStatus(required=True)
 
 
@@ -108,6 +81,32 @@ class InfrahubBranch(BranchType):
     )
     has_schema_changes = Field(NonRequiredBooleanValueField, required=False)
 
+    @classmethod
+    async def get_list(
+        cls,
+        fields: StandardNodeQueryFields,
+        graphql_context: GraphqlContext,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        async with graphql_context.db.start_session(read_only=True) as db:
+            objs = await Branch.get_list(db=db, **kwargs)
+            return [await obj.to_graphql(fields=fields) for obj in objs]
+
+    @classmethod
+    async def get_by_name(
+        cls,
+        fields: dict,
+        graphql_context: GraphqlContext,
+        name: str,
+    ) -> dict[str, Any]:
+        branch_responses = await cls.get_list(
+            fields=StandardNodeQueryFields(node=fields), graphql_context=graphql_context, name=name
+        )
+
+        if branch_responses:
+            return branch_responses[0]
+        raise BranchNotFoundError(f"Branch with name '{name}' not found")
+
     class Meta:
         description = "InfrahubBranch"
         name = "InfrahubBranch"
@@ -115,6 +114,7 @@ class InfrahubBranch(BranchType):
 
 class InfrahubBranchEdge(ObjectType):
     node = Field(InfrahubBranch, required=True)
+    node_metadata = Field(InfrahubStandardNodeMetaData, required=True)
 
 
 class InfrahubBranchType(ObjectType):

--- a/backend/infrahub/graphql/types/metadata.py
+++ b/backend/infrahub/graphql/types/metadata.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from graphene import DateTime, ObjectType, String
+
+
+class InfrahubNodeMetaData(ObjectType):
+    created_at = DateTime(required=False, description="Date/Time the object has been created")
+    created_by = String(
+        required=False, description="UUID of the user that created the object, even if the user is later deleted"
+    )
+    updated_by = String(
+        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
+    )
+    updated_at = DateTime(
+        required=False, description="Date/Time when the object was last modified by a user or a system task"
+    )
+
+
+class InfrahubRelationshipMetaData(ObjectType):
+    created_at = DateTime(required=False, description="Date/Time the object has been created")
+    created_by = String(
+        required=False, description="UUID of the user that created the object, even if the user is later deleted"
+    )
+    updated_by = String(
+        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
+    )
+    updated_at = DateTime(
+        required=False, description="Date/Time when the object was last modified by a user or a system task"
+    )

--- a/backend/infrahub/graphql/types/metadata.py
+++ b/backend/infrahub/graphql/types/metadata.py
@@ -1,29 +1,17 @@
 from __future__ import annotations
 
-from graphene import DateTime, ObjectType, String
+from graphene import DateTime, Field, ObjectType, String
 
 
-class InfrahubNodeMetaData(ObjectType):
+class InfrahubStandardNodeMetaAccount(ObjectType):
+    id = String(required=True)
+    display_name = String(required=False)
+
+
+class InfrahubStandardNodeMetaData(ObjectType):
     created_at = DateTime(required=False, description="Date/Time the object has been created")
-    created_by = String(
-        required=False, description="UUID of the user that created the object, even if the user is later deleted"
-    )
-    updated_by = String(
-        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
-    )
+    created_by = Field(InfrahubStandardNodeMetaAccount, required=False)
     updated_at = DateTime(
         required=False, description="Date/Time when the object was last modified by a user or a system task"
     )
-
-
-class InfrahubRelationshipMetaData(ObjectType):
-    created_at = DateTime(required=False, description="Date/Time the object has been created")
-    created_by = String(
-        required=False, description="UUID of the user that created the object, even if the user is later deleted"
-    )
-    updated_by = String(
-        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
-    )
-    updated_at = DateTime(
-        required=False, description="Date/Time when the object was last modified by a user or a system task"
-    )
+    updated_by = Field(InfrahubStandardNodeMetaAccount, required=False)

--- a/backend/infrahub/graphql/types/node.py
+++ b/backend/infrahub/graphql/types/node.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from graphene import DateTime, Field, ObjectType, String
+from graphene import ObjectType
 from graphene.types.objecttype import ObjectTypeOptions
 
 from infrahub.core.schema import MainSchemaTypes
@@ -12,24 +12,7 @@ class InfrahubObjectOptions(ObjectTypeOptions):
     schema: MainSchemaTypes
 
 
-class InfrahubNodeMetaObject(ObjectType):
-    created_at = DateTime(required=False, description="Date/Time the object has been created")
-    created_by = String(
-        required=False, description="UUID of the user that created the object, even if the user is later deleted"
-    )
-    updated_by = String(
-        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
-    )
-    updated_at = DateTime(
-        required=False, description="Date/Time when the object was last modified by a user or a system task"
-    )
-
-
-class InfrahubNodeMeta(ObjectType):
-    node_metadata = Field(InfrahubNodeMetaObject, required=False)
-
-
-class InfrahubObject(InfrahubNodeMeta):
+class InfrahubObject(ObjectType):
     @classmethod
     def __init_subclass_with_meta__(
         cls,

--- a/backend/infrahub/graphql/types/node.py
+++ b/backend/infrahub/graphql/types/node.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from graphene import Field, ObjectType, String
+from graphene import DateTime, Field, ObjectType, String
 from graphene.types.objecttype import ObjectTypeOptions
 
 from infrahub.core.schema import MainSchemaTypes
@@ -13,20 +13,20 @@ class InfrahubObjectOptions(ObjectTypeOptions):
 
 
 class InfrahubNodeMetaObject(ObjectType):
-    created_at = String(required=False, description="Date/Time the object has been created")
+    created_at = DateTime(required=False, description="Date/Time the object has been created")
     created_by = String(
         required=False, description="UUID of the user that created the object, even if the user is later deleted"
     )
     updated_by = String(
         required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
     )
-    updated_at = String(
+    updated_at = DateTime(
         required=False, description="Date/Time when the object was last modified by a user or a system task"
     )
 
 
 class InfrahubNodeMeta(ObjectType):
-    meta = Field(InfrahubNodeMetaObject, required=False)
+    node_metadata = Field(InfrahubNodeMetaObject, required=False)
 
 
 class InfrahubObject(InfrahubNodeMeta):

--- a/backend/infrahub/graphql/types/node.py
+++ b/backend/infrahub/graphql/types/node.py
@@ -2,17 +2,34 @@ from __future__ import annotations
 
 from typing import Any
 
-from graphene import ObjectType
+from graphene import Field, ObjectType, String
 from graphene.types.objecttype import ObjectTypeOptions
 
-from infrahub.core.schema import GenericSchema, MainSchemaTypes, NodeSchema, ProfileSchema, TemplateSchema
+from infrahub.core.schema import MainSchemaTypes
 
 
 class InfrahubObjectOptions(ObjectTypeOptions):
     schema: MainSchemaTypes
 
 
-class InfrahubObject(ObjectType):
+class InfrahubNodeMetaObject(ObjectType):
+    created_at = String(required=False, description="Date/Time the object has been created")
+    created_by = String(
+        required=False, description="UUID of the user that created the object, even if the user is later deleted"
+    )
+    updated_by = String(
+        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
+    )
+    updated_at = String(
+        required=False, description="Date/Time when the object was last modified by a user or a system task"
+    )
+
+
+class InfrahubNodeMeta(ObjectType):
+    meta = Field(InfrahubNodeMetaObject, required=False)
+
+
+class InfrahubObject(InfrahubNodeMeta):
     @classmethod
     def __init_subclass_with_meta__(
         cls,
@@ -21,7 +38,27 @@ class InfrahubObject(ObjectType):
         _meta: InfrahubObjectOptions | None = None,
         **options: Any,
     ) -> None:
-        if not isinstance(schema, NodeSchema | GenericSchema | ProfileSchema | TemplateSchema):
+        if not isinstance(schema, MainSchemaTypes):
+            raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
+
+        if not _meta:
+            _meta = InfrahubObjectOptions(cls)
+
+        _meta.schema = schema
+
+        super().__init_subclass_with_meta__(_meta=_meta, interfaces=interfaces, **options)
+
+
+class InfrahubObjectWithoutMeta(ObjectType):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        schema: MainSchemaTypes | None = None,
+        interfaces: tuple = (),
+        _meta: InfrahubObjectOptions | None = None,
+        **options: Any,
+    ) -> None:
+        if not isinstance(schema, MainSchemaTypes):
             raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
 
         if not _meta:

--- a/backend/infrahub/graphql/types/relationship.py
+++ b/backend/infrahub/graphql/types/relationship.py
@@ -9,10 +9,10 @@ class RelationshipPeer(ObjectType):
 
 
 class InfrahubRelationshipMetaObject(ObjectType):
-    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_by = String(required=False, description="User that last modified the relationship")
     updated_at = DateTime(
         required=False,
-        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
+        description="Date/Time when the relationship was last modified by a user or a system task",
     )
 
 

--- a/backend/infrahub/graphql/types/relationship.py
+++ b/backend/infrahub/graphql/types/relationship.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from graphene import Field, List, NonNull, ObjectType, String
+from graphene import DateTime, Field, List, NonNull, ObjectType, String
 
 
 class RelationshipPeer(ObjectType):
@@ -10,17 +10,13 @@ class RelationshipPeer(ObjectType):
 
 class InfrahubRelationshipMetaObject(ObjectType):
     updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
-    updated_at = String(
+    updated_at = DateTime(
         required=False,
         description="Date/Time when the attribute or relationship was last modified by a user or a system task",
     )
 
 
-class InfrahubRelationshipMeta(ObjectType):
-    meta = Field(InfrahubRelationshipMetaObject, required=False)
-
-
-class Relationship(InfrahubRelationshipMeta):
+class Relationship(InfrahubRelationshipMetaObject):
     id = String(required=False)
     identifier = String(required=False)
     peers = List(NonNull(RelationshipPeer))

--- a/backend/infrahub/graphql/types/relationship.py
+++ b/backend/infrahub/graphql/types/relationship.py
@@ -8,7 +8,19 @@ class RelationshipPeer(ObjectType):
     kind = String(required=False)
 
 
-class Relationship(ObjectType):
+class InfrahubRelationshipMetaObject(ObjectType):
+    updated_by = String(required=False, description="UUID of the user that last modified the attribute or relationship")
+    updated_at = String(
+        required=False,
+        description="Date/Time when the attribute or relationship was last modified by a user or a system task",
+    )
+
+
+class InfrahubRelationshipMeta(ObjectType):
+    meta = Field(InfrahubRelationshipMetaObject, required=False)
+
+
+class Relationship(InfrahubRelationshipMeta):
     id = String(required=False)
     identifier = String(required=False)
     peers = List(NonNull(RelationshipPeer))

--- a/backend/infrahub/graphql/types/standard_node.py
+++ b/backend/infrahub/graphql/types/standard_node.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import ObjectType
+from graphene import Field, ObjectType, String
 from graphene.types.objecttype import ObjectTypeOptions
 
 from infrahub import config
@@ -15,7 +15,24 @@ class InfrahubObjectTypeOptions(ObjectTypeOptions):
     model = None
 
 
-class InfrahubObjectType(ObjectType):
+class InfrahubNodeMetaObject(ObjectType):
+    created_at = String(required=False, description="Date/Time the object has been created")
+    created_by = String(
+        required=False, description="UUID of the user that created the object, even if the user is later deleted"
+    )
+    updated_by = String(
+        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
+    )
+    updated_at = String(
+        required=False, description="Date/Time when the object was last modified by a user or a system task"
+    )
+
+
+class InfrahubNodeMeta(ObjectType):
+    meta = Field(InfrahubNodeMetaObject, required=False)
+
+
+class InfrahubObjectType(InfrahubNodeMeta):
     @classmethod
     def __init_subclass_with_meta__(cls, model=None, interfaces=(), _meta=None, **options) -> None:
         if not _meta:

--- a/backend/infrahub/graphql/types/standard_node.py
+++ b/backend/infrahub/graphql/types/standard_node.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Field, ObjectType, String
+from graphene import DateTime, Field, ObjectType, String
 from graphene.types.objecttype import ObjectTypeOptions
 
 from infrahub import config
@@ -16,20 +16,20 @@ class InfrahubObjectTypeOptions(ObjectTypeOptions):
 
 
 class InfrahubNodeMetaObject(ObjectType):
-    created_at = String(required=False, description="Date/Time the object has been created")
+    created_at = DateTime(required=False, description="Date/Time the object has been created")
     created_by = String(
         required=False, description="UUID of the user that created the object, even if the user is later deleted"
     )
     updated_by = String(
         required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
     )
-    updated_at = String(
+    updated_at = DateTime(
         required=False, description="Date/Time when the object was last modified by a user or a system task"
     )
 
 
 class InfrahubNodeMeta(ObjectType):
-    meta = Field(InfrahubNodeMetaObject, required=False)
+    node_metadata = Field(InfrahubNodeMetaObject, required=False)
 
 
 class InfrahubObjectType(InfrahubNodeMeta):

--- a/backend/infrahub/graphql/types/standard_node.py
+++ b/backend/infrahub/graphql/types/standard_node.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import DateTime, Field, ObjectType, String
+from graphene import ObjectType
 from graphene.types.objecttype import ObjectTypeOptions
 
 from infrahub import config
 
 if TYPE_CHECKING:
+    from infrahub.core.node.standard import StandardNodeQueryFields
     from infrahub.graphql.initialization import GraphqlContext
 
 
@@ -15,24 +16,7 @@ class InfrahubObjectTypeOptions(ObjectTypeOptions):
     model = None
 
 
-class InfrahubNodeMetaObject(ObjectType):
-    created_at = DateTime(required=False, description="Date/Time the object has been created")
-    created_by = String(
-        required=False, description="UUID of the user that created the object, even if the user is later deleted"
-    )
-    updated_by = String(
-        required=False, description="UUID of the user that last modified the object, even if the user is later deleted"
-    )
-    updated_at = DateTime(
-        required=False, description="Date/Time when the object was last modified by a user or a system task"
-    )
-
-
-class InfrahubNodeMeta(ObjectType):
-    node_metadata = Field(InfrahubNodeMetaObject, required=False)
-
-
-class InfrahubObjectType(InfrahubNodeMeta):
+class InfrahubObjectType(ObjectType):
     @classmethod
     def __init_subclass_with_meta__(cls, model=None, interfaces=(), _meta=None, **options) -> None:
         if not _meta:
@@ -43,7 +27,9 @@ class InfrahubObjectType(InfrahubNodeMeta):
         super().__init_subclass_with_meta__(_meta=_meta, interfaces=interfaces, **options)
 
     @classmethod
-    async def get_list(cls, fields: dict[str, Any], graphql_context: GraphqlContext, **kwargs) -> list[dict[str, Any]]:
+    async def get_list(
+        cls, fields: StandardNodeQueryFields, graphql_context: GraphqlContext, **kwargs
+    ) -> list[dict[str, Any]]:
         async with graphql_context.db.session(database=config.SETTINGS.database.database_name) as db:
             filters = {key: value for key, value in kwargs.items() if "__" in key and value}
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,7 +37,11 @@ from infrahub.core.initialization import (
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.attribute_schema import AttributeSchema
-from infrahub.core.schema.definitions.core import core_profile_schema_definition
+from infrahub.core.schema.definitions.core import (
+    core_account_token,
+    core_generic_account,
+    core_profile_schema_definition,
+)
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
@@ -469,7 +473,9 @@ async def data_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
                 "namespace": "Lineage",
             },
             core_profile_schema_definition,
-        ]
+            core_generic_account,
+        ],
+        "nodes": [core_account_token],
     }
 
     schema = SchemaRoot(**SCHEMA)

--- a/backend/tests/unit/core/constraint_validators/test_determiner.py
+++ b/backend/tests/unit/core/constraint_validators/test_determiner.py
@@ -144,6 +144,7 @@ class TestConstraintDeterminer:
             c
             for c in constraints
             if c.constraint_name not in ["node.generate_profile.update", "node.uniqueness_constraints.update"]
+            and c.path.schema_kind in ["TestCar", "TestPerson"]
         ]
         assert len(relevant_constraints) == len(constraint_info_set)
         assert set(relevant_constraints) == constraint_info_set

--- a/backend/tests/unit/core/test_types.py
+++ b/backend/tests/unit/core/test_types.py
@@ -39,6 +39,7 @@ def _get_path_field_list(include_binary_address: bool, fields: dict[str, Field])
         "source",
         "permissions",
         "updated_at",
+        "updated_by",
     ]
     included = ["binary_address"] if include_binary_address else []
     for name in fields.keys():

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -9,7 +9,7 @@ from tests.helpers.test_app import TestInfrahubApp
 
 
 def test_check_branch_type_has_corresponding_infrahub_branch_value_field():
-    exempted_fields = ("id", "created_at")
+    exempted_fields = ("id", "created_at", "node_metadata")
     for field_name, field_value in BranchType._meta.fields.items():
         if field_name in exempted_fields:
             continue
@@ -357,7 +357,7 @@ class TestBranchQuery(TestInfrahubApp):
                 InfrahubBranch {
                     edges {
                         node {
-                            meta {
+                            node_metadata {
                                 created_by
                                 created_at
                                 updated_by
@@ -366,17 +366,13 @@ class TestBranchQuery(TestInfrahubApp):
                             id
                             name {
                                 value
-                                meta {
-                                    updated_by
-                                    updated_at
-                                }
+                                updated_by
+                                updated_at
                             }
                             description {
                                 value
-                                meta {
-                                    updated_by
-                                    updated_at
-                                }
+                                updated_by
+                                updated_at
                             }
                         }
                     }
@@ -394,4 +390,12 @@ class TestBranchQuery(TestInfrahubApp):
         assert all_branches.data
 
         for branch in all_branches.data["InfrahubBranch"]["edges"]:
-            assert branch["node"]["meta"]["created_at"]
+            assert branch["node"]["name"]["value"]
+            assert branch["node"]["name"]["updated_at"] is None
+            assert branch["node"]["name"]["updated_by"] is None
+
+            assert branch["node"]["description"]["value"]
+            assert branch["node"]["description"]["updated_at"] is None
+            assert branch["node"]["description"]["updated_by"] is None
+
+            assert branch["node"]["node_metadata"]["created_at"]

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -342,3 +342,56 @@ class TestBranchQuery(TestInfrahubApp):
         assert all_branches.errors
         assert len(all_branches.errors)
         assert all_branches.errors[0].message == "limit must be >= 1"
+
+    async def test_paginated_branch_query_meta_data(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema,
+        session_admin,
+        client,
+        service,
+    ) -> None:
+        query = """
+            query {
+                InfrahubBranch {
+                    edges {
+                        node {
+                            meta {
+                                created_by
+                                created_at
+                                updated_by
+                                updated_at
+                            }
+                            id
+                            name {
+                                value
+                                meta {
+                                    updated_by
+                                    updated_at
+                                }
+                            }
+                            description {
+                                value
+                                meta {
+                                    updated_by
+                                    updated_at
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        all_branches = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+        assert all_branches.errors is None
+        assert all_branches.data
+
+        for branch in all_branches.data["InfrahubBranch"]["edges"]:
+            assert branch["node"]["meta"]["created_at"]

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -356,23 +356,17 @@ class TestBranchQuery(TestInfrahubApp):
             query {
                 InfrahubBranch {
                     edges {
+                        node_metadata {
+                            created_at
+                            updated_at
+                        }
                         node {
-                            node_metadata {
-                                created_by
-                                created_at
-                                updated_by
-                                updated_at
-                            }
                             id
                             name {
                                 value
-                                updated_by
-                                updated_at
                             }
                             description {
                                 value
-                                updated_by
-                                updated_at
                             }
                         }
                     }
@@ -391,11 +385,5 @@ class TestBranchQuery(TestInfrahubApp):
 
         for branch in all_branches.data["InfrahubBranch"]["edges"]:
             assert branch["node"]["name"]["value"]
-            assert branch["node"]["name"]["updated_at"] is None
-            assert branch["node"]["name"]["updated_by"] is None
-
             assert branch["node"]["description"]["value"]
-            assert branch["node"]["description"]["updated_at"] is None
-            assert branch["node"]["description"]["updated_by"] is None
-
-            assert branch["node"]["node_metadata"]["created_at"]
+            assert branch["node_metadata"]["created_at"]

--- a/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
+++ b/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
@@ -31,7 +31,7 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
         CoreProposedChange {
             edges {
                 node {
-                    meta {
+                    node_metadata {
                         created_by
                         created_at
                         updated_by
@@ -40,20 +40,16 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
                     id
                     name {
                         value
-                        meta {
-                            updated_by
-                            updated_at
-                        }
+                        updated_by
+                        updated_at
                     }
                     description {
                         value
-                        meta {
-                            updated_by
-                            updated_at
-                        }
+                        updated_by
+                        updated_at
                     }
                     reviewers {
-                        meta {
+                        node_metadata {
                             created_at
                             updated_at
                             created_by
@@ -62,18 +58,14 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
                         edges {
                             node {
                                 name {
-                                    meta {
-                                        updated_at
-                                        updated_by
-                                    }
                                     value
+                                    updated_by
+                                    updated_at
                                 }
                                 description {
-                                    meta {
-                                        updated_at
-                                        updated_by
-                                    }
                                     value
+                                    updated_by
+                                    updated_at
                                 }
                             }
                         }
@@ -313,10 +305,10 @@ async def test_proposed_change_query_meta_data(
     await proposed_change.new(
         db=db,
         name="pc-1",
+        description="sample description",
         destination_branch="main",
         source_branch=branch_name,
         state="open",
-        created_by=await NodeManager.get_one(db=db, id=session_admin.account_id),
     )
     await proposed_change.save(db=db)
 
@@ -333,6 +325,15 @@ async def test_proposed_change_query_meta_data(
     assert response.data
 
     for prc in response.data["CoreProposedChange"]["edges"]:
-        assert prc["node"]["meta"]["created_by"]
-        assert prc["node"]["name"]["meta"]["updated_at"]
-        assert prc["node"]["description"]["meta"]["updated_at"]
+        assert prc["node"]["name"]["value"]
+        assert prc["node"]["name"]["updated_by"]
+        assert prc["node"]["name"]["updated_at"]
+
+        assert prc["node"]["description"]["value"]
+        assert prc["node"]["description"]["updated_by"]
+        assert prc["node"]["description"]["updated_at"]
+
+        assert prc["node"]["node_metadata"]["created_by"]
+        assert prc["node"]["node_metadata"]["created_at"]
+        assert prc["node"]["node_metadata"]["updated_by"]
+        assert prc["node"]["node_metadata"]["updated_at"]

--- a/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
+++ b/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
@@ -26,6 +26,65 @@ query actions($proposed_change_id: String!) {
 """
 
 
+PROPOSED_CHANGE_META_DATA_QUERY = """
+    query {
+        CoreProposedChange {
+            edges {
+                node {
+                    meta {
+                        created_by
+                        created_at
+                        updated_by
+                        updated_at
+                    }
+                    id
+                    name {
+                        value
+                        meta {
+                            updated_by
+                            updated_at
+                        }
+                    }
+                    description {
+                        value
+                        meta {
+                            updated_by
+                            updated_at
+                        }
+                    }
+                    reviewers {
+                        meta {
+                            created_at
+                            updated_at
+                            created_by
+                            updated_by
+                        }
+                        edges {
+                            node {
+                                name {
+                                    meta {
+                                        updated_at
+                                        updated_by
+                                    }
+                                    value
+                                }
+                                description {
+                                    meta {
+                                        updated_at
+                                        updated_by
+                                    }
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
 async def test_proposed_change_open(
     db: InfrahubDatabase, register_core_models_schema: None, session_admin: AccountSession
 ) -> None:
@@ -239,3 +298,41 @@ async def test_proposed_change_draft(
         "You do not have the permission to perform this action",
         "The proposed change is a draft",
     ]
+
+
+async def test_proposed_change_query_meta_data(
+    db: InfrahubDatabase, register_core_models_schema: None, session_admin: AccountSession
+) -> None:
+    registry.permission_backends = [LocalPermissionBackend()]
+
+    branch_name = "test-pc"
+    source_branch = Branch(name=branch_name)
+    await source_branch.save(db=db)
+
+    proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    await proposed_change.new(
+        db=db,
+        name="pc-1",
+        destination_branch="main",
+        source_branch=branch_name,
+        state="open",
+        created_by=await NodeManager.get_one(db=db, id=session_admin.account_id),
+    )
+    await proposed_change.save(db=db)
+
+    service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
+
+    response = await graphql_query(
+        query=PROPOSED_CHANGE_META_DATA_QUERY,
+        db=db,
+        service=service,
+        account_session=session_admin,
+    )
+
+    assert not response.errors
+    assert response.data
+
+    for prc in response.data["CoreProposedChange"]["edges"]:
+        assert prc["node"]["meta"]["created_by"]
+        assert prc["node"]["name"]["meta"]["updated_at"]
+        assert prc["node"]["description"]["meta"]["updated_at"]

--- a/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
+++ b/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
@@ -30,13 +30,12 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
     query {
         CoreProposedChange {
             edges {
+                node_metadata {
+                    created_at
+                    updated_at
+                }
                 node {
-                    node_metadata {
-                        created_by
-                        created_at
-                        updated_by
-                        updated_at
-                    }
+
                     id
                     name {
                         value
@@ -49,13 +48,11 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
                         updated_at
                     }
                     reviewers {
-                        node_metadata {
-                            created_at
-                            updated_at
-                            created_by
-                            updated_by
-                        }
                         edges {
+                            node_metadata {
+                                created_at
+                                updated_at
+                            }
                             node {
                                 name {
                                     value
@@ -333,7 +330,5 @@ async def test_proposed_change_query_meta_data(
         assert prc["node"]["description"]["updated_by"]
         assert prc["node"]["description"]["updated_at"]
 
-        assert prc["node"]["node_metadata"]["created_by"]
-        assert prc["node"]["node_metadata"]["created_at"]
-        assert prc["node"]["node_metadata"]["updated_by"]
-        assert prc["node"]["node_metadata"]["updated_at"]
+        assert prc["node_metadata"]["created_at"]
+        assert prc["node_metadata"]["updated_at"]

--- a/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
+++ b/backend/tests/unit/graphql/queries/test_proposed_change_actions.py
@@ -39,12 +39,16 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
                     id
                     name {
                         value
-                        updated_by
+                        updated_by {
+                            id
+                        }
                         updated_at
                     }
                     description {
                         value
-                        updated_by
+                        updated_by {
+                            id
+                        }
                         updated_at
                     }
                     reviewers {
@@ -56,12 +60,16 @@ PROPOSED_CHANGE_META_DATA_QUERY = """
                             node {
                                 name {
                                     value
-                                    updated_by
+                                    updated_by {
+                                        id
+                                    }
                                     updated_at
                                 }
                                 description {
                                     value
-                                    updated_by
+                                    updated_by {
+                                        id
+                                    }
                                     updated_at
                                 }
                             }
@@ -298,6 +306,9 @@ async def test_proposed_change_query_meta_data(
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)
 
+    initial_user = "bob"
+    update_user = "alice"
+
     proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
     await proposed_change.new(
         db=db,
@@ -307,7 +318,9 @@ async def test_proposed_change_query_meta_data(
         source_branch=branch_name,
         state="open",
     )
-    await proposed_change.save(db=db)
+    await proposed_change.save(db=db, user_id=initial_user)
+    proposed_change.description.value = "updated description"
+    await proposed_change.save(db=db, user_id=update_user)
 
     service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
 
@@ -323,11 +336,11 @@ async def test_proposed_change_query_meta_data(
 
     for prc in response.data["CoreProposedChange"]["edges"]:
         assert prc["node"]["name"]["value"]
-        assert prc["node"]["name"]["updated_by"]
+        assert prc["node"]["name"]["updated_by"]["id"] == initial_user
         assert prc["node"]["name"]["updated_at"]
 
         assert prc["node"]["description"]["value"]
-        assert prc["node"]["description"]["updated_by"]
+        assert prc["node"]["description"]["updated_by"]["id"] == update_user
         assert prc["node"]["description"]["updated_at"]
 
         assert prc["node_metadata"]["created_at"]

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -1878,10 +1878,10 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
     query {
         TestPerson {
             edges {
+                node_metadata {
+                    updated_at
+                }
                 node {
-                    node_metadata {
-                        updated_at
-                    }
                     id
                 }
             }
@@ -1900,7 +1900,8 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
 
     assert result1.errors is None
     assert result1.data
-    assert result1.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+    assert result1.data["TestPerson"]["edges"][0]["node"]["id"]
+    assert result1.data["TestPerson"]["edges"][0]["node_metadata"]["updated_at"]
 
     p2 = await Node.init(db=db, schema="TestPerson")
     await p2.new(db=db, firstname="Jane", lastname="Doe")
@@ -1918,14 +1919,14 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
 
     assert result2.errors is None
     assert result2.data
-    assert result2.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
-    assert result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
-    assert result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"] == Timestamp(
-        result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
+    assert result2.data["TestPerson"]["edges"][0]["node_metadata"]["updated_at"]
+    assert result2.data["TestPerson"]["edges"][1]["node_metadata"]["updated_at"]
+    assert result2.data["TestPerson"]["edges"][1]["node_metadata"]["updated_at"] == Timestamp(
+        result2.data["TestPerson"]["edges"][1]["node_metadata"]["updated_at"]
     ).to_string(with_z=False)
     assert (
-        result2.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
-        != result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
+        result2.data["TestPerson"]["edges"][0]["node_metadata"]["updated_at"]
+        != result2.data["TestPerson"]["edges"][1]["node_metadata"]["updated_at"]
     )
 
 
@@ -1950,10 +1951,10 @@ async def test_query_relationship_updated_at(
                     id
                     tags {
                         edges {
+                            node_metadata {
+                                updated_at
+                            }
                             node {
-                                node_metadata {
-                                    updated_at
-                                }
                                 name {
                                     value
                                 }
@@ -1999,18 +2000,15 @@ async def test_query_relationship_updated_at(
     assert result2.errors is None
     assert result2.data
     assert len(result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"]) == 2
+    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node_metadata"]["updated_at"] is not None
     assert (
-        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
-        is not None
-    )
-    assert (
-        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node_metadata"]["updated_at"]
         != result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["properties"]["updated_at"]
     )
-    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"][
+    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node_metadata"][
         "updated_at"
     ] == Timestamp(
-        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node_metadata"]["updated_at"]
     ).to_string(with_z=False)
 
 

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -1879,7 +1879,9 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
         TestPerson {
             edges {
                 node {
-                    _updated_at
+                    node_metadata {
+                        updated_at
+                    }
                     id
                 }
             }
@@ -1898,7 +1900,7 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
 
     assert result1.errors is None
     assert result1.data
-    assert result1.data["TestPerson"]["edges"][0]["node"]["_updated_at"]
+    assert result1.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
 
     p2 = await Node.init(db=db, schema="TestPerson")
     await p2.new(db=db, firstname="Jane", lastname="Doe")
@@ -1916,14 +1918,14 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
 
     assert result2.errors is None
     assert result2.data
-    assert result2.data["TestPerson"]["edges"][0]["node"]["_updated_at"]
-    assert result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"]
-    assert result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"] == Timestamp(
-        result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"]
+    assert result2.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+    assert result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
+    assert result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"] == Timestamp(
+        result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
     ).to_string(with_z=False)
     assert (
-        result2.data["TestPerson"]["edges"][0]["node"]["_updated_at"]
-        != result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"]
+        result2.data["TestPerson"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+        != result2.data["TestPerson"]["edges"][1]["node"]["node_metadata"]["updated_at"]
     )
 
 
@@ -1949,7 +1951,9 @@ async def test_query_relationship_updated_at(
                     tags {
                         edges {
                             node {
-                                _updated_at
+                                node_metadata {
+                                    updated_at
+                                }
                                 name {
                                     value
                                 }
@@ -1995,13 +1999,18 @@ async def test_query_relationship_updated_at(
     assert result2.errors is None
     assert result2.data
     assert len(result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"]) == 2
-    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["_updated_at"] is not None
     assert (
-        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["_updated_at"]
+        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
+        is not None
+    )
+    assert (
+        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
         != result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["properties"]["updated_at"]
     )
-    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["_updated_at"] == Timestamp(
-        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["_updated_at"]
+    assert result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"][
+        "updated_at"
+    ] == Timestamp(
+        result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["node_metadata"]["updated_at"]
     ).to_string(with_z=False)
 
 

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -58,7 +58,6 @@ async def test_generate_graphql_object(
         "level",
         "mylist",
         "name",
-        "node_metadata",
         "status",
         "time",
     ]
@@ -83,7 +82,6 @@ async def test_generate_graphql_object_with_interface(
         "id",
         "name",
         "nbr_doors",
-        "node_metadata",
     ]
 
 
@@ -150,16 +148,20 @@ async def test_generate_object_types(
         "member_of_groups",
         "name",
         "nbr_seats",
-        "node_metadata",
         "owner",
         "profiles",
         "subscriber_of_groups",
         "transmission",
     ]
 
-    assert sorted(edged_car._meta.fields.keys()) == ["node"]
+    assert sorted(edged_car._meta.fields.keys()) == ["node", "node_metadata"]
     assert str(edged_car._meta.fields["node"].type) == "TestCar"
-    assert sorted(nested_edged_car._meta.fields.keys()) == ["node", "properties"]
+    assert sorted(nested_edged_car._meta.fields.keys()) == [
+        "node",
+        "node_metadata",
+        "properties",
+        "relationship_metadata",
+    ]
     assert str(nested_edged_car._meta.fields["node"].type) == "TestCar"
     assert str(nested_edged_car._meta.fields["properties"].type) == "RelationshipProperty"
 
@@ -173,13 +175,17 @@ async def test_generate_object_types(
         "id",
         "member_of_groups",
         "name",
-        "node_metadata",
         "profiles",
         "subscriber_of_groups",
     ]
-    assert sorted(edged_person._meta.fields.keys()) == ["node"]
+    assert sorted(edged_person._meta.fields.keys()) == ["node", "node_metadata"]
     assert str(edged_person._meta.fields["node"].type) == "TestPerson"
-    assert sorted(nested_edged_person._meta.fields.keys()) == ["node", "properties"]
+    assert sorted(nested_edged_person._meta.fields.keys()) == [
+        "node",
+        "node_metadata",
+        "properties",
+        "relationship_metadata",
+    ]
     assert str(nested_edged_person._meta.fields["node"].type) == "TestPerson"
     assert str(nested_edged_person._meta.fields["properties"].type) == "RelationshipProperty"
     assert sorted(relationship_property._meta.fields.keys()) == [

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -10,6 +10,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.graphql.types import InfrahubObject
+from infrahub.graphql.types.node import InfrahubObjectWithoutMeta
 
 
 async def test_input_type_registration() -> None:
@@ -57,6 +58,7 @@ async def test_generate_graphql_object(
         "level",
         "mylist",
         "name",
+        "node_metadata",
         "status",
         "time",
     ]
@@ -81,6 +83,7 @@ async def test_generate_graphql_object_with_interface(
         "id",
         "name",
         "nbr_doors",
+        "node_metadata",
     ]
 
 
@@ -129,11 +132,11 @@ async def test_generate_object_types(
     relationship_property = gqlm.get_type(name="RelationshipProperty")
 
     assert issubclass(car, InfrahubObject)
-    assert issubclass(edged_car, InfrahubObject)
-    assert issubclass(nested_edged_car, InfrahubObject)
+    assert issubclass(edged_car, InfrahubObjectWithoutMeta)
+    assert issubclass(nested_edged_car, InfrahubObjectWithoutMeta)
     assert issubclass(person, InfrahubObject)
-    assert issubclass(edged_person, InfrahubObject)
-    assert issubclass(nested_edged_person, InfrahubObject)
+    assert issubclass(edged_person, InfrahubObjectWithoutMeta)
+    assert issubclass(nested_edged_person, InfrahubObjectWithoutMeta)
     assert issubclass(relationship_property, graphene.ObjectType)
 
     assert sorted(car._meta.fields.keys()) == [
@@ -147,6 +150,7 @@ async def test_generate_object_types(
         "member_of_groups",
         "name",
         "nbr_seats",
+        "node_metadata",
         "owner",
         "profiles",
         "subscriber_of_groups",
@@ -169,6 +173,7 @@ async def test_generate_object_types(
         "id",
         "member_of_groups",
         "name",
+        "node_metadata",
         "profiles",
         "subscriber_of_groups",
     ]

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -82,8 +82,7 @@ type AnyAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: GenericScalar
 }
 
@@ -153,7 +152,6 @@ type Branch {
   is_default: Boolean
   is_isolated: Boolean @deprecated(reason: "non isolated mode is not supported anymore")
   name: String!
-  node_metadata: InfrahubNodeMetaObject
   origin_branch: String
   status: BranchStatus!
   sync_with_git: Boolean
@@ -570,8 +568,7 @@ type CheckboxAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: Boolean
 }
 
@@ -6481,8 +6478,7 @@ type Dropdown implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: String
 }
 
@@ -7200,8 +7196,7 @@ type IPHost implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: String
   version: Int
   with_hostmask: String
@@ -7227,8 +7222,7 @@ type IPNetwork implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: String
   version: Int
   with_hostmask: String
@@ -7340,7 +7334,6 @@ input InfrahubAccountTokenDeleteInput {
 
 type InfrahubAccountTokenType {
   id: String!
-  node_metadata: InfrahubNodeMetaObject
   token: ValueType
 }
 
@@ -7362,7 +7355,6 @@ type InfrahubBranch {
   is_default: NonRequiredBooleanValueField
   is_isolated: NonRequiredBooleanValueField @deprecated(reason: "non isolated mode is not supported anymore")
   name: RequiredStringValueField!
-  node_metadata: InfrahubNodeMetaObject
   origin_branch: NonRequiredStringValueField
   status: StatusField!
   sync_with_git: NonRequiredBooleanValueField
@@ -7370,6 +7362,7 @@ type InfrahubBranch {
 
 type InfrahubBranchEdge {
   node: InfrahubBranch!
+  node_metadata: InfrahubStandardNodeMetaData!
 }
 
 type InfrahubBranchType {
@@ -7424,21 +7417,6 @@ type InfrahubMutatedRelationship {
   peer: RelatedNode!
 }
 
-type InfrahubNodeMetaObject {
-  """Date/Time the object has been created"""
-  created_at: DateTime
-  """
-  UUID of the user that created the object, even if the user is later deleted
-  """
-  created_by: String
-  """Date/Time when the object was last modified by a user or a system task"""
-  updated_at: DateTime
-  """
-  UUID of the user that last modified the object, even if the user is later deleted
-  """
-  updated_by: String
-}
-
 """Defines node metadata information"""
 type InfrahubNodeMetadata {
   created_at: DateTime
@@ -7457,6 +7435,20 @@ type InfrahubRelationshipMetadata {
   created_by: CoreGenericAccount
   updated_at: DateTime
   updated_by: CoreGenericAccount
+}
+
+type InfrahubStandardNodeMetaAccount {
+  display_name: String
+  id: String!
+}
+
+type InfrahubStandardNodeMetaData {
+  """Date/Time the object has been created"""
+  created_at: DateTime
+  created_by: InfrahubStandardNodeMetaAccount
+  """Date/Time when the object was last modified by a user or a system task"""
+  updated_at: DateTime
+  updated_by: InfrahubStandardNodeMetaAccount
 }
 
 """Token for User Account"""
@@ -7636,8 +7628,7 @@ type JSONAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: GenericScalar
 }
 
@@ -7688,8 +7679,7 @@ type ListAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: GenericScalar
 }
 
@@ -7735,8 +7725,7 @@ type MacAddress implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: String
   version: Int
 }
@@ -9740,32 +9729,14 @@ type NodeMutatedEvent implements EventNodeInterface {
 }
 
 type NonRequiredBooleanValueField {
-  """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
-  """
-  updated_at: DateTime
-  """User that last modified the attribute or relationship"""
-  updated_by: String
   value: Boolean
 }
 
 type NonRequiredIntValueField {
-  """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
-  """
-  updated_at: DateTime
-  """User that last modified the attribute or relationship"""
-  updated_by: String
   value: Int
 }
 
 type NonRequiredStringValueField {
-  """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
-  """
-  updated_at: DateTime
-  """User that last modified the attribute or relationship"""
-  updated_by: String
   value: String
 }
 
@@ -9783,8 +9754,7 @@ type NumberAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: BigInt
 }
 
@@ -11298,12 +11268,6 @@ type Relationships {
 }
 
 type RequiredStringValueField {
-  """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
-  """
-  updated_at: DateTime
-  """User that last modified the attribute or relationship"""
-  updated_by: String
   value: String!
 }
 
@@ -11401,12 +11365,6 @@ type Status {
 }
 
 type StatusField {
-  """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
-  """
-  updated_at: DateTime
-  """User that last modified the attribute or relationship"""
-  updated_by: String
   value: BranchStatus!
 }
 
@@ -11501,8 +11459,7 @@ type TextAttribute implements AttributeInterface {
   Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """User that last modified the attribute"""
-  updated_by: String
+  updated_by: CoreGenericAccount
   value: String
 }
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -79,10 +79,10 @@ type AnyAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: GenericScalar
 }
@@ -568,10 +568,10 @@ type CheckboxAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: Boolean
 }
@@ -6531,10 +6531,10 @@ type Dropdown implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: String
 }
@@ -7160,10 +7160,10 @@ type IPHost implements AttributeInterface {
   prefixlen: Int
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: String
   version: Int
@@ -7187,10 +7187,10 @@ type IPNetwork implements AttributeInterface {
   prefixlen: Int
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: String
   version: Int
@@ -7585,10 +7585,10 @@ type JSONAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: GenericScalar
 }
@@ -7637,10 +7637,10 @@ type ListAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: GenericScalar
 }
@@ -7684,10 +7684,10 @@ type MacAddress implements AttributeInterface {
   """Format used by PostgreSQL"""
   split_notation: String
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: String
   version: Int
@@ -9572,7 +9572,7 @@ type NonRequiredBooleanValueField {
   Date/Time when the attribute or relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute or relationship"""
   updated_by: String
   value: Boolean
 }
@@ -9582,7 +9582,7 @@ type NonRequiredIntValueField {
   Date/Time when the attribute or relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute or relationship"""
   updated_by: String
   value: Int
 }
@@ -9592,7 +9592,7 @@ type NonRequiredStringValueField {
   Date/Time when the attribute or relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute or relationship"""
   updated_by: String
   value: String
 }
@@ -9608,10 +9608,10 @@ type NumberAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: BigInt
 }
@@ -11077,10 +11077,10 @@ type Relationship {
   identifier: String
   peers: [RelationshipPeer!]
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the relationship"""
   updated_by: String
 }
 
@@ -11134,7 +11134,7 @@ type RequiredStringValueField {
   Date/Time when the attribute or relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute or relationship"""
   updated_by: String
   value: String!
 }
@@ -11237,7 +11237,7 @@ type StatusField {
   Date/Time when the attribute or relationship was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute or relationship"""
   updated_by: String
   value: BranchStatus!
 }
@@ -11330,10 +11330,10 @@ type TextAttribute implements AttributeInterface {
   permissions: PermissionType
   source: LineageSource
   """
-  Date/Time when the attribute or relationship was last modified by a user or a system task
+  Date/Time when the attribute was last modified by a user or a system task
   """
   updated_at: DateTime
-  """UUID of the user that last modified the attribute or relationship"""
+  """User that last modified the attribute"""
   updated_by: String
   value: String
 }

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -480,7 +480,6 @@ type BuiltinTag implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -646,7 +645,6 @@ type CoreAccount implements CoreGenericAccount & CoreNode & LineageOwner & Linea
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   password: TextAttribute
   status: Dropdown
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -691,7 +689,6 @@ type CoreAccountGroup implements CoreGroup & LineageOwner & LineageSource {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   roles(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
@@ -773,7 +770,6 @@ type CoreAccountRole implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   permissions(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], identifier__is_protected: Boolean, identifier__owner__id: ID, identifier__source__id: ID, identifier__value: String, identifier__values: [String], ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreBasePermission!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -920,7 +916,6 @@ type CoreArtifact implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   object: NestedEdgedCoreArtifactTarget!
   """None"""
   parameters: JSONAttribute
@@ -954,7 +949,6 @@ type CoreArtifactCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   """None"""
@@ -1084,7 +1078,6 @@ type CoreArtifactDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   parameters: JSONAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -1200,7 +1193,6 @@ type CoreArtifactThread implements CoreNode & CoreThread {
   """None"""
   line_number: NumberAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   resolved: CheckboxAttribute
   """None"""
   storage_id: TextAttribute
@@ -1333,7 +1325,6 @@ type CoreArtifactValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -1448,7 +1439,6 @@ type CoreChangeComment implements CoreComment & CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   text: TextAttribute
 }
@@ -1522,7 +1512,6 @@ type CoreChangeThread implements CoreNode & CoreThread {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   resolved: CheckboxAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -1623,7 +1612,6 @@ type CoreCheckDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None"""
   parameters: JSONAttribute
   query: NestedEdgedCoreGraphQLQuery!
@@ -1801,7 +1789,6 @@ type CoreCustomWebhook implements CoreNode & CoreTaskTarget & CoreWebhook {
   name: TextAttribute
   """Only send node mutation events for nodes of this kind"""
   node_kind: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None"""
   shared_key: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -1907,7 +1894,6 @@ type CoreDataCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2006,7 +1992,6 @@ type CoreDataValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -2096,7 +2081,6 @@ type CoreFileCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2199,7 +2183,6 @@ type CoreFileThread implements CoreNode & CoreThread {
   """None"""
   line_number: NumberAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   repository: NestedEdgedCoreRepository!
   resolved: CheckboxAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2292,7 +2275,6 @@ type CoreGeneratorAction implements CoreAction & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """Short descriptive name"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   triggers(active__is_protected: Boolean, active__owner__id: ID, active__source__id: ID, active__value: Boolean, active__values: [Boolean], branch_scope__is_protected: Boolean, branch_scope__owner__id: ID, branch_scope__source__id: ID, branch_scope__value: String, branch_scope__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreTriggerRule!
 }
@@ -2386,7 +2368,6 @@ type CoreGeneratorAwareGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -2469,7 +2450,6 @@ type CoreGeneratorCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2571,7 +2551,6 @@ type CoreGeneratorDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   parameters: JSONAttribute
   query: NestedEdgedCoreGraphQLQuery!
@@ -2668,7 +2647,6 @@ type CoreGeneratorGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -2745,7 +2723,6 @@ type CoreGeneratorInstance implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   object: NestedEdgedCoreNode!
   """None (required)"""
   status: TextAttribute
@@ -2817,7 +2794,6 @@ type CoreGeneratorValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -2992,7 +2968,6 @@ type CoreGlobalPermission implements CoreBasePermission & CoreNode {
   id: String!
   identifier: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   roles(ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3074,7 +3049,6 @@ type CoreGraphQLQuery implements CoreNode {
   models: ListAttribute
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """
   Operations in use in the query, valid operations: 'query', 'mutation' or 'subscription'
   """
@@ -3126,7 +3100,6 @@ type CoreGraphQLQueryGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None"""
   parameters: JSONAttribute
   parent: NestedEdgedCoreGroup!
@@ -3276,7 +3249,6 @@ type CoreGroupAction implements CoreAction & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """Short descriptive name"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   triggers(active__is_protected: Boolean, active__owner__id: ID, active__source__id: ID, active__value: Boolean, active__values: [Boolean], branch_scope__is_protected: Boolean, branch_scope__owner__id: ID, branch_scope__source__id: ID, branch_scope__value: String, branch_scope__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreTriggerRule!
 }
@@ -3401,7 +3373,6 @@ type CoreGroupTriggerRule implements CoreNode & CoreTriggerRule {
   member_update: Dropdown
   """The name of the trigger rule"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -3549,7 +3520,6 @@ type CoreIPAddressPool implements CoreNode & CoreResourcePool & LineageSource {
   ip_namespace: NestedEdgedBuiltinIPNamespace!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   resources(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3647,7 +3617,6 @@ type CoreIPPrefixPool implements CoreNode & CoreResourcePool & LineageSource {
   ip_namespace: NestedEdgedBuiltinIPNamespace!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   resources(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3769,7 +3738,6 @@ type CoreMenuItem implements CoreMenu & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], include_descendants: Boolean, isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
   namespace: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   order_weight: NumberAttribute
   parent: NestedEdgedCoreMenu!
   path: TextAttribute
@@ -3905,7 +3873,6 @@ type CoreNodeTriggerAttributeMatch implements CoreNode & CoreNodeTriggerMatch {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   trigger: NestedEdgedCoreNodeTriggerRule!
   """The value the attribute is updated to"""
@@ -4041,7 +4008,6 @@ type CoreNodeTriggerRelationshipMatch implements CoreNode & CoreNodeTriggerMatch
   Indicates if the relationship was added or removed or just updated in any way
   """
   modification_type: Dropdown
-  node_metadata: InfrahubNodeMetaObject
   """The node_id of the relationship peer to match against"""
   peer: TextAttribute
   """The name of the relationship to match against (required)"""
@@ -4152,7 +4118,6 @@ type CoreNodeTriggerRule implements CoreNode & CoreTriggerRule {
   name: TextAttribute
   """The kind of node to match against (required)"""
   node_kind: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -4305,7 +4270,6 @@ type CoreNumberPool implements CoreNode & CoreResourcePool & LineageSource {
   node: TextAttribute
   """The attribute of the selected model (required)"""
   node_attribute: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """Defines how this number pool was created"""
   pool_type: TextAttribute
   """The start range for the pool (required)"""
@@ -4433,7 +4397,6 @@ type CoreObjectPermission implements CoreBasePermission & CoreNode {
   name: TextAttribute
   """None (required)"""
   namespace: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   roles(ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -4548,7 +4511,6 @@ type CoreObjectThread implements CoreNode & CoreThread {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   object_path: TextAttribute
   resolved: CheckboxAttribute
@@ -4631,7 +4593,6 @@ type CorePasswordCredential implements CoreCredential & CoreNode {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None"""
   password: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -4745,7 +4706,6 @@ type CoreProposedChange implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   rejected_by(account_type__is_protected: Boolean, account_type__owner__id: ID, account_type__source__id: ID, account_type__value: String, account_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, password__is_protected: Boolean, password__owner__id: ID, password__source__id: ID, password__value: String, password__values: [String], status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String]): NestedPaginatedCoreGenericAccount!
   reviewers(account_type__is_protected: Boolean, account_type__owner__id: ID, account_type__source__id: ID, account_type__value: String, account_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, password__is_protected: Boolean, password__owner__id: ID, password__source__id: ID, password__value: String, password__values: [String], status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String]): NestedPaginatedCoreGenericAccount!
   """None (required)"""
@@ -4853,7 +4813,6 @@ type CoreReadOnlyRepository implements CoreGenericRepository & CoreNode & CoreTa
   location: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   operational_status: Dropdown
   queries(depth__is_protected: Boolean, depth__owner__id: ID, depth__source__id: ID, depth__value: BigInt, depth__values: [BigInt], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], height__is_protected: Boolean, height__owner__id: ID, height__source__id: ID, height__value: BigInt, height__values: [BigInt], ids: [ID], isnull: Boolean, limit: Int, models__is_protected: Boolean, models__owner__id: ID, models__source__id: ID, models__value: GenericScalar, models__values: [GenericScalar], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, operations__is_protected: Boolean, operations__owner__id: ID, operations__source__id: ID, operations__value: GenericScalar, operations__values: [GenericScalar], order: OrderInput, query__is_protected: Boolean, query__owner__id: ID, query__source__id: ID, query__value: String, query__values: [String], variables__is_protected: Boolean, variables__owner__id: ID, variables__source__id: ID, variables__value: GenericScalar, variables__values: [GenericScalar]): NestedPaginatedCoreGraphQLQuery!
   """None"""
@@ -4981,7 +4940,6 @@ type CoreRepository implements CoreGenericRepository & CoreNode & CoreTaskTarget
   location: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   operational_status: Dropdown
   queries(depth__is_protected: Boolean, depth__owner__id: ID, depth__source__id: ID, depth__value: BigInt, depth__values: [BigInt], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], height__is_protected: Boolean, height__owner__id: ID, height__source__id: ID, height__value: BigInt, height__values: [BigInt], ids: [ID], isnull: Boolean, limit: Int, models__is_protected: Boolean, models__owner__id: ID, models__source__id: ID, models__value: GenericScalar, models__values: [GenericScalar], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, operations__is_protected: Boolean, operations__owner__id: ID, operations__source__id: ID, operations__value: GenericScalar, operations__values: [GenericScalar], order: OrderInput, query__is_protected: Boolean, query__owner__id: ID, query__source__id: ID, query__value: String, query__values: [String], variables__is_protected: Boolean, variables__owner__id: ID, variables__source__id: ID, variables__value: GenericScalar, variables__values: [GenericScalar]): NestedPaginatedCoreGraphQLQuery!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5040,7 +4998,6 @@ type CoreRepositoryGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   repository: NestedEdgedCoreGenericRepository!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
@@ -5185,7 +5142,6 @@ type CoreRepositoryValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   repository: NestedEdgedCoreGenericRepository!
   started_at: TextAttribute
@@ -5311,7 +5267,6 @@ type CoreSchemaCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5407,7 +5362,6 @@ type CoreSchemaValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -5493,7 +5447,6 @@ type CoreStandardCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5586,7 +5539,6 @@ type CoreStandardGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -5668,7 +5620,6 @@ type CoreStandardWebhook implements CoreNode & CoreTaskTarget & CoreWebhook {
   name: TextAttribute
   """Only send node mutation events for nodes of this kind"""
   node_kind: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   shared_key: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5801,7 +5752,6 @@ type CoreThreadComment implements CoreComment & CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   text: TextAttribute
   thread: NestedEdgedCoreThread!
@@ -5893,7 +5843,6 @@ type CoreTransformJinja2 implements CoreNode & CoreTransformation {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   query: NestedEdgedCoreGraphQLQuery!
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5988,7 +5937,6 @@ type CoreTransformPython implements CoreNode & CoreTransformation {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   query: NestedEdgedCoreGraphQLQuery!
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -6176,7 +6124,6 @@ type CoreUserValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   repository: NestedEdgedCoreGenericRepository!
   started_at: TextAttribute
@@ -6549,16 +6496,19 @@ type DropdownFields {
 """IPv4 or IPv6 address"""
 type EdgedBuiltinIPAddress {
   node: BuiltinIPAddress
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A generic container for IP prefixes and IP addresses"""
 type EdgedBuiltinIPNamespace {
   node: BuiltinIPNamespace
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """IPv4 or IPv6 prefix also referred as network"""
 type EdgedBuiltinIPPrefix {
   node: BuiltinIPPrefix
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6566,175 +6516,211 @@ Standard Tag object to attach to other objects to provide some context.
 """
 type EdgedBuiltinTag {
   node: BuiltinTag
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """User Account for Infrahub"""
 type EdgedCoreAccount {
   node: CoreAccount
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A group of users to manage common permissions"""
 type EdgedCoreAccountGroup {
   node: CoreAccountGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A role defines a set of permissions to grant to a group of accounts"""
 type EdgedCoreAccountRole {
   node: CoreAccountRole
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """An action that can be executed by a trigger"""
 type EdgedCoreAction {
   node: CoreAction
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreArtifact {
   node: CoreArtifact
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check related to an artifact"""
 type EdgedCoreArtifactCheck {
   node: CoreArtifactCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreArtifactDefinition {
   node: CoreArtifactDefinition
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Extend a node to be associated with artifacts"""
 type EdgedCoreArtifactTarget {
   node: CoreArtifactTarget
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A thread related to an artifact on a proposed change"""
 type EdgedCoreArtifactThread {
   node: CoreArtifactThread
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A validator related to the artifacts"""
 type EdgedCoreArtifactValidator {
   node: CoreArtifactValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A permission grants right to an account"""
 type EdgedCoreBasePermission {
   node: CoreBasePermission
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A comment on proposed change"""
 type EdgedCoreChangeComment {
   node: CoreChangeComment
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A thread on proposed change"""
 type EdgedCoreChangeThread {
   node: CoreChangeThread
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreCheck {
   node: CoreCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreCheckDefinition {
   node: CoreCheckDefinition
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A comment on a Proposed Change"""
 type EdgedCoreComment {
   node: CoreComment
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A credential that could be referenced to access external services."""
 type EdgedCoreCredential {
   node: CoreCredential
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type EdgedCoreCustomWebhook {
   node: CoreCustomWebhook
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check related to some Data"""
 type EdgedCoreDataCheck {
   node: CoreDataCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check to validate the data integrity between two branches"""
 type EdgedCoreDataValidator {
   node: CoreDataValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check related to a file in a Git Repository"""
 type EdgedCoreFileCheck {
   node: CoreFileCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A thread related to a file on a proposed change"""
 type EdgedCoreFileThread {
   node: CoreFileThread
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """An action that runs a generator definition once triggered"""
 type EdgedCoreGeneratorAction {
   node: CoreGeneratorAction
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Group of nodes that are created by a generator. (Aware)"""
 type EdgedCoreGeneratorAwareGroup {
   node: CoreGeneratorAwareGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check related to a Generator instance"""
 type EdgedCoreGeneratorCheck {
   node: CoreGeneratorCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreGeneratorDefinition {
   node: CoreGeneratorDefinition
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Group of nodes that are created by a generator. (local)"""
 type EdgedCoreGeneratorGroup {
   node: CoreGeneratorGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreGeneratorInstance {
   node: CoreGeneratorInstance
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A validator related to generators"""
 type EdgedCoreGeneratorValidator {
   node: CoreGeneratorValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """User Account for Infrahub"""
 type EdgedCoreGenericAccount {
   node: CoreGenericAccount
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A Git Repository integrated with Infrahub"""
 type EdgedCoreGenericRepository {
   node: CoreGenericRepository
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A permission that grants global rights to perform actions in Infrahub"""
 type EdgedCoreGlobalPermission {
   node: CoreGlobalPermission
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A pre-defined GraphQL Query"""
 type EdgedCoreGraphQLQuery {
   node: CoreGraphQLQuery
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Group of nodes associated with a given GraphQLQuery."""
 type EdgedCoreGraphQLQueryGroup {
   node: CoreGraphQLQueryGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Generic Group Object."""
 type EdgedCoreGroup {
   node: CoreGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6742,6 +6728,7 @@ A group action that adds or removes members from a group once triggered
 """
 type EdgedCoreGroupAction {
   node: CoreGroupAction
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6749,36 +6736,43 @@ A trigger rule that matches against updates to memberships within groups
 """
 type EdgedCoreGroupTriggerRule {
   node: CoreGroupTriggerRule
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A pool of IP address resources"""
 type EdgedCoreIPAddressPool {
   node: CoreIPAddressPool
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A pool of IP prefix resources"""
 type EdgedCoreIPPrefixPool {
   node: CoreIPPrefixPool
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Element of the Menu"""
 type EdgedCoreMenu {
   node: CoreMenu
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Menu Item"""
 type EdgedCoreMenuItem {
   node: CoreMenuItem
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Base Node in Infrahub."""
 type EdgedCoreNode {
   node: CoreNode
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A trigger match that matches against attribute changes on a node"""
 type EdgedCoreNodeTriggerAttributeMatch {
   node: CoreNodeTriggerAttributeMatch
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6786,11 +6780,13 @@ A trigger match condition related to changes to nodes within the Infrahub databa
 """
 type EdgedCoreNodeTriggerMatch {
   node: CoreNodeTriggerMatch
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A trigger match that matches against relationship changes on a node"""
 type EdgedCoreNodeTriggerRelationshipMatch {
   node: CoreNodeTriggerRelationshipMatch
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6798,46 +6794,55 @@ A trigger rule that evaluates modifications to nodes within the Infrahub databas
 """
 type EdgedCoreNodeTriggerRule {
   node: CoreNodeTriggerRule
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A pool of number resources"""
 type EdgedCoreNumberPool {
   node: CoreNumberPool
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Component template to create pre-shaped objects."""
 type EdgedCoreObjectComponentTemplate {
   node: CoreObjectComponentTemplate
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A permission that grants rights to perform actions on objects"""
 type EdgedCoreObjectPermission {
   node: CoreObjectPermission
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Template to create pre-shaped objects."""
 type EdgedCoreObjectTemplate {
   node: CoreObjectTemplate
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A thread related to an object on a proposed change"""
 type EdgedCoreObjectThread {
   node: CoreObjectThread
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Username/Password based credential"""
 type EdgedCorePasswordCredential {
   node: CorePasswordCredential
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Base Profile in Infrahub."""
 type EdgedCoreProfile {
   node: CoreProfile
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Metadata related to a proposed change"""
 type EdgedCoreProposedChange {
   node: CoreProposedChange
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6845,21 +6850,25 @@ A Git Repository integrated with Infrahub, Git-side will not be updated
 """
 type EdgedCoreReadOnlyRepository {
   node: CoreReadOnlyRepository
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A Git Repository integrated with Infrahub"""
 type EdgedCoreRepository {
   node: CoreRepository
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Group of nodes associated with a given repository."""
 type EdgedCoreRepositoryGroup {
   node: CoreRepositoryGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A Validator related to a specific repository"""
 type EdgedCoreRepositoryValidator {
   node: CoreRepositoryValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6867,61 +6876,73 @@ The resource manager contains pools of resources to allow for automatic assignme
 """
 type EdgedCoreResourcePool {
   node: CoreResourcePool
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A check related to the schema"""
 type EdgedCoreSchemaCheck {
   node: CoreSchemaCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A validator related to the schema"""
 type EdgedCoreSchemaValidator {
   node: CoreSchemaValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A standard check"""
 type EdgedCoreStandardCheck {
   node: CoreStandardCheck
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Group of nodes of any kind."""
 type EdgedCoreStandardGroup {
   node: CoreStandardGroup
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type EdgedCoreStandardWebhook {
   node: CoreStandardWebhook
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Extend a node to be associated with tasks"""
 type EdgedCoreTaskTarget {
   node: CoreTaskTarget
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A thread on a Proposed Change"""
 type EdgedCoreThread {
   node: CoreThread
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A comment on thread within a Proposed Change"""
 type EdgedCoreThreadComment {
   node: CoreThreadComment
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A file rendered from a Jinja2 template"""
 type EdgedCoreTransformJinja2 {
   node: CoreTransformJinja2
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A transform function written in Python"""
 type EdgedCoreTransformPython {
   node: CoreTransformPython
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Generic Transformation Object."""
 type EdgedCoreTransformation {
   node: CoreTransformation
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6929,20 +6950,24 @@ A rule that allows you to define a trigger and map it to an action that runs onc
 """
 type EdgedCoreTriggerRule {
   node: CoreTriggerRule
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A Validator related to a user defined checks in a repository"""
 type EdgedCoreUserValidator {
   node: CoreUserValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type EdgedCoreValidator {
   node: CoreValidator
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type EdgedCoreWebhook {
   node: CoreWebhook
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6950,11 +6975,13 @@ Resource to be used in a pool, its weight is used to determine its priority on a
 """
 type EdgedCoreWeightedPoolResource {
   node: CoreWeightedPoolResource
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Token for User Account"""
 type EdgedInternalAccountToken {
   node: InternalAccountToken
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """
@@ -6962,51 +6989,61 @@ IPv4 or IPv6 prefix also referred as network which has not been allocated yet
 """
 type EdgedInternalIPPrefixAvailable {
   node: InternalIPPrefixAvailable
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Range of IPv4 or IPv6 addresses which has not been allocated yet"""
 type EdgedInternalIPRangeAvailable {
   node: InternalIPRangeAvailable
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Refresh Token"""
 type EdgedInternalRefreshToken {
   node: InternalRefreshToken
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """A namespace that segments IPAM"""
 type EdgedIpamNamespace {
   node: IpamNamespace
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Any Entities that is responsible for some data."""
 type EdgedLineageOwner {
   node: LineageOwner
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Any Entities that stores or produces data."""
 type EdgedLineageSource {
   node: LineageSource
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Profile for BuiltinIPAddress"""
 type EdgedProfileBuiltinIPAddress {
   node: ProfileBuiltinIPAddress
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Profile for BuiltinIPPrefix"""
 type EdgedProfileBuiltinIPPrefix {
   node: ProfileBuiltinIPPrefix
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Profile for BuiltinTag"""
 type EdgedProfileBuiltinTag {
   node: ProfileBuiltinTag
+  node_metadata: InfrahubNodeMetadata!
 }
 
 """Profile for IpamNamespace"""
 type EdgedProfileIpamNamespace {
   node: ProfileIpamNamespace
+  node_metadata: InfrahubNodeMetadata!
 }
 
 interface EventNodeInterface {
@@ -7402,8 +7439,24 @@ type InfrahubNodeMetaObject {
   updated_by: String
 }
 
+"""Defines node metadata information"""
+type InfrahubNodeMetadata {
+  created_at: DateTime
+  created_by: CoreGenericAccount
+  updated_at: DateTime
+  updated_by: CoreGenericAccount
+}
+
 type InfrahubProfilesRefresh {
   ok: Boolean
+}
+
+"""Defines relationship metadata information"""
+type InfrahubRelationshipMetadata {
+  created_at: DateTime
+  created_by: CoreGenericAccount
+  updated_at: DateTime
+  updated_by: CoreGenericAccount
 }
 
 """Token for User Account"""
@@ -7420,7 +7473,6 @@ type InternalAccountToken implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None"""
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   token: TextAttribute
@@ -7451,7 +7503,6 @@ type InternalIPPrefixAvailable implements BuiltinIPPrefix & CoreNode {
   member_type: Dropdown
   netmask: TextAttribute
   network_address: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedBuiltinIPPrefix!
   prefix: IPNetwork
   profiles(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
@@ -7475,7 +7526,6 @@ type InternalIPRangeAvailable implements BuiltinIPAddress & CoreNode {
   """None (required)"""
   last_address: IPHost
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -7492,7 +7542,6 @@ type InternalRefreshToken implements CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -7511,7 +7560,6 @@ type IpamNamespace implements BuiltinIPNamespace & CoreNode {
   ip_prefixes(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
-  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -8276,24 +8324,27 @@ type Mutation {
 type NestedEdgedBuiltinIPAddress {
   _updated_at: DateTime
   node: BuiltinIPAddress
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A generic container for IP prefixes and IP addresses"""
 type NestedEdgedBuiltinIPNamespace {
   _updated_at: DateTime
   node: BuiltinIPNamespace
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """IPv4 or IPv6 prefix also referred as network"""
 type NestedEdgedBuiltinIPPrefix {
   _updated_at: DateTime
   node: BuiltinIPPrefix
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8301,229 +8352,292 @@ Standard Tag object to attach to other objects to provide some context.
 """
 type NestedEdgedBuiltinTag {
   node: BuiltinTag
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """User Account for Infrahub"""
 type NestedEdgedCoreAccount {
   node: CoreAccount
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A group of users to manage common permissions"""
 type NestedEdgedCoreAccountGroup {
   node: CoreAccountGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A role defines a set of permissions to grant to a group of accounts"""
 type NestedEdgedCoreAccountRole {
   node: CoreAccountRole
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """An action that can be executed by a trigger"""
 type NestedEdgedCoreAction {
   _updated_at: DateTime
   node: CoreAction
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreArtifact {
   node: CoreArtifact
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check related to an artifact"""
 type NestedEdgedCoreArtifactCheck {
   node: CoreArtifactCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreArtifactDefinition {
   node: CoreArtifactDefinition
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Extend a node to be associated with artifacts"""
 type NestedEdgedCoreArtifactTarget {
   _updated_at: DateTime
   node: CoreArtifactTarget
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A thread related to an artifact on a proposed change"""
 type NestedEdgedCoreArtifactThread {
   node: CoreArtifactThread
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A validator related to the artifacts"""
 type NestedEdgedCoreArtifactValidator {
   node: CoreArtifactValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A permission grants right to an account"""
 type NestedEdgedCoreBasePermission {
   _updated_at: DateTime
   node: CoreBasePermission
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A comment on proposed change"""
 type NestedEdgedCoreChangeComment {
   node: CoreChangeComment
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A thread on proposed change"""
 type NestedEdgedCoreChangeThread {
   node: CoreChangeThread
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreCheck {
   _updated_at: DateTime
   node: CoreCheck
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreCheckDefinition {
   node: CoreCheckDefinition
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A comment on a Proposed Change"""
 type NestedEdgedCoreComment {
   _updated_at: DateTime
   node: CoreComment
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A credential that could be referenced to access external services."""
 type NestedEdgedCoreCredential {
   _updated_at: DateTime
   node: CoreCredential
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type NestedEdgedCoreCustomWebhook {
   node: CoreCustomWebhook
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check related to some Data"""
 type NestedEdgedCoreDataCheck {
   node: CoreDataCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check to validate the data integrity between two branches"""
 type NestedEdgedCoreDataValidator {
   node: CoreDataValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check related to a file in a Git Repository"""
 type NestedEdgedCoreFileCheck {
   node: CoreFileCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A thread related to a file on a proposed change"""
 type NestedEdgedCoreFileThread {
   node: CoreFileThread
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """An action that runs a generator definition once triggered"""
 type NestedEdgedCoreGeneratorAction {
   node: CoreGeneratorAction
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Group of nodes that are created by a generator. (Aware)"""
 type NestedEdgedCoreGeneratorAwareGroup {
   node: CoreGeneratorAwareGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check related to a Generator instance"""
 type NestedEdgedCoreGeneratorCheck {
   node: CoreGeneratorCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreGeneratorDefinition {
   node: CoreGeneratorDefinition
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Group of nodes that are created by a generator. (local)"""
 type NestedEdgedCoreGeneratorGroup {
   node: CoreGeneratorGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreGeneratorInstance {
   node: CoreGeneratorInstance
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A validator related to generators"""
 type NestedEdgedCoreGeneratorValidator {
   node: CoreGeneratorValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """User Account for Infrahub"""
 type NestedEdgedCoreGenericAccount {
   _updated_at: DateTime
   node: CoreGenericAccount
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A Git Repository integrated with Infrahub"""
 type NestedEdgedCoreGenericRepository {
   _updated_at: DateTime
   node: CoreGenericRepository
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A permission that grants global rights to perform actions in Infrahub"""
 type NestedEdgedCoreGlobalPermission {
   node: CoreGlobalPermission
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A pre-defined GraphQL Query"""
 type NestedEdgedCoreGraphQLQuery {
   node: CoreGraphQLQuery
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Group of nodes associated with a given GraphQLQuery."""
 type NestedEdgedCoreGraphQLQueryGroup {
   node: CoreGraphQLQueryGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Generic Group Object."""
 type NestedEdgedCoreGroup {
   _updated_at: DateTime
   node: CoreGroup
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8531,7 +8645,9 @@ A group action that adds or removes members from a group once triggered
 """
 type NestedEdgedCoreGroupAction {
   node: CoreGroupAction
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8539,47 +8655,59 @@ A trigger rule that matches against updates to memberships within groups
 """
 type NestedEdgedCoreGroupTriggerRule {
   node: CoreGroupTriggerRule
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A pool of IP address resources"""
 type NestedEdgedCoreIPAddressPool {
   node: CoreIPAddressPool
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A pool of IP prefix resources"""
 type NestedEdgedCoreIPPrefixPool {
   node: CoreIPPrefixPool
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Element of the Menu"""
 type NestedEdgedCoreMenu {
   _updated_at: DateTime
   node: CoreMenu
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Menu Item"""
 type NestedEdgedCoreMenuItem {
   node: CoreMenuItem
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Base Node in Infrahub."""
 type NestedEdgedCoreNode {
   _updated_at: DateTime
   node: CoreNode
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A trigger match that matches against attribute changes on a node"""
 type NestedEdgedCoreNodeTriggerAttributeMatch {
   node: CoreNodeTriggerAttributeMatch
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8588,14 +8716,17 @@ A trigger match condition related to changes to nodes within the Infrahub databa
 type NestedEdgedCoreNodeTriggerMatch {
   _updated_at: DateTime
   node: CoreNodeTriggerMatch
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A trigger match that matches against relationship changes on a node"""
 type NestedEdgedCoreNodeTriggerRelationshipMatch {
   node: CoreNodeTriggerRelationshipMatch
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8603,61 +8734,76 @@ A trigger rule that evaluates modifications to nodes within the Infrahub databas
 """
 type NestedEdgedCoreNodeTriggerRule {
   node: CoreNodeTriggerRule
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A pool of number resources"""
 type NestedEdgedCoreNumberPool {
   node: CoreNumberPool
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Component template to create pre-shaped objects."""
 type NestedEdgedCoreObjectComponentTemplate {
   _updated_at: DateTime
   node: CoreObjectComponentTemplate
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A permission that grants rights to perform actions on objects"""
 type NestedEdgedCoreObjectPermission {
   node: CoreObjectPermission
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Template to create pre-shaped objects."""
 type NestedEdgedCoreObjectTemplate {
   _updated_at: DateTime
   node: CoreObjectTemplate
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A thread related to an object on a proposed change"""
 type NestedEdgedCoreObjectThread {
   node: CoreObjectThread
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Username/Password based credential"""
 type NestedEdgedCorePasswordCredential {
   node: CorePasswordCredential
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Base Profile in Infrahub."""
 type NestedEdgedCoreProfile {
   _updated_at: DateTime
   node: CoreProfile
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Metadata related to a proposed change"""
 type NestedEdgedCoreProposedChange {
   node: CoreProposedChange
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8665,25 +8811,33 @@ A Git Repository integrated with Infrahub, Git-side will not be updated
 """
 type NestedEdgedCoreReadOnlyRepository {
   node: CoreReadOnlyRepository
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A Git Repository integrated with Infrahub"""
 type NestedEdgedCoreRepository {
   node: CoreRepository
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Group of nodes associated with a given repository."""
 type NestedEdgedCoreRepositoryGroup {
   node: CoreRepositoryGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A Validator related to a specific repository"""
 type NestedEdgedCoreRepositoryValidator {
   node: CoreRepositoryValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8692,80 +8846,100 @@ The resource manager contains pools of resources to allow for automatic assignme
 type NestedEdgedCoreResourcePool {
   _updated_at: DateTime
   node: CoreResourcePool
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A check related to the schema"""
 type NestedEdgedCoreSchemaCheck {
   node: CoreSchemaCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A validator related to the schema"""
 type NestedEdgedCoreSchemaValidator {
   node: CoreSchemaValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A standard check"""
 type NestedEdgedCoreStandardCheck {
   node: CoreStandardCheck
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Group of nodes of any kind."""
 type NestedEdgedCoreStandardGroup {
   node: CoreStandardGroup
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type NestedEdgedCoreStandardWebhook {
   node: CoreStandardWebhook
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Extend a node to be associated with tasks"""
 type NestedEdgedCoreTaskTarget {
   _updated_at: DateTime
   node: CoreTaskTarget
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A thread on a Proposed Change"""
 type NestedEdgedCoreThread {
   _updated_at: DateTime
   node: CoreThread
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A comment on thread within a Proposed Change"""
 type NestedEdgedCoreThreadComment {
   node: CoreThreadComment
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A file rendered from a Jinja2 template"""
 type NestedEdgedCoreTransformJinja2 {
   node: CoreTransformJinja2
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A transform function written in Python"""
 type NestedEdgedCoreTransformPython {
   node: CoreTransformPython
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Generic Transformation Object."""
 type NestedEdgedCoreTransformation {
   _updated_at: DateTime
   node: CoreTransformation
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8774,29 +8948,34 @@ A rule that allows you to define a trigger and map it to an action that runs onc
 type NestedEdgedCoreTriggerRule {
   _updated_at: DateTime
   node: CoreTriggerRule
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A Validator related to a user defined checks in a repository"""
 type NestedEdgedCoreUserValidator {
   node: CoreUserValidator
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 type NestedEdgedCoreValidator {
   _updated_at: DateTime
   node: CoreValidator
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A webhook that connects to an external integration"""
 type NestedEdgedCoreWebhook {
   _updated_at: DateTime
   node: CoreWebhook
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8805,14 +8984,17 @@ Resource to be used in a pool, its weight is used to determine its priority on a
 type NestedEdgedCoreWeightedPoolResource {
   _updated_at: DateTime
   node: CoreWeightedPoolResource
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Token for User Account"""
 type NestedEdgedInternalAccountToken {
   node: InternalAccountToken
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """
@@ -8820,86 +9002,101 @@ IPv4 or IPv6 prefix also referred as network which has not been allocated yet
 """
 type NestedEdgedInternalIPPrefixAvailable {
   node: InternalIPPrefixAvailable
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Range of IPv4 or IPv6 addresses which has not been allocated yet"""
 type NestedEdgedInternalIPRangeAvailable {
   node: InternalIPRangeAvailable
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Refresh Token"""
 type NestedEdgedInternalRefreshToken {
   node: InternalRefreshToken
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """A namespace that segments IPAM"""
 type NestedEdgedIpamNamespace {
   node: IpamNamespace
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Any Entities that is responsible for some data."""
 type NestedEdgedLineageOwner {
   _updated_at: DateTime
   node: LineageOwner
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Any Entities that stores or produces data."""
 type NestedEdgedLineageSource {
   _updated_at: DateTime
   node: LineageSource
-  node_metadata: InfrahubNodeMetaObject
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Profile for BuiltinIPAddress"""
 type NestedEdgedProfileBuiltinIPAddress {
   node: ProfileBuiltinIPAddress
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Profile for BuiltinIPPrefix"""
 type NestedEdgedProfileBuiltinIPPrefix {
   node: ProfileBuiltinIPPrefix
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Profile for BuiltinTag"""
 type NestedEdgedProfileBuiltinTag {
   node: ProfileBuiltinTag
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """Profile for IpamNamespace"""
 type NestedEdgedProfileIpamNamespace {
   node: ProfileIpamNamespace
+  node_metadata: InfrahubNodeMetadata!
   properties: RelationshipProperty
+  relationship_metadata: InfrahubRelationshipMetadata!
 }
 
 """IPv4 or IPv6 address"""
 type NestedPaginatedBuiltinIPAddress {
   count: Int!
   edges: [NestedEdgedBuiltinIPAddress!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A generic container for IP prefixes and IP addresses"""
 type NestedPaginatedBuiltinIPNamespace {
   count: Int!
   edges: [NestedEdgedBuiltinIPNamespace!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """IPv4 or IPv6 prefix also referred as network"""
 type NestedPaginatedBuiltinIPPrefix {
   count: Int!
   edges: [NestedEdgedBuiltinIPPrefix!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -8936,7 +9133,6 @@ type NestedPaginatedCoreAccountRole {
 type NestedPaginatedCoreAction {
   count: Int!
   edges: [NestedEdgedCoreAction!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 type NestedPaginatedCoreArtifact {
@@ -8962,7 +9158,6 @@ type NestedPaginatedCoreArtifactDefinition {
 type NestedPaginatedCoreArtifactTarget {
   count: Int!
   edges: [NestedEdgedCoreArtifactTarget!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread related to an artifact on a proposed change"""
@@ -8983,7 +9178,6 @@ type NestedPaginatedCoreArtifactValidator {
 type NestedPaginatedCoreBasePermission {
   count: Int!
   edges: [NestedEdgedCoreBasePermission!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A comment on proposed change"""
@@ -9003,7 +9197,6 @@ type NestedPaginatedCoreChangeThread {
 type NestedPaginatedCoreCheck {
   count: Int!
   edges: [NestedEdgedCoreCheck!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 type NestedPaginatedCoreCheckDefinition {
@@ -9016,14 +9209,12 @@ type NestedPaginatedCoreCheckDefinition {
 type NestedPaginatedCoreComment {
   count: Int!
   edges: [NestedEdgedCoreComment!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A credential that could be referenced to access external services."""
 type NestedPaginatedCoreCredential {
   count: Int!
   edges: [NestedEdgedCoreCredential!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A webhook that connects to an external integration"""
@@ -9112,14 +9303,12 @@ type NestedPaginatedCoreGeneratorValidator {
 type NestedPaginatedCoreGenericAccount {
   count: Int!
   edges: [NestedEdgedCoreGenericAccount!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A Git Repository integrated with Infrahub"""
 type NestedPaginatedCoreGenericRepository {
   count: Int!
   edges: [NestedEdgedCoreGenericRepository!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A permission that grants global rights to perform actions in Infrahub"""
@@ -9147,7 +9336,6 @@ type NestedPaginatedCoreGraphQLQueryGroup {
 type NestedPaginatedCoreGroup {
   count: Int!
   edges: [NestedEdgedCoreGroup!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9186,7 +9374,6 @@ type NestedPaginatedCoreIPPrefixPool {
 type NestedPaginatedCoreMenu {
   count: Int!
   edges: [NestedEdgedCoreMenu!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """Menu Item"""
@@ -9200,7 +9387,6 @@ type NestedPaginatedCoreMenuItem {
 type NestedPaginatedCoreNode {
   count: Int!
   edges: [NestedEdgedCoreNode!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A trigger match that matches against attribute changes on a node"""
@@ -9216,7 +9402,6 @@ A trigger match condition related to changes to nodes within the Infrahub databa
 type NestedPaginatedCoreNodeTriggerMatch {
   count: Int!
   edges: [NestedEdgedCoreNodeTriggerMatch!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A trigger match that matches against relationship changes on a node"""
@@ -9246,7 +9431,6 @@ type NestedPaginatedCoreNumberPool {
 type NestedPaginatedCoreObjectComponentTemplate {
   count: Int!
   edges: [NestedEdgedCoreObjectComponentTemplate!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A permission that grants rights to perform actions on objects"""
@@ -9260,7 +9444,6 @@ type NestedPaginatedCoreObjectPermission {
 type NestedPaginatedCoreObjectTemplate {
   count: Int!
   edges: [NestedEdgedCoreObjectTemplate!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread related to an object on a proposed change"""
@@ -9281,7 +9464,6 @@ type NestedPaginatedCorePasswordCredential {
 type NestedPaginatedCoreProfile {
   count: Int!
   edges: [NestedEdgedCoreProfile!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """Metadata related to a proposed change"""
@@ -9327,7 +9509,6 @@ The resource manager contains pools of resources to allow for automatic assignme
 type NestedPaginatedCoreResourcePool {
   count: Int!
   edges: [NestedEdgedCoreResourcePool!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A check related to the schema"""
@@ -9369,14 +9550,12 @@ type NestedPaginatedCoreStandardWebhook {
 type NestedPaginatedCoreTaskTarget {
   count: Int!
   edges: [NestedEdgedCoreTaskTarget!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread on a Proposed Change"""
 type NestedPaginatedCoreThread {
   count: Int!
   edges: [NestedEdgedCoreThread!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A comment on thread within a Proposed Change"""
@@ -9404,7 +9583,6 @@ type NestedPaginatedCoreTransformPython {
 type NestedPaginatedCoreTransformation {
   count: Int!
   edges: [NestedEdgedCoreTransformation!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9413,7 +9591,6 @@ A rule that allows you to define a trigger and map it to an action that runs onc
 type NestedPaginatedCoreTriggerRule {
   count: Int!
   edges: [NestedEdgedCoreTriggerRule!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A Validator related to a user defined checks in a repository"""
@@ -9426,14 +9603,12 @@ type NestedPaginatedCoreUserValidator {
 type NestedPaginatedCoreValidator {
   count: Int!
   edges: [NestedEdgedCoreValidator!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """A webhook that connects to an external integration"""
 type NestedPaginatedCoreWebhook {
   count: Int!
   edges: [NestedEdgedCoreWebhook!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9442,7 +9617,6 @@ Resource to be used in a pool, its weight is used to determine its priority on a
 type NestedPaginatedCoreWeightedPoolResource {
   count: Int!
   edges: [NestedEdgedCoreWeightedPoolResource!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """Token for User Account"""
@@ -9486,14 +9660,12 @@ type NestedPaginatedIpamNamespace {
 type NestedPaginatedLineageOwner {
   count: Int!
   edges: [NestedEdgedLineageOwner!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """Any Entities that stores or produces data."""
 type NestedPaginatedLineageSource {
   count: Int!
   edges: [NestedEdgedLineageSource!]
-  node_metadata: InfrahubNodeMetaObject
 }
 
 """Profile for BuiltinIPAddress"""
@@ -10360,7 +10532,6 @@ type ProfileBuiltinIPAddress implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10439,7 +10610,6 @@ type ProfileBuiltinIPPrefix implements CoreNode & CoreProfile & LineageSource {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None"""
   member_type: Dropdown
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10523,7 +10693,6 @@ type ProfileBuiltinTag implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10598,7 +10767,6 @@ type ProfileIpamNamespace implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -78,7 +78,12 @@ type AnyAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: GenericScalar
 }
 
@@ -148,6 +153,7 @@ type Branch {
   is_default: Boolean
   is_isolated: Boolean @deprecated(reason: "non isolated mode is not supported anymore")
   name: String!
+  node_metadata: InfrahubNodeMetaObject
   origin_branch: String
   status: BranchStatus!
   sync_with_git: Boolean
@@ -474,6 +480,7 @@ type BuiltinTag implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -560,7 +567,12 @@ type CheckboxAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: Boolean
 }
 
@@ -634,6 +646,7 @@ type CoreAccount implements CoreGenericAccount & CoreNode & LineageOwner & Linea
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   password: TextAttribute
   status: Dropdown
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -678,6 +691,7 @@ type CoreAccountGroup implements CoreGroup & LineageOwner & LineageSource {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   roles(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
@@ -759,6 +773,7 @@ type CoreAccountRole implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   permissions(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], identifier__is_protected: Boolean, identifier__owner__id: ID, identifier__source__id: ID, identifier__value: String, identifier__values: [String], ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreBasePermission!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -905,6 +920,7 @@ type CoreArtifact implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   object: NestedEdgedCoreArtifactTarget!
   """None"""
   parameters: JSONAttribute
@@ -938,6 +954,7 @@ type CoreArtifactCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   """None"""
@@ -1067,6 +1084,7 @@ type CoreArtifactDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   parameters: JSONAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -1182,6 +1200,7 @@ type CoreArtifactThread implements CoreNode & CoreThread {
   """None"""
   line_number: NumberAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   resolved: CheckboxAttribute
   """None"""
   storage_id: TextAttribute
@@ -1314,6 +1333,7 @@ type CoreArtifactValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -1428,6 +1448,7 @@ type CoreChangeComment implements CoreComment & CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   text: TextAttribute
 }
@@ -1501,6 +1522,7 @@ type CoreChangeThread implements CoreNode & CoreThread {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   resolved: CheckboxAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -1601,6 +1623,7 @@ type CoreCheckDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None"""
   parameters: JSONAttribute
   query: NestedEdgedCoreGraphQLQuery!
@@ -1778,6 +1801,7 @@ type CoreCustomWebhook implements CoreNode & CoreTaskTarget & CoreWebhook {
   name: TextAttribute
   """Only send node mutation events for nodes of this kind"""
   node_kind: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None"""
   shared_key: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -1883,6 +1907,7 @@ type CoreDataCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -1981,6 +2006,7 @@ type CoreDataValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -2070,6 +2096,7 @@ type CoreFileCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2172,6 +2199,7 @@ type CoreFileThread implements CoreNode & CoreThread {
   """None"""
   line_number: NumberAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   repository: NestedEdgedCoreRepository!
   resolved: CheckboxAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2264,6 +2292,7 @@ type CoreGeneratorAction implements CoreAction & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """Short descriptive name"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   triggers(active__is_protected: Boolean, active__owner__id: ID, active__source__id: ID, active__value: Boolean, active__values: [Boolean], branch_scope__is_protected: Boolean, branch_scope__owner__id: ID, branch_scope__source__id: ID, branch_scope__value: String, branch_scope__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreTriggerRule!
 }
@@ -2357,6 +2386,7 @@ type CoreGeneratorAwareGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -2439,6 +2469,7 @@ type CoreGeneratorCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -2540,6 +2571,7 @@ type CoreGeneratorDefinition implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   parameters: JSONAttribute
   query: NestedEdgedCoreGraphQLQuery!
@@ -2636,6 +2668,7 @@ type CoreGeneratorGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -2712,6 +2745,7 @@ type CoreGeneratorInstance implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   object: NestedEdgedCoreNode!
   """None (required)"""
   status: TextAttribute
@@ -2783,6 +2817,7 @@ type CoreGeneratorValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -2957,6 +2992,7 @@ type CoreGlobalPermission implements CoreBasePermission & CoreNode {
   id: String!
   identifier: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   roles(ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3038,6 +3074,7 @@ type CoreGraphQLQuery implements CoreNode {
   models: ListAttribute
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """
   Operations in use in the query, valid operations: 'query', 'mutation' or 'subscription'
   """
@@ -3089,6 +3126,7 @@ type CoreGraphQLQueryGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None"""
   parameters: JSONAttribute
   parent: NestedEdgedCoreGroup!
@@ -3238,6 +3276,7 @@ type CoreGroupAction implements CoreAction & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """Short descriptive name"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   triggers(active__is_protected: Boolean, active__owner__id: ID, active__source__id: ID, active__value: Boolean, active__values: [Boolean], branch_scope__is_protected: Boolean, branch_scope__owner__id: ID, branch_scope__source__id: ID, branch_scope__value: String, branch_scope__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreTriggerRule!
 }
@@ -3362,6 +3401,7 @@ type CoreGroupTriggerRule implements CoreNode & CoreTriggerRule {
   member_update: Dropdown
   """The name of the trigger rule"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -3509,6 +3549,7 @@ type CoreIPAddressPool implements CoreNode & CoreResourcePool & LineageSource {
   ip_namespace: NestedEdgedBuiltinIPNamespace!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   resources(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3606,6 +3647,7 @@ type CoreIPPrefixPool implements CoreNode & CoreResourcePool & LineageSource {
   ip_namespace: NestedEdgedBuiltinIPNamespace!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   resources(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -3727,6 +3769,7 @@ type CoreMenuItem implements CoreMenu & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], include_descendants: Boolean, isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
   namespace: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   order_weight: NumberAttribute
   parent: NestedEdgedCoreMenu!
   path: TextAttribute
@@ -3862,6 +3905,7 @@ type CoreNodeTriggerAttributeMatch implements CoreNode & CoreNodeTriggerMatch {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   trigger: NestedEdgedCoreNodeTriggerRule!
   """The value the attribute is updated to"""
@@ -3997,6 +4041,7 @@ type CoreNodeTriggerRelationshipMatch implements CoreNode & CoreNodeTriggerMatch
   Indicates if the relationship was added or removed or just updated in any way
   """
   modification_type: Dropdown
+  node_metadata: InfrahubNodeMetaObject
   """The node_id of the relationship peer to match against"""
   peer: TextAttribute
   """The name of the relationship to match against (required)"""
@@ -4107,6 +4152,7 @@ type CoreNodeTriggerRule implements CoreNode & CoreTriggerRule {
   name: TextAttribute
   """The kind of node to match against (required)"""
   node_kind: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -4259,6 +4305,7 @@ type CoreNumberPool implements CoreNode & CoreResourcePool & LineageSource {
   node: TextAttribute
   """The attribute of the selected model (required)"""
   node_attribute: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """Defines how this number pool was created"""
   pool_type: TextAttribute
   """The start range for the pool (required)"""
@@ -4386,6 +4433,7 @@ type CoreObjectPermission implements CoreBasePermission & CoreNode {
   name: TextAttribute
   """None (required)"""
   namespace: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   roles(ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreAccountRole!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -4500,6 +4548,7 @@ type CoreObjectThread implements CoreNode & CoreThread {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   object_path: TextAttribute
   resolved: CheckboxAttribute
@@ -4582,6 +4631,7 @@ type CorePasswordCredential implements CoreCredential & CoreNode {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None"""
   password: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -4695,6 +4745,7 @@ type CoreProposedChange implements CoreNode & CoreTaskTarget {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   rejected_by(account_type__is_protected: Boolean, account_type__owner__id: ID, account_type__source__id: ID, account_type__value: String, account_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, password__is_protected: Boolean, password__owner__id: ID, password__source__id: ID, password__value: String, password__values: [String], status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String]): NestedPaginatedCoreGenericAccount!
   reviewers(account_type__is_protected: Boolean, account_type__owner__id: ID, account_type__source__id: ID, account_type__value: String, account_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, password__is_protected: Boolean, password__owner__id: ID, password__source__id: ID, password__value: String, password__values: [String], status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String]): NestedPaginatedCoreGenericAccount!
   """None (required)"""
@@ -4802,6 +4853,7 @@ type CoreReadOnlyRepository implements CoreGenericRepository & CoreNode & CoreTa
   location: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   operational_status: Dropdown
   queries(depth__is_protected: Boolean, depth__owner__id: ID, depth__source__id: ID, depth__value: BigInt, depth__values: [BigInt], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], height__is_protected: Boolean, height__owner__id: ID, height__source__id: ID, height__value: BigInt, height__values: [BigInt], ids: [ID], isnull: Boolean, limit: Int, models__is_protected: Boolean, models__owner__id: ID, models__source__id: ID, models__value: GenericScalar, models__values: [GenericScalar], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, operations__is_protected: Boolean, operations__owner__id: ID, operations__source__id: ID, operations__value: GenericScalar, operations__values: [GenericScalar], order: OrderInput, query__is_protected: Boolean, query__owner__id: ID, query__source__id: ID, query__value: String, query__values: [String], variables__is_protected: Boolean, variables__owner__id: ID, variables__source__id: ID, variables__value: GenericScalar, variables__values: [GenericScalar]): NestedPaginatedCoreGraphQLQuery!
   """None"""
@@ -4929,6 +4981,7 @@ type CoreRepository implements CoreGenericRepository & CoreNode & CoreTaskTarget
   location: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   operational_status: Dropdown
   queries(depth__is_protected: Boolean, depth__owner__id: ID, depth__source__id: ID, depth__value: BigInt, depth__values: [BigInt], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], height__is_protected: Boolean, height__owner__id: ID, height__source__id: ID, height__value: BigInt, height__values: [BigInt], ids: [ID], isnull: Boolean, limit: Int, models__is_protected: Boolean, models__owner__id: ID, models__source__id: ID, models__value: GenericScalar, models__values: [GenericScalar], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, operations__is_protected: Boolean, operations__owner__id: ID, operations__source__id: ID, operations__value: GenericScalar, operations__values: [GenericScalar], order: OrderInput, query__is_protected: Boolean, query__owner__id: ID, query__source__id: ID, query__value: String, query__values: [String], variables__is_protected: Boolean, variables__owner__id: ID, variables__source__id: ID, variables__value: GenericScalar, variables__values: [GenericScalar]): NestedPaginatedCoreGraphQLQuery!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -4987,6 +5040,7 @@ type CoreRepositoryGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   repository: NestedEdgedCoreGenericRepository!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
@@ -5131,6 +5185,7 @@ type CoreRepositoryValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   repository: NestedEdgedCoreGenericRepository!
   started_at: TextAttribute
@@ -5256,6 +5311,7 @@ type CoreSchemaCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5351,6 +5407,7 @@ type CoreSchemaValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   started_at: TextAttribute
   state: TextAttribute
@@ -5436,6 +5493,7 @@ type CoreStandardCheck implements CoreCheck & CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   message: TextAttribute
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   origin: TextAttribute
   severity: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5528,6 +5586,7 @@ type CoreStandardGroup implements CoreGroup {
   label: TextAttribute
   members(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedCoreGroup!
   subscribers(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput): NestedPaginatedCoreNode!
 }
@@ -5609,6 +5668,7 @@ type CoreStandardWebhook implements CoreNode & CoreTaskTarget & CoreWebhook {
   name: TextAttribute
   """Only send node mutation events for nodes of this kind"""
   node_kind: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   shared_key: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5741,6 +5801,7 @@ type CoreThreadComment implements CoreComment & CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   text: TextAttribute
   thread: NestedEdgedCoreThread!
@@ -5832,6 +5893,7 @@ type CoreTransformJinja2 implements CoreNode & CoreTransformation {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   query: NestedEdgedCoreGraphQLQuery!
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -5926,6 +5988,7 @@ type CoreTransformPython implements CoreNode & CoreTransformation {
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   query: NestedEdgedCoreGraphQLQuery!
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -6113,6 +6176,7 @@ type CoreUserValidator implements CoreNode & CoreValidator {
   id: String!
   label: TextAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   proposed_change: NestedEdgedCoreProposedChange!
   repository: NestedEdgedCoreGenericRepository!
   started_at: TextAttribute
@@ -6466,7 +6530,12 @@ type Dropdown implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
 }
 
@@ -7090,7 +7159,12 @@ type IPHost implements AttributeInterface {
   permissions: PermissionType
   prefixlen: Int
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
   version: Int
   with_hostmask: String
@@ -7112,7 +7186,12 @@ type IPNetwork implements AttributeInterface {
   permissions: PermissionType
   prefixlen: Int
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
   version: Int
   with_hostmask: String
@@ -7224,6 +7303,7 @@ input InfrahubAccountTokenDeleteInput {
 
 type InfrahubAccountTokenType {
   id: String!
+  node_metadata: InfrahubNodeMetaObject
   token: ValueType
 }
 
@@ -7245,6 +7325,7 @@ type InfrahubBranch {
   is_default: NonRequiredBooleanValueField
   is_isolated: NonRequiredBooleanValueField @deprecated(reason: "non isolated mode is not supported anymore")
   name: RequiredStringValueField!
+  node_metadata: InfrahubNodeMetaObject
   origin_branch: NonRequiredStringValueField
   status: StatusField!
   sync_with_git: NonRequiredBooleanValueField
@@ -7306,6 +7387,21 @@ type InfrahubMutatedRelationship {
   peer: RelatedNode!
 }
 
+type InfrahubNodeMetaObject {
+  """Date/Time the object has been created"""
+  created_at: DateTime
+  """
+  UUID of the user that created the object, even if the user is later deleted
+  """
+  created_by: String
+  """Date/Time when the object was last modified by a user or a system task"""
+  updated_at: DateTime
+  """
+  UUID of the user that last modified the object, even if the user is later deleted
+  """
+  updated_by: String
+}
+
 type InfrahubProfilesRefresh {
   ok: Boolean
 }
@@ -7324,6 +7420,7 @@ type InternalAccountToken implements CoreNode {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None"""
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   token: TextAttribute
@@ -7354,6 +7451,7 @@ type InternalIPPrefixAvailable implements BuiltinIPPrefix & CoreNode {
   member_type: Dropdown
   netmask: TextAttribute
   network_address: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   parent: NestedEdgedBuiltinIPPrefix!
   prefix: IPNetwork
   profiles(ids: [ID], include_descendants: Boolean, isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
@@ -7377,6 +7475,7 @@ type InternalIPRangeAvailable implements BuiltinIPAddress & CoreNode {
   """None (required)"""
   last_address: IPHost
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -7393,6 +7492,7 @@ type InternalRefreshToken implements CoreNode {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
 
@@ -7411,6 +7511,7 @@ type IpamNamespace implements BuiltinIPNamespace & CoreNode {
   ip_prefixes(broadcast_address__is_protected: Boolean, broadcast_address__owner__id: ID, broadcast_address__source__id: ID, broadcast_address__value: String, broadcast_address__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], hostmask__is_protected: Boolean, hostmask__owner__id: ID, hostmask__source__id: ID, hostmask__value: String, hostmask__values: [String], ids: [ID], is_pool__is_protected: Boolean, is_pool__owner__id: ID, is_pool__source__id: ID, is_pool__value: Boolean, is_pool__values: [Boolean], is_top_level__is_protected: Boolean, is_top_level__owner__id: ID, is_top_level__source__id: ID, is_top_level__value: Boolean, is_top_level__values: [Boolean], isnull: Boolean, limit: Int, member_type__is_protected: Boolean, member_type__owner__id: ID, member_type__source__id: ID, member_type__value: String, member_type__values: [String], netmask__is_protected: Boolean, netmask__owner__id: ID, netmask__source__id: ID, netmask__value: String, netmask__values: [String], network_address__is_protected: Boolean, network_address__owner__id: ID, network_address__source__id: ID, network_address__value: String, network_address__values: [String], offset: Int, order: OrderInput, prefix__is_protected: Boolean, prefix__owner__id: ID, prefix__source__id: ID, prefix__value: String, prefix__values: [String], utilization__is_protected: Boolean, utilization__owner__id: ID, utilization__source__id: ID, utilization__value: BigInt, utilization__values: [BigInt]): NestedPaginatedBuiltinIPPrefix!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   name: TextAttribute
+  node_metadata: InfrahubNodeMetaObject
   profiles(ids: [ID], isnull: Boolean, limit: Int, offset: Int, order: OrderInput, profile_name__is_protected: Boolean, profile_name__owner__id: ID, profile_name__source__id: ID, profile_name__value: String, profile_name__values: [String], profile_priority__is_protected: Boolean, profile_priority__owner__id: ID, profile_priority__source__id: ID, profile_priority__value: BigInt, profile_priority__values: [BigInt]): NestedPaginatedCoreProfile!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
 }
@@ -7483,7 +7584,12 @@ type JSONAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: GenericScalar
 }
 
@@ -7530,7 +7636,12 @@ type ListAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: GenericScalar
 }
 
@@ -7572,7 +7683,12 @@ type MacAddress implements AttributeInterface {
   source: LineageSource
   """Format used by PostgreSQL"""
   split_notation: String
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
   version: Int
 }
@@ -8160,6 +8276,7 @@ type Mutation {
 type NestedEdgedBuiltinIPAddress {
   _updated_at: DateTime
   node: BuiltinIPAddress
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8167,6 +8284,7 @@ type NestedEdgedBuiltinIPAddress {
 type NestedEdgedBuiltinIPNamespace {
   _updated_at: DateTime
   node: BuiltinIPNamespace
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8174,6 +8292,7 @@ type NestedEdgedBuiltinIPNamespace {
 type NestedEdgedBuiltinIPPrefix {
   _updated_at: DateTime
   node: BuiltinIPPrefix
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8207,6 +8326,7 @@ type NestedEdgedCoreAccountRole {
 type NestedEdgedCoreAction {
   _updated_at: DateTime
   node: CoreAction
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8230,6 +8350,7 @@ type NestedEdgedCoreArtifactDefinition {
 type NestedEdgedCoreArtifactTarget {
   _updated_at: DateTime
   node: CoreArtifactTarget
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8249,6 +8370,7 @@ type NestedEdgedCoreArtifactValidator {
 type NestedEdgedCoreBasePermission {
   _updated_at: DateTime
   node: CoreBasePermission
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8267,6 +8389,7 @@ type NestedEdgedCoreChangeThread {
 type NestedEdgedCoreCheck {
   _updated_at: DateTime
   node: CoreCheck
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8279,6 +8402,7 @@ type NestedEdgedCoreCheckDefinition {
 type NestedEdgedCoreComment {
   _updated_at: DateTime
   node: CoreComment
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8286,6 +8410,7 @@ type NestedEdgedCoreComment {
 type NestedEdgedCoreCredential {
   _updated_at: DateTime
   node: CoreCredential
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8363,6 +8488,7 @@ type NestedEdgedCoreGeneratorValidator {
 type NestedEdgedCoreGenericAccount {
   _updated_at: DateTime
   node: CoreGenericAccount
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8370,6 +8496,7 @@ type NestedEdgedCoreGenericAccount {
 type NestedEdgedCoreGenericRepository {
   _updated_at: DateTime
   node: CoreGenericRepository
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8395,6 +8522,7 @@ type NestedEdgedCoreGraphQLQueryGroup {
 type NestedEdgedCoreGroup {
   _updated_at: DateTime
   node: CoreGroup
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8430,6 +8558,7 @@ type NestedEdgedCoreIPPrefixPool {
 type NestedEdgedCoreMenu {
   _updated_at: DateTime
   node: CoreMenu
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8443,6 +8572,7 @@ type NestedEdgedCoreMenuItem {
 type NestedEdgedCoreNode {
   _updated_at: DateTime
   node: CoreNode
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8458,6 +8588,7 @@ A trigger match condition related to changes to nodes within the Infrahub databa
 type NestedEdgedCoreNodeTriggerMatch {
   _updated_at: DateTime
   node: CoreNodeTriggerMatch
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8485,6 +8616,7 @@ type NestedEdgedCoreNumberPool {
 type NestedEdgedCoreObjectComponentTemplate {
   _updated_at: DateTime
   node: CoreObjectComponentTemplate
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8498,6 +8630,7 @@ type NestedEdgedCoreObjectPermission {
 type NestedEdgedCoreObjectTemplate {
   _updated_at: DateTime
   node: CoreObjectTemplate
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8517,6 +8650,7 @@ type NestedEdgedCorePasswordCredential {
 type NestedEdgedCoreProfile {
   _updated_at: DateTime
   node: CoreProfile
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8558,6 +8692,7 @@ The resource manager contains pools of resources to allow for automatic assignme
 type NestedEdgedCoreResourcePool {
   _updated_at: DateTime
   node: CoreResourcePool
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8595,6 +8730,7 @@ type NestedEdgedCoreStandardWebhook {
 type NestedEdgedCoreTaskTarget {
   _updated_at: DateTime
   node: CoreTaskTarget
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8602,6 +8738,7 @@ type NestedEdgedCoreTaskTarget {
 type NestedEdgedCoreThread {
   _updated_at: DateTime
   node: CoreThread
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8627,6 +8764,7 @@ type NestedEdgedCoreTransformPython {
 type NestedEdgedCoreTransformation {
   _updated_at: DateTime
   node: CoreTransformation
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8636,6 +8774,7 @@ A rule that allows you to define a trigger and map it to an action that runs onc
 type NestedEdgedCoreTriggerRule {
   _updated_at: DateTime
   node: CoreTriggerRule
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8648,6 +8787,7 @@ type NestedEdgedCoreUserValidator {
 type NestedEdgedCoreValidator {
   _updated_at: DateTime
   node: CoreValidator
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8655,6 +8795,7 @@ type NestedEdgedCoreValidator {
 type NestedEdgedCoreWebhook {
   _updated_at: DateTime
   node: CoreWebhook
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8664,6 +8805,7 @@ Resource to be used in a pool, its weight is used to determine its priority on a
 type NestedEdgedCoreWeightedPoolResource {
   _updated_at: DateTime
   node: CoreWeightedPoolResource
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8703,6 +8845,7 @@ type NestedEdgedIpamNamespace {
 type NestedEdgedLineageOwner {
   _updated_at: DateTime
   node: LineageOwner
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8710,6 +8853,7 @@ type NestedEdgedLineageOwner {
 type NestedEdgedLineageSource {
   _updated_at: DateTime
   node: LineageSource
+  node_metadata: InfrahubNodeMetaObject
   properties: RelationshipProperty
 }
 
@@ -8741,18 +8885,21 @@ type NestedEdgedProfileIpamNamespace {
 type NestedPaginatedBuiltinIPAddress {
   count: Int!
   edges: [NestedEdgedBuiltinIPAddress!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A generic container for IP prefixes and IP addresses"""
 type NestedPaginatedBuiltinIPNamespace {
   count: Int!
   edges: [NestedEdgedBuiltinIPNamespace!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """IPv4 or IPv6 prefix also referred as network"""
 type NestedPaginatedBuiltinIPPrefix {
   count: Int!
   edges: [NestedEdgedBuiltinIPPrefix!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -8789,6 +8936,7 @@ type NestedPaginatedCoreAccountRole {
 type NestedPaginatedCoreAction {
   count: Int!
   edges: [NestedEdgedCoreAction!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 type NestedPaginatedCoreArtifact {
@@ -8814,6 +8962,7 @@ type NestedPaginatedCoreArtifactDefinition {
 type NestedPaginatedCoreArtifactTarget {
   count: Int!
   edges: [NestedEdgedCoreArtifactTarget!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread related to an artifact on a proposed change"""
@@ -8834,6 +8983,7 @@ type NestedPaginatedCoreArtifactValidator {
 type NestedPaginatedCoreBasePermission {
   count: Int!
   edges: [NestedEdgedCoreBasePermission!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A comment on proposed change"""
@@ -8853,6 +9003,7 @@ type NestedPaginatedCoreChangeThread {
 type NestedPaginatedCoreCheck {
   count: Int!
   edges: [NestedEdgedCoreCheck!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 type NestedPaginatedCoreCheckDefinition {
@@ -8865,12 +9016,14 @@ type NestedPaginatedCoreCheckDefinition {
 type NestedPaginatedCoreComment {
   count: Int!
   edges: [NestedEdgedCoreComment!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A credential that could be referenced to access external services."""
 type NestedPaginatedCoreCredential {
   count: Int!
   edges: [NestedEdgedCoreCredential!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A webhook that connects to an external integration"""
@@ -8959,12 +9112,14 @@ type NestedPaginatedCoreGeneratorValidator {
 type NestedPaginatedCoreGenericAccount {
   count: Int!
   edges: [NestedEdgedCoreGenericAccount!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A Git Repository integrated with Infrahub"""
 type NestedPaginatedCoreGenericRepository {
   count: Int!
   edges: [NestedEdgedCoreGenericRepository!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A permission that grants global rights to perform actions in Infrahub"""
@@ -8992,6 +9147,7 @@ type NestedPaginatedCoreGraphQLQueryGroup {
 type NestedPaginatedCoreGroup {
   count: Int!
   edges: [NestedEdgedCoreGroup!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9030,6 +9186,7 @@ type NestedPaginatedCoreIPPrefixPool {
 type NestedPaginatedCoreMenu {
   count: Int!
   edges: [NestedEdgedCoreMenu!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """Menu Item"""
@@ -9043,6 +9200,7 @@ type NestedPaginatedCoreMenuItem {
 type NestedPaginatedCoreNode {
   count: Int!
   edges: [NestedEdgedCoreNode!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A trigger match that matches against attribute changes on a node"""
@@ -9058,6 +9216,7 @@ A trigger match condition related to changes to nodes within the Infrahub databa
 type NestedPaginatedCoreNodeTriggerMatch {
   count: Int!
   edges: [NestedEdgedCoreNodeTriggerMatch!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A trigger match that matches against relationship changes on a node"""
@@ -9087,6 +9246,7 @@ type NestedPaginatedCoreNumberPool {
 type NestedPaginatedCoreObjectComponentTemplate {
   count: Int!
   edges: [NestedEdgedCoreObjectComponentTemplate!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A permission that grants rights to perform actions on objects"""
@@ -9100,6 +9260,7 @@ type NestedPaginatedCoreObjectPermission {
 type NestedPaginatedCoreObjectTemplate {
   count: Int!
   edges: [NestedEdgedCoreObjectTemplate!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread related to an object on a proposed change"""
@@ -9120,6 +9281,7 @@ type NestedPaginatedCorePasswordCredential {
 type NestedPaginatedCoreProfile {
   count: Int!
   edges: [NestedEdgedCoreProfile!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """Metadata related to a proposed change"""
@@ -9165,6 +9327,7 @@ The resource manager contains pools of resources to allow for automatic assignme
 type NestedPaginatedCoreResourcePool {
   count: Int!
   edges: [NestedEdgedCoreResourcePool!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A check related to the schema"""
@@ -9206,12 +9369,14 @@ type NestedPaginatedCoreStandardWebhook {
 type NestedPaginatedCoreTaskTarget {
   count: Int!
   edges: [NestedEdgedCoreTaskTarget!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A thread on a Proposed Change"""
 type NestedPaginatedCoreThread {
   count: Int!
   edges: [NestedEdgedCoreThread!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A comment on thread within a Proposed Change"""
@@ -9239,6 +9404,7 @@ type NestedPaginatedCoreTransformPython {
 type NestedPaginatedCoreTransformation {
   count: Int!
   edges: [NestedEdgedCoreTransformation!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9247,6 +9413,7 @@ A rule that allows you to define a trigger and map it to an action that runs onc
 type NestedPaginatedCoreTriggerRule {
   count: Int!
   edges: [NestedEdgedCoreTriggerRule!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A Validator related to a user defined checks in a repository"""
@@ -9259,12 +9426,14 @@ type NestedPaginatedCoreUserValidator {
 type NestedPaginatedCoreValidator {
   count: Int!
   edges: [NestedEdgedCoreValidator!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """A webhook that connects to an external integration"""
 type NestedPaginatedCoreWebhook {
   count: Int!
   edges: [NestedEdgedCoreWebhook!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """
@@ -9273,6 +9442,7 @@ Resource to be used in a pool, its weight is used to determine its priority on a
 type NestedPaginatedCoreWeightedPoolResource {
   count: Int!
   edges: [NestedEdgedCoreWeightedPoolResource!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """Token for User Account"""
@@ -9316,12 +9486,14 @@ type NestedPaginatedIpamNamespace {
 type NestedPaginatedLineageOwner {
   count: Int!
   edges: [NestedEdgedLineageOwner!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """Any Entities that stores or produces data."""
 type NestedPaginatedLineageSource {
   count: Int!
   edges: [NestedEdgedLineageSource!]
+  node_metadata: InfrahubNodeMetaObject
 }
 
 """Profile for BuiltinIPAddress"""
@@ -9396,14 +9568,32 @@ type NodeMutatedEvent implements EventNodeInterface {
 }
 
 type NonRequiredBooleanValueField {
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: Boolean
 }
 
 type NonRequiredIntValueField {
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: Int
 }
 
 type NonRequiredStringValueField {
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
 }
 
@@ -9417,7 +9607,12 @@ type NumberAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: BigInt
 }
 
@@ -10165,6 +10360,7 @@ type ProfileBuiltinIPAddress implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10243,6 +10439,7 @@ type ProfileBuiltinIPPrefix implements CoreNode & CoreProfile & LineageSource {
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None"""
   member_type: Dropdown
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10326,6 +10523,7 @@ type ProfileBuiltinTag implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10400,6 +10598,7 @@ type ProfileIpamNamespace implements CoreNode & CoreProfile & LineageSource {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
+  node_metadata: InfrahubNodeMetaObject
   """None (required)"""
   profile_name: TextAttribute
   """None"""
@@ -10877,6 +11076,12 @@ type Relationship {
   id: String
   identifier: String
   peers: [RelationshipPeer!]
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
 }
 
 type RelationshipAdd {
@@ -10925,6 +11130,12 @@ type Relationships {
 }
 
 type RequiredStringValueField {
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String!
 }
 
@@ -11022,6 +11233,12 @@ type Status {
 }
 
 type StatusField {
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
+  updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: BranchStatus!
 }
 
@@ -11112,7 +11329,12 @@ type TextAttribute implements AttributeInterface {
   owner: LineageOwner
   permissions: PermissionType
   source: LineageSource
+  """
+  Date/Time when the attribute or relationship was last modified by a user or a system task
+  """
   updated_at: DateTime
+  """UUID of the user that last modified the attribute or relationship"""
+  updated_by: String
   value: String
 }
 


### PR DESCRIPTION
This PR builds on #7683 but also replaces some parts as per the query defined in IFC-1813.

I.e the format looks like this:

```graphql
query CoreProposedChange {
  CoreProposedChange {
    edges {
      node_metadata {
          created_by {
            id
            display_label
          }
          updated_by {
            id
            display_label            
          }
          updated_at        
      }
      node {       
        name {
          value
          created_at
          created_by {
            id
            display_label
          }
          updated_at
          updated_by {
            id
            display_label
          }
        }
        reviewers {
          edges {
            properties { } Keep but deprecate
            relationship_metadata {
              updated_by
              updated_at
              * Also add existing properties fields
            }
            node_metadata {
              created_by
              created_at
              updated_by
              updated_at              
            }
            node { 
              name {
                value
                updated_at
                updated_by
              }
            }
          }
        }
      }
    }
  }
}
```

There are some parts of this PR which will be modified and combined with what we have in #7859, for the StandardNode's i.e. the Branch objects. I will work on those modifications once both of these PRs are merged.

One comment around this one is that the goal here is to get the query and response format correct, there's still an issue of looking up the display labels for any IDs under the created_by or updated_by fields. But we should be able to add that once the structure is in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL exposes per-item audit metadata (node_metadata and relationship_metadata) with created_at/created_by and updated_at/updated_by across nodes, relationships, attributes and branches.
* **Refactor**
  * Query/resolver/data-loader flows now accept per-call metadata selection so metadata is loaded only when requested.
  * Several list endpoints and mutations return flattened node representations.
* **Tests**
  * Added/updated tests validating metadata fields in queries and paginated responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->