### PR TITLE
fix(backend): do not delete rels when previewing mutation object

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1091,7 +1091,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
             if key in self._relationships:
                 rel: RelationshipManager = getattr(self, key)
-                changed |= await rel.update(db=db, data=value)
+                changed |= await rel.update(db=db, data=value, process_delete=process_pools)
 
         return changed
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1072,7 +1072,12 @@ class RelationshipManager:
 
         return self._relationships.as_list()
 
-    async def update(self, data: list[str | Node] | dict[str, Any] | str | Node | None, db: InfrahubDatabase) -> bool:
+    async def update(
+        self,
+        data: list[str | Node] | dict[str, Any] | str | Node | None,
+        db: InfrahubDatabase,
+        process_delete: bool = True,
+    ) -> bool:
         """Replace and Update the list of relationships with this one."""
         if not isinstance(data, list):
             list_data: Sequence[str | Node | dict[str, Any] | None] = [data]
@@ -1098,8 +1103,9 @@ class RelationshipManager:
 
             if item is None:
                 if previous_relationships:
-                    for rel in previous_relationships.values():
-                        await rel.delete(db=db)
+                    if process_delete:
+                        for rel in previous_relationships.values():
+                            await rel.delete(db=db)
                     changed = True
                 continue
 

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -1627,6 +1627,32 @@ async def test_removing_mandatory_relationship_not_allowed(
     assert len(result.errors) == 1
     assert result.errors[0].message == "Too few relationships, min 1 at owner"
 
+    query = """
+    query {
+        TestDog(ids: ["%(animal_id)s"]) {
+            edges {
+                node {
+                    owner {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }""" % {"animal_id": dog1.id}
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.data["TestDog"]["edges"][0]["node"]["owner"]["node"] is not None
+    retrieved_owner_id = result.data["TestDog"]["edges"][0]["node"]["owner"]["node"]["id"]
+    assert retrieved_owner_id == person1.id
+
 
 async def test_updating_relationship_when_peer_side_is_required(
     db: InfrahubDatabase, default_branch, animal_person_schema

--- a/changelog/7853.fixed.md
+++ b/changelog/7853.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue where removing a mandatory relationship was allowed.


### PR DESCRIPTION
PR https://github.com/opsmill/infrahub/pull/7508 introduced a regression where relationship constraints would not rollback the transaction in case of failures due to the introduction of a "preview object" executed outside of the transaction. This would leave objects with nulled relationships where it would not have been allowed.

Make sure those deletions are not processed when building this preview object.
Also add more coverage to the unit test.

Fixes #7853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended removal of mandatory relationships; relationship updates now preserve consistent state when deletion is conditionally skipped.

* **Tests**
  * Added test coverage to confirm required relationships remain intact after failed update attempts.

* **Changelog**
  * Added a release note documenting the fix for mandatory relationship removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->