### PR TITLE
set updated_at/by for peer Nodes when updating rel on default/global

### DIFF
--- a/backend/DATABASE.md
+++ b/backend/DATABASE.md
@@ -299,3 +299,55 @@ When a NodeSchema's `name`, `namespace`, or `inherit_from` changes, labels must 
 **Result:** Multiple Node vertices with same UUID exist, but only one is active per branch/time.
 
 **Important:** All UUID-based queries must account for duplicate-UUID nodes by filtering for the active one.
+
+## Finding Active Nodes on Default/Global Branch
+
+When querying for Node vertices that are active on the default or global branch (e.g., to update metadata), you must verify that the relevant edges are active. This is especially important when multiple Node vertices with the same UUID may exist due to schema migrations.
+
+### Pattern: Active Node via Edge Path
+
+To find Nodes that are currently active on `branch_level = 1`:
+
+1. Filter edges by `branch_level = 1`
+2. Order by `from DESC, status ASC` to get the latest edge
+3. Take the first result with `LIMIT 1`
+4. Verify the edge has `status = "active"` and `to IS NULL`
+
+### Example: Active Peer Nodes for a Relationship
+
+When a Relationship vertex may have IS_RELATED edges to more than 2 Node vertices (due to schema migrations), find only the active peer nodes:
+
+```cypher
+// Get distinct peer nodes connected via branch_level = 1 edges
+CALL (rl) {
+    MATCH (peer:Node)-[r_rel:IS_RELATED]-(rl)
+    WHERE r_rel.branch_level = 1
+    RETURN DISTINCT peer
+}
+WITH rl, peer
+// For each peer, verify IS_RELATED edge is active
+CALL (peer, rl) {
+    MATCH (peer)-[r_rel:IS_RELATED]-(rl)
+    WHERE r_rel.branch_level = 1
+    ORDER BY r_rel.from DESC, r_rel.status ASC
+    LIMIT 1
+    WITH peer, r_rel
+    WHERE r_rel.status = "active" AND r_rel.to IS NULL
+    // Also verify IS_PART_OF edge is active (node exists)
+    MATCH (peer)-[r_part:IS_PART_OF]->(:Root)
+    WHERE r_part.branch_level = 1
+    ORDER BY r_part.from DESC, r_part.status ASC
+    LIMIT 1
+    WITH peer, r_part
+    WHERE r_part.status = "active" AND r_part.to IS NULL
+    // Node is confirmed active, safe to update
+    SET peer.updated_at = $at, peer.updated_by = $user_id
+}
+```
+
+### Key Points
+
+- **Two-edge validation**: Verify both the connecting edge (e.g., IS_RELATED) AND the IS_PART_OF edge to Root
+- **DISTINCT first**: When multiple vertices may match, get DISTINCT nodes first, then validate each
+- **Order then filter**: Always `ORDER BY ... LIMIT 1` first, then `WHERE status = "active"` to handle the case where the latest edge is a deletion
+- **No `to` timestamp**: `to IS NULL` ensures the edge is currently valid (not expired)

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -340,6 +340,11 @@ class RelationshipCreateQuery(RelationshipWriteQuery):
             r1,
             r2,
         )
+        if self.branch.is_default or self.branch.is_global:
+            query_create += """
+        SET s.updated_at = $at, s.updated_by = $user_id
+        SET d.updated_at = $at, d.updated_by = $user_id
+            """
 
         self.add_to_query(query_create)
         self.return_labels = ["s", "d", "rl", "r1", "r2", "r3", "r4"]
@@ -396,6 +401,8 @@ CREATE (rl)-[:HAS_%s { branch: $branch, branch_level: $branch_level, status: "ac
 class RelationshipUpdatePropertyQuery(RelationshipWriteQuery):
     name = "relationship_property_update"
     type = QueryType.WRITE
+    insert_return = False
+    raise_error_if_empty = False
 
     def __init__(
         self,
@@ -410,7 +417,7 @@ class RelationshipUpdatePropertyQuery(RelationshipWriteQuery):
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
-        self.params["rel_node_id"] = self.rel_id
+        self.params["rel_node_id"] = self.rel_id or (self.rel.id if self.rel else None)
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
         self.params["user_id"] = self.user_id
@@ -422,7 +429,7 @@ class RelationshipUpdatePropertyQuery(RelationshipWriteQuery):
         if self.branch.is_default or self.branch.is_global:
             rel_query += """
             SET rl.updated_at = $at, rl.updated_by = $user_id
-            WITH *
+            WITH rl
             """
         self.add_to_query(rel_query)
 
@@ -452,6 +459,33 @@ WITH rl
         self.query_add_all_node_property_create(branch_filter=branch_filter)
         self.query_add_all_flag_property_create()
 
+        # Update peer node metadata at the end (only on default/global branch)
+        if self.branch.is_default or self.branch.is_global:
+            peer_metadata_query = """
+WITH rl
+CALL (rl) {
+    MATCH (peer:Node)-[r_rel:IS_RELATED]-(rl)
+    WHERE r_rel.branch_level = 1
+    WITH DISTINCT peer, rl
+    CALL (peer, rl) {
+        MATCH (peer)-[r_rel:IS_RELATED]-(rl)
+        WHERE r_rel.branch_level = 1
+        ORDER BY r_rel.from DESC, r_rel.status ASC
+        LIMIT 1
+        WITH peer, r_rel
+        WHERE r_rel.status = "active" AND r_rel.to IS NULL
+        MATCH (peer)-[r_part:IS_PART_OF]->(:Root)
+        WHERE r_part.branch_level = 1
+        ORDER BY r_part.from DESC, r_part.status ASC
+        LIMIT 1
+        WITH peer, r_part
+        WHERE r_part.status = "active" AND r_part.to IS NULL
+        SET peer.updated_at = $at, peer.updated_by = $user_id
+    }
+}
+            """
+            self.add_to_query(peer_metadata_query)
+
     def query_add_all_flag_property_merge(self) -> None:
         for prop_name, prop_value in self.flag_properties_to_update.items():
             self.query_add_flag_property_merge(name=prop_name, value=prop_value)
@@ -459,7 +493,6 @@ WITH rl
     def query_add_flag_property_merge(self, name: str, value: bool) -> None:
         self.add_to_query("MERGE (prop_%s:Boolean { value: $prop_%s })" % (name, name))
         self.params[f"prop_{name}"] = value
-        self.return_labels.append(f"prop_{name}")
 
     def query_add_all_node_property_merge(self, branch_filter: str) -> None:
         for prop_name, prop_value in self.node_properties_to_update.items():
@@ -484,7 +517,6 @@ WITH rl
             WHERE $prop_%(prop_name)s IS NULL OR r_%(prop_name)s.status = "active"
                 """ % {"branch_filter": branch_filter, "prop_name": prop_name}
             self.add_to_query(node_query)
-            self.return_labels.append(f"prop_{prop_name}")
 
     def query_add_all_flag_property_create(self) -> None:
         for prop_name in self.flag_properties_to_update:
@@ -583,7 +615,9 @@ class RelationshipDeleteQuery(RelationshipWriteQuery):
         }
         if self.branch.is_default or self.branch.is_global:
             rel_match_query += """
-            SET rl.updated_at = $at, rl.updated_by = $user_id
+        SET rl.updated_at = $at, rl.updated_by = $user_id
+        SET s.updated_at = $at, s.updated_by = $user_id
+        SET d.updated_at = $at, d.updated_by = $user_id
             """
         self.add_to_query(rel_match_query)
 
@@ -1257,6 +1291,10 @@ class RelationshipDeleteAllQuery(Query):
                 self.add_to_query(sub_query)
 
         # We only want to return uuid/kind of `Node` connected through `IS_RELATED` edges.
+        peer_node_metadata_update = ""
+        if self.branch.is_default or self.branch.is_global:
+            peer_node_metadata_update = "SET n.updated_at = $at, n.updated_by = $user_id"
+
         query = """
         CALL (rl) {
             MATCH (rl)-[active_edge:IS_RELATED]->(n)
@@ -1267,6 +1305,7 @@ class RelationshipDeleteAllQuery(Query):
             WHERE active_edge.status = "active"
             CREATE (rl)-[deleted_edge:IS_RELATED $rel_prop]->(n)
             SET deleted_edge.hierarchy = active_edge.hierarchy
+            %(peer_node_metadata_update)s
             WITH rl, active_edge, n
             WHERE active_edge.branch = $branch AND active_edge.to IS NULL
             SET active_edge.to = $at, active_edge.to_user_id = $user_id
@@ -1286,6 +1325,7 @@ class RelationshipDeleteAllQuery(Query):
             WHERE active_edge.status = "active"
             CREATE (rl)<-[deleted_edge:IS_RELATED $rel_prop]-(n)
             SET deleted_edge.hierarchy = active_edge.hierarchy
+            %(peer_node_metadata_update)s
             WITH rl, active_edge, n
             WHERE active_edge.branch = $branch AND active_edge.to IS NULL
             SET active_edge.to = $at, active_edge.to_user_id = $user_id
@@ -1296,7 +1336,11 @@ class RelationshipDeleteAllQuery(Query):
                 "inbound" as rel_direction
         }
         RETURN DISTINCT uuid, kind, rel_identifier, rel_direction
-        """ % {"active_rel_filter": active_rel_filter, "id_func": db.get_id_function_name()}
+        """ % {
+            "active_rel_filter": active_rel_filter,
+            "id_func": db.get_id_function_name(),
+            "peer_node_metadata_update": peer_node_metadata_update,
+        }
         self.add_to_query(query)
 
     def get_deleted_relationships_changelog(

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -24,6 +24,7 @@ from infrahub.core.query.relationship import (
     RelationshipGetPeerQuery,
     RelationshipPeerData,
     RelationshipQuery,
+    RelationshipUpdatePropertyQuery,
     RelData,
 )
 from infrahub.core.relationship import Relationship
@@ -166,6 +167,49 @@ async def test_query_RelationshipCreateQuery(
         relationships=["IS_RELATED"],
     )
     assert len(paths) == 1
+
+
+async def test_query_RelationshipCreateQuery_updates_node_metadata(
+    db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, person_jack_main: Node
+) -> None:
+    """Test that RelationshipCreateQuery updates updated_at/updated_by on source and destination nodes."""
+    person_schema = registry.schema.get(name="TestPerson")
+    rel_schema = person_schema.get_relationship("tags")
+
+    create_time = Timestamp()
+    query = await RelationshipCreateQuery.init(
+        db=db,
+        source=person_jack_main,
+        destination=tag_blue_main,
+        schema=rel_schema,
+        rel=Relationship,
+        branch=default_branch,
+        at=create_time,
+        user_id="test_user",
+    )
+    await query.execute(db=db)
+
+    # Verify node metadata was updated using NodeManager
+    nodes_by_id = await NodeManager.get_many(
+        db=db,
+        branch=default_branch,
+        ids=[person_jack_main.id, tag_blue_main.id],
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+    )
+
+    # Verify source node metadata was updated
+    source_node = nodes_by_id[person_jack_main.id]
+    assert source_node._get_created_by() == SYSTEM_USER_ID
+    assert source_node._get_created_at() < create_time
+    assert source_node._get_updated_by() == "test_user"
+    assert source_node._get_updated_at() == create_time
+
+    # Verify destination node metadata was updated
+    dest_node = nodes_by_id[tag_blue_main.id]
+    assert dest_node._get_created_by() == SYSTEM_USER_ID
+    assert dest_node._get_created_at() < create_time
+    assert dest_node._get_updated_by() == "test_user"
+    assert dest_node._get_updated_at() == create_time
 
 
 async def test_query_RelationshipCreateQuery_w_node_property(
@@ -515,6 +559,55 @@ async def test_query_RelationshipDeleteQuery(
                 assert active_on_main or deleted_on_branch or deleted_on_branch_2
 
 
+async def test_query_RelationshipDeleteQuery_updates_node_metadata(
+    db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, person_jack_tags_main: Node
+) -> None:
+    """Test that RelationshipDeleteQuery updates updated_at/updated_by on source and destination nodes."""
+    person_schema = registry.schema.get(name="TestPerson")
+    rel_schema = person_schema.get_relationship("tags")
+
+    jack_main = await NodeManager.get_one(db=db, id=person_jack_tags_main.id)
+    tags_rels = await jack_main.tags.get(db=db)
+    blue_tag_rel = [t for t in tags_rels if t.peer_id == tag_blue_main.id][0]
+
+    delete_time = Timestamp()
+    query = await RelationshipDeleteQuery.init(
+        db=db,
+        source=person_jack_tags_main,
+        destination=tag_blue_main,
+        schema=rel_schema,
+        rel=blue_tag_rel,
+        branch=default_branch,
+        source_branch=default_branch,
+        destination_branch=default_branch,
+        at=delete_time,
+        user_id="delete_user",
+    )
+    await query.execute(db=db)
+
+    # Verify node metadata was updated using NodeManager
+    nodes_by_id = await NodeManager.get_many(
+        db=db,
+        branch=default_branch,
+        ids=[person_jack_tags_main.id, tag_blue_main.id],
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+    )
+
+    # Verify source node metadata was updated
+    source_node = nodes_by_id[person_jack_tags_main.id]
+    assert source_node._get_created_by() == SYSTEM_USER_ID
+    assert source_node._get_created_at() < delete_time
+    assert source_node._get_updated_by() == "delete_user"
+    assert source_node._get_updated_at() == delete_time
+
+    # Verify destination node metadata was updated
+    dest_node = nodes_by_id[tag_blue_main.id]
+    assert dest_node._get_created_by() == SYSTEM_USER_ID
+    assert dest_node._get_created_at() < delete_time
+    assert dest_node._get_updated_by() == "delete_user"
+    assert dest_node._get_updated_at() == delete_time
+
+
 async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
 ) -> None:
@@ -565,6 +658,55 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
     )
     await query.execute(db=db)
     await verify_no_duplicate_paths(db=db)
+
+
+async def test_query_RelationshipUpdatePropertyQuery_updates_node_metadata(
+    db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, person_jack_tags_main: Node
+) -> None:
+    """Test that RelationshipUpdatePropertyQuery updates updated_at/updated_by on peer nodes."""
+    person_schema = registry.schema.get(name="TestPerson")
+    rel_schema = person_schema.get_relationship("tags")
+
+    jack_main = await NodeManager.get_one(db=db, id=person_jack_tags_main.id)
+    tags_rels = await jack_main.tags.get(db=db)
+    blue_tag_rel = [t for t in tags_rels if t.peer_id == tag_blue_main.id][0]
+
+    update_time = Timestamp()
+    query = await RelationshipUpdatePropertyQuery.init(
+        db=db,
+        branch=default_branch,
+        source=person_jack_tags_main,
+        destination=tag_blue_main,
+        schema=rel_schema,
+        rel=blue_tag_rel,
+        at=update_time,
+        user_id="update_user",
+        flag_properties_to_update={"is_protected": True},
+        node_properties_to_update={},
+    )
+    await query.execute(db=db)
+
+    # Verify node metadata was updated using NodeManager
+    nodes_by_id = await NodeManager.get_many(
+        db=db,
+        branch=default_branch,
+        ids=[person_jack_tags_main.id, tag_blue_main.id],
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+    )
+
+    # Verify source node metadata was updated
+    source_node = nodes_by_id[person_jack_tags_main.id]
+    assert source_node._get_created_by() == SYSTEM_USER_ID
+    assert source_node._get_created_at() < update_time
+    assert source_node._get_updated_by() == "update_user"
+    assert source_node._get_updated_at() == update_time
+
+    # Verify destination node metadata was updated
+    dest_node = nodes_by_id[tag_blue_main.id]
+    assert dest_node._get_created_by() == SYSTEM_USER_ID
+    assert dest_node._get_created_at() < update_time
+    assert dest_node._get_updated_by() == "update_user"
+    assert dest_node._get_updated_at() == update_time
 
 
 async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch, tag_blue_main: Node) -> None:


### PR DESCRIPTION
when we update a Relationship on the default or global branch, we need to set the `updated_at/by` properties on both peer `Node`s, otherwise the destination peer Node will not get its updated_at/by metadata set correctly

also includes an update to `DATABASE.md` to help with cypher query generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive new documentation section with patterns and practical examples for identifying active nodes on default and global branches and managing their relationships.

* **Improvements**
  * Enhanced metadata synchronization to ensure modification timestamps are consistently propagated and properly maintained across all related entities whenever relationship operations (creation, updates, or deletions) occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->