### PR TITLE
Add branch metadata

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -375,7 +375,7 @@ async def load_schema(
                 branch.is_isolated = True
                 log.info("Branch converted to isolated mode because the schema has changed", branch=branch.name)
 
-            await branch.save(db=dbt)
+            await branch.save(db=dbt, user_id=account_session.account_id)
             updated_branch = registry.schema.get_schema_branch(name=branch.name)
             updated_hash = updated_branch.get_hash()
 

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Self, Union, cast
 from pydantic import Field, field_validator
 
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, SYSTEM_USER_ID
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.models import SchemaBranchHash  # noqa: TC001
 from infrahub.core.node.standard import StandardNode
@@ -281,9 +281,9 @@ class Branch(StandardNode):
 
         return start, end
 
-    async def create(self, db: InfrahubDatabase) -> bool:
+    async def create(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         self.graph_version = GRAPH_VERSION
-        return await super().create(db=db)
+        return await super().create(db=db, user_id=user_id)
 
     async def delete(self, db: InfrahubDatabase) -> None:
         if self.is_default:
@@ -494,7 +494,9 @@ class Branch(StandardNode):
 
         return filters, params
 
-    async def rebase(self, db: InfrahubDatabase, at: Optional[Union[str, Timestamp]] = None) -> None:
+    async def rebase(
+        self, db: InfrahubDatabase, at: Optional[Union[str, Timestamp]] = None, user_id: str = SYSTEM_USER_ID
+    ) -> None:
         """Rebase the current Branch with its origin branch"""
 
         at = Timestamp(at)
@@ -510,7 +512,7 @@ class Branch(StandardNode):
         #   Otherwise we could endup with a complicated situation
         self.branched_from = at.to_string()
         self.status = BranchStatus.OPEN
-        await self.save(db=db)
+        await self.save(db=db, user_id=user_id)
 
         # Update the branch in the registry after the rebase
         registry.branch[self.name] = self

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -165,7 +165,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         migrations = []
         async with lock.registry.global_graph_lock():
             async with db.start_transaction() as dbt:
-                await obj.rebase(db=dbt)
+                await obj.rebase(db=dbt, user_id=context.account.account_id)
                 log.info("Branch successfully rebased")
 
             if obj.has_schema_changes:
@@ -182,7 +182,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                 )
                 registry.schema.set_schema_branch(name=obj.name, schema=updated_schema)
                 obj.update_schema_hash()
-                await obj.save(db=db)
+                await obj.save(db=db, user_id=context.account.account_id)
 
                 # Execute the migrations
                 migrations = await merger.calculate_migrations(target_schema=updated_schema)
@@ -426,7 +426,7 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             new_schema = origin_schema.duplicate(name=obj.name)
             registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
             obj.update_schema_hash()
-            await obj.save(db=db)
+            await obj.save(db=db, user_id=context.account.account_id)
 
             # Add Branch to registry
             registry.branch[obj.name] = obj

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -7,9 +7,9 @@ from uuid import UUID
 
 import ujson
 from infrahub_sdk.uuidt import UUIDT
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from infrahub.core.constants import NULL_VALUE
+from infrahub.core.constants import NULL_VALUE, SYSTEM_USER_ID
 from infrahub.core.query.standard_node import (
     StandardNodeCreateQuery,
     StandardNodeDeleteQuery,
@@ -18,6 +18,7 @@ from infrahub.core.query.standard_node import (
     StandardNodeQuery,
     StandardNodeUpdateQuery,
 )
+from infrahub.core.timestamp import current_timestamp
 from infrahub.exceptions import Error, InitializationError
 
 if TYPE_CHECKING:
@@ -32,6 +33,9 @@ if TYPE_CHECKING:
 class StandardNode(BaseModel):
     id: Optional[str] = None
     uuid: Optional[UUID] = None
+    created_by: str = Field(default=SYSTEM_USER_ID)
+    updated_by: Optional[str] = Field(default=None)
+    updated_at: Optional[str] = Field(default=None, validate_default=True)
 
     _query: type[StandardNodeQuery] = StandardNodeCreateQuery
     _exclude_attrs: list[str] = ["id", "uuid", "_query"]
@@ -85,13 +89,13 @@ class StandardNode(BaseModel):
 
         return response
 
-    async def save(self, db: InfrahubDatabase) -> bool:
+    async def save(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Create or Update the Node in the database."""
 
         if self.id:
-            return await self.update(db=db)
+            return await self.update(db=db, user_id=user_id)
 
-        return await self.create(db=db)
+        return await self.create(db=db, user_id=user_id)
 
     async def delete(self, db: InfrahubDatabase) -> None:
         """Delete the Node in the database."""
@@ -99,9 +103,9 @@ class StandardNode(BaseModel):
         query: Query = await StandardNodeDeleteQuery.init(db=db, node=self)
         await query.execute(db=db)
 
-    async def create(self, db: InfrahubDatabase) -> bool:
+    async def create(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Create a new node in the database."""
-
+        self.created_by = user_id
         query: Query = await self._query.init(db=db, node=self)
         await query.execute(db=db)
 
@@ -115,9 +119,10 @@ class StandardNode(BaseModel):
 
         return True
 
-    async def update(self, db: InfrahubDatabase) -> bool:
+    async def update(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Update the node in the database if needed."""
-
+        self.updated_by = user_id
+        self.updated_at = current_timestamp()
         query: Query = await StandardNodeUpdateQuery.init(db=db, node=self)
         await query.execute(db=db)
         result = query.get_result()

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -172,7 +172,7 @@ class BranchUpdate(Mutation):
                 setattr(obj, field_name, data[field_name])
 
         async with graphql_context.db.start_transaction() as db:
-            await obj.save(db=db)
+            await obj.save(db=db, user_id=graphql_context.active_account_session.account_id)
 
         return cls(ok=True)
 

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -8,6 +8,7 @@ from infrahub_sdk.exceptions import BranchNotFoundError, GraphQLError
 from infrahub_sdk.graphql import Mutation
 
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.node import Node
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 
     from infrahub_sdk import InfrahubClient
 
-    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
 
@@ -144,21 +145,40 @@ class TestBranchMutations(TestInfrahubApp):
         branch_after = await client.branch.get(branch_name=branch.name)
         assert branch.branched_from != branch_after.branched_from
 
-    async def test_branch_rebase(self, initial_dataset: str, client: InfrahubClient) -> None:
-        branch = await client.branch.create(branch_name="branch_to_rebase_sync")
+    async def test_branch_rebase(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: str,
+        client: InfrahubClient,
+        bot_client: InfrahubClient,
+        admin_account: CoreAccount,
+        bot_account: CoreAccount,
+    ) -> None:
+        branch_name = "branch_to_rebase_sync"
+        branch = await client.branch.create(branch_name=branch_name)
+
+        async with db.start_session() as dbs:
+            rebase_branch_pre = await Branch.get_by_name(db=dbs, name=branch_name)
 
         query = Mutation(
             mutation="BranchRebase",
             input_data={"data": {"name": branch.name}},
             query={"ok": None, "task": {"id": None}, "object": {"id": None}},
         )
-        result = await client.execute_graphql(query=query.render())
+        result = await bot_client.execute_graphql(query=query.render())
         assert result["BranchRebase"]["ok"] is True
         assert result["BranchRebase"]["object"]["id"] == branch.id
         assert result["BranchRebase"]["task"] is None
 
         branch_after = await client.branch.get(branch_name=branch.name)
         assert branch.branched_from != branch_after.branched_from
+
+        # Validate updated_by field is correctly set until this can be queried via GraphQL and the metadata fields
+        async with db.start_session() as dbs:
+            rebase_branch = await Branch.get_by_name(db=dbs, name=branch_name)
+        assert rebase_branch.created_by == admin_account.id
+        assert rebase_branch.updated_by == bot_account.id
+        assert rebase_branch_pre.updated_by != rebase_branch.updated_by
 
     async def test_branch_validate_async(self, initial_dataset: str, client: InfrahubClient) -> None:
         branch = await client.branch.create(branch_name="branch_to_validate_async")
@@ -254,7 +274,9 @@ class TestBranchMutations(TestInfrahubApp):
         assert result["BranchMerge"]["object"]["id"] == branch.id
         assert result["BranchMerge"]["task"]["id"]
 
-    async def test_branch_create(self, initial_dataset: str, client: InfrahubClient) -> None:
+    async def test_branch_create(
+        self, initial_dataset: str, client: InfrahubClient, admin_account: CoreAccount, db: InfrahubDatabase
+    ) -> None:
         query = Mutation(
             mutation="BranchCreate",
             input_data={"data": {"name": "branch-2"}},
@@ -264,6 +286,11 @@ class TestBranchMutations(TestInfrahubApp):
         assert result["BranchCreate"]["ok"] is True
         assert result["BranchCreate"]["object"]["id"] is not None
         assert result["BranchCreate"]["task"] is None
+
+        # Validate created_by field is correctly set until this can be queried via GraphQL and the metadata fields
+        async with db.start_session() as dbs:
+            branch2 = await Branch.get_by_name(db=dbs, name="branch-2")
+        assert branch2.created_by == admin_account.id
 
     async def test_branch_create_duplicate_branch_failed(self, initial_dataset: str, client: InfrahubClient) -> None:
         branch_to_duplicate = await client.branch.create(branch_name="branch_to_duplicate")

--- a/backend/tests/functional/schemas/test_load_on_branch_and_main.py
+++ b/backend/tests/functional/schemas/test_load_on_branch_and_main.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
 
+from infrahub.core.branch import Branch
 from infrahub.core.constants import HashableModelState, RelationshipCardinality
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.definitions.core.artifact import core_artifact_target
 from infrahub.core.schema.definitions.core.lineage import lineage_owner, lineage_source
-from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.schema import CAR_SCHEMA, SNOW_TICKET_SCHEMA, load_schema
 from tests.helpers.schema.car import CAR
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.branch import BranchData
     from infrahub_sdk.node.node import InfrahubNode
 
-    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
     from infrahub.database import InfrahubDatabase
 
 
@@ -176,3 +177,26 @@ class TestLoadOnBranchAndMain(TestInfrahubApp):
             await fresh_car.partner_car.fetch()
             partner_car = cars[0] if car.id == cars[1].id else cars[1]
             assert fresh_car.partner_car.id == partner_car.id
+
+    async def test_load_schema_on_branch_alternate_user(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        bot_client: InfrahubClient,
+        load_schema,
+        admin_account: CoreAccount,
+        bot_account: CoreAccount,
+    ) -> None:
+        branch_name = "user_feature_branch"
+        await client.branch.create(branch_name=branch_name)
+
+        schema_root = SNOW_TICKET_SCHEMA.duplicate()
+        schema_root.version = "1.0"
+
+        response = await bot_client.schema.load(schemas=[schema_root.model_dump()], branch=branch_name)
+        assert len(response.errors) == 0, response.errors
+
+        async with db.start_session() as dbs:
+            feature_branch = await Branch.get_by_name(db=dbs, name=branch_name)
+        assert feature_branch.created_by == admin_account.id
+        assert feature_branch.updated_by == bot_account.id

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -20,6 +20,7 @@ from infrahub.core.initialization import (
     create_root_node,
     initialization,
 )
+from infrahub.core.protocols import CoreAccount
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -65,6 +66,10 @@ class TestInfrahub:
 class TestInfrahubApp(TestInfrahub):
     @pytest.fixture(scope="class")
     def api_admin_token(self) -> str:
+        return str(UUIDT())
+
+    @pytest.fixture(scope="class")
+    def api_bot_token(self) -> str:
         return str(UUIDT())
 
     @pytest.fixture(scope="class")
@@ -174,6 +179,29 @@ class TestInfrahubApp(TestInfrahub):
             yield sdk_client
 
     @pytest.fixture(scope="class")
+    async def bot_client(
+        self,
+        test_client: InfrahubTestClient,
+        api_bot_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> InfrahubClient:
+        """Similar to `client` fixture but using bot account credentials.
+
+        The reason for having this fixture is to be able to differentiate actions performed by
+        admin user vs another user in tests.
+        """
+        config = Config(
+            api_token=api_bot_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
+        )
+
+        return InfrahubClient(config=config)
+
+    @pytest.fixture(scope="class")
     async def unprivileged_client(
         self,
         test_client: InfrahubTestClient,
@@ -193,22 +221,46 @@ class TestInfrahubApp(TestInfrahub):
         return sdk_client
 
     @pytest.fixture(scope="class")
-    async def initialize_registry(
+    async def admin_account(
         self,
         db: InfrahubDatabase,
         register_core_schema: SchemaBranch,
         bus_simulator: BusSimulator,
         api_admin_token: str,
+    ) -> CoreAccount:
+        return await create_account(
+            db=db, name="admin", password=config.SETTINGS.initial.admin_password, token_value=api_admin_token
+        )
+
+    @pytest.fixture(scope="class")
+    async def bot_account(
+        self,
+        db: InfrahubDatabase,
+        register_core_schema: SchemaBranch,
+        bus_simulator: BusSimulator,
+        api_bot_token: str,
+    ) -> CoreAccount:
+        return await create_account(
+            db=db, name="infrahub-bot", password=config.SETTINGS.initial.admin_password, token_value=api_bot_token
+        )
+
+    @pytest.fixture(scope="class")
+    async def initialize_registry(
+        self,
+        db: InfrahubDatabase,
+        register_core_schema: SchemaBranch,
+        bus_simulator: BusSimulator,
+        admin_account: CoreAccount,
+        bot_account: CoreAccount,
         api_unprivileged_token: str,
     ) -> None:
         unprivileged_account = await create_account(
             db=db, name="unprivileged", password="testing_unprivileged_password", token_value=api_unprivileged_token
         )
-        admin_account = await create_account(
-            db=db, name="admin", password=config.SETTINGS.initial.admin_password, token_value=api_admin_token
-        )
 
-        await create_default_account_groups(db=db, admin_accounts=[admin_account], accounts=[unprivileged_account])
+        await create_default_account_groups(
+            db=db, admin_accounts=[admin_account, bot_account], accounts=[unprivileged_account]
+        )
 
         # This call emits a warning related to the fact database index manager has not been initialized.
         graphql_registry.clear_cache()

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -1,6 +1,7 @@
 import pytest
 from infrahub_sdk.client import InfrahubClient
 
+from infrahub.auth import AccountSession
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
@@ -343,7 +344,7 @@ async def test_branch_rebase_wrong_branch(
 
 
 async def test_branch_update_description(
-    db: InfrahubDatabase, base_dataset_02, local_services: InfrahubServices
+    db: InfrahubDatabase, base_dataset_02: dict, session_admin: AccountSession, local_services: InfrahubServices
 ) -> None:
     branch4 = await create_branch(branch_name="branch4", db=db)
 
@@ -361,7 +362,9 @@ async def test_branch_update_description(
     """
 
     branch4.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, branch=branch4, service=local_services)
+    gql_params = await prepare_graphql_params(
+        db=db, branch=branch4, account_session=session_admin, service=local_services
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -376,7 +379,10 @@ async def test_branch_update_description(
 
     branch4_updated = await Branch.get_by_name(db=db, name="branch4")
 
+    assert not branch4.updated_at
     assert branch4_updated.description == "testing"
+    assert branch4_updated.updated_at
+    assert branch4_updated.updated_by == session_admin.account_id
 
 
 async def test_branch_merge_wrong_branch(


### PR DESCRIPTION
Adds metadata to StandardNode or rather Branch. This PR takes a more pragmatic approach than what we have in #7701. The reason is that there's not much that a user can change on a branch. Mainly the description of a branch. Instead the focus is to allow us to create the user that created the branch as well as the user who last updated it, this could be due to changing the description, doing a rebase or loading a schema. It also includes a new .updated_at timestamp.

This doesn't yet expose this information to the GraphQL layer, that will be done in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit fields (created_by, updated_by, updated_at) and capture the acting user for branch/node create, update, rebase, save and schema load operations.

* **Tests**
  * Expanded unit and functional tests and fixtures to validate audit metadata and that acting account (admin/bot) is recorded correctly across branch and schema workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->