### PR TITLE
Pass account ID from mutations to Node methods

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
 
 from infrahub.core.constants import (
+    SYSTEM_USER_ID,
     InfrahubKind,
     MetadataOptions,
     RelationshipCardinality,
@@ -1415,6 +1416,7 @@ class NodeManager:
         branch: Branch | str | None = None,
         at: Timestamp | None = None,
         cascade_delete: bool = True,
+        user_id: str = SYSTEM_USER_ID,
     ) -> list[Node]:
         """Returns list of deleted nodes because of cascading deletes"""
         branch = await registry.get_branch(branch=branch, db=db)
@@ -1429,7 +1431,7 @@ class NodeManager:
                 nodes_to_delete += list(node_map.values())
 
         for node in nodes_to_delete:
-            await node.delete(db=db, at=at)
+            await node.delete(db=db, at=at, user_id=user_id)
 
         return nodes_to_delete
 

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from infrahub import lock
 from infrahub.core import registry
-from infrahub.core.constants import RelationshipCardinality, RelationshipKind
+from infrahub.core.constants import SYSTEM_USER_ID, RelationshipCardinality, RelationshipKind
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.node import Node
 from infrahub.core.node.lock_utils import get_lock_names_on_object_mutation
@@ -180,11 +180,12 @@ async def _do_create_node(
     fields_to_validate: list[str],
     data: dict[str, Any],
     at: Timestamp | None = None,
+    user_id: str = SYSTEM_USER_ID,
 ) -> Node:
     obj = await node_class.init(db=db, schema=schema, branch=branch)
     await obj.new(db=db, **data)
     await node_constraint_runner.check(node=obj, field_filters=fields_to_validate)
-    await obj.save(db=db, at=at)
+    await obj.save(db=db, at=at, user_id=user_id)
 
     object_template = await obj.get_object_template(db=db)
     if object_template:
@@ -205,6 +206,7 @@ async def create_node(
     branch: Branch,
     schema: MainSchemaTypes,
     at: Timestamp | None = None,
+    user_id: str = SYSTEM_USER_ID,
 ) -> Node:
     """Create a node in the database if constraint checks succeed."""
 
@@ -237,6 +239,7 @@ async def create_node(
                 fields_to_validate=fields_to_validate,
                 data=data,
                 at=at,
+                user_id=user_id,
             )
         else:
             async with db.start_transaction() as dbt:
@@ -253,11 +256,12 @@ async def create_node(
                     fields_to_validate=fields_to_validate,
                     data=data,
                     at=at,
+                    user_id=user_id,
                 )
 
     if await get_profile_ids(db=db, obj=obj):
         node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
         await node_profiles_applier.apply_profiles(node=obj)
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
 
     return obj

--- a/backend/infrahub/core/protocols_base.py
+++ b/backend/infrahub/core/protocols_base.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
+from infrahub.core.constants import SYSTEM_USER_ID
+
 if TYPE_CHECKING:
     from neo4j import AsyncResult, AsyncSession, AsyncTransaction, Record
 
@@ -82,8 +84,10 @@ class CoreNode(Protocol):
         at: Timestamp | str | None = None,
     ) -> Self: ...
     async def new(self, db: InfrahubDatabase, id: str | None = None, **kwargs: Any) -> Self: ...
-    async def save(self, db: InfrahubDatabase, at: Timestamp | None = None) -> Self: ...
-    async def delete(self, db: InfrahubDatabase, at: Timestamp | None = None) -> None: ...
+    async def save(self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID) -> Self: ...
+    async def delete(
+        self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID
+    ) -> None: ...
     async def load(
         self,
         db: InfrahubDatabase,

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -7,6 +7,7 @@ from starlette.background import BackgroundTasks
 
 from infrahub.context import InfrahubContext
 from infrahub.core import registry
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
 from infrahub.graphql.registry import registry as graphql_registry
@@ -74,6 +75,13 @@ class GraphqlContext:
 
     def get_context(self) -> InfrahubContext:
         return InfrahubContext.init(branch=self.branch, account=self.active_account_session)
+
+    @property
+    def assigned_user_id(self) -> str:
+        """Return the user ID to be used for assignments in this context."""
+        if self.account_session and self.account_session.account_id:
+            return self.account_session.account_id
+        return SYSTEM_USER_ID
 
 
 async def prepare_graphql_params(

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -99,7 +99,7 @@ class AccountMixin:
         )
 
         async with db.start_transaction() as dbt:
-            await obj.save(db=dbt)
+            await obj.save(db=dbt, user_id=account.id)
 
         fields = extract_graphql_fields(info=info)
         return cls(object=await obj.to_graphql(db=db, fields=fields.get("object", {})), ok=True)  # type: ignore[call-arg]
@@ -126,7 +126,7 @@ class AccountMixin:
             raise NodeNotFoundError(node_type="AccountToken", identifier=token_id)
 
         async with db.start_transaction() as dbt:
-            await results[0].delete(db=dbt)
+            await results[0].delete(db=dbt, user_id=account.id)
 
         return cls(ok=True)  # type: ignore[call-arg]
 
@@ -144,7 +144,7 @@ class AccountMixin:
                 getattr(account, field).value = value
 
         async with db.start_transaction() as dbt:
-            await account.save(db=dbt)
+            await account.save(db=dbt, user_id=account.id)
 
         return cls(ok=True)  # type: ignore[call-arg]
 

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -102,7 +102,7 @@ class UpdateComputedAttribute(Mutation):
         if attribute_field.value != str(data.value):
             attribute_field.value = str(data.value)
             async with graphql_context.db.start_transaction() as dbt:
-                await target_node.save(db=dbt, fields=[str(data.attribute)])
+                await target_node.save(db=dbt, fields=[str(data.attribute)], user_id=graphql_context.assigned_user_id)
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")

--- a/backend/infrahub/graphql/mutations/display_label.py
+++ b/backend/infrahub/graphql/mutations/display_label.py
@@ -93,7 +93,7 @@ class UpdateDisplayLabel(Mutation):
             await target_node.set_display_label(value=str(data.value))
 
             async with graphql_context.db.start_transaction() as dbt:
-                await target_node.save(db=dbt, fields=["display_label"])
+                await target_node.save(db=dbt, fields=["display_label"], user_id=graphql_context.assigned_user_id)
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")

--- a/backend/infrahub/graphql/mutations/hfid.py
+++ b/backend/infrahub/graphql/mutations/hfid.py
@@ -100,7 +100,7 @@ class UpdateHFID(Mutation):
             await target_node.set_human_friendly_id(value=updated_hfid)
 
             async with graphql_context.db.start_transaction() as dbt:
-                await target_node.save(db=dbt, fields=["human_friendly_id"])
+                await target_node.save(db=dbt, fields=["human_friendly_id"], user_id=graphql_context.assigned_user_id)
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -150,7 +150,8 @@ class InfrahubMutationMixin:
         database: InfrahubDatabase | None = None,
         override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
-        db = database or info.context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
         schema = cls._meta.active_schema
 
         create_data = dict(data)
@@ -161,6 +162,7 @@ class InfrahubMutationMixin:
             db=db,
             branch=branch,
             schema=schema,
+            user_id=graphql_context.assigned_user_id,
         )
 
         graphql_response = await build_graphql_response(info=info, db=db, obj=obj)
@@ -239,12 +241,13 @@ class InfrahubMutationMixin:
     async def mutate_update_object(
         cls,
         db: InfrahubDatabase,
-        info: GraphQLResolveInfo,  # noqa: ARG003
+        info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
         obj: Node,
         skip_uniqueness_check: bool = False,
     ) -> Node:
+        graphql_context: GraphqlContext = info.context
         component_registry = get_component_registry()
         node_constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
 
@@ -264,7 +267,7 @@ class InfrahubMutationMixin:
             node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
             updated_field_names = await node_profiles_applier.apply_profiles(node=obj)
             fields += updated_field_names
-        await obj.save(db=db, fields=fields)
+        await obj.save(db=db, fields=fields, user_id=graphql_context.assigned_user_id)
 
         return obj
 
@@ -381,7 +384,9 @@ class InfrahubMutationMixin:
     async def _delete_obj(cls, graphql_context: GraphqlContext, branch: Branch, obj: Node) -> list[Node]:
         db = graphql_context.db
         async with db.start_transaction() as dbt:
-            deleted = await NodeManager.delete(db=dbt, branch=branch, nodes=[obj])
+            deleted = await NodeManager.delete(
+                db=dbt, branch=branch, nodes=[obj], user_id=graphql_context.assigned_user_id
+            )
         deleted_str = ", ".join([f"{d.get_kind()}({d.get_id()})" for d in deleted])
         log.info(f"nodes deleted: {deleted_str}")
         return deleted

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -199,6 +199,6 @@ class InfrahubProfilesRefresh(Mutation):
         node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
         updated_fields = await node_profiles_applier.apply_profiles(node=obj)
         if updated_fields:
-            await obj.save(db=db, fields=updated_fields)
+            await obj.save(db=db, fields=updated_fields, user_id=graphql_context.assigned_user_id)
 
         return cls(ok=True)

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -292,7 +292,7 @@ class ProposedChangeReview(Mutation):
                     current_user=current_user,
                     context=graphql_context,
                 )
-                await proposed_change.save(db=db)
+                await proposed_change.save(db=db, user_id=graphql_context.active_account_session.account_id)
 
                 if event:
                     event_service = await get_event_service()
@@ -426,7 +426,7 @@ class ProposedChangeMerge(Mutation):
 
         async with graphql_context.db.start_session() as db:
             proposed_change.state.value = ProposedChangeState.MERGING.value
-            await proposed_change.save(db=db)
+            await proposed_change.save(db=db, user_id=graphql_context.assigned_user_id)
 
         if wait_until_completion:
             await graphql_context.service.workflow.execute_workflow(

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -118,7 +118,7 @@ class RelationshipAdd(Mutation):
                     if group_event_type != GroupUpdateType.NONE:
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.create_relationship(relationship=rel)
-                    await rel.save(db=db)
+                    await rel.save(db=db, user_id=graphql_context.assigned_user_id)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
@@ -242,7 +242,7 @@ class RelationshipRemove(Mutation):
                     if group_event_type != GroupUpdateType.NONE:
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.delete_relationship(relationship=rel)
-                    await rel.delete(db=db)
+                    await rel.delete(db=db, user_id=graphql_context.assigned_user_id)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:


### PR DESCRIPTION
Small change just to pass along the user information from the GraphQL layer into the node layer to make testing easier before all of the pieces are in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Database operations now include user attribution tracking for improved audit trail visibility across create, update, and delete actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->