### PR TITLE
Use CoreAccount for metadata in InfrahubBranch query

### DIFF
--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -10,7 +10,7 @@ import ujson
 from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel, Field, field_validator
 
-from infrahub.core.constants import NULL_VALUE, SYSTEM_USER_ID
+from infrahub.core.constants import NULL_VALUE, SYSTEM_USER_ID, InfrahubKind
 from infrahub.core.query.standard_node import (
     StandardNodeCreateQuery,
     StandardNodeDeleteQuery,
@@ -152,10 +152,10 @@ class StandardNode(BaseModel):
                     meta_response["updated_at"] = Timestamp(self.updated_at).to_datetime() if self.updated_at else None
                 case "created_by":
                     if self.created_by and self.created_by != SYSTEM_USER_ID:
-                        meta_response["created_by"] = {"id": self.created_by}
+                        meta_response["created_by"] = {"id": self.created_by, "__kind__": InfrahubKind.ACCOUNT}
                 case "updated_by":
                     if self.updated_by and self.updated_by != SYSTEM_USER_ID:
-                        meta_response["updated_by"] = {"id": self.updated_by}
+                        meta_response["updated_by"] = {"id": self.updated_by, "__kind__": InfrahubKind.ACCOUNT}
 
         return {"node": node_response, "node_metadata": meta_response}
 

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -66,6 +66,7 @@ from .types import (
 )
 from .types.attribute import BaseAttribute as BaseAttributeType
 from .types.attribute import TextAttributeType
+from .types.branch import InfrahubBranchEdge
 from .types.context import ContextInput
 from .types.event import EVENT_TYPES
 from .types.node import InfrahubObjectWithoutMeta
@@ -263,6 +264,19 @@ class GraphQLSchemaManager:
         )
         self.generate_graphql_paginated_object(schema=node_interface_schema, edge=edged_interface, populate_cache=True)
 
+    def _patch_static_types(self, node_metadata: type[InfrahubObject]) -> None:
+        """Patch statically defined GraphQL types to use dynamically generated types.
+
+        Some GraphQL types like InfrahubBranchEdge are defined statically but need to
+        reference dynamically generated types (like node_metadata with GenericAccount).
+        This method patches those static types after the dynamic types are created.
+
+        The method checks if the patch has already been applied to avoid redundant updates.
+        """
+        current_field = InfrahubBranchEdge._meta.fields.get("node_metadata")
+        if current_field is None or current_field.type != node_metadata:
+            InfrahubBranchEdge._meta.fields["node_metadata"] = graphene.Field(node_metadata, required=True)
+
     def _load_all_enum_types(self, node_schemas: Iterable[MainSchemaTypes]) -> None:
         for node_schema in node_schemas:
             self._load_enum_type(node_schema=node_schema)
@@ -342,6 +356,9 @@ class GraphQLSchemaManager:
 
         # Complete the CoreNode interface (edged/paginated) now that node_metadata exists
         self._complete_node_interface(node_metadata=node_metadata)
+
+        # Patch statically defined types to use dynamically generated types
+        self._patch_static_types(node_metadata=node_metadata)
 
         relationship_property = self.get_type(name="RelationshipProperty")
         for data_type in ATTRIBUTE_TYPES.values():

--- a/backend/infrahub/graphql/types/metadata.py
+++ b/backend/infrahub/graphql/types/metadata.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-from graphene import DateTime, Field, ObjectType, String
-
-
-class InfrahubStandardNodeMetaAccount(ObjectType):
-    id = String(required=True)
-    display_name = String(required=False)
+from graphene import DateTime, ObjectType
 
 
 class InfrahubStandardNodeMetaData(ObjectType):
+    """Base metadata type for standard nodes.
+
+    Note: created_by and updated_by fields are added dynamically by
+    GraphQLSchemaManager._patch_static_types() to use the GenericAccount interface.
+    """
+
     created_at = DateTime(required=False, description="Date/Time the object has been created")
-    created_by = Field(InfrahubStandardNodeMetaAccount, required=False)
     updated_at = DateTime(
         required=False, description="Date/Time when the object was last modified by a user or a system task"
     )
-    updated_by = Field(InfrahubStandardNodeMetaAccount, required=False)

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -7362,7 +7362,7 @@ type InfrahubBranch {
 
 type InfrahubBranchEdge {
   node: InfrahubBranch!
-  node_metadata: InfrahubStandardNodeMetaData!
+  node_metadata: InfrahubNodeMetadata!
 }
 
 type InfrahubBranchType {
@@ -7435,20 +7435,6 @@ type InfrahubRelationshipMetadata {
   created_by: CoreGenericAccount
   updated_at: DateTime
   updated_by: CoreGenericAccount
-}
-
-type InfrahubStandardNodeMetaAccount {
-  display_name: String
-  id: String!
-}
-
-type InfrahubStandardNodeMetaData {
-  """Date/Time the object has been created"""
-  created_at: DateTime
-  created_by: InfrahubStandardNodeMetaAccount
-  """Date/Time when the object was last modified by a user or a system task"""
-  updated_at: DateTime
-  updated_by: InfrahubStandardNodeMetaAccount
 }
 
 """Token for User Account"""


### PR DESCRIPTION
Ensure that we can use the dynamically created CoreAccount from the schema within queries that are statically defined in code. In this case we want to access CoreAccount for metadata purposes for the InfrahubBranch query. We do this by patching the static code class during schema generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced node metadata in GraphQL API to include comprehensive account information for `created_by` and `updated_by` fields.

* **Improvements**
  * Consolidated metadata type structure in the GraphQL schema for improved consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->