### PR TITLE
handle updated/created_at/by metadata in schema migrations

### DIFF
--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -237,6 +237,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
                 CREATE (n)-[:HAS_ATTRIBUTE { branch: $target_branch, branch_level: $branch_level, from: $at, status: attr_rel_status, from_user_id: attr_source_from_user_id }]->(a)
                 WITH attr_rel_status
                 WHERE attr_rel_status = "active"
+                AND a.created_at IS NULL
                 SET a.created_at = $at, a.created_by = attr_source_from_user_id
             }
             RETURN 1 AS done
@@ -648,12 +649,21 @@ CALL (n) {
     // create the outbound edges on the target branch, one subquery per possible type
     // from_user_id is copied from source edge via properties(latest_source_edge)
     // --------------
-    CALL (n, latest_source_edge, peer, edge_type, user_id) {
+    CALL (n) {
+        MATCH (earliest_n:Node {uuid: n.uuid})
+        RETURN earliest_n.created_at AS node_created_at, earliest_n.created_by AS node_created_by
+        ORDER BY earliest_n.created_at ASC
+        LIMIT 1
+    }
+    WITH *, COALESCE(node_created_at, $at) AS node_created_at, COALESCE(node_created_by, user_id) AS node_created_by
+    CALL (n, latest_source_edge, peer, edge_type, node_created_at, node_created_by) {
         WITH edge_type WHERE edge_type = "IS_PART_OF"
         CREATE (n)-[new_edge:IS_PART_OF]->(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
-        SET n.created_at = $at, n.created_by = user_id
+        WITH n
+        WHERE n.created_at IS NULL
+        SET n.created_at = node_created_at, n.created_by = node_created_by
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
         WITH peer, user_id, edge_type
@@ -661,6 +671,8 @@ CALL (n) {
         CREATE (n)-[new_edge:IS_RELATED]->(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        WITH peer
+        WHERE peer.created_at IS NULL
         SET peer.created_at = $at, peer.created_by = user_id
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
@@ -669,6 +681,8 @@ CALL (n) {
         CREATE (n)-[new_edge:HAS_ATTRIBUTE]->(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        WITH peer
+        WHERE peer.created_at IS NULL
         SET peer.created_at = $at, peer.created_by = user_id
     }
     // --------------
@@ -723,6 +737,8 @@ CALL (n) {
         CREATE (n)<-[new_edge:IS_RELATED]-(peer)
         SET new_edge = properties(latest_source_edge)
         SET new_edge.from = $at, new_edge.branch_level = $branch_level, new_edge.branch = $target_branch
+        WITH peer
+        WHERE peer.created_at IS NULL
         SET peer.created_at = $at, peer.created_by = user_id
     }
     CALL (n, latest_source_edge, peer, edge_type, user_id) {
@@ -799,14 +815,22 @@ class DiffMergeMetadataQuery(Query):
 UNWIND $node_uuids AS node_uuid
 CALL (node_uuid) {
     MATCH (n:Node {uuid: node_uuid})-[e:IS_PART_OF]->(:Root)
-    WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
+    WHERE e.branch IN [$target_branch, $global_branch]
     AND (
-        (e.branch = $target_branch AND e.from <= $branched_from)
-        OR (e.branch IN [$source_branch, $global_branch] AND e.from <= $at)
+        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at))
+        OR (e.branch = $global_branch AND e.from <= $at)
     )
-    RETURN n
-    ORDER BY e.from DESC
+    RETURN n, e AS is_part_of_e
+    ORDER BY e.from DESC, e.status ASC
     LIMIT 1
+}
+// --------------------
+// Special handling for the new version of a migrated kind/inheritance Node
+// --------------------
+CALL (n, is_part_of_e) {
+    WITH n, is_part_of_e
+    WHERE n.updated_at IS NULL
+    SET n.updated_at = is_part_of_e.from, n.updated_by = is_part_of_e.from_user_id
 }
 // --------------------
 // Get all the Attributes and Relationships for this Node that were active on this branch at some point
@@ -832,7 +856,7 @@ OR exists((field)-[{branch: $target_branch, to: $at}]-())
 // Prefer non-system users (those not starting with "__")
 // --------------------
 CALL (field) {
-    MATCH ()-[edge {branch: $source_branch}]-(field)
+    MATCH ()-[edge:!HAS_ATTRIBUTE&!IS_RELATED {branch: $source_branch}]-(field)
     WHERE edge.from <= $at
     // Collect both from and to timestamps as potential "change times"
     WITH edge,

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -646,8 +646,7 @@ CALL (n) {
         SET latest_target_edge.to = $at, latest_target_edge.to_user_id = user_id
     }
     // --------------
-    // create the outbound edges on the target branch, one subquery per possible type
-    // from_user_id is copied from source edge via properties(latest_source_edge)
+    // get the earliest created time to handle migrated kind/inheritance Nodes
     // --------------
     CALL (n) {
         MATCH (earliest_n:Node {uuid: n.uuid})
@@ -656,6 +655,10 @@ CALL (n) {
         LIMIT 1
     }
     WITH *, COALESCE(node_created_at, $at) AS node_created_at, COALESCE(node_created_by, user_id) AS node_created_by
+    // --------------
+    // create the outbound edges on the target branch, one subquery per possible type
+    // from_user_id is copied from source edge via properties(latest_source_edge)
+    // --------------
     CALL (n, latest_source_edge, peer, edge_type, node_created_at, node_created_by) {
         WITH edge_type WHERE edge_type = "IS_PART_OF"
         CREATE (n)-[new_edge:IS_PART_OF]->(peer)
@@ -826,6 +829,7 @@ CALL (node_uuid) {
 }
 // --------------------
 // Special handling for the new version of a migrated kind/inheritance Node
+// set updated_at/by to the time/user that created the new version of the Node
 // --------------------
 CALL (n, is_part_of_e) {
     WITH n, is_part_of_e
@@ -856,6 +860,8 @@ OR exists((field)-[{branch: $target_branch, to: $at}]-())
 // Prefer non-system users (those not starting with "__")
 // --------------------
 CALL (field) {
+    // ignore HAS_ATTRIBUTE and IS_RELATED b/c these show when an Attribute/Relationship was created/deleted
+    // not when it was updated
     MATCH ()-[edge:!HAS_ATTRIBUTE&!IS_RELATED {branch: $source_branch}]-(field)
     WHERE edge.from <= $at
     // Collect both from and to timestamps as potential "change times"

--- a/backend/infrahub/core/metadata/query/node_metadata.py
+++ b/backend/infrahub/core/metadata/query/node_metadata.py
@@ -126,12 +126,11 @@ class NodeMetadataDefaultBranchQuery(Query):
 // ------------------
 // Part 1: Get node metadata with deletion status
 // ------------------
-MATCH (n:Node)
-WHERE n.uuid IN $node_uuids
-CALL (n) {
-    MATCH (n)-[r_ipo:IS_PART_OF]->(root:Root)
+UNWIND $node_uuids AS node_uuid
+CALL (node_uuid) {
+    MATCH (n:Node {uuid: node_uuid})-[r_ipo:IS_PART_OF]->(root:Root)
     WHERE r_ipo.branch = $branch
-    RETURN r_ipo
+    RETURN n, r_ipo
     ORDER BY r_ipo.from DESC
     LIMIT 1
 }

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core import registry
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.schema.manager import SchemaManager
@@ -26,7 +27,7 @@ class Migration017(InternalSchemaMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         """
         Load CoreProfile schema node in db.
         """

--- a/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core import registry
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.diff.payload_builder import get_display_labels_per_kind
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot, internal_schema
@@ -95,5 +96,5 @@ class Migration018(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         return await validate_nulls_in_uniqueness_constraints(db=db)

--- a/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.log import get_logger
 
@@ -22,5 +23,5 @@ class Migration025(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         return await validate_nulls_in_uniqueness_constraints(db=db)

--- a/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
@@ -4,6 +4,7 @@ import ipaddress
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core.branch.models import Branch
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
@@ -28,7 +29,7 @@ class Migration026(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Sequence
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SchemaPathType
+from infrahub.core.constants import SYSTEM_USER_ID, SchemaPathType
 from infrahub.core.initialization import initialization
 from infrahub.core.migrations.shared import InternalSchemaMigration, MigrationResult, SchemaMigration
 from infrahub.core.path import SchemaPath
@@ -35,7 +35,7 @@ class Migration031(InternalSchemaMigration):
     minimum_version: int = 30
     migrations: Sequence[SchemaMigration] = []
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         """Retrieve all number attributes that have a min/max/excluded_values
         For any of these attributes, check if corresponding existing nodes are valid."""
 

--- a/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
@@ -4,6 +4,7 @@ import ipaddress
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core.branch.models import Branch
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
@@ -37,7 +38,7 @@ class Migration038(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -47,11 +47,14 @@ class AttributeAddQuery(Query):
         else:
             self.params["attr_value"] = NULL_VALUE
 
+        self.params["user_id"] = self.user_id
+
         self.params["rel_props"] = {
             "branch": self.branch.name,
             "branch_level": self.branch.hierarchy_level,
             "status": RelationshipStatus.ACTIVE.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         self.params["is_protected_default"] = False
@@ -104,7 +107,7 @@ class AttributeAddQuery(Query):
         CREATE (a)-[:IS_PROTECTED $rel_props]->(is_protected_value)
         %(uuid_generation)s
         FOREACH (i in CASE WHEN has_attr_e.status = "deleted" THEN [1] ELSE [] END |
-            SET has_attr_e.to = $current_time
+            SET has_attr_e.to = $current_time, has_attr_e.to_user_id = $user_id
         )
         """ % {
             "match_query": match_query,

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -59,6 +59,9 @@ class AttributeAddQuery(Query):
 
         self.params["is_protected_default"] = False
 
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         attr_value_label = GraphAttributeValueNode.get_default_label()
         if not is_large_attribute_type(self.attribute_kind):
             # should be indexed
@@ -106,6 +109,14 @@ class AttributeAddQuery(Query):
         CREATE (a)-[:HAS_VALUE $rel_props ]->(av)
         CREATE (a)-[:IS_PROTECTED $rel_props]->(is_protected_value)
         %(uuid_generation)s
+        // Set metadata on Attribute and Node vertices if on default/global branch
+        WITH a, n, has_attr_e
+        CALL (a, n) {
+            WITH a, n
+            WHERE $set_metadata
+            SET a.created_at = $current_time, a.created_by = $user_id, a.updated_at = $current_time, a.updated_by = $user_id
+            SET n.updated_at = $current_time, n.updated_by = $user_id
+        }
         FOREACH (i in CASE WHEN has_attr_e.status = "deleted" THEN [1] ELSE [] END |
             SET has_attr_e.to = $current_time, has_attr_e.to_user_id = $user_id
         )

--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -53,11 +53,14 @@ class AttributeRemoveQuery(Query):
         self.params["current_time"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
 
+        self.params["user_id"] = self.user_id
+
         self.params["rel_props"] = {
             "branch": self.branch.name,
             "branch_level": self.branch.hierarchy_level,
             "status": RelationshipStatus.DELETED.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         def render_sub_query_per_rel_type(rel_type: str, rel_def: FieldInfo) -> str:
@@ -123,7 +126,7 @@ class AttributeRemoveQuery(Query):
         }
         WITH p2 as peer_node, rb, active_attr
         FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
-            SET rb.to = $current_time
+            SET rb.to = $current_time, rb.to_user_id = $user_id
         )
         RETURN DISTINCT active_attr
         """ % {

--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -63,6 +63,9 @@ class AttributeRemoveQuery(Query):
             "from_user_id": self.user_id,
         }
 
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         def render_sub_query_per_rel_type(rel_type: str, rel_def: FieldInfo) -> str:
             subquery = [
                 "WITH peer_node, rb, active_attr",
@@ -109,9 +112,9 @@ class AttributeRemoveQuery(Query):
         }
         WITH n1 as active_node, r1 as rb, attr1 as active_attr
         WHERE rb.status = "active"
-        WITH active_attr
+        WITH active_node, active_attr
         MATCH (active_attr)-[]-(peer)
-        WITH DISTINCT active_attr, peer
+        WITH DISTINCT active_node, active_attr, peer
         CALL (active_attr, peer) {
             MATCH (active_attr)-[r]-(peer)
             WHERE %(branch_filter)s
@@ -119,15 +122,23 @@ class AttributeRemoveQuery(Query):
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH a1 as active_attr, r1 as rb, p1 as peer_node
+        WITH active_node, a1 as active_attr, r1 as rb, p1 as peer_node
         WHERE rb.status = "active"
         CALL (peer_node, rb, active_attr) {
             %(sub_query_all)s
         }
-        WITH p2 as peer_node, rb, active_attr
+        WITH p2 as peer_node, rb, active_node, active_attr
         FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
             SET rb.to = $current_time, rb.to_user_id = $user_id
         )
+        // Set metadata on Attribute and Node vertices if on default/global branch
+        WITH active_attr, active_node
+        CALL (active_attr, active_node) {
+            WITH active_attr, active_node
+            WHERE $set_metadata
+            SET active_attr.updated_at = $current_time, active_attr.updated_by = $user_id
+            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+        }
         RETURN DISTINCT active_attr
         """ % {
             "branch_filter": branch_filter,

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -32,7 +32,6 @@ class AttributeRenameQuery(Query):
     ) -> None:
         self.previous_attr = previous_attr
         self.new_attr = new_attr
-
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
@@ -94,11 +93,14 @@ class AttributeRenameQuery(Query):
         self.params["current_time"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
 
+        self.params["user_id"] = self.user_id
+
         self.params["rel_props_create"] = {
             "branch": self.branch.name,
             "branch_level": self.branch.hierarchy_level,
             "status": RelationshipStatus.ACTIVE.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         self.params["rel_props_delete"] = {
@@ -106,6 +108,7 @@ class AttributeRenameQuery(Query):
             "branch_level": self.branch.hierarchy_level,
             "status": RelationshipStatus.DELETED.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         sub_queries_create = [
@@ -175,7 +178,7 @@ class AttributeRenameQuery(Query):
         else:
             query = """
             FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
-                SET rb.to = $current_time
+                SET rb.to = $current_time, rb.to_user_id = $user_id
             )
             RETURN DISTINCT new_attr
             """

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -111,6 +111,9 @@ class AttributeRenameQuery(Query):
             "from_user_id": self.user_id,
         }
 
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         sub_queries_create = [
             self._render_sub_query_per_rel_type_create_new(rel_type, rel_def)
             for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
@@ -148,8 +151,9 @@ class AttributeRenameQuery(Query):
         WHERE rb.status = "active"
         CREATE (new_attr:Attribute { name: $new_attr.name, branch_support: $new_attr.branch_support })
         %(add_uuid)s
-        WITH active_attr, new_attr
+        WITH active_node, active_attr, new_attr
         MATCH (active_attr)-[]-(peer)
+        WITH DISTINCT active_node, active_attr, new_attr, peer
         CALL (active_attr, peer) {
             MATCH (active_attr)-[r]-(peer)
             WHERE %(branch_filter)s
@@ -157,12 +161,12 @@ class AttributeRenameQuery(Query):
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH a1 as active_attr, r1 as rb, p1 as peer_node, new_attr
+        WITH active_node, a1 as active_attr, r1 as rb, p1 as peer_node, new_attr
         WHERE rb.status = "active"
         CALL (peer_node, rb, active_attr, new_attr){
             %(sub_query_create_all)s
         }
-        WITH p2 as peer_node, rb, new_attr, active_attr
+        WITH p2 as peer_node, rb, new_attr, active_attr, active_node
         """ % {"branch_filter": branch_filter, "add_uuid": add_uuid, "sub_query_create_all": sub_query_create_all}
         self.add_to_query(query)
 
@@ -180,6 +184,15 @@ class AttributeRenameQuery(Query):
             FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
                 SET rb.to = $current_time, rb.to_user_id = $user_id
             )
+            WITH new_attr, active_node
+            // Set metadata on new Attribute and Node vertices if on default/global branch
+            CALL (new_attr, active_node) {
+                WITH new_attr, active_node
+                WHERE $set_metadata
+                SET new_attr.created_at = $current_time, new_attr.created_by = $user_id
+                SET new_attr.updated_at = $current_time, new_attr.updated_by = $user_id
+                SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+            }
             RETURN DISTINCT new_attr
             """
             self.add_to_query(query)

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -40,7 +40,6 @@ class NodeDuplicateQuery(Query):
     ) -> None:
         self.previous_node = previous_node
         self.new_node = new_node
-
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
@@ -140,14 +139,18 @@ class NodeDuplicateQuery(Query):
         self.params["branch_level"] = self.branch.hierarchy_level
         self.params["branch_support"] = self.new_node.branch_support
 
+        self.params["user_id"] = self.user_id
+
         self.params["rel_props_new"] = {
             "status": RelationshipStatus.ACTIVE.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         self.params["rel_props_prev"] = {
             "status": RelationshipStatus.DELETED.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         sub_query_out, sub_query_out_args = self._render_sub_query_out()
@@ -185,7 +188,7 @@ class NodeDuplicateQuery(Query):
         }
         WITH p2 as peer_node, rel_outband, active_node, new_node
         FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_outband.to = $current_time
+            SET rel_outband.to = $current_time, rel_outband.to_user_id = $user_id
         )
         WITH DISTINCT active_node, new_node
         // Process Inbound Relationship
@@ -205,7 +208,7 @@ class NodeDuplicateQuery(Query):
         }
         WITH p2 as peer_node, rel_inband, active_node, new_node
         FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_inband.to = $current_time
+            SET rel_inband.to = $current_time, rel_inband.to_user_id = $user_id
         )
 
         RETURN DISTINCT new_node

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -153,6 +153,9 @@ class NodeDuplicateQuery(Query):
             "from_user_id": self.user_id,
         }
 
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         sub_query_out, sub_query_out_args = self._render_sub_query_out()
         sub_query_in, sub_query_in_args = self._render_sub_query_in()
 
@@ -171,6 +174,16 @@ class NodeDuplicateQuery(Query):
         WHERE rb.status = "active"
         CREATE (new_node:Node:%(labels)s { uuid: active_node.uuid, kind: $new_node.kind, namespace: $new_node.namespace, branch_support: $new_node.branch_support })
         WITH active_node, new_node
+        // Set metadata on new Node vertex
+        CALL (active_node, new_node) {
+            // always pass created_by/at from active node
+            SET new_node.created_at = active_node.created_at, new_node.created_by = active_node.created_by
+            WITH new_node
+            // set updated_by/at if we're on the default/global branch
+            WHERE $set_metadata
+            SET new_node.updated_at = $current_time, new_node.updated_by = $user_id
+        }
+
         // Process Outbound Relationship
         MATCH (active_node)-[]->(peer)
         WITH DISTINCT active_node, new_node, peer
@@ -210,7 +223,6 @@ class NodeDuplicateQuery(Query):
         FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
             SET rel_inband.to = $current_time, rel_inband.to_user_id = $user_id
         )
-
         RETURN DISTINCT new_node
         """ % {
             "branch_filter": branch_filter,

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.types import is_large_attribute_type
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
@@ -26,6 +27,7 @@ class AttributeKindUpdateMigrationQuery(AttributeMigrationQuery):
         self.params["branch_level"] = self.branch.hierarchy_level
         self.params["at"] = self.at.to_string()
         self.params["attr_name"] = self.migration.previous_attribute_schema.name
+        self.params["user_id"] = self.user_id
         new_attr_value_labels = "AttributeValue"
         if needs_index:
             new_attr_value_labels += ":AttributeValueIndexed"
@@ -109,6 +111,7 @@ CALL (attr, has_value_e, av) {
     SET new_has_value_e.branch = $branch
     SET new_has_value_e.branch_level = $branch_level
     SET new_has_value_e.from = $at
+    SET new_has_value_e.from_user_id = $user_id
     SET new_has_value_e.to = NULL
 
     // ------------
@@ -123,6 +126,7 @@ CALL (attr, has_value_e, av) {
     SET deleted_has_value_e.branch = $branch
     SET deleted_has_value_e.branch_level = $branch_level
     SET deleted_has_value_e.from = $at
+    SET deleted_has_value_e.from_user_id = $user_id
     SET deleted_has_value_e.to = NULL
 }
 
@@ -133,7 +137,7 @@ CALL (attr, has_value_e, av) {
 CALL (has_value_e) {
     WITH has_value_e
     WHERE has_value_e.branch = $branch
-    SET has_value_e.to = $at
+    SET has_value_e.to = $at, has_value_e.to_user_id = $user_id
 }
         """ % {
             "schema_kind": self.migration.previous_schema.kind,
@@ -153,10 +157,11 @@ class AttributeKindUpdateMigration(AttributeSchemaMigration):
         branch: Branch,
         at: Timestamp | str | None = None,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
+        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         is_indexed_previous = is_large_attribute_type(self.previous_attribute_schema.kind)
         is_indexed_new = is_large_attribute_type(self.new_attribute_schema.kind)
         if is_indexed_previous is is_indexed_new:
             return MigrationResult()
 
-        return await super().execute(db=db, branch=branch, at=at, queries=queries)
+        return await super().execute(db=db, branch=branch, at=at, queries=queries, user_id=user_id)

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -28,6 +28,10 @@ class AttributeKindUpdateMigrationQuery(AttributeMigrationQuery):
         self.params["at"] = self.at.to_string()
         self.params["attr_name"] = self.migration.previous_attribute_schema.name
         self.params["user_id"] = self.user_id
+
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         new_attr_value_labels = "AttributeValue"
         if needs_index:
             new_attr_value_labels += ":AttributeValueIndexed"
@@ -138,6 +142,16 @@ CALL (has_value_e) {
     WITH has_value_e
     WHERE has_value_e.branch = $branch
     SET has_value_e.to = $at, has_value_e.to_user_id = $user_id
+}
+
+// ------------
+// Set metadata on Attribute and Node vertices if on default/global branch
+// ------------
+CALL (attr, n) {
+    WITH attr, n
+    WHERE $set_metadata
+    SET attr.updated_at = $at, attr.updated_by = $user_id
+    SET n.updated_at = $at, n.updated_by = $user_id
 }
         """ % {
             "schema_kind": self.migration.previous_schema.kind,

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations.query.attribute_remove import AttributeRemoveQuery
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
@@ -73,6 +74,7 @@ class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
         branch: Branch,
         at: Timestamp | str | None = None,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,  # noqa: ARG002
+        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         if (
             # no change in whether the attribute should be used on profiles
@@ -87,4 +89,4 @@ class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
         if not self.new_attribute_schema.support_profiles:
             profiles_queries.append(ProfilesAttributeRemoveMigrationQuery)
 
-        return await super().execute(db=db, branch=branch, at=at, queries=profiles_queries)
+        return await super().execute(db=db, branch=branch, at=at, queries=profiles_queries, user_id=user_id)

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core import registry
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.node import Node
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
@@ -65,10 +66,11 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         branch: Branch,
         at: Timestamp | str | None = None,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
+        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         if self.new_attribute_schema.inherited is True:
             return MigrationResult()
-        return await super().execute(db=db, branch=branch, at=at, queries=queries)
+        return await super().execute(db=db, branch=branch, at=at, queries=queries, user_id=user_id)
 
     async def execute_post_queries(
         self,
@@ -76,6 +78,7 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         result: MigrationResult,
         branch: Branch,
         at: Timestamp,  # noqa: ARG002
+        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         if self.new_attribute_schema.kind != "NumberPool":
             return result

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -59,6 +59,9 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
             "from_user_id": self.user_id,
         }
 
+        # Set metadata for vertex properties on default/global branch
+        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
+
         node_remove_query = self.render_node_remove_query(branch_filter=branch_filter)
 
         query = """
@@ -74,6 +77,13 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
         WITH n1 as active_node, r1 as rb
         WHERE rb.status = "active"
         %(node_remove_query)s
+        WITH active_node
+        // Set metadata on Node vertex if on default/global branch
+        CALL (active_node) {
+            WITH active_node
+            WHERE $set_metadata
+            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+        }
         RETURN DISTINCT active_node
         """ % {
             "branch_filter": branch_filter,
@@ -105,6 +115,11 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
         }
         WITH n1 as active_node, rel_inband1 as rel_inband, p1 as peer_node
         WHERE rel_inband.status = "active"
+        CALL (peer_node) {
+            WITH peer_node
+            WHERE $set_metadata
+            SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
+        }
         CALL (%(sub_query_args)s) {
             %(sub_query)s
         }
@@ -152,6 +167,11 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
         }
         WITH n1 as active_node, rel_outband1 as rel_outband, p1 as peer_node
         WHERE rel_outband.status = "active"
+        CALL (peer_node) {
+            WITH peer_node
+            WHERE $set_metadata
+            SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
+        }
         CALL (%(sub_query_args)s) {
             %(sub_query)s
         }

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -51,10 +51,12 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
         self.params["branch_name"] = self.branch.name
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
+        self.params["user_id"] = self.user_id
 
         self.params["rel_props"] = {
             "status": RelationshipStatus.DELETED.value,
             "from": self.at.to_string(),
+            "from_user_id": self.user_id,
         }
 
         node_remove_query = self.render_node_remove_query(branch_filter=branch_filter)
@@ -108,7 +110,7 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
         }
         WITH p2 as peer_node, rel_inband, active_node
         FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_inband.to = $current_time
+            SET rel_inband.to = $current_time, rel_inband.to_user_id = $user_id
         )
         """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
         return query
@@ -154,7 +156,7 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
             %(sub_query)s
         }
         FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_outband.to = $current_time
+            SET rel_outband.to = $current_time, rel_outband.to_user_id = $user_id
         )
         """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
 

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from typing_extensions import Self
 
 from infrahub.core import registry
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema, SchemaRoot, internal_schema
@@ -62,6 +63,7 @@ class SchemaMigration(BaseModel):
         result: MigrationResult,
         branch: Branch,  # noqa: ARG002
         at: Timestamp,  # noqa: ARG002
+        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         return result
 
@@ -71,6 +73,7 @@ class SchemaMigration(BaseModel):
         result: MigrationResult,
         branch: Branch,  # noqa: ARG002
         at: Timestamp,  # noqa: ARG002
+        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         return result
 
@@ -81,10 +84,11 @@ class SchemaMigration(BaseModel):
         branch: Branch,
         at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]],
+        user_id: str,
     ) -> MigrationResult:
         for migration_query in queries:
             try:
-                query = await migration_query.init(db=db, branch=branch, at=at, migration=self)
+                query = await migration_query.init(db=db, branch=branch, at=at, migration=self, user_id=user_id)
                 await query.execute(db=db)
                 result.nbr_migrations_executed += query.get_nbr_migrations_executed()
             except Exception as exc:
@@ -99,15 +103,18 @@ class SchemaMigration(BaseModel):
         branch: Branch,
         at: Timestamp | str | None = None,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
+        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         async with db.start_transaction() as ts:
             result = MigrationResult()
             at = Timestamp(at)
 
-            await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at)
+            await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at, user_id=user_id)
             queries_to_execute = queries or self.queries
-            await self.execute_queries(db=ts, result=result, branch=branch, at=at, queries=queries_to_execute)
-            await self.execute_post_queries(db=ts, result=result, branch=branch, at=at)
+            await self.execute_queries(
+                db=ts, result=result, branch=branch, at=at, queries=queries_to_execute, user_id=user_id
+            )
+            await self.execute_post_queries(db=ts, result=result, branch=branch, at=at, user_id=user_id)
 
         return result
 
@@ -209,14 +216,14 @@ class InternalSchemaMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
         result = MigrationResult()
 
         default_branch = registry.get_branch_from_registry()
 
         for migration in self.migrations:
             try:
-                execution_result = await migration.execute(db=db, branch=default_branch)
+                execution_result = await migration.execute(db=db, branch=default_branch, user_id=user_id)
                 result.errors.extend(execution_result.errors)
             except Exception as exc:
                 result.errors.append(str(exc))

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -13,7 +13,7 @@ from neo4j.graph import Relationship as Neo4jRelationship
 from opentelemetry import trace
 
 from infrahub import config
-from infrahub.core.constants import PermissionLevel
+from infrahub.core.constants import SYSTEM_USER_ID, PermissionLevel
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import QueryError
 
@@ -352,6 +352,7 @@ class Query(ABC):
         offset: int | None = None,
         order_by: list[str] | None = None,
         branch_agnostic: bool = False,
+        user_id: str = SYSTEM_USER_ID,
     ):
         if branch:
             self.branch = branch
@@ -367,6 +368,7 @@ class Query(ABC):
         self.limit = limit
         self.offset = offset
         self.order_by = order_by
+        self.user_id = user_id
 
         # Initialize internal variables
         self.params: dict = {}

--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -27,7 +27,6 @@ class AttributeQuery(Query):
     def __init__(
         self,
         attr: BaseAttribute,
-        user_id: str,
         attr_id: str | None = None,
         at: Timestamp | str | None = None,
         branch: Branch | None = None,
@@ -35,7 +34,6 @@ class AttributeQuery(Query):
     ):
         self.attr = attr
         self.attr_id = attr_id or attr.db_id
-        self.user_id = user_id
 
         if at:
             self.at = Timestamp(at)

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -752,10 +752,13 @@ WITH *,
 WITH *, a.created_at AS created_at, a.created_by AS created_by
             """
         else:
-            # use the "lower" (:Attribute)-[]->() edge to handle the case when the attribute
-            # is on a migrated-kind node
             last_created_query = """
-WITH *, r1.from AS created_at, r1.from_user_id AS created_by
+CALL (a) {
+    MATCH ()-[e:HAS_ATTRIBUTE {status: "active"}]->(a)
+    RETURN e.from AS created_at, e.from_user_id AS created_by
+    ORDER BY e.from ASC
+    LIMIT 1
+}
             """
         self.add_to_query(last_created_query)
         self.return_labels.extend(["created_at", "created_by"])

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -755,7 +755,7 @@ WITH *, a.created_at AS created_at, a.created_by AS created_by
             # use the "lower" (:Attribute)-[]->() edge to handle the case when the attribute
             # is on a migrated-kind node
             last_created_query = """
-WITH *, r2.from AS created_at, r2.from_user_id AS created_by
+WITH *, r1.from AS created_at, r1.from_user_id AS created_by
             """
         self.add_to_query(last_created_query)
         self.return_labels.extend(["created_at", "created_by"])

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -107,7 +107,6 @@ class PeerInfo:
 class NodeQuery(Query):
     def __init__(
         self,
-        user_id: str,
         node: Node | None = None,
         node_id: str | None = None,
         node_db_id: int | None = None,
@@ -115,7 +114,6 @@ class NodeQuery(Query):
         branch: Branch | None = None,
         **kwargs,
     ) -> None:
-        self.user_id = user_id
         self.node = node
         self.node_id = node_id or id
         self.node_db_id = node_db_id
@@ -754,8 +752,10 @@ WITH *,
 WITH *, a.created_at AS created_at, a.created_by AS created_by
             """
         else:
+            # use the "lower" (:Attribute)-[]->() edge to handle the case when the attribute
+            # is on a migrated-kind node
             last_created_query = """
-WITH *, r1.from AS created_at, r1.from_user_id AS created_by
+WITH *, r2.from AS created_at, r2.from_user_id AS created_by
             """
         self.add_to_query(last_created_query)
         self.return_labels.extend(["created_at", "created_by"])
@@ -787,7 +787,7 @@ WITH *, a.updated_at AS updated_at, a.updated_by AS updated_by
                 """
             last_updated_query = """
 CALL (a) {
-    MATCH (a)-[r]-(property)
+    MATCH (a)-[r]->(property)
     WHERE %(branch_filter)s
     %(time_details)s
     WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
@@ -1072,7 +1072,9 @@ WITH *, rel.updated_at AS updated_at, rel.updated_by AS updated_by
                 """
             last_updated_query = """
 CALL (rel) {
-    MATCH (rel)-[r]-(property)
+    // don't use IS_RELATED edges to handle the case when at least one of the
+    // peers is a migrated-kind node
+    MATCH (rel)-[r:!IS_RELATED]->(property)
     WHERE %(branch_filter)s
     %(time_details)s
     WITH collect(from_details) AS from_details_list, collect(to_details) AS to_details_list
@@ -1276,6 +1278,24 @@ class NodeListGetInfoQuery(Query):
     def _needs_user_timestamp_metadata(self) -> bool:
         return bool(self.include_metadata & MetadataOptions.USER_TIMESTAMPS)
 
+    def _add_created_metadata_to_query(self, branch_filter_str: str) -> None:
+        if self.branch.is_default or self.branch.is_global:
+            created_metadata_query = """
+WITH *, n.created_at AS created_at, n.created_by AS created_by
+            """
+        else:
+            created_metadata_query = """
+CALL (n) {
+    MATCH (:Node {uuid: n.uuid})-[r:IS_PART_OF {status: "active"}]->(:Root)
+    WHERE %(branch_filter)s
+    RETURN r.from AS created_at, r.from_user_id AS created_by
+    ORDER BY r.from ASC
+    LIMIT 1
+}
+            """ % {"branch_filter": branch_filter_str}
+        self.add_to_query(created_metadata_query)
+        self.return_labels.extend(["created_at", "created_by"])
+
     def _add_updated_metadata_to_query(self, branch_filter_str: str) -> None:
         if self.branch.is_default or self.branch.is_global:
             last_update_query = """
@@ -1303,15 +1323,6 @@ WITH *, n.updated_at AS updated_at, n.updated_by AS updated_by
 MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
 WHERE %(branch_filter)s
 WITH DISTINCT n, r_is_part_of, field
-CALL (n, field) {
-    MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED]-(field)
-    WHERE %(branch_filter)s
-    RETURN r.status = "active" AS is_active
-    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
-    LIMIT 1
-}
-WITH n, r_is_part_of, field
-WHERE is_active = TRUE
 CALL (field) {
     MATCH (field)-[r]-(property)
     WHERE %(branch_filter)s
@@ -1364,9 +1375,8 @@ WITH n, r_is_part_of, head(collect(updated_at)) AS updated_at, head(collect(upda
         ]
 
         if self._needs_user_timestamp_metadata():
-            self.return_labels.append("r_is_part_of.from AS created_at")
-            self.return_labels.append("r_is_part_of.from_user_id AS created_by")
             self._add_updated_metadata_to_query(branch_filter_str=branch_filter)
+            self._add_created_metadata_to_query(branch_filter_str=branch_filter)
 
     async def get_nodes(self, db: InfrahubDatabase, duplicate: bool = False) -> AsyncIterator[NodeToProcess]:
         """Return all the node objects as NodeToProcess."""

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -268,17 +268,7 @@ class RelationshipQuery(Query):
         self.add_to_query(destination_query_match)
 
 
-class RelationshipWriteQuery(RelationshipQuery):
-    def __init__(
-        self,
-        user_id: str,
-        **kwargs,
-    ):
-        self.user_id = user_id
-        super().__init__(**kwargs)
-
-
-class RelationshipCreateQuery(RelationshipWriteQuery):
+class RelationshipCreateQuery(RelationshipQuery):
     name = "relationship_create"
 
     type: QueryType = QueryType.WRITE
@@ -398,7 +388,7 @@ CREATE (rl)-[:HAS_%s { branch: $branch, branch_level: $branch_level, status: "ac
         self.add_to_query(query)
 
 
-class RelationshipUpdatePropertyQuery(RelationshipWriteQuery):
+class RelationshipUpdatePropertyQuery(RelationshipQuery):
     name = "relationship_property_update"
     type = QueryType.WRITE
     insert_return = False
@@ -561,7 +551,7 @@ CALL (rl) {
         self.add_to_query(query)
 
 
-class RelationshipDeleteQuery(RelationshipWriteQuery):
+class RelationshipDeleteQuery(RelationshipQuery):
     name = "relationship_delete"
     type = QueryType.WRITE
     insert_return = False
@@ -1208,9 +1198,8 @@ class RelationshipDeleteAllQuery(Query):
     type = QueryType.WRITE
     insert_return = False
 
-    def __init__(self, node_id: str, user_id: str, **kwargs):
+    def __init__(self, node_id: str, **kwargs):
         self.node_id = node_id
-        self.user_id = user_id
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -2115,7 +2115,6 @@ class TestDiffAndMerge:
         assert undeleted_car_with_metadata.color._get_updated_at() == car_camry_created_at
         assert undeleted_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
 
-    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
     async def test_diff_and_merge_with_migrated_node_kind_and_migrated_inheritance(
         self,
         db: InfrahubDatabase,
@@ -2154,6 +2153,7 @@ class TestDiffAndMerge:
             nbr_engine=1,
             owner=person_2,
         )
+        e_car_1_created_at = e_car_1._get_created_at()
         e_car_2 = await create_and_save(
             db=db,
             branch=default_branch,
@@ -2163,6 +2163,7 @@ class TestDiffAndMerge:
             nbr_engine=2,
             owner=person_3,
         )
+        e_car_2_created_at = e_car_2._get_created_at()
         original_e_car_1_owner = person_2
 
         # new branch
@@ -2191,7 +2192,10 @@ class TestDiffAndMerge:
                 path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewElectricCar", field_name="namespace"
             ),
         )
-        execution_result = await migration.execute(db=db, branch=branch2)
+        migration1_at = Timestamp()
+        execution_result = await migration.execute(
+            db=db, branch=branch2, at=migration1_at, user_id="migration-user-one"
+        )
         assert not execution_result.errors
 
         # update car owner
@@ -2217,18 +2221,21 @@ class TestDiffAndMerge:
                 path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewElectricCar", field_name="inherit_from"
             ),
         )
-        execution_result = await migration.execute(db=db, branch=branch2)
+        migration2_at = Timestamp()
+        execution_result = await migration.execute(
+            db=db, branch=branch2, at=migration2_at, user_id="migration-user-two"
+        )
         assert not execution_result.errors
 
         # delete a car
         migrated_car_to_delete = await NodeManager.get_one(db=db, branch=branch2, id=e_car_2.id)
-        await migrated_car_to_delete.delete(db=db, user_id="branch-user")
+        await migrated_car_to_delete.delete(db=db, user_id="branch-user-delete")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         updated_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         registry.schema.set_schema_branch(name=default_branch.name, schema=updated_schema_branch)
@@ -2256,16 +2263,84 @@ class TestDiffAndMerge:
         with pytest.raises(NodeNotFoundError):
             await NodeManager.get_one(db=db, branch=branch2, id=e_car_2.id, raise_on_error=True)
 
-        # Validate metadata on migrated car - should have updated_at from merge
+        # Validate node-level metadata on migrated car after merge
         migrated_car_with_metadata = await NodeManager.get_one(
-            db=db, branch=default_branch, id=e_car_1.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+            db=db,
+            branch=default_branch,
+            id=e_car_1.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
         )
-        assert migrated_car_with_metadata._get_updated_at() == at
+        # Node created_at is from first migration time (when the new kind was created on branch)
+        assert migrated_car_with_metadata._get_created_at() == e_car_1_created_at
+        assert migrated_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        # Node was updated by branch-user at branch update time
+        assert migrated_car_with_metadata._get_updated_at() == merge_at
         assert migrated_car_with_metadata._get_updated_by() == "branch-user"
+
+        # Validate attribute-level metadata on migrated car after merge
+        # Color attribute was updated by branch-user
+        assert migrated_car_with_metadata.color._get_created_at() == e_car_1_created_at
+        assert migrated_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert migrated_car_with_metadata.color._get_updated_at() == merge_at
+        assert migrated_car_with_metadata.color._get_updated_by() == "branch-user"
+
+        # Other attributes should have migration1 created_at, updated_at from last migration
+        assert migrated_car_with_metadata.name._get_created_at() == e_car_1_created_at
+        assert migrated_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert migrated_car_with_metadata.name._get_updated_at() == e_car_1_created_at
+        assert migrated_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship-level metadata on migrated car after merge
+        # Owner relationship was updated by branch-user
+        owner_rel = await migrated_car_with_metadata.owner.get(db=db)
+        assert owner_rel._get_created_at() == merge_at
+        assert owner_rel._get_created_by() == "branch-user"
+        assert owner_rel._get_updated_at() == merge_at
+        assert owner_rel._get_updated_by() == "branch-user"
+
+        # Validate metadata on deleted car using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[e_car_2.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 1
+
+        deleted_car_meta = node_metadatas[0]
+        assert deleted_car_meta.uuid == e_car_2.id
+        assert deleted_car_meta.is_deleted is True
+        # Deleted car should have migration1 created_at, updated_at from branch user delete
+        assert deleted_car_meta.created_at == e_car_2_created_at
+        assert deleted_car_meta.created_by == SYSTEM_USER_ID
+        assert deleted_car_meta.updated_at == merge_at
+        assert deleted_car_meta.updated_by == "branch-user-delete"
+
+        # Validate deleted car's attributes metadata
+        for attr in deleted_car_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_at == e_car_2_created_at
+            assert attr.created_by == SYSTEM_USER_ID
+            assert attr.updated_at == merge_at
+            assert attr.updated_by == "branch-user-delete"
+
+        # Validate deleted car's relationships metadata
+        for rel in deleted_car_meta.relationships:
+            assert rel.is_deleted is True
+            assert rel.created_at == e_car_2_created_at
+            assert rel.created_by == SYSTEM_USER_ID
+            assert rel.updated_at == merge_at
+            assert rel.updated_by == "branch-user-delete"
 
         await verify_no_duplicate_paths(db=db)
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         rolled_back_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         registry.schema.set_schema_branch(name=default_branch.name, schema=rolled_back_schema_branch)
@@ -2284,7 +2359,76 @@ class TestDiffAndMerge:
         undeleted_car = await NodeManager.get_one(db=db, branch=default_branch, id=e_car_2.id)
         assert undeleted_car.get_kind() == "TestElectricCar"
 
-    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
+        # Validate node-level metadata after rollback for e_car_1
+        rolled_back_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            branch=default_branch,
+            id=e_car_1.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
+        )
+        # After rollback, should have original created_at and no user updates
+        assert rolled_back_car_with_metadata._get_created_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata._get_updated_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate attribute-level metadata after rollback
+        assert rolled_back_car_with_metadata.color._get_created_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.color._get_updated_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+        assert rolled_back_car_with_metadata.name._get_created_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.name._get_updated_at() == e_car_1_created_at
+        assert rolled_back_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship-level metadata after rollback for e_car_1
+        # After rollback, owner relationship should have original timestamps restored
+        owner_rel_manager = rolled_back_car_with_metadata.get_relationship(name="owner")
+        owner_rel = await owner_rel_manager.get(db=db)
+        assert owner_rel._get_created_at() == e_car_1_created_at
+        assert owner_rel._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel._get_updated_at() == e_car_1_created_at
+        assert owner_rel._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate undeleted car (e_car_2) metadata after rollback
+        undeleted_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            branch=default_branch,
+            id=e_car_2.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
+        )
+        # Should have original timestamps restored
+        assert undeleted_car_with_metadata._get_created_at() == e_car_2_created_at
+        assert undeleted_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata._get_updated_at() == e_car_2_created_at
+        assert undeleted_car_with_metadata._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate attribute metadata on undeleted car
+        assert undeleted_car_with_metadata.color._get_created_at() == e_car_2_created_at
+        assert undeleted_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata.color._get_updated_at() == e_car_2_created_at
+        assert undeleted_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship metadata on undeleted car after rollback
+        owner_rel_manager = undeleted_car_with_metadata.get_relationship(name="owner")
+        owner_rel = await owner_rel_manager.get(db=db)
+        assert owner_rel._get_created_at() == e_car_2_created_at
+        assert owner_rel._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel._get_updated_at() == e_car_2_created_at
+        assert owner_rel._get_updated_by() == SYSTEM_USER_ID
+
     async def test_diff_and_merge_with_migrated_node_kind_peer(
         self,
         db: InfrahubDatabase,
@@ -2297,6 +2441,8 @@ class TestDiffAndMerge:
         person_jane_main: Node,
         person_john_main: Node,
     ):
+        car_accord_created_at = car_accord_main._get_created_at()
+        car_camry_created_at = car_camry_main._get_created_at()
         original_car_owner = person_john_main
         main_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.update_schema_branch(
@@ -2337,7 +2483,10 @@ class TestDiffAndMerge:
                 path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"
             ),
         )
-        execution_result = await migration.execute(db=db, branch=default_branch)
+        migration_at = Timestamp()
+        execution_result = await migration.execute(
+            db=db, branch=default_branch, at=migration_at, user_id="migration-user"
+        )
         assert not execution_result.errors
 
         # create new branch
@@ -2352,13 +2501,13 @@ class TestDiffAndMerge:
 
         # delete a car
         migrated_car_to_delete = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
-        await migrated_car_to_delete.delete(db=db, user_id="branch-user")
+        await migrated_car_to_delete.delete(db=db, user_id="branch-user-delete")
 
-        at = Timestamp()
+        merge_at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=at)
+        await diff_merger.merge_graph(at=merge_at)
 
         updated_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         registry.schema.set_schema_branch(name=default_branch.name, schema=updated_schema_branch)
@@ -2383,14 +2532,84 @@ class TestDiffAndMerge:
 
         # Validate metadata on merged car - should have updated_at from merge
         merged_car_with_metadata = await NodeManager.get_one(
-            db=db, branch=default_branch, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+            db=db,
+            branch=default_branch,
+            id=car_accord_main.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
         )
-        assert merged_car_with_metadata._get_updated_at() == at
+        assert merged_car_with_metadata._get_created_at() == car_accord_created_at
+        assert merged_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert merged_car_with_metadata._get_updated_at() == merge_at
         assert merged_car_with_metadata._get_updated_by() == "branch-user"
+
+        # Validate attribute-level metadata on merged car
+        assert merged_car_with_metadata.color._get_created_at() == car_accord_created_at
+        assert merged_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert merged_car_with_metadata.color._get_updated_at() == merge_at
+        assert merged_car_with_metadata.color._get_updated_by() == "branch-user"
+
+        # Other attributes should retain migration timestamps
+        assert merged_car_with_metadata.name._get_created_at() == car_accord_created_at
+        assert merged_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert merged_car_with_metadata.name._get_updated_at() == car_accord_created_at
+        assert merged_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        assert merged_car_with_metadata.nbr_seats._get_created_at() == car_accord_created_at
+        assert merged_car_with_metadata.nbr_seats._get_created_by() == SYSTEM_USER_ID
+        assert merged_car_with_metadata.nbr_seats._get_updated_at() == car_accord_created_at
+        assert merged_car_with_metadata.nbr_seats._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship-level metadata on merged car
+        # Owner relationship was updated by branch-user
+        owner_rel = await merged_car_with_metadata.owner.get(db=db)
+        assert owner_rel._get_created_at() == merge_at
+        assert owner_rel._get_created_by() == "branch-user"
+        assert owner_rel._get_updated_at() == merge_at
+        assert owner_rel._get_updated_by() == "branch-user"
+
+        # Validate metadata on deleted car using NodeMetadataDefaultBranchQuery
+        node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db,
+            branch=default_branch,
+            node_uuids=[car_camry_main.id],
+        )
+        await node_metadata_query.execute(db=db)
+        node_metadatas = node_metadata_query.get_metadatas()
+        assert len(node_metadatas) == 1
+
+        deleted_car_meta = node_metadatas[0]
+        assert deleted_car_meta.uuid == car_camry_main.id
+        assert deleted_car_meta.is_deleted is True
+        # Deleted car should have branch user delete timestamp
+        assert deleted_car_meta.created_at == car_camry_created_at
+        assert deleted_car_meta.created_by == SYSTEM_USER_ID
+        assert deleted_car_meta.updated_at == merge_at
+        assert deleted_car_meta.updated_by == "branch-user-delete"
+
+        # Validate deleted car's attributes metadata
+        for attr in deleted_car_meta.attributes:
+            assert attr.is_deleted is True
+            assert attr.created_at == car_camry_created_at
+            assert attr.created_by == SYSTEM_USER_ID
+            assert attr.updated_at == merge_at
+            assert attr.updated_by == "branch-user-delete"
+
+        # Validate deleted car's relationships metadata
+        for rel in deleted_car_meta.relationships:
+            assert rel.is_deleted is True
+            assert rel.created_at == car_camry_created_at
+            assert rel.created_by == SYSTEM_USER_ID
+            assert rel.updated_at == merge_at
+            assert rel.updated_by == "branch-user-delete"
 
         await verify_no_duplicate_paths(db=db)
 
-        await diff_merger.rollback(at=at)
+        await diff_merger.rollback(at=merge_at)
 
         retrieved_still_migrated_car = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
         assert retrieved_still_migrated_car.get_kind() == "Test2NewCar"
@@ -2400,3 +2619,74 @@ class TestDiffAndMerge:
         # get undeleted node
         undeleted_car = await NodeManager.get_one(db=db, branch=default_branch, id=car_camry_main.id)
         assert undeleted_car.get_kind() == "Test2NewCar"
+
+        # Validate node-level metadata after rollback for car_accord
+        # Rollback only reverts data changes, not the schema migration
+        rolled_back_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            branch=default_branch,
+            id=car_accord_main.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
+        )
+        # After rollback, should have post-migration timestamps (migration wasn't rolled back)
+        assert rolled_back_car_with_metadata._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata._get_updated_at() == migration_at
+        assert rolled_back_car_with_metadata._get_updated_by() == "migration-user"
+
+        # Validate attribute-level metadata after rollback
+        assert rolled_back_car_with_metadata.color._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.color._get_updated_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+        assert rolled_back_car_with_metadata.name._get_created_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
+        assert rolled_back_car_with_metadata.name._get_updated_at() == car_accord_created_at
+        assert rolled_back_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship-level metadata after rollback for car_accord
+        # After rollback, owner relationship should have post-migration timestamps restored
+        owner_rel_manager = rolled_back_car_with_metadata.get_relationship(name="owner")
+        owner_rel = await owner_rel_manager.get(db=db)
+        assert owner_rel._get_created_at() == car_accord_created_at
+        assert owner_rel._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel._get_updated_at() == car_accord_created_at
+        assert owner_rel._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate undeleted car (car_camry) metadata after rollback
+        undeleted_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            branch=default_branch,
+            id=car_camry_main.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
+        )
+        # Should have post-migration timestamps restored
+        assert undeleted_car_with_metadata._get_created_at() == car_camry_created_at
+        assert undeleted_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata._get_updated_at() == migration_at
+        assert undeleted_car_with_metadata._get_updated_by() == "migration-user"
+
+        # Validate attribute metadata on undeleted car
+        assert undeleted_car_with_metadata.color._get_created_at() == car_camry_created_at
+        assert undeleted_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
+        assert undeleted_car_with_metadata.color._get_updated_at() == car_camry_created_at
+        assert undeleted_car_with_metadata.color._get_updated_by() == SYSTEM_USER_ID
+
+        # Validate relationship metadata on undeleted car after rollback
+        owner_rel_manager = undeleted_car_with_metadata.get_relationship(name="owner")
+        owner_rel = await owner_rel_manager.get(db=db)
+        assert owner_rel._get_created_at() == car_camry_created_at
+        assert owner_rel._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel._get_updated_at() == car_camry_created_at
+        assert owner_rel._get_updated_by() == SYSTEM_USER_ID

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -19,6 +19,7 @@ from infrahub.core.diff.model.path import ConflictSelection
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.metadata.query.node_metadata import NodeMetadataDefaultBranchQuery
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
@@ -1855,7 +1856,6 @@ class TestDiffAndMerge:
 
         await verify_no_duplicate_paths(db=db)
 
-    @pytest.mark.skip(reason="Waiting on updates to include metadata in schema migrations")
     async def test_diff_and_merge_with_migrated_node_kind(
         self,
         db: InfrahubDatabase,
@@ -1865,11 +1865,13 @@ class TestDiffAndMerge:
         car_person_schema: SchemaBranch,
         car_accord_main: Node,
         car_camry_main: Node,
+        car_yaris_main: Node,
         person_jane_main: Node,
         person_john_main: Node,
     ) -> None:
         car_accord_created_at = car_accord_main._get_created_at()
         car_camry_created_at = car_camry_main._get_created_at()
+        car_yaris_created_at = car_yaris_main._get_created_at()
 
         schema_main = registry.schema.get_schema_branch(name=default_branch.name)
         await registry.schema.update_schema_branch(db=db, branch=default_branch, schema=schema_main, update_db=True)
@@ -1900,10 +1902,11 @@ class TestDiffAndMerge:
                 path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"
             ),
         )
-        execution_result = await migration.execute(db=db, branch=branch2)
+        migration_at = Timestamp()
+        execution_result = await migration.execute(db=db, branch=branch2, at=migration_at, user_id="migration-user")
         assert not execution_result.errors
 
-        # update car owner
+        # update car owner and color
         migrated_car = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await migrated_car.owner.update(db=db, data=person_jane_main.id)
         new_color = "#654321"
@@ -1951,32 +1954,70 @@ class TestDiffAndMerge:
 
         # Validate node-level metadata on migrated car after merge
         migrated_car_with_metadata = await NodeManager.get_one(
-            db=db, branch=default_branch, id=car_accord_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+            db=db,
+            branch=default_branch,
+            id=car_accord_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS,
+            prefetch_relationships=True,
         )
-        # Node was created at merge time (migrated kind)
-        assert migrated_car_with_metadata._get_created_at() == merge_at
+        # Node created_at is from migration time (when the new kind was created on branch)
+        assert migrated_car_with_metadata._get_created_at() == car_accord_created_at
         assert migrated_car_with_metadata._get_created_by() == SYSTEM_USER_ID
-        # Node was updated by branch-user-update (the last user to modify this node on branch)
+        # Node was updated by branch-user-update at the branch update time
         assert migrated_car_with_metadata._get_updated_at() == merge_at
         assert migrated_car_with_metadata._get_updated_by() == "branch-user-update"
 
         # Validate attribute-level metadata on migrated car after merge
         # Color attribute was updated by branch-user-update
-        assert migrated_car_with_metadata.color._get_created_at() == merge_at
+        assert migrated_car_with_metadata.color._get_created_at() == car_accord_created_at
         assert migrated_car_with_metadata.color._get_created_by() == SYSTEM_USER_ID
         assert migrated_car_with_metadata.color._get_updated_at() == merge_at
         assert migrated_car_with_metadata.color._get_updated_by() == "branch-user-update"
 
-        # Other attributes should have been migrated but not updated by user
-        assert migrated_car_with_metadata.name._get_created_at() == merge_at
-        assert migrated_car_with_metadata.name._get_created_by() == SYSTEM_USER_ID
-        assert migrated_car_with_metadata.name._get_updated_at() == merge_at
-        assert migrated_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
+        # Other attributes should have migration created_at, updated_at from migration
+        for attr_name in ("name", "nbr_seats"):
+            attr = migrated_car_with_metadata.get_attribute(name=attr_name)
+            assert attr._get_created_at() == car_accord_created_at
+            assert attr._get_created_by() == SYSTEM_USER_ID
+            assert attr._get_updated_at() == car_accord_created_at
+            assert attr._get_updated_by() == SYSTEM_USER_ID
 
-        assert migrated_car_with_metadata.nbr_seats._get_created_at() == merge_at
-        assert migrated_car_with_metadata.nbr_seats._get_created_by() == SYSTEM_USER_ID
-        assert migrated_car_with_metadata.nbr_seats._get_updated_at() == merge_at
-        assert migrated_car_with_metadata.nbr_seats._get_updated_by() == SYSTEM_USER_ID
+        owner_rel = await migrated_car_with_metadata.owner.get(db=db)
+        assert owner_rel._get_created_at() == merge_at
+        assert owner_rel._get_created_by() == "branch-user-update"
+        assert owner_rel._get_updated_at() == merge_at
+        assert owner_rel._get_updated_by() == "branch-user-update"
+
+        # Validate metadata on migrated car with no updates
+        unchanged_car_with_metadata = await NodeManager.get_one(
+            db=db,
+            branch=default_branch,
+            id=car_yaris_main.id,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+                relationship_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+            prefetch_relationships=True,
+        )
+        assert unchanged_car_with_metadata._get_created_at() == car_yaris_created_at
+        assert unchanged_car_with_metadata._get_created_by() == SYSTEM_USER_ID
+        assert unchanged_car_with_metadata._get_updated_at() == merge_at
+        assert unchanged_car_with_metadata._get_updated_by() == "migration-user"
+
+        for attr_name in ("name", "nbr_seats"):
+            attr = unchanged_car_with_metadata.get_attribute(name=attr_name)
+            assert attr._get_created_at() == car_yaris_created_at
+            assert attr._get_created_by() == SYSTEM_USER_ID
+            assert attr._get_updated_at() == car_yaris_created_at
+            assert attr._get_updated_by() == SYSTEM_USER_ID
+
+        owner_rel_manager = unchanged_car_with_metadata.get_relationship(name="owner")
+        owner_rel = await owner_rel_manager.get(db=db)
+        assert owner_rel._get_created_at() == car_yaris_created_at
+        assert owner_rel._get_created_by() == SYSTEM_USER_ID
+        assert owner_rel._get_updated_at() == car_yaris_created_at
+        assert owner_rel._get_updated_by() == SYSTEM_USER_ID
 
         # Validate metadata on deleted car using NodeMetadataDefaultBranchQuery
         node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
@@ -1991,8 +2032,8 @@ class TestDiffAndMerge:
         deleted_car_meta = node_metadatas[0]
         assert deleted_car_meta.uuid == car_camry_main.id
         assert deleted_car_meta.is_deleted is True
-        # Deleted car should have merge_at timestamp and branch-user-delete as updater
-        assert deleted_car_meta.created_at == merge_at
+        # Deleted car should have migration created_at, updated_at from branch user delete
+        assert deleted_car_meta.created_at == car_camry_created_at
         assert deleted_car_meta.created_by == SYSTEM_USER_ID
         assert deleted_car_meta.updated_at == merge_at
         assert deleted_car_meta.updated_by == "branch-user-delete"
@@ -2000,10 +2041,17 @@ class TestDiffAndMerge:
         # Validate deleted car's attributes metadata
         for attr in deleted_car_meta.attributes:
             assert attr.is_deleted is True
-            assert attr.created_at == merge_at
+            assert attr.created_at == car_camry_created_at
             assert attr.created_by == SYSTEM_USER_ID
             assert attr.updated_at == merge_at
             assert attr.updated_by == "branch-user-delete"
+
+        for rel in deleted_car_meta.relationships:
+            assert rel.is_deleted is True
+            assert rel.created_at == car_camry_created_at
+            assert rel.created_by == SYSTEM_USER_ID
+            assert rel.updated_at == merge_at
+            assert rel.updated_by == "branch-user-delete"
 
         await verify_no_duplicate_paths(db=db)
 

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -2,10 +2,12 @@ import uuid
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SchemaPathType
+from infrahub.core.constants import SYSTEM_USER_ID, MetadataOptions, SchemaPathType
 from infrahub.core.initialization import (
     create_branch,
 )
+from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.attribute_name_update import (
     AttributeNameUpdateMigration,
     AttributeNameUpdateMigrationQuery01,
@@ -128,43 +130,50 @@ async def test_migration(
     assert await count_relationships(db=db) == count_rels + 9
 
 
-async def test_migration_with_user_id(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_profile1_main: Node
-) -> None:
-    """Test that the user_id passed to migration.execute() is correctly set on the renamed attribute's metadata."""
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
+async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
+    """Test that metadata is set correctly when renaming an attribute."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
     prev_car_schema = schema.get(name="TestCar")
     prev_attr = prev_car_schema.get_attribute(name="color")
     prev_attr.id = str(uuid.uuid4())
     candidate_schema = schema.duplicate()
     new_car_schema = candidate_schema.get(name="TestCar")
     new_attr = new_car_schema.get_attribute(name="color")
-    new_attr.name = "new-color"
+    new_attr.name = "new_color"
     new_attr.id = prev_attr.id
+
+    test_user_id = "test-metadata-user"
+    migration_time = Timestamp()
 
     migration = AttributeNameUpdateMigration(
         previous_node_schema=prev_car_schema,
         new_node_schema=new_car_schema,
-        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new_color"),
     )
-
-    test_user_id = "test-rename-migration-user"
-    migration_time = Timestamp()
-    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
-
+    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
     assert not execution_result.errors
-    assert execution_result.nbr_migrations_executed == 2
 
-    # Query for the new attribute edges created by the migration and verify user_id metadata
-    query = """
-    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "new-color"})
-    MATCH (attr)-[r {status: "active"}]-()
-    RETURN r.from_user_id as from_user_id, r.from as from_time
-    """
-    results = await db.execute_query(query=query, params={"car_uuid": car_accord_main.id})
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    car_schema = schema_branch.get(name="TestCar", duplicate=False)
+    color_attr = car_schema.get_attribute(name="color")
+    color_attr.name = "new_color"
 
-    # All active edges on the renamed attribute should have the test user_id
-    assert len(results) > 0, "Expected at least one active edge on renamed attribute"
-    for record in results:
-        assert record["from_user_id"] == test_user_id
-        assert record["from_time"] == migration_time.to_string()
+    updated_car = await NodeManager.get_one(
+        db=db,
+        branch=branch,
+        id=car_accord_main.id,
+        include_metadata=MetadataQueryOptions(
+            node_level=MetadataOptions.USER_TIMESTAMPS, attribute_level=MetadataOptions.USER_TIMESTAMPS
+        ),
+        fields={"new_color": True},
+    )
+    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_by() == SYSTEM_USER_ID
+    assert updated_car._get_updated_at() == migration_time
+    assert updated_car._get_updated_by() == test_user_id
+
+    new_attr = updated_car.new_color
+    assert new_attr._get_created_at() == migration_time
+    assert new_attr._get_created_by() == test_user_id
+    assert new_attr._get_updated_at() == migration_time
+    assert new_attr._get_updated_by() == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -10,7 +10,9 @@ from infrahub.core.migrations.schema.attribute_name_update import (
     AttributeNameUpdateMigration,
     AttributeNameUpdateMigrationQuery01,
 )
+from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -124,3 +126,45 @@ async def test_migration(
 
     assert await count_nodes(db=db, label="Attribute") == count_attr_node + 3
     assert await count_relationships(db=db) == count_rels + 9
+
+
+async def test_migration_with_user_id(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_profile1_main: Node
+) -> None:
+    """Test that the user_id passed to migration.execute() is correctly set on the renamed attribute's metadata."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    prev_attr = prev_car_schema.get_attribute(name="color")
+    prev_attr.id = str(uuid.uuid4())
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="color")
+    new_attr.name = "new-color"
+    new_attr.id = prev_attr.id
+
+    migration = AttributeNameUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
+    )
+
+    test_user_id = "test-rename-migration-user"
+    migration_time = Timestamp()
+    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
+
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 2
+
+    # Query for the new attribute edges created by the migration and verify user_id metadata
+    query = """
+    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "new-color"})
+    MATCH (attr)-[r {status: "active"}]-()
+    RETURN r.from_user_id as from_user_id, r.from as from_time
+    """
+    results = await db.execute_query(query=query, params={"car_uuid": car_accord_main.id})
+
+    # All active edges on the renamed attribute should have the test user_id
+    assert len(results) > 0, "Expected at least one active edge on renamed attribute"
+    for record in results:
+        assert record["from_user_id"] == test_user_id
+        assert record["from_time"] == migration_time.to_string()

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -13,6 +13,7 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
     NodeAttributeRemoveMigration,
     NodeAttributeRemoveMigrationQuery01,
 )
+from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
@@ -153,3 +154,43 @@ async def test_migration(db: InfrahubDatabase, default_branch, init_database, sc
     assert execution_result.nbr_migrations_executed == 5
     assert await count_nodes(db=db, label="TestCar") == 5
     assert await count_nodes(db=db, label="Attribute") == 5
+
+
+async def test_migration_with_user_id(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
+    """Test that the user_id passed to migration.execute() is correctly set on the created attribute's metadata."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    car_schema = schema.get_node(name="TestCar")
+
+    # Remove the color attribute first so we can re-add it with a specific user_id
+    remove_migration = NodeAttributeRemoveMigration(
+        previous_node_schema=car_schema,
+        new_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+    )
+    await remove_migration.execute(db=db, branch=default_branch)
+
+    test_user_id = "test-migration-user"
+    migration = NodeAttributeAddMigration(
+        new_node_schema=car_schema,
+        previous_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+    )
+    migration_time = Timestamp()
+    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
+
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 1
+
+    # Verify directly via Cypher that from_user_id is set on the edges
+    query = """
+    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "color"})
+    MATCH (attr)-[r {status: "active", from: $migration_time}]-()
+    RETURN r.from_user_id as from_user_id
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"car_uuid": car_accord_main.id, "migration_time": migration_time.to_string()},
+    )
+    assert len(results) > 0, "Expected at least one active edge on added attribute"
+    for record in results:
+        assert record["from_user_id"] == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -4,7 +4,9 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import HashableModelState, SchemaPathType
+from infrahub.core.constants import SYSTEM_USER_ID, HashableModelState, MetadataOptions, SchemaPathType
+from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_add import (
     NodeAttributeAddMigration,
     NodeAttributeAddMigrationQuery01,
@@ -156,41 +158,48 @@ async def test_migration(db: InfrahubDatabase, default_branch, init_database, sc
     assert await count_nodes(db=db, label="Attribute") == 5
 
 
-async def test_migration_with_user_id(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
-    """Test that the user_id passed to migration.execute() is correctly set on the created attribute's metadata."""
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
+async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
+    """Test that vertex metadata is set correctly when adding an attribute"""
+    schema = registry.schema.get_schema_branch(name=branch.name)
     car_schema = schema.get_node(name="TestCar")
 
-    # Remove the color attribute first so we can re-add it with a specific user_id
+    # Remove the color attribute first so we can re-add it
     remove_migration = NodeAttributeRemoveMigration(
         previous_node_schema=car_schema,
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    await remove_migration.execute(db=db, branch=default_branch)
+    await remove_migration.execute(db=db, branch=branch)
 
-    test_user_id = "test-migration-user"
+    test_user_id = "test-metadata-user"
+    migration_time = Timestamp()
+
     migration = NodeAttributeAddMigration(
         new_node_schema=car_schema,
         previous_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    migration_time = Timestamp()
-    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
-
+    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
     assert not execution_result.errors
-    assert execution_result.nbr_migrations_executed == 1
 
-    # Verify directly via Cypher that from_user_id is set on the edges
-    query = """
-    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "color"})
-    MATCH (attr)-[r {status: "active", from: $migration_time}]-()
-    RETURN r.from_user_id as from_user_id
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"car_uuid": car_accord_main.id, "migration_time": migration_time.to_string()},
+    nodes = await NodeManager.get_many(
+        db=db,
+        ids=[car_accord_main.id],
+        branch=branch,
+        include_metadata=MetadataQueryOptions(
+            node_level=MetadataOptions.USER_TIMESTAMPS,
+            attribute_level=MetadataOptions.USER_TIMESTAMPS,
+        ),
     )
-    assert len(results) > 0, "Expected at least one active edge on added attribute"
-    for record in results:
-        assert record["from_user_id"] == test_user_id
+    node = nodes[car_accord_main.id]
+    assert node._get_created_at() < migration_time
+    assert node._get_created_by() == SYSTEM_USER_ID
+    assert node._get_updated_at() == migration_time
+    assert node._get_updated_by() == test_user_id
+
+    # Verify attribute metadata via the Node object
+    attr = node.color
+    assert attr._get_created_at() == migration_time
+    assert attr._get_created_by() == test_user_id
+    assert attr._get_updated_at() == migration_time
+    assert attr._get_updated_by() == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -2,7 +2,9 @@ from typing import Any
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import HashableModelState, SchemaPathType
+from infrahub.core.constants import SYSTEM_USER_ID, HashableModelState, MetadataOptions, SchemaPathType
+from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_remove import (
     NodeAttributeRemoveMigration,
     NodeAttributeRemoveMigrationQuery01,
@@ -124,39 +126,49 @@ async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accor
     assert await count_relationships(db=db) == count_rels + 6
 
 
-async def test_migration_with_user_id(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
-    """Test that the user_id passed to migration.execute() is correctly set on the created deleted edges."""
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
+async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
+    """Test that metadata is set correctly when removing an attribute."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
     attr = car_schema.get_attribute(name="color")
     attr.state = HashableModelState.ABSENT
+
+    test_user_id = "test-metadata-user"
+    migration_time = Timestamp()
 
     migration = NodeAttributeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-
-    test_user_id = "test-remove-migration-user"
-    migration_time = Timestamp()
-    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
-
+    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
     assert not execution_result.errors
-    assert execution_result.nbr_migrations_executed == 1
 
-    # Query for the deleted edges created by the migration and verify user_id metadata
+    updated_car = await NodeManager.get_one(
+        db=db,
+        branch=branch,
+        id=car_accord_main.id,
+        include_metadata=MetadataQueryOptions(node_level=MetadataOptions.USER_TIMESTAMPS),
+        fields={"color": True},
+    )
+    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_by() == SYSTEM_USER_ID
+    assert updated_car._get_updated_at() == migration_time
+    assert updated_car._get_updated_by() == test_user_id
+
+    # Query for the deleted attribute edges and verify metadata
     query = """
-    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "color"})
-    MATCH (attr)-[r {branch: $branch, status: "deleted"}]-()
-    RETURN r.from_user_id as from_user_id, r.from as from_time
+    MATCH (n:TestCar {uuid: $node_uuid})-[r:HAS_ATTRIBUTE {branch: $branch, status: "deleted"}]->(attr:Attribute {name: "color"})
+    RETURN r.from_user_id as from_user_id, r.from as from_time, n.updated_at as updated_at, n.updated_by as updated_by
     """
     results = await db.execute_query(
-        query=query, params={"car_uuid": car_accord_main.id, "branch": default_branch.name}
+        query=query,
+        params={"node_uuid": car_accord_main.id, "branch": branch.name},
     )
-
-    # All deleted edges created during the migration should have the test user_id
-    assert len(results) > 0, "Expected at least one deleted edge"
-    for record in results:
-        assert record["from_user_id"] == test_user_id
-        assert record["from_time"] == migration_time.to_string()
+    assert len(results) > 0, "Expected at least one deleted HAS_ATTRIBUTE edge"
+    assert results[0]["from_user_id"] == test_user_id
+    assert results[0]["from_time"] == migration_time.to_string()
+    if branch.is_default:
+        assert results[0]["updated_at"] == migration_time.to_string()
+        assert results[0]["updated_by"] == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -10,6 +10,7 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -121,3 +122,41 @@ async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accor
     assert execution_result.nbr_migrations_executed == 2
     assert await count_nodes(db=db, label="Attribute") == count_attr_node
     assert await count_relationships(db=db) == count_rels + 6
+
+
+async def test_migration_with_user_id(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
+    """Test that the user_id passed to migration.execute() is correctly set on the created deleted edges."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    car_schema = candidate_schema.get(name="TestCar")
+    attr = car_schema.get_attribute(name="color")
+    attr.state = HashableModelState.ABSENT
+
+    migration = NodeAttributeRemoveMigration(
+        previous_node_schema=schema.get(name="TestCar"),
+        new_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+    )
+
+    test_user_id = "test-remove-migration-user"
+    migration_time = Timestamp()
+    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
+
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 1
+
+    # Query for the deleted edges created by the migration and verify user_id metadata
+    query = """
+    MATCH (n:TestCar {uuid: $car_uuid})-[:HAS_ATTRIBUTE]->(attr:Attribute {name: "color"})
+    MATCH (attr)-[r {branch: $branch, status: "deleted"}]-()
+    RETURN r.from_user_id as from_user_id, r.from as from_time
+    """
+    results = await db.execute_query(
+        query=query, params={"car_uuid": car_accord_main.id, "branch": default_branch.name}
+    )
+
+    # All deleted edges created during the migration should have the test user_id
+    assert len(results) > 0, "Expected at least one deleted edge"
+    for record in results:
+        assert record["from_user_id"] == test_user_id
+        assert record["from_time"] == migration_time.to_string()

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -8,6 +8,7 @@ from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.constants import TestKind
@@ -226,3 +227,49 @@ async def test_inheritance_migration_on_branch_and_main(
     assert not execution_result_default.errors
 
     await verify_no_duplicate_paths(db=db)
+
+
+async def test_migration_with_user_id(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
+) -> None:
+    """Test that the user_id passed to migration.execute() is correctly set on the duplicated node edges."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    car_schema = candidate_schema.get(name="TestCar")
+    candidate_schema.delete(name="TestCar")
+    car_schema.name = "NewCar"
+    car_schema.namespace = "Test2"
+    candidate_schema.set(name="Test2NewCar", schema=car_schema)
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestCar"),
+        new_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+
+    test_user_id = "test-kind-migration-user"
+    migration_time = Timestamp()
+    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
+
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 2
+
+    # Query for the new node edges created by the migration and verify user_id metadata
+    # The migration duplicates nodes with new labels, so we check edges on the new label
+    query = """
+    MATCH (n:Test2NewCar {uuid: $car_uuid})
+    MATCH (n)-[r {status: "active", from: $migration_time}]-()
+    RETURN DISTINCT r.from_user_id as from_user_id
+    """
+    results = await db.execute_query(
+        query=query,
+        params={
+            "car_uuid": car_accord_main.id,
+            "migration_time": migration_time.to_string(),
+        },
+    )
+
+    # All active edges created during the migration should have the test user_id
+    assert len(results) > 0, "Expected at least one active edge on duplicated node"
+    for record in results:
+        assert record["from_user_id"] == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -232,6 +232,7 @@ async def test_inheritance_migration_on_branch_and_main(
 
 async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
     """Test that metadata is set correctly when updating node kind."""
+    car_created_at = car_accord_main._get_created_at()
     schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
@@ -264,19 +265,19 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         ),
         prefetch_relationships=True,
     )
-    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_at() == car_created_at
     assert updated_car._get_created_by() == SYSTEM_USER_ID
     assert updated_car._get_updated_at() == migration_time
     assert updated_car._get_updated_by() == test_user_id
     for attr_name in car_schema.attribute_names:
         attr = updated_car.get_attribute(name=attr_name)
-        assert attr._get_created_at() < migration_time
+        assert attr._get_created_at() == car_created_at
         assert attr._get_created_by() == SYSTEM_USER_ID
         assert attr._get_updated_at() == attr._get_created_at()
         assert attr._get_updated_by() == SYSTEM_USER_ID
     rel_manager = updated_car.get_relationship(name="owner")
     rel = await rel_manager.get(db=db)
-    assert rel._get_created_at() < migration_time
+    assert rel._get_created_at() == car_created_at
     assert rel._get_created_by() == SYSTEM_USER_ID
     assert rel._get_updated_at() == rel._get_created_at()
     assert rel._get_updated_by() == SYSTEM_USER_ID

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -1,8 +1,9 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import RelationshipHierarchyDirection, SchemaPathType
+from infrahub.core.constants import SYSTEM_USER_ID, MetadataOptions, RelationshipHierarchyDirection, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration, NodeKindUpdateMigrationQuery01
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
@@ -229,11 +230,9 @@ async def test_inheritance_migration_on_branch_and_main(
     await verify_no_duplicate_paths(db=db)
 
 
-async def test_migration_with_user_id(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-) -> None:
-    """Test that the user_id passed to migration.execute() is correctly set on the duplicated node edges."""
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
+async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
+    """Test that metadata is set correctly when updating node kind."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
     candidate_schema.delete(name="TestCar")
@@ -241,35 +240,67 @@ async def test_migration_with_user_id(
     car_schema.namespace = "Test2"
     candidate_schema.set(name="Test2NewCar", schema=car_schema)
 
+    test_user_id = "test-metadata-user"
+    migration_time = Timestamp()
+
     migration = NodeKindUpdateMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
     )
-
-    test_user_id = "test-kind-migration-user"
-    migration_time = Timestamp()
-    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
-
+    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
     assert not execution_result.errors
-    assert execution_result.nbr_migrations_executed == 2
 
-    # Query for the new node edges created by the migration and verify user_id metadata
-    # The migration duplicates nodes with new labels, so we check edges on the new label
+    registry.schema.set_schema_branch(name=branch.name, schema=candidate_schema)
+
+    updated_car = await NodeManager.get_one(
+        db=db,
+        branch=branch,
+        id=car_accord_main.id,
+        include_metadata=MetadataQueryOptions(
+            node_level=MetadataOptions.USER_TIMESTAMPS,
+            attribute_level=MetadataOptions.USER_TIMESTAMPS,
+            relationship_level=MetadataOptions.USER_TIMESTAMPS,
+        ),
+        prefetch_relationships=True,
+    )
+    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_by() == SYSTEM_USER_ID
+    assert updated_car._get_updated_at() == migration_time
+    assert updated_car._get_updated_by() == test_user_id
+    for attr_name in car_schema.attribute_names:
+        attr = updated_car.get_attribute(name=attr_name)
+        assert attr._get_created_at() < migration_time
+        assert attr._get_created_by() == SYSTEM_USER_ID
+        assert attr._get_updated_at() == attr._get_created_at()
+        assert attr._get_updated_by() == SYSTEM_USER_ID
+    rel_manager = updated_car.get_relationship(name="owner")
+    rel = await rel_manager.get(db=db)
+    assert rel._get_created_at() < migration_time
+    assert rel._get_created_by() == SYSTEM_USER_ID
+    assert rel._get_updated_at() == rel._get_created_at()
+    assert rel._get_updated_by() == SYSTEM_USER_ID
+
+    # Query for the NEW active node edges and verify metadata
     query = """
-    MATCH (n:Test2NewCar {uuid: $car_uuid})
-    MATCH (n)-[r {status: "active", from: $migration_time}]-()
+    MATCH (n:Test2NewCar {uuid: $node_uuid})-[r {branch: $branch, status: "active", from: $migration_time}]-()
     RETURN DISTINCT r.from_user_id as from_user_id
     """
     results = await db.execute_query(
         query=query,
-        params={
-            "car_uuid": car_accord_main.id,
-            "migration_time": migration_time.to_string(),
-        },
+        params={"node_uuid": car_accord_main.id, "branch": branch.name, "migration_time": migration_time.to_string()},
     )
+    assert len(results) == 1, "Expected exactly one active edge on migrated node"
+    assert results[0]["from_user_id"] == test_user_id
 
-    # All active edges created during the migration should have the test user_id
-    assert len(results) > 0, "Expected at least one active edge on duplicated node"
-    for record in results:
-        assert record["from_user_id"] == test_user_id
+    # Query for the OLD deleted node edges and verify metadata
+    query = """
+    MATCH (n:TestCar {uuid: $node_uuid})-[r {branch: $branch, status: "deleted", from: $migration_time}]-()
+    RETURN DISTINCT r.from_user_id as from_user_id
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"node_uuid": car_accord_main.id, "branch": branch.name, "migration_time": migration_time.to_string()},
+    )
+    assert len(results) == 1, "Expected exactly one deleted edge on old node"
+    assert results[0]["from_user_id"] == test_user_id

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -144,41 +144,56 @@ async def test_migration_agnostic_relationship(
     await validate_node_relationships(node=car, db=db, branch=registry.get_global_branch())
 
 
-async def test_migration_with_user_id(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
-) -> None:
-    """Test that the user_id passed to migration.execute() is correctly set on the deleted edges."""
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
+async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
+    """Test that metadata is set correctly when removing a node."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     candidate_schema.delete(name="TestCar")
+
+    test_user_id = "test-metadata-user"
+    migration_time = Timestamp()
 
     migration = NodeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=None,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
-
-    test_user_id = "test-remove-node-migration-user"
-    migration_time = Timestamp()
-    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
-
+    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
     assert not execution_result.errors
-    assert execution_result.nbr_migrations_executed == 2
 
-    # Query for the deleted edges created by the migration and verify user_id metadata
+    # Query for the deleted Node and its edge metadata
     query = """
-    MATCH (n:TestCar {uuid: $car_uuid})-[r {status: "deleted", from: $migration_time}]-()
-    RETURN DISTINCT r.from_user_id as from_user_id
+    MATCH (n:TestCar {uuid: $node_uuid})-[r:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root)
+    RETURN r.from_user_id as from_user_id, r.from as from_time, n.updated_at as updated_at, n.updated_by as updated_by
     """
     results = await db.execute_query(
         query=query,
-        params={
-            "car_uuid": car_accord_main.id,
-            "migration_time": migration_time.to_string(),
-        },
+        params={"node_uuid": car_accord_main.id, "branch": branch.name},
     )
+    assert len(results) == 1, "Expected exactly one deleted IS_PART_OF edge"
+    assert results[0]["from_user_id"] == test_user_id
+    assert results[0]["from_time"] == migration_time.to_string()
+    if branch.is_default:
+        assert results[0]["updated_at"] == migration_time.to_string()
+        assert results[0]["updated_by"] == test_user_id
 
-    # All deleted edges created during the migration should have the test user_id
-    assert len(results) > 0, "Expected at least one deleted edge"
-    for record in results:
-        assert record["from_user_id"] == test_user_id
+    # Query for the deleted Attributes/Relationships
+    query = """
+    MATCH (n:TestCar {uuid: $node_uuid})
+    MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED {branch: $branch, status: "deleted"}]->(field)
+    RETURN r.from_user_id as from_user_id, r.from as from_time,
+        field.updated_at as updated_at, field.updated_by as updated_by,
+        field.name AS name, field.uuid AS uuid
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"node_uuid": car_accord_main.id, "branch": branch.name},
+    )
+    for result in results:
+        name = result["name"]
+        uuid = result["uuid"]
+        assert result["from_user_id"] == test_user_id, f"Wrong from_user_id on edge to {name} ({uuid})"
+        assert result["from_time"] == migration_time.to_string(), f"Wrong from_time on edge to {name} ({uuid})"
+        if branch.is_default:
+            assert result["updated_at"] == migration_time.to_string(), f"Wrong updated_at on {name} ({uuid})"
+            assert result["updated_by"] == test_user_id, f"Wrong updated_by on {name} ({uuid})"

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -9,6 +9,7 @@ from infrahub.core.migrations.schema.node_remove import (
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.helpers.schema import load_schema
@@ -141,3 +142,43 @@ async def test_migration_agnostic_relationship(
 
     await validate_node_relationships(node=person_john, db=db, branch=registry.get_global_branch())
     await validate_node_relationships(node=car, db=db, branch=registry.get_global_branch())
+
+
+async def test_migration_with_user_id(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
+) -> None:
+    """Test that the user_id passed to migration.execute() is correctly set on the deleted edges."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    candidate_schema.delete(name="TestCar")
+
+    migration = NodeRemoveMigration(
+        previous_node_schema=schema.get(name="TestCar"),
+        new_node_schema=None,
+        schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
+    )
+
+    test_user_id = "test-remove-node-migration-user"
+    migration_time = Timestamp()
+    execution_result = await migration.execute(db=db, branch=default_branch, at=migration_time, user_id=test_user_id)
+
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 2
+
+    # Query for the deleted edges created by the migration and verify user_id metadata
+    query = """
+    MATCH (n:TestCar {uuid: $car_uuid})-[r {status: "deleted", from: $migration_time}]-()
+    RETURN DISTINCT r.from_user_id as from_user_id
+    """
+    results = await db.execute_query(
+        query=query,
+        params={
+            "car_uuid": car_accord_main.id,
+            "migration_time": migration_time.to_string(),
+        },
+    )
+
+    # All deleted edges created during the migration should have the test user_id
+    assert len(results) > 0, "Expected at least one deleted edge"
+    for record in results:
+        assert record["from_user_id"] == test_user_id


### PR DESCRIPTION
IFC-2091

- update all of our schema migrations to include handling for updating updated/created_at/by metadata correctly
- pass `user_id` all over the place in the schema migrations
- a few other small cypher changes fix bugs identified during testing
- a bunch of new tests and test updates

I think this PR is big enough already, so the code to pass the user_id down into the migrations will come in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved metadata tracking for creation and modification timestamps during system migrations and operations.
  * Enhanced user attribution to properly record who performed system operations.
  * Fixed metadata propagation for node relationships and attributes during migrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->