### PR TITLE
Move metadata edit modal into ObjectDataDisplay component

### DIFF
--- a/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.ts
+++ b/frontend/app/src/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData.ts
@@ -1,4 +1,4 @@
-import type { NodeSchema } from "@/entities/schema/types";
+import type { ModelSchema } from "@/entities/schema/types";
 
 const metadataFields = ["source", "owner", "is_protected"];
 
@@ -18,7 +18,7 @@ const isValueValid = (value: any) => {
 };
 
 const getMutationMetaDetailsFromFormData = (
-  schema: NodeSchema,
+  schema: ModelSchema,
   data: any,
   row: any,
   type: any,

--- a/frontend/app/src/entities/nodes/object-item-meta-edit/object-item-meta-edit.tsx
+++ b/frontend/app/src/entities/nodes/object-item-meta-edit/object-item-meta-edit.tsx
@@ -13,11 +13,11 @@ import { stringifyWithoutQuotes } from "@/shared/utils/string";
 import { currentBranchAtom } from "@/entities/branches/stores";
 import { updateObjectWithId } from "@/entities/nodes/api/updateObjectWithId";
 import getMutationMetaDetailsFromFormData from "@/entities/nodes/object-item-meta-edit/getMutationMetaDetailsFromFormData";
-import type { NodeSchema } from "@/entities/schema/types";
+import type { ModelSchema } from "@/entities/schema/types";
 
 interface Props {
   row: any;
-  schema: NodeSchema;
+  schema: ModelSchema;
   type: "attribute" | "relationship";
   attributeOrRelationshipToEdit: any;
   attributeOrRelationshipName: any;

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display.tsx
@@ -1,15 +1,23 @@
 import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify-icon/react";
+import { useAtom } from "jotai";
 
+import { queryClient } from "@/shared/api/rest/client";
 import { ButtonWithTooltip } from "@/shared/components/buttons/button-primitive";
 import MetaDetailsTooltip from "@/shared/components/display/meta-details-tooltips";
+import SlideOver from "@/shared/components/display/slide-over";
 import { sortByOrderWeight } from "@/shared/utils/common";
 
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
 import { ObjectAttributeValue } from "@/entities/nodes/getObjectItemDisplayValue";
+import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 import { getAttributesVisibleInDetailedView } from "@/entities/nodes/object/utils/get-attributes-visible-in-detailed-view";
 import { getRelationshipsVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import { ObjectAttributeRow } from "@/entities/nodes/object-item-details/object-attribute-row";
 import RelationshipDetails from "@/entities/nodes/object-item-details/relationship-details-paginated";
+import ObjectItemMetaEdit from "@/entities/nodes/object-item-meta-edit/object-item-meta-edit";
+import { showMetaEditState } from "@/entities/nodes/stores/metaEditFieldDetails.atom";
+import { metaEditFieldDetailsState } from "@/entities/nodes/stores/showMetaEdit.atom";
 import type {
   NodeAttributeWithMetadata,
   NodeObjectWithMetadata,
@@ -23,15 +31,27 @@ interface ObjectDataDisplayProps {
   objectSchema: ModelSchema;
   objectData: NodeObjectWithMetadata;
   permission: Permission;
-  onClickMetadata?: (attribute: AttributeSchema) => void;
 }
 
 export function ObjectDataDisplay({
   objectSchema,
   objectData,
   permission,
-  onClickMetadata,
 }: ObjectDataDisplayProps) {
+  const { currentBranch } = useCurrentBranch();
+  const [showMetaEditModal, setShowMetaEditModal] = useAtom(showMetaEditState);
+  const [metaEditFieldDetails, setMetaEditFieldDetails] = useAtom(metaEditFieldDetailsState);
+
+  const onClickMetadata = (attribute: AttributeSchema) => {
+    setMetaEditFieldDetails({
+      type: "attribute",
+      attributeOrRelationshipName: attribute.name,
+      label: attribute.label || attribute.name,
+    });
+
+    setShowMetaEditModal(true);
+  };
+
   const attributes = getAttributesVisibleInDetailedView(objectSchema.attributes ?? []);
   const relationships = getRelationshipsVisibleInDetailedView(objectSchema.relationships ?? []);
   const fields = sortByOrderWeight([...attributes, ...relationships]);
@@ -64,6 +84,39 @@ export function ObjectDataDisplay({
           />
         );
       })}
+
+      <SlideOver
+        title={
+          <div className="space-y-2">
+            <div className="flex w-full items-center">
+              <span className="mr-3 font-semibold text-lg">{metaEditFieldDetails?.label}</span>
+              <div className="flex-1"></div>
+              <div className="flex items-center">
+                <Icon icon={"mdi:layers-triple"} />
+                <div className="ml-1.5 pb-1">{currentBranch.name}</div>
+              </div>
+            </div>
+            <div className="text-gray-500">Metadata</div>
+          </div>
+        }
+        open={showMetaEditModal}
+        setOpen={setShowMetaEditModal}
+      >
+        <ObjectItemMetaEdit
+          closeDrawer={() => setShowMetaEditModal(false)}
+          onUpdateComplete={async () => {
+            await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
+          }}
+          attributeOrRelationshipToEdit={
+            objectData[metaEditFieldDetails?.attributeOrRelationshipName]?.properties ||
+            objectData[metaEditFieldDetails?.attributeOrRelationshipName]
+          }
+          schema={objectSchema}
+          attributeOrRelationshipName={metaEditFieldDetails?.attributeOrRelationshipName}
+          type={metaEditFieldDetails?.type!}
+          row={objectData}
+        />
+      </SlideOver>
     </div>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-card.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-card.tsx
@@ -1,19 +1,9 @@
-import { Icon } from "@iconify-icon/react";
-import { useAtom } from "jotai";
-
-import { queryClient } from "@/shared/api/rest/client";
-import SlideOver from "@/shared/components/display/slide-over";
 import { Card, CardWithBorder } from "@/shared/components/ui/card";
 
-import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
-import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 import { ObjectDataDisplay } from "@/entities/nodes/object/ui/object-details/object-data-display";
-import ObjectItemMetaEdit from "@/entities/nodes/object-item-meta-edit/object-item-meta-edit";
-import { showMetaEditState } from "@/entities/nodes/stores/metaEditFieldDetails.atom";
-import { metaEditFieldDetailsState } from "@/entities/nodes/stores/showMetaEdit.atom";
 import type { NodeObjectWithMetadata } from "@/entities/nodes/types";
 import type { Permission } from "@/entities/permission/types";
-import type { AttributeSchema, ModelSchema } from "@/entities/schema/types";
+import type { ModelSchema } from "@/entities/schema/types";
 
 interface ObjectDetailsCardProps {
   objectSchema: ModelSchema;
@@ -28,65 +18,15 @@ export function ObjectDetailsCard({
   permission,
   className,
 }: ObjectDetailsCardProps) {
-  const { currentBranch } = useCurrentBranch();
-  const [showMetaEditModal, setShowMetaEditModal] = useAtom(showMetaEditState);
-  const [metaEditFieldDetails, setMetaEditFieldDetails] = useAtom(metaEditFieldDetailsState);
-
-  const handleMetadataClick = (attribute: AttributeSchema) => {
-    setMetaEditFieldDetails({
-      type: "attribute",
-      attributeOrRelationshipName: attribute.name,
-      label: attribute.label || attribute.name,
-    });
-
-    setShowMetaEditModal(true);
-  };
-
   return (
-    <>
-      <Card className={className} data-testid="object-details">
-        <CardWithBorder.Title className="border-gray-200 border-b">Details</CardWithBorder.Title>
+    <Card className={className} data-testid="object-details">
+      <CardWithBorder.Title className="border-gray-200 border-b">Details</CardWithBorder.Title>
 
-        <ObjectDataDisplay
-          objectSchema={objectSchema}
-          objectData={objectData}
-          permission={permission}
-          onClickMetadata={handleMetadataClick}
-        />
-      </Card>
-
-      <SlideOver
-        title={
-          <div className="space-y-2">
-            <div className="flex w-full items-center">
-              <span className="mr-3 font-semibold text-lg">{metaEditFieldDetails?.label}</span>
-              <div className="flex-1"></div>
-              <div className="flex items-center">
-                <Icon icon={"mdi:layers-triple"} />
-                <div className="ml-1.5 pb-1">{currentBranch.name}</div>
-              </div>
-            </div>
-            <div className="text-gray-500">Metadata</div>
-          </div>
-        }
-        open={showMetaEditModal}
-        setOpen={setShowMetaEditModal}
-      >
-        <ObjectItemMetaEdit
-          closeDrawer={() => setShowMetaEditModal(false)}
-          onUpdateComplete={async () => {
-            await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
-          }}
-          attributeOrRelationshipToEdit={
-            objectData[metaEditFieldDetails?.attributeOrRelationshipName]?.properties ||
-            objectData[metaEditFieldDetails?.attributeOrRelationshipName]
-          }
-          schema={objectSchema}
-          attributeOrRelationshipName={metaEditFieldDetails?.attributeOrRelationshipName}
-          type={metaEditFieldDetails?.type!}
-          row={objectData}
-        />
-      </SlideOver>
-    </>
+      <ObjectDataDisplay
+        objectSchema={objectSchema}
+        objectData={objectData}
+        permission={permission}
+      />
+    </Card>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated type definitions across metadata editing components for internal consistency.

* **Improvements**
  * Integrated metadata editing directly into object data display with inline SlideOver UI for a streamlined editing experience.
  * Simplified object details card presentation by consolidating metadata editing workflow internally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->