### PR TITLE
pass user ID from merge/rebase/load to schema migrations

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -387,6 +387,7 @@ async def load_schema(
             new_schema=candidate_schema,
             previous_schema=origin_schema,
             migrations=result.migrations,
+            user_id=account_session.account_id,
         )
         migration_error_msgs = await service.workflow.execute_workflow(
             workflow=SCHEMA_APPLY_MIGRATION,

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -193,6 +193,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                         new_schema=candidate_schema,
                         previous_schema=schema_in_main_before,
                         migrations=migrations,
+                        user_id=context.account.account_id,
                     )
                 )
                 for error in errors:
@@ -297,6 +298,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                     new_schema=merger.destination_schema,
                     previous_schema=merger.initial_source_schema,
                     migrations=merger.migrations,
+                    user_id=context.account.account_id,
                 )
             )
             for error in errors:

--- a/backend/infrahub/core/migrations/schema/models.py
+++ b/backend/infrahub/core/migrations/schema/models.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.models import SchemaUpdateMigrationInfo
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -15,6 +16,7 @@ class SchemaApplyMigrationData(BaseModel):
     new_schema: SchemaBranch
     previous_schema: SchemaBranch
     migrations: list[SchemaUpdateMigrationInfo]
+    user_id: str = SYSTEM_USER_ID
 
     @model_serializer()
     def serialize_model(self) -> dict[str, Any]:
@@ -23,6 +25,7 @@ class SchemaApplyMigrationData(BaseModel):
             "previous_schema": self.previous_schema.to_dict_schema_object(),
             "new_schema": self.new_schema.to_dict_schema_object(),
             "migrations": [migration.model_dump() for migration in self.migrations],
+            "user_id": self.user_id,
         }
 
     @field_validator("new_schema", "previous_schema", mode="before")

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -8,6 +8,7 @@ from prefect.cache_policies import NONE
 from prefect.logging import get_run_logger
 
 from infrahub.core.branch import Branch  # noqa: TC001
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations import MIGRATION_MAP
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.workers.dependencies import get_database
@@ -57,6 +58,7 @@ async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str
             previous_node_schema=previous_node_schema,
             schema_path=migration.path,
             database=await get_database(),
+            user_id=message.user_id,
         )
 
     async for _, result in batch.execute():
@@ -79,6 +81,7 @@ async def schema_path_migrate(
     database: InfrahubDatabase,
     new_node_schema: MainSchemaTypes | None = None,
     previous_node_schema: MainSchemaTypes | None = None,
+    user_id: str = SYSTEM_USER_ID,
 ) -> SchemaMigrationPathResponseData:
     log = get_run_logger()
 
@@ -101,7 +104,7 @@ async def schema_path_migrate(
             previous_node_schema=previous_node_schema,  # type: ignore[arg-type]
             schema_path=schema_path,
         )
-        execution_result = await migration.execute(db=db, branch=branch)
+        execution_result = await migration.execute(db=db, branch=branch, user_id=user_id)
 
         log.info(f"Migration completed for {migration_name}")
         log.debug(f"execution_result {execution_result}")

--- a/backend/tests/functional/api/test_load_schema.py
+++ b/backend/tests/functional/api/test_load_schema.py
@@ -6,9 +6,12 @@ import pytest
 from infrahub_sdk.schema import GenericSchemaAPI as SDKGenericSchema
 
 from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
+from infrahub.core.query.node import MetadataOptions
 from infrahub.core.registry import registry
 from infrahub.core.schema import core_models
 from infrahub.core.schema.basenode_schema import OPTIONAL_TEXT_FIELDS
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
@@ -19,6 +22,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.protocols import CoreAccount
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
     from tests.conftest import TestHelper
@@ -56,6 +60,68 @@ class TestLoadSchemaAPI(TestInfrahubApp):
         updated_relationship_count = await count_relationships(db=db)
 
         assert first_relationship_count == updated_relationship_count
+
+    async def test_schema_migration_updates_node_metadata(
+        self,
+        initial_dataset: str,
+        client: InfrahubClient,
+        helper: TestHelper,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+    ) -> None:
+        """Test that schema migrations update node metadata (updated_at/by) correctly."""
+        # Load initial schema
+        await client.schema.load(schemas=[helper.schema_file("infra_simple_01.json")])
+
+        # Create a TestDevice node
+        device = await client.create(
+            kind="TestDevice",
+            name="metadata-test-device",
+            type="router",
+            role="router",
+            status="active",
+        )
+        await device.save()
+        device_id = device.id
+
+        # Record time before schema change
+        time_before_migration = Timestamp()
+
+        # Modify schema to add a new attribute to TestDevice
+        updated_schema = helper.schema_file("infra_simple_01.json")
+        for node in updated_schema["nodes"]:
+            if node["name"] == "Device" and node["namespace"] == "Test":
+                node["attributes"].append({"name": "location", "kind": "Text", "optional": True})
+                break
+
+        # Load updated schema - this should trigger a migration
+        update_result = await client.schema.load(schemas=[updated_schema])
+        assert update_result.schema_updated
+
+        # Query the node with metadata
+        nodes = await NodeManager.get_many(
+            db=db,
+            ids=[device_id],
+            branch=default_branch,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+        )
+        node = nodes[device_id]
+
+        # Verify node metadata was updated by the migration
+        assert node._get_created_at() < time_before_migration
+        assert node._get_created_by() == admin_account.id
+        assert node._get_updated_at() > time_before_migration
+        assert node._get_updated_by() == admin_account.id
+
+        # Verify the new attribute exists and has proper metadata
+        assert node.location._get_created_at() > time_before_migration
+        assert node.location._get_created_by() == admin_account.id
+        assert node.location._get_updated_at() == node.location._get_created_at()
+        assert node.location._get_updated_by() == admin_account.id
 
     async def test_schema_load_with_absent_schema(
         self,

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -7,7 +7,12 @@ from infrahub.core.initialization import (
     create_branch,
 )
 from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
+from infrahub.core.metadata.query.node_metadata import NodeMetadataDefaultBranchQuery
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreAccount
+from infrahub.core.query.node import MetadataOptions
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from infrahub.exceptions import InitializationError, SchemaNotFoundError
@@ -70,7 +75,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         await megane.new(
             db=db, name="Megane", description="Renault Megane", color="#c93420", manufacturer=renault, owner=john
         )
-        await megane.save(db=db)
+        await megane.save(db=db, user_id="megane-creator")
 
         clio = await Node.init(schema=CAR_KIND, db=db)
         await clio.new(
@@ -115,7 +120,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         # Create Data in MAIN after BRANCH1 was created
         jane = await Node.init(schema=PERSON_KIND, db=db)
         await jane.new(db=db, name="Jane", height=165, description="The famous Jane Doe")
-        await jane.save(db=db)
+        await jane.save(db=db, user_id="jane-creator")
 
         honda = await Node.init(schema=MANUFACTURER_KIND_01, db=db)
         await honda.new(db=db, name="honda", description="Honda Motor Co., Ltd")
@@ -133,7 +138,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
 
         blue = await Node.init(schema=TAG_KIND, db=db)
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
-        await blue.save(db=db)
+        await blue.save(db=db, user_id="blue-creator")
 
         objs = {
             "john": john.id,
@@ -340,10 +345,18 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         assert len(renault_cars) == 2
 
     async def test_rebase(
-        self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        initial_dataset,
+        admin_account: CoreAccount,
     ) -> None:
+        time_before_rebase = Timestamp()
         branch = await client.branch.rebase(branch_name=self.branch1.name)
         assert branch
+        time_after_rebase = Timestamp()
+
         person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=default_branch)
         height_attr_schema = person_schema.get_attribute(name="height")
         assert height_attr_schema.id
@@ -367,6 +380,34 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         honda = manufacturers[0]
         honda_cars = await honda.cars.get_peers(db=db)  # type: ignore[attr-defined]
         assert len(honda_cars) == 2
+
+        # Validate metadata on nodes modified by rebase migrations
+        # Jane was created in main after branch1 was created, so she was migrated during rebase
+        # The migration added the 'lastname' attribute and removed 'height'
+        updated_branch_1 = await Branch.get_by_name(db=db, name=self.branch1.name)
+        jane_with_metadata = await NodeManager.get_one(
+            db=db,
+            id=initial_dataset["jane"],
+            branch=updated_branch_1,
+            include_metadata=MetadataQueryOptions(
+                node_level=MetadataOptions.USER_TIMESTAMPS,
+                attribute_level=MetadataOptions.USER_TIMESTAMPS,
+            ),
+        )
+
+        # Node should have been updated during the rebase migration
+        assert jane_with_metadata._get_created_at() < time_before_rebase
+        assert jane_with_metadata._get_created_by() == "jane-creator"
+        assert time_before_rebase < jane_with_metadata._get_updated_at() < time_after_rebase
+        assert jane_with_metadata._get_updated_by() == admin_account.id
+
+        # The new 'lastname' attribute should have been created during the migration
+        lastname_attr = jane_with_metadata.get_attribute(name="lastname")
+        assert lastname_attr._get_created_at() < time_after_rebase
+        assert lastname_attr._get_created_at() > time_before_rebase
+        assert lastname_attr._get_created_by() == admin_account.id
+        assert lastname_attr._get_updated_at() == lastname_attr._get_created_at()
+        assert lastname_attr._get_updated_by() == admin_account.id
 
     async def test_step04_check(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step04
@@ -474,12 +515,20 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         assert "profiles" in car_schema.relationship_names
 
     async def test_step05_merge(
-        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step06, schema_interior_base
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset,
+        schema_step06,
+        schema_interior_base,
+        admin_account: CoreAccount,
     ) -> None:
         response = await client.schema.load(schemas=[schema_step06], branch=self.branch1.name)
         assert not response.errors
 
+        time_before_merge = Timestamp()
         await client.branch.merge(branch_name=self.branch1.name)
+        time_after_merge = Timestamp()
 
         updated_branch = await Branch.get_by_name(name=self.branch1.name, db=db)
         updated_schema_default = await registry.schema.load_schema_from_db(db=db)
@@ -490,6 +539,31 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         updated_interiors_schema = updated_schema_branch.get(name="TestingInterior", duplicate=False)
         assert updated_interiors_schema.attribute_names == ["material"]
         assert "cars" in updated_interiors_schema.relationship_names
+
+        # Validate metadata on deleted blue tag using NodeMetadataDefaultBranchQuery
+        # The blue tag was deleted during the merge because TestingTag was removed in schema_step04
+        default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
+        blue_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+            db=db, branch=default_branch, node_uuids=[initial_dataset["blue"]]
+        )
+        await blue_metadata_query.execute(db=db)
+        blue_metadatas = blue_metadata_query.get_metadatas()
+
+        assert len(blue_metadatas) == 1
+        blue_metadata = blue_metadatas[0]
+
+        # Verify the blue tag is marked as deleted
+        assert blue_metadata.is_deleted is True
+        assert blue_metadata.uuid == initial_dataset["blue"]
+        assert blue_metadata.kind == TAG_KIND
+
+        # Verify metadata timestamps - created before merge, updated during merge
+        assert blue_metadata.created_at is not None
+        assert blue_metadata.created_at < time_before_merge
+        assert blue_metadata.created_by == "blue-creator"
+        assert blue_metadata.updated_at is not None
+        assert time_before_merge < blue_metadata.updated_at < time_after_merge
+        assert blue_metadata.updated_by == admin_account.id
 
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)


### PR DESCRIPTION
pass user_id from schema load/merge branch/rebase branch into schema migration execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema migrations now track the user who initiates them, enabling proper attribution in node metadata during migration operations across branches.

* **Tests**
  * Added tests to verify that schema migrations correctly update node and attribute metadata with proper timestamps and user attribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->