### PR TITLE
Add GraphQL metadata sort options

### DIFF
--- a/backend/infrahub/constants/enums.py
+++ b/backend/infrahub/constants/enums.py
@@ -1,0 +1,12 @@
+from enum import StrEnum
+
+
+class OrderDirection(StrEnum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
+class OrderByField(StrEnum):
+    ID = "id"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -9,7 +9,7 @@ from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, SYSTEM_USER_ID
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.models import SchemaBranchHash  # noqa: TC001
-from infrahub.core.node.standard import StandardNode
+from infrahub.core.node.standard import StandardNode, StandardNodeOrdering
 from infrahub.core.query import Query, QueryType
 from infrahub.core.query.branch import (
     BranchNodeGetListQuery,
@@ -156,14 +156,17 @@ class Branch(StandardNode):
         limit: int = 1000,
         ids: list[str] | None = None,
         name: str | None = None,
+        node_ordering: StandardNodeOrdering | None = None,
         **kwargs: Any,
     ) -> list[Self]:
+        node_ordering = node_ordering or StandardNodeOrdering()
         query: Query = await BranchNodeGetListQuery.init(
             db=db,
             node_class=cls,
             ids=ids,
             node_name=name,
             limit=limit,
+            node_ordering=node_ordering,
             **kwargs,
         )
         await query.execute(db=db)

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -10,6 +10,7 @@ import ujson
 from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel, Field, field_validator
 
+from infrahub.constants.enums import OrderByField, OrderDirection
 from infrahub.core.constants import NULL_VALUE, SYSTEM_USER_ID, InfrahubKind
 from infrahub.core.query.standard_node import (
     StandardNodeCreateQuery,
@@ -29,6 +30,12 @@ if TYPE_CHECKING:
 
     from infrahub.core.query import Query
     from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class StandardNodeOrdering:
+    order_by: OrderByField = field(default=OrderByField.ID)
+    direction: OrderDirection = field(default=OrderDirection.ASC)
 
 
 @dataclass(slots=True)
@@ -296,10 +303,12 @@ class StandardNode(BaseModel):
         limit: int = 1000,
         ids: list[str] | None = None,
         name: str | None = None,
+        node_ordering: StandardNodeOrdering | None = None,
         **kwargs: dict[str, Any],
     ) -> list[Self]:
+        node_ordering = node_ordering or StandardNodeOrdering()
         query: Query = await StandardNodeGetListQuery.init(
-            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, **kwargs
+            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, node_ordering=node_ordering, **kwargs
         )
         await query.execute(db=db)
 

--- a/backend/infrahub/core/query/standard_node.py
+++ b/backend/infrahub/core/query/standard_node.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 
+from infrahub.constants.enums import OrderByField
 from infrahub.core.query import Query, QueryType
 from infrahub.exceptions import InitializationError
 
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from infrahub.core.node.standard import StandardNode
+    from infrahub.core.node.standard import StandardNode, StandardNodeOrdering
     from infrahub.database import InfrahubDatabase
 
 
@@ -137,6 +138,7 @@ class StandardNodeGetListQuery(Query):
     def __init__(
         self,
         node_class: StandardNode,
+        node_ordering: StandardNodeOrdering,
         ids: list[str] | None = None,
         node_name: str | None = None,
         partial_match: bool = False,
@@ -146,6 +148,7 @@ class StandardNodeGetListQuery(Query):
         self.node_name = node_name
         self.node_class = node_class
         self.partial_match = partial_match
+        self.node_ordering = node_ordering
 
         super().__init__(**kwargs)
 
@@ -178,4 +181,12 @@ class StandardNodeGetListQuery(Query):
         self.add_to_query(query)
 
         self.return_labels = ["n"]
-        self.order_by = [f"{db.get_id_function_name()}(n)"]
+        match self.node_ordering.order_by:
+            case OrderByField.ID:
+                self.order_by = [f"{db.get_id_function_name()}(n)"]
+            case OrderByField.CREATED_AT:
+                self.order_by = [f"n.created_at {self.node_ordering.direction.value}"]
+            case OrderByField.UPDATED_AT:
+                self.order_by = [f"n.updated_at {self.node_ordering.direction.value}"]
+            case _:
+                assert_never(self.node_ordering.order_by)

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -21,6 +21,7 @@ from infrahub.core.schema import (
 from infrahub.graphql.mutations.attribute import BaseAttributeCreate, BaseAttributeUpdate
 from infrahub.graphql.mutations.graphql_query import InfrahubGraphQLQueryMutation
 from infrahub.graphql.mutations.profile import InfrahubProfileMutation
+from infrahub.graphql.types.metadata import OrderInput
 from infrahub.types import ATTRIBUTE_TYPES, InfrahubDataType, get_attribute_type
 
 from .constants import NODE_METADATA_TYPE, RELATIONSHIP_METADATA_TYPE
@@ -84,10 +85,6 @@ class DeleteInput(graphene.InputObjectType):
 
 
 GraphQLTypes = type[InfrahubMutation] | type[BaseAttributeType] | type[graphene.Interface] | type[graphene.ObjectType]
-
-
-class OrderInput(graphene.InputObjectType):
-    disable = graphene.Boolean(required=False)
 
 
 @dataclass

--- a/backend/infrahub/graphql/models.py
+++ b/backend/infrahub/graphql/models.py
@@ -1,6 +1,36 @@
-from pydantic import BaseModel
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from infrahub.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from infrahub.constants.enums import OrderDirection
 
 
-# Corresponds to infrahub.graphql.manager.OrderInput
-class OrderModel(BaseModel):
+@dataclass
+class NodeMetaOrder:
+    created_at: OrderDirection | None = None
+    updated_at: OrderDirection | None = None
+
+
+@dataclass
+class OrderModel:
+    # Corresponds to infrahub.graphql.manager.OrderInput
     disable: bool | None = None
+    node_metadata: NodeMetaOrder | None = None
+
+    @classmethod
+    def from_input(cls, input_data: dict[str, Any] | None) -> OrderModel | None:
+        """Convert the dictionary type input data from GraphQL into an OrderModel instance."""
+        if not input_data:
+            return None
+
+        order_model = cls(**input_data)
+        order_model.validate()
+        return order_model
+
+    def validate(self) -> None:
+        if self.node_metadata and self.node_metadata.created_at and self.node_metadata.updated_at:
+            raise ValidationError("Cannot order by both created_at and updated_at simultaneously.")

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -2,16 +2,48 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import ID, Boolean, Field, Int, List, NonNull, String
+from graphene import ID, Argument, Boolean, Field, Int, List, NonNull, String
 
-from infrahub.core.node.standard import StandardNodeQueryFields
+from infrahub.constants.enums import OrderByField, OrderDirection
+from infrahub.core.node.standard import StandardNodeOrdering, StandardNodeQueryFields
 from infrahub.core.registry import registry
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types import BranchType, InfrahubBranch, InfrahubBranchType
+from infrahub.graphql.types.metadata import OrderInput
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
+
+
+def standard_node_ordering_from_order_input(order: OrderInput | None = None) -> StandardNodeOrdering:
+    """Create a StandardNodeOrdering from an OrderInput.
+
+    Args:
+        order: Optional ordering specification from GraphQL input.
+
+    Returns:
+        StandardNodeOrdering with the specified field and direction, or defaults to ID with no direction.
+
+    Raises:
+        ValidationError: If both created_at and updated_at are specified.
+    """
+    if order is None or not order.node_metadata:
+        return StandardNodeOrdering()
+
+    created_at = getattr(order.node_metadata, "created_at", None)
+    updated_at = getattr(order.node_metadata, "updated_at", None)
+
+    if created_at and updated_at:
+        raise ValidationError("Only one of 'created_at' or 'updated_at' can be specified for ordering.")
+
+    if created_at:
+        return StandardNodeOrdering(order_by=OrderByField.CREATED_AT, direction=OrderDirection(created_at.value))
+
+    if updated_at:
+        return StandardNodeOrdering(order_by=OrderByField.UPDATED_AT, direction=OrderDirection(updated_at.value))
+
+    return StandardNodeOrdering()
 
 
 async def branch_resolver(
@@ -43,11 +75,14 @@ async def infrahub_branch_resolver(
     name__value: str | None = None,
     ids: list[str] | None = None,
     partial_match: bool = False,
+    order: OrderInput | None = None,
 ) -> dict[str, Any]:
     if isinstance(limit, int) and limit < 1:
         raise ValidationError("limit must be >= 1")
     if isinstance(offset, int) and offset < 0:
         raise ValidationError("offset must be >= 0")
+
+    node_ordering = standard_node_ordering_from_order_input(order)
 
     fields = extract_graphql_fields(info)
     result: dict[str, Any] = {}
@@ -65,11 +100,16 @@ async def infrahub_branch_resolver(
             ids=ids,
             exclude_global=True,
             partial_match=partial_match,
+            node_ordering=node_ordering,
         )
         result["edges"] = branches
     if "count" in fields:
         result["count"] = await InfrahubBranchType.get_list_count(
-            graphql_context=info.context, name=name__value, ids=ids, partial_match=partial_match
+            graphql_context=info.context,
+            name=name__value,
+            ids=ids,
+            partial_match=partial_match,
+            node_ordering=node_ordering,
         )
 
     if "default_branch" in fields:
@@ -90,6 +130,11 @@ InfrahubBranchQueryList = Field(
     name__value=String(),
     ids=List(ID),
     partial_match=Boolean(default_value=False),
+    order=Argument(
+        OrderInput,
+        required=False,
+        description="Define ordering of results for branch queries.",
+    ),
     description="Retrieve paginated information about active branches.",
     resolver=infrahub_branch_resolver,
     required=True,

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -16,10 +16,9 @@ from infrahub.core.node import Node
 from infrahub.core.protocols import BuiltinIPNamespace, BuiltinIPPrefix
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.exceptions import ValidationError
+from infrahub.graphql.models import OrderModel
 from infrahub.graphql.parser import extract_selection
 from infrahub.graphql.permissions import get_permissions
-
-from ..models import OrderModel
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -31,7 +30,6 @@ if TYPE_CHECKING:
     from infrahub.core.schema import NodeSchema
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
-    from infrahub.graphql.models import OrderModel
 
 
 def _ip_range_display_label(node: Node) -> str:
@@ -311,7 +309,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
     info: GraphQLResolveInfo,
     offset: int | None = None,
     limit: int | None = None,
-    order: OrderModel | None = None,
+    order: dict[str, Any] | None = None,
     partial_match: bool = False,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
@@ -324,6 +322,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
     if not isinstance(schema, GenericSchema) or schema.kind not in [InfrahubKind.IPADDRESS, InfrahubKind.IPPREFIX]:
         raise ValidationError(f"{schema.kind} is not {InfrahubKind.IPADDRESS} or {InfrahubKind.IPPREFIX}")
 
+    order_model = OrderModel.from_input(input_data=order)
     fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
     kinds_to_filter: list[str] = kwargs.pop("kinds", [])  # type: ignore[assignment]
@@ -402,7 +401,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
                 account=graphql_context.account_session,
                 include_metadata=MetadataOptions.LINKED_NODES,
                 partial_match=partial_match,
-                order=order,
+                order=order_model,
             )
 
             if fetch_first_node_context and len(objs) > 2:

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -146,7 +146,7 @@ async def default_paginated_list_resolver(
     info: GraphQLResolveInfo,
     offset: int | None = None,
     limit: int | None = None,
-    order: OrderModel | None = None,
+    order: dict | None = None,
     partial_match: bool = False,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
@@ -155,6 +155,8 @@ async def default_paginated_list_resolver(
         if isinstance(info.return_type, GraphQLNonNull)
         else info.return_type.graphene_type._meta.schema
     )
+
+    order_model = OrderModel.from_input(input_data=order)
 
     fields = await extract_selection(info=info, schema=schema)
 
@@ -203,7 +205,7 @@ async def default_paginated_list_resolver(
                 offset=offset,
                 account=graphql_context.account_session,
                 partial_match=partial_match,
-                order=order,
+                order=order_model,
             )
 
         if "count" in fields:

--- a/backend/infrahub/graphql/types/enums.py
+++ b/backend/infrahub/graphql/types/enums.py
@@ -1,5 +1,6 @@
 from graphene import Enum
 
+from infrahub.constants.enums import OrderDirection
 from infrahub.core import constants
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.permissions import constants as permission_constants
@@ -13,3 +14,5 @@ Severity = Enum.from_enum(constants.Severity)
 BranchRelativePermissionDecision = Enum.from_enum(permission_constants.BranchRelativePermissionDecision)
 
 InfrahubBranchStatus = Enum.from_enum(BranchStatus)
+
+InfrahubOrderDirection = Enum.from_enum(OrderDirection)

--- a/backend/infrahub/graphql/types/metadata.py
+++ b/backend/infrahub/graphql/types/metadata.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
-from graphene import DateTime, ObjectType
+from graphene import Boolean, DateTime, Field, InputObjectType, ObjectType
+
+from infrahub.graphql.types.enums import InfrahubOrderDirection
+
+
+class InfrahubNodeMetadataOrder(InputObjectType):
+    created_at = Field(InfrahubOrderDirection, required=False, description="Order by creation timestamp")
+    updated_at = Field(InfrahubOrderDirection, required=False, description="Order by updated timestamp")
+
+
+class OrderInput(InputObjectType):
+    disable = Boolean(required=False)
+    node_metadata = Field(InfrahubNodeMetadataOrder, required=False, description="Order settings for branch metadata")
 
 
 class InfrahubStandardNodeMetaData(ObjectType):

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -480,3 +480,287 @@ class TestBranchQuery(TestInfrahubApp):
             assert result.errors is None
             assert result.data
             assert result.data["InfrahubBranch"]["count"] == test_case.expected_count
+
+    async def test_order_by_created_at_ascending(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+        session_admin: AccountSession,
+    ) -> None:
+        """Test that branches can be ordered by created_at in ascending order."""
+        branch_names = ["alpha-branch", "beta-branch", "gamma-branch"]
+        for branch_name in branch_names:
+            create_branch_query = """
+            mutation($branch_name: String!) {
+                BranchCreate(data: { name: $branch_name, description: "test" }) {
+                    ok
+                    object { id name }
+                }
+            }
+            """
+            gql_params = await prepare_graphql_params(
+                db=db, branch=default_branch, account_session=session_admin, service=service
+            )
+            result = await graphql(
+                schema=gql_params.schema,
+                source=create_branch_query,
+                context_value=gql_params.context,
+                root_value=None,
+                variable_values={"branch_name": branch_name},
+            )
+            assert result.errors is None
+
+        query = """
+        query {
+            InfrahubBranch(order: {node_metadata: {created_at: ASC}}) {
+                edges {
+                    node_metadata { created_at }
+                    node { name { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+
+        assert result.errors is None
+        assert result.data
+        edges = result.data["InfrahubBranch"]["edges"]
+
+        timestamps = [edge["node_metadata"]["created_at"] for edge in edges]
+        assert timestamps == sorted(timestamps), "Branches should be ordered by created_at ascending"
+
+        assert edges[0]["node"]["name"]["value"] == "main"
+
+    async def test_order_by_created_at_descending(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+        session_admin: AccountSession,
+    ) -> None:
+        """Test that branches can be ordered by created_at in descending order."""
+        branch_names = ["delta-branch", "epsilon-branch", "zeta-branch"]
+        for branch_name in branch_names:
+            create_branch_query = """
+            mutation($branch_name: String!) {
+                BranchCreate(data: { name: $branch_name, description: "test" }) {
+                    ok
+                    object { id name }
+                }
+            }
+            """
+            gql_params = await prepare_graphql_params(
+                db=db, branch=default_branch, account_session=session_admin, service=service
+            )
+            result = await graphql(
+                schema=gql_params.schema,
+                source=create_branch_query,
+                context_value=gql_params.context,
+                root_value=None,
+                variable_values={"branch_name": branch_name},
+            )
+            assert result.errors is None
+
+        query = """
+        query InfrahubBranch($direction: OrderDirection!) {
+            InfrahubBranch(order: {node_metadata: {created_at: $direction}}) {
+                edges {
+                    node_metadata { created_at }
+                    node { name { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            variable_values={"direction": "DESC"},
+            root_value=None,
+        )
+
+        assert result.errors is None
+        assert result.data
+        edges = result.data["InfrahubBranch"]["edges"]
+
+        timestamps = [edge["node_metadata"]["created_at"] for edge in edges]
+        assert timestamps == sorted(timestamps, reverse=True), "Branches should be ordered by created_at descending"
+
+        assert edges[0]["node"]["name"]["value"] == "zeta-branch"
+        assert edges[1]["node"]["name"]["value"] == "epsilon-branch"
+        assert edges[2]["node"]["name"]["value"] == "delta-branch"
+
+    async def test_order_by_updated_at_ascending(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+        session_admin: AccountSession,
+    ) -> None:
+        """Test that branches can be ordered by updated_at in ascending order."""
+        branch_names = ["eta-branch", "theta-branch", "iota-branch"]
+
+        for branch_name in branch_names:
+            create_branch_query = """
+            mutation($branch_name: String!) {
+                BranchCreate(data: { name: $branch_name, description: "initial" }) {
+                    ok
+                    object { id name }
+                }
+            }
+            """
+            gql_params = await prepare_graphql_params(
+                db=db, branch=default_branch, account_session=session_admin, service=service
+            )
+            result = await graphql(
+                schema=gql_params.schema,
+                source=create_branch_query,
+                context_value=gql_params.context,
+                root_value=None,
+                variable_values={"branch_name": branch_name},
+            )
+            assert result.errors is None
+
+        update_order = ["iota-branch", "theta-branch", "eta-branch"]
+        for branch_name in update_order:
+            branch = await Branch.get_by_name(name=branch_name, db=db)
+            branch.description = f"updated description for {branch_name}"
+            await branch.save(db=db)
+
+        query = """
+        query {
+            InfrahubBranch(order: {node_metadata: {updated_at: ASC}}) {
+                edges {
+                    node_metadata { updated_at }
+                    node { name { value } description { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+
+        assert result.errors is None
+        assert result.data
+        edges = result.data["InfrahubBranch"]["edges"]
+
+        test_branch_names = set(branch_names)
+        test_edges = [e for e in edges if e["node"]["name"]["value"] in test_branch_names]
+
+        timestamps = [edge["node_metadata"]["updated_at"] for edge in test_edges]
+        assert timestamps == sorted(timestamps), "Branches should be ordered by updated_at ascending"
+
+        result_branch_names = [e["node"]["name"]["value"] for e in test_edges]
+        assert result_branch_names == update_order, "Updated branches should appear in update order (ascending)"
+
+    async def test_order_by_updated_at_descending(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+        session_admin: AccountSession,
+    ) -> None:
+        """Test that branches can be ordered by updated_at in descending order."""
+        branch_names = ["kappa-branch", "lambda-branch", "mu-branch"]
+
+        # Create all branches first
+        for branch_name in branch_names:
+            create_branch_query = """
+            mutation($branch_name: String!) {
+                BranchCreate(data: { name: $branch_name, description: "initial" }) {
+                    ok
+                    object { id name }
+                }
+            }
+            """
+            gql_params = await prepare_graphql_params(
+                db=db, branch=default_branch, account_session=session_admin, service=service
+            )
+            result = await graphql(
+                schema=gql_params.schema,
+                source=create_branch_query,
+                context_value=gql_params.context,
+                root_value=None,
+                variable_values={"branch_name": branch_name},
+            )
+            assert result.errors is None
+
+        update_order = ["kappa-branch", "lambda-branch", "mu-branch"]
+        for branch_name in update_order:
+            branch = await Branch.get_by_name(name=branch_name, db=db)
+            branch.description = f"updated description for {branch_name}"
+            await branch.save(db=db)
+
+        query = """
+        query {
+            InfrahubBranch(order: {node_metadata: {updated_at: DESC}}) {
+                edges {
+                    node_metadata { updated_at }
+                    node { name { value } description { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+
+        assert result.errors is None
+        assert result.data
+        edges = result.data["InfrahubBranch"]["edges"]
+
+        test_branch_names = set(branch_names)
+        test_edges = [e for e in edges if e["node"]["name"]["value"] in test_branch_names]
+
+        timestamps = [edge["node_metadata"]["updated_at"] for edge in test_edges]
+        assert timestamps == sorted(timestamps, reverse=True), "Branches should be ordered by updated_at descending"
+
+        result_branch_names = [e["node"]["name"]["value"] for e in test_edges]
+        assert result_branch_names == list(reversed(update_order)), (
+            "Updated branches should appear in reverse update order (descending)"
+        )
+
+    async def test_order_by_only_one_field_allowed(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+    ) -> None:
+        """Test that specifying both created_at and updated_at returns an error."""
+        query = """
+        query {
+            InfrahubBranch(order: {node_metadata: {created_at: ASC, updated_at: DESC}}) {
+                edges {
+                    node { name { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+
+        assert result.errors is not None
+        assert len(result.errors) > 0
+        assert "created_at" in str(result.errors[0]) or "updated_at" in str(result.errors[0])

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -7425,6 +7425,13 @@ type InfrahubNodeMetadata {
   updated_by: CoreGenericAccount
 }
 
+input InfrahubNodeMetadataOrder {
+  """Order by creation timestamp"""
+  created_at: OrderDirection = null
+  """Order by updated timestamp"""
+  updated_at: OrderDirection = null
+}
+
 type InfrahubProfilesRefresh {
   ok: Boolean
 }
@@ -9778,8 +9785,16 @@ type ObjectPermissionNode {
   node: ObjectPermission!
 }
 
+"""An enumeration."""
+enum OrderDirection {
+  ASC
+  DESC
+}
+
 input OrderInput {
   disable: Boolean
+  """Order settings for branch metadata"""
+  node_metadata: InfrahubNodeMetadataOrder = null
 }
 
 """IPv4 or IPv6 address"""
@@ -11119,7 +11134,15 @@ type Query {
   IPPrefixGetNextAvailable(prefix_id: String!, prefix_length: Int): IPPrefixGetNextAvailable! @deprecated(reason: "This query has been renamed to 'InfrahubIPPrefixGetNextAvailable'. It will be removed in the next version of Infrahub.")
   InfrahubAccountToken(limit: Int, offset: Int): AccountTokenEdges!
   """Retrieve paginated information about active branches."""
-  InfrahubBranch(ids: [ID], limit: Int, name__value: String, offset: Int, partial_match: Boolean = false): InfrahubBranchType!
+  InfrahubBranch(
+    ids: [ID]
+    limit: Int
+    name__value: String
+    offset: Int
+    """Define ordering of results for branch queries."""
+    order: OrderInput
+    partial_match: Boolean = false
+  ): InfrahubBranchType!
   InfrahubEvent(
     """Filter the query to specific accounts"""
     account__ids: [String!]


### PR DESCRIPTION
Add sort options for metadata to GraphQL layer, fully implemented for the standard nodes (i.e. only InfrahubBranch) and just included the API bindings for the dynamically defined schema nodes.

Example query for InfrahubBranch:

```graphql
        query {
            InfrahubBranch(order: {node_metadata: {updated_at: DESC}}) {
                edges {
                    node_metadata { updated_at }
                    node { name { value } description { value } }
                }
            }
        }
```

In this current implementation I've forbidden anyone from combining updated_at with created_at, specifically for these two fields I don't think it matters much as there won't be much overlap with anything that has the same timestamp. However it might come into play at some later time for other fields. It seems like the order of what the user requests (i.e. if created_at is defined before updated_at) is kept within the info object but not in the created models. At some later point we could analyze the actual query and retain the internal order, for now we raise an error if someone specifies both updated_at and created_at)

I've added the same "order" part to the other dynamically created options, but those doesn't currently do anything, they are just a dummy entry so that the frontend team can experiment with what it will look like for the other node types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can request ordered node/branch lists (by id, created_at, updated_at) with ASC/DESC via new GraphQL Order input and types. Ordering is validated (mutually exclusive timestamp fields).
* **Tests**
  * Added GraphQL tests verifying ordering behavior (asc/desc) and invalid ordering combinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->