### PR TITLE
add metadata to edges/vertices when loading schemas to the database

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -366,6 +366,7 @@ async def load_schema(
                 diff=result.diff,
                 limit=result.diff.all,
                 update_db=True,
+                user_id=account_session.account_id,
             )
             branch.update_schema_hash()
             log.info("Schema has been updated", branch=branch.name, hash=branch.active_schema_hash.main)

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -27,7 +27,7 @@ class Migration017(InternalSchemaMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
         """
         Load CoreProfile schema node in db.
         """
@@ -36,6 +36,8 @@ class Migration017(InternalSchemaMigration):
         manager.set_schema_branch(name=default_branch.name, schema=self.get_internal_schema())
 
         db.add_schema(manager.get_schema_branch(default_branch.name))
-        await manager.load_node_to_db(node=core_profile_schema_definition, db=db, branch=default_branch)
+        await manager.load_node_to_db(
+            node=core_profile_schema_definition, db=db, branch=default_branch, user_id=user_id
+        )
 
         return MigrationResult()

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -6,7 +6,7 @@ from cachetools import LRUCache
 from infrahub_sdk.schema import BranchSchema as SDKBranchSchema
 
 from infrahub import lock
-from infrahub.core.constants import MetadataOptions
+from infrahub.core.constants import SYSTEM_USER_ID, MetadataOptions
 from infrahub.core.manager import NodeManager
 from infrahub.core.models import (
     HashableModelDiff,
@@ -179,15 +179,18 @@ class SchemaManager(NodeManager):
         diff: SchemaDiff | None = None,
         limit: list[str] | None = None,
         update_db: bool = True,
+        user_id: str = SYSTEM_USER_ID,
     ) -> None:
         branch = await registry.get_branch(branch=branch, db=db)
 
         updated_schema = None
         if update_db:
             if diff:
-                schema_diff = await self.update_schema_to_db(schema=schema, db=db, branch=branch, diff=diff)
+                schema_diff = await self.update_schema_to_db(
+                    schema=schema, db=db, branch=branch, diff=diff, user_id=user_id
+                )
             else:
-                await self.load_schema_to_db(schema=schema, db=db, branch=branch, limit=limit)
+                await self.load_schema_to_db(schema=schema, db=db, branch=branch, limit=limit, user_id=user_id)
                 # After updating the schema into the db
                 # we need to pull a fresh version because some default value are managed/generated within the node object
                 schema_diff = None
@@ -217,6 +220,7 @@ class SchemaManager(NodeManager):
         schema: SchemaBranch,
         db: InfrahubDatabase,
         diff: SchemaDiff,
+        user_id: str,
         branch: Branch | str | None = None,
     ) -> SchemaBranchDiff:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
@@ -227,7 +231,7 @@ class SchemaManager(NodeManager):
         added_generics = []
         for item_kind in diff.added.keys():
             item = schema.get(name=item_kind, duplicate=False)
-            node = await self.load_node_to_db(node=item, branch=branch, db=db)
+            node = await self.load_node_to_db(node=item, branch=branch, db=db, user_id=user_id)
             schema.set(name=item_kind, schema=node)
             if item.is_node_schema:
                 added_nodes.append(item_kind)
@@ -239,9 +243,11 @@ class SchemaManager(NodeManager):
         for item_kind, item_diff in diff.changed.items():
             item = schema.get(name=item_kind, duplicate=False)
             if item_diff:
-                node = await self.update_node_in_db_based_on_diff(node=item, branch=branch, db=db, diff=item_diff)
+                node = await self.update_node_in_db_based_on_diff(
+                    node=item, branch=branch, db=db, diff=item_diff, user_id=user_id
+                )
             else:
-                node = await self.update_node_in_db(node=item, branch=branch, db=db)
+                node = await self.update_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
             schema.set(name=item_kind, schema=node)
             if item.is_node_schema:
                 changed_nodes.append(item_kind)
@@ -252,7 +258,7 @@ class SchemaManager(NodeManager):
         removed_generics = []
         for item_kind in diff.removed.keys():
             item = schema.get(name=item_kind, duplicate=False)
-            node = await self.delete_node_in_db(node=item, branch=branch, db=db)
+            node = await self.delete_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
             schema.delete(name=item_kind)
             if item.is_node_schema:
                 removed_nodes.append(item_kind)
@@ -274,6 +280,7 @@ class SchemaManager(NodeManager):
         db: InfrahubDatabase,
         branch: Branch | str | None = None,
         limit: list[str] | None = None,
+        user_id: str = SYSTEM_USER_ID,
     ) -> None:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
 
@@ -284,16 +291,17 @@ class SchemaManager(NodeManager):
                 continue
             item = schema.get(name=item_kind, duplicate=False)
             if not item.id:
-                node = await self.load_node_to_db(node=item, branch=branch, db=db)
+                node = await self.load_node_to_db(node=item, branch=branch, db=db, user_id=user_id)
                 schema.set(name=item_kind, schema=node)
             else:
-                node = await self.update_node_in_db(node=item, branch=branch, db=db)
+                node = await self.update_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
                 schema.set(name=item_kind, schema=node)
 
     async def load_node_to_db(
         self,
         node: NodeSchema | GenericSchema,
         db: InfrahubDatabase,
+        user_id: str,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Load a Node with its attributes and its relationships to the database."""
@@ -314,7 +322,7 @@ class SchemaManager(NodeManager):
         schema_dict = node.model_dump(exclude={"id", "state", "filters", "relationships", "attributes"})
         obj = await Node.init(schema=node_schema, branch=branch, db=db)
         await obj.new(**schema_dict, db=db)
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
         new_node.id = obj.id
 
         # Then create the Attributes and the relationships
@@ -325,7 +333,7 @@ class SchemaManager(NodeManager):
             for item in node.attributes:
                 if item.inherited is False:
                     new_attr = await self.create_attribute_in_db(
-                        schema=attribute_schema, item=item, parent=obj, branch=branch, db=db
+                        schema=attribute_schema, item=item, parent=obj, branch=branch, db=db, user_id=user_id
                     )
                 else:
                     new_attr = item.duplicate()
@@ -334,7 +342,7 @@ class SchemaManager(NodeManager):
             for item in node.relationships:
                 if item.inherited is False:
                     new_rel = await self.create_relationship_in_db(
-                        schema=relationship_schema, item=item, parent=obj, branch=branch, db=db
+                        schema=relationship_schema, item=item, parent=obj, branch=branch, db=db, user_id=user_id
                     )
                 else:
                     new_rel = item.duplicate()
@@ -348,6 +356,7 @@ class SchemaManager(NodeManager):
         self,
         db: InfrahubDatabase,
         node: NodeSchema | GenericSchema,
+        user_id: str,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Update a Node with its attributes and its relationships in the database."""
@@ -375,7 +384,7 @@ class SchemaManager(NodeManager):
         await obj.relationships.update(
             db=db, data=[item.id for item in node.local_relationships if item.id and item.name != "profiles"]
         )
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
 
         # Then Update the Attributes and the relationships
 
@@ -388,19 +397,19 @@ class SchemaManager(NodeManager):
 
         for item in node.local_attributes:
             if item.id and item.id in items:
-                await self.update_attribute_in_db(item=item, attr=items[item.id], db=db)
+                await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, user_id=user_id)
             elif not item.id:
                 new_attr = await self.create_attribute_in_db(
-                    schema=attribute_schema, item=item, branch=branch, db=db, parent=obj
+                    schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
                 )
                 new_node.attributes.append(new_attr)
 
         for item in node.local_relationships:
             if item.id and item.id in items:
-                await self.update_relationship_in_db(item=item, rel=items[item.id], db=db)
+                await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, user_id=user_id)
             elif not item.id:
                 new_rel = await self.create_relationship_in_db(
-                    schema=relationship_schema, item=item, branch=branch, db=db, parent=obj
+                    schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
                 )
                 new_node.relationships.append(new_rel)
 
@@ -413,6 +422,7 @@ class SchemaManager(NodeManager):
         db: InfrahubDatabase,
         diff: HashableModelDiff,
         node: NodeSchema | GenericSchema,
+        user_id: str,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Update a Node with its attributes and its relationships in the database based on a HashableModelDiff."""
@@ -491,21 +501,21 @@ class SchemaManager(NodeManager):
         if diff_relationships:
             await obj.relationships.update(db=db, data=[item.id for item in node.local_relationships if item.id])
 
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
 
         if diff_attributes:
             for item in node.local_attributes:
                 # if item is in changed and has no ID, then it is being overridden from a generic and must be added
                 if item.name in diff_attributes.added or (item.name in diff_attributes.changed and item.id is None):
                     created_item = await self.create_attribute_in_db(
-                        schema=attribute_schema, item=item, branch=branch, db=db, parent=obj
+                        schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
                     )
                     new_attr = new_node.get_attribute(name=item.name)
                     new_attr.id = created_item.id
                 elif item.name in diff_attributes.changed and item.id and item.id in items:
-                    await self.update_attribute_in_db(item=item, attr=items[item.id], db=db)
+                    await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, user_id=user_id)
                 elif item.name in diff_attributes.removed and item.id and item.id in items:
-                    await items[item.id].delete(db=db)
+                    await items[item.id].delete(db=db, user_id=user_id)
                 elif (
                     (item.name in diff_attributes.removed or item.name in diff_attributes.changed)
                     and item.id
@@ -520,14 +530,14 @@ class SchemaManager(NodeManager):
                     item.name in diff_relationships.changed and item.id is None
                 ):
                     created_rel = await self.create_relationship_in_db(
-                        schema=relationship_schema, item=item, branch=branch, db=db, parent=obj
+                        schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
                     )
                     new_rel = new_node.get_relationship(name=item.name)
                     new_rel.id = created_rel.id
                 elif item.name in diff_relationships.changed and item.id and item.id in items:
-                    await self.update_relationship_in_db(item=item, rel=items[item.id], db=db)
+                    await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, user_id=user_id)
                 elif item.name in diff_relationships.removed and item.id and item.id in items:
-                    await items[item.id].delete(db=db)
+                    await items[item.id].delete(db=db, user_id=user_id)
                 elif (
                     (item.name in diff_relationships.removed or item.name in diff_relationships.changed)
                     and item.id
@@ -545,7 +555,7 @@ class SchemaManager(NodeManager):
         if field_names_to_remove:
             for field_schema in items.values():
                 if field_schema.name.value in field_names_to_remove:
-                    await field_schema.delete(db=db)
+                    await field_schema.delete(db=db, user_id=user_id)
 
         # Save back the node with the (potentially) newly created IDs in the SchemaManager
         self.set(name=new_node.kind, schema=new_node, branch=branch.name)
@@ -555,6 +565,7 @@ class SchemaManager(NodeManager):
         self,
         db: InfrahubDatabase,
         node: NodeSchema | GenericSchema,
+        user_id: str,
         branch: Branch | str | None = None,
     ) -> None:
         """Delete the node with its attributes and relationships."""
@@ -570,47 +581,59 @@ class SchemaManager(NodeManager):
 
         # First delete the attributes and the relationships
         for attr_schema_node in (await obj.attributes.get_peers(db=db)).values():
-            await attr_schema_node.delete(db=db)
+            await attr_schema_node.delete(db=db, user_id=user_id)
         for rel_schema_node in (await obj.relationships.get_peers(db=db)).values():
-            await rel_schema_node.delete(db=db)
+            await rel_schema_node.delete(db=db, user_id=user_id)
 
-        await obj.delete(db=db)
+        await obj.delete(db=db, user_id=user_id)
 
     @staticmethod
     async def create_attribute_in_db(
-        schema: NodeSchema, item: AttributeSchema, branch: Branch, parent: Node, db: InfrahubDatabase
+        schema: NodeSchema,
+        item: AttributeSchema,
+        branch: Branch,
+        parent: Node,
+        db: InfrahubDatabase,
+        user_id: str,
     ) -> AttributeSchema:
         obj = await Node.init(schema=schema, branch=branch, db=db)
         await obj.new(**item.to_node(), node=parent, db=db)
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
         new_item = item.duplicate()
         new_item.id = obj.id
         return new_item
 
     @staticmethod
-    async def update_attribute_in_db(item: AttributeSchema, attr: Node, db: InfrahubDatabase) -> None:
+    async def update_attribute_in_db(item: AttributeSchema, attr: Node, db: InfrahubDatabase, user_id: str) -> None:
         item_dict = item.model_dump(exclude={"id", "state", "filters"})
         for key, value in item_dict.items():
             getattr(attr, key).value = value
-        await attr.save(db=db)
+        await attr.save(db=db, user_id=user_id)
 
     @staticmethod
     async def create_relationship_in_db(
-        schema: NodeSchema, item: RelationshipSchema, branch: Branch, parent: Node, db: InfrahubDatabase
+        schema: NodeSchema,
+        item: RelationshipSchema,
+        branch: Branch,
+        parent: Node,
+        db: InfrahubDatabase,
+        user_id: str,
     ) -> RelationshipSchema:
         obj = await Node.init(schema=schema, branch=branch, db=db)
         await obj.new(**item.model_dump(exclude={"id", "state", "filters"}), node=parent, db=db)
-        await obj.save(db=db)
+        await obj.save(db=db, user_id=user_id)
         new_item = item.duplicate()
         new_item.id = obj.id
         return new_item
 
     @staticmethod
-    async def update_relationship_in_db(item: RelationshipSchema, rel: Node, db: InfrahubDatabase) -> None:
+    async def update_relationship_in_db(
+        item: RelationshipSchema, rel: Node, db: InfrahubDatabase, user_id: str
+    ) -> None:
         item_dict = item.model_dump(exclude={"id", "state", "filters"})
         for key, value in item_dict.items():
             getattr(rel, key).value = value
-        await rel.save(db=db)
+        await rel.save(db=db, user_id=user_id)
 
     async def load_schema(
         self,

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -329,11 +329,11 @@ async def update_registry(
             log.info(f"Schema has diff, will need to be updated {diff.all}", branch=branch.name)
             async with db.start_transaction() as dbt:
                 await registry.schema.update_schema_branch(
-                    schema=tmp_schema, db=dbt, branch=branch.name, limit=diff.all, update_db=True
+                    schema=tmp_schema, db=dbt, branch=branch.name, limit=diff.all, update_db=True, user_id=account_id
                 )
                 branch.update_schema_hash()
                 log.info("Schema has been updated", branch=branch.name, hash=branch.active_schema_hash.main)
-                await branch.save(db=dbt)
+                await branch.save(db=dbt, user_id=account_id)
 
             await service.component.refresh_schema_hash(branches=[branch.name])
 

--- a/backend/tests/benchmark/test_load_node_to_db.py
+++ b/backend/tests/benchmark/test_load_node_to_db.py
@@ -34,4 +34,4 @@ def test_load_node_to_db_node_schema(
     }
     node = NodeSchema(**SCHEMA)
 
-    aio_benchmark(registry.schema.load_node_to_db, node=node, db=db, branch=default_branch)
+    aio_benchmark(registry.schema.load_node_to_db, node=node, db=db, branch=default_branch, user_id="user-id")

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -1556,13 +1556,23 @@ class TestSchemaLifecycleGenericUpdatedWithLegacyDuplicates(SchemaLifecycleGener
             for attr_name in ("generic_attr_text", "generic_attr_num"):
                 attr = node_schema.get_attribute(attr_name)
                 new_attr = await registry.schema.create_attribute_in_db(
-                    db=db, branch=default_branch, schema=attribute_schema, parent=node_schema_instance, item=attr
+                    db=db,
+                    branch=default_branch,
+                    schema=attribute_schema,
+                    parent=node_schema_instance,
+                    item=attr,
+                    user_id="user-id",
                 )
                 attr.id = new_attr.id
             for rel_name in ("things", "favorite_thing"):
                 rel = node_schema.get_relationship(rel_name)
                 new_rel = await registry.schema.create_relationship_in_db(
-                    db=db, branch=default_branch, schema=relationship_schema, parent=node_schema_instance, item=rel
+                    db=db,
+                    branch=default_branch,
+                    schema=relationship_schema,
+                    parent=node_schema_instance,
+                    item=rel,
+                    user_id="user-id",
                 )
                 rel.id = new_rel.id
             main_schema_branch.set(name=schema_kind, schema=node_schema)

--- a/backend/tests/unit/core/migrations/graph/test_017.py
+++ b/backend/tests/unit/core/migrations/graph/test_017.py
@@ -15,7 +15,7 @@ async def test_migration_017(
     item = registry.schema.get(name="CoreProfile")
     # Make sure to remove CoreProfile from database if it is there
     if item.id is not None:
-        _ = await registry.schema.delete_node_in_db(node=item, branch=default_branch, db=db)
+        _ = await registry.schema.delete_node_in_db(node=item, branch=default_branch, db=db, user_id="user-id")
 
     # Remove CoreProfile from registry
     schema_branch = registry.schema.get_schema_branch(default_branch.name)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -17,11 +17,13 @@ from infrahub.core.constants import (
     BranchSupportType,
     HashableModelState,
     InfrahubKind,
+    MetadataOptions,
     RelationshipCardinality,
     RelationshipDeleteBehavior,
     RelationshipKind,
     SchemaPathType,
 )
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import (
     AttributeSchema,
@@ -37,6 +39,7 @@ from infrahub.core.schema.computed_attribute import ComputedAttribute
 from infrahub.core.schema.definitions.core.template import core_object_component_template, core_object_template
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from tests.conftest import TestHelper
@@ -2598,7 +2601,7 @@ async def test_load_node_to_db_node_schema(db: InfrahubDatabase, default_branch:
         ],
         relationships=[RelationshipSchema(name="others", peer="BuiltinCriticality", optional=True, cardinality="many")],
     )
-    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch)
+    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, user_id="user-id")
 
     node2 = registry.schema.get(name=node.kind, branch=default_branch)
     assert node2.id
@@ -2621,7 +2624,7 @@ async def test_load_node_to_db_generic_schema(db: InfrahubDatabase, default_bran
         ],
     }
     node = GenericSchema(**SCHEMA)
-    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch)
+    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, user_id="user-id")
 
     results = await SchemaManager.query(
         schema="SchemaGeneric", filters={"kind__value": "InfraGenericInterface"}, branch=default_branch, db=db
@@ -2673,7 +2676,7 @@ async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branc
 
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
-    await registry.schema.load_node_to_db(node=NodeSchema(**SCHEMA), db=db, branch=default_branch)
+    await registry.schema.load_node_to_db(node=NodeSchema(**SCHEMA), db=db, branch=default_branch, user_id="user-id")
 
     node = registry.schema.get(name="BuiltinCriticality", branch=default_branch)
 
@@ -2682,7 +2685,7 @@ async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branc
     new_node.default_filter = "kind__value"
     new_node.attributes[0].unique = False
 
-    await registry.schema.update_node_in_db(node=new_node, db=db, branch=default_branch)
+    await registry.schema.update_node_in_db(node=new_node, db=db, branch=default_branch, user_id="user-id")
 
     results = await SchemaManager.get_many(ids=[node.id, new_node.attributes[0].id], db=db)
 
@@ -2748,6 +2751,211 @@ async def test_load_schema_to_db_simple_01(
         schema=node_schema, filters={"name__value": "Device"}, db=db, branch=default_branch
     )
     assert len(results) == 1
+
+
+async def test_load_schema_to_db_includes_metadata(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_internal_models_schema: SchemaBranch,
+    branch: Branch,
+    schema_criticality_tag: dict,
+) -> None:
+    """Verify that SchemaNode, SchemaAttribute, and SchemaRelationship metadata is properly set."""
+    test_user_id = "test-user-id-12345"
+
+    # Record time window around schema load
+    time_before = Timestamp()
+
+    # Register and load the schema with a specific user_id
+    schema = SchemaRoot(**schema_criticality_tag)
+    new_schema = registry.schema.register_schema(schema=schema, branch=branch.name)
+    await registry.schema.load_schema_to_db(schema=new_schema, db=db, branch=branch, user_id=test_user_id)
+
+    time_after = Timestamp()
+
+    # Query the SchemaNode (BuiltinCriticality) with metadata
+    node_schema = registry.schema.get(name="SchemaNode")
+    results = await SchemaManager.query(
+        schema=node_schema,
+        filters={"name__value": "Criticality"},
+        db=db,
+        branch=branch,
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+    )
+    assert len(results) == 1
+
+    schema_node = results[0]
+
+    # Verify SchemaNode metadata with time window
+    assert time_before < schema_node._get_created_at() < time_after
+    assert schema_node._get_created_by() == test_user_id
+    assert time_before < schema_node._get_updated_at() < time_after
+    assert schema_node._get_updated_by() == test_user_id
+
+    # Get attribute Relationship edges and peers using query_peers with fetch_peers=True
+    attributes_rel_schema = node_schema.get_relationship(name="attributes")
+    attr_edge_results = await NodeManager.query_peers(
+        db=db,
+        branch=branch,
+        ids=[schema_node.id],
+        source_kind="SchemaNode",
+        schema=attributes_rel_schema,
+        filters={},
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+        fetch_peers=True,
+    )
+    assert len(attr_edge_results) > 0
+
+    # Verify metadata on the first attribute edge (Relationship object)
+    first_attr_edge = attr_edge_results[0]
+    assert time_before < first_attr_edge._get_created_at() < time_after
+    assert first_attr_edge._get_created_by() == test_user_id
+    assert time_before < first_attr_edge._get_updated_at() < time_after
+    assert first_attr_edge._get_updated_by() == test_user_id
+
+    # Verify metadata on the peer (SchemaAttribute node) retrieved from the relationship
+    first_attr = await first_attr_edge.get_peer(db=db)
+    assert time_before < first_attr._get_created_at() < time_after
+    assert first_attr._get_created_by() == test_user_id
+    assert time_before < first_attr._get_updated_at() < time_after
+    assert first_attr._get_updated_by() == test_user_id
+
+    # Verify metadata on an attribute of first_attr (SchemaAttribute.name)
+    first_attr_name = first_attr.get_attribute("name")
+    assert time_before < first_attr_name._get_created_at() < time_after
+    assert first_attr_name._get_created_by() == test_user_id
+    assert time_before < first_attr_name._get_updated_at() < time_after
+    assert first_attr_name._get_updated_by() == test_user_id
+
+    # Get relationship Relationship edges and peers using query_peers with fetch_peers=True
+    relationships_rel_schema = node_schema.get_relationship(name="relationships")
+    rel_edge_results = await NodeManager.query_peers(
+        db=db,
+        branch=branch,
+        ids=[schema_node.id],
+        source_kind="SchemaNode",
+        schema=relationships_rel_schema,
+        filters={},
+        include_metadata=MetadataOptions.USER_TIMESTAMPS,
+        fetch_peers=True,
+    )
+    assert len(rel_edge_results) > 0
+
+    # Verify metadata on the first relationship edge (Relationship object)
+    first_rel_edge = rel_edge_results[0]
+    assert time_before < first_rel_edge._get_created_at() < time_after
+    assert first_rel_edge._get_created_by() == test_user_id
+    assert time_before < first_rel_edge._get_updated_at() < time_after
+    assert first_rel_edge._get_updated_by() == test_user_id
+
+    # Verify metadata on the peer (SchemaRelationship node) retrieved from the relationship
+    first_rel = await first_rel_edge.get_peer(db=db)
+    assert time_before < first_rel._get_created_at() < time_after
+    assert first_rel._get_created_by() == test_user_id
+    assert time_before < first_rel._get_updated_at() < time_after
+    assert first_rel._get_updated_by() == test_user_id
+
+    # Verify metadata on an attribute of first_rel (SchemaRelationship.name)
+    first_rel_name = first_rel.get_attribute("name")
+    assert time_before < first_rel_name._get_created_at() < time_after
+    assert first_rel_name._get_created_by() == test_user_id
+    assert time_before < first_rel_name._get_updated_at() < time_after
+    assert first_rel_name._get_updated_by() == test_user_id
+
+    time_before_str = time_before.to_string()
+    time_after_str = time_after.to_string()
+
+    query_params = {
+        "branch": branch.name,
+        "time_before": time_before_str,
+        "time_after": time_after_str,
+        "user_id": test_user_id,
+    }
+    find_illegal_schema_edges_query = """
+// ------------
+// Start with all SchemaNode, SchemaAttribute, and SchemaRelationship vertices
+// and check all linked edges
+// ------------
+MATCH (n:SchemaNode|SchemaAttribute|SchemaRelationship)
+CALL (n) {
+    OPTIONAL MATCH (n)-[r]-(peer)
+    WHERE r.status <> "active"
+    OR r.branch <> $branch
+    OR r.from < $time_before
+    OR r.from > $time_after
+    OR r.from_user_id <> $user_id
+    RETURN r, peer
+}
+WITH n, collect(
+    CASE WHEN r IS NOT NULL OR peer IS NOT NULL THEN {
+        edge_type: type(r),
+        edge_from: r.from,
+        edge_from_user_id: r.from_user_id,
+        peer_labels: labels(peer),
+        peer_uuid: peer.uuid
+    }
+    ELSE NULL
+    END
+) AS illegal_node_edges
+// ------------
+// For each SchemaNode, SchemaAttribute, and SchemaRelationship, check all linked Attribute/Relationship vertices
+// and their linked edges
+// ------------
+MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+WITH DISTINCT n, illegal_node_edges, field
+CALL (field) {
+    OPTIONAL MATCH (field)-[r]-(prop)
+    WHERE r.status <> "active"
+    OR r.branch <> $branch
+    OR r.from < $time_before
+    OR r.from > $time_after
+    OR r.from_user_id <> $user_id
+    RETURN r, prop
+}
+WITH n, illegal_node_edges, collect (
+    CASE WHEN r IS NOT NULL OR prop IS NOT NULL THEN {
+        edge_type: type(r),
+        edge_from: r.from,
+        edge_from_user_id: r.from_user_id,
+        peer_labels: labels(prop),
+        peer_value: COALESCE(prop.uuid, prop.value)
+    }
+    ELSE NULL
+    END
+) AS illegal_field_edges
+WITH n, illegal_node_edges, illegal_field_edges
+WHERE size(illegal_node_edges) > 0 OR size(illegal_field_edges) > 0
+RETURN n.uuid AS node_uuid, n.kind AS node_kind, illegal_node_edges, illegal_field_edges
+    """
+
+    records = await db.execute_query(query=find_illegal_schema_edges_query, params=query_params)
+
+    # The query only returns records with illegal edges, so any results indicate a failure
+    error_messages = []
+    for record in records:
+        node_uuid = record.get("node_uuid")
+        node_kind = record.get("node_kind")
+
+        illegal_node_edges = [e for e in record.get("illegal_node_edges", []) if e is not None]
+        illegal_field_edges = [e for e in record.get("illegal_field_edges", []) if e is not None]
+
+        for edge in illegal_node_edges:
+            error_messages.append(
+                f"Illegal edge on {node_kind} '{node_uuid}': "
+                f"type={edge.get('edge_type')}, from={edge.get('edge_from')}, "
+                f"from_user_id={edge.get('edge_from_user_id')}, "
+                f"peer_labels={edge.get('peer_labels')}, peer_uuid={edge.get('peer_uuid')}"
+            )
+
+        for edge in illegal_field_edges:
+            error_messages.append(
+                f"Illegal field edge on {node_kind} '{node_uuid}': "
+                f"type={edge.get('edge_type')}, from={edge.get('edge_from')}, "
+                f"from_user_id={edge.get('edge_from_user_id')}, "
+                f"peer_labels={edge.get('peer_labels')}, peer_value={edge.get('peer_value')}"
+            )
+
+    assert not error_messages, "Found illegal edges:\n" + "\n".join(error_messages)
 
 
 async def test_load_schema_to_db_w_generics_01(


### PR DESCRIPTION
- pass the user ID all the way down through the schema update logic so that it can be applied to the updated schema edges and vertices in the database
- add a pretty simple test to validate that all SchemaNode/Attibute/Relationship vertices and linked edges have the correct metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User attribution now recorded for all schema updates, improving audit trail visibility.
  * Metadata tracking (timestamps and user IDs) added for schema operations to enhance change history and accountability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->