### PR TITLE
Fixed relationship fields not being cleared when removing a profile from a node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ coverage.xml
 script.py
 **/*.local.*
 local/*
-.vscode/settings.json
+**/.vscode/settings.json
 node_modules/*
 development/docker-compose.override.yml
 development/docker-compose.dev-override.yml

--- a/changelog/+relationship-profile-removal.fixed.md
+++ b/changelog/+relationship-profile-removal.fixed.md
@@ -1,0 +1,1 @@
+Fixed relationship fields not being cleared when removing a profile from a node

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -160,6 +160,37 @@ describe("getRelationshipDefaultValue", () => {
       });
     });
 
+    it("returns empty value when profile source was removed from node", () => {
+      // GIVEN
+      store.set(profileSchemasAtom, [
+        { kind: "ProfileTestDevice", namespace: "Profile" } as ProfileSchema,
+      ]);
+
+      // Relationship data has a profile source, but the profile is no longer assigned to the node
+      const relationshipData = buildRelationshipOneData({
+        properties: {
+          source: {
+            id: "removed-profile-id",
+            display_label: "Removed Profile",
+            __typename: "ProfileTestDevice",
+          },
+        },
+      });
+      const objectTemplate = null;
+      const profiles: ProfileData[] = []; // Profile was removed
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        relationshipData,
+        objectTemplate,
+        profiles,
+        relationshipName: "testRelationship",
+      });
+
+      // THEN - should be empty since the profile was removed
+      expect(defaultValue).to.deep.equal({ source: null, value: null });
+    });
+
     it("returns relationship from template when no relationship data is provided", () => {
       // GIVEN
       store.set(nodeSchemasAtom, [
@@ -455,6 +486,55 @@ describe("getRelationshipDefaultValue", () => {
           },
         ],
       });
+    });
+
+    it("returns empty value when profile source was removed from node with cardinality many", () => {
+      // GIVEN
+      store.set(profileSchemasAtom, [
+        { kind: "ProfileTestDevice", namespace: "Profile" } as ProfileSchema,
+      ]);
+
+      // Relationship data has a profile source, but the profile is no longer assigned to the node
+      const relationshipData: RelationshipManyType = {
+        edges: [
+          buildRelationshipOneData({
+            properties: {
+              source: {
+                id: "removed-profile-id",
+                display_label: "Removed Profile",
+                __typename: "ProfileTestDevice",
+              },
+            },
+          }),
+          buildRelationshipOneData({
+            node: {
+              id: "relationship-two-id",
+              display_label: "Relationship Two",
+              __typename: "RelationshipTwo",
+            },
+            properties: {
+              source: {
+                id: "removed-profile-id",
+                display_label: "Removed Profile",
+                __typename: "ProfileTestDevice",
+              },
+            },
+          }),
+        ],
+      };
+      const objectTemplate = null;
+      const profiles: ProfileData[] = []; // Profile was removed
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        relationshipData,
+        objectTemplate,
+        profiles,
+        relationshipName: "manyRelationship",
+      });
+
+      // THEN - should be empty since the profile was removed
+      expect(defaultValue).to.deep.equal({ source: null, value: null });
     });
 
     it("returns relationships from template with cardinality many", () => {

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -667,6 +667,7 @@ describe("getRelationshipDefaultValue", () => {
       const objectTemplate = null;
       const parentSchema = generateNodeSchema({
         kind: "TestParent",
+        display_labels: ["name__value"],
         relationships: [
           {
             ...generateRelationshipSchema(),
@@ -694,6 +695,9 @@ describe("getRelationshipDefaultValue", () => {
         __typename: "TestParent",
       };
 
+      // Register the parent schema so getNodeLabel can resolve the display_label
+      store.set(nodeSchemasAtom, [parentSchema]);
+
       // WHEN
       const defaultValue = getRelationshipDefaultValue({
         relationshipData,
@@ -709,7 +713,11 @@ describe("getRelationshipDefaultValue", () => {
         source: {
           type: "user",
         },
-        value: parentData,
+        value: {
+          id: parentData.id,
+          display_label: parentData.display_label,
+          __typename: parentData.__typename,
+        },
       });
     });
   });

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -42,7 +42,11 @@ describe("getRelationshipDefaultValue", () => {
       const objectTemplate = null;
 
       // WHEN
-      const defaultValue = getRelationshipDefaultValue({ relationshipData, objectTemplate });
+      const defaultValue = getRelationshipDefaultValue({
+        relationshipData,
+        objectTemplate,
+        relationshipName: "testRelationship",
+      });
 
       // THEN
       expect(defaultValue).to.deep.equal({ source: null, value: null });
@@ -54,7 +58,11 @@ describe("getRelationshipDefaultValue", () => {
       const objectTemplate = null;
 
       // WHEN
-      const defaultValue = getRelationshipDefaultValue({ relationshipData, objectTemplate });
+      const defaultValue = getRelationshipDefaultValue({
+        relationshipData,
+        objectTemplate,
+        relationshipName: "testRelationship",
+      });
 
       // THEN
       expect(defaultValue).to.deep.equal({
@@ -85,7 +93,11 @@ describe("getRelationshipDefaultValue", () => {
       const objectTemplate = null;
 
       // WHEN
-      const defaultValue = getRelationshipDefaultValue({ relationshipData, objectTemplate });
+      const defaultValue = getRelationshipDefaultValue({
+        relationshipData,
+        objectTemplate,
+        relationshipName: "testRelationship",
+      });
 
       // THEN
       expect(defaultValue).to.deep.equal({

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -3,13 +3,12 @@ import * as R from "remeda";
 import { DEFAULT_FORM_FIELD_VALUE } from "@/shared/components/form/constants";
 import type { ProfileData } from "@/shared/components/form/object-form";
 import type {
-  EmptyFieldValue,
   FormRelationshipValue,
   RelationshipValueFromPool,
   RelationshipValueFromProfile,
   RelationshipValueFromTemplate,
   RelationshipValueFromUser,
-  TemplateSource,
+  TemplateSource
 } from "@/shared/components/form/type";
 
 import type { Node, RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";
@@ -157,111 +156,6 @@ const getRelationshipValueFromParent = (
   }
 
   return null;
-};
-
-export const getRelationshipDefaultValueFromData = (
-  relationshipData: RelationshipType,
-  peerField?: string
-):
-  | RelationshipValueFromUser
-  | RelationshipValueFromPool
-  | RelationshipValueFromProfile
-  | EmptyFieldValue
-  | null => {
-  if ("edges" in relationshipData) {
-    // If edges are empty, return null to allow profile fallback
-    if (relationshipData.edges.length === 0) {
-      return null;
-    }
-
-    const values = relationshipData.edges
-      .map(({ node }) =>
-        node
-          ? {
-              id: node.id,
-              display_label: node.display_label,
-              __typename: node.__typename,
-              ...(peerField && (node as Record<string, unknown>)[peerField] !== undefined
-                ? { [peerField]: (node as Record<string, unknown>)[peerField] }
-                : {}),
-            }
-          : null
-      )
-      .filter((n) => !!n);
-
-    // Check if all edges have a profile source
-    const edgesWithSource = relationshipData.edges.filter(
-      (edge) => edge.properties?.source?.__typename
-    );
-
-    if (edgesWithSource.length > 0 && edgesWithSource.length === relationshipData.edges.length) {
-      // All edges have a source - check if they're all from profiles
-      const allFromProfile = edgesWithSource.every((edge) => {
-        const { isProfile } = getSchema(edge.properties?.source?.__typename);
-        return isProfile;
-      });
-
-      if (allFromProfile) {
-        // Return null to allow profile fallback logic to handle this
-        // The profile may have been removed, so we should re-evaluate from current profiles
-        return null;
-      }
-    }
-
-    return {
-      source: {
-        type: "user",
-      },
-      value: values,
-    };
-  }
-
-  // If node is null, return null to allow profile fallback
-  if (!relationshipData.node) {
-    return null;
-  }
-
-  if (!relationshipData.properties?.source?.__typename) {
-    return {
-      source: {
-        type: "user",
-      },
-      value: relationshipData.node,
-    };
-  }
-
-  const source = relationshipData.properties.source;
-  const { schema: sourceSchema, isProfile, isGeneric } = getSchema(source.__typename);
-
-  if (!isGeneric && sourceSchema && sourceSchema.inherit_from?.includes(RESOURCE_GENERIC_KIND)) {
-    if (!relationshipData.node) {
-      console.error("Source is a pool but node is null on relationship", relationshipData);
-      return { source: null, value: null };
-    }
-
-    return {
-      source: {
-        type: "pool",
-        label: source.display_label ?? null,
-        id: source.id as string,
-        kind: source.__typename as string,
-      },
-      value: relationshipData.node,
-    };
-  }
-
-  if (isProfile) {
-    // Return null to allow profile fallback logic to handle this
-    // The profile may have been removed, so we should re-evaluate from current profiles
-    return null;
-  }
-
-  return {
-    source: {
-      type: "user",
-    },
-    value: relationshipData.node,
-  };
 };
 
 export const getRelationshipDefaultValueFromTemplate = (

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -136,7 +136,7 @@ const getRelationshipValueFromParent = (
   schema: ModelSchema | null | undefined,
   parentSchema: ModelSchema | null | undefined,
   parentData: NodeObject | null | undefined,
-  relationshipName: string | undefined
+  relationshipName: string
 ): RelationshipValueFromUser | null => {
   if (!parentSchema || !parentData || !schema) return null;
 

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -11,7 +11,7 @@ import type {
   TemplateSource,
 } from "@/shared/components/form/type";
 
-import type { Node, RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";
+import type { RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeObject, NodeRelationship } from "@/entities/nodes/types";
 import { RESOURCE_GENERIC_KIND } from "@/entities/resource-manager/constants";
@@ -151,7 +151,11 @@ const getRelationshipValueFromParent = (
   if (relationshipToParent && relationshipFromParent) {
     return {
       source: { type: "user" },
-      value: parentData as Node,
+      value: {
+        id: parentData.id,
+        display_label: getNodeLabel(parentData),
+        __typename: parentData.__typename,
+      },
     };
   }
 

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -8,7 +8,7 @@ import type {
   RelationshipValueFromProfile,
   RelationshipValueFromTemplate,
   RelationshipValueFromUser,
-  TemplateSource
+  TemplateSource,
 } from "@/shared/components/form/type";
 
 import type { Node, RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -12,7 +12,7 @@ import type {
   TemplateSource,
 } from "@/shared/components/form/type";
 
-import type { RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";
+import type { Node, RelationshipType } from "@/entities/nodes/getObjectItemDisplayValue";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import type { NodeObject, NodeRelationship } from "@/entities/nodes/types";
 import { RESOURCE_GENERIC_KIND } from "@/entities/resource-manager/constants";
@@ -45,38 +45,118 @@ export const getRelationshipDefaultValue = ({
     return { source: null, value: null };
   }
 
-  if (relationshipData) {
-    const valueFromData = getRelationshipDefaultValueFromData(relationshipData, relationshipName);
-    if (valueFromData !== null) {
-      return valueFromData;
-    }
-    // If valueFromData is null (empty edges or null node), fall through to template/profile fallback
-  }
-
-  if (parentSchema && parentData && schema) {
-    const relationshipToParent = schema.relationships?.find((r) => {
-      return r.kind === "Parent" && r.name === relationshipName;
-    });
-
-    const relationshipFromParent = parentSchema.relationships?.find((r) => {
-      return r.kind === "Component" && isOfKind(r.peer, schema);
-    });
-
-    if (relationshipToParent && relationshipFromParent) {
-      return {
-        source: {
-          type: "user",
-        },
-        value: parentData,
-      };
-    }
-  }
-
   return (
+    getRelationshipValueFromUser(relationshipData, relationshipName) ??
+    getRelationshipValueFromParent(schema, parentSchema, parentData, relationshipName) ??
     getRelationshipDefaultValueFromTemplate(objectTemplate, relationshipName) ??
     getRelationshipDefaultValueFromProfiles(relationshipName, profiles) ??
     DEFAULT_FORM_FIELD_VALUE
   );
+};
+
+const getRelationshipValueFromUser = (
+  relationshipData: RelationshipType | undefined,
+  peerField?: string
+): RelationshipValueFromUser | RelationshipValueFromPool | null => {
+  if (!relationshipData) return null;
+
+  if ("edges" in relationshipData) {
+    if (relationshipData.edges.length === 0) return null;
+
+    // Check if all edges come from a profile source - if so, return null to allow profile fallback
+    const edgesWithSource = relationshipData.edges.filter(
+      (edge) => edge.properties?.source?.__typename
+    );
+
+    if (edgesWithSource.length > 0 && edgesWithSource.length === relationshipData.edges.length) {
+      const allFromProfile = edgesWithSource.every((edge) => {
+        const { isProfile } = getSchema(edge.properties?.source?.__typename);
+        return isProfile;
+      });
+
+      if (allFromProfile) return null;
+    }
+
+    const values = relationshipData.edges
+      .map(({ node }) =>
+        node
+          ? {
+              id: node.id,
+              display_label: node.display_label,
+              __typename: node.__typename,
+              ...(peerField && (node as Record<string, unknown>)[peerField] !== undefined
+                ? { [peerField]: (node as Record<string, unknown>)[peerField] }
+                : {}),
+            }
+          : null
+      )
+      .filter((n) => !!n);
+
+    return {
+      source: { type: "user" },
+      value: values,
+    };
+  }
+
+  // Cardinality one
+  if (!relationshipData.node) return null;
+
+  const source = relationshipData.properties?.source;
+  if (!source?.__typename) {
+    return {
+      source: { type: "user" },
+      value: relationshipData.node,
+    };
+  }
+
+  const { schema: sourceSchema, isProfile, isGeneric } = getSchema(source.__typename);
+
+  // Return null for profile sources to allow profile fallback
+  if (isProfile) return null;
+
+  // Handle pool sources
+  if (!isGeneric && sourceSchema && sourceSchema.inherit_from?.includes(RESOURCE_GENERIC_KIND)) {
+    return {
+      source: {
+        type: "pool",
+        label: source.display_label ?? null,
+        id: source.id as string,
+        kind: source.__typename as string,
+      },
+      value: relationshipData.node,
+    };
+  }
+
+  return {
+    source: { type: "user" },
+    value: relationshipData.node,
+  };
+};
+
+const getRelationshipValueFromParent = (
+  schema: ModelSchema | null | undefined,
+  parentSchema: ModelSchema | null | undefined,
+  parentData: NodeObject | null | undefined,
+  relationshipName: string | undefined
+): RelationshipValueFromUser | null => {
+  if (!parentSchema || !parentData || !schema) return null;
+
+  const relationshipToParent = schema.relationships?.find((r) => {
+    return r.kind === "Parent" && r.name === relationshipName;
+  });
+
+  const relationshipFromParent = parentSchema.relationships?.find((r) => {
+    return r.kind === "Component" && isOfKind(r.peer, schema);
+  });
+
+  if (relationshipToParent && relationshipFromParent) {
+    return {
+      source: { type: "user" },
+      value: parentData as Node,
+    };
+  }
+
+  return null;
 };
 
 export const getRelationshipDefaultValueFromData = (

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -269,7 +269,7 @@ export const getRelationshipDefaultValueFromProfiles = (
   const source = {
     type: "profile" as const,
     id: profileWithDefaultValueForField.id,
-    label: profileWithDefaultValueForField.display_label,
+    label: profileWithDefaultValueForField.display_label ?? null,
     kind: profileWithDefaultValueForField.__typename,
   };
 

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -24,7 +24,7 @@ type GetRelationshipDefaultValueParams = {
   objectTemplate: NodeObject | null | undefined;
   profiles?: Array<ProfileData>;
   isFilterForm?: boolean;
-  relationshipName?: string;
+  relationshipName: string;
   schema?: ModelSchema | null;
   parentSchema?: ModelSchema | null;
   parentData?: NodeObject | null;
@@ -55,7 +55,7 @@ export const getRelationshipDefaultValue = ({
 
 const getRelationshipValueFromUser = (
   relationshipData: RelationshipType | undefined,
-  peerField?: string
+  peerField: string
 ): RelationshipValueFromUser | RelationshipValueFromPool | null => {
   if (!relationshipData) return null;
 

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -122,19 +122,9 @@ export const getRelationshipDefaultValueFromData = (
       });
 
       if (allFromProfile) {
-        // Use the first edge's source as the profile source
-        const firstEdgeSource = edgesWithSource[0]?.properties?.source;
-        if (firstEdgeSource?.__typename) {
-          return {
-            source: {
-              type: "profile",
-              label: firstEdgeSource.display_label ?? null,
-              id: firstEdgeSource.id as string,
-              kind: firstEdgeSource.__typename,
-            },
-            value: values,
-          };
-        }
+        // Return null to allow profile fallback logic to handle this
+        // The profile may have been removed, so we should re-evaluate from current profiles
+        return null;
       }
     }
 
@@ -181,15 +171,9 @@ export const getRelationshipDefaultValueFromData = (
   }
 
   if (isProfile) {
-    return {
-      source: {
-        type: "profile",
-        label: source.display_label ?? null,
-        id: source.id as string,
-        kind: source.__typename as string,
-      },
-      value: relationshipData.node,
-    };
+    // Return null to allow profile fallback logic to handle this
+    // The profile may have been removed, so we should re-evaluate from current profiles
+    return null;
   }
 
   return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relationship fields are now cleared when a profile is removed from a node.
  * Relationship values avoid stale references when source profiles are missing.

* **Tests**
  * Added tests ensuring defaults become empty when related profiles are no longer present and display labels resolve correctly.

* **Refactor**
  * Internal relationship-value logic reorganized for clearer, more reliable fallback behavior.

* **Chores**
  * Changelog entry added and repository ignore patterns broadened.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->