### PR TITLE
Remove background_execution param in client.branch.create call

### DIFF
--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -59,7 +59,7 @@ class TestProfiles(TestInfrahubApp):
         try:
             return await client.branch.get(branch_name=branch_name)
         except BranchNotFoundError:
-            return await client.branch.create(branch_name=branch_name, background_execution=None)
+            return await client.branch.create(branch_name=branch_name)
 
     @pytest.fixture(scope="class")
     async def load_schema(self, client: InfrahubClient, default_branch: Branch) -> None:


### PR DESCRIPTION
Small fix to prepare for https://github.com/opsmill/infrahub-sdk-python/pull/696 where this deprecated param was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for internal API call handling in branch creation scenarios.

---

**Note:** This release contains only internal test updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->