### PR TITLE
Add metadata popover to display node creation and update info in object header

### DIFF
--- a/frontend/app/src/entities/artifacts/ui/artifact-header.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-header.tsx
@@ -2,6 +2,7 @@ import type { ArtifactObject } from "@/entities/artifacts/types";
 import { ArtifactDetailsMenu } from "@/entities/artifacts/ui/artifact-details-menu";
 import { ArtifactGenerateButton } from "@/entities/artifacts/ui/artifact-generate-button";
 import { ArtifactStatusBadge } from "@/entities/artifacts/ui/artifact-status-badge";
+import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 interface ArtifactHeaderProps {
@@ -12,7 +13,7 @@ export function ArtifactHeader({ artifact }: ArtifactHeaderProps) {
   return (
     <div className="flex items-center gap-2">
       <h1 className="font-bold text-xl">{getNodeLabel(artifact)}</h1>
-
+      <NodeMetadataPopover objectKind={artifact.__typename} objectId={artifact.id} />
       <ArtifactStatusBadge status={artifact.status.value} />
 
       <div className="ml-auto flex items-center gap-1">

--- a/frontend/app/src/entities/branches/ui/branch-details/branch-attributes.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-details/branch-attributes.tsx
@@ -1,6 +1,5 @@
 import {
   BoxIcon,
-  CalendarIcon,
   CheckIcon,
   CircleIcon,
   GitCommitIcon,
@@ -64,14 +63,6 @@ export function BranchAttributes({ branch }: BranchAttributesProps) {
           </BranchAttributeValue>
         </>
       )}
-
-      <BranchAttributeLabel>
-        <CalendarIcon className="size-3.5" /> Created at
-      </BranchAttributeLabel>
-
-      <BranchAttributeValue>
-        <DateDisplay date={branch.created_at} className="text-sm" />
-      </BranchAttributeValue>
     </Card>
   );
 }

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
@@ -5,6 +5,7 @@ import { Row, type RowProps } from "@/shared/components/container";
 import { classNames, sortByOrderWeight } from "@/shared/utils/common";
 
 import { getPrefixAttributesVisibleInListView } from "@/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view";
+import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 import { ObjectDetailsMenu } from "@/entities/nodes/object/ui/object-details/object-details-menu";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/utils/get-relationships-visible-in-list-view";
@@ -46,9 +47,9 @@ export function IpamDetailsHeader({
 
   return (
     <Row className={classNames("relative", className)} {...props}>
-      <Row>
-        <h2 className="font-semibold text-lg">{getNodeLabel(ipPrefixNode)}</h2>
-
+      <h2 className="font-semibold text-lg">{getNodeLabel(ipPrefixNode)}</h2>
+      <Row className="gap-0">
+        <NodeMetadataPopover objectId={ipPrefixNode.id} objectKind={ipPrefixNode.__typename} />
         <ObjectDetailsMenu
           objectSchema={ipPrefixSchema}
           objectData={ipPrefixNode}

--- a/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import { jsonToGraphQLQuery } from "json-to-graphql-query";
 
+import { nodeMetadataFragment } from "@/shared/api/graphql/fragments";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { ContextParams } from "@/shared/api/types";
 
@@ -17,24 +18,7 @@ const getNodeMetadataQuery = ({ objectId, objectKind }: GetNodeMetadataQueryPara
         __args: {
           ids: [objectId],
         },
-        edges: {
-          node_metadata: {
-            created_at: true,
-            created_by: {
-              id: true,
-              display_label: true,
-              hfid: true,
-              __typename: true,
-            },
-            updated_at: true,
-            updated_by: {
-              id: true,
-              display_label: true,
-              hfid: true,
-              __typename: true,
-            },
-          },
-        },
+        edges: nodeMetadataFragment,
       },
     },
   };

--- a/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
@@ -1,0 +1,63 @@
+import { gql } from "@apollo/client";
+import { jsonToGraphQLQuery } from "json-to-graphql-query";
+
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+import type { ContextParams } from "@/shared/api/types";
+
+export interface GetNodeMetadataQueryParams {
+  objectId: string;
+  objectKind: string;
+}
+
+const getNodeMetadataQuery = ({ objectId, objectKind }: GetNodeMetadataQueryParams) => {
+  const query = {
+    query: {
+      __name: `GetNodeMetadata${objectKind}`,
+      [objectKind]: {
+        __args: {
+          ids: [objectId],
+        },
+        edges: {
+          node_metadata: {
+            created_at: true,
+            created_by: {
+              id: true,
+              display_label: true,
+              hfid: true,
+              __typename: true,
+            },
+            updated_at: true,
+            updated_by: {
+              id: true,
+              display_label: true,
+              hfid: true,
+              __typename: true,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return gql(jsonToGraphQLQuery(query));
+};
+
+export interface GetNodeMetadataFromApiParams extends ContextParams {
+  objectId: string;
+  objectKind: string;
+}
+
+export const getNodeMetadataFromApi = async ({
+  objectId,
+  objectKind,
+  branchName,
+  atDate,
+}: GetNodeMetadataFromApiParams) => {
+  return graphqlClient.query({
+    query: getNodeMetadataQuery({ objectId, objectKind }),
+    context: {
+      branch: branchName,
+      date: atDate,
+    },
+  });
+};

--- a/frontend/app/src/entities/nodes/object/domain/get-node-metadata.query.ts
+++ b/frontend/app/src/entities/nodes/object/domain/get-node-metadata.query.ts
@@ -1,0 +1,32 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+
+import type { ContextParams } from "@/shared/api/types";
+import { datetimeAtom } from "@/shared/stores/time.atom";
+
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+
+import { type GetNodeMetadataParams, getNodeMetadata } from "./get-node-metadata";
+import { objectQueryKeys } from "./object.query-keys";
+
+export function getNodeMetadataQueryOptions(params: GetNodeMetadataParams) {
+  return queryOptions({
+    queryKey: objectQueryKeys.metadata(params),
+    queryFn: async () => {
+      return getNodeMetadata(params);
+    },
+  });
+}
+
+export function useGetNodeMetadata(params: Omit<GetNodeMetadataParams, keyof ContextParams>) {
+  const { currentBranch } = useCurrentBranch();
+  const timeMachineDate = useAtomValue(datetimeAtom);
+
+  return useQuery(
+    getNodeMetadataQueryOptions({
+      branchName: currentBranch.name,
+      atDate: timeMachineDate,
+      ...params,
+    })
+  );
+}

--- a/frontend/app/src/entities/nodes/object/domain/get-node-metadata.query.ts
+++ b/frontend/app/src/entities/nodes/object/domain/get-node-metadata.query.ts
@@ -5,9 +5,11 @@ import type { ContextParams } from "@/shared/api/types";
 import { datetimeAtom } from "@/shared/stores/time.atom";
 
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
-
-import { type GetNodeMetadataParams, getNodeMetadata } from "./get-node-metadata";
-import { objectQueryKeys } from "./object.query-keys";
+import {
+  type GetNodeMetadataParams,
+  getNodeMetadata,
+} from "@/entities/nodes/object/domain/get-node-metadata";
+import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
 
 export function getNodeMetadataQueryOptions(params: GetNodeMetadataParams) {
   return queryOptions({

--- a/frontend/app/src/entities/nodes/object/domain/get-node-metadata.ts
+++ b/frontend/app/src/entities/nodes/object/domain/get-node-metadata.ts
@@ -1,0 +1,35 @@
+import {
+  type GetNodeMetadataFromApiParams,
+  getNodeMetadataFromApi,
+} from "@/entities/nodes/object/api/get-node-metadata-from-api";
+import type { NodeMetadata } from "@/entities/nodes/types";
+
+export type GetNodeMetadataParams = GetNodeMetadataFromApiParams;
+
+export type GetNodeMetadata = (params: GetNodeMetadataParams) => Promise<NodeMetadata>;
+
+export const getNodeMetadata: GetNodeMetadata = async ({
+  objectId,
+  objectKind,
+  branchName,
+  atDate,
+}) => {
+  const { data, errors } = await getNodeMetadataFromApi({
+    objectId,
+    objectKind,
+    branchName,
+    atDate,
+  });
+
+  if (errors?.[0]?.message) {
+    throw new Error(errors[0].message);
+  }
+
+  const nodeMetadata = data[objectKind]?.edges?.[0]?.node_metadata;
+
+  if (!nodeMetadata) {
+    throw new Error("Node metadata not found");
+  }
+
+  return nodeMetadata;
+};

--- a/frontend/app/src/entities/nodes/object/domain/object.query-keys.ts
+++ b/frontend/app/src/entities/nodes/object/domain/object.query-keys.ts
@@ -55,6 +55,8 @@ export const objectQueryKeys = {
     ] as const,
   ancestors: (params: ObjectDetailKeysParams) =>
     [...objectQueryKeys.detail(params), "ancestors"] as const,
+  metadata: (params: ObjectDetailKeysParams) =>
+    [...objectQueryKeys.lists(params), params.objectId, "metadata"] as const,
   tree: ({ parentObjectId, ...params }: ObjectTreeKeysParams) =>
     [...objectQueryKeys.lists(params), "tree", parentObjectId] as const,
 };

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.test.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.test.tsx
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import type { NodeMetadata } from "@/entities/nodes/types";
+import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
+
+import { render } from "../../../../../../tests/components/render";
+import { generateNodeSchema } from "../../../../../../tests/fake/schema";
+import { NodeMetadata as NodeMetadataComponent } from "./node-metadata-popover";
+
+vi.mock("@/entities/nodes/object/domain/get-node-metadata.query", () => ({
+  useGetNodeMetadata: vi.fn(),
+}));
+
+import { useGetNodeMetadata } from "@/entities/nodes/object/domain/get-node-metadata.query";
+
+describe("NodeMetadata", () => {
+  const coreAccountSchema = generateNodeSchema({
+    kind: "CoreAccount",
+    name: "Account",
+    namespace: "Core",
+    label: "Account",
+    display_labels: ["name__value"],
+  });
+
+  beforeEach(() => {
+    store.set(nodeSchemasAtom, [coreAccountSchema]);
+  });
+
+  const mockMetadata: NodeMetadata = {
+    created_at: "2024-01-15T10:30:00Z",
+    created_by: {
+      id: "user-1",
+      display_label: "John Doe",
+      __typename: "CoreAccount",
+      hfid: ["john-doe"],
+    },
+    updated_at: "2024-01-16T14:20:00Z",
+    updated_by: {
+      id: "user-2",
+      display_label: "Jane Smith",
+      __typename: "CoreAccount",
+      hfid: ["jane-smith"],
+    },
+  };
+
+  it("displays loading state while fetching metadata", async () => {
+    // GIVEN
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Loading...").first()).toBeVisible();
+  });
+
+  it("displays error message when fetch fails", async () => {
+    // GIVEN
+    const errorMessage = "Failed to fetch metadata";
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: new Error(errorMessage),
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText(errorMessage)).toBeVisible();
+  });
+
+  it("displays error message when no data is returned", async () => {
+    // GIVEN
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("No metadata available")).toBeVisible();
+  });
+
+  it("displays metadata fields with values", async () => {
+    // GIVEN
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: mockMetadata,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Created at")).toBeVisible();
+    await expect.element(component.getByText("Created by")).toBeVisible();
+    await expect.element(component.getByText("Updated at")).toBeVisible();
+    await expect.element(component.getByText("Updated by")).toBeVisible();
+
+    // Verify user links are displayed with their display labels
+    await expect.element(component.getByText("John Doe")).toBeVisible();
+    await expect.element(component.getByText("Jane Smith")).toBeVisible();
+  });
+
+  it("displays metadata when created_by is null", async () => {
+    // GIVEN
+    const metadataWithoutCreatedBy: NodeMetadata = {
+      ...mockMetadata,
+      created_by: null,
+    };
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: metadataWithoutCreatedBy,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Created by")).toBeVisible();
+    await expect.element(component.getByText("Created at")).toBeVisible();
+    // Verify updated_by user link is displayed
+    await expect.element(component.getByRole("link", { name: "Jane Smith" })).toBeVisible();
+  });
+
+  it("displays metadata when updated_by is null", async () => {
+    // GIVEN
+    const metadataWithoutUpdatedBy: NodeMetadata = {
+      ...mockMetadata,
+      updated_by: null,
+    };
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: metadataWithoutUpdatedBy,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Updated by")).toBeVisible();
+    await expect.element(component.getByText("Updated at")).toBeVisible();
+    // Verify created_by user link is displayed
+    await expect.element(component.getByRole("link", { name: "John Doe" })).toBeVisible();
+  });
+
+  it("renders user links with correct URLs", async () => {
+    // GIVEN
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: mockMetadata,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    const createdByLink = component.getByRole("link", { name: "John Doe" });
+    await expect.element(createdByLink).toBeVisible();
+    await expect.element(createdByLink).toHaveAttribute("href", "/objects/CoreAccount/user-1");
+
+    const updatedByLink = component.getByRole("link", { name: "Jane Smith" });
+    await expect.element(updatedByLink).toBeVisible();
+    await expect.element(updatedByLink).toHaveAttribute("href", "/objects/CoreAccount/user-2");
+  });
+
+  it("displays system user when id is __system__", async () => {
+    // GIVEN
+    const metadataWithSystemUser: NodeMetadata = {
+      created_at: "2024-01-15T10:30:00Z",
+      created_by: {
+        id: "__system__",
+        display_label: "System",
+        __typename: "[Infrahub System]",
+        hfid: ["__system__"],
+      },
+      updated_at: "2024-01-16T14:20:00Z",
+      updated_by: {
+        id: "__system__",
+        display_label: "[Infrahub System]",
+        __typename: "CoreAccount",
+        hfid: ["__system__"],
+      },
+    };
+    vi.mocked(useGetNodeMetadata).mockReturnValue({
+      data: metadataWithSystemUser,
+      isPending: false,
+      error: null,
+    } as any);
+
+    // WHEN
+    const component = await render(
+      <NodeMetadataComponent objectKind="InfraDevice" objectId="test-id" />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Created by")).toBeVisible();
+    await expect.element(component.getByText("Updated by")).toBeVisible();
+
+    // Verify system user links are displayed
+    const systemLabel = component.getByText("[Infrahub System]");
+    await expect.element(systemLabel).toBeVisible();
+    await expect.element(systemLabel).not.toHaveAttribute("href");
+  });
+});

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
@@ -50,22 +50,24 @@ export function NodeMetadata({ objectKind, objectId }: NodeMetadataProps) {
     return <ErrorScreen className="p-4" message="No metadata available" />;
   }
 
+  const { created_at, created_by, updated_at, updated_by } = data;
+
   const items = [
     {
       name: "Created at",
-      value: formatFullDate(data.created_at),
+      value: created_at ? formatFullDate(created_at) : "-",
     },
     {
       name: "Created by",
-      value: <UserLink user={data.created_by} />,
+      value: <UserLink user={created_by} />,
     },
     {
       name: "Updated at",
-      value: formatFullDate(data.updated_at),
+      value: updated_at ? formatFullDate(updated_at) : "-",
     },
     {
       name: "Updated by",
-      value: <UserLink user={data.updated_by} />,
+      value: <UserLink user={updated_by} />,
     },
   ];
 

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
@@ -17,7 +17,7 @@ function UserLink({ user }: { user: NodeCore | null }) {
   if (!user) return <>-</>;
 
   if (user.id === "__system__") {
-    return user.display_label;
+    return <span>{user.display_label}</span>;
   }
 
   return (
@@ -82,7 +82,7 @@ export function NodeMetadataPopover(props: NodeMetadataProps) {
           size="icon"
           variant="ghost"
           className="text-gray-500"
-          data-testid="node-metadata-button"
+          aria-label="View node metadata"
         >
           <Icon icon="mdi:information-slab-circle-outline" />
         </Button>

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
@@ -1,0 +1,83 @@
+import { Icon } from "@iconify-icon/react";
+import { Link } from "react-router";
+
+import { Button } from "@/shared/components/buttons/button-primitive";
+import ErrorScreen from "@/shared/components/errors/error-screen";
+import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
+import { PropertyList } from "@/shared/components/table/property-list";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
+import { formatFullDate } from "@/shared/utils/date";
+
+import { useGetNodeMetadata } from "@/entities/nodes/object/domain/get-node-metadata.query";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
+import type { NodeCore } from "@/entities/nodes/types";
+import { getObjectDetailsUrl } from "@/entities/nodes/utils";
+
+function UserLink({ user }: { user: NodeCore | null }) {
+  if (!user) return <>-</>;
+
+  return <Link to={getObjectDetailsUrl(user.__typename, user.id)}>{getNodeLabel(user)}</Link>;
+}
+
+interface NodeMetadataProps {
+  objectKind: string;
+  objectId: string;
+}
+
+export function NodeMetadata({ objectKind, objectId }: NodeMetadataProps) {
+  const { data, isPending, error } = useGetNodeMetadata({ objectKind, objectId });
+
+  if (isPending) {
+    return <LoadingIndicator className="h-36 w-50" />;
+  }
+
+  if (error) {
+    return <ErrorScreen className="p-4" message={error.message} />;
+  }
+
+  if (!data) {
+    return <ErrorScreen className="p-4" message="No metadata available" />;
+  }
+
+  const items = [
+    {
+      name: "Created at",
+      value: formatFullDate(data.created_at),
+    },
+    {
+      name: "Created by",
+      value: <UserLink user={data.created_by} />,
+    },
+    {
+      name: "Updated at",
+      value: formatFullDate(data.updated_at),
+    },
+    {
+      name: "Updated by",
+      value: <UserLink user={data.updated_by} />,
+    },
+  ];
+
+  return <PropertyList properties={items} valueClassName="text-right" />;
+}
+
+export function NodeMetadataPopover(props: NodeMetadataProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="text-gray-500"
+          data-testid="node-metadata-button"
+        >
+          <Icon icon="mdi:information-slab-circle-outline" />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent>
+        <NodeMetadata {...props} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
@@ -1,10 +1,10 @@
 import { Icon } from "@iconify-icon/react";
-import { Link } from "react-router";
 
 import { Button } from "@/shared/components/buttons/button-primitive";
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 import { PropertyList } from "@/shared/components/table/property-list";
+import { Link } from "@/shared/components/ui/link";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import { formatFullDate } from "@/shared/utils/date";
 
@@ -20,14 +20,7 @@ function UserLink({ user }: { user: NodeCore | null }) {
     return <span>{user.display_label}</span>;
   }
 
-  return (
-    <Link
-      className="underline decoration-dotted hover:decoration-solid"
-      to={getObjectDetailsUrl(user.__typename, user.id)}
-    >
-      {getNodeLabel(user)}
-    </Link>
-  );
+  return <Link to={getObjectDetailsUrl(user.__typename, user.id)}>{getNodeLabel(user)}</Link>;
 }
 
 interface NodeMetadataProps {

--- a/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/node-metadata-popover.tsx
@@ -16,7 +16,18 @@ import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 function UserLink({ user }: { user: NodeCore | null }) {
   if (!user) return <>-</>;
 
-  return <Link to={getObjectDetailsUrl(user.__typename, user.id)}>{getNodeLabel(user)}</Link>;
+  if (user.id === "__system__") {
+    return user.display_label;
+  }
+
+  return (
+    <Link
+      className="underline decoration-dotted hover:decoration-solid"
+      to={getObjectDetailsUrl(user.__typename, user.id)}
+    >
+      {getNodeLabel(user)}
+    </Link>
+  );
 }
 
 interface NodeMetadataProps {

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
@@ -1,4 +1,5 @@
 import { queryClient } from "@/shared/api/rest/client";
+import { Row } from "@/shared/components/container";
 import Content from "@/shared/components/layout/content";
 import { Skeleton } from "@/shared/components/skeleton";
 
@@ -29,7 +30,7 @@ export function ObjectDetailsHeader({ schema, objectId }: ObjectDetailsHeaderPro
   const title = isPending ? (
     <Skeleton className="h-6 w-60" />
   ) : (
-    <div className="flex items-center gap-3">
+    <Row>
       {objectDetailsData ? getNodeLabel(objectDetailsData) : `${schema.label} not found`}
       <NodeMetadataPopover objectId={objectId} objectKind={schema.kind!} />
       <ObjectDetailsButton
@@ -38,7 +39,7 @@ export function ObjectDetailsHeader({ schema, objectId }: ObjectDetailsHeaderPro
         data-testid="object-details-button"
         hfid={objectDetailsData?.hfid && JSON.stringify(objectDetailsData?.hfid)}
       />
-    </div>
+    </Row>
   );
 
   return (

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "@/shared/components/skeleton";
 
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-keys";
+import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 import { ObjectDetailsButton } from "@/entities/nodes/object/ui/object-details-button";
 import { ObjectHelpButton } from "@/entities/nodes/object/ui/object-help-button";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
@@ -30,7 +31,7 @@ export function ObjectDetailsHeader({ schema, objectId }: ObjectDetailsHeaderPro
   ) : (
     <div className="flex items-center gap-3">
       {objectDetailsData ? getNodeLabel(objectDetailsData) : `${schema.label} not found`}
-
+      <NodeMetadataPopover objectId={objectId} objectKind={schema.kind!} />
       <ObjectDetailsButton
         id={objectId}
         objectKind={schema.kind!}

--- a/frontend/app/src/entities/nodes/types.ts
+++ b/frontend/app/src/entities/nodes/types.ts
@@ -64,6 +64,13 @@ export type NodeObjectWithMetadata = NodeCore & {
   [key: string]: NodeAttributeWithMetadata | NodeRelationshipWithMetadata;
 };
 
+export interface NodeMetadata {
+  created_at: string;
+  created_by: NodeCore | null;
+  updated_at: string;
+  updated_by: NodeCore | null;
+}
+
 export interface NodeCoreWithChildrenCount extends NodeCore {
   children: {
     count: number;

--- a/frontend/app/src/entities/nodes/types.ts
+++ b/frontend/app/src/entities/nodes/types.ts
@@ -65,9 +65,9 @@ export type NodeObjectWithMetadata = NodeCore & {
 };
 
 export interface NodeMetadata {
-  created_at: string;
+  created_at: string | null;
   created_by: NodeCore | null;
-  updated_at: string;
+  updated_at: string | null;
   updated_by: NodeCore | null;
 }
 

--- a/frontend/app/src/pages/branches/details.tsx
+++ b/frontend/app/src/pages/branches/details.tsx
@@ -18,6 +18,7 @@ import { BranchStatusBadge } from "@/entities/branches/ui/branch-list-item/branc
 import { ArtifactsDiff } from "@/entities/diff/artifact-diff/artifacts-diff";
 import { FilesDiff } from "@/entities/diff/file-diff/files-diff";
 import { NodeDiff } from "@/entities/diff/node-diff";
+import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 
 const BRANCH_TABS = {
   DETAILS: "details",
@@ -52,6 +53,7 @@ function BranchDetailsPage() {
       <header className="p-5 pb-2">
         <Row>
           <h1 className="font-bold text-xl">{branch.name}</h1>
+          <NodeMetadataPopover objectKind="InfrahubBranch" objectId={branch.id} />
           {branch.is_default ? (
             <BranchDefaultBadge className="text-sm" />
           ) : (

--- a/frontend/app/src/pages/resource-manager/resource-pool-details.tsx
+++ b/frontend/app/src/pages/resource-manager/resource-pool-details.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useParams } from "react-router";
 
 import { queryClient } from "@/shared/api/rest/client";
+import { Row } from "@/shared/components/container";
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import NoDataFound from "@/shared/components/errors/no-data-found";
 import ObjectEditSlideOverTrigger from "@/shared/components/form/object-edit-slide-over-trigger";
@@ -17,6 +18,7 @@ import {
   ObjectAttributeValue,
 } from "@/entities/nodes/getObjectItemDisplayValue";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 import { ObjectHelpButton } from "@/entities/nodes/object/ui/object-help-button";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
@@ -160,7 +162,12 @@ const ResourcePoolContent = ({
   return (
     <Content.Card>
       <Content.CardTitle
-        title={getNodeLabel(resourcePool)}
+        title={
+          <Row>
+            <span>{getNodeLabel(resourcePool)}</span>
+            <NodeMetadataPopover objectId={resourcePoolId} objectKind={resourcePoolKind} />
+          </Row>
+        }
         isReloadLoading={isRefetching}
         reload={handleRefetchAll}
         end={

--- a/frontend/app/src/shared/api/graphql/fragments.ts
+++ b/frontend/app/src/shared/api/graphql/fragments.ts
@@ -1,0 +1,15 @@
+export const nodeCoreFragment = {
+  id: true,
+  display_label: true,
+  hfid: true,
+  __typename: true,
+} as const;
+
+export const nodeMetadataFragment = {
+  node_metadata: {
+    created_at: true,
+    created_by: nodeCoreFragment,
+    updated_at: true,
+    updated_by: nodeCoreFragment,
+  },
+} as const;

--- a/frontend/app/src/shared/components/ui/link.tsx
+++ b/frontend/app/src/shared/components/ui/link.tsx
@@ -8,7 +8,10 @@ export const Link = (props: LinkProps) => {
   return (
     <RouterLink
       {...propsToPass}
-      className={classNames("cursor-pointer rounded-md underline", className)}
+      className={classNames(
+        "cursor-pointer rounded-md underline decoration-dotted hover:decoration-solid",
+        className
+      )}
     >
       {children}
     </RouterLink>

--- a/frontend/app/tests/e2e/branches/branches.spec.ts
+++ b/frontend/app/tests/e2e/branches/branches.spec.ts
@@ -29,7 +29,6 @@ test.describe("Branches creation and deletion", () => {
 
   test.describe("when logged in as Admin", () => {
     test.describe.configure({ mode: "serial" });
-    test.slow();
     test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
 
     const BRANCH_NAME_1 = generateRandomBranchName();
@@ -61,6 +60,13 @@ test.describe("Branches creation and deletion", () => {
 
       await page.getByLabel("Branches list").getByText(BRANCH_NAME_1).click();
       await expect(page.getByText(`Name${BRANCH_NAME_1}`)).toBeVisible();
+
+      await page.getByRole("button", { name: "View node metadata" }).click();
+      await expect(page.getByText("Created at")).toBeVisible();
+      await expect(page.getByText("Created by")).toBeVisible();
+      await expect(page.getByText("Updated at")).toBeVisible();
+      await expect(page.getByText("Updated by")).toBeVisible();
+
       expect(page.url()).toContain(`/branches/${BRANCH_NAME_1}`);
     });
 

--- a/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-2_data-lineage-and-metadata.spec.ts
+++ b/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-2_data-lineage-and-metadata.spec.ts
@@ -6,14 +6,6 @@ import { saveScreenshotForDocs } from "../../../utils";
 test.describe("Getting started with Infrahub - Data lineage and metadata", () => {
   test.use({ storageState: ACCOUNT_STATE_PATH.READ_WRITE });
 
-  test.beforeEach(async function ({ page }) {
-    page.on("response", async (response) => {
-      if (response.status() === 500) {
-        await expect(response.url()).toBe("This URL responded with a 500 status");
-      }
-    });
-  });
-
   test("1. Explore and update object metadata", async ({ page }) => {
     await test.step("Go to the detailed page of any device", async () => {
       await page.goto("/objects/InfraDevice");

--- a/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-2_data-lineage-and-metadata.spec.ts
+++ b/frontend/app/tests/e2e/docs-regression-check/tutorials/tutorial-2_data-lineage-and-metadata.spec.ts
@@ -21,6 +21,7 @@ test.describe("Getting started with Infrahub - Data lineage and metadata", () =>
     });
 
     await test.step("Explore Description attribute metadata", async () => {
+      await expect(page.getByText("Siteatl1")).toBeVisible();
       await page.getByText("Description-").getByTestId("view-metadata-button").click();
       await expect(page.getByText("Is protectedFalse")).toBeVisible();
       await saveScreenshotForDocs(page, "tutorial_4_metadata");

--- a/frontend/app/tests/e2e/objects/artifact.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact.spec.ts
@@ -2,10 +2,9 @@ import { expect, test } from "@playwright/test";
 
 import { ACCOUNT_STATE_PATH } from "../../constants";
 
-test.describe.fixme("/objects/CoreArtifact - Artifact page", () => {
+test.describe("/objects/CoreArtifact - Artifact page", () => {
   test.describe.configure({ mode: "serial" });
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
-  test.slow();
 
   test("should generate artifacts successfully", async ({ page }) => {
     await page.goto(
@@ -21,6 +20,13 @@ test.describe.fixme("/objects/CoreArtifact - Artifact page", () => {
 
     await page.getByRole("link", { name: "startup-config" }).first().click();
     await expect(page.getByText("no aaa root").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "View node metadata" }).click();
+
+    await expect(page.getByText("Created at")).toBeVisible();
+    await expect(page.getByText("Created by")).toBeVisible();
+    await expect(page.getByText("Updated at")).toBeVisible();
+    await expect(page.getByText("Updated by")).toBeVisible();
   });
 
   test.describe("when logged in", async () => {

--- a/frontend/app/tests/e2e/objects/hierarchy/object-hierarchy-tree-list.spec.ts
+++ b/frontend/app/tests/e2e/objects/hierarchy/object-hierarchy-tree-list.spec.ts
@@ -47,6 +47,7 @@ test.describe("Object hierarchy tree lite - Focused tree view", () => {
     });
 
     await page.getByTestId("breadcrumb-navigation").getByRole("link", { name: "Country" }).click();
+    await expect(page.getByRole("link", { name: "Australia" })).toBeVisible();
 
     await test.step("add a sibling node - lite tree should refresh", async () => {
       await page.getByTestId("create-object-button").click();

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -82,7 +82,7 @@ test.describe("/objects/:objectKind/:objectId", () => {
 
       await page.getByRole("link", { name: "atl1-edge1" }).click();
 
-      await page.getByTestId("node-metadata-button").click();
+      await page.getByRole("button", { name: "View node metadata" }).click();
 
       await expect(page.getByText("Created at")).toBeVisible();
       await expect(page.getByText("Created by")).toBeVisible();

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -76,5 +76,18 @@ test.describe("/objects/:objectKind/:objectId", () => {
       const nodeSelector = page.getByLabel("Circuit Endpoint").getByTestId("select-value");
       await expect(nodeSelector).not.toBeEmpty(); // ID is in the input but it's dynamic
     });
+
+    test("should display node metadata popover", async ({ page }) => {
+      await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+
+      await page.getByRole("link", { name: "atl1-edge1" }).click();
+
+      await page.getByTestId("node-metadata-button").click();
+
+      await expect(page.getByText("Created at")).toBeVisible();
+      await expect(page.getByText("Created by")).toBeVisible();
+      await expect(page.getByText("Updated at")).toBeVisible();
+      await expect(page.getByText("Updated by")).toBeVisible();
+    });
   });
 });

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -6,7 +6,6 @@ import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
 
 test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
   test.describe.configure({ mode: "serial" });
-  test.slow();
   const BRANCH_NAME = generateRandomBranchName("object-relationships");
 
   test.beforeAll(async ({ request }) => {
@@ -95,6 +94,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
 
       await test.step("Edit a relationship", async () => {
         await page.getByRole("link", { name: "Loopback0", exact: true }).click();
+        await expect(page.getByText('NameLoopback0')).toBeVisible();
 
         await page.getByTestId("edit-button").click();
         await expect(page.getByText("Device *")).toBeVisible();

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -94,7 +94,7 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
 
       await test.step("Edit a relationship", async () => {
         await page.getByRole("link", { name: "Loopback0", exact: true }).click();
-        await expect(page.getByText('NameLoopback0')).toBeVisible();
+        await expect(page.getByText("NameLoopback0")).toBeVisible();
 
         await page.getByTestId("edit-button").click();
         await expect(page.getByText("Device *")).toBeVisible();

--- a/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
+++ b/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
@@ -40,6 +40,12 @@ test.describe("/resource-manager - Resource Manager", () => {
     await expect(page.getByText("Description-")).toBeVisible();
     expect(page.url()).toContain("/resource-manager/");
 
+    await page.getByRole("button", { name: "View node metadata" }).click();
+    await expect(page.getByText("Created at")).toBeVisible();
+    await expect(page.getByText("Created by")).toBeVisible();
+    await expect(page.getByText("Updated at")).toBeVisible();
+    await expect(page.getByText("Updated by")).toBeVisible();
+
     await page.getByTestId("edit-button").click();
     await expect(page.getByLabel("Default Prefix Type")).toContainText("IP PrefixIpam");
     await page.getByLabel("Description").fill("a test pool for e2e");


### PR DESCRIPTION
<img width="1522" height="576" alt="image" src="https://github.com/user-attachments/assets/1c89b70b-6532-4513-9cef-1b9c3b0babee" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node metadata popover added across object, artifact, IPAM, resource-pool and branch headers — shows Created/Updated timestamps and user links with loading, error and empty states.
* **APIs & Hooks**
  * Client-side metadata retrieval via GraphQL honoring branch/date and a React hook providing keyed queries.
* **Types**
  * New nullable NodeMetadata shape for audit fields.
* **Tests**
  * Unit and E2E tests added/updated to verify popover behavior and metadata visibility.
* **Style**
  * Link styling enhanced with dotted decoration on hover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->