### PR TITLE
Set updated_by and updated_at on branch creation

### DIFF
--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -176,6 +176,8 @@ class StandardNode(BaseModel):
     async def create(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Create a new node in the database."""
         self.created_by = user_id
+        self.updated_by = self.created_by
+        self.updated_at = self.created_at
         query: Query = await self._query.init(db=db, node=self)
         await query.execute(db=db)
 

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -379,9 +379,11 @@ async def test_branch_update_description(
 
     branch4_updated = await Branch.get_by_name(db=db, name="branch4")
 
-    assert not branch4.updated_at
+    assert branch4.updated_at == branch4.created_at
     assert branch4_updated.description == "testing"
+    assert branch4.updated_at
     assert branch4_updated.updated_at
+    assert branch4_updated.updated_at > branch4.updated_at
     assert branch4_updated.updated_by == session_admin.account_id
 
 


### PR DESCRIPTION
Ensure that se set updated_by and updated_at during standard node creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit field initialization to ensure update timestamps and user information are accurately recorded when nodes are created, improving audit trail completeness and data integrity tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->