### PR TITLE
Remove unused prop enableCopyToClipboard from ObjectAttributeRow

### DIFF
--- a/frontend/app/src/entities/nodes/object-item-details/object-attribute-row.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/object-attribute-row.tsx
@@ -1,26 +1,14 @@
 import type { ReactElement } from "react";
 
-import { CopyToClipboard } from "@/shared/components/buttons/copy-to-clipboard";
-
 type ObjectAttributeRowProps = {
   name: string;
   value: string | ReactElement;
-  enableCopyToClipboard?: boolean;
 };
-export const ObjectAttributeRow = ({
-  name,
-  value,
-  enableCopyToClipboard,
-}: ObjectAttributeRowProps) => {
+export const ObjectAttributeRow = ({ name, value }: ObjectAttributeRowProps) => {
   return (
     <div className="grid grid-cols-[200px_auto] gap-4 px-4 py-2 text-xs">
       <dt className="flex h-8 items-center font-medium text-gray-500">{name}</dt>
-      <dd className="flex items-center gap-2">
-        {value}
-        {enableCopyToClipboard && (
-          <CopyToClipboard className="text-gray-500" text={value.toString()} />
-        )}
-      </dd>
+      <dd className="flex items-center gap-2">{value}</dd>
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed copy-to-clipboard functionality from object attribute details display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->