### PR TITLE
Display "No task" on branch details when task are empty

### DIFF
--- a/changelog/+task-empty.added.md
+++ b/changelog/+task-empty.added.md
@@ -1,0 +1,1 @@
+Display "No task" on branch details when task are empty.

--- a/frontend/app/src/entities/tasks/ui/task-display.tsx
+++ b/frontend/app/src/entities/tasks/ui/task-display.tsx
@@ -100,10 +100,18 @@ export function TaskDisplay({ branch, workflow, relatedNode }: TaskDisplayProps)
     return <LoadingIndicator className="p-4" />;
   }
 
+  const tasks = data[TASK_OBJECT].edges?.map(({ node }) => node) ?? [];
+
+  if (tasks.length === 0) {
+    return (
+      <span className="m-auto flex flex-col gap-4 rounded-md bg-gray-100 p-4 text-sm">No task</span>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-2 overflow-scroll">
-      {data[TASK_OBJECT].edges?.map((edge, index) => (
-        <Task key={index} task={edge.node} />
+      {tasks.map((task, index) => (
+        <Task key={index} task={task} />
       ))}
     </div>
   );

--- a/frontend/app/tests/e2e/branches/merge-branch.spec.ts
+++ b/frontend/app/tests/e2e/branches/merge-branch.spec.ts
@@ -23,6 +23,7 @@ test.describe("Branch - Merge action", () => {
       await page.getByText("Tasks").click();
       await expect(page.getByText("Loading...Loading...")).toBeVisible();
       await expect(page.getByText("Loading...Loading...")).not.toBeVisible();
+      await expect(page.getByText("No task")).toBeVisible();
     });
 
     await test.step("Merge the branch and verify button state", async () => {


### PR DESCRIPTION
Attempt to fix flaky in merge-branch.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch details now show a clear "No task" message when there are no tasks to display, improving empty-state clarity.

* **Tests**
  * End-to-end tests updated to assert the empty-task message appears after loading completes, ensuring the empty-state is validated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->