### PR TITLE
Bump pre-commit ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.9
+    rev: v0.14.10
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
Bump pre-commit ruff version which fixes the following error

```
ruff failed
  Cause: Failed to parse /Users/solaopsmill/opsmill/infrahub/pyproject.toml
  Cause: TOML parse error at line 522, column 5
    |
522 |     "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
    |     ^^^^^^^^^^
Unknown rule selector: `ASYNC240`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and automated code quality checks to improve consistency across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->