### PR TITLE
fix(backend, tests): flaky prefect worker test

### DIFF
--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -63,7 +63,7 @@ class TestInfrahub:
         return branch
 
 
-class TestInfrahubApp(TestInfrahub):
+class TestInfrahubAppBase(TestInfrahub):
     @pytest.fixture(scope="class")
     def api_admin_token(self) -> str:
         return str(UUIDT())
@@ -101,22 +101,6 @@ class TestInfrahubApp(TestInfrahub):
         config.OVERRIDE.cache = cache
         with dependency_provider.scope(build_cache, lambda: cache):
             yield cache
-
-    @pytest.fixture(scope="class", autouse=True)
-    async def workflow_local(
-        self, prefect: Generator[str, None, None], dependency_provider: Provider
-    ) -> AsyncGenerator[WorkflowLocalExecution, None]:
-        original = config.OVERRIDE.workflow
-        workflow = WorkflowLocalExecution()
-        await setup_task_manager()
-        config.OVERRIDE.workflow = workflow
-        with dependency_provider.scope(build_workflow, lambda: workflow):
-            yield workflow
-        config.OVERRIDE.workflow = original
-
-    @pytest.fixture(scope="class", autouse=True)
-    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
-        return app.state.service
 
     @pytest.fixture(scope="class")
     async def register_internal_schema(self, db: InfrahubDatabase, default_branch: Branch) -> SchemaBranch:
@@ -283,3 +267,39 @@ class TestInfrahubApp(TestInfrahub):
             await asyncio.sleep(1)
 
         pytest.fail(f"unable to find prefect event '{event_name}'")
+
+
+class TestInfrahubApp(TestInfrahubAppBase):
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_local(
+        self, prefect: Generator[str, None, None], dependency_provider: Provider
+    ) -> AsyncGenerator[WorkflowLocalExecution, None]:
+        original = config.OVERRIDE.workflow
+        workflow = WorkflowLocalExecution()
+        await setup_task_manager()
+        config.OVERRIDE.workflow = workflow
+        with dependency_provider.scope(build_workflow, lambda: workflow):
+            yield workflow
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+
+class TestInfrahubAppWithoutLocalWorkflow(TestInfrahubAppBase):
+    @pytest.fixture(scope="class")
+    async def workflow_local(
+        self, prefect: Generator[str, None, None], dependency_provider: Provider
+    ) -> AsyncGenerator[WorkflowLocalExecution, None]:
+        original = config.OVERRIDE.workflow
+        workflow = WorkflowLocalExecution()
+        await setup_task_manager()
+        config.OVERRIDE.workflow = workflow
+        with dependency_provider.scope(build_workflow, lambda: workflow):
+            yield workflow
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class")
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -22,11 +22,11 @@ from infrahub.workflows.models import WorkerPoolDefinition
 from tests.helpers.constants import (
     PORT_PREFECT,
 )
-from tests.helpers.test_app import TestInfrahubApp
+from tests.helpers.test_app import TestInfrahubAppWithoutLocalWorkflow
 from tests.helpers.utils import start_prefect_server_container
 
 
-class TestWorkerInfrahubAsync(TestInfrahubApp):
+class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
     @classmethod
     async def wait_for_flow(
         cls, client: PrefectClient, work_pool_id: UUID, interval: int = 1, timeout: int = 10

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import ExitStack
-from typing import Any, Generator
+from typing import Any, AsyncGenerator, Generator
 from uuid import UUID
 
 import pytest
@@ -10,6 +10,9 @@ from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.client.schemas.filters import WorkPoolFilter, WorkPoolFilterId
 from prefect.client.schemas.objects import FlowRun, StateType, WorkPool
+from prefect.events.worker import EventsWorker
+from prefect.logging.handlers import APILogWorker
+from prefect.results import _default_storages
 from prefect.workers.base import BaseWorkerResult
 
 from infrahub.tasks.dummy import DUMMY_FLOW, DUMMY_FLOW_BROKEN
@@ -114,7 +117,7 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         prefect_client: PrefectClient,
         work_pool: WorkPool,
         git_global_config_env_setting: Any,
-    ) -> InfrahubWorkerAsync:
+    ) -> AsyncGenerator[InfrahubWorkerAsync, None]:
         worker = InfrahubWorkerAsync(work_pool_name=work_pool.name)
 
         await worker.setup(client=client, metric_port=0)
@@ -124,4 +127,11 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         active_workers = await prefect_client.read_workers_for_work_pool(work_pool_name=work_pool.name)
         assert active_workers[0].name == worker.name
 
-        return worker
+        yield worker
+
+        # Clear local worker instances to avoid issues with multiple test classes running in the same pytest worker
+        EventsWorker.drain_all()
+        APILogWorker.drain_all()
+
+        # Clear local worker result storage cache
+        _default_storages.clear()


### PR DESCRIPTION
Tests would fail when the `TestWorkerInfrahubAsync` fixtures are used multiple times within the same pytest worker because of stale caches and state (pointing to previous references and Prefect API servers). Make sure we clear those. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure organization to enhance test isolation and resource management between test executions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->