### PR TITLE
remove IS_VISIBLE properties from diffs

### DIFF
--- a/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
+++ b/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
@@ -26,10 +26,25 @@ class RemoveIsVisibleRelationshipQuery(Query):
         self.add_to_query(query)
 
 
+class RemoveIsVisibleFromDiffsQuery(Query):
+    name = "remove_is_visible_from_diffs"
+    type = QueryType.WRITE
+    insert_return = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        query = """
+        MATCH (diff_prop:DiffProperty {property_type: "IS_VISIBLE"})
+        CALL (diff_prop) {
+            DETACH DELETE diff_prop
+        } IN TRANSACTIONS
+        """
+        self.add_to_query(query)
+
+
 class Migration049(GraphMigration):
     name: str = "049_remove_is_visible_relationship"
     minimum_version: int = 48
-    queries: Sequence[type[Query]] = [RemoveIsVisibleRelationshipQuery]
+    queries: Sequence[type[Query]] = [RemoveIsVisibleRelationshipQuery, RemoveIsVisibleFromDiffsQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()


### PR DESCRIPTION
existing diffs that include IS_VISIBLE edges will break now that is_visible support is completely removed from infrahub. this updates the existing migration to remove IS_VISIBLE to also delete it from existing diffs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration process to execute additional cleanup operations during system upgrades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->