### PR TITLE
allow running a single migration again

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -319,11 +319,12 @@ async def detect_migration_to_run(
             get_migration_console().log(
                 f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
             )
-    else:
-        migrations.extend(await get_graph_migrations(current_graph_version=current_graph_version))
-        if not migrations:
-            get_migration_console().log(f"Database up-to-date (v{current_graph_version}), no migration to execute.")
-            return []
+            return migrations
+
+    migrations.extend(await get_graph_migrations(current_graph_version=current_graph_version))
+    if not migrations:
+        get_migration_console().log(f"Database up-to-date (v{current_graph_version}), no migration to execute.")
+        return []
 
     get_migration_console().log(
         f"Database needs to be updated (v{current_graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -65,6 +65,7 @@ def get_timestamp_string() -> str:
 if TYPE_CHECKING:
     from infrahub.cli.context import CliContext
     from infrahub.core.migrations.shared import MigrationTypes
+    from infrahub.core.root import Root
     from infrahub.database import InfrahubDatabase
     from infrahub.database.index import IndexManagerBase
 
@@ -93,12 +94,40 @@ def callback() -> None:
     """
 
 
+async def do_migrate(
+    db: InfrahubDatabase,
+    root_node: Root,
+    check: bool = False,
+    migration_number: int | None = None,
+) -> None:
+    """Core migration logic that can be called independently of CLI.
+
+    Args:
+        db: The database connection.
+        root_node: The root node containing the current graph version.
+        check: If True, only check which migrations need to run without applying them.
+        migration_number: If provided, run only this specific migration.
+    """
+    migrations = await detect_migration_to_run(
+        current_graph_version=root_node.graph_version, migration_number=migration_number
+    )
+
+    if check or not migrations:
+        return
+
+    await migrate_database(
+        db=db, migrations=migrations, initialize=True, update_graph_version=(migration_number is None)
+    )
+
+
 @app.command(name="migrate")
 async def migrate_cmd(
     ctx: typer.Context,
     check: bool = typer.Option(False, help="Check the state of the database without applying the migrations."),
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
-    migration_number: int | None = typer.Option(None, help="Apply a specific migration by number"),
+    migration_number: int | None = typer.Option(
+        None, help="Apply a specific migration by number, regardless of current database version"
+    ),
 ) -> None:
     """Check the current format of the internal graph and apply the necessary migrations"""
     logging.getLogger("infrahub").setLevel(logging.WARNING)
@@ -111,14 +140,7 @@ async def migrate_cmd(
     dbdriver = await context.init_db(retry=1)
 
     root_node = await get_root_node(db=dbdriver)
-    migrations = await detect_migration_to_run(
-        current_graph_version=root_node.graph_version, migration_number=migration_number
-    )
-
-    if check or not migrations:
-        return
-
-    await migrate_database(db=dbdriver, migrations=migrations, initialize=True)
+    await do_migrate(db=dbdriver, root_node=root_node, check=check, migration_number=migration_number)
 
     await dbdriver.close()
 
@@ -292,13 +314,11 @@ async def detect_migration_to_run(
         migration = get_migration_by_number(migration_number)
         migrations.append(migration)
         if current_graph_version > migration.minimum_version:
+            get_migration_console().log(f"Migration {migration_number} will be re-applied.")
+        else:
             get_migration_console().log(
-                f"Migration {migration_number} already applied. To apply again, run the command without the --check flag."
+                f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
             )
-            return []
-        get_migration_console().log(
-            f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
-        )
     else:
         migrations.extend(await get_graph_migrations(current_graph_version=current_graph_version))
         if not migrations:
@@ -312,7 +332,10 @@ async def detect_migration_to_run(
 
 
 async def migrate_database(
-    db: InfrahubDatabase, migrations: Sequence[MigrationTypes], initialize: bool = False
+    db: InfrahubDatabase,
+    migrations: Sequence[MigrationTypes],
+    initialize: bool = False,
+    update_graph_version: bool = True,
 ) -> bool:
     """Apply the latest migrations to the database, this function will print the status directly in the console.
 
@@ -322,6 +345,7 @@ async def migrate_database(
         db: The database object.
         migrations: Sequence of migrations to apply.
         initialize: Whether to initialize the registry before running migrations.
+        update_graph_version: Whether to update the graph version after each migration.
     """
     if not migrations:
         return True
@@ -339,8 +363,9 @@ async def migrate_database(
             validation_result = await migration.validate_migration(db=db)
             if validation_result.success:
                 get_migration_console().log(f"Migration: {migration.name} {SUCCESS_BADGE}")
-                root_node.graph_version = migration.minimum_version + 1
-                await root_node.save(db=db)
+                if update_graph_version:
+                    root_node.graph_version = migration.minimum_version + 1
+                    await root_node.save(db=db)
 
         if not execution_result.success or (validation_result and not validation_result.success):
             get_migration_console().log(f"Migration: {migration.name} {FAILED_BADGE}")

--- a/backend/tests/unit/cli/test_migrate.py
+++ b/backend/tests/unit/cli/test_migrate.py
@@ -97,10 +97,7 @@ class TestDoMigrate:
         # Reload root node to check if version changed
         root_node = await get_root_node(db=db)
 
-        if test_case.expected_version_number:
-            assert root_node.graph_version == 1  # Migration001.minimum_version + 1
-        else:
-            assert root_node.graph_version == 0
+        assert root_node.graph_version == test_case.expected_version_number
 
         # Restore original version for other tests
         root_node.graph_version = initial_version

--- a/backend/tests/unit/cli/test_migrate.py
+++ b/backend/tests/unit/cli/test_migrate.py
@@ -1,0 +1,270 @@
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from infrahub.cli.db import do_migrate
+from infrahub.core.initialization import get_root_node
+from infrahub.core.migrations.shared import GraphMigration, MigrationResult
+from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class DoMigrateTestCase:
+    """Test case parameters for do_migrate tests."""
+
+    check: bool
+    migration_number: int | None
+    expected_version_number: int
+    description: str
+
+
+class Migration001(GraphMigration):
+    """Dummy migration for testing purposes with name matching migration number 1."""
+
+    name: str = "001_dummy_migration"
+    minimum_version: int = 0
+    queries: list = []
+
+    async def validate_migration(self, db):
+        return MigrationResult()
+
+
+class Migration042(GraphMigration):
+    """Dummy migration for testing purposes with name matching migration number 42."""
+
+    name: str = "042_dummy_migration"
+    minimum_version: int = 41
+    queries: list = []
+
+    async def validate_migration(self, db):
+        return MigrationResult()
+
+
+class TestDoMigrate:
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            DoMigrateTestCase(
+                check=False,
+                migration_number=None,
+                expected_version_number=1,
+                description="Normal run: should update graph version",
+            ),
+            DoMigrateTestCase(
+                check=True,
+                migration_number=None,
+                expected_version_number=0,
+                description="Check only: should not update graph version",
+            ),
+            DoMigrateTestCase(
+                check=False,
+                migration_number=1,
+                expected_version_number=0,
+                description="Specific migration: should not update graph version",
+            ),
+            DoMigrateTestCase(
+                check=True,
+                migration_number=1,
+                expected_version_number=0,
+                description="Check with specific migration: should not update graph version",
+            ),
+        ],
+        ids=lambda tc: tc.description,
+    )
+    async def test_do_migrate_check_flag(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        test_case: DoMigrateTestCase,
+    ):
+        """Test that check=True prevents migrations from running."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version to 0 so Migration001 is applicable
+        root_node.graph_version = 0
+        await root_node.save(db=db)
+
+        with patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001]):
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=test_case.check,
+                migration_number=test_case.migration_number,
+            )
+
+        # Reload root node to check if version changed
+        root_node = await get_root_node(db=db)
+
+        if test_case.expected_version_number:
+            assert root_node.graph_version == 1  # Migration001.minimum_version + 1
+        else:
+            assert root_node.graph_version == 0
+
+        # Restore original version for other tests
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)
+
+    async def test_do_migrate_no_migrations_to_run(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+    ):
+        """Test that no changes occur when no migrations are applicable."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version higher than Migration001's minimum_version
+        root_node.graph_version = 100
+        await root_node.save(db=db)
+
+        with patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001]):
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=False,
+                migration_number=None,
+            )
+
+        # Reload and verify no change
+        root_node = await get_root_node(db=db)
+        assert root_node.graph_version == 100
+
+        # Restore original version
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)
+
+    async def test_do_migrate_update_graph_version_true_without_migration_number(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+    ):
+        """Test that update_graph_version=True when no specific migration is requested."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version to 0 so Migration001 is applicable
+        root_node.graph_version = 0
+        await root_node.save(db=db)
+
+        with patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001]):
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=False,
+                migration_number=None,
+            )
+
+        # Reload and verify version updated
+        root_node = await get_root_node(db=db)
+        assert root_node.graph_version == 1  # Migration001.minimum_version + 1
+
+        # Restore original version
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)
+
+    async def test_do_migrate_update_graph_version_false_with_migration_number(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+    ):
+        """Test that update_graph_version=False when a specific migration is requested."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version to 0 so Migration001 is applicable
+        root_node.graph_version = 0
+        await root_node.save(db=db)
+
+        mock_execute = AsyncMock(return_value=MigrationResult())
+
+        with (
+            patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001]),
+            patch.object(Migration001, "execute", mock_execute),
+        ):
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=False,
+                migration_number=1,
+            )
+
+            # Verify migration was executed
+            mock_execute.assert_awaited_once()
+
+        # Reload and verify version NOT updated (because migration_number was specified)
+        root_node = await get_root_node(db=db)
+        assert root_node.graph_version == 0
+
+        # Restore original version
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)
+
+    async def test_do_migrate_runs_specific_migration_by_number(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+    ):
+        """Test that migration_number selects the correct migration."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version high enough that Migration001 would be skipped in normal run
+        # but Migration042 would be found by number
+        root_node.graph_version = 50
+        await root_node.save(db=db)
+
+        with patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001, Migration042]):
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=False,
+                migration_number=42,
+            )
+
+        # Migration ran but version not updated (because migration_number was specified)
+        root_node = await get_root_node(db=db)
+        assert root_node.graph_version == 50
+
+        # Restore original version
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)
+
+    async def test_do_migrate_reruns_already_applied_migration(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+    ):
+        """Test that a specific migration can be re-run even if already applied."""
+        root_node = await get_root_node(db=db)
+        initial_version = root_node.graph_version
+
+        # Set graph version higher than Migration001's minimum_version (already applied)
+        root_node.graph_version = 10
+        await root_node.save(db=db)
+
+        mock_execute = AsyncMock(return_value=MigrationResult())
+
+        with (
+            patch("infrahub.core.migrations.graph.MIGRATIONS", [Migration001]),
+            patch.object(Migration001, "execute", mock_execute),
+        ):
+            # This should still run Migration001 because migration_number is specified
+            await do_migrate(
+                db=db,
+                root_node=root_node,
+                check=False,
+                migration_number=1,
+            )
+
+            # Verify migration was executed even though it was already applied
+            mock_execute.assert_awaited_once()
+
+        # Version should not change (migration_number specified)
+        root_node = await get_root_node(db=db)
+        assert root_node.graph_version == 10
+
+        # Restore original version
+        root_node.graph_version = initial_version
+        await root_node.save(db=db)

--- a/changelog/+b583d9b0.fixed.md
+++ b/changelog/+b583d9b0.fixed.md
@@ -1,0 +1,1 @@
+Re-enable running a single migration in `infrahub db migrate` using the `--migration-number` option

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -44,7 +44,7 @@ $ infrahub db migrate [OPTIONS] [CONFIG_FILE]
 **Options**:
 
 * `--check / --no-check`: Check the state of the database without applying the migrations.  [default: no-check]
-* `--migration-number INTEGER`: Apply a specific migration by number
+* `--migration-number INTEGER`: Apply a specific migration by number, regardless of current database version
 * `--help`: Show this message and exit.
 
 ## `infrahub db check-inheritance`


### PR DESCRIPTION
an update to `infrahub db migrate` made it impossible to run one migration

this update re-implements that functionality and adds some tests to prevent it from regressing again in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized migration entry point and an option to control whether the repository graph version is updated after migrations; improved handling and messaging when targeting a specific migration number, including support for re-applying a specific migration.

* **Tests**
  * Added end-to-end unit tests covering migration selection, re-run behavior, check mode, and graph version updates.

* **Documentation**
  * Clarified CLI help text for the --migration-number option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->