### PR TITLE
feat: make DiffTreeSummary GraphQL count fields non-optional [#7778]

### DIFF
--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -60,10 +60,10 @@ class ConflictDetails(ObjectType):
 
 
 class DiffSummaryCounts(ObjectType):
-    num_added = Int(required=False)
-    num_updated = Int(required=False)
-    num_removed = Int(required=False)
-    num_conflicts = Int(required=False)
+    num_added = Int(required=True)
+    num_updated = Int(required=True)
+    num_removed = Int(required=True)
+    num_conflicts = Int(required=True)
 
 
 class DiffProperty(ObjectType):
@@ -146,7 +146,7 @@ class DiffTreeSummary(DiffSummaryCounts):
     diff_branch = String(required=True)
     from_time = DateTime(required=True)
     to_time = DateTime(required=True)
-    num_unchanged = Int(required=False)
+    num_unchanged = Int(required=True)
     num_untracked_base_changes = Int(required=False)
     num_untracked_diff_changes = Int(required=False)
 

--- a/changelog/7778.changed.md
+++ b/changelog/7778.changed.md
@@ -1,0 +1,1 @@
+Changed DiffTreeSummary GraphQL type count fields to be non-optional

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -6334,10 +6334,10 @@ type DiffAttribute {
   contains_conflict: Boolean!
   last_changed_at: DateTime!
   name: String!
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
-  num_updated: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
+  num_updated: Int!
   path_identifier: String!
   properties: [DiffProperty!]
   status: DiffAction!
@@ -6350,10 +6350,10 @@ type DiffNode {
   kind: String!
   label: String!
   last_changed_at: DateTime
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
-  num_updated: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
+  num_updated: Int!
   parent: DiffNodeParent
   path_identifier: String!
   relationships: [DiffRelationship!]!
@@ -6386,10 +6386,10 @@ type DiffRelationship {
   label: String
   last_changed_at: DateTime
   name: String!
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
-  num_updated: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
+  num_updated: Int!
   path_identifier: String!
   status: DiffAction!
 }
@@ -6398,10 +6398,10 @@ type DiffSingleRelationship {
   conflict: ConflictDetails
   contains_conflict: Boolean!
   last_changed_at: DateTime
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
-  num_updated: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
+  num_updated: Int!
   path_identifier: String!
   peer_id: String!
   peer_label: String
@@ -6415,12 +6415,12 @@ type DiffTree {
   from_time: DateTime!
   name: String
   nodes: [DiffNode!]
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
   num_untracked_base_changes: Int
   num_untracked_diff_changes: Int
-  num_updated: Int
+  num_updated: Int!
   to_time: DateTime!
 }
 
@@ -6435,13 +6435,13 @@ type DiffTreeSummary {
   base_branch: String!
   diff_branch: String!
   from_time: DateTime!
-  num_added: Int
-  num_conflicts: Int
-  num_removed: Int
-  num_unchanged: Int
+  num_added: Int!
+  num_conflicts: Int!
+  num_removed: Int!
+  num_unchanged: Int!
   num_untracked_base_changes: Int
   num_untracked_diff_changes: Int
-  num_updated: Int
+  num_updated: Int!
   to_time: DateTime!
 }
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Diff count fields (num_added, num_updated, num_removed, num_conflicts, num_unchanged) in the GraphQL diff/tree responses are now required (non-null). Clients should expect these counts to always be present and handle them as non-null integers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Makes count fields in the DiffTreeSummary and related GraphQL types non-optional (required), so consumers don't need to handle null scenarios for values that always exist.

- Changed `num_added`, `num_updated`, `num_removed`, `num_conflicts` in DiffSummaryCounts to required
- Changed `num_unchanged` in DiffTreeSummary to required

Closes #7778

## Test plan
- [x] Run unit tests: `uv run pytest backend/tests/unit/graphql/diff/test_diff_tree_query.py` (18 passed)
- [x] Run related tests: `uv run pytest backend/tests/unit/core/diff/repository/test_diff_summary_counts.py` (6 passed)
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)