### PR TITLE
fix(backend): add locking on relationship count constraints

### DIFF
--- a/backend/infrahub/core/node/lock_utils.py
+++ b/backend/infrahub/core/node/lock_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 from typing import TYPE_CHECKING
 
+from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.node import Node
 from infrahub.core.schema import GenericSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
 
 
 RESOURCE_POOL_LOCK_NAMESPACE = "resource_pool"
+RELATIONSHIP_COUNT_LOCK_NAMESPACE = "relationship_count"
 
 
 def _get_kinds_to_lock_on_object_mutation(kind: str, schema_branch: SchemaBranch) -> list[str]:
@@ -55,7 +57,8 @@ def _hash(value: str) -> str:
 def get_lock_names_on_object_mutation(node: Node, schema_branch: SchemaBranch) -> list[str]:
     """
     Return lock names for object on which we want to avoid concurrent mutation (create/update).
-    Lock names include kind, some generic kinds, resource pool ids, and values of attributes of corresponding uniqueness constraints.
+    Lock names include kind, some generic kinds, resource pool ids, peer ids for cardinality one relationships,
+    and values of attributes of corresponding uniqueness constraints.
     """
 
     lock_names: set[str] = set()
@@ -66,12 +69,30 @@ def get_lock_names_on_object_mutation(node: Node, schema_branch: SchemaBranch) -
         if attribute is not None and getattr(attribute, "from_pool", None) and "id" in attribute.from_pool:
             lock_names.add(f"{RESOURCE_POOL_LOCK_NAMESPACE}.{attribute.from_pool['id']}")
 
-    # Check if relationships allocate resources
+    # Check if relationships allocate resources or have cardinality one constraint
     for rel_name in node._relationships:
         rel_manager: RelationshipManager = getattr(node, rel_name)
         for rel in rel_manager._relationships:
             if rel.from_pool and "id" in rel.from_pool:
                 lock_names.add(f"{RESOURCE_POOL_LOCK_NAMESPACE}.{rel.from_pool['id']}")
+
+            peer_id = rel.peer_id
+            if not peer_id or not rel.schema.identifier:
+                continue
+
+            # Check if this node's relationship has cardinality one or max/min_count constraint
+            # This prevents concurrent updates to the same node's constrained relationship
+            if rel.schema.cardinality == RelationshipCardinality.ONE or rel.schema.max_count or rel.schema.min_count:
+                lock_names.add(f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.{rel.schema.identifier}.{node.id}")
+
+            # Check if the peer has count constraints on the reverse relationship
+            # This includes cardinality one, max_count, and min_count constraints
+            peer_schema = schema_branch.get(name=rel.schema.peer, duplicate=False)
+            peer_rel = peer_schema.get_relationship_by_identifier(id=rel.schema.identifier, raise_on_error=False)
+            if peer_rel and (
+                peer_rel.cardinality == RelationshipCardinality.ONE or peer_rel.max_count or peer_rel.min_count
+            ):
+                lock_names.add(f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.{rel.schema.identifier}.{peer_id}")
 
     lock_kinds = _get_kinds_to_lock_on_object_mutation(node.get_kind(), schema_branch)
     for kind in lock_kinds:

--- a/backend/tests/component/core/test_get_kinds_lock.py
+++ b/backend/tests/component/core/test_get_kinds_lock.py
@@ -6,10 +6,12 @@ from infrahub.core import registry
 from infrahub.core.constants.infrahubkind import GRAPHQLQUERY, GRAPHQLQUERYGROUP
 from infrahub.core.initialization import create_branch
 from infrahub.core.node.lock_utils import (
+    RELATIONSHIP_COUNT_LOCK_NAMESPACE,
     _get_kinds_to_lock_on_object_mutation,
     _hash,
     get_lock_names_on_object_mutation,
 )
+from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 from tests.node_creation import create_and_save
@@ -61,9 +63,15 @@ class TestGetKindsLock(TestInfrahubApp):
         with patch("infrahub.core.node.create.InfrahubMultiLock") as mock_infrahub_multi_lock:
             group = await client.create(kind=GRAPHQLQUERYGROUP, name="a_gql_group", query=graphql_query)
             await group.save()
-            mock_infrahub_multi_lock.assert_called_once_with(
-                lock_registry=lock.registry, locks=["global.object.CoreGroup." + _hash("a_gql_group")], metrics=False
-            )
+            mock_infrahub_multi_lock.assert_called_once()
+            call_kwargs = mock_infrahub_multi_lock.call_args.kwargs
+            assert call_kwargs["lock_registry"] == lock.registry
+            assert call_kwargs["metrics"] is False
+            assert len(call_kwargs["locks"]) == 2
+            assert call_kwargs["locks"][0] == "global.object.CoreGroup." + _hash("a_gql_group")
+            # The second lock uses a temporary ID generated during node creation preview,
+            # so we only verify the prefix pattern
+            assert call_kwargs["locks"][1].startswith("relationship_count.coregraphqlquery__coregraphqlquerygroup.")
 
         # Test upsert the same node
         with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
@@ -71,7 +79,12 @@ class TestGetKindsLock(TestInfrahubApp):
             await group.save(allow_upsert=True)
 
             mock_infrahub_multi_lock.assert_called_with(
-                lock_registry=lock.registry, locks=["global.object.CoreGroup." + _hash("a_gql_group")], metrics=False
+                lock_registry=lock.registry,
+                locks=[
+                    "global.object.CoreGroup." + _hash("a_gql_group"),
+                    "relationship_count.coregraphqlquery__coregraphqlquerygroup." + group.id,
+                ],
+                metrics=False,
             )
 
         # Test updating group name
@@ -80,7 +93,12 @@ class TestGetKindsLock(TestInfrahubApp):
             await group.save()
 
             mock_infrahub_multi_lock.assert_called_once_with(
-                lock_registry=lock.registry, locks=["global.object.CoreGroup." + _hash("new_group_name")], metrics=False
+                lock_registry=lock.registry,
+                locks=[
+                    "global.object.CoreGroup." + _hash("new_group_name"),
+                    "relationship_count.coregraphqlquery__coregraphqlquerygroup." + group.id,
+                ],
+                metrics=False,
             )
 
         # Test updating other field not present in uniqueness constraint
@@ -106,16 +124,22 @@ class TestGetKindsLock(TestInfrahubApp):
 
         #     mock_infrahub_multi_lock.assert_called_once_with(lock_registry=lock.registry, locks=[], metrics=False)
 
-        # Test lock onanother branch
+        # Test lock on another branch
         other_branch = await create_branch(branch_name="other_branch", db=db)
         with patch("infrahub.core.node.create.InfrahubMultiLock") as mock_infrahub_multi_lock:
             group = await client.create(
                 kind=GRAPHQLQUERYGROUP, name="one_more_group", query=graphql_query, branch=other_branch.name
             )
             await group.save()
-            mock_infrahub_multi_lock.assert_called_once_with(
-                lock_registry=lock.registry, locks=["global.object.CoreGroup." + _hash("one_more_group")], metrics=False
-            )
+            mock_infrahub_multi_lock.assert_called_once()
+            call_kwargs = mock_infrahub_multi_lock.call_args.kwargs
+            assert call_kwargs["lock_registry"] == lock.registry
+            assert call_kwargs["metrics"] is False
+            assert len(call_kwargs["locks"]) == 2
+            assert call_kwargs["locks"][0] == "global.object.CoreGroup." + _hash("one_more_group")
+            # The second lock uses a temporary ID generated during node creation preview,
+            # so we only verify the prefix pattern
+            assert call_kwargs["locks"][1].startswith("relationship_count.coregraphqlquery__coregraphqlquerygroup.")
 
     async def test_lock_other_branch(
         self,
@@ -149,7 +173,8 @@ class TestGetKindsLock(TestInfrahubApp):
         person = await create_and_save(db=db, schema="TestPerson", name="John")
         car = await create_and_save(db=db, schema="TestCar", name="mercedes", color="blue", owner=person)
         assert get_lock_names_on_object_mutation(car, schema_branch=schema_branch) == [
-            "global.object.TestCar." + _hash("mercedes") + "." + _hash("blue")
+            "global.object.TestCar." + _hash("mercedes") + "." + _hash("blue"),
+            "relationship_count.testcar__testperson." + car.id,
         ]
 
     async def test_lock_names_optional_empty_attribute(
@@ -168,3 +193,183 @@ class TestGetKindsLock(TestInfrahubApp):
         assert get_lock_names_on_object_mutation(person, schema_branch=schema_branch) == [
             "global.object.TestPerson." + _hash("") + "." + _hash("John")
         ]
+
+    async def test_lock_names_peer_cardinality_one_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+        car_person_schema_unregistered: SchemaRoot,
+    ) -> None:
+        """Test that we add locks for relationships where the peer has cardinality one.
+
+        Uses car_person_schema which already has Car->Person with cardinality one (owner).
+        Person has a many relationship back via 'cars'.
+        """
+        schema = deepcopy(car_person_schema_unregistered)
+        # Remove uniqueness constraints to focus on relationship locking
+        schema.nodes[0].uniqueness_constraints = []
+        schema.nodes[1].uniqueness_constraints = []
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Create a person (the peer with cardinality one from Car's perspective)
+        person = await create_and_save(db=db, schema="TestPerson", name="John")
+
+        # Create a car linked to that person via the cardinality-one 'owner' relationship
+        car = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person)
+
+        # The lock names should include the relationship_count lock for the person
+        # because Car.owner has cardinality one
+        lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{car.id}"
+        assert expected_lock in lock_names
+
+    async def test_lock_names_direct_cardinality_one_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+        car_person_schema_unregistered: SchemaRoot,
+    ) -> None:
+        """Test that we add locks for direct cardinality one relationships on the node side.
+
+        Uses car_person_schema - Car has an optional cardinality one 'driver' relationship to Person.
+        This tests the case where the node being created has an optional cardinality one relationship.
+        """
+        schema = deepcopy(car_person_schema_unregistered)
+        # Remove uniqueness constraints to focus on relationship locking
+        schema.nodes[0].uniqueness_constraints = []
+        schema.nodes[1].uniqueness_constraints = []
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Create persons - one as owner (required), one as driver (optional cardinality one)
+        owner = await create_and_save(db=db, schema="TestPerson", name="John")
+        driver = await create_and_save(db=db, schema="TestPerson", name="Jane")
+
+        # Create a car with both owner and driver relationships
+        # driver is an optional cardinality-one relationship (uses identifier "cars_driven__driver")
+        car = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=owner, driver=driver)
+
+        # The lock names should include relationship_count locks for both cardinality one relationships
+        lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
+
+        # Lock for the owner relationship (Parent kind, cardinality one)
+        owner_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{car.id}"
+        # Lock for the driver relationship (cardinality one with identifier)
+        driver_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.cars_driven__driver.{car.id}"
+
+        assert owner_lock in lock_names
+        assert driver_lock in lock_names
+
+    async def test_lock_names_max_count_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+        car_person_schema_unregistered: SchemaRoot,
+    ) -> None:
+        """Test that we add locks for relationships where the peer has max_count constraint.
+
+        Modifies car_person_schema to add max_count on Person's cars relationship.
+        """
+        schema = deepcopy(car_person_schema_unregistered)
+        # Remove uniqueness constraints to focus on relationship locking
+        schema.nodes[0].uniqueness_constraints = []
+        schema.nodes[1].uniqueness_constraints = []
+        # Change owner from Parent to Generic (Parent has special constraints)
+        schema.nodes[0].relationships[0].kind = "Generic"
+        # Change Car's owner relationship to many with max_count
+        schema.nodes[0].relationships[0].cardinality = "many"
+        # Add max_count to Person's 'cars' relationship
+        schema.nodes[1].relationships[0].max_count = 3
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Create a person
+        person = await create_and_save(db=db, schema="TestPerson", name="John")
+
+        # Create a car linked to that person
+        car = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person)
+
+        # The lock names should include the relationship_count lock for the person's ID
+        # because Person.cars has max_count constraint
+        lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{person.id}"
+        assert expected_lock in lock_names
+
+    async def test_lock_names_min_count_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+        car_person_schema_unregistered: SchemaRoot,
+    ) -> None:
+        """Test that we add locks for relationships where the peer has min_count constraint.
+
+        Modifies car_person_schema to add min_count on Person's cars relationship.
+        """
+        schema = deepcopy(car_person_schema_unregistered)
+        # Remove uniqueness constraints to focus on relationship locking
+        schema.nodes[0].uniqueness_constraints = []
+        schema.nodes[1].uniqueness_constraints = []
+        # Change owner from Parent to Generic (Parent has special constraints)
+        schema.nodes[0].relationships[0].kind = "Generic"
+        # Change Car's owner relationship to many with min_count
+        schema.nodes[0].relationships[0].cardinality = "many"
+        # Add min_count to Person's 'cars' relationship
+        schema.nodes[1].relationships[0].min_count = 1
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Create a person
+        person = await create_and_save(db=db, schema="TestPerson", name="John")
+
+        # Create a car linked to that person
+        car = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=person)
+
+        # The lock names should include the relationship_count lock for the person's ID
+        # because Person.cars has min_count constraint
+        lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{person.id}"
+        assert expected_lock in lock_names
+
+    async def test_lock_names_direct_min_count_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+        car_person_schema_unregistered: SchemaRoot,
+    ) -> None:
+        """Test that we add locks for direct min_count relationships on the node side.
+
+        Modifies car_person_schema to add min_count on Car's owner relationship.
+        This tests the case where the node being created has a min_count constraint.
+        """
+        schema = deepcopy(car_person_schema_unregistered)
+        # Remove uniqueness constraints to focus on relationship locking
+        schema.nodes[0].uniqueness_constraints = []
+        schema.nodes[1].uniqueness_constraints = []
+        # Change Car's owner relationship to many with min_count
+        schema.nodes[0].relationships[0].cardinality = "many"
+        schema.nodes[0].relationships[0].min_count = 1
+        schema.nodes[0].relationships[0].kind = "Generic"
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Create persons
+        person1 = await create_and_save(db=db, schema="TestPerson", name="John")
+        person2 = await create_and_save(db=db, schema="TestPerson", name="Jane")
+
+        # Create a car linked to persons
+        car = await create_and_save(db=db, schema="TestCar", name="mercedes", owner=[person1, person2])
+
+        # The lock names should include the relationship_count lock for the car's node ID
+        lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{car.id}"
+        assert expected_lock in lock_names

--- a/changelog/7972.fixed.md
+++ b/changelog/7972.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where parallel create or update operations would attach multiple peers to a cardinality one relationship.

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -265,6 +265,78 @@ Container (session)
 | `default_branch` | function | Creates default + global branches |
 | `register_core_models_schema` | function | Registers core schema |
 
+### Schema Fixtures
+
+**Always prefer existing schema fixtures** over creating new ones. The codebase provides several reusable schema fixtures in `backend/tests/conftest.py`:
+
+| Fixture | Description |
+|---------|-------------|
+| `car_person_schema` | Basic registered schema with TestCar and TestPerson nodes |
+| `car_person_schema_unregistered` | Unregistered version for custom modifications |
+| `car_person_schema_branch_local` | Schema with branch-local support |
+| `register_core_models_schema` | Core Infrahub models only |
+
+**When to use existing fixtures:**
+
+```python
+# GOOD: Use existing fixture directly
+async def test_my_feature(db: InfrahubDatabase, car_person_schema: SchemaBranch):
+    # car_person_schema provides TestCar, TestPerson with relationships
+    ...
+```
+
+**When you need additional schema elements:**
+
+1. **Live update within the test** - Use `deepcopy` to modify an unregistered schema fixture:
+
+```python
+from copy import deepcopy
+
+async def test_with_custom_constraint(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema_unregistered: SchemaRoot,
+):
+    # Copy and modify the schema
+    custom_schema = deepcopy(car_person_schema_unregistered)
+    custom_schema.nodes[0].uniqueness_constraints = [["name__value", "color__value"]]
+
+    # Register the modified schema
+    registry.schema.register_schema(schema=custom_schema, branch=default_branch.name)
+    ...
+```
+
+2. **Update the base fixture** - If the modification is broadly useful, add it to `backend/tests/conftest.py`:
+
+```python
+# In conftest.py - add a new reusable fixture
+@pytest.fixture
+async def car_person_schema_with_extra_attr(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema_unregistered: SchemaRoot
+) -> SchemaBranch:
+    schema = deepcopy(car_person_schema_unregistered)
+    schema.nodes[0].attributes.append(
+        AttributeSchema(name="year", kind="Number", optional=True)
+    )
+    return registry.schema.register_schema(schema=schema, branch=default_branch.name)
+```
+
+**Avoid:**
+
+- Creating inline schema dictionaries when existing fixtures suffice
+- Duplicating schema definitions across test files
+- Defining schemas in test files that could be shared fixtures
+
+**Schema files in `backend/tests/fixtures/schemas/`:**
+
+For JSON-based schemas, use the helper methods:
+
+```python
+# Load schema from fixtures directory
+schema_dict = helper.schema_file("infra_simple_01.json")
+await client.schema.load(schemas=[schema_dict])
+```
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
This covers relationship min_count, max_count constraints as well as cardinality one relationships.

Fixes https://github.com/opsmill/infrahub/issues/7972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locking to enforce relationship cardinality and min/max constraints during concurrent create/update, preventing duplicate peer associations for one-to-one relationships.
* **Tests**
  * Added coverage validating relationship-count locking for various cardinality and count-constraint scenarios.
* **Documentation**
  * Expanded testing guidance with schema fixture usage and examples for modifying schemas within tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->