### PR TITLE
Split ruff test violations into smaller components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -736,8 +736,81 @@ allow-dunder-method-names = [
     "ARG001",  # Unused function argument
     "ARG002",  # Unused method argument
     "ARG003",  # Unused class method argument
+]
+
+"backend/tests/*.py" = [
     ##################################################################################################
-    # Review and change the below later                                                              #
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN201",   # Missing return type annotation for public function
+    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
+    "PLR0915",  # Too many statements
+    "PT018",    # Assertion should be broken down into multiple parts
+    "PT021",    # Use `yield` instead of `request.addfinalizer`
+]
+
+"backend/tests/helpers/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
+    "ASYNC109", # Async function definition with a `timeout` parameter
+    "PT018",    # Assertion should be broken down into multiple parts
+]
+
+"backend/tests/fixtures/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN201",   # Missing return type annotation for public function
+]
+
+"backend/tests/functional/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN201",   # Missing return type annotation for public function
+    "ANN202",   # Missing return type annotation for private function
+    "ASYNC109", # Async function definition with a `timeout` parameter
+    "PLR0915",  # Too many statements
+    "PT011",    # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+    "PT012",    # `pytest.raises()` block should contain a single simple statement
+    "PT018",    # Assertion should be broken down into multiple parts
+]
+
+"backend/tests/integration/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN002",   # Missing type annotation for `*args`
+    "ANN003",   # Missing type annotation for `**kwargs`
+    "ANN201",   # Missing return type annotation for public function
+    "ANN202",   # Missing return type annotation for private function
+    "PLR0915",  # Too many statements
+    "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
+    "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+    "PT012",    # `pytest.raises()` block should contain a single simple statement
+    "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
+]
+
+"backend/tests/scale/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN002",   # Missing type annotation for `*args`
+    "ANN003",   # Missing type annotation for `**kwargs`
+    "ANN201",   # Missing return type annotation for public function
+    "ANN202",   # Missing return type annotation for private function
+]
+
+"backend/tests/unit/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
     ##################################################################################################
     "ANN001",   # Missing type annotation for function argument
     "ANN002",   # Missing type annotation for `*args`
@@ -745,16 +818,23 @@ allow-dunder-method-names = [
     "ANN201",   # Missing return type annotation for public function
     "ANN202",   # Missing return type annotation for private function
     "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
-    "ASYNC109", # Async function definition with a `timeout` parameter
     "PLR0915",  # Too many statements
     "PT003",    # `scope='function'` is implied in `@pytest.fixture()`
-    "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
     "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
+    "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
     "PT011",    # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
     "PT012",    # `pytest.raises()` block should contain a single simple statement
-    "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
     "PT018",    # Assertion should be broken down into multiple parts
-    "PT021",    # Use `yield` instead of `request.addfinalizer`
+]
+
+"backend/tests/query_benchmark/**.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "ANN001",   # Missing type annotation for function argument
+    "ANN202",   # Missing return type annotation for private function
+    "PT003",    # `scope='function'` is implied in `@pytest.fixture()`
+    "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
 ]
 
 "backend/tests/integration_docker/test_schema_migration.py" = [


### PR DESCRIPTION
Break apart the current ruff violations for tests into smaller components and only ignore the violations under the current section. Will make it easier to fix issues in isolation and prevent new violations in the sections that don't currently have any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting and testing configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->