### PR TITLE
Remove abstract base class from query

### DIFF
--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -54,11 +54,15 @@ class AccountGlobalPermissionQuery(Query):
     name: str = "account_global_permissions"
     type: QueryType = QueryType.READ
 
-    def __init__(self, account_id: str, **kwargs: Any):
+    def __init__(
+        self,
+        account_id: str,
+        branch: Branch | None = None,
+        branch_agnostic: bool = False,
+    ) -> None:
+        super().__init__(branch=branch, branch_agnostic=branch_agnostic)
         self.account_id = account_id
-        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["account_id"] = self.account_id
 
         branch_filter, branch_params = self.branch.get_query_filter_path(
@@ -66,7 +70,6 @@ class AccountGlobalPermissionQuery(Query):
         )
         self.params.update(branch_params)
 
-        # ruff: noqa: E501
         query = """
         MATCH (account:%(generic_account_node)s)
         WHERE account.uuid = $account_id
@@ -293,7 +296,7 @@ class AccountObjectPermissionQuery(Query):
 
 
 async def fetch_permissions(account_id: str, db: InfrahubDatabase, branch: Branch) -> AssignedPermissions:
-    query1 = await AccountGlobalPermissionQuery.init(db=db, branch=branch, account_id=account_id, branch_agnostic=True)
+    query1 = AccountGlobalPermissionQuery(branch=branch, account_id=account_id, branch_agnostic=True)
     await query1.execute(db=db)
     global_permissions = query1.get_permissions()
 

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -336,7 +335,7 @@ class QueryStat:
         return cls(**data)
 
 
-class Query(ABC):
+class Query:
     name: str = "base-query"
     type: QueryType
 
@@ -403,8 +402,12 @@ class Query(ABC):
 
         return query
 
-    @abstractmethod
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        # Avoid using this method for new queries and look at migrating older queries. The
+        # problem here is that we loose so much information with the `**kwargs` we should instead
+        # populate this information via the constructor and anything done within the existing query_init methods
+        # could either be handled within __init__ or via dedicated methods within each Query class where appropriate,
+        # i.e. things might need to happend in a certain order or we just want to separate the logic better.
         raise NotImplementedError
 
     def get_context(self) -> dict[str, str]:


### PR DESCRIPTION
Remove ABC from the base Query class in order to start using the `__init__()` method directly for future queries. Also converted one query to the cleaner format as an example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal query initialization to use explicit parameters, reducing ambiguity.
  * Converted the core query base to a concrete, configurable implementation for more predictable behavior.
  * Simplified permission-fetching instantiation to use direct parameter passing, improving clarity and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->