### PR TITLE
Fix broken documentation links and exclude deprecated tutorials

### DIFF
--- a/docs/docs/development/frontend/getting-set-up.mdx
+++ b/docs/docs/development/frontend/getting-set-up.mdx
@@ -34,7 +34,7 @@ npm install
 npm start
 ```
 
-You can access your local server at [http://localhost:8080/](http://localhost:8080/). If you are not familiar with Infrahub, follow our [tutorial](../../tutorials/getting-started/readme.mdx).
+You can access your local server at [http://localhost:8080/](http://localhost:8080/). If you are not familiar with Infrahub, follow our [Getting Started Guide](../../getting-started/overview.mdx).
 
 ## 3. Run all tests
 

--- a/docs/docs/release-notes/infrahub/release-0_16_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_16_0.mdx
@@ -51,7 +51,7 @@ Adding a Number Pool:
 
 See the Resource Manager documentation for more information on managing and utilizing Resource Pools:
 
-- [Tutorials - Resource Manager](../../tutorials/getting-started/resource-manager.mdx)
+- [Resource Manager Tutorial](../../topics/resource-manager.mdx)
 
 ### Unified storage
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -52,7 +52,7 @@ const config: Config = {
           routeBasePath: "/",
           sidebarCollapsed: true,
           sidebarPath: "./sidebars.ts",
-          exclude: ["**/AGENTS.md"],
+          exclude: ["**/AGENTS.md", "tutorials/getting-started/**"],
         },
         blog: false,
         theme: {


### PR DESCRIPTION
- Update frontend getting-set-up guide to link to Getting Started Guide
  instead of removed tutorials/getting-started
- Update 0.16.0 release notes to link to resource-manager topic page
  instead of removed tutorial
- Exclude tutorials/getting-started directory from documentation build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links to the Getting Started Guide in setup documentation.
  * Updated links to the Resource Manager Tutorial in release notes.
  * Improved documentation navigation structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->