### PR TITLE
Remove "account" parameter from NodeManager methods

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -98,7 +98,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         partial_match: bool = ...,
         branch_agnostic: bool = ...,
         order: OrderModel | None = ...,
@@ -118,7 +117,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         partial_match: bool = ...,
         branch_agnostic: bool = ...,
         order: OrderModel | None = ...,
@@ -137,7 +135,6 @@ class NodeManager:
         branch: Branch | str | None = None,
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
         prefetch_relationships: bool = False,
-        account=None,
         partial_match: bool = False,
         branch_agnostic: bool = False,
         order: OrderModel | None = None,
@@ -171,7 +168,6 @@ class NodeManager:
                 branch=branch,
                 include_metadata=include_metadata,
                 prefetch_relationships=prefetch_relationships,
-                account=account,
                 branch_agnostic=branch_agnostic,
             )
             return [node] if node else []
@@ -230,7 +226,6 @@ class NodeManager:
         filters: dict | None = None,
         at: Timestamp | str | None = None,
         branch: Branch | str | None = None,
-        account=None,  # noqa: ARG003
         partial_match: bool = False,
         branch_agnostic: bool = False,
     ) -> int:
@@ -534,7 +529,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol | None: ...
 
@@ -551,7 +545,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol: ...
 
@@ -568,7 +561,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol | None: ...
 
@@ -585,7 +577,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node | None: ...
 
@@ -602,7 +593,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node: ...
 
@@ -619,7 +609,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node | None: ...
 
@@ -635,7 +624,6 @@ class NodeManager:
         branch: Branch | str | None = None,
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
         prefetch_relationships: bool = False,
-        account=None,
         branch_agnostic: bool = False,
     ) -> Node | SchemaProtocol | None:
         branch = await registry.get_branch(branch=branch, db=db)
@@ -657,7 +645,6 @@ class NodeManager:
             at=at,
             include_metadata=include_metadata,
             prefetch_relationships=prefetch_relationships,
-            account=account,
             branch_agnostic=branch_agnostic,
             order=OrderModel(disable=True),
         )
@@ -694,7 +681,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
     ) -> SchemaProtocol | None: ...
 
     @overload
@@ -710,7 +696,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol: ...
 
@@ -727,7 +712,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol | None: ...
 
@@ -744,7 +728,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node: ...
 
@@ -761,7 +744,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node | None: ...
 
@@ -778,7 +760,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Node | None: ...
 
@@ -794,7 +775,6 @@ class NodeManager:
         branch: Branch | str | None = None,
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
         prefetch_relationships: bool = False,
-        account=None,
         branch_agnostic: bool = False,
     ) -> Node | SchemaProtocol | None:
         branch = await registry.get_branch(branch=branch, db=db)
@@ -844,7 +824,6 @@ class NodeManager:
             at=at,
             include_metadata=include_metadata,
             prefetch_relationships=prefetch_relationships,
-            account=account,
             branch_agnostic=branch_agnostic,
             order=OrderModel(disable=True),
         )
@@ -876,7 +855,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> SchemaProtocol: ...
 
@@ -892,7 +870,6 @@ class NodeManager:
         branch: Branch | str | None = ...,
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
-        account=...,
         branch_agnostic: bool = ...,
     ) -> Any: ...
 
@@ -907,7 +884,6 @@ class NodeManager:
         branch: Branch | str | None = None,
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
         prefetch_relationships: bool = False,
-        account=None,
         branch_agnostic: bool = False,
     ) -> Any:
         branch = await registry.get_branch(branch=branch, db=db)
@@ -935,7 +911,6 @@ class NodeManager:
             branch=branch,
             include_metadata=include_metadata,
             prefetch_relationships=prefetch_relationships,
-            account=account,
             branch_agnostic=branch_agnostic,
         )
         if not node:

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -399,7 +399,6 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
                 branch=graphql_context.branch,
                 limit=query_limit,
                 offset=offset,
-                account=graphql_context.account_session,
                 include_metadata=MetadataOptions.LINKED_NODES,
                 partial_match=partial_match,
                 order=order_model,

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -204,7 +204,6 @@ async def default_paginated_list_resolver(
                 branch=graphql_context.branch,
                 limit=limit,
                 offset=offset,
-                account=graphql_context.account_session,
                 partial_match=partial_match,
                 order=order_model,
             )

--- a/backend/infrahub/graphql/types/standard_node.py
+++ b/backend/infrahub/graphql/types/standard_node.py
@@ -38,14 +38,12 @@ class InfrahubObjectType(ObjectType):
                     filters=filters,
                     at=graphql_context.at,
                     branch=graphql_context.branch,
-                    account=graphql_context.account_session,
                     db=db,
                 )
             else:
                 objs = await cls._meta.model.get_list(
                     at=graphql_context.at,
                     branch=graphql_context.branch,
-                    account=graphql_context.account_session,
                     db=db,
                 )
 


### PR DESCRIPTION
The "account" parameter to these NodeManager methods have been undefined in terms of type and aren't actually used. They were included in an early implementation as a placeholder but we don't need them and currently they are only messing up the typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the account parameter from node query and retrieval methods in the backend API, including query, count, and retrieval operations. This change also removes account-related arguments from GraphQL resolver calls that construct node queries, simplifying method signatures and reducing parameter passing overhead throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->