### PR TITLE
fix(backend, tests): too many db connections in integration tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -146,6 +146,11 @@ async def db(
         await driver.close()
 
 
+@pytest.fixture(scope="class")
+async def db_class() -> InfrahubDatabase:
+    return await build_database(singleton=False)
+
+
 @pytest.fixture
 async def empty_database(db: InfrahubDatabase) -> None:
     await do_empty_database(db=db)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -449,12 +449,40 @@ def prefect_container(request: pytest.FixtureRequest, load_settings_before_sessi
     return start_prefect_server_container(request)
 
 
+@pytest.fixture(scope="class")
+def prefect_container_class(
+    request: pytest.FixtureRequest, load_settings_before_session: None
+) -> dict[int, int] | None:
+    return start_prefect_server_container(request)
+
+
 @pytest.fixture(scope="module")
 def prefect(
     prefect_container: dict[int, int] | None, reload_settings_before_each_module: None
 ) -> Generator[str, None, None]:
     if prefect_container:
         server_port = prefect_container[PORT_PREFECT]
+        server_api_url = f"http://localhost:{server_port}/api"
+    else:
+        server_api_url = f"http://localhost:{PORT_PREFECT}/api"
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            prefect_settings.temporary_settings(
+                updates={
+                    prefect_settings.PREFECT_API_URL: server_api_url,
+                }
+            )
+        )
+        yield server_api_url
+
+
+@pytest.fixture(scope="class")
+def prefect_class(
+    prefect_container_class: dict[int, int] | None, reload_settings_before_each_module: None
+) -> Generator[str, None, None]:
+    if prefect_container_class:
+        server_port = prefect_container_class[PORT_PREFECT]
         server_api_url = f"http://localhost:{server_port}/api"
     else:
         server_api_url = f"http://localhost:{PORT_PREFECT}/api"

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -121,10 +121,15 @@ class TestInfrahubAppBase(TestInfrahub):
         return schema_branch
 
     @pytest.fixture(scope="class")
+    async def class_db(self) -> InfrahubDatabase:
+        return await build_database(singleton=False)
+
+    @pytest.fixture(scope="class")
     async def test_client(
         self,
         dependency_provider: Provider,
         db: InfrahubDatabase,
+        class_db: InfrahubDatabase,
         initialize_registry: None,
         redis: dict[int, int] | None,
         nats: dict[int, int] | None,
@@ -135,7 +140,7 @@ class TestInfrahubAppBase(TestInfrahub):
         # NOTE 2: FastAPI does not have an asynchronous TestClient, thus we rely on httpx.AsyncClient which does not trigger
         # lifespan events (see https://fastapi.tiangolo.com/advanced/async-tests/#in-detail).
         async def _db(singleton: bool = True) -> InfrahubDatabase:
-            return await build_database(singleton=False)
+            return class_db
 
         with dependency_provider.scope(build_database, _db):
             async with lifespan(app):

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -121,15 +121,11 @@ class TestInfrahubAppBase(TestInfrahub):
         return schema_branch
 
     @pytest.fixture(scope="class")
-    async def class_db(self) -> InfrahubDatabase:
-        return await build_database(singleton=False)
-
-    @pytest.fixture(scope="class")
     async def test_client(
         self,
         dependency_provider: Provider,
         db: InfrahubDatabase,
-        class_db: InfrahubDatabase,
+        db_class: InfrahubDatabase,
         initialize_registry: None,
         redis: dict[int, int] | None,
         nats: dict[int, int] | None,
@@ -140,7 +136,7 @@ class TestInfrahubAppBase(TestInfrahub):
         # NOTE 2: FastAPI does not have an asynchronous TestClient, thus we rely on httpx.AsyncClient which does not trigger
         # lifespan events (see https://fastapi.tiangolo.com/advanced/async-tests/#in-detail).
         async def _db(singleton: bool = True) -> InfrahubDatabase:
-            return class_db
+            return db_class
 
         with dependency_provider.scope(build_database, _db):
             async with lifespan(app):

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -1,11 +1,9 @@
 import asyncio
-from contextlib import ExitStack
-from typing import Any, AsyncGenerator, Generator
+from typing import Any, AsyncGenerator
 from uuid import UUID
 
 import pytest
 from infrahub_sdk import InfrahubClient
-from prefect import settings as prefect_settings
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.client.schemas.filters import WorkPoolFilter, WorkPoolFilterId
@@ -22,11 +20,7 @@ from infrahub.workers.infrahub_async import (
 from infrahub.workflows.catalogue import INFRAHUB_WORKER_POOL
 from infrahub.workflows.initialization import setup_blocks
 from infrahub.workflows.models import WorkerPoolDefinition
-from tests.helpers.constants import (
-    PORT_PREFECT,
-)
 from tests.helpers.test_app import TestInfrahubAppWithoutLocalWorkflow
-from tests.helpers.utils import start_prefect_server_container
 
 
 class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
@@ -62,34 +56,8 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         )
 
     @pytest.fixture(scope="class")
-    def prefect_container_class(
-        self, request: pytest.FixtureRequest, load_settings_before_session: Any
-    ) -> dict[int, int] | None:
-        return start_prefect_server_container(request)
-
-    @pytest.fixture(scope="class")
-    def prefect_server(
-        self, prefect_container_class: dict[int, int] | None, reload_settings_before_each_module: Any
-    ) -> Generator[str, None, None]:
-        if prefect_container_class:
-            server_port = prefect_container_class[PORT_PREFECT]
-            server_api_url = f"http://localhost:{server_port}/api"
-        else:
-            server_api_url = f"http://localhost:{PORT_PREFECT}/api"
-
-        with ExitStack() as stack:
-            stack.enter_context(
-                prefect_settings.temporary_settings(
-                    updates={
-                        prefect_settings.PREFECT_API_URL: server_api_url,
-                    }
-                )
-            )
-            yield server_api_url
-
-    @pytest.fixture(scope="class")
-    async def prefect_client(self, prefect_server: str) -> PrefectClient:
-        return PrefectClient(api=prefect_server)
+    async def prefect_client(self, prefect_class: str) -> PrefectClient:
+        return PrefectClient(api=prefect_class)
 
     @pytest.fixture(scope="class")
     async def work_pool(self, prefect_client: PrefectClient) -> WorkPool:

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -64,18 +64,14 @@ class TestInfrahubClient:
         await initialization(db=db)
 
     @pytest.fixture(scope="class")
-    async def class_db(self) -> InfrahubDatabase:
-        return await build_database(singleton=False)
-
-    @pytest.fixture(scope="class")
     async def test_client(
         self,
         base_dataset,
         workflow_local,
-        class_db,
+        db_class: InfrahubDatabase,
     ) -> AsyncGenerator[InfrahubTestClient, None]:
         async def _db(singleton: bool = True) -> InfrahubDatabase:
-            return class_db
+            return db_class
 
         with dependency_provider.scope(build_database, _db):
             async with lifespan(app):

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from typing import AsyncGenerator
 
 import pytest
 import yaml
+from fast_depends import dependency_provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.protocols import CoreCheckDefinition, CoreGraphQLQuery, CoreTransformJinja2, CoreTransformPython
@@ -15,9 +17,10 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.utils import count_relationships, delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.git import InfrahubRepository
-from infrahub.server import app, app_initialization
+from infrahub.server import app, lifespan
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.utils import get_models_dir
+from infrahub.workers.dependencies import build_database
 from infrahub.workflows.initialization import setup_task_manager
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_app import TestInfrahubApp
@@ -61,13 +64,22 @@ class TestInfrahubClient:
         await initialization(db=db)
 
     @pytest.fixture(scope="class")
+    async def class_db(self) -> InfrahubDatabase:
+        return await build_database(singleton=False)
+
+    @pytest.fixture(scope="class")
     async def test_client(
         self,
         base_dataset,
         workflow_local,
-    ) -> InfrahubTestClient:
-        await app_initialization(app)
-        return InfrahubTestClient(app=app)
+        class_db,
+    ) -> AsyncGenerator[InfrahubTestClient, None]:
+        async def _db(singleton: bool = True) -> InfrahubDatabase:
+            return class_db
+
+        with dependency_provider.scope(build_database, _db):
+            async with lifespan(app):
+                yield InfrahubTestClient(app=app)
 
     @pytest.fixture
     async def client(self, test_client: InfrahubTestClient, integration_helper) -> InfrahubClient:


### PR DESCRIPTION
Since the neo4j driver upgrade, we must ensure the neo4j driver is properly closed and that a closed driver is not re-used. We disabled singletons during DI to get that behavior.

A side effect is that during some integration tests that leverage local workers, some tasks/flows depend on the injected database instance, which would trigger new driver instances with new db connections. Those instances would not get cleaned since it's not using a singleton nor used within a context manager that would close the underlying db driver.

Fix this by introducing a new class level fixture for the db instance and use it within the injected dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable database fixture to improve test stability and speed.
  * Simplified Prefect testing by replacing dynamic server orchestration with a direct client-based approach.
  * Updated test client and Prefect client interfaces to use async and dependency-driven setups for more consistent integration testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->