### PR TITLE
Fix false deprecation warnings for parameters in TextAttributeSchema

### DIFF
--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -117,20 +117,15 @@ class SchemaRoot(BaseModel):
                     )
                 )
             for attribute in model.attributes:
-                if attribute.max_length is not None:
+                # Check if the attribute has tracked any deprecated field usage
+                # This is set by reconcile_parameters when values are synced from top-level to parameters
+                deprecated_fields = getattr(attribute, "_deprecated_fields_used", set())
+                for field_name in deprecated_fields:
                     warnings.append(
                         SchemaWarning(
                             type=SchemaWarningType.DEPRECATION,
                             kinds=[SchemaWarningKind(kind=model.kind, field=attribute.name)],
-                            message="Use of 'max_length' on attributes is deprecated, use parameters instead",
-                        )
-                    )
-                if attribute.min_length is not None:
-                    warnings.append(
-                        SchemaWarning(
-                            type=SchemaWarningType.DEPRECATION,
-                            kinds=[SchemaWarningKind(kind=model.kind, field=attribute.name)],
-                            message="Use of 'min_length' on attributes is deprecated, use parameters instead",
+                            message=f"Use of '{field_name}' on attributes is deprecated, use parameters instead",
                         )
                     )
 

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -119,8 +119,8 @@ class SchemaRoot(BaseModel):
             for attribute in model.attributes:
                 # Check if the attribute has tracked any deprecated field usage
                 # This is set by reconcile_parameters when values are synced from top-level to parameters
-                deprecated_fields = getattr(attribute, "_deprecated_fields_used", set())
-                for field_name in deprecated_fields:
+                deprecated_fields: set[str] = getattr(attribute, "_deprecated_fields_used", set())
+                for field_name in sorted(deprecated_fields):
                     warnings.append(
                         SchemaWarning(
                             type=SchemaWarningType.DEPRECATION,

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -237,18 +237,28 @@ class TextAttributeSchema(AttributeSchema):
         description="Extra parameters specific to text attributes",
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )
+    _deprecated_fields_used: set[str] = set()
 
     @model_validator(mode="after")
     def reconcile_parameters(self) -> Self:
+        deprecated_fields: set[str] = set()
         if self.regex != self.parameters.regex:
+            # If parameters.regex is None but self.regex is set, user used deprecated syntax
+            if self.parameters.regex is None and self.regex is not None:
+                deprecated_fields.add("regex")
             final_regex = self.parameters.regex if self.parameters.regex is not None else self.regex
             self.regex = self.parameters.regex = final_regex
         if self.min_length != self.parameters.min_length:
+            if self.parameters.min_length is None and self.min_length is not None:
+                deprecated_fields.add("min_length")
             final_min_length = self.parameters.min_length if self.parameters.min_length is not None else self.min_length
             self.min_length = self.parameters.min_length = final_min_length
         if self.max_length != self.parameters.max_length:
+            if self.parameters.max_length is None and self.max_length is not None:
+                deprecated_fields.add("max_length")
             final_max_length = self.parameters.max_length if self.parameters.max_length is not None else self.max_length
             self.max_length = self.parameters.max_length = final_max_length
+        self._deprecated_fields_used = deprecated_fields
         return self
 
     def get_regex(self) -> str | None:

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -4,7 +4,7 @@ import enum
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import Field, PrivateAttr, ValidationInfo, field_validator, model_validator
 
 from infrahub import config
 from infrahub.core.constants.schema import UpdateSupport
@@ -237,7 +237,7 @@ class TextAttributeSchema(AttributeSchema):
         description="Extra parameters specific to text attributes",
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )
-    _deprecated_fields_used: set[str] = set()
+    _deprecated_fields_used: set[str] = PrivateAttr(default_factory=set)
 
     @model_validator(mode="after")
     def reconcile_parameters(self) -> Self:

--- a/backend/tests/unit/core/test_schema.py
+++ b/backend/tests/unit/core/test_schema.py
@@ -124,6 +124,44 @@ SCHEMA_WARNING_TESTCASES: list[SchemaWarningTestCaseData] = [
             ),
         ],
     ),
+    SchemaWarningTestCaseData(
+        name="use_min_max_length_in_parameters_no_warning",
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    namespace="Test",
+                    name="Ticket",
+                    attributes=[
+                        TextAttributeSchema(
+                            name="name",
+                            kind="Text",
+                            parameters=TextAttributeParameters(min_length=1, max_length=40),
+                        )
+                    ],
+                )
+            ]
+        ),
+        warnings=[],
+    ),
+    SchemaWarningTestCaseData(
+        name="use_regex_in_parameters_no_warning",
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    namespace="Test",
+                    name="Device",
+                    attributes=[
+                        TextAttributeSchema(
+                            name="hostname",
+                            kind="Text",
+                            parameters=TextAttributeParameters(regex="^[a-zA-Z][a-zA-Z0-9._-]*$"),
+                        )
+                    ],
+                )
+            ]
+        ),
+        warnings=[],
+    ),
 ]
 
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema attribute deprecation warnings to specifically identify which fields are deprecated rather than using generic messages.
  * Enhanced detection system to correctly distinguish between deprecated field usage and proper parameter-based configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Fixes false deprecation warnings when `min_length`, `max_length`, or `regex` are correctly defined in the `parameters` block
- Tracks deprecated field usage during `reconcile_parameters` to distinguish between top-level (deprecated) and parameters (correct) usage
- Adds test coverage for correct parameters usage

## Test plan

- [ ] Verify no deprecation warnings when using `parameters` block correctly
- [ ] Verify deprecation warnings still appear when using top-level fields (deprecated syntax)
- [ ] Run unit tests: `uv run pytest backend/tests/unit/core/test_schema.py::test_schema_warnings -v`

Fixes #7995