### PR TITLE
special filtering for created/updated_at at midnight

### DIFF
--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -148,6 +148,9 @@ def _transform_metadata_day_filters(filters: dict[str, Any]) -> dict[str, Any]:
     When a filter like `node_metadata__created_at="2025-02-03T00:00:00"` has a time
     of exactly midnight, transform it into __after and __before filters to match
     the entire day (inclusive of midnight).
+
+    If __after or __before filters are already explicitly defined, they will not be
+    overwritten by the generated day range filters.
     """
     result = dict(filters)
     metadata_datetime_fields = ("node_metadata__created_at", "node_metadata__updated_at")
@@ -163,12 +166,17 @@ def _transform_metadata_day_filters(filters: dict[str, Any]) -> dict[str, Any]:
             # Remove the exact match filter
             del result[field]
             # Add __after filter with one microsecond before midnight to include objects at exactly midnight
-            # Since __after uses >, we need (midnight - 1 microsecond) so that > includes midnight
-            one_microsecond_before = value - timedelta(microseconds=1)
-            result[f"{field}__after"] = one_microsecond_before
+            # Skip if __after is already explicitly defined
+            after_key = f"{field}__after"
+            if after_key not in result:
+                one_microsecond_before = value - timedelta(microseconds=1)
+                result[after_key] = one_microsecond_before
             # Add __before filter with next day (exclusive: <)
-            next_day = value + timedelta(days=1)
-            result[f"{field}__before"] = next_day
+            # Skip if __before is already explicitly defined
+            before_key = f"{field}__before"
+            if before_key not in result:
+                next_day = value + timedelta(days=1)
+                result[before_key] = next_day
 
     return result
 

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from graphql.type.definition import GraphQLNonNull
@@ -141,6 +142,37 @@ async def parent_field_name_resolver(parent: dict[str, dict], info: GraphQLResol
     return parent[info.field_name]
 
 
+def _transform_metadata_day_filters(filters: dict[str, Any]) -> dict[str, Any]:
+    """Transform metadata datetime filters with 00:00:00 time into day range filters.
+
+    When a filter like `node_metadata__created_at="2025-02-03T00:00:00"` has a time
+    of exactly midnight, transform it into __after and __before filters to match
+    the entire day (inclusive of midnight).
+    """
+    result = dict(filters)
+    metadata_datetime_fields = ("node_metadata__created_at", "node_metadata__updated_at")
+
+    for field in metadata_datetime_fields:
+        if field not in result:
+            continue
+        value = result[field]
+        if not isinstance(value, datetime):
+            continue
+        # Check if time is midnight (00:00:00)
+        if value.hour == 0 and value.minute == 0 and value.second == 0 and value.microsecond == 0:
+            # Remove the exact match filter
+            del result[field]
+            # Add __after filter with one microsecond before midnight to include objects at exactly midnight
+            # Since __after uses >, we need (midnight - 1 microsecond) so that > includes midnight
+            one_microsecond_before = value - timedelta(microseconds=1)
+            result[f"{field}__after"] = one_microsecond_before
+            # Add __before filter with next day (exclusive: <)
+            next_day = value + timedelta(days=1)
+            result[f"{field}__before"] = next_day
+
+    return result
+
+
 @trace.get_tracer(__name__).start_as_current_span("default_paginated_list_resolver")
 async def default_paginated_list_resolver(
     root: dict,  # noqa: ARG001
@@ -167,6 +199,7 @@ async def default_paginated_list_resolver(
         filters = {
             key: value for key, value in kwargs.items() if ("__" in key and value is not None) or key in ("ids", "hfid")
         }
+        filters = _transform_metadata_day_filters(filters)
 
         edges: dict[str, Any] = fields.get("edges", {})
         node_fields = edges.get("node", {})

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -151,6 +151,11 @@ async def empty_database(db: InfrahubDatabase) -> None:
     await do_empty_database(db=db)
 
 
+@pytest.fixture(scope="class")
+async def empty_database_scope_class(db: InfrahubDatabase) -> None:
+    await do_empty_database(db=db)
+
+
 async def do_empty_database(db: InfrahubDatabase) -> None:
     await delete_all_nodes(db=db)
     await create_root_node(db=db)
@@ -161,12 +166,24 @@ async def reset_registry(db: InfrahubDatabase) -> None:
     await do_reset_registry(db=db)
 
 
+@pytest.fixture(scope="class")
+async def reset_registry_scope_class(db: InfrahubDatabase) -> None:
+    await do_reset_registry(db=db)
+
+
 async def do_reset_registry(db: InfrahubDatabase) -> None:
     registry.delete_all()
 
 
 @pytest.fixture
 async def default_branch(reset_registry, local_storage_dir, empty_database, db: InfrahubDatabase) -> Branch:
+    return await do_default_branch(db=db)
+
+
+@pytest.fixture(scope="class")
+async def default_branch_scope_class(
+    reset_registry_scope_class, local_storage_dir_scope_class, empty_database_scope_class, db: InfrahubDatabase
+) -> Branch:
     return await do_default_branch(db=db)
 
 
@@ -215,6 +232,12 @@ def local_storage_dir(tmp_path: Path) -> Path:
     return do_local_storage_dir(tmp_path=tmp_path)
 
 
+@pytest.fixture(scope="class")
+def local_storage_dir_scope_class(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_path = tmp_path_factory.mktemp("storage_class")
+    return do_local_storage_dir(tmp_path=tmp_path)
+
+
 def do_local_storage_dir(tmp_path: Path) -> Path:
     storage_dir = tmp_path / "storage"
     storage_dir.mkdir()
@@ -230,6 +253,11 @@ async def register_internal_models_schema(default_branch: Branch) -> SchemaBranc
     return await do_register_internal_models_schema(branch=default_branch)
 
 
+@pytest.fixture(scope="class")
+async def register_internal_models_schema_scope_class(default_branch_scope_class: Branch) -> SchemaBranch:
+    return await do_register_internal_models_schema(branch=default_branch_scope_class)
+
+
 async def do_register_internal_models_schema(branch: Branch) -> SchemaBranch:
     schema = SchemaRoot(**internal_schema)
     schema_branch = registry.schema.register_schema(schema=schema, branch=branch.name)
@@ -240,6 +268,13 @@ async def do_register_internal_models_schema(branch: Branch) -> SchemaBranch:
 @pytest.fixture
 async def register_core_models_schema(default_branch: Branch, register_internal_models_schema) -> SchemaBranch:
     return await do_register_core_models_schema(branch=default_branch)
+
+
+@pytest.fixture(scope="class")
+async def register_core_models_schema_scope_class(
+    default_branch_scope_class: Branch, register_internal_models_schema_scope_class
+) -> SchemaBranch:
+    return await do_register_core_models_schema(branch=default_branch_scope_class)
 
 
 async def do_register_core_models_schema(branch: Branch) -> SchemaBranch:
@@ -464,6 +499,15 @@ def enable_broker_config():
 
 @pytest.fixture
 async def data_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+    do_data_schema(branch=default_branch)
+
+
+@pytest.fixture(scope="class")
+async def data_schema_scope_class(db: InfrahubDatabase, default_branch_scope_class: Branch) -> None:
+    do_data_schema(branch=default_branch_scope_class)
+
+
+def do_data_schema(branch: Branch) -> None:
     SCHEMA: dict[str, Any] = {
         "generics": [
             {
@@ -482,11 +526,22 @@ async def data_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
     }
 
     schema = SchemaRoot(**SCHEMA)
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
 
 
 @pytest.fixture
 async def group_schema(db: InfrahubDatabase, default_branch: Branch, data_schema) -> None:
+    do_group_schema(branch=default_branch)
+
+
+@pytest.fixture(scope="class")
+async def group_schema_scope_class(
+    db: InfrahubDatabase, default_branch_scope_class: Branch, data_schema_scope_class
+) -> None:
+    do_group_schema(branch=default_branch_scope_class)
+
+
+def do_group_schema(branch: Branch) -> None:
     SCHEMA: dict[str, Any] = {
         "generics": [
             {
@@ -519,7 +574,7 @@ async def group_schema(db: InfrahubDatabase, default_branch: Branch, data_schema
     }
 
     schema = SchemaRoot(**SCHEMA)
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -182,7 +182,10 @@ async def default_branch(reset_registry, local_storage_dir, empty_database, db: 
 
 @pytest.fixture(scope="class")
 async def default_branch_scope_class(
-    reset_registry_scope_class, local_storage_dir_scope_class, empty_database_scope_class, db: InfrahubDatabase
+    reset_registry_scope_class: None,
+    local_storage_dir_scope_class: Path,
+    empty_database_scope_class: None,
+    db: InfrahubDatabase,
 ) -> Branch:
     return await do_default_branch(db=db)
 
@@ -272,7 +275,7 @@ async def register_core_models_schema(default_branch: Branch, register_internal_
 
 @pytest.fixture(scope="class")
 async def register_core_models_schema_scope_class(
-    default_branch_scope_class: Branch, register_internal_models_schema_scope_class
+    default_branch_scope_class: Branch, register_internal_models_schema_scope_class: SchemaBranch
 ) -> SchemaBranch:
     return await do_register_core_models_schema(branch=default_branch_scope_class)
 
@@ -536,7 +539,7 @@ async def group_schema(db: InfrahubDatabase, default_branch: Branch, data_schema
 
 @pytest.fixture(scope="class")
 async def group_schema_scope_class(
-    db: InfrahubDatabase, default_branch_scope_class: Branch, data_schema_scope_class
+    db: InfrahubDatabase, default_branch_scope_class: Branch, data_schema_scope_class: None
 ) -> None:
     do_group_schema(branch=default_branch_scope_class)
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1739,8 +1739,8 @@ async def criticality_schema(
 async def criticality_schema_scope_class(
     db: InfrahubDatabase,
     default_branch_scope_class: Branch,
-    group_schema_scope_class,
-    data_schema_scope_class,
+    group_schema_scope_class: None,
+    data_schema_scope_class: None,
     criticality_schema_root_scope_class: SchemaRoot,
 ) -> NodeSchema:
     return do_criticality_schema(branch=default_branch_scope_class, schema_root=criticality_schema_root_scope_class)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1672,6 +1672,15 @@ async def all_attribute_default_types_schema(
 
 @pytest.fixture
 async def criticality_schema_root(register_core_models_schema: None) -> SchemaRoot:
+    return do_criticality_schema_root()
+
+
+@pytest.fixture(scope="class")
+async def criticality_schema_root_scope_class(register_core_models_schema_scope_class: None) -> SchemaRoot:
+    return do_criticality_schema_root()
+
+
+def do_criticality_schema_root() -> SchemaRoot:
     generic_schema: dict[str, Any] = {
         "name": "GenericCriticality",
         "namespace": "Test",
@@ -1723,11 +1732,24 @@ async def criticality_schema(
     data_schema,
     criticality_schema_root: SchemaRoot,
 ) -> NodeSchema:
-    registry.schema.register_schema(schema=criticality_schema_root, branch=default_branch.name)
-    registry.schema.process_schema_branch(name=default_branch.name)
-    return registry.schema.get_node_schema(
-        name=criticality_schema_root.nodes[0].kind, branch=default_branch.name, duplicate=False
-    )
+    return do_criticality_schema(branch=default_branch, schema_root=criticality_schema_root)
+
+
+@pytest.fixture(scope="class")
+async def criticality_schema_scope_class(
+    db: InfrahubDatabase,
+    default_branch_scope_class: Branch,
+    group_schema_scope_class,
+    data_schema_scope_class,
+    criticality_schema_root_scope_class: SchemaRoot,
+) -> NodeSchema:
+    return do_criticality_schema(branch=default_branch_scope_class, schema_root=criticality_schema_root_scope_class)
+
+
+def do_criticality_schema(branch: Branch, schema_root: SchemaRoot) -> NodeSchema:
+    registry.schema.register_schema(schema=schema_root, branch=branch.name)
+    registry.schema.process_schema_branch(name=branch.name)
+    return registry.schema.get_node_schema(name=schema_root.nodes[0].kind, branch=branch.name, duplicate=False)
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/metadata/test_graphql_query_metadata.py
+++ b/backend/tests/unit/graphql/metadata/test_graphql_query_metadata.py
@@ -8,11 +8,13 @@ This module contains tests for:
 """
 
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 import pytest
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants import MetadataOptions
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -1254,3 +1256,202 @@ class TestMetadataFilters:
         # node2 was updated on the branch after branch-node5 was created
         assert names == ["node2", "branch-node5"]
         assert timestamps == sorted(timestamps, reverse=True)
+
+    # ========== Day Range Filter Tests ==========
+
+    async def test_created_at_day_filter_includes_all_nodes_created_today(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter with today's midnight includes all nodes created today."""
+        # Get today's date at midnight (00:00:00) - this triggers day filter transformation
+        # Use Timestamp for proper ZoneInfo timezone handling
+        now = Timestamp()
+        today_midnight = now.to_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!) {
+            TestCriticality(node_metadata__created_at: $dayFilter) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # All 4 nodes were created today, so day filter should return all of them
+        data = await self._run_query(db, query, default_branch_scope_class, {"dayFilter": today_midnight})
+        assert data["TestCriticality"]["count"] == 4
+        assert self._get_names(data) == {"node1", "node2", "node3", "node4"}
+
+    async def test_created_at_day_filter_excludes_nodes_from_different_day(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter with yesterday's midnight excludes nodes created today."""
+        # Get yesterday's date at midnight - no nodes should match
+        now = Timestamp()
+        yesterday_midnight = (now.to_datetime() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!) {
+            TestCriticality(node_metadata__created_at: $dayFilter) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # No nodes were created yesterday
+        data = await self._run_query(db, query, default_branch_scope_class, {"dayFilter": yesterday_midnight})
+        assert data["TestCriticality"]["count"] == 0
+
+    async def test_updated_at_day_filter_includes_all_nodes_updated_today(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter on updated_at with today's midnight includes all nodes updated today."""
+        now = Timestamp()
+        today_midnight = now.to_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!) {
+            TestCriticality(node_metadata__updated_at: $dayFilter) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # All 4 nodes have updated_at set to today (either from creation or explicit update)
+        data = await self._run_query(db, query, default_branch_scope_class, {"dayFilter": today_midnight})
+        assert data["TestCriticality"]["count"] == 4
+        assert self._get_names(data) == {"node1", "node2", "node3", "node4"}
+
+    async def test_updated_at_day_filter_excludes_nodes_from_different_day(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter on updated_at with yesterday's midnight excludes nodes updated today."""
+        now = Timestamp()
+        yesterday_midnight = (now.to_datetime() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!) {
+            TestCriticality(node_metadata__updated_at: $dayFilter) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # No nodes were updated yesterday
+        data = await self._run_query(db, query, default_branch_scope_class, {"dayFilter": yesterday_midnight})
+        assert data["TestCriticality"]["count"] == 0
+
+    async def test_day_filter_on_user_branch(
+        self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter works correctly on user branch."""
+        now = Timestamp()
+        today_midnight = now.to_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!) {
+            TestCriticality(node_metadata__created_at: $dayFilter) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # On user branch: 4 main branch nodes + 2 branch-specific nodes = 6 total
+        data = await self._run_query(db, query, metadata_filter_data.user_branch, {"dayFilter": today_midnight})
+        assert data["TestCriticality"]["count"] == 6
+        assert self._get_names(data) == {"node1", "node2", "node3", "node4", "branch-node5", "branch-node6"}
+
+    async def test_day_filter_combined_with_other_filters(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that day filter can be combined with other filters."""
+        now = Timestamp()
+        today_midnight = now.to_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        query = """
+        query($dayFilter: DateTime!, $userId: ID!) {
+            TestCriticality(
+                node_metadata__created_at: $dayFilter,
+                node_metadata__created_by__id: $userId
+            ) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # Filter: created today AND created by Alice (node1, node3)
+        data = await self._run_query(
+            db,
+            query,
+            default_branch_scope_class,
+            {"dayFilter": today_midnight, "userId": metadata_filter_data.user_alice},
+        )
+        assert data["TestCriticality"]["count"] == 2
+        assert self._get_names(data) == {"node1", "node3"}
+
+    async def test_non_midnight_datetime_uses_exact_match(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that non-midnight datetime does exact match, not day range."""
+        # Use a specific time (not midnight) - this should NOT trigger day filter transformation
+        # and should use exact match instead, which won't match any nodes
+        now = Timestamp()
+        specific_time = now.to_datetime().replace(hour=14, minute=30, second=0, microsecond=0)
+
+        query = """
+        query($exactTime: DateTime!) {
+            TestCriticality(node_metadata__created_at: $exactTime) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        # Exact match with a specific time won't match any nodes (they have different microsecond timestamps)
+        data = await self._run_query(db, query, default_branch_scope_class, {"exactTime": specific_time})
+        assert data["TestCriticality"]["count"] == 0
+
+    async def test_exact_timestamp_match_returns_single_node(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
+    ) -> None:
+        """Test that using a node's exact created_at/updated_at timestamp returns only that node."""
+        # Get node1's exact timestamps using NodeManager.query
+        nodes = await NodeManager.query(
+            db=db,
+            branch=default_branch_scope_class,
+            schema="TestCriticality",
+            filters={"name__value": "node1"},
+            include_metadata=MetadataOptions.TIMESTAMPS,
+        )
+        assert len(nodes) == 1
+        node1 = nodes[0]
+        node1_created_at = node1._get_created_at().to_datetime()
+        node1_updated_at = node1._get_updated_at().to_datetime()
+
+        # Test exact match on created_at - should return only node1
+        created_at_query = """
+        query($exactTime: DateTime!) {
+            TestCriticality(node_metadata__created_at: $exactTime) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        created_data = await self._run_query(
+            db, created_at_query, default_branch_scope_class, {"exactTime": node1_created_at}
+        )
+        assert created_data["TestCriticality"]["count"] == 1
+        assert self._get_names(created_data) == {"node1"}
+
+        # Test exact match on updated_at - should return only node1
+        updated_at_query = """
+        query($exactTime: DateTime!) {
+            TestCriticality(node_metadata__updated_at: $exactTime) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        updated_data = await self._run_query(
+            db, updated_at_query, default_branch_scope_class, {"exactTime": node1_updated_at}
+        )
+        assert updated_data["TestCriticality"]["count"] == 1
+        assert self._get_names(updated_data) == {"node1"}

--- a/backend/tests/unit/graphql/metadata/test_midnight_special_case.py
+++ b/backend/tests/unit/graphql/metadata/test_midnight_special_case.py
@@ -1,0 +1,147 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+from infrahub.graphql.resolvers.resolver import _transform_metadata_day_filters
+
+
+class TestMetadataDayFilterTransformation:
+    """Unit tests for _transform_metadata_day_filters function."""
+
+    def test_transform_created_at_midnight_to_day_range(self) -> None:
+        """Test that created_at with midnight time is transformed into day range."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        filters = {"node_metadata__created_at": midnight}
+
+        result = _transform_metadata_day_filters(filters)
+
+        # __after should be one microsecond before midnight to include objects at exactly midnight
+        expected_after = midnight - timedelta(microseconds=1)
+        assert "node_metadata__created_at" not in result
+        assert result["node_metadata__created_at__after"] == expected_after
+        assert result["node_metadata__created_at__before"] == midnight + timedelta(days=1)
+
+    def test_transform_updated_at_midnight_to_day_range(self) -> None:
+        """Test that updated_at with midnight time is transformed into day range."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        filters = {"node_metadata__updated_at": midnight}
+
+        result = _transform_metadata_day_filters(filters)
+
+        # __after should be one microsecond before midnight to include objects at exactly midnight
+        expected_after = midnight - timedelta(microseconds=1)
+        assert "node_metadata__updated_at" not in result
+        assert result["node_metadata__updated_at__after"] == expected_after
+        assert result["node_metadata__updated_at__before"] == midnight + timedelta(days=1)
+
+    def test_non_midnight_time_not_transformed(self) -> None:
+        """Test that non-midnight datetime is not transformed."""
+        non_midnight = datetime(2025, 2, 3, 14, 30, 0, tzinfo=UTC)
+        filters = {"node_metadata__created_at": non_midnight}
+
+        result = _transform_metadata_day_filters(filters)
+
+        assert result["node_metadata__created_at"] == non_midnight
+        assert "node_metadata__created_at__after" not in result
+        assert "node_metadata__created_at__before" not in result
+
+    def test_midnight_with_microseconds_not_transformed(self) -> None:
+        """Test that midnight with microseconds is not transformed."""
+        almost_midnight = datetime(2025, 2, 3, 0, 0, 0, 1, tzinfo=UTC)
+        filters = {"node_metadata__created_at": almost_midnight}
+
+        result = _transform_metadata_day_filters(filters)
+
+        assert result["node_metadata__created_at"] == almost_midnight
+        assert "node_metadata__created_at__after" not in result
+
+    def test_midnight_with_timezone_offset_still_transforms(self) -> None:
+        """Test that midnight with timezone offset still triggers transformation."""
+        # Midnight in UTC+5:30 timezone
+        tz_offset = timezone(timedelta(hours=5, minutes=30))
+        midnight_offset = datetime(2025, 2, 3, 0, 0, 0, tzinfo=tz_offset)
+        filters = {"node_metadata__created_at": midnight_offset}
+
+        result = _transform_metadata_day_filters(filters)
+
+        expected_after = midnight_offset - timedelta(microseconds=1)
+        assert "node_metadata__created_at" not in result
+        assert result["node_metadata__created_at__after"] == expected_after
+        assert result["node_metadata__created_at__before"] == midnight_offset + timedelta(days=1)
+
+    def test_preserves_other_filters(self) -> None:
+        """Test that other filters are preserved unchanged."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight,
+            "name__value": "test",
+            "ids": ["id1", "id2"],
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        assert result["name__value"] == "test"
+        assert result["ids"] == ["id1", "id2"]
+
+    def test_transforms_both_created_and_updated_at(self) -> None:
+        """Test that both created_at and updated_at are transformed when both are midnight."""
+        midnight1 = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        midnight2 = datetime(2025, 2, 5, 0, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight1,
+            "node_metadata__updated_at": midnight2,
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        assert "node_metadata__created_at" not in result
+        assert "node_metadata__updated_at" not in result
+        assert result["node_metadata__created_at__after"] == midnight1 - timedelta(microseconds=1)
+        assert result["node_metadata__created_at__before"] == midnight1 + timedelta(days=1)
+        assert result["node_metadata__updated_at__after"] == midnight2 - timedelta(microseconds=1)
+        assert result["node_metadata__updated_at__before"] == midnight2 + timedelta(days=1)
+
+    def test_empty_filters_returns_empty(self) -> None:
+        """Test that empty filters returns empty dict."""
+        result = _transform_metadata_day_filters({})
+        assert result == {}
+
+    def test_non_datetime_value_not_transformed(self) -> None:
+        """Test that non-datetime values are not transformed."""
+        filters = {"node_metadata__created_at": "2025-02-03T00:00:00Z"}
+
+        result = _transform_metadata_day_filters(filters)
+
+        assert result["node_metadata__created_at"] == "2025-02-03T00:00:00Z"
+
+    def test_non_utc_timezone_midnight_preserves_timezone_in_filters(self) -> None:
+        """Test that midnight in non-UTC timezone produces correct __after and __before with preserved timezone."""
+        # Create midnight in US Eastern timezone (UTC-5)
+        eastern_tz = timezone(timedelta(hours=-5))
+        midnight_eastern = datetime(2025, 3, 15, 0, 0, 0, tzinfo=eastern_tz)
+        filters = {"node_metadata__created_at": midnight_eastern}
+
+        result = _transform_metadata_day_filters(filters)
+
+        # Verify original filter is removed
+        assert "node_metadata__created_at" not in result
+
+        # Verify __after is one microsecond before midnight in the same timezone
+        after_value = result["node_metadata__created_at__after"]
+        assert after_value.year == 2025
+        assert after_value.month == 3
+        assert after_value.day == 14  # Previous day
+        assert after_value.hour == 23
+        assert after_value.minute == 59
+        assert after_value.second == 59
+        assert after_value.microsecond == 999999
+        assert after_value.tzinfo == eastern_tz  # Timezone preserved
+
+        # Verify __before is midnight of the next day in the same timezone
+        before_value = result["node_metadata__created_at__before"]
+        assert before_value.year == 2025
+        assert before_value.month == 3
+        assert before_value.day == 16  # Next day
+        assert before_value.hour == 0
+        assert before_value.minute == 0
+        assert before_value.second == 0
+        assert before_value.microsecond == 0
+        assert before_value.tzinfo == eastern_tz  # Timezone preserved

--- a/backend/tests/unit/graphql/metadata/test_midnight_special_case.py
+++ b/backend/tests/unit/graphql/metadata/test_midnight_special_case.py
@@ -145,3 +145,80 @@ class TestMetadataDayFilterTransformation:
         assert before_value.second == 0
         assert before_value.microsecond == 0
         assert before_value.tzinfo == eastern_tz  # Timezone preserved
+
+    def test_existing_after_filter_not_overwritten(self) -> None:
+        """Test that explicitly defined __after filter is not overwritten by day range transformation."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        explicit_after = datetime(2025, 2, 2, 12, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight,
+            "node_metadata__created_at__after": explicit_after,
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        # Original exact match should be removed
+        assert "node_metadata__created_at" not in result
+        # __after should retain the explicit value
+        assert result["node_metadata__created_at__after"] == explicit_after
+        # __before should be generated since it wasn't explicitly defined
+        assert result["node_metadata__created_at__before"] == midnight + timedelta(days=1)
+
+    def test_existing_before_filter_not_overwritten(self) -> None:
+        """Test that explicitly defined __before filter is not overwritten by day range transformation."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        explicit_before = datetime(2025, 2, 3, 18, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight,
+            "node_metadata__created_at__before": explicit_before,
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        # Original exact match should be removed
+        assert "node_metadata__created_at" not in result
+        # __after should be generated since it wasn't explicitly defined
+        expected_after = midnight - timedelta(microseconds=1)
+        assert result["node_metadata__created_at__after"] == expected_after
+        # __before should retain the explicit value
+        assert result["node_metadata__created_at__before"] == explicit_before
+
+    def test_existing_both_filters_not_overwritten(self) -> None:
+        """Test that explicitly defined __after and __before filters are both preserved."""
+        midnight = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        explicit_after = datetime(2025, 2, 2, 12, 0, 0, tzinfo=UTC)
+        explicit_before = datetime(2025, 2, 3, 18, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight,
+            "node_metadata__created_at__after": explicit_after,
+            "node_metadata__created_at__before": explicit_before,
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        # Original exact match should be removed
+        assert "node_metadata__created_at" not in result
+        # Both __after and __before should retain their explicit values
+        assert result["node_metadata__created_at__after"] == explicit_after
+        assert result["node_metadata__created_at__before"] == explicit_before
+
+    def test_existing_filter_for_different_field_not_affected(self) -> None:
+        """Test that __after/__before for one field doesn't affect another field's transformation."""
+        midnight_created = datetime(2025, 2, 3, 0, 0, 0, tzinfo=UTC)
+        midnight_updated = datetime(2025, 2, 5, 0, 0, 0, tzinfo=UTC)
+        explicit_after = datetime(2025, 2, 2, 12, 0, 0, tzinfo=UTC)
+        filters = {
+            "node_metadata__created_at": midnight_created,
+            "node_metadata__created_at__after": explicit_after,
+            "node_metadata__updated_at": midnight_updated,
+        }
+
+        result = _transform_metadata_day_filters(filters)
+
+        # created_at should preserve explicit __after
+        assert result["node_metadata__created_at__after"] == explicit_after
+        assert result["node_metadata__created_at__before"] == midnight_created + timedelta(days=1)
+
+        # updated_at should generate both filters normally
+        assert result["node_metadata__updated_at__after"] == midnight_updated - timedelta(microseconds=1)
+        assert result["node_metadata__updated_at__before"] == midnight_updated + timedelta(days=1)

--- a/backend/tests/unit/graphql/test_graphql_query_metadata.py
+++ b/backend/tests/unit/graphql/test_graphql_query_metadata.py
@@ -7,7 +7,7 @@ This module contains tests for:
 - Branch-specific metadata behavior
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -381,24 +381,24 @@ class MetadataFilterTestData:
     """Test data container for metadata filter tests."""
 
     # User IDs
-    user_alice: str = "user-alice-uuid"
-    user_bob: str = "user-bob-uuid"
-    user_charlie: str = "user-charlie-uuid"
-    user_diana: str = "user-diana-uuid"
+    user_alice: str
+    user_bob: str
+    user_charlie: str
+    user_diana: str
 
     # Timestamps captured after node creation/updates
-    ts_after_node1: Timestamp = field(default_factory=Timestamp)
-    ts_after_node2: Timestamp = field(default_factory=Timestamp)
-    ts_after_node4: Timestamp = field(default_factory=Timestamp)
-    ts_after_node1_update: Timestamp = field(default_factory=Timestamp)
+    ts_after_node1: Timestamp
+    ts_after_node2: Timestamp
+    ts_after_node4: Timestamp
+    ts_after_node1_update: Timestamp
 
     # Branches
-    user_branch: Branch | None = None
+    user_branch: Branch
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 async def metadata_filter_data(
-    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+    db: InfrahubDatabase, default_branch_scope_class: Branch, criticality_schema_scope_class: NodeSchema
 ) -> MetadataFilterTestData:
     """Set up test data for metadata filter tests.
 
@@ -407,65 +407,79 @@ async def metadata_filter_data(
     - Updates to some nodes by different users
     - A user branch with 2 new nodes and 1 updated node
     """
-    data = MetadataFilterTestData()
+    # User IDs for test data
+    user_alice = "user-alice-uuid"
+    user_bob = "user-bob-uuid"
+    user_charlie = "user-charlie-uuid"
+    user_diana = "user-diana-uuid"
 
     # ========== DATA SETUP ON DEFAULT BRANCH ==========
 
     # Node 1: created by Alice on default branch
-    node1 = await Node.init(db=db, schema=criticality_schema)
+    node1 = await Node.init(db=db, schema=criticality_schema_scope_class)
     await node1.new(db=db, name="node1", level=1)
-    await node1.save(db=db, user_id=data.user_alice)
-    data.ts_after_node1 = Timestamp()
+    await node1.save(db=db, user_id=user_alice)
+    ts_after_node1 = Timestamp()
 
     # Node 2: created by Bob on default branch
-    node2 = await Node.init(db=db, schema=criticality_schema)
+    node2 = await Node.init(db=db, schema=criticality_schema_scope_class)
     await node2.new(db=db, name="node2", level=2)
-    await node2.save(db=db, user_id=data.user_bob)
-    data.ts_after_node2 = Timestamp()
+    await node2.save(db=db, user_id=user_bob)
+    ts_after_node2 = Timestamp()
 
     # Node 3: created by Alice on default branch
-    node3 = await Node.init(db=db, schema=criticality_schema)
+    node3 = await Node.init(db=db, schema=criticality_schema_scope_class)
     await node3.new(db=db, name="node3", level=3)
-    await node3.save(db=db, user_id=data.user_alice)
+    await node3.save(db=db, user_id=user_alice)
 
     # Node 4: created by Charlie on default branch
-    node4 = await Node.init(db=db, schema=criticality_schema)
+    node4 = await Node.init(db=db, schema=criticality_schema_scope_class)
     await node4.new(db=db, name="node4", level=4)
-    await node4.save(db=db, user_id=data.user_charlie)
-    data.ts_after_node4 = Timestamp()
+    await node4.save(db=db, user_id=user_charlie)
+    ts_after_node4 = Timestamp()
 
     # Update node1 (by Bob) on default branch
     node1_refreshed = await NodeManager.get_one(db=db, id=node1.id)
     node1_refreshed.level.value = 10  # type: ignore[attr-defined]
-    await node1_refreshed.save(db=db, user_id=data.user_bob)
-    data.ts_after_node1_update = Timestamp()
+    await node1_refreshed.save(db=db, user_id=user_bob)
+    ts_after_node1_update = Timestamp()
 
     # Update node3 (by Charlie) on default branch
     node3_refreshed = await NodeManager.get_one(db=db, id=node3.id)
     node3_refreshed.level.value = 30  # type: ignore[attr-defined]
-    await node3_refreshed.save(db=db, user_id=data.user_charlie)
+    await node3_refreshed.save(db=db, user_id=user_charlie)
 
     # ========== CREATE USER BRANCH ==========
-    data.user_branch = await create_branch(branch_name="test-metadata-filters-branch", db=db)
+    user_branch = await create_branch(branch_name="test-metadata-filters-branch", db=db)
 
     # ========== DATA SETUP ON USER BRANCH ==========
 
     # Node 5: created by Diana on user branch
-    node5 = await Node.init(db=db, schema=criticality_schema, branch=data.user_branch)
+    node5 = await Node.init(db=db, schema=criticality_schema_scope_class, branch=user_branch)
     await node5.new(db=db, name="branch-node5", level=5)
-    await node5.save(db=db, user_id=data.user_diana)
+    await node5.save(db=db, user_id=user_diana)
 
     # Node 6: created by Alice on user branch
-    node6 = await Node.init(db=db, schema=criticality_schema, branch=data.user_branch)
+    node6 = await Node.init(db=db, schema=criticality_schema_scope_class, branch=user_branch)
     await node6.new(db=db, name="branch-node6", level=6)
-    await node6.save(db=db, user_id=data.user_alice)
+    await node6.save(db=db, user_id=user_alice)
 
     # Update node2 (by Diana) on user branch - modifies a main branch node on the branch
-    node2_branch = await NodeManager.get_one(db=db, id=node2.id, branch=data.user_branch)
+    node2_branch = await NodeManager.get_one(db=db, id=node2.id, branch=user_branch)
     node2_branch.level.value = 20  # type: ignore[attr-defined]
-    await node2_branch.save(db=db, user_id=data.user_diana)
+    await node2_branch.save(db=db, user_id=user_diana)
 
-    return data
+    return MetadataFilterTestData(
+        user_alice=user_alice,
+        user_bob=user_bob,
+        user_charlie=user_charlie,
+        user_diana=user_diana,
+        ts_after_node1=ts_after_node1,
+        ts_after_node2=ts_after_node2,
+        ts_after_node4=ts_after_node4,
+        ts_after_node1_update=ts_after_node1_update,
+        user_branch=user_branch,
+    )
 
 
 class TestMetadataFilters:
@@ -494,7 +508,7 @@ class TestMetadataFilters:
     # ========== DateTime Filter Tests on Default Branch ==========
 
     async def test_created_at_after_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_at__after filter on default branch."""
         query = """
@@ -507,13 +521,13 @@ class TestMetadataFilters:
         """
         # Nodes created after node1 should be node2, node3, node4
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node1.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node1.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 3
         assert self._get_names(data) == {"node2", "node3", "node4"}
 
     async def test_created_at_before_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_at__before filter on default branch."""
         query = """
@@ -526,13 +540,13 @@ class TestMetadataFilters:
         """
         # Nodes created before node3 should be node1, node2
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node2.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node2.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 2
         assert self._get_names(data) == {"node1", "node2"}
 
     async def test_updated_at_after_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_at__after filter on default branch."""
         query = """
@@ -545,13 +559,13 @@ class TestMetadataFilters:
         """
         # Nodes updated after all initial creates (only node1 and node3 were updated later)
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node4.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node4.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 2
         assert self._get_names(data) == {"node1", "node3"}
 
     async def test_updated_at_before_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_at__before filter on default branch."""
         query = """
@@ -566,7 +580,7 @@ class TestMetadataFilters:
         # - node1 (just updated), node2 (never updated), node4 (never updated)
         # - node3 was updated AFTER ts_after_node1_update so it's excluded
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node1_update.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node1_update.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 3
         assert self._get_names(data) == {"node1", "node2", "node4"}
@@ -574,7 +588,7 @@ class TestMetadataFilters:
     # ========== ID-based Filter Tests on Default Branch ==========
 
     async def test_created_by_id_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_by__id filter on default branch."""
         query = """
@@ -586,17 +600,17 @@ class TestMetadataFilters:
         }
         """
         # Nodes created by Alice should be node1, node3
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_alice})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_alice})
         assert data["TestCriticality"]["count"] == 2
         assert self._get_names(data) == {"node1", "node3"}
 
         # Nodes created by Bob should be node2
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_bob})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_bob})
         assert data["TestCriticality"]["count"] == 1
         assert self._get_names(data) == {"node2"}
 
     async def test_created_by_ids_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_by__ids filter on default branch."""
         query = """
@@ -609,13 +623,16 @@ class TestMetadataFilters:
         """
         # Nodes created by Alice or Bob should be node1, node2, node3
         data = await self._run_query(
-            db, query, default_branch, {"userIds": [metadata_filter_data.user_alice, metadata_filter_data.user_bob]}
+            db,
+            query,
+            default_branch_scope_class,
+            {"userIds": [metadata_filter_data.user_alice, metadata_filter_data.user_bob]},
         )
         assert data["TestCriticality"]["count"] == 3
         assert self._get_names(data) == {"node1", "node2", "node3"}
 
     async def test_updated_by_id_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_by__id filter on default branch."""
         query = """
@@ -627,17 +644,19 @@ class TestMetadataFilters:
         }
         """
         # Nodes last updated by Bob should be node1 (updated), node2 (created by Bob)
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_bob})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_bob})
         assert data["TestCriticality"]["count"] == 2
         assert self._get_names(data) == {"node1", "node2"}
 
         # Nodes last updated by Charlie should be node3 (updated), node4 (created by Charlie)
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_charlie})
+        data = await self._run_query(
+            db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_charlie}
+        )
         assert data["TestCriticality"]["count"] == 2
         assert self._get_names(data) == {"node3", "node4"}
 
     async def test_updated_by_ids_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_by__ids filter on default branch."""
         query = """
@@ -650,7 +669,10 @@ class TestMetadataFilters:
         """
         # Nodes last updated by Bob or Charlie should be all 4 nodes
         data = await self._run_query(
-            db, query, default_branch, {"userIds": [metadata_filter_data.user_bob, metadata_filter_data.user_charlie]}
+            db,
+            query,
+            default_branch_scope_class,
+            {"userIds": [metadata_filter_data.user_bob, metadata_filter_data.user_charlie]},
         )
         assert data["TestCriticality"]["count"] == 4
         assert self._get_names(data) == {"node1", "node2", "node3", "node4"}
@@ -661,7 +683,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_by__id filter on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($userId: ID!) {
             TestCriticality(node_metadata__created_by__id: $userId) {
@@ -688,7 +709,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_by__id filter on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($userId: ID!) {
             TestCriticality(node_metadata__updated_by__id: $userId) {
@@ -715,7 +735,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_by__ids filter on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($userIds: [ID]!) {
             TestCriticality(node_metadata__created_by__ids: $userIds) {
@@ -737,7 +756,7 @@ class TestMetadataFilters:
     # ========== Combined ID-based Filter Tests ==========
 
     async def test_combined_created_by_ids_and_updated_by_id_on_default_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test combining created_by__ids and updated_by__id on default branch."""
         query = """
@@ -752,7 +771,7 @@ class TestMetadataFilters:
         data = await self._run_query(
             db,
             query,
-            default_branch,
+            default_branch_scope_class,
             {
                 "createdByIds": [metadata_filter_data.user_alice, metadata_filter_data.user_bob],
                 "updatedById": metadata_filter_data.user_bob,
@@ -765,7 +784,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test combining created_by__ids and updated_by__id on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($createdByIds: [ID]!, $updatedById: ID!) {
             TestCriticality(node_metadata__created_by__ids: $createdByIds, node_metadata__updated_by__id: $updatedById) {
@@ -807,7 +825,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_at__after filter on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($cutoff: DateTime!) {
             TestCriticality(node_metadata__created_at__after: $cutoff) {
@@ -827,7 +844,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test updated_at__after filter on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($cutoff: DateTime!) {
             TestCriticality(node_metadata__updated_at__after: $cutoff) {
@@ -848,7 +864,7 @@ class TestMetadataFilters:
         assert self._get_names(data) == {"node3", "branch-node5", "branch-node6", "node2"}
 
     async def test_combined_created_by_and_created_at_after(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test combining created_by__id with created_at__after"""
         query = """
@@ -863,14 +879,14 @@ class TestMetadataFilters:
         data = await self._run_query(
             db,
             query,
-            default_branch,
+            default_branch_scope_class,
             {"userId": metadata_filter_data.user_alice, "cutoff": metadata_filter_data.ts_after_node1.to_datetime()},
         )
         assert data["TestCriticality"]["count"] == 1
         assert self._get_names(data) == {"node3"}
 
     async def test_combined_updated_by_and_updated_at_after(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test combining updated_by__id with updated_at__after"""
         query = """
@@ -885,14 +901,14 @@ class TestMetadataFilters:
         data = await self._run_query(
             db,
             query,
-            default_branch,
+            default_branch_scope_class,
             {"userId": metadata_filter_data.user_charlie, "cutoff": metadata_filter_data.ts_after_node4.to_datetime()},
         )
         assert data["TestCriticality"]["count"] == 1
         assert self._get_names(data) == {"node3"}
 
     async def test_created_at_range(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test created_at__after combined with created_at__before (date range)"""
         query = """
@@ -907,7 +923,7 @@ class TestMetadataFilters:
         data = await self._run_query(
             db,
             query,
-            default_branch,
+            default_branch_scope_class,
             {
                 "after": metadata_filter_data.ts_after_node1.to_datetime(),
                 "before": metadata_filter_data.ts_after_node4.to_datetime(),
@@ -919,7 +935,7 @@ class TestMetadataFilters:
     # ========== Combined Filter + Order Tests (Same Field) ==========
 
     async def test_filter_and_order_by_created_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_at__after and ordering by created_at ASC."""
         query = """
@@ -938,7 +954,7 @@ class TestMetadataFilters:
         """
         # Filter: nodes created after node1, Order: by created_at ASC
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node1.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node1.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 3
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
@@ -948,7 +964,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps)
 
     async def test_filter_and_order_by_created_at_desc(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_at__before and ordering by created_at DESC."""
         query = """
@@ -967,7 +983,7 @@ class TestMetadataFilters:
         """
         # Filter: nodes created before node2, Order: by created_at DESC
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node2.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node2.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
@@ -977,7 +993,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps, reverse=True)
 
     async def test_filter_and_order_by_updated_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by updated_at__after and ordering by updated_at DESC."""
         query = """
@@ -997,7 +1013,7 @@ class TestMetadataFilters:
         # Filter: nodes updated after node4 creation, Order: by updated_at DESC
         # node1 and node3 were updated after node4 was created
         data = await self._run_query(
-            db, query, default_branch, {"cutoff": metadata_filter_data.ts_after_node4.to_datetime()}
+            db, query, default_branch_scope_class, {"cutoff": metadata_filter_data.ts_after_node4.to_datetime()}
         )
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
@@ -1007,7 +1023,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps, reverse=True)
 
     async def test_filter_by_created_by_and_order_by_created_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_by__id and ordering by created_at ASC."""
         query = """
@@ -1025,7 +1041,7 @@ class TestMetadataFilters:
         }
         """
         # Filter: nodes created by Alice, Order: by created_at ASC
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_alice})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_alice})
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
         timestamps = [e["node_metadata"]["created_at"] for e in data["TestCriticality"]["edges"]]
@@ -1034,7 +1050,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps)
 
     async def test_filter_by_updated_by_and_order_by_updated_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by updated_by__id and ordering by updated_at DESC."""
         query = """
@@ -1052,7 +1068,7 @@ class TestMetadataFilters:
         }
         """
         # Filter: nodes last updated by Bob (node1, node2), Order: by updated_at DESC
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_bob})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_bob})
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
         timestamps = [e["node_metadata"]["updated_at"] for e in data["TestCriticality"]["edges"]]
@@ -1063,7 +1079,7 @@ class TestMetadataFilters:
     # ========== Combined Filter + Order Tests (Different Fields) ==========
 
     async def test_filter_by_created_by_order_by_updated_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_by__id and ordering by updated_at DESC."""
         query = """
@@ -1082,7 +1098,7 @@ class TestMetadataFilters:
         """
         # Filter: nodes created by Alice (node1, node3), Order: by updated_at DESC
         # node3 was updated more recently than node1
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_alice})
+        data = await self._run_query(db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_alice})
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
         timestamps = [e["node_metadata"]["updated_at"] for e in data["TestCriticality"]["edges"]]
@@ -1091,7 +1107,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps, reverse=True)
 
     async def test_filter_by_updated_by_order_by_created_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by updated_by__id and ordering by created_at ASC."""
         query = """
@@ -1109,7 +1125,9 @@ class TestMetadataFilters:
         }
         """
         # Filter: nodes last updated by Charlie (node3, node4), Order: by created_at ASC
-        data = await self._run_query(db, query, default_branch, {"userId": metadata_filter_data.user_charlie})
+        data = await self._run_query(
+            db, query, default_branch_scope_class, {"userId": metadata_filter_data.user_charlie}
+        )
         assert data["TestCriticality"]["count"] == 2
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
         timestamps = [e["node_metadata"]["created_at"] for e in data["TestCriticality"]["edges"]]
@@ -1118,7 +1136,7 @@ class TestMetadataFilters:
         assert timestamps == sorted(timestamps)
 
     async def test_filter_by_created_by_ids_order_by_updated_at(
-        self, db: InfrahubDatabase, default_branch: Branch, metadata_filter_data: MetadataFilterTestData
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_by__ids and ordering by updated_at ASC."""
         query = """
@@ -1137,7 +1155,10 @@ class TestMetadataFilters:
         """
         # Filter: nodes created by Alice or Bob (node1, node2, node3), Order: by updated_at ASC
         data = await self._run_query(
-            db, query, default_branch, {"userIds": [metadata_filter_data.user_alice, metadata_filter_data.user_bob]}
+            db,
+            query,
+            default_branch_scope_class,
+            {"userIds": [metadata_filter_data.user_alice, metadata_filter_data.user_bob]},
         )
         assert data["TestCriticality"]["count"] == 3
         names = [e["node"]["name"]["value"] for e in data["TestCriticality"]["edges"]]
@@ -1150,7 +1171,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_at__after and ordering by updated_at DESC on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($cutoff: DateTime!) {
             TestCriticality(
@@ -1180,7 +1200,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by created_by__id and ordering by created_at ASC on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($userId: ID!) {
             TestCriticality(
@@ -1211,7 +1230,6 @@ class TestMetadataFilters:
         self, db: InfrahubDatabase, metadata_filter_data: MetadataFilterTestData
     ) -> None:
         """Test filtering by updated_by__id and ordering by updated_at DESC on user branch."""
-        assert metadata_filter_data.user_branch is not None
         query = """
         query($userId: ID!) {
             TestCriticality(


### PR DESCRIPTION
IFC-1947

- add new special handling that allows filtering for a whole day's worth of metadata if the input time is midnight in any timezone
  - basically, if you filter to Interfaces with `node_metadata__created_at=2025-12-31T00:00:00`, then this will be translated to `node_metadata__created_at__after=2025-12-30T23:59:59.999999` and `node_metadata__created_at__before=2026-01-01T00:00:00`
- updates to use class-scoped fixtures for some existing metadata filtering tests to make them run faster. probably a good pattern to use in other places


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata datetime filtering: exact-midnight created_at/updated_at values are now treated as full-day ranges when querying.

* **Behavior**
  * Day-range interpretation is applied automatically during query handling so midnight datetimes return that day's results.

* **Tests**
  * Added comprehensive unit tests for midnight/day-range behavior and many edge cases.
  * Improved test infrastructure with class-scoped fixtures and reusable schema helpers for better isolation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->