### PR TITLE
fix warnings for deprecated attr regex/min/max

### DIFF
--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -238,19 +238,6 @@ class TextAttributeSchema(AttributeSchema):
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )
 
-    @model_validator(mode="after")
-    def reconcile_parameters(self) -> Self:
-        if self.regex != self.parameters.regex:
-            final_regex = self.parameters.regex if self.parameters.regex is not None else self.regex
-            self.regex = self.parameters.regex = final_regex
-        if self.min_length != self.parameters.min_length:
-            final_min_length = self.parameters.min_length if self.parameters.min_length is not None else self.min_length
-            self.min_length = self.parameters.min_length = final_min_length
-        if self.max_length != self.parameters.max_length:
-            final_max_length = self.parameters.max_length if self.parameters.max_length is not None else self.max_length
-            self.max_length = self.parameters.max_length = final_max_length
-        return self
-
     def get_regex(self) -> str | None:
         return self.parameters.regex
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -54,7 +54,7 @@ from infrahub.core.schema import (
     SchemaRoot,
     TemplateSchema,
 )
-from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters, TextAttributeParameters
 from infrahub.core.schema.attribute_schema import get_attribute_schema_class_for_kind
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
@@ -545,6 +545,7 @@ class SchemaBranch:
         self.generate_identifiers()
         self.process_default_values()
         self.process_deprecations()
+        self.reconcile_text_attribute_parameters()
         self.process_cardinality_counts()
         self.process_inheritance()
         self.process_hierarchy()
@@ -1834,6 +1835,53 @@ class SchemaBranch:
             for item in node.attributes + node.relationships:
                 if item.is_deprecated and not item.optional:
                     item.optional = True
+
+            self.set(name=name, schema=node)
+
+    def reconcile_text_attribute_parameters(self) -> None:
+        """Reconcile regex, min_length, max_length between top-level fields and parameters for Text/TextArea attributes."""
+        for name in self.all_names:
+            node = self.get(name=name, duplicate=False)
+
+            # Check if any Text/TextArea attribute needs reconciliation
+            change_required = False
+            for attr in node.attributes:
+                if not isinstance(attr.parameters, TextAttributeParameters):
+                    continue
+                if (
+                    attr.regex != attr.parameters.regex
+                    or attr.min_length != attr.parameters.min_length
+                    or attr.max_length != attr.parameters.max_length
+                ):
+                    change_required = True
+                    break
+
+            if not change_required:
+                continue
+
+            node = node.duplicate()
+            for attr in node.attributes:
+                if not isinstance(attr.parameters, TextAttributeParameters):
+                    continue
+
+                # Reconcile regex
+                if attr.regex != attr.parameters.regex:
+                    final_regex = attr.parameters.regex if attr.parameters.regex is not None else attr.regex
+                    attr.regex = attr.parameters.regex = final_regex
+
+                # Reconcile min_length
+                if attr.min_length != attr.parameters.min_length:
+                    final_min_length = (
+                        attr.parameters.min_length if attr.parameters.min_length is not None else attr.min_length
+                    )
+                    attr.min_length = attr.parameters.min_length = final_min_length
+
+                # Reconcile max_length
+                if attr.max_length != attr.parameters.max_length:
+                    final_max_length = (
+                        attr.parameters.max_length if attr.parameters.max_length is not None else attr.max_length
+                    )
+                    attr.max_length = attr.parameters.max_length = final_max_length
 
             self.set(name=name, schema=node)
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -501,11 +501,34 @@ class SchemaBranch:
 
         return fields or None
 
+    def _reconcile_incoming_text_attribute_parameters(self, schema: SchemaRoot) -> None:
+        """Ensure deprecated Text attribute fields are copied to parameters in incoming schema.
+
+        This handles the case where a schema update uses deprecated regex/min_length/max_length
+        fields instead of parameters. We need to copy those values to parameters so they will
+        be properly merged during update().
+        """
+        for item in schema.nodes + schema.generics:
+            for attr in item.attributes:
+                if not isinstance(attr.parameters, TextAttributeParameters):
+                    continue
+
+                # Copy deprecated field values to parameters if parameters are None
+                if attr.regex is not None and attr.parameters.regex is None:
+                    attr.parameters.regex = attr.regex
+                if attr.min_length is not None and attr.parameters.min_length is None:
+                    attr.parameters.min_length = attr.min_length
+                if attr.max_length is not None and attr.parameters.max_length is None:
+                    attr.parameters.max_length = attr.max_length
+
     def load_schema(self, schema: SchemaRoot) -> None:
         """Load a SchemaRoot object and store all NodeSchema or GenericSchema.
 
         In the current implementation, if a schema object present in the SchemaRoot already exist, it will be overwritten.
         """
+        # Reconcile deprecated text attribute parameters before merging
+        self._reconcile_incoming_text_attribute_parameters(schema)
+
         for item in schema.nodes + schema.generics:
             try:
                 if item.id:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -501,25 +501,67 @@ class SchemaBranch:
 
         return fields or None
 
-    def _reconcile_incoming_text_attribute_parameters(self, schema: SchemaRoot) -> None:
-        """Ensure deprecated Text attribute fields are copied to parameters in incoming schema.
+    def _text_attr_needs_reconciliation(self, attr: AttributeSchema) -> bool:
+        """Check if a Text attribute needs reconciliation between deprecated fields and parameters."""
+        if not isinstance(attr.parameters, TextAttributeParameters):
+            return False
+        return (
+            attr.regex != attr.parameters.regex
+            or attr.min_length != attr.parameters.min_length
+            or attr.max_length != attr.parameters.max_length
+        )
 
-        This handles the case where a schema update uses deprecated regex/min_length/max_length
-        fields instead of parameters. We need to copy those values to parameters so they will
-        be properly merged during update().
+    def _reconcile_text_attr(self, attr: AttributeSchema) -> None:
+        """Reconcile a single Text attribute's deprecated fields with parameters.
+
+        Parameters take precedence over deprecated top-level fields when both are set.
         """
-        for item in schema.nodes + schema.generics:
-            for attr in item.attributes:
-                if not isinstance(attr.parameters, TextAttributeParameters):
-                    continue
+        if not isinstance(attr.parameters, TextAttributeParameters):
+            return
 
-                # Copy deprecated field values to parameters if parameters are None
-                if attr.regex is not None and attr.parameters.regex is None:
-                    attr.parameters.regex = attr.regex
-                if attr.min_length is not None and attr.parameters.min_length is None:
-                    attr.parameters.min_length = attr.min_length
-                if attr.max_length is not None and attr.parameters.max_length is None:
-                    attr.parameters.max_length = attr.max_length
+        # Sync regex: parameters takes precedence
+        if attr.parameters.regex is not None:
+            attr.regex = attr.parameters.regex
+        elif attr.regex is not None:
+            attr.parameters.regex = attr.regex
+
+        # Sync min_length: parameters takes precedence
+        if attr.parameters.min_length is not None:
+            attr.min_length = attr.parameters.min_length
+        elif attr.min_length is not None:
+            attr.parameters.min_length = attr.min_length
+
+        # Sync max_length: parameters takes precedence
+        if attr.parameters.max_length is not None:
+            attr.max_length = attr.parameters.max_length
+        elif attr.max_length is not None:
+            attr.parameters.max_length = attr.max_length
+
+    def _reconcile_text_attribute_parameters(self, schema: SchemaRoot | None = None) -> None:
+        """Reconcile regex, min_length, max_length between deprecated fields and parameters for Text attributes.
+
+        Args:
+            schema: If provided, reconcile incoming schema data before merging.
+                   If None, reconcile already-loaded schemas (e.g., from database).
+        """
+        if schema:
+            # Incoming schema: modify in place
+            for item in schema.nodes + schema.generics:
+                for attr in item.attributes:
+                    self._reconcile_text_attr(attr)
+            return
+
+        # Loaded schemas: need to duplicate before modifying
+        for name in self.all_names:
+            node = self.get(name=name, duplicate=False)
+
+            if not any(self._text_attr_needs_reconciliation(attr) for attr in node.attributes):
+                continue
+
+            node = node.duplicate()
+            for attr in node.attributes:
+                self._reconcile_text_attr(attr)
+            self.set(name=name, schema=node)
 
     def load_schema(self, schema: SchemaRoot) -> None:
         """Load a SchemaRoot object and store all NodeSchema or GenericSchema.
@@ -527,7 +569,7 @@ class SchemaBranch:
         In the current implementation, if a schema object present in the SchemaRoot already exist, it will be overwritten.
         """
         # Reconcile deprecated text attribute parameters before merging
-        self._reconcile_incoming_text_attribute_parameters(schema)
+        self._reconcile_text_attribute_parameters(schema)
 
         for item in schema.nodes + schema.generics:
             try:
@@ -568,7 +610,7 @@ class SchemaBranch:
         self.generate_identifiers()
         self.process_default_values()
         self.process_deprecations()
-        self.reconcile_text_attribute_parameters()
+        self._reconcile_text_attribute_parameters()
         self.process_cardinality_counts()
         self.process_inheritance()
         self.process_hierarchy()
@@ -1858,53 +1900,6 @@ class SchemaBranch:
             for item in node.attributes + node.relationships:
                 if item.is_deprecated and not item.optional:
                     item.optional = True
-
-            self.set(name=name, schema=node)
-
-    def reconcile_text_attribute_parameters(self) -> None:
-        """Reconcile regex, min_length, max_length between top-level fields and parameters for Text/TextArea attributes."""
-        for name in self.all_names:
-            node = self.get(name=name, duplicate=False)
-
-            # Check if any Text/TextArea attribute needs reconciliation
-            change_required = False
-            for attr in node.attributes:
-                if not isinstance(attr.parameters, TextAttributeParameters):
-                    continue
-                if (
-                    attr.regex != attr.parameters.regex
-                    or attr.min_length != attr.parameters.min_length
-                    or attr.max_length != attr.parameters.max_length
-                ):
-                    change_required = True
-                    break
-
-            if not change_required:
-                continue
-
-            node = node.duplicate()
-            for attr in node.attributes:
-                if not isinstance(attr.parameters, TextAttributeParameters):
-                    continue
-
-                # Reconcile regex
-                if attr.regex != attr.parameters.regex:
-                    final_regex = attr.parameters.regex if attr.parameters.regex is not None else attr.regex
-                    attr.regex = attr.parameters.regex = final_regex
-
-                # Reconcile min_length
-                if attr.min_length != attr.parameters.min_length:
-                    final_min_length = (
-                        attr.parameters.min_length if attr.parameters.min_length is not None else attr.min_length
-                    )
-                    attr.min_length = attr.parameters.min_length = final_min_length
-
-                # Reconcile max_length
-                if attr.max_length != attr.parameters.max_length:
-                    final_max_length = (
-                        attr.parameters.max_length if attr.parameters.max_length is not None else attr.max_length
-                    )
-                    attr.max_length = attr.parameters.max_length = final_max_length
 
             self.set(name=name, schema=node)
 

--- a/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
@@ -309,16 +309,6 @@ class TestUpdateAttributeParameters(TestInfrahubApp):
                     "kinds": [{"kind": "TestingThingLegacy", "field": "value"}],
                     "message": "Use of 'min_length' on attributes is deprecated, use parameters instead",
                 },
-                {
-                    "type": "deprecation",
-                    "kinds": [{"kind": "TestingThing", "field": "value"}],
-                    "message": "Use of 'max_length' on attributes is deprecated, use parameters instead",
-                },
-                {
-                    "type": "deprecation",
-                    "kinds": [{"kind": "TestingThing", "field": "value"}],
-                    "message": "Use of 'min_length' on attributes is deprecated, use parameters instead",
-                },
             ],
         }
 

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -382,12 +382,12 @@ async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
 
 
 async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
-    """Test that SchemaBranch.reconcile_text_attribute_parameters() syncs top-level and parameters fields."""
+    """Test that SchemaBranch.load_schema() syncs top-level and parameters fields for Text attributes."""
     regex = "abc"
     min_length = 3
     max_length = 5
 
-    # Test reconciliation when parameters are set
+    # Test reconciliation when parameters are set (new style)
     SCHEMA_WITH_PARAMS: dict[str, Any] = {
         "nodes": [
             {
@@ -411,15 +411,7 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema_root)
 
-    # Before reconciliation, top-level fields are not synced
-    node = schema_branch.get(name="TestDevice", duplicate=False)
-    desc_attr = node.get_attribute(name="description")
-    assert desc_attr.parameters.regex == regex
-    assert desc_attr.regex is None  # Not synced yet
-
-    # After reconciliation, both should be synced
-    schema_branch.reconcile_text_attribute_parameters()
-
+    # After load_schema, both deprecated fields and parameters should be synced
     node = schema_branch.get(name="TestDevice", duplicate=False)
     desc_attr = node.get_attribute(name="description")
     assert desc_attr.parameters.regex == desc_attr.regex == regex
@@ -452,15 +444,7 @@ async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
     schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema_root)
 
-    # Before reconciliation, parameters are not synced
-    node = schema_branch.get(name="TestRouter", duplicate=False)
-    hostname_attr = node.get_attribute(name="hostname")
-    assert hostname_attr.regex == regex
-    assert hostname_attr.parameters.regex is None  # Not synced yet
-
-    # After reconciliation, both should be synced
-    schema_branch.reconcile_text_attribute_parameters()
-
+    # After load_schema, both deprecated fields and parameters should be synced
     node = schema_branch.get(name="TestRouter", duplicate=False)
     hostname_attr = node.get_attribute(name="hostname")
     assert hostname_attr.parameters.regex == hostname_attr.regex == regex

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -381,6 +381,93 @@ async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
     assert criticality.get_attribute(name="color").optional is True
 
 
+async def test_schema_branch_reconcile_text_attribute_parameters() -> None:
+    """Test that SchemaBranch.reconcile_text_attribute_parameters() syncs top-level and parameters fields."""
+    regex = "abc"
+    min_length = 3
+    max_length = 5
+
+    # Test reconciliation when parameters are set
+    SCHEMA_WITH_PARAMS: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {
+                        "name": "description",
+                        "kind": "Text",
+                        "parameters": {"regex": regex, "min_length": min_length, "max_length": max_length},
+                    },
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_PARAMS)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    # Before reconciliation, top-level fields are not synced
+    node = schema_branch.get(name="TestDevice", duplicate=False)
+    desc_attr = node.get_attribute(name="description")
+    assert desc_attr.parameters.regex == regex
+    assert desc_attr.regex is None  # Not synced yet
+
+    # After reconciliation, both should be synced
+    schema_branch.reconcile_text_attribute_parameters()
+
+    node = schema_branch.get(name="TestDevice", duplicate=False)
+    desc_attr = node.get_attribute(name="description")
+    assert desc_attr.parameters.regex == desc_attr.regex == regex
+    assert desc_attr.parameters.min_length == desc_attr.min_length == min_length
+    assert desc_attr.parameters.max_length == desc_attr.max_length == max_length
+
+    # Test reconciliation when top-level fields are set (deprecated style)
+    SCHEMA_WITH_TOP_LEVEL: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "Router",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {
+                        "name": "hostname",
+                        "kind": "Text",
+                        "regex": regex,
+                        "min_length": min_length,
+                        "max_length": max_length,
+                    },
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_TOP_LEVEL)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    # Before reconciliation, parameters are not synced
+    node = schema_branch.get(name="TestRouter", duplicate=False)
+    hostname_attr = node.get_attribute(name="hostname")
+    assert hostname_attr.regex == regex
+    assert hostname_attr.parameters.regex is None  # Not synced yet
+
+    # After reconciliation, both should be synced
+    schema_branch.reconcile_text_attribute_parameters()
+
+    node = schema_branch.get(name="TestRouter", duplicate=False)
+    hostname_attr = node.get_attribute(name="hostname")
+    assert hostname_attr.parameters.regex == hostname_attr.regex == regex
+    assert hostname_attr.parameters.min_length == hostname_attr.min_length == min_length
+    assert hostname_attr.parameters.max_length == hostname_attr.max_length == max_length
+
+
 async def test_schema_branch_add_groups(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -22,6 +22,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema
+from infrahub.core.schema.attribute_parameters import TextAttributeParameters
 from infrahub.core.timestamp import Timestamp, current_timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
@@ -311,10 +312,7 @@ async def test_validate_content_dropdown(
     assert "invalid-choice must be one of" in str(exc.value)
 
 
-@pytest.mark.parametrize("params_only", [False, True])
-async def test_validate_content_text_parameters(
-    db: InfrahubDatabase, default_branch: Branch, params_only: bool
-) -> None:
+async def test_validate_content_text_parameters(db: InfrahubDatabase, default_branch: Branch) -> None:
     regex = "^[a-z]*$"
     min_length = 2
     max_length = 5
@@ -322,15 +320,13 @@ async def test_validate_content_text_parameters(
         namespace="Test",
         name="Node",
         attributes=[
-            AttributeSchema(name="text_test", kind="Text", regex=regex, min_length=min_length, max_length=max_length)
+            AttributeSchema(
+                name="text_test",
+                kind="Text",
+                parameters=TextAttributeParameters(regex=regex, min_length=min_length, max_length=max_length),
+            )
         ],
     )
-    attr_schema = node_schema.get_attribute("text_test")
-    assert attr_schema.regex == attr_schema.parameters.regex
-    assert attr_schema.min_length == attr_schema.parameters.min_length
-    assert attr_schema.max_length == attr_schema.parameters.max_length
-    if params_only:
-        attr_schema.regex = attr_schema.min_length = attr_schema.min_length = None
 
     new_node = await Node.init(db=db, branch=default_branch, schema=node_schema)
     with pytest.raises(ValidationError, match=r"must have a minimum length of 2"):

--- a/backend/tests/unit/core/test_schema.py
+++ b/backend/tests/unit/core/test_schema.py
@@ -124,6 +124,44 @@ SCHEMA_WARNING_TESTCASES: list[SchemaWarningTestCaseData] = [
             ),
         ],
     ),
+    SchemaWarningTestCaseData(
+        name="use_min_max_length_in_parameters_no_warning",
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    namespace="Test",
+                    name="Ticket",
+                    attributes=[
+                        TextAttributeSchema(
+                            name="name",
+                            kind="Text",
+                            parameters=TextAttributeParameters(min_length=1, max_length=40),
+                        )
+                    ],
+                )
+            ]
+        ),
+        warnings=[],
+    ),
+    SchemaWarningTestCaseData(
+        name="use_regex_in_parameters_no_warning",
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    namespace="Test",
+                    name="Device",
+                    attributes=[
+                        TextAttributeSchema(
+                            name="hostname",
+                            kind="Text",
+                            parameters=TextAttributeParameters(regex="^[a-zA-Z][a-zA-Z0-9._-]*$"),
+                        )
+                    ],
+                )
+            ]
+        ),
+        warnings=[],
+    ),
 ]
 
 
@@ -367,32 +405,6 @@ def test_core_models() -> None:
 
 def test_internal_schema() -> None:
     assert SchemaRoot(**internal_schema)
-
-
-async def test_attribute_schema_parameters() -> None:
-    regex = "abc"
-    min_length = 3
-    max_length = 5
-
-    attr_schema = TextAttributeSchema(
-        name="something", kind="Text", parameters={"regex": regex, "min_length": min_length, "max_length": max_length}
-    )
-    assert isinstance(attr_schema.parameters, TextAttributeParameters)
-    assert attr_schema.parameters.regex == attr_schema.regex == regex
-    assert attr_schema.parameters.min_length == attr_schema.min_length == min_length
-    assert attr_schema.parameters.max_length == attr_schema.max_length == max_length
-
-    attr_schema = TextAttributeSchema(
-        name="something", kind="Text", regex=regex, min_length=min_length, max_length=max_length
-    )
-    assert isinstance(attr_schema.parameters, TextAttributeParameters)
-    assert attr_schema.parameters.regex == attr_schema.regex == regex
-    assert attr_schema.parameters.min_length == attr_schema.min_length == min_length
-    assert attr_schema.parameters.max_length == attr_schema.max_length == max_length
-
-    # TODO: update text of error message in this situation
-    with pytest.raises(ValidationError):
-        attr_schema = AttributeSchema(name="something", kind="Number", parameters={"regex": "abc"})
 
 
 async def test_attribute_schema_choices_invalid_kind() -> None:

--- a/changelog/7995.fixed.md
+++ b/changelog/7995.fixed.md
@@ -1,0 +1,1 @@
+Stop showing warnings for deprecated attribute schema fields (regex, min_length, max_length) when they are not used


### PR DESCRIPTION
fixes #7995 

the root of the problem described in the bug is that we use the same data structures for both 
 - validating a schema update coming from a user
 - representing that schema inside of the backend code
so we do not have a good way to perform validation on a schema that is separate from the internal backend logic. we want to continue to allow users to set `regex`, `min_length`, and `max_length` at the Attribute level for backwards compatibility, but the preferred method for setting these properties is now to use `Attribute.parameters.regex/min/max_length` and the simplest solution to this problem was to reconcile the property in both places (i.e. `Attribute.regex = Attribute.parameters.regex`), but then we lose the information about whether `Attribute.regex` was set by the user or not

the changes in this PR are to only perform the parameter reconciliation when loading an updated schema and when retrieving a schema from the database (in case it is a legacy Attribute that only has the Attribute-level `regex/min/max_length` set

I believe this is a very edgy edge case b/c I don't think that we have other deprecated elements of schemas that we need to support in multiple places, so I don't think this approach needs to be very modular/generic at this time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled spurious deprecation warnings for text attribute fields (regex, min_length, max_length) when using the new parameters-based schema.

* **Refactor**
  * Improved reconciliation so text attribute parameters and deprecated top-level fields stay synchronized, with parameters taking precedence for consistency.

* **Tests**
  * Added and updated tests to validate parameter-based text attributes and reconciliation behavior.

* **Documentation**
  * Added changelog entry noting the deprecation-warning change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->