### PR TITLE
Loosen version requirements for testcontainers httpx

### DIFF
--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "testcontainers>=4.8,<4.9",
     "psutil",
     "pytest",
-    "httpx<0.28",
+    "httpx>=0.20",
     "pydantic>=2.10.6,<3",
     "prefect-client==3.6.7",
 ]

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -531,7 +531,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = "<0.28" },
+    { name = "httpx", specifier = ">=0.20" },
     { name = "prefect-client", specifier = "==3.6.7" },
     { name = "psutil" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },


### PR DESCRIPTION
I ran into some issues when trying to upgrade the testcontainers version in the SDK to 1.7.0b0 because the pinning of httpx is too restrictive.

It seems like this changed during the migration to uv.

https://github.com/opsmill/infrahub/blob/infrahub-v1.5.5/python_testcontainers/pyproject.toml#L40
vs:
https://github.com/opsmill/infrahub/blob/infrahub-v1.6.2/python_testcontainers/pyproject.toml#L24

I've updated it to set it as loose as it currently is in the SDK instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency compatibility to support a wider range of library versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->