### PR TITLE
support migrating attribute kind on profiles

### DIFF
--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -135,7 +135,9 @@ CALL (has_value_e) {
     SET has_value_e.to = $at
 }
         """ % {
-            "schema_kinds": f"{self.migration.previous_schema.kind}|Profile{self.migration.previous_schema.kind}",
+            "schema_kinds": (
+                f"{self.migration.previous_schema.kind}|Profile{self.migration.previous_schema.kind}|Template{self.migration.previous_schema.kind}"
+            ),
             "branch_filter": branch_filter,
             "new_attr_value_labels": new_attr_value_labels,
         }

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -34,7 +34,7 @@ class AttributeKindUpdateMigrationQuery(AttributeMigrationQuery):
 // ------------
 // start with all the Attribute vertices we might care about
 // ------------
-MATCH (n:%(schema_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+MATCH (n:%(schema_kinds)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
 WHERE attr.name = $attr_name
 WITH DISTINCT n, attr
 
@@ -70,7 +70,7 @@ CALL (av_is_default, av_value) {
 // ------------
 WITH 1 AS one
 LIMIT 1
-MATCH (n:%(schema_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+MATCH (n:%(schema_kinds)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
 WHERE attr.name = $attr_name
 WITH DISTINCT n, attr
 
@@ -87,7 +87,6 @@ CALL (n, attr) {
     WHERE is_active AND is_indexed <> $needs_index
     RETURN has_value_e, av
 }
-
 
 // ------------
 // create and update the HAS_VALUE edges
@@ -136,7 +135,7 @@ CALL (has_value_e) {
     SET has_value_e.to = $at
 }
         """ % {
-            "schema_kind": self.migration.previous_schema.kind,
+            "schema_kinds": f"{self.migration.previous_schema.kind}|Profile{self.migration.previous_schema.kind}",
             "branch_filter": branch_filter,
             "new_attr_value_labels": new_attr_value_labels,
         }

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -24,6 +24,26 @@ def get_attribute_parameters_class_for_kind(kind: str) -> type[AttributeParamete
 class AttributeParameters(HashableModel):
     model_config = ConfigDict(extra="forbid")
 
+    @classmethod
+    def convert_from(cls, source: AttributeParameters) -> Self:
+        """Convert from another AttributeParameters subclass.
+
+        When changing attribute kinds, parameters convert between different subclasses
+        (e.g., TextAttributeParameters -> NumberAttributeParameters).
+        Fields from the source that don't exist in the target are silently dropped.
+        Fields with the same name in both classes are preserved.
+
+        Args:
+            source: The source AttributeParameters instance to convert from
+
+        Returns:
+            A new instance of the target class with compatible fields populated
+        """
+        target_fields = set(cls.model_fields.keys())
+        source_data = source.model_dump()
+        filtered_data = {k: v for k, v in source_data.items() if k in target_fields}
+        return cls(**filtered_data)
+
 
 class TextAttributeParameters(AttributeParameters):
     regex: str | None = Field(

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Self
+from typing import Any, Self
 
 from pydantic import ConfigDict, Field, model_validator
 
@@ -28,19 +28,26 @@ class AttributeParameters(HashableModel):
     def convert_from(cls, source: AttributeParameters) -> Self:
         """Convert from another AttributeParameters subclass.
 
-        When changing attribute kinds, parameters convert between different subclasses
-        (e.g., TextAttributeParameters -> NumberAttributeParameters).
-        Fields from the source that don't exist in the target are silently dropped.
-        Fields with the same name in both classes are preserved.
-
         Args:
             source: The source AttributeParameters instance to convert from
 
         Returns:
             A new instance of the target class with compatible fields populated
         """
-        target_fields = set(cls.model_fields.keys())
         source_data = source.model_dump()
+        return cls.convert_from_dict(source_data=source_data)
+
+    @classmethod
+    def convert_from_dict(cls, source_data: dict[str, Any]) -> Self:
+        """Convert from a dictionary to the target class.
+
+        Args:
+            source_data: The source dictionary to convert from
+
+        Returns:
+            A new instance of the target class with compatible fields populated
+        """
+        target_fields = set(cls.model_fields.keys())
         filtered_data = {k: v for k, v in source_data.items() if k in target_fields}
         return cls(**filtered_data)
 

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -114,13 +114,24 @@ class AttributeSchema(GeneratedAttributeSchema):
     @field_validator("parameters", mode="before")
     @classmethod
     def set_parameters_type(cls, value: Any, info: ValidationInfo) -> Any:
-        """Override parameters class if using base AttributeParameters class and should be using a subclass"""
+        """Override parameters class if using base AttributeParameters class and should be using a subclass.
+
+        This validator handles parameter type conversion when an attribute's kind changes.
+        Fields from the source that don't exist in the target are silently dropped.
+        Fields with the same name in both classes are preserved.
+        """
         kind = info.data["kind"]
         expected_parameters_class = get_attribute_parameters_class_for_kind(kind=kind)
         if value is None:
             return expected_parameters_class()
         if not isinstance(value, expected_parameters_class) and isinstance(value, AttributeParameters):
-            return expected_parameters_class(**value.model_dump())
+            return expected_parameters_class.convert_from(value)
+        if isinstance(value, dict):
+            # Filter dict to only include fields that exist in the expected class
+            # This handles kind changes when parameters is serialized as a dict (e.g., from model_dump())
+            target_fields = set(expected_parameters_class.model_fields.keys())
+            filtered_data = {k: v for k, v in value.items() if k in target_fields}
+            return expected_parameters_class(**filtered_data)
         return value
 
     @model_validator(mode="after")

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -127,11 +127,7 @@ class AttributeSchema(GeneratedAttributeSchema):
         if not isinstance(value, expected_parameters_class) and isinstance(value, AttributeParameters):
             return expected_parameters_class.convert_from(value)
         if isinstance(value, dict):
-            # Filter dict to only include fields that exist in the expected class
-            # This handles kind changes when parameters is serialized as a dict (e.g., from model_dump())
-            target_fields = set(expected_parameters_class.model_fields.keys())
-            filtered_data = {k: v for k, v in value.items() if k in target_fields}
-            return expected_parameters_class(**filtered_data)
+            return expected_parameters_class.convert_from_dict(source_data=value)
         return value
 
     @model_validator(mode="after")

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -36,7 +36,7 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["null_value"] = NULL_VALUE
 
         query = """
-        MATCH p = (n:%(node_kind)s)
+        MATCH (n:%(node_kinds)s)
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -51,7 +51,7 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         WHERE all(r in relationships(full_path) WHERE r.status = "active")
         AND attribute_value IS NOT NULL
         AND attribute_value <> $null_value
-        """ % {"branch_filter": branch_filter, "node_kind": self.node_schema.kind}
+        """ % {"branch_filter": branch_filter, "node_kinds": f"{self.node_schema.kind}|Profile{self.node_schema.kind}"}
 
         self.add_to_query(query)
         self.return_labels = ["node.uuid", "attribute_value", "value_relationship.branch as value_branch"]

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -51,7 +51,10 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         WHERE all(r in relationships(full_path) WHERE r.status = "active")
         AND attribute_value IS NOT NULL
         AND attribute_value <> $null_value
-        """ % {"branch_filter": branch_filter, "node_kinds": f"{self.node_schema.kind}|Profile{self.node_schema.kind}"}
+        """ % {
+            "branch_filter": branch_filter,
+            "node_kinds": f"{self.node_schema.kind}|Profile{self.node_schema.kind}|Template{self.node_schema.kind}",
+        }
 
         self.add_to_query(query)
         self.return_labels = ["node.uuid", "attribute_value", "value_relationship.branch as value_branch"]

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -222,8 +222,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         )
         await thing_two.save(db=db)
 
-        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=default_branch)
-        profile_thing = await Node.init(db=db, schema=profile_schema, branch=default_branch)
+        profile_thing = await Node.init(db=db, schema=PROFILE_THING_KIND, branch=default_branch)
         await profile_thing.new(
             db=db,
             profile_name="test_profile",

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -10,6 +10,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema.attribute_parameters import AttributeParameters, TextAttributeParameters
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import BranchNotFoundError
 from tests.helpers.test_app import TestInfrahubApp
@@ -17,6 +18,7 @@ from tests.helpers.test_app import TestInfrahubApp
 from ..shared import load_schema
 
 THING_KIND = "TestingThing"
+PROFILE_THING_KIND = "ProfileTestingThing"
 
 
 @dataclass
@@ -92,10 +94,10 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             "name": "Thing",
             "namespace": "Testing",
             "attributes": [
-                {"name": "text_value", "kind": "Text"},
-                {"name": "text_area_value", "kind": "TextArea"},
-                {"name": "list_value", "kind": "List"},
-                {"name": "url_value", "kind": "URL"},
+                {"name": "text_value", "kind": "Text", "optional": True},
+                {"name": "text_area_value", "kind": "TextArea", "optional": True},
+                {"name": "list_value", "kind": "List", "optional": True},
+                {"name": "url_value", "kind": "URL", "optional": True},
             ],
         }
 
@@ -220,9 +222,21 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         )
         await thing_two.save(db=db)
 
+        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=default_branch)
+        profile_thing = await Node.init(db=db, schema=profile_schema, branch=default_branch)
+        await profile_thing.new(
+            db=db,
+            profile_name="test_profile",
+            text_value="PROFILE_TEXT",
+            text_area_value="profile area value",
+            url_value="https://profile.example.com",
+        )
+        await profile_thing.save(db=db)
+
         objs = {
             "thing_one": thing_one,
             "thing_two": thing_two,
+            "profile_thing": profile_thing,
         }
 
         return objs
@@ -251,6 +265,16 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "display_label": True,
                 "human_friendly_id": True,
             },
+            (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
+                "profile_name": True,
+                "profile_priority": True,
+                "text_value": True,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
         }
         await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
@@ -264,10 +288,15 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
     ) -> None:
         response = await client.schema.load(schemas=[schema_step_02], branch=branch.name)
         assert response.errors
-        error_messages = response.errors["errors"][0]["message"].split("\n")
-        assert len(error_messages) == 4
+        error_messages: list[str] = response.errors["errors"][0]["message"].split("\n")
+        assert len(error_messages) == 6
         assert all(
-            em.startswith("Attribute-level 'kind' constraint violation on schema 'TestingThing")
+            em.startswith(
+                (
+                    ("Attribute-level 'kind' constraint violation on schema 'TestingThing"),
+                    ("Attribute-level 'kind' constraint violation on schema 'ProfileTestingThing"),
+                )
+            )
             for em in error_messages
         )
 
@@ -282,6 +311,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         response = await client.schema.load(schemas=[schema_step_03], branch=branch.name)
         assert not response.errors
 
+        # Validate corresponding profile schema attribute has the correct kind and parameters
+        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=branch)
+        updated_profile_attr = profile_schema.get_attribute("text_value")
+        assert updated_profile_attr.kind == "TextArea"
+        assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
+
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
                 "text_value": False,
@@ -292,6 +327,17 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "human_friendly_id": True,
             },
             (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Profile instance text_value should now be non-indexed (TextArea)
+            (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
+                "profile_name": True,
+                "profile_priority": True,
                 "text_value": False,
                 "text_area_value": False,
                 "list_value": False,
@@ -327,6 +373,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
         assert not response.errors
 
+        # Validate corresponding profile schema attribute has the correct kind and parameters
+        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=branch)
+        updated_profile_attr = profile_schema.get_attribute("text_area_value")
+        assert updated_profile_attr.kind == "Text"
+        assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
+
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
                 "text_value": False,
@@ -337,6 +389,17 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "human_friendly_id": True,
             },
             (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Profile instance text_area_value should now be indexed (Text)
+            (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
+                "profile_name": True,
+                "profile_priority": True,
                 "text_value": False,
                 "text_area_value": True,
                 "list_value": False,
@@ -355,8 +418,20 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         schema_step_05: dict[str, Any],
         client: InfrahubClient,
     ) -> None:
+        # First verify the url_value attribute has base AttributeParameters before the update
+        profile_schema_before = registry.schema.get(name=PROFILE_THING_KIND, branch=branch)
+        url_attr_before = profile_schema_before.get_attribute("url_value")
+        assert url_attr_before.kind == "URL"
+        assert type(url_attr_before.parameters) is AttributeParameters
+
         response = await client.schema.load(schemas=[schema_step_05], branch=branch.name)
         assert not response.errors
+
+        # Validate corresponding profile schema attribute has the correct kind and parameters
+        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=branch)
+        updated_profile_attr = profile_schema.get_attribute("url_value")
+        assert updated_profile_attr.kind == "Text"
+        assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
 
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
@@ -368,6 +443,17 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "human_friendly_id": True,
             },
             (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Profile instance url_value stays indexed (Text is also indexed)
+            (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
+                "profile_name": True,
+                "profile_priority": True,
                 "text_value": False,
                 "text_area_value": True,
                 "list_value": False,
@@ -389,6 +475,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         response = await client.schema.load(schemas=[schema_step_06], branch=branch.name)
         assert not response.errors
 
+        # Validate corresponding profile schema attribute has the correct kind and parameters
+        profile_schema = registry.schema.get(name=PROFILE_THING_KIND, branch=branch)
+        updated_profile_attr = profile_schema.get_attribute("text_area_value")
+        assert updated_profile_attr.kind == "TextArea"
+        assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
+
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
                 "text_value": False,
@@ -399,6 +491,17 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "human_friendly_id": True,
             },
             (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Profile instance text_area_value should now be non-indexed (TextArea)
+            (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
+                "profile_name": True,
+                "profile_priority": True,
                 "text_value": False,
                 "text_area_value": False,
                 "list_value": False,

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -19,6 +19,7 @@ from ..shared import load_schema
 
 THING_KIND = "TestingThing"
 PROFILE_THING_KIND = "ProfileTestingThing"
+TEMPLATE_THING_KIND = "TemplateTestingThing"
 
 
 @dataclass
@@ -93,6 +94,8 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         return {
             "name": "Thing",
             "namespace": "Testing",
+            "generate_template": True,
+            "generate_profile": True,
             "attributes": [
                 {"name": "text_value", "kind": "Text", "optional": True},
                 {"name": "text_area_value", "kind": "TextArea", "optional": True},
@@ -232,10 +235,21 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         )
         await profile_thing.save(db=db)
 
+        template_thing = await Node.init(db=db, schema=TEMPLATE_THING_KIND, branch=default_branch)
+        await template_thing.new(
+            db=db,
+            template_name="test_template",
+            text_value="TEMPLATE_TEXT",
+            text_area_value="template area value",
+            url_value="https://template.example.com",
+        )
+        await template_thing.save(db=db)
+
         objs = {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "profile_thing": profile_thing,
+            "template_thing": template_thing,
         }
 
         return objs
@@ -274,6 +288,15 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "display_label": True,
                 "human_friendly_id": True,
             },
+            (TEMPLATE_THING_KIND, initial_objects["template_thing"].id): {
+                "template_name": True,
+                "text_value": True,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
         }
         await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
@@ -288,12 +311,13 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         response = await client.schema.load(schemas=[schema_step_02], branch=branch.name)
         assert response.errors
         error_messages: list[str] = response.errors["errors"][0]["message"].split("\n")
-        assert len(error_messages) == 6
+        assert len(error_messages) == 8
         assert all(
             em.startswith(
                 (
                     ("Attribute-level 'kind' constraint violation on schema 'TestingThing"),
                     ("Attribute-level 'kind' constraint violation on schema 'ProfileTestingThing"),
+                    ("Attribute-level 'kind' constraint violation on schema 'TemplateTestingThing"),
                 )
             )
             for em in error_messages
@@ -316,6 +340,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         assert updated_profile_attr.kind == "TextArea"
         assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
 
+        # Validate corresponding template schema attribute has the correct kind and parameters
+        template_schema = registry.schema.get(name=TEMPLATE_THING_KIND, branch=branch)
+        updated_template_attr = template_schema.get_attribute("text_value")
+        assert updated_template_attr.kind == "TextArea"
+        assert isinstance(updated_template_attr.parameters, TextAttributeParameters)
+
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
                 "text_value": False,
@@ -337,6 +367,16 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
                 "profile_name": True,
                 "profile_priority": True,
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Template instance text_value should now be non-indexed (TextArea)
+            (TEMPLATE_THING_KIND, initial_objects["template_thing"].id): {
+                "template_name": True,
                 "text_value": False,
                 "text_area_value": False,
                 "list_value": False,
@@ -378,6 +418,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         assert updated_profile_attr.kind == "Text"
         assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
 
+        # Validate corresponding template schema attribute has the correct kind and parameters
+        template_schema = registry.schema.get(name=TEMPLATE_THING_KIND, branch=branch)
+        updated_template_attr = template_schema.get_attribute("text_area_value")
+        assert updated_template_attr.kind == "Text"
+        assert isinstance(updated_template_attr.parameters, TextAttributeParameters)
+
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
                 "text_value": False,
@@ -406,6 +452,16 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "display_label": True,
                 "human_friendly_id": True,
             },
+            # Template instance text_area_value should now be indexed (Text)
+            (TEMPLATE_THING_KIND, initial_objects["template_thing"].id): {
+                "template_name": True,
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
         }
         await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
@@ -423,6 +479,11 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         assert url_attr_before.kind == "URL"
         assert type(url_attr_before.parameters) is AttributeParameters
 
+        template_schema_before = registry.schema.get(name=TEMPLATE_THING_KIND, branch=branch)
+        template_url_attr_before = template_schema_before.get_attribute("url_value")
+        assert template_url_attr_before.kind == "URL"
+        assert type(template_url_attr_before.parameters) is AttributeParameters
+
         response = await client.schema.load(schemas=[schema_step_05], branch=branch.name)
         assert not response.errors
 
@@ -431,6 +492,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         updated_profile_attr = profile_schema.get_attribute("url_value")
         assert updated_profile_attr.kind == "Text"
         assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
+
+        # Validate corresponding template schema attribute has the correct kind and parameters
+        template_schema = registry.schema.get(name=TEMPLATE_THING_KIND, branch=branch)
+        updated_template_attr = template_schema.get_attribute("url_value")
+        assert updated_template_attr.kind == "Text"
+        assert isinstance(updated_template_attr.parameters, TextAttributeParameters)
 
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
@@ -460,6 +527,16 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
                 "display_label": True,
                 "human_friendly_id": True,
             },
+            # Template instance url_value stays indexed (Text is also indexed)
+            (TEMPLATE_THING_KIND, initial_objects["template_thing"].id): {
+                "template_name": True,
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
         }
         await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
@@ -479,6 +556,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         updated_profile_attr = profile_schema.get_attribute("text_area_value")
         assert updated_profile_attr.kind == "TextArea"
         assert isinstance(updated_profile_attr.parameters, TextAttributeParameters)
+
+        # Validate corresponding template schema attribute has the correct kind and parameters
+        template_schema = registry.schema.get(name=TEMPLATE_THING_KIND, branch=branch)
+        updated_template_attr = template_schema.get_attribute("text_area_value")
+        assert updated_template_attr.kind == "TextArea"
+        assert isinstance(updated_template_attr.parameters, TextAttributeParameters)
 
         kind_index_map = {
             (THING_KIND, initial_objects["thing_one"].id): {
@@ -501,6 +584,16 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             (PROFILE_THING_KIND, initial_objects["profile_thing"].id): {
                 "profile_name": True,
                 "profile_priority": True,
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+                "display_label": True,
+                "human_friendly_id": True,
+            },
+            # Template instance text_area_value should now be non-indexed (TextArea)
+            (TEMPLATE_THING_KIND, initial_objects["template_thing"].id): {
+                "template_name": True,
                 "text_value": False,
                 "text_area_value": False,
                 "list_value": False,

--- a/backend/tests/unit/core/schema/test_attribute_parameters.py
+++ b/backend/tests/unit/core/schema/test_attribute_parameters.py
@@ -260,3 +260,127 @@ def test_validate_min_max_text_attribute() -> None:
         TextAttributeParameters(min_length=10, max_length=5)
 
     assert config.SETTINGS.main.schema_strict_mode
+
+
+def test_convert_from_text_to_number_parameters() -> None:
+    """Test converting TextAttributeParameters to NumberAttributeParameters."""
+    text_params = TextAttributeParameters(regex="^[a-z]+$", min_length=1, max_length=10)
+    number_params = NumberAttributeParameters.convert_from(text_params)
+
+    # Should create a valid NumberAttributeParameters with default values
+    assert isinstance(number_params, NumberAttributeParameters)
+    assert number_params.min_value is None
+    assert number_params.max_value is None
+    assert number_params.excluded_values is None
+
+
+def test_convert_from_number_to_text_parameters() -> None:
+    """Test converting NumberAttributeParameters to TextAttributeParameters."""
+    number_params = NumberAttributeParameters(min_value=0, max_value=100)
+    text_params = TextAttributeParameters.convert_from(number_params)
+
+    # Should create a valid TextAttributeParameters with default values
+    assert isinstance(text_params, TextAttributeParameters)
+    assert text_params.regex is None
+    assert text_params.min_length is None
+    assert text_params.max_length is None
+
+
+def test_convert_from_to_base_parameters() -> None:
+    """Test converting to base AttributeParameters class."""
+    from infrahub.core.schema.attribute_parameters import AttributeParameters
+
+    text_params = TextAttributeParameters(regex="test", min_length=5)
+    base_params = AttributeParameters.convert_from(text_params)
+    assert isinstance(base_params, AttributeParameters)
+
+
+def test_convert_from_same_class() -> None:
+    """Test converting from the same class type preserves values."""
+    text_params = TextAttributeParameters(regex="test", min_length=5, max_length=20)
+    converted = TextAttributeParameters.convert_from(text_params)
+
+    assert isinstance(converted, TextAttributeParameters)
+    assert converted.regex == "test"
+    assert converted.min_length == 5
+    assert converted.max_length == 20
+
+
+def test_convert_from_number_pool_to_number_parameters() -> None:
+    """Test converting NumberPoolParameters to NumberAttributeParameters."""
+    pool_params = NumberPoolParameters(start_range=10, end_range=100)
+    number_params = NumberAttributeParameters.convert_from(pool_params)
+
+    assert isinstance(number_params, NumberAttributeParameters)
+    assert number_params.min_value is None
+    assert number_params.max_value is None
+
+
+def test_attribute_schema_kind_change_text_to_number() -> None:
+    """Test that changing AttributeSchema kind from Text to Number handles parameters."""
+    from infrahub.core.schema.attribute_schema import AttributeSchema
+
+    # Create a Text attribute with parameters
+    text_attr = AttributeSchema(
+        name="test_attr",
+        kind="Text",
+        parameters=TextAttributeParameters(regex="^[a-z]+$", min_length=1, max_length=10),
+    )
+
+    # Create a Number attribute by modifying the kind in the dumped data
+    # This simulates what happens during schema updates
+    attr_data = text_attr.model_dump()
+    attr_data["kind"] = "Number"
+
+    # This should not raise an error about extra fields
+    number_attr = AttributeSchema(**attr_data)
+
+    assert number_attr.kind == "Number"
+    assert isinstance(number_attr.parameters, NumberAttributeParameters)
+    # Parameters should have default values since fields don't overlap
+    assert number_attr.parameters.min_value is None
+    assert number_attr.parameters.max_value is None
+
+
+def test_attribute_schema_kind_change_number_to_text() -> None:
+    """Test that changing AttributeSchema kind from Number to Text handles parameters."""
+    from infrahub.core.schema.attribute_schema import AttributeSchema
+
+    # Create a Number attribute with parameters
+    number_attr = AttributeSchema(
+        name="test_attr",
+        kind="Number",
+        parameters=NumberAttributeParameters(min_value=0, max_value=100),
+    )
+
+    # Create a Text attribute by modifying the kind in the dumped data
+    attr_data = number_attr.model_dump()
+    attr_data["kind"] = "Text"
+
+    # This should not raise an error about extra fields
+    text_attr = AttributeSchema(**attr_data)
+
+    assert text_attr.kind == "Text"
+    assert isinstance(text_attr.parameters, TextAttributeParameters)
+    # Parameters should have default values since fields don't overlap
+    assert text_attr.parameters.regex is None
+    assert text_attr.parameters.min_length is None
+    assert text_attr.parameters.max_length is None
+
+
+def test_attribute_schema_kind_change_with_parameters_object() -> None:
+    """Test kind change when AttributeParameters object is passed directly (not dict)."""
+    from infrahub.core.schema.attribute_schema import AttributeSchema
+
+    text_params = TextAttributeParameters(regex="test")
+
+    # This simulates a case where parameters is an object (not a dict) and kind doesn't match
+    # The validator should handle this by using convert_from
+    number_attr = AttributeSchema(
+        name="test_attr",
+        kind="Number",
+        parameters=text_params,
+    )
+
+    assert number_attr.kind == "Number"
+    assert isinstance(number_attr.parameters, NumberAttributeParameters)

--- a/backend/tests/unit/core/schema/test_attribute_parameters.py
+++ b/backend/tests/unit/core/schema/test_attribute_parameters.py
@@ -12,10 +12,12 @@ from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.registry import registry
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import (
+    AttributeParameters,
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
 )
+from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
@@ -288,8 +290,6 @@ def test_convert_from_number_to_text_parameters() -> None:
 
 def test_convert_from_to_base_parameters() -> None:
     """Test converting to base AttributeParameters class."""
-    from infrahub.core.schema.attribute_parameters import AttributeParameters
-
     text_params = TextAttributeParameters(regex="test", min_length=5)
     base_params = AttributeParameters.convert_from(text_params)
     assert isinstance(base_params, AttributeParameters)
@@ -318,8 +318,6 @@ def test_convert_from_number_pool_to_number_parameters() -> None:
 
 def test_attribute_schema_kind_change_text_to_number() -> None:
     """Test that changing AttributeSchema kind from Text to Number handles parameters."""
-    from infrahub.core.schema.attribute_schema import AttributeSchema
-
     # Create a Text attribute with parameters
     text_attr = AttributeSchema(
         name="test_attr",
@@ -344,8 +342,6 @@ def test_attribute_schema_kind_change_text_to_number() -> None:
 
 def test_attribute_schema_kind_change_number_to_text() -> None:
     """Test that changing AttributeSchema kind from Number to Text handles parameters."""
-    from infrahub.core.schema.attribute_schema import AttributeSchema
-
     # Create a Number attribute with parameters
     number_attr = AttributeSchema(
         name="test_attr",
@@ -370,8 +366,6 @@ def test_attribute_schema_kind_change_number_to_text() -> None:
 
 def test_attribute_schema_kind_change_with_parameters_object() -> None:
     """Test kind change when AttributeParameters object is passed directly (not dict)."""
-    from infrahub.core.schema.attribute_schema import AttributeSchema
-
     text_params = TextAttributeParameters(regex="test")
 
     # This simulates a case where parameters is an object (not a dict) and kind doesn't match


### PR DESCRIPTION
fixes #7943

- adds support to correctly migrate attributes on profiles when their associated node schema is updated
- adds support to correctly migrate attributes on templates when their associated node schema is updated
- adds support for turning one kind of AttributeParameters into another. for example, `TextAttributeParamters` to plain `AttributeParameters` or vice versa which would be necessary when converting Text to/from URL or something

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-kind parameter conversion helpers to safely migrate attribute parameters between kinds.

* **Bug Fixes / Improvements**
  * Query selection expanded to include profile and template schema variants so migrations and validations apply consistently across variants.
  * Safer parameter handling when changing attribute kinds; non-matching fields are dropped and matching fields preserved.

* **Tests**
  * Added unit and integration tests covering parameter conversions and multi-kind (profile/template) migration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->