### PR TITLE
Refactor Database Queries to return structured data

### DIFF
--- a/backend/infrahub/core/ipam/reconciler.py
+++ b/backend/infrahub/core/ipam/reconciler.py
@@ -101,16 +101,18 @@ class IpamReconciler:
         )
         await query.execute(db=self.db)
 
-        ip_node_uuid = query.get_ip_node_uuid()
-        if not ip_node_uuid:
+        data = query.get_data()
+        if not data or not data.ip_node_uuid:
             node_type = InfrahubKind.IPPREFIX
             if isinstance(ip_value, ipaddress.IPv6Interface | ipaddress.IPv4Interface):
                 node_type = InfrahubKind.IPADDRESS
             raise NodeNotFoundError(node_type=node_type, identifier=str(ip_value))
-        current_parent_uuid = query.get_current_parent_uuid()
-        calculated_parent_uuid = query.get_calculated_parent_uuid()
-        current_children_uuids = set(query.get_current_children_uuids())
-        calculated_children_uuids = set(query.get_calculated_children_uuids())
+
+        ip_node_uuid = data.ip_node_uuid
+        current_parent_uuid = data.current_parent_uuid
+        calculated_parent_uuid = data.calculated_parent_uuid
+        current_children_uuids = set(data.current_children_uuids)
+        calculated_children_uuids = set(data.calculated_children_uuids)
 
         all_uuids: set[str] = set()
         all_uuids = (all_uuids | {ip_node_uuid}) if ip_node_uuid else all_uuids

--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -40,25 +40,18 @@ class PrefixUtilizationGetter:
         )
         await query.execute(db=self.db)
 
-        for result in query.get_results():
-            prefix_node = result.get_node("pfx")
-            prefix_id = str(prefix_node.get("uuid"))
-            branch_name = str(result.get("branch"))
-            child_node = result.get_node("child")
-            if InfrahubKind.IPADDRESS in child_node.labels:
+        for item in query.get_data():
+            if InfrahubKind.IPADDRESS in item.child_labels:
                 child_type = PrefixMemberType.ADDRESS
             else:
                 child_type = PrefixMemberType.PREFIX
-            child_value_node = result.get_node("av")
-            child_prefixlen = child_value_node.get("prefixlen")
-            child_ip_value = child_value_node.get("value")
 
-            if prefix_id not in self._results_by_prefix_id:
-                self._results_by_prefix_id[prefix_id] = {}
-            if branch_name not in self._results_by_prefix_id[prefix_id]:
-                self._results_by_prefix_id[prefix_id][branch_name] = []
-            self._results_by_prefix_id[prefix_id][branch_name].append(
-                PrefixChildDetails(child_type=child_type, prefixlen=child_prefixlen, ip_value=child_ip_value)
+            if item.prefix_uuid not in self._results_by_prefix_id:
+                self._results_by_prefix_id[item.prefix_uuid] = {}
+            if item.branch not in self._results_by_prefix_id[item.prefix_uuid]:
+                self._results_by_prefix_id[item.prefix_uuid][item.branch] = []
+            self._results_by_prefix_id[item.prefix_uuid][item.branch].append(
+                PrefixChildDetails(child_type=child_type, prefixlen=item.prefixlen, ip_value=item.ip_value)
             )
 
     async def get_children(

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Iterable
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.graph.schema import GraphAttributeIPHostNode, GraphAttributeIPNetworkNode
 from infrahub.core.ipam.constants import AllIPTypes, IPAddressType, IPNetworkType
-from infrahub.core.query import QueryType
+from infrahub.core.query import QueryResult, QueryType
 from infrahub.core.registry import registry
 from infrahub.core.utils import convert_ip_to_binary_str
 
@@ -242,6 +242,48 @@ async def get_ip_addresses(
     return query.get_addresses()
 
 
+@dataclass(frozen=True)
+class IPPrefixUtilizationResult:
+    """Result from IPPrefixUtilization containing prefix child allocation data."""
+
+    prefix_uuid: str
+    """UUID of the parent prefix node."""
+
+    child_uuid: str
+    """UUID of the child node (prefix or address)."""
+
+    child_kind: str
+    """Kind/type of the child node."""
+
+    child_labels: tuple[str, ...]
+    """Labels of the child node (used to determine if IPADDRESS or IPPREFIX)."""
+
+    ip_value: str
+    """IP value (address or prefix) of the child."""
+
+    prefixlen: int
+    """Prefix length of the child IP value."""
+
+    branch: str
+    """Branch name where this allocation exists."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> IPPrefixUtilizationResult:
+        """Convert raw QueryResult to typed dataclass."""
+        pfx = result.get_node("pfx")
+        child = result.get_node("child")
+        av = result.get_node("av")
+        return cls(
+            prefix_uuid=str(pfx.get("uuid")),
+            child_uuid=str(child.get("uuid")),
+            child_kind=child.get("kind"),
+            child_labels=tuple(child.labels),
+            ip_value=av.get("value"),
+            prefixlen=av.get("prefixlen"),
+            branch=str(result.get("branch")),
+        )
+
+
 class IPPrefixUtilization(Query):
     name = "ipprefix_utilization_prefix"
     type = QueryType.READ
@@ -314,6 +356,59 @@ class IPPrefixUtilization(Query):
         }
         self.return_labels = ["pfx", "child", "av", "branch_level", "branch"]
         self.add_to_query(query)
+
+    def get_data(self) -> list[IPPrefixUtilizationResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of IPPrefixUtilizationResult containing prefix child allocation data.
+        """
+        return [IPPrefixUtilizationResult.from_db(result) for result in self.get_results()]
+
+
+@dataclass(frozen=True)
+class IPPrefixReconcileQueryResult:
+    """Result from IPPrefixReconcileQuery containing IP reconciliation data."""
+
+    ip_node_uuid: str | None
+    """UUID of the IP node being reconciled, or None if not found."""
+
+    current_parent_uuid: str | None
+    """UUID of the current parent prefix, or None if no parent exists."""
+
+    calculated_parent_uuid: str | None
+    """UUID of the calculated correct parent prefix, or None if should be top-level."""
+
+    current_children_uuids: tuple[str, ...]
+    """UUIDs of current child prefixes/addresses."""
+
+    calculated_children_uuids: tuple[str, ...]
+    """UUIDs of calculated correct child prefixes/addresses."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> IPPrefixReconcileQueryResult:
+        """Convert raw QueryResult to typed dataclass."""
+
+        def get_optional_node_uuid(label: str) -> str | None:
+            """Extract UUID from an optional node (may be None from OPTIONAL MATCH)."""
+            node = result.get(label)
+            return str(node.get("uuid")) if node and node.get("uuid") else None
+
+        def get_collection_uuids(label: str) -> tuple[str, ...]:
+            """Extract UUIDs from a node collection (may contain None from COLLECT)."""
+            return tuple(
+                str(n.get("uuid"))
+                for n in result.get_node_collection(label)
+                if n and n.get("uuid")
+            )
+
+        return cls(
+            ip_node_uuid=get_optional_node_uuid("ip_node"),
+            current_parent_uuid=get_optional_node_uuid("current_parent"),
+            calculated_parent_uuid=get_optional_node_uuid("new_parent"),
+            current_children_uuids=get_collection_uuids("current_children"),
+            calculated_children_uuids=get_collection_uuids("new_children"),
+        )
 
 
 class IPPrefixReconcileQuery(Query):
@@ -702,44 +797,14 @@ class IPPrefixReconcileQuery(Query):
         self.order_by = ["ip_node.uuid"]
         self.return_labels = ["ip_node", "current_parent", "current_children", "new_parent", "new_children"]
 
-    def _get_uuid_from_query(self, node_name: str) -> str | None:
+    def get_data(self) -> IPPrefixReconcileQueryResult | None:
+        """Return single result as typed dataclass instance.
+
+        Returns:
+            IPPrefixReconcileQueryResult containing reconciliation data,
+            or None if no results found.
+        """
         results = list(self.get_results())
         if not results:
             return None
-        result = results[0]
-        node = result.get(node_name)
-        if not node:
-            return None
-        node_uuid = node.get("uuid")
-        if node_uuid:
-            return str(node_uuid)
-        return None
-
-    def _get_uuids_from_query_list(self, alias_name: str) -> list[str]:
-        results = list(self.get_results())
-        if not results:
-            return []
-        result = results[0]
-        element_uuids = []
-        for element in result.get(alias_name):
-            if not element:
-                continue
-            element_uuid = element.get("uuid")
-            if element_uuid:
-                element_uuids.append(str(element_uuid))
-        return element_uuids
-
-    def get_ip_node_uuid(self) -> str | None:
-        return self._get_uuid_from_query("ip_node")
-
-    def get_current_parent_uuid(self) -> str | None:
-        return self._get_uuid_from_query("current_parent")
-
-    def get_calculated_parent_uuid(self) -> str | None:
-        return self._get_uuid_from_query("new_parent")
-
-    def get_current_children_uuids(self) -> list[str]:
-        return self._get_uuids_from_query_list("current_children")
-
-    def get_calculated_children_uuids(self) -> list[str]:
-        return self._get_uuids_from_query_list("new_children")
+        return IPPrefixReconcileQueryResult.from_db(results[0])

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -396,11 +396,7 @@ class IPPrefixReconcileQueryResult:
 
         def get_collection_uuids(label: str) -> tuple[str, ...]:
             """Extract UUIDs from a node collection (may contain None from COLLECT)."""
-            return tuple(
-                str(n.get("uuid"))
-                for n in result.get_node_collection(label)
-                if n and n.get("uuid")
-            )
+            return tuple(str(n.get("uuid")) for n in result.get_node_collection(label) if n and n.get("uuid"))
 
         return cls(
             ip_node_uuid=get_optional_node_uuid("ip_node"),

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -14,7 +14,7 @@ from infrahub.core.changelog.models import (
 )
 from infrahub.core.constants import InfrahubKind, MetadataOptions, RelationshipDirection, RelationshipStatus
 from infrahub.core.constants.database import DatabaseEdgeType
-from infrahub.core.query import Query, QueryType
+from infrahub.core.query import Query, QueryResult, QueryType
 from infrahub.core.query.subquery import build_subquery_filter, build_subquery_order
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import extract_field_filters
@@ -1124,6 +1124,25 @@ class RelationshipGetByIdentifierQuery(Query):
             yield data
 
 
+@dataclass(frozen=True)
+class RelationshipCountPerNodeResult:
+    """Result from RelationshipCountPerNodeQuery containing peer count info."""
+
+    peer_uuid: str
+    """UUID of the peer node."""
+
+    count: int
+    """Number of relationship peers for this node."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> RelationshipCountPerNodeResult:
+        """Convert raw QueryResult to typed dataclass."""
+        return cls(
+            peer_uuid=result.get_as_type("peer_node.uuid", str),
+            count=result.get_as_type("nbr_peers", int),
+        )
+
+
 class RelationshipCountPerNodeQuery(Query):
     name = "relationship_count_per_node"
     type: QueryType = QueryType.READ
@@ -1172,16 +1191,51 @@ class RelationshipCountPerNodeQuery(Query):
         self.order_by = ["peer_node.uuid"]
         self.return_labels = ["peer_node.uuid", "COUNT(peer_node.uuid) as nbr_peers"]
 
+    def get_data(self) -> list[RelationshipCountPerNodeResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of RelationshipCountPerNodeResult containing peer count info.
+        """
+        return [RelationshipCountPerNodeResult.from_db(result) for result in self.get_results()]
+
     async def get_count_per_peer(self) -> dict[str, int]:
         data: dict[str, int] = {}
-        for result in self.results:
-            data[result.get("peer_node.uuid")] = result.get("nbr_peers")
+        for item in self.get_data():
+            data[item.peer_uuid] = item.count
 
         for node_id in self.node_ids:
             if node_id not in data:
                 data[node_id] = 0
 
         return data
+
+
+@dataclass(frozen=True)
+class RelationshipDeleteAllQueryResult:
+    """Result from RelationshipDeleteAllQuery containing deleted relationship info."""
+
+    uuid: str
+    """UUID of the peer node whose relationship was deleted."""
+
+    kind: str
+    """Kind/type of the peer node."""
+
+    rel_identifier: str
+    """Relationship schema identifier name."""
+
+    rel_direction: str
+    """Direction of the relationship ("outbound" or "inbound")."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> RelationshipDeleteAllQueryResult:
+        """Convert raw QueryResult to typed dataclass."""
+        return cls(
+            uuid=result.get_as_type("uuid", str),
+            kind=result.get_as_type("kind", str),
+            rel_identifier=result.get_as_type("rel_identifier", str),
+            rel_direction=result.get_as_type("rel_direction", str),
+        )
 
 
 class RelationshipDeleteAllQuery(Query):
@@ -1314,50 +1368,52 @@ class RelationshipDeleteAllQuery(Query):
         }
         self.add_to_query(query)
 
+    def get_data(self) -> list[RelationshipDeleteAllQueryResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of RelationshipDeleteAllQueryResult containing deleted relationship info.
+        """
+        return [RelationshipDeleteAllQueryResult.from_db(result) for result in self.get_results()]
+
     def get_deleted_relationships_changelog(
         self, node_schema: NodeSchema
     ) -> list[RelationshipCardinalityOneChangelog | RelationshipCardinalityManyChangelog]:
-        rel_identifier_to_changelog_mapper = {}
+        rel_identifier_to_changelog_mapper: dict[str, ChangelogRelationshipMapper] = {}
 
-        for result in self.get_results():
-            peer_uuid = result.data["uuid"]
-            if peer_uuid == self.node_id:
+        for item in self.get_data():
+            if item.uuid == self.node_id:
                 continue
 
-            rel_identifier = result.data["rel_identifier"]
-            kind = result.data["kind"]
             deleted_rel_schemas = [
-                rel_schema for rel_schema in node_schema.relationships if rel_schema.identifier == rel_identifier
+                rel_schema for rel_schema in node_schema.relationships if rel_schema.identifier == item.rel_identifier
             ]
 
             if len(deleted_rel_schemas) == 0:
                 continue  # TODO Unidirectional relationship changelog should be handled, cf IFC-1319.
 
             if len(deleted_rel_schemas) > 2:
-                log.error(f"Duplicated relationship schema with identifier {rel_identifier}")
+                log.error(f"Duplicated relationship schema with identifier {item.rel_identifier}")
                 continue
 
             if len(deleted_rel_schemas) == 2:
                 # Hierarchical schema nodes have 2 relationships with `parent_child` identifiers,
                 # which are differentiated by their direction within the database.
-                # assert rel_identifier != PARENT_CHILD_IDENTIFIER
-
-                rel_direction = result.data["rel_direction"]
                 deleted_rel_schema = (
                     deleted_rel_schemas[0]
-                    if deleted_rel_schemas[0].direction.value == rel_direction
+                    if deleted_rel_schemas[0].direction.value == item.rel_direction
                     else deleted_rel_schemas[1]
                 )
             else:
                 deleted_rel_schema = deleted_rel_schemas[0]
 
             try:
-                changelog_mapper = rel_identifier_to_changelog_mapper[rel_identifier]
+                changelog_mapper = rel_identifier_to_changelog_mapper[item.rel_identifier]
             except KeyError:
                 changelog_mapper = ChangelogRelationshipMapper(schema=deleted_rel_schema)
-                rel_identifier_to_changelog_mapper[rel_identifier] = changelog_mapper
+                rel_identifier_to_changelog_mapper[item.rel_identifier] = changelog_mapper
 
-            changelog_mapper.delete_relationship(peer_id=peer_uuid, peer_kind=kind, rel_schema=deleted_rel_schema)
+            changelog_mapper.delete_relationship(peer_id=item.uuid, peer_kind=item.kind, rel_schema=deleted_rel_schema)
 
         return [changelog_mapper.changelog for changelog_mapper in rel_identifier_to_changelog_mapper.values()]
 

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -1367,6 +1367,7 @@ class RelationshipDeleteAllQuery(Query):
             "peer_node_metadata_update": peer_node_metadata_update,
         }
         self.add_to_query(query)
+        self.return_labels = ["uuid", "kind", "rel_identifier", "rel_direction"]
 
     def get_data(self) -> list[RelationshipDeleteAllQueryResult]:
         """Return results as typed dataclass instances.

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -1,23 +1,73 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generator
-
-from pydantic import BaseModel, ConfigDict
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipStatus
-from infrahub.core.query import Query, QueryType
+from infrahub.core.query import Query, QueryResult, QueryType
 
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreNumberPool
     from infrahub.database import InfrahubDatabase
 
 
-class NumberPoolIdentifierData(BaseModel):
-    model_config = ConfigDict(frozen=True)
+@dataclass(frozen=True)
+class NumberPoolIdentifierData:
+    """Result containing a pool reservation value and its identifier."""
 
     value: int
     identifier: str
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> NumberPoolIdentifierData:
+        """Convert raw QueryResult to typed dataclass."""
+        return cls(
+            value=result.get_as_type("value", return_type=int),
+            identifier=result.get_as_type("identifier", return_type=str),
+        )
+
+
+@dataclass(frozen=True)
+class PoolIdentifierResult:
+    """Result from pool identifier queries containing allocation and identifier data."""
+
+    allocated_uuid: str
+    """UUID of the allocated resource (address or prefix)."""
+
+    identifier: str
+    """Identifier used for the reservation."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> PoolIdentifierResult:
+        """Convert raw QueryResult to typed dataclass."""
+        return cls(
+            allocated_uuid=result.get_as_type("allocated_uuid", str),
+            identifier=result.get_as_type("identifier", str),
+        )
+
+
+@dataclass(frozen=True)
+class NumberPoolAllocatedResult:
+    """Result from NumberPoolGetAllocated containing allocated number info."""
+
+    id: str
+    """UUID of the node with the allocated number."""
+
+    branch: str
+    """Branch where the allocation exists."""
+
+    value: int
+    """The allocated number value."""
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> NumberPoolAllocatedResult:
+        """Convert raw QueryResult to typed dataclass."""
+        return cls(
+            id=result.get_as_type("id", str),
+            branch=result.get_as_type("branch", str),
+            value=result.get_as_type("value", int),
+        )
 
 
 class IPAddressPoolGetIdentifiers(Query):
@@ -44,7 +94,15 @@ class IPAddressPoolGetIdentifiers(Query):
         WHERE allocated.uuid in $addresses
         """ % {"ipaddress_pool": InfrahubKind.IPADDRESSPOOL}
         self.add_to_query(query)
-        self.return_labels = ["allocated", "reservation"]
+        self.return_labels = ["allocated.uuid AS allocated_uuid", "reservation.identifier AS identifier"]
+
+    def get_data(self) -> list[PoolIdentifierResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of PoolIdentifierResult containing allocation and identifier data.
+        """
+        return [PoolIdentifierResult.from_db(result) for result in self.get_results()]
 
 
 class IPAddressPoolGetReserved(Query):
@@ -159,6 +217,14 @@ class NumberPoolGetAllocated(Query):
         self.return_labels = ["n.uuid as id", "hv.branch as branch", "av.value as value"]
         self.order_by = ["av.value"]
 
+    def get_data(self) -> list[NumberPoolAllocatedResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of NumberPoolAllocatedResult containing allocated number info.
+        """
+        return [NumberPoolAllocatedResult.from_db(result) for result in self.get_results()]
+
 
 class NumberPoolGetReserved(Query):
     name = "numberpool_get_reserved"
@@ -205,17 +271,31 @@ class NumberPoolGetReserved(Query):
         self.return_labels = ["reservation.value AS value", "r.identifier AS identifier"]
 
     def get_reservation(self) -> int | None:
+        """Return the reserved value for a single identifier.
+
+        Returns:
+            The reserved integer value, or None if no reservation exists.
+        """
         result = self.get_result()
         if result:
             return result.get_as_optional_type("value", return_type=int)
         return None
 
+    def get_data(self) -> list[NumberPoolIdentifierData]:
+        """Return all reservations as typed dataclass instances.
+
+        Returns:
+            List of NumberPoolIdentifierData containing value and identifier.
+        """
+        return [NumberPoolIdentifierData.from_db(result) for result in self.get_results()]
+
     def get_reservations(self) -> Generator[NumberPoolIdentifierData]:
-        for result in self.results:
-            yield NumberPoolIdentifierData.model_construct(
-                value=result.get_as_type("value", return_type=int),
-                identifier=result.get_as_type("identifier", return_type=str),
-            )
+        """Yield reservations as typed dataclass instances.
+
+        Yields:
+            NumberPoolIdentifierData for each reservation.
+        """
+        yield from self.get_data()
 
 
 class PoolChangeReserved(Query):
@@ -282,7 +362,6 @@ This will be especially important as we want to support upsert with NumberPool
 class NumberPoolGetUsed(Query):
     name = "number_pool_get_used"
     type = QueryType.READ
-    return_model = NumberPoolIdentifierData
 
     def __init__(
         self,
@@ -331,11 +410,13 @@ class NumberPoolGetUsed(Query):
         self.order_by = ["value"]
 
     def iter_results(self) -> Generator[NumberPoolIdentifierData]:
-        for result in self.results:
-            yield self.return_model.model_construct(
-                value=result.get_as_type("value", return_type=int),
-                identifier=result.get_as_type("identifier", return_type=str),
-            )
+        """Yield used pool values as typed dataclass instances.
+
+        Yields:
+            NumberPoolIdentifierData for each used value in the pool.
+        """
+        for result in self.get_results():
+            yield NumberPoolIdentifierData.from_db(result)
 
 
 class NumberPoolSetReserved(Query):
@@ -405,7 +486,15 @@ class PrefixPoolGetIdentifiers(Query):
         WHERE allocated.uuid in $prefixes
         """ % {"ipaddress_pool": InfrahubKind.IPPREFIXPOOL}
         self.add_to_query(query)
-        self.return_labels = ["allocated", "reservation"]
+        self.return_labels = ["allocated.uuid AS allocated_uuid", "reservation.identifier AS identifier"]
+
+    def get_data(self) -> list[PoolIdentifierResult]:
+        """Return results as typed dataclass instances.
+
+        Returns:
+            List of PoolIdentifierResult containing allocation and identifier data.
+        """
+        return [PoolIdentifierResult.from_db(result) for result in self.get_results()]
 
 
 class PrefixPoolGetReserved(Query):

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -130,17 +130,16 @@ class PoolAllocated(ObjectType):
             node_fields = edges.get("node", {})
 
             nodes = []
-            for result in query.get_results():
-                child_node = result.get_node("child")
-                child_value_node = result.get_node("av")
-                node_id = str(child_node.get("uuid"))
-
-                child_ip_value = child_value_node.get("value")
-                kind = child_node.get("kind")
-                branch_name = str(result.get("branch"))
-
+            for item in query.get_data():
                 nodes.append(
-                    {"node": {"id": node_id, "kind": kind, "branch": branch_name, "display_label": child_ip_value}}
+                    {
+                        "node": {
+                            "id": item.child_uuid,
+                            "kind": item.child_kind,
+                            "branch": item.branch,
+                            "display_label": item.ip_value,
+                        }
+                    }
                 )
 
             if "identifier" in node_fields:
@@ -158,10 +157,8 @@ class PoolAllocated(ObjectType):
                 await identifier_query.execute(db=graphql_context.db)
 
                 reservations = {}
-                for result in identifier_query.get_results():
-                    reservation = result.get_rel("reservation")
-                    allocated = result.get_node("allocated")
-                    reservations[allocated.get("uuid")] = reservation.get("identifier")
+                for item in identifier_query.get_data():
+                    reservations[item.allocated_uuid] = item.identifier
 
                 for node in nodes:
                     node["node"]["identifier"] = reservations.get(node["node"]["id"])
@@ -284,13 +281,13 @@ async def resolve_number_pool_allocation(
     if "edges" in fields:
         await query.execute(db=db)
         edges = []
-        for entry in query.results:
+        for item in query.get_data():
             node = {
                 "node": {
-                    "id": entry.get_as_optional_type("id", str),
+                    "id": item.id,
                     "kind": pool.node.value,  # type: ignore[attr-defined]
-                    "branch": entry.get_as_optional_type("branch", str),
-                    "display_label": entry.get_as_optional_type("value", int),
+                    "branch": item.branch,
+                    "display_label": item.value,
                 }
             }
             edges.append(node)

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from graphene import BigInt, Field, Float, Int, List, NonNull, ObjectType, String
 
@@ -129,7 +129,7 @@ class PoolAllocated(ObjectType):
 
             node_fields = edges.get("node", {})
 
-            nodes = []
+            nodes: list[dict[str, dict[str, str | None]]] = []
             for item in query.get_data():
                 nodes.append(
                     {
@@ -151,17 +151,21 @@ class PoolAllocated(ObjectType):
                 identifier_query_class = identifier_query_map.get(pool.get_kind())
                 if not identifier_query_class:
                     raise ValidationError(input_value=f"This query doesn't get support {pool.get_kind()}")
-                identifier_query = await identifier_query_class.init(
-                    db=graphql_context.db, at=graphql_context.at, pool_id=pool_id, allocated=allocated_ids
+                identifier_query = cast(
+                    "IPAddressPoolGetIdentifiers | PrefixPoolGetIdentifiers",
+                    await identifier_query_class.init(
+                        db=graphql_context.db, at=graphql_context.at, pool_id=pool_id, allocated=allocated_ids
+                    ),
                 )
                 await identifier_query.execute(db=graphql_context.db)
 
-                reservations = {}
-                for item in identifier_query.get_data():
-                    reservations[item.allocated_uuid] = item.identifier
+                reservations: dict[str, str] = {}
+                for identifier_item in identifier_query.get_data():
+                    reservations[identifier_item.allocated_uuid] = identifier_item.identifier
 
                 for node in nodes:
-                    node["node"]["identifier"] = reservations.get(node["node"]["id"])
+                    node_id = cast("str", node["node"]["id"])
+                    node["node"]["identifier"] = reservations.get(node_id)
 
             response["edges"] = nodes
 

--- a/backend/infrahub/pools/number.py
+++ b/backend/infrahub/pools/number.py
@@ -37,14 +37,7 @@ class NumberUtilizationGetter:
         query = await NumberPoolGetAllocated.init(db=self.db, pool=self.pool, branch=self.branch, branch_agnostic=True)
         await query.execute(db=self.db)
 
-        self.used = [
-            UsedNumber(
-                number=result.get_as_type(label="value", return_type=int),
-                branch=result.get_as_type(label="branch", return_type=str),
-            )
-            for result in query.results
-            if result.get_as_optional_type(label="value", return_type=int) is not None
-        ]
+        self.used = [UsedNumber(number=item.value, branch=item.branch) for item in query.get_data()]
 
         self.used_default_branch = {entry.number for entry in self.used if entry.branch == registry.default_branch}
         used_branches = {entry.number for entry in self.used if entry.branch != registry.default_branch}

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -509,9 +509,7 @@ async def test_reconcile_parent_child_identification(
             assert data.calculated_parent_uuid is None
         else:
             assert parent == prefix_id_map.get(data.calculated_parent_uuid)
-        assert prefix_children == {
-            prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map
-        }
+        assert prefix_children == {prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map}
         assert address_children == {
             address_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in address_id_map
         }

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -32,16 +32,18 @@ async def test_ipprefix_reconcile_query_simple(db: InfrahubDatabase, default_bra
     query = await IPPrefixReconcileQuery.init(db=db, branch=default_branch, ip_value=ip_network, namespace=namespace)
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == prefix_140.id
-    assert query.get_current_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_current_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == prefix_140.id
+    assert data.current_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.current_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
         ip_dataset_01["address10"].id,
     }
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -58,11 +60,13 @@ async def test_ipprefix_reconcile_query_for_new_prefix(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net140"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net140"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -79,11 +83,13 @@ async def test_ipprefix_reconcile_query_for_new_address(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net145"].id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net145"].id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_ipprefix_reconcile_query_for_new_address_with_node(
@@ -100,11 +106,13 @@ async def test_ipprefix_reconcile_query_for_new_address_with_node(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == new_address.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net145"].id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == new_address.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net145"].id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_parents(
@@ -116,11 +124,13 @@ async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_parents
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net143"].id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net143"].id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_children(
@@ -132,11 +142,13 @@ async def test_ipprefix_reconcile_query_for_new_prefix_multiple_possible_childre
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert query.get_calculated_children_uuids() == [ip_dataset_01["net140"].id]
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert data.calculated_children_uuids == (ip_dataset_01["net140"].id,)
 
 
 async def test_ipprefix_reconcile_query_for_new_address_multiple_possible_children(
@@ -148,11 +160,13 @@ async def test_ipprefix_reconcile_query_for_new_address_multiple_possible_childr
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_ipprefix_reconcile_query_for_new_prefix_exactly_one_possible_child_address(
@@ -164,11 +178,13 @@ async def test_ipprefix_reconcile_query_for_new_prefix_exactly_one_possible_chil
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net140"].id
-    assert query.get_calculated_children_uuids() == [ip_dataset_01["address10"].id]
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net140"].id
+    assert data.calculated_children_uuids == (ip_dataset_01["address10"].id,)
 
 
 async def test_ipprefix_reconcile_query_for_new_prefix_v6(
@@ -180,11 +196,13 @@ async def test_ipprefix_reconcile_query_for_new_prefix_v6(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net161"].id
-    assert query.get_calculated_children_uuids() == [ip_dataset_01["net162"].id]
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net161"].id
+    assert data.calculated_children_uuids == (ip_dataset_01["net162"].id,)
 
 
 async def test_ipprefix_reconcile_query_for_new_address_v6(
@@ -196,11 +214,13 @@ async def test_ipprefix_reconcile_query_for_new_address_v6(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net162"].id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net162"].id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_ipprefix_reconcile_query_get_deleted_node_by_prefix(
@@ -215,11 +235,13 @@ async def test_ipprefix_reconcile_query_get_deleted_node_by_prefix(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -243,11 +265,13 @@ async def test_ipprefix_reconcile_query_get_deleted_node_by_uuid(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == net140.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == net140.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -277,11 +301,13 @@ async def test_ipprefix_reconcile_query_deleted_children_ignored_on_branch(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == net140_branch.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == net140_branch.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         # should not be included b/c the address was deleted
@@ -310,11 +336,13 @@ async def test_ipprefix_reconcile_query_deleted_parent_ignored_on_branch(
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == net140_branch.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() is None
-    assert set(query.get_calculated_children_uuids()) == {
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == net140_branch.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid is None
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -348,10 +376,12 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == new_parent_branch.id
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == new_parent_branch.id
     expected_children = {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
@@ -359,17 +389,19 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
         ip_dataset_01["address10"].id,
         new_address_branch.id,
     }
-    assert set(query.get_calculated_children_uuids()) == expected_children
+    assert set(data.calculated_children_uuids) == expected_children
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=branch2, ip_value=ipaddress.ip_interface("10.10.0.1"), namespace=ns1_id
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == new_address_branch.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == new_parent_branch.id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == new_address_branch.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == new_parent_branch.id
+    assert data.calculated_children_uuids == ()
 
     await branch2.rebase(db=db)
 
@@ -378,10 +410,12 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() is None
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == new_parent_branch.id
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid is None
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == new_parent_branch.id
 
     expected_children_after_rebase = {
         ip_dataset_01["net142"].id,
@@ -390,17 +424,19 @@ async def test_branch_updates_respected(db: InfrahubDatabase, default_branch: Br
         new_address_branch.id,
         new_address_main.id,
     }
-    assert set(query.get_calculated_children_uuids()) == expected_children_after_rebase
+    assert set(data.calculated_children_uuids) == expected_children_after_rebase
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=branch2, ip_value=ipaddress.ip_interface("10.10.0.2"), namespace=ns1_id
     )
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == new_address_main.id
-    assert query.get_current_parent_uuid() is None
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == new_parent_branch.id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == new_address_main.id
+    assert data.current_parent_uuid is None
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == new_parent_branch.id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_reconcile_parent_child_identification(
@@ -444,12 +480,13 @@ async def test_reconcile_parent_child_identification(
             db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=prefix_to_check
         )
         await query.execute(db=db)
-        calculated_parent_uuid = query.get_calculated_parent_uuid()
+        data = query.get_data()
+        assert data is not None
         if parent is None:
-            assert calculated_parent_uuid is None
+            assert data.calculated_parent_uuid is None
         else:
-            assert parent == prefix_id_map.get(calculated_parent_uuid)
-        assert children == {prefix_id_map.get(ccu) for ccu in query.get_calculated_children_uuids()}
+            assert parent == prefix_id_map.get(data.calculated_parent_uuid)
+        assert children == {prefix_id_map.get(ccu) for ccu in data.calculated_children_uuids}
 
     for prefix_to_check, parent, prefix_children, address_children in (
         (ipaddress.ip_network("136.136.136.136/32"), "136.136.136.128/28", set(), {"136.136.136.136/32"}),
@@ -466,16 +503,17 @@ async def test_reconcile_parent_child_identification(
         )
         await query.execute(db=db)
 
-        calculated_parent_uuid = query.get_calculated_parent_uuid()
+        data = query.get_data()
+        assert data is not None
         if parent is None:
-            assert calculated_parent_uuid is None
+            assert data.calculated_parent_uuid is None
         else:
-            assert parent == prefix_id_map.get(calculated_parent_uuid)
+            assert parent == prefix_id_map.get(data.calculated_parent_uuid)
         assert prefix_children == {
-            prefix_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in prefix_id_map
+            prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map
         }
         assert address_children == {
-            address_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in address_id_map
+            address_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in address_id_map
         }
 
 
@@ -502,8 +540,10 @@ async def test_address_cannot_be_parent(
             db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ip_value
         )
         await query.execute(db=db)
-        assert query.get_calculated_parent_uuid() is None
-        assert query.get_calculated_children_uuids() == []
+        data = query.get_data()
+        assert data is not None
+        assert data.calculated_parent_uuid is None
+        assert data.calculated_children_uuids == ()
 
 
 async def test_adjacent_parents_and_addresses(
@@ -536,70 +576,78 @@ async def test_adjacent_parents_and_addresses(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.0.2.0/32")
     )
     await query.execute(db=db)
-    assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/31"
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/31"
+    assert data.calculated_children_uuids == ()
     # test prefix 192.0.2.0/31
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.0.2.0/31")
     )
     await query.execute(db=db)
-    assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/30"
-    assert {address_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in address_id_map} == {
+    data = query.get_data()
+    assert data is not None
+    assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/30"
+    assert {address_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in address_id_map} == {
         "192.0.2.0/31",
         "192.0.2.1/31",
     }
-    assert {prefix_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in prefix_id_map} == {
-        "192.0.2.0/32"
-    }
+    assert {prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map} == {"192.0.2.0/32"}
     # test prefix 192.0.2.0/30
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.0.2.0/30")
     )
     await query.execute(db=db)
-    assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/29"
-    assert {address_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in address_id_map} == {
+    data = query.get_data()
+    assert data is not None
+    assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/29"
+    assert {address_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in address_id_map} == {
         "192.0.2.2/31",
         "192.0.2.3/31",
     }
-    assert {prefix_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in prefix_id_map} == {
-        "192.0.2.0/31"
-    }
+    assert {prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map} == {"192.0.2.0/31"}
     # test prefix 192.0.2.0/29
     query = await IPPrefixReconcileQuery.init(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.0.2.0/29")
     )
     await query.execute(db=db)
-    assert query.get_calculated_parent_uuid() is None
-    assert {address_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in address_id_map} == {
+    data = query.get_data()
+    assert data is not None
+    assert data.calculated_parent_uuid is None
+    assert {address_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in address_id_map} == {
         "192.0.2.4/31",
         "192.0.2.5/31",
         "192.0.2.6/31",
     }
-    assert {prefix_id_map[ccu] for ccu in query.get_calculated_children_uuids() if ccu in prefix_id_map} == {
-        "192.0.2.0/30"
-    }
+    assert {prefix_id_map[ccu] for ccu in data.calculated_children_uuids if ccu in prefix_id_map} == {"192.0.2.0/30"}
     # test children address find correct parent
     for address in ("192.0.2.0/31", "192.0.2.1/31"):
         query = await IPPrefixReconcileQuery.init(
             db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_interface(address)
         )
         await query.execute(db=db)
-        assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/31"
-        assert query.get_calculated_children_uuids() == []
+        data = query.get_data()
+        assert data is not None
+        assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/31"
+        assert data.calculated_children_uuids == ()
     for address in ("192.0.2.2/31", "192.0.2.3/31"):
         query = await IPPrefixReconcileQuery.init(
             db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_interface(address)
         )
         await query.execute(db=db)
-        assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/30"
-        assert query.get_calculated_children_uuids() == []
+        data = query.get_data()
+        assert data is not None
+        assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/30"
+        assert data.calculated_children_uuids == ()
     for address in ("192.0.2.4/31", "192.0.2.5/31", "192.0.2.6/31"):
         query = await IPPrefixReconcileQuery.init(
             db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_interface(address)
         )
         await query.execute(db=db)
-        assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/29"
-        assert query.get_calculated_children_uuids() == []
+        data = query.get_data()
+        assert data is not None
+        assert prefix_id_map[data.calculated_parent_uuid] == "192.0.2.0/29"
+        assert data.calculated_children_uuids == ()
 
 
 async def test_root_ip_prefix_exists_reconcile(
@@ -620,8 +668,10 @@ async def test_root_ip_prefix_exists_reconcile(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.168.0.0/16")
     )
     await query.execute(db=db)
-    assert query.get_calculated_parent_uuid() == root_prefix_node.id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.calculated_parent_uuid == root_prefix_node.id
+    assert data.calculated_children_uuids == ()
 
 
 async def test_root_ip_prefix_added_reconcile(
@@ -642,8 +692,10 @@ async def test_root_ip_prefix_added_reconcile(
         db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("0.0.0.0/0")
     )
     await query.execute(db=db)
-    assert query.get_calculated_parent_uuid() is None
-    assert query.get_calculated_children_uuids() == [child_prefix_node.id]
+    data = query.get_data()
+    assert data is not None
+    assert data.calculated_parent_uuid is None
+    assert data.calculated_children_uuids == (child_prefix_node.id,)
 
 
 async def test_reconcile_query_on_migrated_kind_node(
@@ -685,12 +737,14 @@ async def test_reconcile_query_on_migrated_kind_node(
     query = await IPPrefixReconcileQuery.init(db=db, branch=branch, ip_value=ip_network, namespace=namespace)
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == prefix_140.id
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == prefix_140.id
     # the wrong parent and wrong child confirm that we retrieved the correct Node from the database: the IpamIPPrefixTwo instance
-    assert query.get_current_parent_uuid() == wrong_parent.id
-    assert set(query.get_current_children_uuids()) == {wrong_child.id}
-    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
-    assert set(query.get_calculated_children_uuids()) == {
+    assert data.current_parent_uuid == wrong_parent.id
+    assert set(data.current_children_uuids) == {wrong_child.id}
+    assert data.calculated_parent_uuid == ip_dataset_01["net146"].id
+    assert set(data.calculated_children_uuids) == {
         ip_dataset_01["net142"].id,
         ip_dataset_01["net144"].id,
         ip_dataset_01["net145"].id,
@@ -728,8 +782,10 @@ async def test_reconcile_query_for_address_with_prefix_added_on_branch_and_merge
     query = await IPPrefixReconcileQuery.init(db=db, branch=branch, ip_value=ip_interface, namespace=namespace)
     await query.execute(db=db)
 
-    assert query.get_ip_node_uuid() == address_10.id
-    assert query.get_current_parent_uuid() == new_prefix.id
-    assert query.get_current_children_uuids() == []
-    assert query.get_calculated_parent_uuid() == new_prefix.id
-    assert query.get_calculated_children_uuids() == []
+    data = query.get_data()
+    assert data is not None
+    assert data.ip_node_uuid == address_10.id
+    assert data.current_parent_uuid == new_prefix.id
+    assert data.current_children_uuids == ()
+    assert data.calculated_parent_uuid == new_prefix.id
+    assert data.calculated_children_uuids == ()

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -50,23 +50,55 @@ Pydantic is appropriate when you need:
 
 ### Dataclasses (Internal Structures)
 
-Use dataclasses for internal data structures that don't require validation or serialization:
+Use dataclasses for internal data structures that don't require validation or serialization.
+
+**Prefer frozen dataclasses** (`frozen=True`) when instances don't need to be mutated after creation. Frozen dataclasses are immutable, memory efficient, hashable, and make code easier to reason about:
 
 ```python
-# ✅ Good - Internal data transfer
+# ✅ Good - Frozen dataclass for immutable data
 from dataclasses import dataclass
 
-@dataclass
+@dataclass(frozen=True)
 class QueryContext:
     branch_name: str
     at_time: str | None = None
     include_deleted: bool = False
 
+# ✅ Good - Mutable dataclass only when mutation is required
 @dataclass
-class NodeDiff:
+class NodeDiffBuilder:
     node_id: str
-    changed_attributes: list[str]
-    previous_values: dict[str, Any]
+    changed_attributes: list[str]  # Will be appended to during processing
+```
+
+**Document attributes with inline docstrings** below each attribute, not in the class docstring:
+
+```python
+# ✅ Good - Attribute docstrings below each field
+@dataclass(frozen=True)
+class RelationshipPeerData:
+    branch: str
+
+    source_id: UUID
+    """UUID of the Source Node."""
+
+    peer_kind: str
+    """Kind of the Peer Node."""
+
+    rel_node_db_id: str | None = None
+    """Internal DB ID of the Relationship Node."""
+
+# ❌ Bad - Attributes documented in class docstring
+@dataclass(frozen=True)
+class RelationshipPeerData:
+    """Data about a relationship peer.
+
+    Attributes:
+        source_id: UUID of the Source Node.
+        peer_id: UUID of the Peer Node.
+    """
+    source_id: UUID
+    peer_id: UUID
 ```
 
 Dataclasses are appropriate when you need:
@@ -74,6 +106,8 @@ Dataclasses are appropriate when you need:
 - Simple internal data containers
 - Lightweight objects without validation overhead
 - Data passed between internal functions/classes
+
+Use `frozen=True` unless you have a specific reason to mutate instances (e.g., builder pattern, accumulating results during iteration).
 
 ### Avoid Plain Dictionaries
 

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -174,6 +174,36 @@ class MyQuery(Query):
 - Use `str | None` for optional strings (Python 3.10+)
 - Use `list[Type]` instead of `List[Type]` (Python 3.9+)
 
+## Python Version Compatibility
+
+The `python_testcontainers` package supports Python 3.10+, while the main backend requires Python 3.12+. When writing code that may be shared or used in `python_testcontainers`, be mindful of version-specific features.
+
+### datetime.UTC (Python 3.11+)
+
+The `datetime.UTC` constant was introduced in Python 3.11. For Python 3.10 compatibility, use `timezone.utc` instead:
+
+```python
+# ❌ Bad - Python 3.11+ only
+from datetime import UTC, datetime
+now = datetime.now(UTC)
+
+# ✅ Good - Works in Python 3.10+
+from datetime import datetime, timezone
+now = datetime.now(timezone.utc)
+```
+
+### Other Version-Specific Features
+
+When using newer Python features, verify they're available in the minimum supported version:
+
+| Feature | Minimum Version |
+|---------|-----------------|
+| `datetime.UTC` | 3.11 |
+| `str \| None` union syntax | 3.10 |
+| `list[Type]` generic syntax | 3.9 |
+| `match` statements | 3.10 |
+| `Self` type hint | 3.11 (use `typing_extensions.Self` for 3.10) |
+
 ## Function Call Style
 
 Always use keyword arguments when calling functions and methods. This improves readability and makes code more resilient to parameter reordering:

--- a/dev/knowledge/backend/query-pattern.md
+++ b/dev/knowledge/backend/query-pattern.md
@@ -1,0 +1,401 @@
+# Query Pattern
+
+> Part of: `dev/knowledge/backend/` | Related: [Architecture](architecture.md)
+
+All database access in Infrahub goes through Query classes that encapsulate Cypher queries with proper parameterization, branch-awareness, and temporal versioning. Queries return typed dataclass results for type safety and clear API contracts.
+
+## Query Lifecycle
+
+### Initialization
+
+```python
+query = await MyQuery.init(db=db, branch=branch, **kwargs)
+```
+
+The `init()` classmethod calls `query_init()` for async initialization (schema lookups, etc.).
+
+### Building
+
+Queries are built by adding Cypher clauses:
+
+```python
+def __init__(self, node_id: str, **kwargs):
+    super().__init__(**kwargs)
+    self.params["node_id"] = node_id
+    self.add_to_query("MATCH (n:Node { uuid: $node_id })")
+    self.add_to_query("WHERE n.status = 'active'")
+    self.update_return_labels(["n"])
+```
+
+| Method | Purpose |
+|--------|---------|
+| `add_to_query(str)` | Append Cypher clause(s) |
+| `add_subquery(str, alias)` | Wrap in `CALL (alias) { }` block |
+| `update_return_labels(list)` | Add labels to RETURN clause |
+
+### Execution
+
+```python
+await query.execute(db=db)
+
+# Use typed results
+for item in query.get_data():
+    print(item.uuid)  # IDE autocomplete works
+```
+
+### Query Preview
+
+Useful for debugging:
+
+```python
+query = await MyQuery.init(db=db, branch=branch, node_id="abc123")
+print(query.get_query())  # Preview generated Cypher
+print(query.get_query(var=True, inline=True))  # With variables substituted
+await query.execute(db=db)  # Execute when ready
+```
+
+## Core Patterns
+
+### Query Naming
+
+Each query must have a unique `name` attribute, using lowercase with dashes:
+
+```python
+class MyCustomQuery(Query):
+    name = "my-custom-query"  # Unique, lowercase, dash-separated
+    type = QueryType.READ
+```
+
+### Parameter Binding
+
+All user input must be parameterized to prevent Cypher injection and enable query caching:
+
+```python
+# Good: Parameterized
+self.params["uuid"] = user_provided_id
+self.add_to_query("MATCH (n { uuid: $uuid })")
+
+# Bad: String interpolation (security risk)
+self.add_to_query(f"MATCH (n {{ uuid: '{user_provided_id}' }})")
+```
+
+### Return Labels
+
+The RETURN clause is automatically generated from `return_labels`. Call `update_return_labels()` to specify what to return:
+
+```python
+self.add_to_query("MATCH (n:Node)-[r:REL]->(p:Peer)")
+self.update_return_labels(["n", "r", "p"])  # Generates: RETURN n, r, p
+```
+
+To write the RETURN clause directly in your query, set `insert_return = False`:
+
+```python
+class MyQuery(Query):
+    name = "my-query"
+    type = QueryType.READ
+    insert_return = False  # Disable automatic RETURN generation
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_to_query("MATCH (n:Node)")
+        self.add_to_query("RETURN n.uuid AS uuid, n.name AS name")  # Manual RETURN
+```
+
+### Pagination
+
+Pagination (`LIMIT`/`OFFSET`) is automatically appended based on constructor parameters. To write pagination directly in your query, set `insert_limit = False`:
+
+```python
+class MyQuery(Query):
+    name = "my-query"
+    type = QueryType.READ
+    insert_limit = False  # Disable automatic LIMIT/OFFSET
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_to_query("MATCH (n:Node)")
+        self.add_to_query("RETURN n LIMIT 100")  # Manual pagination
+```
+
+## Result Dataclass Pattern
+
+All queries must expose results through frozen dataclasses. This provides type safety, IDE autocompletion, and a clear API contract between queries and callers.
+
+### Basic Structure
+
+```python
+from dataclasses import dataclass
+from infrahub.core.query import Query, QueryResult, QueryType
+
+@dataclass(frozen=True)
+class MyQueryResult:
+    """Result from MyQuery."""
+    uuid: str
+    name: str
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> MyQueryResult:
+        """Convert raw QueryResult to typed dataclass."""
+        node = result.get_node("n")
+        return cls(uuid=node.get("uuid"), name=node.get("name"))
+
+class MyQuery(Query):
+    name = "my-query"
+    type = QueryType.READ
+
+    def __init__(self, node_id: str, **kwargs):
+        super().__init__(**kwargs)
+        self.params["node_id"] = node_id
+        self.add_to_query("MATCH (n:Node { uuid: $node_id })")
+        self.update_return_labels(["n"])
+
+    def get_data(self) -> list[MyQueryResult]:
+        """Return results as typed dataclass instances."""
+        return [MyQueryResult.from_db(r) for r in self.get_results()]
+```
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Result dataclass | `{QueryName}Result` | `NodeGetListQueryResult` |
+| Factory method | `from_db(cls, result)` | `MyQueryResult.from_db(result)` |
+| Query method | `get_data()` | Returns typed results |
+
+### Pattern Examples
+
+**Scalar values** (`RETURN n.uuid AS uuid, n.kind AS kind`):
+
+```python
+@dataclass(frozen=True)
+class ScalarResult:
+    uuid: str
+    kind: str
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> ScalarResult:
+        return cls(uuid=result.get_as_type("uuid", str), kind=result.get_as_type("kind", str))
+```
+
+**Single node** (`RETURN n`):
+
+```python
+@dataclass(frozen=True)
+class SingleNodeResult:
+    uuid: str
+    kind: str
+    db_id: str
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> SingleNodeResult:
+        node = result.get_node("n")
+        return cls(uuid=node.get("uuid"), kind=node.get("kind"), db_id=node.element_id)
+```
+
+**Node + relationship** (`RETURN n, r`):
+
+```python
+@dataclass(frozen=True)
+class NodeWithRelResult:
+    node_uuid: str
+    rel_branch: str
+    rel_status: str
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> NodeWithRelResult:
+        node, rel = result.get_node("n"), result.get_rel("r")
+        return cls(node_uuid=node.get("uuid"), rel_branch=rel.get("branch"), rel_status=rel.get("status"))
+```
+
+**Collection** (`RETURN n, collect(related) AS related`):
+
+```python
+@dataclass(frozen=True)
+class CollectionResult:
+    primary_uuid: str
+    related_uuids: tuple[str, ...]  # tuple for frozen dataclass
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> CollectionResult:
+        node = result.get_node("n")
+        related = result.get_node_collection("related")
+        return cls(primary_uuid=node.get("uuid"), related_uuids=tuple(r.get("uuid") for r in related))
+```
+
+**Optional values**:
+
+```python
+@dataclass(frozen=True)
+class OptionalResult:
+    uuid: str
+    description: str | None
+
+    @classmethod
+    def from_db(cls, result: QueryResult) -> OptionalResult:
+        return cls(uuid=result.get_as_type("uuid", str), description=result.get_as_optional_type("description", str))
+```
+
+### Query Method Patterns
+
+```python
+# Multiple results:
+def get_data(self) -> list[MyQueryResult]:
+    return [MyQueryResult.from_db(r) for r in self.get_results()]
+
+# Large result sets (memory efficient):
+def get_data_iterator(self) -> Iterator[MyQueryResult]:
+    for result in self.get_results():
+        yield MyQueryResult.from_db(result)
+
+# Single result:
+def get_data(self) -> MyQueryResult | None:
+    result = self.get_result()
+    return MyQueryResult.from_db(result) if result else None
+```
+
+### Guidelines
+
+- Use `@dataclass(frozen=True)` for immutability and hashability (NOT Pydantic)
+- Flatten aggressively: replace `node.get("prop")` chains with simple attributes
+- Only include fields actually used by callers
+- Use tuples instead of lists for collection fields (frozen dataclass requirement)
+- Use `get_as_type()` for scalars, `get_as_optional_type()` for nullable values
+- Use generators for large result sets to avoid memory issues
+
+### Optimizing Cypher RETURN
+
+When possible, return only needed properties instead of entire nodes:
+
+```cypher
+-- Before (returns entire nodes)
+RETURN n, r, p
+
+-- After (returns only needed properties)
+RETURN n.uuid AS node_uuid, n.name AS node_name, r.branch AS rel_branch
+```
+
+This reduces data transfer and memory usage.
+
+## Internals
+
+This section documents internal implementation details. External callers should use the typed dataclass pattern above.
+
+### Query Base Class
+
+**Location:** `backend/infrahub/core/query/__init__.py`
+
+```python
+class Query:
+    name: str = "base-query"
+    type: QueryType  # READ or WRITE
+
+    def __init__(
+        self,
+        branch: Branch | None = None,
+        at: Timestamp | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        order_by: list[str] | None = None,
+        branch_agnostic: bool = False,
+        user_id: str = SYSTEM_USER_ID,
+    ) -> None:
+        self.params: dict = {}
+        self.query_lines: list[str] = []
+        self.return_labels: list[str] = []
+        self.results: list[QueryResult] = []
+```
+
+| Attribute | Purpose |
+|-----------|---------|
+| `query_lines` | List of Cypher clauses being built |
+| `params` | Dictionary of parameterized values (`$name` → value) |
+| `return_labels` | Labels to include in RETURN clause |
+| `results` | List of `QueryResult` after execution |
+| `branch` | Branch context for the query |
+| `at` | Timestamp for time-travel queries |
+
+### QueryResult (Internal)
+
+> **Note:** QueryResult is for internal query implementation. Use it only inside `from_db()` methods. External callers must use typed dataclass results.
+
+Wraps Neo4j records and provides typed access methods:
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `get(label)` | `Neo4jNode \| Neo4jRelationship` | Get item by label |
+| `get_node(label)` | `Neo4jNode` | Get node with type checking |
+| `get_rel(label)` | `Neo4jRelationship` | Get relationship with type checking |
+| `get_as_type(label, type)` | `type` | Get scalar as specific type |
+| `get_as_optional_type(label, type)` | `type \| None` | Get optional scalar |
+| `get_nodes()` | `Generator[Neo4jNode]` | Iterate all nodes |
+| `get_rels()` | `Generator[Neo4jRelationship]` | Iterate all relationships |
+| `get_node_collection(label)` | `list[Neo4jNode]` | Get collected nodes |
+
+### Query Element Builders
+
+Helper dataclasses for building Cypher patterns:
+
+```python
+# Node pattern: (n:Label { uuid: $uuid })
+QueryNode(name="n", labels=["Label"], params={"uuid": "$uuid"})
+
+# Relationship pattern with direction: -[r:IS_PART_OF]->
+QueryRel(name="r", labels=["IS_PART_OF"], direction=QueryRelDirection.OUTBOUND)
+```
+
+### Query Types
+
+| Type | Enum Value | Purpose |
+|------|------------|---------|
+| READ | `QueryType.READ` | Select-like operations, no side effects |
+| WRITE | `QueryType.WRITE` | Create/Update/Delete operations |
+
+### Domain-Specific Queries
+
+Specialized base classes for different domains:
+
+| Base Class | Location | Purpose |
+|------------|----------|---------|
+| `NodeQuery` | `node.py` | Node CRUD with node resolution |
+| `RelationshipQuery` | `relationship.py` | Relationship operations |
+| `AttributeQuery` | `attribute.py` | Attribute value management |
+| `DiffQuery` | `diff.py` | Change detection between branches/times |
+| `StandardNodeQuery` | `standard_node.py` | Simple non-graph node CRUD |
+
+### Design Decisions
+
+**Database Object in Initialization:** The `InfrahubDatabase` object is passed during initialization for:
+
+1. **Schema access via database proxy:** Enables temporal queries using previous schema versions
+
+   ```python
+   schema = db.schema.get(name="MyNode", branch=branch)  # Good
+   schema = registry.schema.get(name="MyNode")  # Avoid: loses temporal flexibility
+   ```
+
+2. **Database type abstraction:** Contains database-specific functions
+
+   ```python
+   id_func = db.get_id_function_name()  # Returns "elementId" for Neo4j
+   ```
+
+## Key Locations
+
+| Component | Location |
+|-----------|----------|
+| Base classes | `backend/infrahub/core/query/__init__.py` |
+| Node queries | `backend/infrahub/core/query/node.py` |
+| Relationship queries | `backend/infrahub/core/query/relationship.py` |
+| Attribute queries | `backend/infrahub/core/query/attribute.py` |
+| Diff queries | `backend/infrahub/core/query/diff.py` |
+| Subquery filters | `backend/infrahub/core/query/subquery.py` |
+| IPAM queries | `backend/infrahub/core/query/ipam.py` |
+| Branch queries | `backend/infrahub/core/query/branch.py` |
+| Standard node queries | `backend/infrahub/core/query/standard_node.py` |
+
+## See Also
+
+- [Backend Architecture](architecture.md) - Overall backend structure
+- [Testing](testing.md) - Query testing patterns
+- [Python Coding Standards](../../guidelines/backend/python.md) - Dataclass conventions

--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -29,7 +29,7 @@ class InfrahubResultContext(BaseModel):
 
 class InfrahubActiveMeasurementItem(BaseModel):
     definition: MeasurementDefinition
-    start_time: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     context: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -23,18 +23,18 @@ class MeasurementDefinition(BaseModel):
 
 class InfrahubResultContext(BaseModel):
     name: str
-    value: Union[int, float, str]
+    value: int | float | str
     unit: ContextUnit
 
 
 class InfrahubActiveMeasurementItem(BaseModel):
     definition: MeasurementDefinition
-    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(UTC))
     context: dict[str, Any] = Field(default_factory=dict)
 
 
 class InfrahubMeasurementItem(BaseModel):
     name: str
-    value: Union[int, float, str]
+    value: int | float | str
     unit: ContextUnit
     context: dict[str, Any] = Field(default_factory=dict)

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import TracebackType
 from typing import Any
 
@@ -37,7 +37,7 @@ class InfrahubPerformanceTest:
         self.env_vars = {}
         self.project_name = ""
         self.test_info = {}
-        self.start_time = datetime.now(timezone.utc)
+        self.start_time = datetime.now(UTC)
         self.end_time: datetime | None = None
         self.results_url = results_url
         self.scraper_endpoint = ""
@@ -59,7 +59,7 @@ class InfrahubPerformanceTest:
 
     def finalize(self, session: pytest.Session) -> None:
         if self.initialized:
-            self.end_time = datetime.now(timezone.utc)
+            self.end_time = datetime.now(UTC)
             self.extract_test_session_information(session)
             self.send_results()
 
@@ -131,7 +131,7 @@ class InfrahubPerformanceTest:
         if not exc_type and self.active_measurements:
             self.add_measurement(
                 definition=self.active_measurements.definition,
-                value=(datetime.now(timezone.utc) - self.active_measurements.start_time).total_seconds() * 1000,
+                value=(datetime.now(UTC) - self.active_measurements.start_time).total_seconds() * 1000,
                 context=self.active_measurements.context,
             )
 

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from types import TracebackType
 from typing import Any
 
@@ -37,7 +37,7 @@ class InfrahubPerformanceTest:
         self.env_vars = {}
         self.project_name = ""
         self.test_info = {}
-        self.start_time = datetime.now(UTC)
+        self.start_time = datetime.now(timezone.utc)
         self.end_time: datetime | None = None
         self.results_url = results_url
         self.scraper_endpoint = ""
@@ -59,7 +59,7 @@ class InfrahubPerformanceTest:
 
     def finalize(self, session: pytest.Session) -> None:
         if self.initialized:
-            self.end_time = datetime.now(UTC)
+            self.end_time = datetime.now(timezone.utc)
             self.extract_test_session_information(session)
             self.send_results()
 
@@ -131,7 +131,7 @@ class InfrahubPerformanceTest:
         if not exc_type and self.active_measurements:
             self.add_measurement(
                 definition=self.active_measurements.definition,
-                value=(datetime.now(UTC) - self.active_measurements.start_time).total_seconds() * 1000,
+                value=(datetime.now(timezone.utc) - self.active_measurements.start_time).total_seconds() * 1000,
                 context=self.active_measurements.context,
             )
 


### PR DESCRIPTION
Replaces https://github.com/opsmill/infrahub/pull/7769

This PR implement the change started in #7769 to create a cleaner boundary between the Query Result and the rest of the code by leveraging a dataclass to return all the results.

Since we already discussed it and it felt like there was a general agreement this is something we want to do, I went ahead and migrated all (most) of the queries. As such, it felt like the command wasn't needed anymore.
Instead, I created a new entry in `dev/knowledge/backend` to capture the best practices around Query. I purposefully didn't include the latest change that were introduced in https://github.com/opsmill/infrahub/pull/7979 since the design is still being discussed. Once we have finalized the design it would be good to update the KB. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data access patterns across query and resource management modules for enhanced type safety and consistency.
  * Consolidated query result handling to use unified typed data access methods throughout the backend system.

* **Documentation**
  * Updated Python coding guidelines with frozen dataclass recommendations and version compatibility details.
  * Added comprehensive Query pattern documentation for backend development practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->