### PR TITLE
Doc: Webhook updates

### DIFF
--- a/docs/docs/guides/python-transform.mdx
+++ b/docs/docs/guides/python-transform.mdx
@@ -237,8 +237,8 @@ The next step is to create the actual Python transform. The transform is a Pytho
 
 <Tabs groupId="convertResponse">
   <TabItem value="Non-converted query response">
+  <!-- vale Infrahub.spelling = NO -->
 ```python
-    <!-- vale Infrahub.spelling = NO -->
 from infrahub_sdk.transforms import InfrahubTransform
 class DeviceConfigTransform(InfrahubTransform):
     query = "device_config_query"

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -6,9 +6,18 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import FastapiWebhookReciever from '!!raw-loader!../media/fastapi_webhook_receiver.txt';
 
-# Webhooks
+# What are webhooks?
 
-The **Webhook System** enables external notifications based on the [Events](./events.mdx) system within InfraHub, which also powers the [Activity Log](./activity-log.mdx).
+Webhooks are HTTP callbacks that deliver data to external systems in real-time when an [event](./events.mdx) occurs within Infrahub. They allow you to:
+
+- Notify external systems about changes in your infrastructure (for example new configuration generated)
+- Trigger automated workflows in CI/CD pipelines 
+- Keep other tools and services synchronized with your infrastructure data
+- Build custom integrations with your existing toolchain
+
+:::info
+The **Webhook System** also powers the [Activity Log](./activity-log.mdx).
+:::
 
 ## Configuring webhooks
 
@@ -237,10 +246,8 @@ Here are some example payloads of some events that may be sent.
 
 ## Custom webhook transformation
 
-The `data` value from the payloads above gets passed into the [Python Transformation](../guides/python-transform.mdx) `transform` method.
+The `data` object from the payloads above is passed to the `transform` method of your [Python transform](../guides/python-transform.mdx).
 
 :::note
-In a future release, we will be providing the full event payload rather than only the `data` subset.
-
-https://github.com/opsmill/infrahub/issues/6815
+In a future release, we plan to pass the full event payload (not just `data`). Track progress in [issue #6815](https://github.com/opsmill/infrahub/issues/6815).
 :::

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -11,7 +11,7 @@ import FastapiWebhookReciever from '!!raw-loader!../media/fastapi_webhook_receiv
 Webhooks are HTTP callbacks that deliver data to external systems in real-time when an [event](./events.mdx) occurs within Infrahub. They allow you to:
 
 - Notify external systems about changes in your infrastructure (for example new configuration generated)
-- Trigger automated workflows in CI/CD pipelines 
+- Trigger automated workflows in CI/CD pipelines
 - Keep other tools and services synchronized with your infrastructure data
 - Build custom integrations with your existing toolchain
 

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -108,6 +108,7 @@ Here are some example payloads of some events that may be sent.
 <!-- vale off -->
 <Tabs>
   <TabItem value="infrahub.branch.created" label="infrahub.branch.created" default>
+
 ```json
 {
   "data": {
@@ -122,8 +123,10 @@ Here are some example payloads of some events that may be sent.
   "event": "infrahub.branch.created"
 }
 ```
+
   </TabItem>
   <TabItem value="infrahub.node.created" label="infrahub.node.created">
+
 ```json
 {
   "data": {
@@ -195,9 +198,11 @@ Here are some example payloads of some events that may be sent.
   "event": "infrahub.node.created"
 }
 ```
+
   </TabItem>
 
   <TabItem value="infrahub.node.updated" label="infrahub.node.updated">
+
 ```json
 {
   "data": {
@@ -240,6 +245,7 @@ Here are some example payloads of some events that may be sent.
   "event": "infrahub.node.updated"
 }
 ```
+
   </TabItem>
 </Tabs>
 <!-- vale on -->
@@ -247,7 +253,3 @@ Here are some example payloads of some events that may be sent.
 ## Custom webhook transformation
 
 The `data` object from the payloads above is passed to the `transform` method of your [Python transform](../guides/python-transform.mdx).
-
-:::note
-In a future release, we plan to pass the full event payload (not just `data`). Track progress in [issue #6815](https://github.com/opsmill/infrahub/issues/6815).
-:::

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -67,6 +67,7 @@ Node kind can only be used where `node_kind` is `True` in [Infrahub events](../r
 
 - **Description**: A description can be set to identify the webhooks purpose.
 - **URL**: The destination URL can be configured, such as `http://ansible-eda:8080`.
+- **Transformation** (Custom Webhook only): The Python transformation used to customize the webhook payload before being sent to the webhook receiver.
 
 ### Shared key for security
 
@@ -75,7 +76,9 @@ A **shared key** can be configured to sign webhook requests. This key ensures th
 When a webhook is sent:
 
 1. The sender generates a signature using the shared key.
-2. The signature is included in the request headers.
+2. The signature is included in the request headers (`webhook-signature`).
+3. The message ID is included in the request headers (`webhook-id`).
+4. The timestamp is included in the request headers (`webhook-timestamp`).
 
 The receiver then uses the same shared key to verify the signature, confirming that the message has not been tampered with and that it is from a trusted source.
 
@@ -231,3 +234,13 @@ Here are some example payloads of some events that may be sent.
   </TabItem>
 </Tabs>
 <!-- vale on -->
+
+## Custom webhook transformation
+
+The `data` value from the payloads above gets passed into the [Python Transformation](../guides/python-transform.mdx) `transform` method.
+
+:::note
+In a future release, we will be providing the full event payload rather than only the `data` subset.
+
+https://github.com/opsmill/infrahub/issues/6815
+:::


### PR DESCRIPTION
- Add what headers are passed in when `Shared Key` is used
- Add section to denote what part of the event payload is passed into a `Python Transformation` when using a custom webhook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Python transform guide for improved code clarity
  * Expanded Webhooks documentation with real-time, event-driven description and enumerated use cases
  * Added explicit security header names and extended configuration guidance
  * Introduced JSON payload examples for additional webhook events
  * Added Custom Webhook Transformation documentation section

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->