### PR TITLE
Rewrite graphql list permissions tests

### DIFF
--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -90,8 +90,8 @@ query {
 
 @dataclass
 class PermissionsTestData:
-    first_account: CoreAccount
-    default_branch: Branch
+    account: CoreAccount
+    branch: Branch
 
 
 @pytest.fixture
@@ -169,7 +169,7 @@ async def object_permissions_data(
     await group.members.add(db=db, data={"id": first_account.id})
     await group.members.save(db=db)
 
-    return PermissionsTestData(first_account=first_account, default_branch=default_branch)
+    return PermissionsTestData(account=first_account, branch=default_branch)
 
 
 class TestObjectPermissions:
@@ -177,12 +177,12 @@ class TestObjectPermissions:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS, context_value=gql_params.context)
@@ -207,7 +207,7 @@ class TestObjectPermissions:
         branch2 = await create_branch(branch_name="pr-12345", db=db)
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
@@ -232,12 +232,12 @@ class TestObjectPermissions:
         """In the main branch the first account doesn't have the permission to make changes"""
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.branch, account_session=session
         )
 
         result = await graphql(
@@ -274,12 +274,12 @@ class TestObjectPermissions:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_IP_PREFIX_POOL, context_value=gql_params.context)
@@ -306,7 +306,7 @@ class TestObjectPermissions:
 
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
@@ -343,7 +343,7 @@ class TestObjectPermissions:
 
         session = AccountSession(
             authenticated=True,
-            account_id=object_permissions_data.first_account.id,
+            account_id=object_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
@@ -443,7 +443,7 @@ async def attribute_permissions_data(
     await tag.new(db=db, name="Blue", description="Blue tag")
     await tag.save(db=db)
 
-    return PermissionsTestData(first_account=first_account, default_branch=default_branch)
+    return PermissionsTestData(account=first_account, branch=default_branch)
 
 
 class TestAttributePermissions:
@@ -453,12 +453,12 @@ class TestAttributePermissions:
         """In the main branch the first account doesn't have the permission to make changes, so attribute cannot be changed"""
         session = AccountSession(
             authenticated=True,
-            account_id=attribute_permissions_data.first_account.id,
+            account_id=attribute_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=attribute_permissions_data.default_branch, account_session=session
+            db=db, include_mutation=True, branch=attribute_permissions_data.branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS_ATTR, context_value=gql_params.context)
@@ -477,7 +477,7 @@ class TestAttributePermissions:
         branch2 = await create_branch(branch_name="pr-12345", db=db)
         session = AccountSession(
             authenticated=True,
-            account_id=attribute_permissions_data.first_account.id,
+            account_id=attribute_permissions_data.account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import uuid4
+
+import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.account import ObjectPermission
@@ -19,7 +22,6 @@ if TYPE_CHECKING:
     from infrahub.core.protocols import CoreAccount
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-    from tests.unit.graphql.conftest import PermissionsHelper
 
 
 QUERY_TAGS = """
@@ -86,93 +88,101 @@ query {
 """
 
 
+@dataclass
+class PermissionsTestData:
+    first_account: CoreAccount
+    default_branch: Branch
+
+
+@pytest.fixture
+async def object_permissions_data(
+    db: InfrahubDatabase,
+    default_permission_backend: None,
+    register_core_models_schema: SchemaBranch,
+    default_branch: Branch,
+    first_account: CoreAccount,
+) -> PermissionsTestData:
+    permissions = []
+    for object_permission in [
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.CREATE.value,
+            decision=PermissionDecisionFlag.ALLOW_OTHER,
+        ),
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.DELETE.value,
+            decision=PermissionDecisionFlag.ALLOW_OTHER,
+        ),
+        ObjectPermission(
+            namespace="Core",
+            name="*",
+            action=PermissionAction.ANY.value,
+            decision=PermissionDecisionFlag.ALLOW_OTHER,
+        ),
+        ObjectPermission(
+            namespace="Core",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+        ObjectPermission(
+            namespace="Ipam",
+            name="*",
+            action=PermissionAction.ANY.value,
+            decision=PermissionDecisionFlag.ALLOW_OTHER,
+        ),
+        ObjectPermission(
+            namespace="Ipam",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+    ]:
+        obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await obj.new(
+            db=db,
+            namespace=object_permission.namespace,
+            name=object_permission.name,
+            action=object_permission.action,
+            decision=object_permission.decision,
+        )
+        await obj.save(db=db)
+        permissions.append(obj)
+
+    role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+    await role.new(db=db, name="admin", permissions=permissions)
+    await role.save(db=db)
+
+    group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+    await group.new(db=db, name="admin", roles=[role])
+    await group.save(db=db)
+
+    await group.members.add(db=db, data={"id": first_account.id})
+    await group.members.save(db=db)
+
+    return PermissionsTestData(first_account=first_account, default_branch=default_branch)
+
+
 class TestObjectPermissions:
-    async def test_setup(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        register_core_models_schema: SchemaBranch,
-        default_branch: Branch,
-        permissions_helper: PermissionsHelper,
-        first_account: CoreAccount,
-    ) -> None:
-        permissions_helper._first = first_account
-        permissions_helper._default_branch = default_branch
-
-        permissions = []
-        for object_permission in [
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.VIEW.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.CREATE.value,
-                decision=PermissionDecisionFlag.ALLOW_OTHER,
-            ),
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.DELETE.value,
-                decision=PermissionDecisionFlag.ALLOW_OTHER,
-            ),
-            ObjectPermission(
-                namespace="Core",
-                name="*",
-                action=PermissionAction.ANY.value,
-                decision=PermissionDecisionFlag.ALLOW_OTHER,
-            ),
-            ObjectPermission(
-                namespace="Core",
-                name="*",
-                action=PermissionAction.VIEW.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-            ObjectPermission(
-                namespace="Ipam",
-                name="*",
-                action=PermissionAction.ANY.value,
-                decision=PermissionDecisionFlag.ALLOW_OTHER,
-            ),
-            ObjectPermission(
-                namespace="Ipam",
-                name="*",
-                action=PermissionAction.VIEW.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-        ]:
-            obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-            await obj.new(
-                db=db,
-                namespace=object_permission.namespace,
-                name=object_permission.name,
-                action=object_permission.action,
-                decision=object_permission.decision,
-            )
-            await obj.save(db=db)
-            permissions.append(obj)
-
-        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
-        await role.new(db=db, name="admin", permissions=permissions)
-        await role.save(db=db)
-
-        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
-        await group.new(db=db, name="admin", roles=[role])
-        await group.save(db=db)
-
-        await group.members.add(db=db, data={"id": first_account.id})
-        await group.members.save(db=db)
-
-    async def test_first_account_tags(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
+    async def test_first_account_tags(self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS, context_value=gql_params.context)
@@ -191,12 +201,15 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData
     ) -> None:
         """In other branches the permissions for the first account is less restrictive"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(db=db, include_mutation=True, branch=branch2, account_session=session)
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS, context_value=gql_params.context)
@@ -214,14 +227,17 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_list_permissions_for_generics(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes"""
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
         )
 
         result = await graphql(
@@ -253,14 +269,17 @@ class TestObjectPermissions:
         } in result.data["BuiltinIPNamespace"]["permissions"]["edges"]
 
     async def test_first_account_ipprefix_pool(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
+            db=db, include_mutation=True, branch=object_permissions_data.default_branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_IP_PREFIX_POOL, context_value=gql_params.context)
@@ -279,14 +298,17 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch_non_isolated(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData
     ) -> None:
         """In other branches the permissions for the first account should be updated if we modify the main branch"""
 
         branch2 = await create_branch(branch_name="pr-123abc", db=db)
 
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(db=db, include_mutation=True, branch=branch2, account_session=session)
 
@@ -320,7 +342,10 @@ class TestObjectPermissions:
         await admin_role.save(db=db)
 
         session = AccountSession(
-            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+            authenticated=True,
+            account_id=object_permissions_data.first_account.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(db=db, include_mutation=True, branch=branch2, account_session=session)
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS, context_value=gql_params.context)
@@ -357,84 +382,83 @@ query {
 """
 
 
+@pytest.fixture
+async def attribute_permissions_data(
+    db: InfrahubDatabase,
+    default_permission_backend: None,
+    register_core_models_schema: SchemaBranch,
+    default_branch: Branch,
+    first_account: CoreAccount,
+) -> PermissionsTestData:
+    permissions = []
+    for object_permission in [
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.CREATE.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.DELETE.value,
+            decision=PermissionDecisionFlag.ALLOW_ALL,
+        ),
+        ObjectPermission(
+            namespace="Builtin",
+            name="*",
+            action=PermissionAction.UPDATE.value,
+            decision=PermissionDecisionFlag.ALLOW_OTHER,
+        ),
+    ]:
+        obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await obj.new(
+            db=db,
+            namespace=object_permission.namespace,
+            name=object_permission.name,
+            action=object_permission.action,
+            decision=object_permission.decision,
+        )
+        await obj.save(db=db)
+        permissions.append(obj)
+
+    role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+    await role.new(db=db, name="admin", permissions=permissions)
+    await role.save(db=db)
+
+    group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+    await group.new(db=db, name="admin", roles=[role])
+    await group.save(db=db)
+
+    await group.members.add(db=db, data={"id": first_account.id})
+    await group.members.save(db=db)
+
+    tag = await Node.init(db=db, schema=InfrahubKind.TAG)
+    await tag.new(db=db, name="Blue", description="Blue tag")
+    await tag.save(db=db)
+
+    return PermissionsTestData(first_account=first_account, default_branch=default_branch)
+
+
 class TestAttributePermissions:
-    async def test_setup(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        register_core_models_schema: SchemaBranch,
-        default_branch: Branch,
-        permissions_helper: PermissionsHelper,
-        first_account: CoreAccount,
-    ) -> None:
-        permissions_helper._first = first_account
-        permissions_helper._default_branch = default_branch
-
-        permissions = []
-        for object_permission in [
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.VIEW.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.CREATE.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.DELETE.value,
-                decision=PermissionDecisionFlag.ALLOW_ALL,
-            ),
-            ObjectPermission(
-                namespace="Builtin",
-                name="*",
-                action=PermissionAction.UPDATE.value,
-                decision=PermissionDecisionFlag.ALLOW_OTHER,
-            ),
-        ]:
-            obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-            await obj.new(
-                db=db,
-                namespace=object_permission.namespace,
-                name=object_permission.name,
-                action=object_permission.action,
-                decision=object_permission.decision,
-            )
-            await obj.save(db=db)
-            permissions.append(obj)
-
-        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
-        await role.new(db=db, name="admin", permissions=permissions)
-        await role.save(db=db)
-
-        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
-        await group.new(db=db, name="admin", roles=[role])
-        await group.save(db=db)
-
-        await group.members.add(db=db, data={"id": first_account.id})
-        await group.members.save(db=db)
-
-        tag = await Node.init(db=db, schema=InfrahubKind.TAG)
-        await tag.new(db=db, name="Blue", description="Blue tag")
-        await tag.save(db=db)
-
     async def test_first_account_tags_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, attribute_permissions_data: PermissionsTestData
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, so attribute cannot be changed"""
         session = AccountSession(
             authenticated=True,
-            account_id=permissions_helper.first.id,
+            account_id=attribute_permissions_data.first_account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )
         gql_params = await prepare_graphql_params(
-            db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
+            db=db, include_mutation=True, branch=attribute_permissions_data.default_branch, account_session=session
         )
 
         result = await graphql(schema=gql_params.schema, source=QUERY_TAGS_ATTR, context_value=gql_params.context)
@@ -447,13 +471,13 @@ class TestAttributePermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, attribute_permissions_data: PermissionsTestData
     ) -> None:
         """In other branches the permissions for the first account is less restrictive, attribute should be updatable"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)
         session = AccountSession(
             authenticated=True,
-            account_id=permissions_helper.first.id,
+            account_id=attribute_permissions_data.first_account.id,
             session_id=str(uuid4()),
             auth_type=AuthType.JWT,
         )


### PR DESCRIPTION
The tests could not be run independently without observing failure due to the usage of the `test_setup` method combined with how fixtures were used. This change replaces the `test_setup` pattern with a proper fixture. The tests now use this fixture which allow us to run them in isolation if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly improved test infrastructure for permission-related tests by introducing fixture-driven setup that centralizes test data initialization, reduces code duplication, and enhances maintainability across all test methods.
  * Introduced consistent, reusable data structures for both object and attribute permission test scenarios, streamlining test implementations and reducing repetitive setup boilerplate code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->