### PR TITLE
fix(docs): use fqdn for HA db address

### DIFF
--- a/development/deploy.tf
+++ b/development/deploy.tf
@@ -49,7 +49,7 @@ infrahub:
       enabled: false
     infrahubServer:
       env:
-        INFRAHUB_DB_ADDRESS: infrahub-headless
+        INFRAHUB_DB_ADDRESS: infrahub-headless.${local.target_namespace}.svc.cluster.local # use FQDN to match neo4j's Helm cluster domain so that client-side routing is used
         INFRAHUB_DB_PROTOCOL: neo4j # required for client-side routing
         INFRAHUB_BROKER_ADDRESS: messagequeue-rabbitmq
         INFRAHUB_CACHE_ADDRESS: redis-sentinel-proxy
@@ -83,7 +83,7 @@ infrahub:
     replicas: 3
     infrahubTaskWorker:
       env:
-        INFRAHUB_DB_ADDRESS: infrahub-headless
+        INFRAHUB_DB_ADDRESS: infrahub-headless.${local.target_namespace}.svc.cluster.local # use FQDN to match neo4j's Helm cluster domain so that client-side routing is used
         INFRAHUB_DB_PROTOCOL: neo4j # required for client-side routing
         INFRAHUB_BROKER_ADDRESS: messagequeue-rabbitmq
         INFRAHUB_CACHE_ADDRESS: redis-sentinel-proxy

--- a/development/k8s/infrahub-values.yaml
+++ b/development/k8s/infrahub-values.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 infrahub:
   global:
     infrahubTag: 1.4.10
@@ -8,7 +9,7 @@ infrahub:
       enabled: false
     infrahubServer:
       env:
-        INFRAHUB_DB_ADDRESS: infrahub-headless
+        INFRAHUB_DB_ADDRESS: infrahub-headless.infrahub.svc.cluster.local # use FQDN to match neo4j's Helm cluster domain so that client-side routing is used
         INFRAHUB_DB_PROTOCOL: neo4j # required for client-side routing
         INFRAHUB_BROKER_ADDRESS: messagequeue-rabbitmq
         INFRAHUB_CACHE_ADDRESS: redis-sentinel-proxy
@@ -40,7 +41,7 @@ infrahub:
     replicas: 3
     infrahubTaskWorker:
       env:
-        INFRAHUB_DB_ADDRESS: infrahub-headless
+        INFRAHUB_DB_ADDRESS: infrahub-headless.infrahub.svc.cluster.local # use FQDN to match neo4j's Helm cluster domain so that client-side routing is used
         INFRAHUB_DB_PROTOCOL: neo4j # required for client-side routing
         INFRAHUB_BROKER_ADDRESS: messagequeue-rabbitmq
         INFRAHUB_CACHE_ADDRESS: redis-sentinel-proxy


### PR DESCRIPTION
Otherwise server-side routing is used in Helm deployments which lead to neo4j notification spam because server-side routing does not forward notification disablement config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database connection to use fully qualified domain names, improving Kubernetes cluster networking and enabling consistent client-side routing for DB access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->