### PR TITLE
'at' param in schema load and all migrations

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -36,6 +36,7 @@ from infrahub.core.schema import (
     TemplateSchema,
 )
 from infrahub.core.schema.constants import SchemaNamespace  # noqa: TC001
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.validators.models.validate_migration import (
     SchemaValidateMigrationData,
     SchemaValidatorPathResponseData,
@@ -353,6 +354,8 @@ async def load_schema(
         if error_messages:
             raise SchemaNotValidError(",\n".join(error_messages))
 
+        schema_load_at = Timestamp()
+
         # ----------------------------------------------------------
         # Update the schema
         # ----------------------------------------------------------
@@ -367,6 +370,7 @@ async def load_schema(
                 limit=result.diff.all,
                 update_db=True,
                 user_id=account_session.account_id,
+                at=schema_load_at,
             )
             branch.update_schema_hash()
             log.info("Schema has been updated", branch=branch.name, hash=branch.active_schema_hash.main)
@@ -389,6 +393,7 @@ async def load_schema(
             previous_schema=origin_schema,
             migrations=result.migrations,
             user_id=account_session.account_id,
+            at=schema_load_at,
         )
         migration_error_msgs = await service.workflow.execute_workflow(
             workflow=SCHEMA_APPLY_MIGRATION,

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -40,7 +40,7 @@ from infrahub.core.migrations.exceptions import MigrationFailureError
 from infrahub.core.migrations.graph import get_graph_migrations, get_migration_by_number
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.migrations.schema.tasks import schema_apply_migrations
-from infrahub.core.migrations.shared import get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, get_migration_console
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.definitions.deprecated import deprecated_models
 from infrahub.core.schema.manager import SchemaManager
@@ -358,7 +358,7 @@ async def migrate_database(
     root_node = await get_root_node(db=db)
 
     for migration in migrations:
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         validation_result = None
 
         if execution_result.success:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -44,6 +44,7 @@ from infrahub.core.migrations.shared import get_migration_console
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.definitions.deprecated import deprecated_models
 from infrahub.core.schema.manager import SchemaManager
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import DatabaseType
@@ -357,7 +358,7 @@ async def migrate_database(
     root_node = await get_root_node(db=db)
 
     for migration in migrations:
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         validation_result = None
 
         if execution_result.success:
@@ -502,6 +503,7 @@ async def update_core_schema(db: InfrahubDatabase, initialize: bool = True, debu
     schema_default_branch.process()
     registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
 
+    update_at = Timestamp()
     async with db.start_transaction() as dbt:
         await registry.schema.update_schema_branch(
             schema=candidate_schema,
@@ -510,6 +512,7 @@ async def update_core_schema(db: InfrahubDatabase, initialize: bool = True, debu
             diff=result.diff,
             limit=result.diff.all,
             update_db=True,
+            at=update_at,
         )
         default_branch.update_schema_hash()
         get_migration_console().log(
@@ -527,6 +530,7 @@ async def update_core_schema(db: InfrahubDatabase, initialize: bool = True, debu
         new_schema=candidate_schema,
         previous_schema=origin_schema,
         migrations=result.migrations,
+        at=update_at,
     )
     migration_error_msgs = await schema_apply_migrations(message=apply_migration_data)
 

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -399,7 +399,7 @@ class Branch(StandardNode):
     ) -> None:
         """Rebase the current Branch with its origin branch"""
 
-        at = Timestamp()
+        at = Timestamp(at)
 
         await self.rebase_graph(db=db, at=at)
 

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -88,7 +88,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
 
         try:
             log.info(f"Running migrations for branch '{obj.name}'")
-            await migration_runner.run(db=db)
+            await migration_runner.run(db=db, at=Timestamp())
         except MigrationFailureError as exc:
             log.error(f"Failed to run migrations for branch '{obj.name}': {exc.errors}")
             raise
@@ -170,7 +170,8 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         migrations = []
         async with lock.registry.global_graph_lock():
             async with db.start_transaction() as dbt:
-                await obj.rebase(db=dbt, user_id=context.account.account_id)
+                rebase_at = Timestamp()
+                await obj.rebase(db=dbt, user_id=context.account.account_id, at=rebase_at)
                 log.info("Branch successfully rebased")
 
             if obj.has_schema_changes:
@@ -199,6 +200,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                         previous_schema=schema_in_main_before,
                         migrations=migrations,
                         user_id=context.account.account_id,
+                        at=rebase_at,
                     )
                 )
                 for error in errors:
@@ -291,7 +293,8 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                 diff_locker=DiffLocker(),
                 workflow=get_workflow(),
             )
-            branch_diff = await merger.merge()
+            merge_at = Timestamp()
+            branch_diff = await merger.merge(at=merge_at)
             await merger.update_schema()
 
         changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=obj, db=db)
@@ -304,6 +307,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                     previous_schema=merger.initial_source_schema,
                     migrations=merger.migrations,
                     user_id=context.account.account_id,
+                    at=merge_at,
                 )
             )
             for error in errors:

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -30,6 +30,7 @@ from infrahub.core.protocols import CoreAccount, CoreAccountGroup, CoreAccountRo
 from infrahub.core.root import Root
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.manager import SchemaManager
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
@@ -527,7 +528,7 @@ async def first_time_initialization(db: InfrahubDatabase) -> None:
     schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
     schema_branch.load_schema(schema=SchemaRoot(**core_models))
     schema_branch.process()
-    await registry.schema.load_schema_to_db(schema=schema_branch, branch=default_branch, db=db)
+    await registry.schema.load_schema_to_db(schema=schema_branch, branch=default_branch, db=db, at=Timestamp())
     registry.schema.set_schema_branch(name=default_branch.name, schema=schema_branch)
     default_branch.update_schema_hash()
     await default_branch.save(db=db)

--- a/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
+++ b/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
@@ -12,6 +12,7 @@ from infrahub.database.neo4j import IndexManagerNeo4j
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -23,7 +24,7 @@ class Migration014(GraphMigration):
     queries: Sequence[type[Query]] = []
     minimum_version: int = 13
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         result = MigrationResult()
 
         # Only execute this migration for Neo4j

--- a/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
+++ b/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.constants.database import IndexType
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.database import DatabaseType
 from infrahub.database.index import IndexItem
@@ -12,7 +12,6 @@ from infrahub.database.neo4j import IndexManagerNeo4j
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -24,7 +23,8 @@ class Migration014(GraphMigration):
     queries: Sequence[type[Query]] = []
     minimum_version: int = 13
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         result = MigrationResult()
 
         # Only execute this migration for Neo4j

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -4,14 +4,13 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.diff.repository.repository import DiffRepository
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.dependencies.registry import build_component_registry, get_component_registry
 from infrahub.log import get_logger
 
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -26,7 +25,8 @@ class Migration015(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -11,6 +11,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -25,7 +26,7 @@ class Migration015(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -11,6 +11,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -25,7 +26,7 @@ class Migration016(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -4,14 +4,13 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.diff.repository.repository import DiffRepository
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.dependencies.registry import build_component_registry, get_component_registry
 from infrahub.log import get_logger
 
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -26,7 +25,8 @@ class Migration016(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -12,6 +12,7 @@ from infrahub.log import get_logger
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -27,7 +28,7 @@ class Migration017(InternalSchemaMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
         """
         Load CoreProfile schema node in db.
         """
@@ -37,7 +38,7 @@ class Migration017(InternalSchemaMigration):
 
         db.add_schema(manager.get_schema_branch(default_branch.name))
         await manager.load_node_to_db(
-            node=core_profile_schema_definition, db=db, branch=default_branch, user_id=user_id
+            node=core_profile_schema_definition, db=db, branch=default_branch, user_id=user_id, at=at
         )
 
         return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core import registry
-from infrahub.core.constants import SYSTEM_USER_ID
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.log import get_logger
@@ -12,7 +11,6 @@ from infrahub.log import get_logger
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -28,10 +26,13 @@ class Migration017(InternalSchemaMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """
         Load CoreProfile schema node in db.
         """
+        db = migration_input.db
+        at = migration_input.at
+        user_id = migration_input.user_id
         default_branch = registry.get_branch_from_registry()
         manager = SchemaManager()
         manager.set_schema_branch(name=default_branch.name, schema=self.get_internal_schema())

--- a/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core import registry
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.diff.payload_builder import get_display_labels_per_kind
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot, internal_schema
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.validators.uniqueness.checker import UniquenessChecker
@@ -16,7 +15,6 @@ from infrahub.log import get_logger
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.core.validators.uniqueness.model import NonUniqueNode
     from infrahub.database import InfrahubDatabase
 
@@ -97,5 +95,5 @@ class Migration018(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
-        return await validate_nulls_in_uniqueness_constraints(db=db)
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        return await validate_nulls_in_uniqueness_constraints(db=migration_input.db)

--- a/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
@@ -16,6 +16,7 @@ from infrahub.log import get_logger
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.core.validators.uniqueness.model import NonUniqueNode
     from infrahub.database import InfrahubDatabase
 
@@ -96,5 +97,5 @@ class Migration018(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         return await validate_nulls_in_uniqueness_constraints(db=db)

--- a/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
+++ b/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
@@ -9,6 +9,7 @@ from infrahub.log import get_logger
 from ...query import Query, QueryType
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -140,9 +141,9 @@ class Migration020(GraphMigration):
         DeleteDuplicateIsProtectedEdgesQuery,
     ]
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         # skip the transaction b/c it will run out of memory on a large database
-        return await self.do_execute(db=db)
+        return await self.do_execute(db=db, at=at)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         result = MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
+++ b/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core.constants.database import DatabaseEdgeType
-from infrahub.core.migrations.shared import GraphMigration, MigrationResult
+from infrahub.core.migrations.shared import GraphMigration, MigrationInput, MigrationResult
 from infrahub.log import get_logger
 
 from ...query import Query, QueryType
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -141,9 +140,9 @@ class Migration020(GraphMigration):
         DeleteDuplicateIsProtectedEdgesQuery,
     ]
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         # skip the transaction b/c it will run out of memory on a large database
-        return await self.do_execute(db=db, at=at)
+        return await self.do_execute(migration_input=migration_input)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         result = MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
@@ -10,6 +10,7 @@ from ..shared import InternalSchemaMigration, SchemaMigration
 from .m018_uniqueness_nulls import validate_nulls_in_uniqueness_constraints
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -23,5 +24,5 @@ class Migration025(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         return await validate_nulls_in_uniqueness_constraints(db=db)

--- a/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m025_uniqueness_nulls.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
-from infrahub.core.constants import SYSTEM_USER_ID
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.log import get_logger
 
 from ..shared import InternalSchemaMigration, SchemaMigration
 from .m018_uniqueness_nulls import validate_nulls_in_uniqueness_constraints
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -24,5 +22,5 @@ class Migration025(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
-        return await validate_nulls_in_uniqueness_constraints(db=db)
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        return await validate_nulls_in_uniqueness_constraints(db=migration_input.db)

--- a/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
@@ -4,18 +4,16 @@ import ipaddress
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -29,7 +27,9 @@ class Migration026(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
@@ -9,13 +9,13 @@ from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.shared import MigrationResult
-from infrahub.core.timestamp import Timestamp
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -29,12 +29,11 @@ class Migration026(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)
 
-        at = Timestamp()
         for branch in await Branch.get_list(db=db):
             prefix_0000s = await NodeManager.query(
                 db=db, schema="BuiltinIPPrefix", branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -4,14 +4,13 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.diff.repository.repository import DiffRepository
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.dependencies.registry import build_component_registry, get_component_registry
 from infrahub.log import get_logger
 
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -28,7 +27,8 @@ class Migration028(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -11,6 +11,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -27,7 +28,7 @@ class Migration028(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         default_branch = registry.get_branch_from_registry()
         build_component_registry()
         component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -11,6 +11,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -574,7 +575,7 @@ class Migration029(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         migration_result = MigrationResult()
         limit = self.limit
         offset = 0

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -4,14 +4,13 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from infrahub.core.constants import RelationshipDirection
 from infrahub.core.constants.database import DatabaseEdgeType
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.query import Query, QueryType
 from infrahub.log import get_logger
 
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -575,8 +574,9 @@ class Migration029(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         migration_result = MigrationResult()
+        db = migration_input.db
         limit = self.limit
         offset = 0
         more_nodes_to_process = True

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -19,6 +19,7 @@ from infrahub.log import get_logger
 from infrahub.types import Number
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -35,7 +36,7 @@ class Migration031(InternalSchemaMigration):
     minimum_version: int = 30
     migrations: Sequence[SchemaMigration] = []
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         """Retrieve all number attributes that have a min/max/excluded_values
         For any of these attributes, check if corresponding existing nodes are valid."""
 

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, Sequence
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SYSTEM_USER_ID, SchemaPathType
+from infrahub.core.constants import SchemaPathType
 from infrahub.core.initialization import initialization
-from infrahub.core.migrations.shared import InternalSchemaMigration, MigrationResult, SchemaMigration
+from infrahub.core.migrations.shared import InternalSchemaMigration, MigrationInput, MigrationResult, SchemaMigration
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import GenericSchema, NodeSchema
 from infrahub.core.schema.attribute_parameters import NumberAttributeParameters
@@ -19,7 +19,6 @@ from infrahub.log import get_logger
 from infrahub.types import Number
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -36,7 +35,7 @@ class Migration031(InternalSchemaMigration):
     minimum_version: int = 30
     migrations: Sequence[SchemaMigration] = []
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Retrieve all number attributes that have a min/max/excluded_values
         For any of these attributes, check if corresponding existing nodes are valid."""
 
@@ -44,6 +43,7 @@ class Migration031(InternalSchemaMigration):
             return MigrationResult()
 
         # load schemas from database into registry
+        db = migration_input.db
         initialize_lock()
         await initialization(db=db)
 

--- a/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
@@ -10,6 +10,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -68,7 +69,7 @@ class Migration032(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         migration_result = MigrationResult()
 
         try:

--- a/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.query import Query, QueryType
 from infrahub.core.query.branch import DeleteBranchRelationshipsQuery
 from infrahub.log import get_logger
@@ -10,7 +10,6 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -69,7 +68,8 @@ class Migration032(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         migration_result = MigrationResult()
 
         try:

--- a/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
+++ b/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core.initialization import initialization
 from infrahub.core.manager import NodeManager
-from infrahub.core.migrations.shared import ArbitraryMigration, MigrationResult
+from infrahub.core.migrations.shared import ArbitraryMigration, MigrationInput, MigrationResult
 from infrahub.core.timestamp import Timestamp
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
@@ -59,7 +59,8 @@ class Migration034(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         try:
             initialize_lock()
             await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
+++ b/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
@@ -59,7 +59,7 @@ class Migration034(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         try:
             initialize_lock()
             await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
@@ -7,6 +7,7 @@ from infrahub.core.migrations.shared import GraphMigration, MigrationResult
 from ...query import Query, QueryType
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -38,6 +39,6 @@ class Migration035(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         # overrides parent class to skip transaction in case there are a lot of relationships to delete
-        return await self.do_execute(db=db)
+        return await self.do_execute(db=db, at=at)

--- a/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core.migrations.shared import GraphMigration, MigrationResult
+from infrahub.core.migrations.shared import GraphMigration, MigrationInput, MigrationResult
 
 from ...query import Query, QueryType
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -39,6 +38,6 @@ class Migration035(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         # overrides parent class to skip transaction in case there are a lot of relationships to delete
-        return await self.do_execute(db=db, at=at)
+        return await self.do_execute(migration_input=migration_input)

--- a/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
+++ b/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
@@ -12,6 +12,7 @@ from infrahub.database.neo4j import IndexManagerNeo4j
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -23,7 +24,7 @@ class Migration036(GraphMigration):
     queries: Sequence[type[Query]] = []
     minimum_version: int = 35
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         result = MigrationResult()
 
         # Only execute this migration for Neo4j

--- a/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
+++ b/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.constants.database import IndexType
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.database import DatabaseType
 from infrahub.database.index import IndexItem
@@ -12,7 +12,6 @@ from infrahub.database.neo4j import IndexManagerNeo4j
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -24,7 +23,8 @@ class Migration036(GraphMigration):
     queries: Sequence[type[Query]] = []
     minimum_version: int = 35
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         result = MigrationResult()
 
         # Only execute this migration for Neo4j

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -14,6 +14,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -463,7 +464,7 @@ class Migration037(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: PLR0915
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002, PLR0915
         console = get_migration_console()
         result = MigrationResult()
 

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from infrahub.constants.database import IndexType
 from infrahub.core.attribute import MAX_STRING_LENGTH
-from infrahub.core.migrations.shared import MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.query import Query, QueryType
 from infrahub.database.index import IndexItem
 from infrahub.database.neo4j import IndexManagerNeo4j
@@ -14,7 +14,6 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -464,8 +463,9 @@ class Migration037(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002, PLR0915
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:  # noqa: PLR0915
         console = get_migration_console()
+        db = migration_input.db
         result = MigrationResult()
 
         # find the active schema attributes that have a LARGE_ATTRIBUTE_TYPE kind on all branches

--- a/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
@@ -4,18 +4,16 @@ import ipaddress
 from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -38,7 +36,9 @@ class Migration038(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
@@ -9,13 +9,13 @@ from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.shared import MigrationResult
-from infrahub.core.timestamp import Timestamp
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
 from ..shared import InternalSchemaMigration, SchemaMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -38,12 +38,11 @@ class Migration038(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:  # noqa: ARG002
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)
 
-        at = Timestamp()
         for branch in await Branch.get_list(db=db):
             prefix_0000s = await NodeManager.query(
                 db=db, schema="BuiltinIPPrefix", branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}

--- a/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
+++ b/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
@@ -19,6 +19,7 @@ from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
     from infrahub.core.ipam.constants import AllIPTypes
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -233,7 +234,7 @@ class Migration039(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         console = get_migration_console()
         result = MigrationResult()
         # load schemas from database into registry

--- a/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
+++ b/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
@@ -10,7 +10,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
-from infrahub.core.migrations.shared import MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.query import Query, QueryType
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
@@ -19,7 +19,6 @@ from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
     from infrahub.core.ipam.constants import AllIPTypes
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -234,7 +233,8 @@ class Migration039(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         console = get_migration_console()
         result = MigrationResult()
         # load schemas from database into registry

--- a/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
+++ b/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
@@ -7,7 +7,7 @@ from rich import print as rprint
 from infrahub.core.branch import Branch
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import get_root_node
-from infrahub.core.migrations.shared import MigrationResult
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
 from infrahub.core.query import Query, QueryType
 from infrahub.dependencies.registry import build_component_registry, get_component_registry
 from infrahub.log import get_logger
@@ -15,7 +15,6 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -141,7 +140,8 @@ class Migration041(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         root_node = await get_root_node(db=db)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)

--- a/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
+++ b/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
@@ -15,6 +15,7 @@ from infrahub.log import get_logger
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 log = get_logger()
@@ -140,7 +141,7 @@ class Migration041(ArbitraryMigration):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         root_node = await get_root_node(db=db)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)

--- a/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
@@ -87,13 +87,13 @@ class Migration042(MigrationRequiringRebase):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
         return await self._do_execute_for_branch(db=db, branch=default_branch)
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         return await self._do_execute_for_branch(db=db, branch=branch)
 
     async def _do_execute_for_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:

--- a/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
@@ -7,7 +7,7 @@ from rich.progress import Progress
 from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import get_root_node
 from infrahub.core.manager import NodeManager
-from infrahub.core.migrations.shared import MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.query import Query, QueryType
 from infrahub.core.timestamp import Timestamp
 from infrahub.log import get_logger
@@ -87,14 +87,15 @@ class Migration042(MigrationRequiringRebase):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
         return await self._do_execute_for_branch(db=db, branch=default_branch)
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:  # noqa: ARG002
-        return await self._do_execute_for_branch(db=db, branch=branch)
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
+        return await self._do_execute_for_branch(db=migration_input.db, branch=branch)
 
     async def _do_execute_for_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
         console = get_migration_console()

--- a/backend/infrahub/core/migrations/graph/m043_create_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_create_hfid_display_label_in_db.py
@@ -16,6 +16,7 @@ from infrahub.core.query import Query, QueryType
 from .load_schema_branch import get_or_load_schema_branch
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -48,7 +49,7 @@ class Migration043(MigrationRequiringRebase):
     name: str = "043_create_hfid_display_label_in_db"
     minimum_version: int = 42
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         result = MigrationResult()
 
         root_node = await get_root_node(db=db, initialize=False)
@@ -104,7 +105,7 @@ class Migration043(MigrationRequiringRebase):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=default_branch)
+                    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:
@@ -113,7 +114,7 @@ class Migration043(MigrationRequiringRebase):
 
         return result
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
         result = MigrationResult()
 
         schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
@@ -155,7 +156,7 @@ class Migration043(MigrationRequiringRebase):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=branch)
+                    execution_result = await migration.execute(db=db, branch=branch, at=at)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m043_create_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_create_hfid_display_label_in_db.py
@@ -9,14 +9,18 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, SchemaPathType
 from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.schema.node_attribute_add import NodeAttributeAddMigration
-from infrahub.core.migrations.shared import MigrationRequiringRebase, MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import (
+    MigrationInput,
+    MigrationRequiringRebase,
+    MigrationResult,
+    get_migration_console,
+)
 from infrahub.core.path import SchemaPath
 from infrahub.core.query import Query, QueryType
 
 from .load_schema_branch import get_or_load_schema_branch
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -49,7 +53,8 @@ class Migration043(MigrationRequiringRebase):
     name: str = "043_create_hfid_display_label_in_db"
     minimum_version: int = 42
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         result = MigrationResult()
 
         root_node = await get_root_node(db=db, initialize=False)
@@ -105,7 +110,7 @@ class Migration043(MigrationRequiringRebase):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+                    execution_result = await migration.execute(migration_input=migration_input, branch=default_branch)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:
@@ -114,7 +119,8 @@ class Migration043(MigrationRequiringRebase):
 
         return result
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
+        db = migration_input.db
         result = MigrationResult()
 
         schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
@@ -156,7 +162,7 @@ class Migration043(MigrationRequiringRebase):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=branch, at=at)
+                    execution_result = await migration.execute(migration_input=migration_input, branch=branch)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
@@ -11,7 +11,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, BranchSupportType, RelationshipDirection
 from infrahub.core.initialization import get_root_node
-from infrahub.core.migrations.shared import MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.query import Query, QueryType
 from infrahub.core.schema import NodeSchema
 from infrahub.exceptions import SchemaNotFoundError
@@ -711,7 +711,9 @@ class Migration044(MigrationRequiringRebase):
 
         print("done")
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -824,7 +826,9 @@ class Migration044(MigrationRequiringRebase):
 
             offset += self.update_batch_size
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         default_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
         main_schema_branch = await get_or_load_schema_branch(db=db, branch=default_branch)
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)

--- a/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
     from infrahub.core.schema import AttributeSchema, NodeSchema, ProfileSchema, TemplateSchema
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
-
 
 console = get_migration_console()
 
@@ -631,6 +631,7 @@ class Migration044(MigrationRequiringRebase):
         schema: NodeSchema | ProfileSchema | TemplateSchema,
         schema_branch: SchemaBranch,
         attribute_schema_map: dict[AttributeSchema, AttributeSchema],
+        at: Timestamp,
         progress: Progress | None = None,
         update_task: TaskID | None = None,
     ) -> None:
@@ -696,6 +697,7 @@ class Migration044(MigrationRequiringRebase):
                     branch=branch,
                     attribute_schema=destination_attribute_schema,
                     values_by_id_map=formatted_schema_path_values_map,
+                    at=at,
                 )
                 await update_display_label_query.execute(db=db)
 
@@ -709,7 +711,7 @@ class Migration044(MigrationRequiringRebase):
 
         print("done")
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -754,6 +756,7 @@ class Migration044(MigrationRequiringRebase):
                         schema=node_schema,
                         schema_branch=main_schema_branch,
                         attribute_schema_map=attribute_schema_map,
+                        at=at,
                         progress=progress,
                         update_task=update_task,
                     )
@@ -770,6 +773,7 @@ class Migration044(MigrationRequiringRebase):
         schema_branch: SchemaBranch,
         source_attribute_schema: AttributeSchema,
         destination_attribute_schema: AttributeSchema,
+        at: Timestamp,
     ) -> None:
         print(f"Processing {schema.kind}.{destination_attribute_schema.name} for {branch.name}...", end="")
 
@@ -814,12 +818,13 @@ class Migration044(MigrationRequiringRebase):
                 branch=branch,
                 attribute_schema=destination_attribute_schema,
                 values_by_id_map=formatted_schema_path_values_map,
+                at=at,
             )
             await update_attr_values_query.execute(db=db)
 
             offset += self.update_batch_size
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
         default_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
         main_schema_branch = await get_or_load_schema_branch(db=db, branch=default_branch)
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)
@@ -869,6 +874,7 @@ class Migration044(MigrationRequiringRebase):
                         schema=node_schema,
                         schema_branch=schema_branch,
                         attribute_schema_map=schemas_for_universal_update_map,
+                        at=at,
                     )
 
                 if not schemas_for_targeted_update_map:
@@ -882,6 +888,7 @@ class Migration044(MigrationRequiringRebase):
                         schema_branch=schema_branch,
                         source_attribute_schema=source_attribute_schema,
                         destination_attribute_schema=destination_attribute_schema,
+                        at=at,
                     )
 
         except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
+++ b/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
@@ -8,15 +8,13 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.graph.m044_backfill_hfid_display_label_in_db import DefaultBranchNodeCount, Migration044
-from infrahub.core.migrations.shared import MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult, get_migration_console
 from infrahub.exceptions import SchemaNotFoundError
 
 from .load_schema_branch import get_or_load_schema_branch
 
 if TYPE_CHECKING:
     from infrahub.core.schema import ProfileSchema, TemplateSchema
-    from infrahub.core.timestamp import Timestamp
-    from infrahub.database import InfrahubDatabase
 
 
 console = get_migration_console()
@@ -31,7 +29,9 @@ class Migration045(Migration044):
     minimum_version: int = 44
     update_batch_size: int = 1000
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -87,7 +87,9 @@ class Migration045(Migration044):
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         default_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
         main_schema_branch = await get_or_load_schema_branch(db=db, branch=default_branch)
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)

--- a/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
+++ b/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
@@ -15,6 +15,7 @@ from .load_schema_branch import get_or_load_schema_branch
 
 if TYPE_CHECKING:
     from infrahub.core.schema import ProfileSchema, TemplateSchema
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -30,7 +31,7 @@ class Migration045(Migration044):
     minimum_version: int = 44
     update_batch_size: int = 1000
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -77,6 +78,7 @@ class Migration045(Migration044):
                         schema=node_schema,
                         schema_branch=main_schema_branch,
                         attribute_schema_map=attribute_schema_map,
+                        at=at,
                         progress=progress,
                         update_task=update_task,
                     )
@@ -85,7 +87,7 @@ class Migration045(Migration044):
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
         default_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
         main_schema_branch = await get_or_load_schema_branch(db=db, branch=default_branch)
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)
@@ -143,6 +145,7 @@ class Migration045(Migration044):
                         schema=node_schema,
                         schema_branch=schema_branch,
                         attribute_schema_map=schemas_for_universal_update_map,
+                        at=at,
                     )
 
                 if not schemas_for_targeted_update_map:
@@ -156,6 +159,7 @@ class Migration045(Migration044):
                         schema_branch=schema_branch,
                         source_attribute_schema=source_attribute_schema,
                         destination_attribute_schema=destination_attribute_schema,
+                        at=at,
                     )
 
         except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
+++ b/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
@@ -16,7 +16,7 @@ from infrahub.core.migrations.graph.m044_backfill_hfid_display_label_in_db impor
     UpdateAttributeValuesQuery,
 )
 from infrahub.core.migrations.schema.node_attribute_add import NodeAttributeAddMigration
-from infrahub.core.migrations.shared import ArbitraryMigration, MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import ArbitraryMigration, MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.path import SchemaPath
 from infrahub.core.query import Query, QueryType
 
@@ -25,7 +25,6 @@ from .load_schema_branch import get_or_load_schema_branch
 if TYPE_CHECKING:
     from infrahub.core.schema import AttributeSchema, MainSchemaTypes, NodeSchema, SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -135,13 +134,14 @@ class Migration046(ArbitraryMigration):
 
         print("done")
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         try:
-            return await self._do_execute(db=db, at=at)
+            return await self._do_execute(migration_input=migration_input)
         except Exception as exc:
             return MigrationResult(errors=[str(exc)])
 
-    async def _do_execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def _do_execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         console = get_migration_console()
         result = MigrationResult()
 
@@ -189,7 +189,7 @@ class Migration046(ArbitraryMigration):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=global_branch, at=at)
+                    execution_result = await migration.execute(migration_input=migration_input, branch=global_branch)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
+++ b/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
@@ -25,6 +25,7 @@ from .load_schema_branch import get_or_load_schema_branch
 if TYPE_CHECKING:
     from infrahub.core.schema import AttributeSchema, MainSchemaTypes, NodeSchema, SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -134,13 +135,13 @@ class Migration046(ArbitraryMigration):
 
         print("done")
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         try:
-            return await self._do_execute(db=db)
+            return await self._do_execute(db=db, at=at)
         except Exception as exc:
             return MigrationResult(errors=[str(exc)])
 
-    async def _do_execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def _do_execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         console = get_migration_console()
         result = MigrationResult()
 
@@ -188,7 +189,7 @@ class Migration046(ArbitraryMigration):
 
             for migration in migrations:
                 try:
-                    execution_result = await migration.execute(db=db, branch=global_branch)
+                    execution_result = await migration.execute(db=db, branch=global_branch, at=at)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
+++ b/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
@@ -9,7 +9,12 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, NULL_VALUE, BranchSupportType
 from infrahub.core.initialization import get_root_node
-from infrahub.core.migrations.shared import MigrationRequiringRebase, MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import (
+    MigrationInput,
+    MigrationRequiringRebase,
+    MigrationResult,
+    get_migration_console,
+)
 from infrahub.core.query import Query, QueryType
 
 from .load_schema_branch import get_or_load_schema_branch
@@ -480,7 +485,9 @@ class Migration047(MigrationRequiringRebase):
 
             offset += self.update_batch_size
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -563,7 +570,9 @@ class Migration047(MigrationRequiringRebase):
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)
 
         base_node_schema = schema_branch.get("SchemaNode", duplicate=False)

--- a/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
+++ b/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from infrahub.core.schema import AttributeSchema, MainSchemaTypes
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -409,6 +410,7 @@ class Migration047(MigrationRequiringRebase):
         schema: MainSchemaTypes,
         schema_branch: SchemaBranch,
         attribute_schema: AttributeSchema,
+        at: Timestamp,
         progress: Progress | None = None,
         update_task: TaskID | None = None,
     ) -> None:
@@ -466,6 +468,7 @@ class Migration047(MigrationRequiringRebase):
                     branch=branch,
                     attribute_schema=attribute_schema,
                     values_by_id_map=formatted_schema_path_values_map,
+                    at=at,
                 )
                 await update_display_label_query.execute(db=db)
 
@@ -477,7 +480,7 @@ class Migration047(MigrationRequiringRebase):
 
             offset += self.update_batch_size
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -531,7 +534,7 @@ class Migration047(MigrationRequiringRebase):
                             break
 
                         create_display_label_query = await CreateDisplayLabelNullQuery.init(
-                            db=db, branch=default_branch, node_uuids=batch_uuids
+                            db=db, branch=default_branch, node_uuids=batch_uuids, at=at
                         )
                         await create_display_label_query.execute(db=db)
 
@@ -551,6 +554,7 @@ class Migration047(MigrationRequiringRebase):
                             schema=main_schema_branch.get(name=node_schema_name, duplicate=False),
                             schema_branch=main_schema_branch,
                             attribute_schema=display_label_attribute_schema,
+                            at=at,
                             progress=progress,
                             update_task=backfill_task,
                         )
@@ -559,7 +563,7 @@ class Migration047(MigrationRequiringRebase):
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
         schema_branch = await get_or_load_schema_branch(db=db, branch=branch)
 
         base_node_schema = schema_branch.get("SchemaNode", duplicate=False)
@@ -579,7 +583,7 @@ class Migration047(MigrationRequiringRebase):
                         break
 
                     create_display_label_query = await CreateDisplayLabelNullQuery.init(
-                        db=db, branch=branch, node_uuids=batch_uuids
+                        db=db, branch=branch, node_uuids=batch_uuids, at=at
                     )
                     await create_display_label_query.execute(db=db)
 
@@ -599,6 +603,7 @@ class Migration047(MigrationRequiringRebase):
                     schema=node_schema,
                     schema_branch=schema_branch,
                     attribute_schema=display_label_attribute_schema,
+                    at=at,
                 )
 
         except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
+++ b/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
@@ -7,6 +7,7 @@ from infrahub.core.migrations.shared import ArbitraryMigration, MigrationResult,
 from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -143,18 +144,18 @@ class Migration048(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         console = get_migration_console()
 
         console.log("Deleting duplicate edges for all Relationships", end="...")
         delete_duplicate_edges_query = await DeleteDuplicatedRelationshipEdges.init(
-            db=db, migrated_kind_nodes_only=False
+            db=db, migrated_kind_nodes_only=False, at=at
         )
         await delete_duplicate_edges_query.execute(db=db)
         console.log("done")
 
         console.log("Undeleting Relationship properties", end="...")
-        undelete_rel_props_query = await UndeleteRelationshipProperties.init(db=db)
+        undelete_rel_props_query = await UndeleteRelationshipProperties.init(db=db, at=at)
         await undelete_rel_props_query.execute(db=db)
         console.log("done")
 

--- a/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
+++ b/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.migrations.graph.m041_deleted_dup_edges import DeleteDuplicatedRelationshipEdges
-from infrahub.core.migrations.shared import ArbitraryMigration, MigrationResult, get_migration_console
+from infrahub.core.migrations.shared import ArbitraryMigration, MigrationInput, MigrationResult, get_migration_console
 from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -144,7 +143,9 @@ class Migration048(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        at = migration_input.at
         console = get_migration_console()
 
         console.log("Deleting duplicate edges for all Relationships", end="...")

--- a/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
+++ b/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
@@ -8,6 +8,7 @@ from infrahub.core.query import Query, QueryType
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -49,5 +50,5 @@ class Migration049(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        return await self.do_execute(db=db)
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+        return await self.do_execute(db=db, at=at)

--- a/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
+++ b/backend/infrahub/core/migrations/graph/m049_remove_is_visible_relationship.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.query import Query, QueryType
 
-from ..shared import GraphMigration
+from ..shared import GraphMigration, MigrationInput
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -50,5 +49,5 @@ class Migration049(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
-        return await self.do_execute(db=db, at=at)
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        return await self.do_execute(migration_input=migration_input)

--- a/backend/infrahub/core/migrations/graph/m050_backfill_vertex_metadata.py
+++ b/backend/infrahub/core/migrations/graph/m050_backfill_vertex_metadata.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.query import Query, QueryType
 
-from ..shared import GraphMigration
+from ..shared import GraphMigration, MigrationInput
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -165,5 +164,5 @@ class Migration050(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
-        return await self.do_execute(db=db, at=at)
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        return await self.do_execute(migration_input=migration_input)

--- a/backend/infrahub/core/migrations/graph/m050_backfill_vertex_metadata.py
+++ b/backend/infrahub/core/migrations/graph/m050_backfill_vertex_metadata.py
@@ -8,6 +8,7 @@ from infrahub.core.query import Query, QueryType
 from ..shared import GraphMigration
 
 if TYPE_CHECKING:
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -164,5 +165,5 @@ class Migration050(GraphMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        return await self.do_execute(db=db)
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+        return await self.do_execute(db=db, at=at)

--- a/backend/infrahub/core/migrations/graph/m051_subtract_branched_from_microsecond.py
+++ b/backend/infrahub/core/migrations/graph/m051_subtract_branched_from_microsecond.py
@@ -17,7 +17,7 @@ class Migration051(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
         result = MigrationResult()
 
         branches = await Branch.get_list(db=db)

--- a/backend/infrahub/core/migrations/graph/m051_subtract_branched_from_microsecond.py
+++ b/backend/infrahub/core/migrations/graph/m051_subtract_branched_from_microsecond.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.branch import Branch
-from infrahub.core.migrations.shared import ArbitraryMigration, MigrationResult
+from infrahub.core.migrations.shared import ArbitraryMigration, MigrationInput, MigrationResult
 from infrahub.core.timestamp import Timestamp
 
 if TYPE_CHECKING:
@@ -17,7 +17,8 @@ class Migration051(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:  # noqa: ARG002
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
         result = MigrationResult()
 
         branches = await Branch.get_list(db=db)

--- a/backend/infrahub/core/migrations/runner.py
+++ b/backend/infrahub/core/migrations/runner.py
@@ -7,7 +7,7 @@ from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph import MIGRATIONS
 
 from .exceptions import MigrationFailureError
-from .shared import MigrationRequiringRebase
+from .shared import MigrationInput, MigrationRequiringRebase
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -41,7 +41,9 @@ class MigrationRunner:
             return
 
         for migration in self.applicable_migrations:
-            execution_result = await migration.execute_against_branch(db=db, branch=self.branch, at=at)
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=db, at=at), branch=self.branch
+            )
             validation_result = None
 
             if execution_result.success:

--- a/backend/infrahub/core/migrations/runner.py
+++ b/backend/infrahub/core/migrations/runner.py
@@ -11,6 +11,7 @@ from .shared import MigrationRequiringRebase
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -35,12 +36,12 @@ class MigrationRunner:
     def has_migrations(self) -> bool:
         return bool(self.applicable_migrations)
 
-    async def run(self, db: InfrahubDatabase) -> None:
+    async def run(self, db: InfrahubDatabase, at: Timestamp) -> None:
         if not self.has_migrations():
             return
 
         for migration in self.applicable_migrations:
-            execution_result = await migration.execute_against_branch(db=db, branch=self.branch)
+            execution_result = await migration.execute_against_branch(db=db, branch=self.branch, at=at)
             validation_result = None
 
             if execution_result.success:

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -170,7 +170,7 @@ class AttributeKindUpdateMigration(AttributeSchemaMigration):
         self,
         db: InfrahubDatabase,
         branch: Branch,
-        at: Timestamp | str | None = None,
+        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
         user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.types import is_large_attribute_type
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
-from ..shared import AttributeSchemaMigration, MigrationResult
+from ..shared import AttributeSchemaMigration, MigrationInput, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.branch.models import Branch
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -168,15 +166,13 @@ class AttributeKindUpdateMigration(AttributeSchemaMigration):
 
     async def execute(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         branch: Branch,
-        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
-        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         is_indexed_previous = is_large_attribute_type(self.previous_attribute_schema.kind)
         is_indexed_new = is_large_attribute_type(self.new_attribute_schema.kind)
         if is_indexed_previous is is_indexed_new:
             return MigrationResult()
 
-        return await super().execute(db=db, branch=branch, at=at, queries=queries, user_id=user_id)
+        return await super().execute(migration_input=migration_input, branch=branch, queries=queries)

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -72,7 +72,7 @@ class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
         self,
         db: InfrahubDatabase,
         branch: Branch,
-        at: Timestamp | str | None = None,
+        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,  # noqa: ARG002
         user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations.query.attribute_remove import AttributeRemoveQuery
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
 from ..query.attribute_add import AttributeAddQuery
-from ..shared import AttributeSchemaMigration, MigrationResult
+from ..shared import AttributeSchemaMigration, MigrationInput, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.branch.models import Branch
     from infrahub.core.schema import MainSchemaTypes
-    from infrahub.core.timestamp import Timestamp
-    from infrahub.database import InfrahubDatabase
 
 
 def _get_node_kinds(schema: MainSchemaTypes) -> list[str]:
@@ -70,11 +67,9 @@ class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
 
     async def execute(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         branch: Branch,
-        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,  # noqa: ARG002
-        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         if (
             # no change in whether the attribute should be used on profiles
@@ -89,4 +84,4 @@ class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
         if not self.new_attribute_schema.support_profiles:
             profiles_queries.append(ProfilesAttributeRemoveMigrationQuery)
 
-        return await super().execute(db=db, branch=branch, at=at, queries=profiles_queries, user_id=user_id)
+        return await super().execute(migration_input=migration_input, branch=branch, queries=profiles_queries)

--- a/backend/infrahub/core/migrations/schema/models.py
+++ b/backend/infrahub/core/migrations/schema/models.py
@@ -7,6 +7,7 @@ from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.models import SchemaUpdateMigrationInfo
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 
 
 class SchemaApplyMigrationData(BaseModel):
@@ -16,6 +17,7 @@ class SchemaApplyMigrationData(BaseModel):
     new_schema: SchemaBranch
     previous_schema: SchemaBranch
     migrations: list[SchemaUpdateMigrationInfo]
+    at: Timestamp
     user_id: str = SYSTEM_USER_ID
 
     @model_serializer()
@@ -26,12 +28,18 @@ class SchemaApplyMigrationData(BaseModel):
             "new_schema": self.new_schema.to_dict_schema_object(),
             "migrations": [migration.model_dump() for migration in self.migrations],
             "user_id": self.user_id,
+            "at": self.at.to_string(),
         }
 
     @field_validator("new_schema", "previous_schema", mode="before")
     @classmethod
     def validate_schema_branch(cls, value: Any) -> SchemaBranch:
         return SchemaBranch.validate(data=value)
+
+    @field_validator("at", mode="before")
+    @classmethod
+    def validate_at(cls, value: Any) -> Timestamp:
+        return Timestamp(value)
 
 
 class SchemaMigrationPathResponseData(BaseModel):

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -64,7 +64,7 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         self,
         db: InfrahubDatabase,
         branch: Branch,
-        at: Timestamp | str | None = None,
+        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
         user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core import registry
-from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.node import Node
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
@@ -12,16 +11,14 @@ from infrahub.tasks.registry import update_branch_registry
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
 from ..query.attribute_add import AttributeAddQuery
-from ..shared import AttributeSchemaMigration, MigrationResult
+from ..shared import AttributeSchemaMigration, MigrationInput, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.attribute_schema import AttributeSchema
-    from infrahub.database import InfrahubDatabase
 
     from ...branch import Branch
-    from ...timestamp import Timestamp
 
 
 class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuery):
@@ -62,26 +59,25 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
 
     async def execute(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         branch: Branch,
-        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
-        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
         if self.new_attribute_schema.inherited is True:
             return MigrationResult()
-        return await super().execute(db=db, branch=branch, at=at, queries=queries, user_id=user_id)
+        return await super().execute(migration_input=migration_input, branch=branch, queries=queries)
 
     async def execute_post_queries(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         result: MigrationResult,
         branch: Branch,
-        at: Timestamp,
-        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         if self.new_attribute_schema.kind != "NumberPool":
             return result
+
+        db = migration_input.db
+        at = migration_input.at
 
         number_pool: CoreNumberPool = await Node.fetch_or_create_number_pool(
             db=db,

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -77,7 +77,7 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         db: InfrahubDatabase,
         result: MigrationResult,
         branch: Branch,
-        at: Timestamp,  # noqa: ARG002
+        at: Timestamp,
         user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         if self.new_attribute_schema.kind != "NumberPool":
@@ -88,6 +88,7 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             branch=branch,
             schema_node=self.new_schema,  # type: ignore
             schema_attribute=self.new_attribute_schema,
+            at=at,
         )
 
         await update_branch_registry(db=db, branch=branch)
@@ -108,11 +109,11 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             return result
 
         for node, number in zip(nodes, numbers, strict=True):
-            await number_pool.reserve(db=db, number=number, identifier=node.get_id())
+            await number_pool.reserve(db=db, number=number, identifier=node.get_id(), at=at)
             attr = getattr(node, self.new_attribute_schema.name)
             attr.value = number
             attr.source = number_pool.id
 
-            await node.save(db=db, fields=[self.new_attribute_schema.name])
+            await node.save(db=db, fields=[self.new_attribute_schema.name], at=at)
 
         return result

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -10,6 +10,7 @@ from prefect.logging import get_run_logger
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations import MIGRATION_MAP
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.workers.dependencies import get_database
 from infrahub.workflows.utils import add_branch_tag
@@ -107,7 +108,9 @@ async def schema_path_migrate(
             previous_node_schema=previous_node_schema,  # type: ignore[arg-type]
             schema_path=schema_path,
         )
-        execution_result = await migration.execute(db=db, branch=branch, at=at, user_id=user_id)
+        execution_result = await migration.execute(
+            migration_input=MigrationInput(db=db, at=at, user_id=user_id), branch=branch
+        )
 
         log.info(f"Migration completed for {migration_name}")
         log.debug(f"execution_result {execution_result}")

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -18,6 +18,7 @@ from .models import SchemaApplyMigrationData, SchemaMigrationPathResponseData
 
 if TYPE_CHECKING:
     from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -59,6 +60,7 @@ async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str
             schema_path=migration.path,
             database=await get_database(),
             user_id=message.user_id,
+            at=message.at,
         )
 
     async for _, result in batch.execute():
@@ -79,6 +81,7 @@ async def schema_path_migrate(
     migration_name: str,
     schema_path: SchemaPath,
     database: InfrahubDatabase,
+    at: Timestamp,
     new_node_schema: MainSchemaTypes | None = None,
     previous_node_schema: MainSchemaTypes | None = None,
     user_id: str = SYSTEM_USER_ID,
@@ -104,7 +107,7 @@ async def schema_path_migrate(
             previous_node_schema=previous_node_schema,  # type: ignore[arg-type]
             schema_path=schema_path,
         )
-        execution_result = await migration.execute(db=db, branch=branch, user_id=user_id)
+        execution_result = await migration.execute(db=db, branch=branch, at=at, user_id=user_id)
 
         log.info(f"Migration completed for {migration_name}")
         log.debug(f"execution_result {execution_result}")

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -46,6 +47,13 @@ class MigrationResult(BaseModel):
         return False
 
 
+@dataclass
+class MigrationInput:
+    db: InfrahubDatabase
+    at: Timestamp = field(default_factory=Timestamp)
+    user_id: str = SYSTEM_USER_ID
+
+
 class SchemaMigration(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str = Field(..., description="Name of the migration")
@@ -59,37 +67,37 @@ class SchemaMigration(BaseModel):
 
     async def execute_pre_queries(
         self,
-        db: InfrahubDatabase,  # noqa: ARG002
+        migration_input: MigrationInput,  # noqa: ARG002
         result: MigrationResult,
         branch: Branch,  # noqa: ARG002
-        at: Timestamp,  # noqa: ARG002
-        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         return result
 
     async def execute_post_queries(
         self,
-        db: InfrahubDatabase,  # noqa: ARG002
+        migration_input: MigrationInput,  # noqa: ARG002
         result: MigrationResult,
         branch: Branch,  # noqa: ARG002
-        at: Timestamp,  # noqa: ARG002
-        user_id: str,  # noqa: ARG002
     ) -> MigrationResult:
         return result
 
     async def execute_queries(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         result: MigrationResult,
         branch: Branch,
-        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]],
-        user_id: str,
     ) -> MigrationResult:
         for migration_query in queries:
             try:
-                query = await migration_query.init(db=db, branch=branch, at=at, migration=self, user_id=user_id)
-                await query.execute(db=db)
+                query = await migration_query.init(
+                    db=migration_input.db,
+                    branch=branch,
+                    at=migration_input.at,
+                    migration=self,
+                    user_id=migration_input.user_id,
+                )
+                await query.execute(db=migration_input.db)
                 result.nbr_migrations_executed += query.get_nbr_migrations_executed()
             except Exception as exc:
                 result.errors.append(str(exc))
@@ -99,22 +107,20 @@ class SchemaMigration(BaseModel):
 
     async def execute(
         self,
-        db: InfrahubDatabase,
+        migration_input: MigrationInput,
         branch: Branch,
-        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
-        user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
-        async with db.start_transaction() as ts:
+        async with migration_input.db.start_transaction() as ts:
             result = MigrationResult()
-            at = Timestamp(at)
+            txn_migration_input = MigrationInput(db=ts, at=migration_input.at, user_id=migration_input.user_id)
 
-            await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at, user_id=user_id)
+            await self.execute_pre_queries(migration_input=txn_migration_input, result=result, branch=branch)
             queries_to_execute = queries or self.queries
             await self.execute_queries(
-                db=ts, result=result, branch=branch, at=at, queries=queries_to_execute, user_id=user_id
+                migration_input=txn_migration_input, result=result, branch=branch, queries=queries_to_execute
             )
-            await self.execute_post_queries(db=ts, result=result, branch=branch, at=at, user_id=user_id)
+            await self.execute_post_queries(migration_input=txn_migration_input, result=result, branch=branch)
 
         return result
 
@@ -174,16 +180,17 @@ class GraphMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
-        async with db.start_transaction() as ts:
-            return await self.do_execute(db=ts, at=at)
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        async with migration_input.db.start_transaction() as ts:
+            txn_migration_input = MigrationInput(db=ts, at=migration_input.at)
+            return await self.do_execute(migration_input=txn_migration_input)
 
-    async def do_execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def do_execute(self, migration_input: MigrationInput) -> MigrationResult:
         result = MigrationResult()
         for migration_query in self.queries:
             try:
-                query = await migration_query.init(db=db, at=at)
-                await query.execute(db=db)
+                query = await migration_query.init(db=migration_input.db, at=migration_input.at)
+                await query.execute(db=migration_input.db)
             except Exception as exc:
                 result.errors.append(str(exc))
                 return result
@@ -216,14 +223,14 @@ class InternalSchemaMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         result = MigrationResult()
 
         default_branch = registry.get_branch_from_registry()
 
         for migration in self.migrations:
             try:
-                execution_result = await migration.execute(db=db, branch=default_branch, at=at, user_id=user_id)
+                execution_result = await migration.execute(migration_input=migration_input, branch=default_branch)
                 result.errors.extend(execution_result.errors)
             except Exception as exc:
                 result.errors.append(str(exc))
@@ -243,7 +250,7 @@ class ArbitraryMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         raise NotImplementedError()
 
 
@@ -259,11 +266,11 @@ class MigrationRequiringRebase(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    async def execute_against_branch(self, migration_input: MigrationInput, branch: Branch) -> MigrationResult:
         """Method that will be run against non-default branches, it assumes that the branches have been rebased."""
         raise NotImplementedError()
 
-    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Method that will be run against the default branch."""
         raise NotImplementedError()
 

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -101,7 +101,7 @@ class SchemaMigration(BaseModel):
         self,
         db: InfrahubDatabase,
         branch: Branch,
-        at: Timestamp | str | None = None,
+        at: Timestamp,
         queries: Sequence[type[MigrationBaseQuery]] | None = None,
         user_id: str = SYSTEM_USER_ID,
     ) -> MigrationResult:
@@ -174,15 +174,15 @@ class GraphMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         async with db.start_transaction() as ts:
-            return await self.do_execute(db=ts)
+            return await self.do_execute(db=ts, at=at)
 
-    async def do_execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def do_execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         result = MigrationResult()
         for migration_query in self.queries:
             try:
-                query = await migration_query.init(db=db)
+                query = await migration_query.init(db=db, at=at)
                 await query.execute(db=db)
             except Exception as exc:
                 result.errors.append(str(exc))
@@ -216,14 +216,14 @@ class InternalSchemaMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError
 
-    async def execute(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> MigrationResult:
         result = MigrationResult()
 
         default_branch = registry.get_branch_from_registry()
 
         for migration in self.migrations:
             try:
-                execution_result = await migration.execute(db=db, branch=default_branch, user_id=user_id)
+                execution_result = await migration.execute(db=db, branch=default_branch, at=at, user_id=user_id)
                 result.errors.extend(execution_result.errors)
             except Exception as exc:
                 result.errors.append(str(exc))
@@ -243,7 +243,7 @@ class ArbitraryMigration(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         raise NotImplementedError()
 
 
@@ -259,11 +259,11 @@ class MigrationRequiringRebase(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
         """Method that will be run against non-default branches, it assumes that the branches have been rebased."""
         raise NotImplementedError()
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase, at: Timestamp) -> MigrationResult:
         """Method that will be run against the default branch."""
         raise NotImplementedError()
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -408,6 +408,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         schema_node: NodeSchema | GenericSchema,
         schema_attribute: AttributeSchema,
         branch: Branch | None = None,
+        at: Timestamp | None = None,
     ) -> CoreNumberPool:
         """Fetch or create a number pool based on the schema attribute parameters.
 
@@ -456,7 +457,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     end_range=number_pool_parameters.end_range,
                     pool_type=NumberPoolType.SCHEMA.value,
                 )
-                await number_pool.save(db=db)
+                await number_pool.save(db=db, at=at)
 
                 # Do a lookup of the number pool to get the correct mapped type from the registry
                 # without this we don't get access to the .get_resource() method.

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1181,6 +1181,7 @@ class RelationshipManager:
         db: InfrahubDatabase,
         process_delete: bool = True,
         user_id: str = SYSTEM_USER_ID,
+        at: Timestamp | None = None,
     ) -> bool:
         """Replace and Update the list of relationships with this one."""
         if not isinstance(data, list):
@@ -1189,6 +1190,7 @@ class RelationshipManager:
             list_data = data
 
         await self._validate_hierarchy()
+        update_at = Timestamp(at)
 
         # Reset the list of relationship and save the previous one to see if we can reuse some
         previous_relationships = {rel.peer_id: rel for rel in await self.get_relationships(db=db) if rel.peer_id}
@@ -1211,7 +1213,7 @@ class RelationshipManager:
                 if previous_relationships:
                     if process_delete:
                         for rel in previous_relationships.values():
-                            await rel.delete(db=db, user_id=user_id)
+                            await rel.delete(db=db, at=update_at, user_id=user_id)
                     changed = True
                 continue
 
@@ -1231,7 +1233,11 @@ class RelationshipManager:
             # If the item is not present in the previous list of relationship, we create a new one.
             self._relationships.append(
                 await self.rel_class(
-                    schema=self.schema, branch=self.branch, source_kind=self.node.get_kind(), at=self.at, node=self.node
+                    schema=self.schema,
+                    branch=self.branch,
+                    source_kind=self.node.get_kind(),
+                    at=update_at,
+                    node=self.node,
                 ).new(db=db, data=item)
             )
             changed = True

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -25,6 +25,7 @@ from infrahub.core.schema import (
     SchemaRoot,
     TemplateSchema,
 )
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import parse_node_kind
 from infrahub.exceptions import SchemaNotFoundError
 from infrahub.log import get_logger
@@ -36,7 +37,6 @@ log = get_logger()
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -179,18 +179,20 @@ class SchemaManager(NodeManager):
         diff: SchemaDiff | None = None,
         limit: list[str] | None = None,
         update_db: bool = True,
+        at: Timestamp | None = None,
         user_id: str = SYSTEM_USER_ID,
     ) -> None:
         branch = await registry.get_branch(branch=branch, db=db)
+        at = Timestamp(at)
 
         updated_schema = None
         if update_db:
             if diff:
                 schema_diff = await self.update_schema_to_db(
-                    schema=schema, db=db, branch=branch, diff=diff, user_id=user_id
+                    schema=schema, db=db, branch=branch, diff=diff, at=at, user_id=user_id
                 )
             else:
-                await self.load_schema_to_db(schema=schema, db=db, branch=branch, limit=limit, user_id=user_id)
+                await self.load_schema_to_db(schema=schema, db=db, branch=branch, limit=limit, at=at, user_id=user_id)
                 # After updating the schema into the db
                 # we need to pull a fresh version because some default value are managed/generated within the node object
                 schema_diff = None
@@ -201,7 +203,7 @@ class SchemaManager(NodeManager):
                     )
 
             updated_schema = await self.load_schema_from_db(
-                db=db, branch=branch, schema=schema, schema_diff=schema_diff
+                db=db, branch=branch, schema=schema, schema_diff=schema_diff, at=at
             )
 
         self.set_schema_branch(name=branch.name, schema=updated_schema or schema)
@@ -221,6 +223,7 @@ class SchemaManager(NodeManager):
         db: InfrahubDatabase,
         diff: SchemaDiff,
         user_id: str,
+        at: Timestamp,
         branch: Branch | str | None = None,
     ) -> SchemaBranchDiff:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
@@ -231,7 +234,7 @@ class SchemaManager(NodeManager):
         added_generics = []
         for item_kind in diff.added.keys():
             item = schema.get(name=item_kind, duplicate=False)
-            node = await self.load_node_to_db(node=item, branch=branch, db=db, user_id=user_id)
+            node = await self.load_node_to_db(node=item, branch=branch, db=db, at=at, user_id=user_id)
             schema.set(name=item_kind, schema=node)
             if item.is_node_schema:
                 added_nodes.append(item_kind)
@@ -244,10 +247,10 @@ class SchemaManager(NodeManager):
             item = schema.get(name=item_kind, duplicate=False)
             if item_diff:
                 node = await self.update_node_in_db_based_on_diff(
-                    node=item, branch=branch, db=db, diff=item_diff, user_id=user_id
+                    node=item, branch=branch, db=db, diff=item_diff, at=at, user_id=user_id
                 )
             else:
-                node = await self.update_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
+                node = await self.update_node_in_db(node=item, branch=branch, db=db, at=at, user_id=user_id)
             schema.set(name=item_kind, schema=node)
             if item.is_node_schema:
                 changed_nodes.append(item_kind)
@@ -258,7 +261,7 @@ class SchemaManager(NodeManager):
         removed_generics = []
         for item_kind in diff.removed.keys():
             item = schema.get(name=item_kind, duplicate=False)
-            node = await self.delete_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
+            node = await self.delete_node_in_db(node=item, branch=branch, db=db, at=at, user_id=user_id)
             schema.delete(name=item_kind)
             if item.is_node_schema:
                 removed_nodes.append(item_kind)
@@ -281,9 +284,10 @@ class SchemaManager(NodeManager):
         branch: Branch | str | None = None,
         limit: list[str] | None = None,
         user_id: str = SYSTEM_USER_ID,
+        at: Timestamp | None = None,
     ) -> None:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
-
+        at = Timestamp(at)
         branch = await registry.get_branch(branch=branch, db=db)
 
         for item_kind in schema.node_names + schema.generic_names_without_templates:
@@ -291,10 +295,10 @@ class SchemaManager(NodeManager):
                 continue
             item = schema.get(name=item_kind, duplicate=False)
             if not item.id:
-                node = await self.load_node_to_db(node=item, branch=branch, db=db, user_id=user_id)
+                node = await self.load_node_to_db(node=item, branch=branch, db=db, at=at, user_id=user_id)
                 schema.set(name=item_kind, schema=node)
             else:
-                node = await self.update_node_in_db(node=item, branch=branch, db=db, user_id=user_id)
+                node = await self.update_node_in_db(node=item, branch=branch, db=db, at=at, user_id=user_id)
                 schema.set(name=item_kind, schema=node)
 
     async def load_node_to_db(
@@ -302,6 +306,7 @@ class SchemaManager(NodeManager):
         node: NodeSchema | GenericSchema,
         db: InfrahubDatabase,
         user_id: str,
+        at: Timestamp,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Load a Node with its attributes and its relationships to the database."""
@@ -322,7 +327,7 @@ class SchemaManager(NodeManager):
         schema_dict = node.model_dump(exclude={"id", "state", "filters", "relationships", "attributes"})
         obj = await Node.init(schema=node_schema, branch=branch, db=db)
         await obj.new(**schema_dict, db=db)
-        await obj.save(db=db, user_id=user_id)
+        await obj.save(db=db, at=at, user_id=user_id)
         new_node.id = obj.id
 
         # Then create the Attributes and the relationships
@@ -333,7 +338,7 @@ class SchemaManager(NodeManager):
             for item in node.attributes:
                 if item.inherited is False:
                     new_attr = await self.create_attribute_in_db(
-                        schema=attribute_schema, item=item, parent=obj, branch=branch, db=db, user_id=user_id
+                        schema=attribute_schema, item=item, parent=obj, branch=branch, db=db, at=at, user_id=user_id
                     )
                 else:
                     new_attr = item.duplicate()
@@ -342,7 +347,7 @@ class SchemaManager(NodeManager):
             for item in node.relationships:
                 if item.inherited is False:
                     new_rel = await self.create_relationship_in_db(
-                        schema=relationship_schema, item=item, parent=obj, branch=branch, db=db, user_id=user_id
+                        schema=relationship_schema, item=item, parent=obj, branch=branch, db=db, at=at, user_id=user_id
                     )
                 else:
                     new_rel = item.duplicate()
@@ -357,6 +362,7 @@ class SchemaManager(NodeManager):
         db: InfrahubDatabase,
         node: NodeSchema | GenericSchema,
         user_id: str,
+        at: Timestamp,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Update a Node with its attributes and its relationships in the database."""
@@ -380,11 +386,11 @@ class SchemaManager(NodeManager):
         new_node = node.duplicate()
 
         # Update the attributes and the relationships nodes as well
-        await obj.attributes.update(db=db, data=[item.id for item in node.local_attributes if item.id])
+        await obj.attributes.update(db=db, data=[item.id for item in node.local_attributes if item.id], at=at)
         await obj.relationships.update(
-            db=db, data=[item.id for item in node.local_relationships if item.id and item.name != "profiles"]
+            db=db, data=[item.id for item in node.local_relationships if item.id and item.name != "profiles"], at=at
         )
-        await obj.save(db=db, user_id=user_id)
+        await obj.save(db=db, at=at, user_id=user_id)
 
         # Then Update the Attributes and the relationships
 
@@ -397,19 +403,19 @@ class SchemaManager(NodeManager):
 
         for item in node.local_attributes:
             if item.id and item.id in items:
-                await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, user_id=user_id)
+                await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, at=at, user_id=user_id)
             elif not item.id:
                 new_attr = await self.create_attribute_in_db(
-                    schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
+                    schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, at=at, user_id=user_id
                 )
                 new_node.attributes.append(new_attr)
 
         for item in node.local_relationships:
             if item.id and item.id in items:
-                await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, user_id=user_id)
+                await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, at=at, user_id=user_id)
             elif not item.id:
                 new_rel = await self.create_relationship_in_db(
-                    schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
+                    schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, at=at, user_id=user_id
                 )
                 new_node.relationships.append(new_rel)
 
@@ -423,6 +429,7 @@ class SchemaManager(NodeManager):
         diff: HashableModelDiff,
         node: NodeSchema | GenericSchema,
         user_id: str,
+        at: Timestamp,
         branch: Branch | str | None = None,
     ) -> NodeSchema | GenericSchema:
         """Update a Node with its attributes and its relationships in the database based on a HashableModelDiff."""
@@ -496,24 +503,24 @@ class SchemaManager(NodeManager):
             items.update({field.id: field for field in missing_attrs + missing_rels})
 
         if diff_attributes:
-            await obj.attributes.update(db=db, data=[item.id for item in node.local_attributes if item.id])
+            await obj.attributes.update(db=db, data=[item.id for item in node.local_attributes if item.id], at=at)
 
         if diff_relationships:
-            await obj.relationships.update(db=db, data=[item.id for item in node.local_relationships if item.id])
+            await obj.relationships.update(db=db, data=[item.id for item in node.local_relationships if item.id], at=at)
 
-        await obj.save(db=db, user_id=user_id)
+        await obj.save(db=db, at=at, user_id=user_id)
 
         if diff_attributes:
             for item in node.local_attributes:
                 # if item is in changed and has no ID, then it is being overridden from a generic and must be added
                 if item.name in diff_attributes.added or (item.name in diff_attributes.changed and item.id is None):
                     created_item = await self.create_attribute_in_db(
-                        schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
+                        schema=attribute_schema, item=item, branch=branch, db=db, parent=obj, at=at, user_id=user_id
                     )
                     new_attr = new_node.get_attribute(name=item.name)
                     new_attr.id = created_item.id
                 elif item.name in diff_attributes.changed and item.id and item.id in items:
-                    await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, user_id=user_id)
+                    await self.update_attribute_in_db(item=item, attr=items[item.id], db=db, at=at, user_id=user_id)
                 elif item.name in diff_attributes.removed and item.id and item.id in items:
                     await items[item.id].delete(db=db, user_id=user_id)
                 elif (
@@ -530,12 +537,12 @@ class SchemaManager(NodeManager):
                     item.name in diff_relationships.changed and item.id is None
                 ):
                     created_rel = await self.create_relationship_in_db(
-                        schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, user_id=user_id
+                        schema=relationship_schema, item=item, branch=branch, db=db, parent=obj, at=at, user_id=user_id
                     )
                     new_rel = new_node.get_relationship(name=item.name)
                     new_rel.id = created_rel.id
                 elif item.name in diff_relationships.changed and item.id and item.id in items:
-                    await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, user_id=user_id)
+                    await self.update_relationship_in_db(item=item, rel=items[item.id], db=db, at=at, user_id=user_id)
                 elif item.name in diff_relationships.removed and item.id and item.id in items:
                     await items[item.id].delete(db=db, user_id=user_id)
                 elif (
@@ -555,7 +562,7 @@ class SchemaManager(NodeManager):
         if field_names_to_remove:
             for field_schema in items.values():
                 if field_schema.name.value in field_names_to_remove:
-                    await field_schema.delete(db=db, user_id=user_id)
+                    await field_schema.delete(db=db, at=at, user_id=user_id)
 
         # Save back the node with the (potentially) newly created IDs in the SchemaManager
         self.set(name=new_node.kind, schema=new_node, branch=branch.name)
@@ -566,6 +573,7 @@ class SchemaManager(NodeManager):
         db: InfrahubDatabase,
         node: NodeSchema | GenericSchema,
         user_id: str,
+        at: Timestamp,
         branch: Branch | str | None = None,
     ) -> None:
         """Delete the node with its attributes and relationships."""
@@ -581,11 +589,11 @@ class SchemaManager(NodeManager):
 
         # First delete the attributes and the relationships
         for attr_schema_node in (await obj.attributes.get_peers(db=db)).values():
-            await attr_schema_node.delete(db=db, user_id=user_id)
+            await attr_schema_node.delete(db=db, at=at, user_id=user_id)
         for rel_schema_node in (await obj.relationships.get_peers(db=db)).values():
-            await rel_schema_node.delete(db=db, user_id=user_id)
+            await rel_schema_node.delete(db=db, at=at, user_id=user_id)
 
-        await obj.delete(db=db, user_id=user_id)
+        await obj.delete(db=db, at=at, user_id=user_id)
 
     @staticmethod
     async def create_attribute_in_db(
@@ -595,20 +603,23 @@ class SchemaManager(NodeManager):
         parent: Node,
         db: InfrahubDatabase,
         user_id: str,
+        at: Timestamp,
     ) -> AttributeSchema:
         obj = await Node.init(schema=schema, branch=branch, db=db)
         await obj.new(**item.to_node(), node=parent, db=db)
-        await obj.save(db=db, user_id=user_id)
+        await obj.save(db=db, at=at, user_id=user_id)
         new_item = item.duplicate()
         new_item.id = obj.id
         return new_item
 
     @staticmethod
-    async def update_attribute_in_db(item: AttributeSchema, attr: Node, db: InfrahubDatabase, user_id: str) -> None:
+    async def update_attribute_in_db(
+        item: AttributeSchema, attr: Node, db: InfrahubDatabase, at: Timestamp, user_id: str
+    ) -> None:
         item_dict = item.model_dump(exclude={"id", "state", "filters"})
         for key, value in item_dict.items():
             getattr(attr, key).value = value
-        await attr.save(db=db, user_id=user_id)
+        await attr.save(db=db, at=at, user_id=user_id)
 
     @staticmethod
     async def create_relationship_in_db(
@@ -618,22 +629,23 @@ class SchemaManager(NodeManager):
         parent: Node,
         db: InfrahubDatabase,
         user_id: str,
+        at: Timestamp,
     ) -> RelationshipSchema:
         obj = await Node.init(schema=schema, branch=branch, db=db)
         await obj.new(**item.model_dump(exclude={"id", "state", "filters"}), node=parent, db=db)
-        await obj.save(db=db, user_id=user_id)
+        await obj.save(db=db, at=at, user_id=user_id)
         new_item = item.duplicate()
         new_item.id = obj.id
         return new_item
 
     @staticmethod
     async def update_relationship_in_db(
-        item: RelationshipSchema, rel: Node, db: InfrahubDatabase, user_id: str
+        item: RelationshipSchema, rel: Node, db: InfrahubDatabase, at: Timestamp, user_id: str
     ) -> None:
         item_dict = item.model_dump(exclude={"id", "state", "filters"})
         for key, value in item_dict.items():
             getattr(rel, key).value = value
-        await rel.save(db=db, user_id=user_id)
+        await rel.save(db=db, at=at, user_id=user_id)
 
     async def load_schema(
         self,

--- a/backend/tests/benchmark/test_load_node_to_db.py
+++ b/backend/tests/benchmark/test_load_node_to_db.py
@@ -9,6 +9,7 @@ from infrahub.core.schema import (
     internal_schema,
 )
 from infrahub.core.schema.manager import SchemaManager
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -34,4 +35,6 @@ def test_load_node_to_db_node_schema(
     }
     node = NodeSchema(**SCHEMA)
 
-    aio_benchmark(registry.schema.load_node_to_db, node=node, db=db, branch=default_branch, user_id="user-id")
+    aio_benchmark(
+        registry.schema.load_node_to_db, node=node, db=db, branch=default_branch, at=Timestamp(), user_id="user-id"
+    )

--- a/backend/tests/functional/api/test_load_schema.py
+++ b/backend/tests/functional/api/test_load_schema.py
@@ -190,7 +190,7 @@ class TestLoadSchemaAPI(TestInfrahubApp):
         default_branch: Branch,
     ) -> None:
         schema = registry.schema.get_schema_branch(name=default_branch.name)
-        await registry.schema.load_schema_to_db(schema=schema, branch=default_branch, db=db)
+        await registry.schema.load_schema_to_db(schema=schema, branch=default_branch, db=db, at=Timestamp())
         creation = await client.schema.load(schemas=[helper.schema_file("infra_simple_01.json")])
         assert not creation.errors
 
@@ -224,7 +224,7 @@ class TestLoadSchemaAPI(TestInfrahubApp):
         default_branch: Branch,
     ) -> None:
         schema = registry.schema.get_schema_branch(name=default_branch.name)
-        await registry.schema.load_schema_to_db(schema=schema, branch=default_branch, db=db)
+        await registry.schema.load_schema_to_db(schema=schema, branch=default_branch, db=db, at=Timestamp())
         simple = await client.schema.load(schemas=[helper.schema_file("infra_simple_01.json")])
         assert not simple.errors
         org_schema = registry.schema.get(name="TestingOrganization", branch=default_branch.name)

--- a/backend/tests/helpers/edge_timestamps.py
+++ b/backend/tests/helpers/edge_timestamps.py
@@ -1,0 +1,34 @@
+from tests.db_snapshot import DbSnapshot
+
+
+def assert_edge_timestamps(
+    before_snapshot: DbSnapshot,
+    after_snapshot: DbSnapshot,
+    expected_timestamp: str,
+) -> None:
+    """Verify all new/modified edges use the expected timestamp.
+
+    For new edges: 'from' must equal expected_timestamp
+    For modified edges: changed 'to' must equal expected_timestamp
+    """
+    before_edges_by_id = {e.db_id: e for e in before_snapshot.edge_map.values()}
+    after_edges_by_id = {e.db_id: e for e in after_snapshot.edge_map.values()}
+
+    for edge_id, after_edge in after_edges_by_id.items():
+        before_edge = before_edges_by_id.get(edge_id)
+
+        if before_edge is None:
+            # New edge - 'from' must equal expected_timestamp
+            from_time = after_edge.properties.get("from")
+            assert from_time == expected_timestamp, (
+                f"New edge {after_edge.edge_type} has from={from_time}, expected {expected_timestamp}"
+            )
+        else:
+            # Check for modified 'to' time (from never changes once set)
+            before_to = before_edge.properties.get("to")
+            after_to = after_edge.properties.get("to")
+
+            if before_to != after_to:
+                assert after_to == expected_timestamp, (
+                    f"Modified edge {after_edge.edge_type} has to={after_to}, expected {expected_timestamp}"
+                )

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -11,6 +11,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.relationship.model import RelationshipManager
 from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from tests.helpers.db_validation import validate_no_duplicate_attributes
@@ -1562,6 +1563,7 @@ class TestSchemaLifecycleGenericUpdatedWithLegacyDuplicates(SchemaLifecycleGener
                     parent=node_schema_instance,
                     item=attr,
                     user_id="user-id",
+                    at=Timestamp(),
                 )
                 attr.id = new_attr.id
             for rel_name in ("things", "favorite_thing"):
@@ -1573,6 +1575,7 @@ class TestSchemaLifecycleGenericUpdatedWithLegacyDuplicates(SchemaLifecycleGener
                     parent=node_schema_instance,
                     item=rel,
                     user_id="user-id",
+                    at=Timestamp(),
                 )
                 rel.id = new_rel.id
             main_schema_branch.set(name=schema_kind, schema=node_schema)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2419,7 +2419,9 @@ async def register_organization_schema(default_branch: Branch, organization_sche
 
 @pytest.fixture
 async def register_core_schema_db(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
-    await registry.schema.load_schema_to_db(schema=register_core_models_schema, branch=default_branch, db=db)
+    await registry.schema.load_schema_to_db(
+        schema=register_core_models_schema, branch=default_branch, db=db, at=Timestamp()
+    )
     updated_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
     registry.schema.set_schema_branch(name=default_branch.name, schema=updated_schema)
 

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -22,6 +22,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.metadata.query.node_metadata import NodeMetadataDefaultBranchQuery
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
@@ -1903,7 +1904,9 @@ class TestDiffAndMerge:
             ),
         )
         migration_at = Timestamp()
-        execution_result = await migration.execute(db=db, branch=branch2, at=migration_at, user_id="migration-user")
+        execution_result = await migration.execute(
+            migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"), branch=branch2
+        )
         assert not execution_result.errors
 
         # update car owner and color
@@ -2194,7 +2197,7 @@ class TestDiffAndMerge:
         )
         migration1_at = Timestamp()
         execution_result = await migration.execute(
-            db=db, branch=branch2, at=migration1_at, user_id="migration-user-one"
+            migration_input=MigrationInput(db=db, at=migration1_at, user_id="migration-user-one"), branch=branch2
         )
         assert not execution_result.errors
 
@@ -2223,7 +2226,7 @@ class TestDiffAndMerge:
         )
         migration2_at = Timestamp()
         execution_result = await migration.execute(
-            db=db, branch=branch2, at=migration2_at, user_id="migration-user-two"
+            migration_input=MigrationInput(db=db, at=migration2_at, user_id="migration-user-two"), branch=branch2
         )
         assert not execution_result.errors
 
@@ -2485,7 +2488,7 @@ class TestDiffAndMerge:
         )
         migration_at = Timestamp()
         execution_result = await migration.execute(
-            db=db, branch=default_branch, at=migration_at, user_id="migration-user"
+            migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"), branch=default_branch
         )
         assert not execution_result.errors
 

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -3302,7 +3302,7 @@ async def test_calculate_with_migrated_kind_node(
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     # attribute and rel changes after migration
@@ -3882,7 +3882,7 @@ async def test_calculate_with_migrated_attr_name(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
     )
 
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     diff_calculator = DiffCalculator(db=db)
@@ -4117,7 +4117,7 @@ async def test_migrated_kind_node_then_peer_delete(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
 
     # migrate TestPerson kind back to original on a different branch
@@ -4133,7 +4133,7 @@ async def test_migrated_kind_node_then_peer_delete(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     # create a branch and delete a car on the branch
@@ -4212,7 +4212,7 @@ async def test_migrated_kind_with_property_level_changes(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     # property-level change after migration
@@ -4398,7 +4398,7 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
 
     # Create a branch after the migration

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -17,6 +17,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.query.relationship_duplicate import RelationshipDuplicateQuery, SchemaRelationshipInfo
 from infrahub.core.migrations.schema.attribute_name_update import AttributeNameUpdateMigration
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -3302,7 +3303,7 @@ async def test_calculate_with_migrated_kind_node(
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     # attribute and rel changes after migration
@@ -3882,7 +3883,7 @@ async def test_calculate_with_migrated_attr_name(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
     )
 
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     diff_calculator = DiffCalculator(db=db)
@@ -4117,7 +4118,7 @@ async def test_migrated_kind_node_then_peer_delete(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
 
     # migrate TestPerson kind back to original on a different branch
@@ -4133,7 +4134,7 @@ async def test_migrated_kind_node_then_peer_delete(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     # create a branch and delete a car on the branch
@@ -4212,7 +4213,7 @@ async def test_migrated_kind_with_property_level_changes(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     # property-level change after migration
@@ -4398,7 +4399,7 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
 
     # Create a branch after the migration

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -715,7 +715,7 @@ async def test_reconcile_query_on_migrated_kind_node(
         new_node_schema=prefix_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="IpamIPPrefixTwo", field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     registry.schema.set(name="IpamIPPrefixTwo", schema=prefix_schema, branch=branch.name)

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -9,6 +9,7 @@ from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.initialization import create_branch, get_default_ipnamespace
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.ipam import IPPrefixReconcileQuery
@@ -715,7 +716,7 @@ async def test_reconcile_query_on_migrated_kind_node(
         new_node_schema=prefix_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="IpamIPPrefixTwo", field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     registry.schema.set(name="IpamIPPrefixTwo", schema=prefix_schema, branch=branch.name)

--- a/backend/tests/unit/core/migrations/graph/test_001.py
+++ b/backend/tests/unit/core/migrations/graph/test_001.py
@@ -1,6 +1,7 @@
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.migrations.graph import Migration001
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -12,7 +13,7 @@ async def test_migration_001_no_version(db: InfrahubDatabase, reset_registry, de
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)
@@ -27,7 +28,7 @@ async def test_migration_001_initial_version(db: InfrahubDatabase, reset_registr
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)
@@ -44,7 +45,7 @@ async def test_migration_001_validate(db: InfrahubDatabase, reset_registry, dele
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     query_init_root = """

--- a/backend/tests/unit/core/migrations/graph/test_001.py
+++ b/backend/tests/unit/core/migrations/graph/test_001.py
@@ -1,7 +1,7 @@
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.migrations.graph import Migration001
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.database import InfrahubDatabase
 
 
@@ -13,7 +13,7 @@ async def test_migration_001_no_version(db: InfrahubDatabase, reset_registry, de
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)
@@ -28,7 +28,7 @@ async def test_migration_001_initial_version(db: InfrahubDatabase, reset_registr
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)
@@ -45,7 +45,7 @@ async def test_migration_001_validate(db: InfrahubDatabase, reset_registry, dele
     await db.execute_query(query=query_init_root)
 
     migration = Migration001()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     query_init_root = """

--- a/backend/tests/unit/core/migrations/graph/test_003.py
+++ b/backend/tests/unit/core/migrations/graph/test_003.py
@@ -1,9 +1,9 @@
 import pytest
 
 from infrahub.core.migrations.graph.m003_relationship_parent_optional import Migration003, Migration003Query01
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -54,7 +54,7 @@ async def test_migration_003(
     nbr_rels_before = await count_relationships(db=db)
 
     migration = Migration003()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_003.py
+++ b/backend/tests/unit/core/migrations/graph/test_003.py
@@ -3,6 +3,7 @@ import pytest
 from infrahub.core.migrations.graph.m003_relationship_parent_optional import Migration003, Migration003Query01
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -53,7 +54,7 @@ async def test_migration_003(
     nbr_rels_before = await count_relationships(db=db)
 
     migration = Migration003()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_012.py
+++ b/backend/tests/unit/core/migrations/graph/test_012.py
@@ -11,6 +11,7 @@ from infrahub.core.migrations.graph.m012_convert_account_generic import (
 )
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -278,7 +279,7 @@ async def test_migration_012(
     nbr_attrs_before = await count_nodes(db=db, label="Attribute")
 
     migration = Migration012()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_012.py
+++ b/backend/tests/unit/core/migrations/graph/test_012.py
@@ -9,9 +9,9 @@ from infrahub.core.migrations.graph.m012_convert_account_generic import (
     Migration012RenameTypeAttributeData,
     Migration012RenameTypeAttributeSchema,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
-from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -279,7 +279,7 @@ async def test_migration_012(
     nbr_attrs_before = await count_nodes(db=db, label="Attribute")
 
     migration = Migration012()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_013.py
+++ b/backend/tests/unit/core/migrations/graph/test_013.py
@@ -12,6 +12,7 @@ from infrahub.core.migrations.graph.m013_convert_git_password_credential import 
 )
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -297,7 +298,7 @@ async def test_migration_013(
     nbr_nodes_before = await count_nodes(db=db)
 
     migration = Migration013()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_013.py
+++ b/backend/tests/unit/core/migrations/graph/test_013.py
@@ -10,9 +10,9 @@ from infrahub.core.migrations.graph.m013_convert_git_password_credential import 
     Migration013ConvertCoreRepositoryWithoutCred,
     Migration013DeleteUsernamePasswordGenericSchema,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
-from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -298,7 +298,7 @@ async def test_migration_013(
     nbr_nodes_before = await count_nodes(db=db)
 
     migration = Migration013()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_014.py
+++ b/backend/tests/unit/core/migrations/graph/test_014.py
@@ -2,7 +2,7 @@ from infrahub.constants.database import IndexType
 from infrahub.core.migrations.graph.m014_remove_index_attr_value import (
     Migration014,
 )
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.database import DatabaseType, InfrahubDatabase
 from infrahub.database.index import IndexItem
 from infrahub.database.memgraph import IndexManagerMemgraph
@@ -29,7 +29,7 @@ async def test_migration_014(
 
     async with db.start_session() as dbs:
         migration = Migration014()
-        execution_result = await migration.execute(db=dbs, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_014.py
+++ b/backend/tests/unit/core/migrations/graph/test_014.py
@@ -2,6 +2,7 @@ from infrahub.constants.database import IndexType
 from infrahub.core.migrations.graph.m014_remove_index_attr_value import (
     Migration014,
 )
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import DatabaseType, InfrahubDatabase
 from infrahub.database.index import IndexItem
 from infrahub.database.memgraph import IndexManagerMemgraph
@@ -28,7 +29,7 @@ async def test_migration_014(
 
     async with db.start_session() as dbs:
         migration = Migration014()
-        execution_result = await migration.execute(db=dbs)
+        execution_result = await migration.execute(db=dbs, at=Timestamp())
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_017.py
+++ b/backend/tests/unit/core/migrations/graph/test_017.py
@@ -1,5 +1,6 @@
 from infrahub.core import registry
 from infrahub.core.migrations.graph import Migration017
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -26,7 +27,7 @@ async def test_migration_017(
 
     async with db.start_session() as dbs:
         migration = Migration017()
-        execution_result = await migration.execute(db=dbs)
+        execution_result = await migration.execute(db=dbs, at=Timestamp())
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_017.py
+++ b/backend/tests/unit/core/migrations/graph/test_017.py
@@ -1,6 +1,6 @@
 from infrahub.core import registry
 from infrahub.core.migrations.graph import Migration017
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.database import InfrahubDatabase
 
 
@@ -27,7 +27,7 @@ async def test_migration_017(
 
     async with db.start_session() as dbs:
         migration = Migration017()
-        execution_result = await migration.execute(db=dbs, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_018_025.py
+++ b/backend/tests/unit/core/migrations/graph/test_018_025.py
@@ -4,10 +4,10 @@ from infrahub.core import registry
 from infrahub.core.branch.models import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph import Migration018, Migration025
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -67,7 +67,7 @@ async def test_migration_018_success(
 ) -> None:
     # check no validation errors for now
     async with db.start_session() as dbs:
-        execution_result = await migration.execute(db=dbs, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)
@@ -95,7 +95,7 @@ async def test_migration_018_fail(
 
     # check validation errors for two cars now
     async with db.start_session() as dbs:
-        execution_result = await migration.execute(db=dbs, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
         assert len(execution_result.errors) == 3
         for error_str in execution_result.errors[1:]:
             assert car_red.name.value in error_str or car_invisible.name.value in error_str

--- a/backend/tests/unit/core/migrations/graph/test_018_025.py
+++ b/backend/tests/unit/core/migrations/graph/test_018_025.py
@@ -7,6 +7,7 @@ from infrahub.core.migrations.graph import Migration018, Migration025
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -66,7 +67,7 @@ async def test_migration_018_success(
 ) -> None:
     # check no validation errors for now
     async with db.start_session() as dbs:
-        execution_result = await migration.execute(db=dbs)
+        execution_result = await migration.execute(db=dbs, at=Timestamp())
         assert not execution_result.errors
 
         validation_result = await migration.validate_migration(db=dbs)
@@ -94,7 +95,7 @@ async def test_migration_018_fail(
 
     # check validation errors for two cars now
     async with db.start_session() as dbs:
-        execution_result = await migration.execute(db=dbs)
+        execution_result = await migration.execute(db=dbs, at=Timestamp())
         assert len(execution_result.errors) == 3
         for error_str in execution_result.errors[1:]:
             assert car_red.name.value in error_str or car_invisible.name.value in error_str

--- a/backend/tests/unit/core/migrations/graph/test_019.py
+++ b/backend/tests/unit/core/migrations/graph/test_019.py
@@ -3,7 +3,7 @@ from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph import Migration019
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot, core_models
-from infrahub.core.timestamp import current_timestamp
+from infrahub.core.timestamp import Timestamp, current_timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import validate_node_relationships
 
@@ -91,7 +91,7 @@ async def test_migration_019(
     # but a manual test confirmed migration solves this issue.
 
     migration = Migration019()
-    await migration.execute(db=db)
+    await migration.execute(db=db, at=Timestamp())
     await migration.validate_migration(db=db)
 
     # Verify edges are correct, ie:
@@ -161,7 +161,7 @@ async def test_incorrectly_deleted_aware_nodes_and_relationship(
     )
 
     migration = Migration019()
-    await migration.execute(db=db)
+    await migration.execute(db=db, at=Timestamp())
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=car, branch=branch, db=db)
@@ -201,7 +201,7 @@ async def test_incorrectly_deleted_agnostic_node(
     )
 
     migration = Migration019()
-    await migration.execute(db=db)
+    await migration.execute(db=db, at=Timestamp())
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=agnostic_car, branch=branch, db=db)
@@ -240,7 +240,7 @@ async def test_incorrectly_deleted_aware_node(db: InfrahubDatabase, branch, car_
     )
 
     migration = Migration019()
-    await migration.execute(db=db)
+    await migration.execute(db=db, at=Timestamp())
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=aware_person, branch=branch, db=db)

--- a/backend/tests/unit/core/migrations/graph/test_019.py
+++ b/backend/tests/unit/core/migrations/graph/test_019.py
@@ -1,9 +1,10 @@
 from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph import Migration019
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot, core_models
-from infrahub.core.timestamp import Timestamp, current_timestamp
+from infrahub.core.timestamp import current_timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import validate_node_relationships
 
@@ -91,7 +92,7 @@ async def test_migration_019(
     # but a manual test confirmed migration solves this issue.
 
     migration = Migration019()
-    await migration.execute(db=db, at=Timestamp())
+    await migration.execute(migration_input=MigrationInput(db=db))
     await migration.validate_migration(db=db)
 
     # Verify edges are correct, ie:
@@ -161,7 +162,7 @@ async def test_incorrectly_deleted_aware_nodes_and_relationship(
     )
 
     migration = Migration019()
-    await migration.execute(db=db, at=Timestamp())
+    await migration.execute(migration_input=MigrationInput(db=db))
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=car, branch=branch, db=db)
@@ -201,7 +202,7 @@ async def test_incorrectly_deleted_agnostic_node(
     )
 
     migration = Migration019()
-    await migration.execute(db=db, at=Timestamp())
+    await migration.execute(migration_input=MigrationInput(db=db))
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=agnostic_car, branch=branch, db=db)
@@ -240,7 +241,7 @@ async def test_incorrectly_deleted_aware_node(db: InfrahubDatabase, branch, car_
     )
 
     migration = Migration019()
-    await migration.execute(db=db, at=Timestamp())
+    await migration.execute(migration_input=MigrationInput(db=db))
     await migration.validate_migration(db=db)
 
     await validate_node_relationships(node=aware_person, branch=branch, db=db)

--- a/backend/tests/unit/core/migrations/graph/test_020.py
+++ b/backend/tests/unit/core/migrations/graph/test_020.py
@@ -65,7 +65,7 @@ class TestDuplicateEdgesDeleted:
 
         # run the migration
         migration = Migration020()
-        await migration.execute(db=db)
+        await migration.execute(db=db, at=Timestamp())
         await migration.validate_migration(db=db)
 
         # validate no duplicate edges

--- a/backend/tests/unit/core/migrations/graph/test_020.py
+++ b/backend/tests/unit/core/migrations/graph/test_020.py
@@ -1,5 +1,6 @@
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m020_duplicate_edges import Migration020
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
@@ -65,7 +66,7 @@ class TestDuplicateEdgesDeleted:
 
         # run the migration
         migration = Migration020()
-        await migration.execute(db=db, at=Timestamp())
+        await migration.execute(migration_input=MigrationInput(db=db))
         await migration.validate_migration(db=db)
 
         # validate no duplicate edges

--- a/backend/tests/unit/core/migrations/graph/test_023.py
+++ b/backend/tests/unit/core/migrations/graph/test_023.py
@@ -7,6 +7,7 @@ from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m023_deduplicate_cardinality_one_relationships import Migration023
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 # redis is required as we will call `initialization` later
@@ -77,7 +78,7 @@ async def test_migration_023(db: InfrahubDatabase, branch, car_person_schema, re
     )
 
     migration = Migration023()
-    await migration.execute(db=db)
+    await migration.execute(db=db, at=Timestamp())
     await migration.validate_migration(db=db)
 
     await check_number_path_between_nodes(

--- a/backend/tests/unit/core/migrations/graph/test_023.py
+++ b/backend/tests/unit/core/migrations/graph/test_023.py
@@ -6,8 +6,8 @@ from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m023_deduplicate_cardinality_one_relationships import Migration023
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 # redis is required as we will call `initialization` later
@@ -78,7 +78,7 @@ async def test_migration_023(db: InfrahubDatabase, branch, car_person_schema, re
     )
 
     migration = Migration023()
-    await migration.execute(db=db, at=Timestamp())
+    await migration.execute(migration_input=MigrationInput(db=db))
     await migration.validate_migration(db=db)
 
     await check_number_path_between_nodes(

--- a/backend/tests/unit/core/migrations/graph/test_024.py
+++ b/backend/tests/unit/core/migrations/graph/test_024.py
@@ -98,7 +98,7 @@ SET main_e.hierarchy = NULL
         real_schema_manager = registry.schema
         try:
             registry.schema = mock_schema_manager
-            await migration.execute(db=db)
+            await migration.execute(db=db, at=Timestamp())
         finally:
             registry.schema = real_schema_manager
         mock_load_schema_from_db.assert_awaited_once()

--- a/backend/tests/unit/core/migrations/graph/test_024.py
+++ b/backend/tests/unit/core/migrations/graph/test_024.py
@@ -11,6 +11,7 @@ from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m024_missing_hierarchy_backfill import Migration024
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -98,7 +99,7 @@ SET main_e.hierarchy = NULL
         real_schema_manager = registry.schema
         try:
             registry.schema = mock_schema_manager
-            await migration.execute(db=db, at=Timestamp())
+            await migration.execute(migration_input=MigrationInput(db=db))
         finally:
             registry.schema = real_schema_manager
         mock_load_schema_from_db.assert_awaited_once()

--- a/backend/tests/unit/core/migrations/graph/test_027.py
+++ b/backend/tests/unit/core/migrations/graph/test_027.py
@@ -1,5 +1,5 @@
 from infrahub.core.migrations.graph.m027_delete_isolated_nodes import Migration027
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.database import InfrahubDatabase
 
 
@@ -22,7 +22,7 @@ async def test_migration_027(
     assert len(results) == 1
 
     migration = Migration027()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_027.py
+++ b/backend/tests/unit/core/migrations/graph/test_027.py
@@ -1,4 +1,5 @@
 from infrahub.core.migrations.graph.m027_delete_isolated_nodes import Migration027
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -21,7 +22,7 @@ async def test_migration_027(
     assert len(results) == 1
 
     migration = Migration027()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_029/test_029.py
+++ b/backend/tests/unit/core/migrations/graph/test_029/test_029.py
@@ -4,6 +4,7 @@ import pytest
 
 from infrahub.cli.db import load_export
 from infrahub.core.migrations.graph.m029_duplicates_cleanup import Migration029
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships
@@ -47,7 +48,7 @@ CALL () {
 
         migration = Migration029()
         migration.limit = 33
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
 
         await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_029/test_029.py
+++ b/backend/tests/unit/core/migrations/graph/test_029/test_029.py
@@ -4,7 +4,7 @@ import pytest
 
 from infrahub.cli.db import load_export
 from infrahub.core.migrations.graph.m029_duplicates_cleanup import Migration029
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships
@@ -48,7 +48,7 @@ CALL () {
 
         migration = Migration029()
         migration.limit = 33
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
 
         await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_030.py
+++ b/backend/tests/unit/core/migrations/graph/test_030.py
@@ -2,6 +2,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m030_illegal_edges import Migration030
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -93,7 +94,7 @@ async def test_migration_030(
         await _add_attribute(db=db, node_id=node.id, branch=branch, at=right_now)
 
     migration = Migration030()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_030.py
+++ b/backend/tests/unit/core/migrations/graph/test_030.py
@@ -93,7 +93,7 @@ async def test_migration_030(
         await _add_attribute(db=db, node_id=node.id, branch=branch, at=right_now)
 
     migration = Migration030()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_031.py
+++ b/backend/tests/unit/core/migrations/graph/test_031.py
@@ -3,7 +3,7 @@ from infrahub_sdk.client import InfrahubClient
 
 from infrahub import config
 from infrahub.core.migrations.graph.m031_check_number_attributes import Migration031
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from tests.helpers.test_app import TestInfrahubApp
 
 schema_number_parameters = {
@@ -43,14 +43,14 @@ class TestMigration031(TestInfrahubApp):
 
         # Run the migration without strict mode, nothing should happen
         migration = Migration031(db=db)
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors
 
         # Run the migration with strict mode, invalid node should show up
         config.SETTINGS.main.schema_strict_mode = True
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert len(execution_result.errors) == 2
         assert (
             execution_result.errors[0]
@@ -70,7 +70,7 @@ class TestMigration031(TestInfrahubApp):
         # Run the migration with strict mode to make sure it doesn't raise an error now that the node has been fixed
         config.SETTINGS.main.schema_strict_mode = True
         migration = Migration031(db=db)
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
 
         config.SETTINGS.main.schema_strict_mode = strict_mode_original_value

--- a/backend/tests/unit/core/migrations/graph/test_031.py
+++ b/backend/tests/unit/core/migrations/graph/test_031.py
@@ -3,6 +3,7 @@ from infrahub_sdk.client import InfrahubClient
 
 from infrahub import config
 from infrahub.core.migrations.graph.m031_check_number_attributes import Migration031
+from infrahub.core.timestamp import Timestamp
 from tests.helpers.test_app import TestInfrahubApp
 
 schema_number_parameters = {
@@ -42,14 +43,14 @@ class TestMigration031(TestInfrahubApp):
 
         # Run the migration without strict mode, nothing should happen
         migration = Migration031(db=db)
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors
 
         # Run the migration with strict mode, invalid node should show up
         config.SETTINGS.main.schema_strict_mode = True
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert len(execution_result.errors) == 2
         assert (
             execution_result.errors[0]
@@ -69,7 +70,7 @@ class TestMigration031(TestInfrahubApp):
         # Run the migration with strict mode to make sure it doesn't raise an error now that the node has been fixed
         config.SETTINGS.main.schema_strict_mode = True
         migration = Migration031(db=db)
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
 
         config.SETTINGS.main.schema_strict_mode = strict_mode_original_value

--- a/backend/tests/unit/core/migrations/graph/test_032.py
+++ b/backend/tests/unit/core/migrations/graph/test_032.py
@@ -5,6 +5,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m032_cleanup_orphaned_branch_relationships import Migration032
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import NodeNotFoundError
 
@@ -42,7 +43,7 @@ SET e.branch = "dead-branch"
 
     # Step 4: Run Migration032
     migration = Migration032()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(db=db, at=Timestamp())
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_032.py
+++ b/backend/tests/unit/core/migrations/graph/test_032.py
@@ -4,8 +4,8 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m032_cleanup_orphaned_branch_relationships import Migration032
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import NodeNotFoundError
 
@@ -43,7 +43,7 @@ SET e.branch = "dead-branch"
 
     # Step 4: Run Migration032
     migration = Migration032()
-    execution_result = await migration.execute(db=db, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors
 
     validation_result = await migration.validate_migration(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_033.py
+++ b/backend/tests/unit/core/migrations/graph/test_033.py
@@ -2,6 +2,7 @@ import pytest
 
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph.m033_deduplicate_relationship_vertices import Migration033
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 
@@ -338,7 +339,7 @@ CREATE (rel_node_two)-[:IS_RELATED {status: "active", branch: rel.branch, branch
     async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts) -> None:
         # Run the migration
         migration = Migration033()
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors

--- a/backend/tests/unit/core/migrations/graph/test_033.py
+++ b/backend/tests/unit/core/migrations/graph/test_033.py
@@ -2,7 +2,7 @@ import pytest
 
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph.m033_deduplicate_relationship_vertices import Migration033
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 
@@ -339,7 +339,7 @@ CREATE (rel_node_two)-[:IS_RELATED {status: "active", branch: rel.branch, branch
     async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts) -> None:
         # Run the migration
         migration = Migration033()
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors

--- a/backend/tests/unit/core/migrations/graph/test_034.py
+++ b/backend/tests/unit/core/migrations/graph/test_034.py
@@ -3,7 +3,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m034_find_orphaned_schema_fields import Migration034
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -43,7 +43,7 @@ class TestMigration034(TestInfrahubApp):
 
         # run the migration
         migration = Migration034()
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors

--- a/backend/tests/unit/core/migrations/graph/test_034.py
+++ b/backend/tests/unit/core/migrations/graph/test_034.py
@@ -3,6 +3,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m034_find_orphaned_schema_fields import Migration034
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -42,7 +43,7 @@ class TestMigration034(TestInfrahubApp):
 
         # run the migration
         migration = Migration034()
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors

--- a/backend/tests/unit/core/migrations/graph/test_037.py
+++ b/backend/tests/unit/core/migrations/graph/test_037.py
@@ -9,10 +9,10 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m037_index_attr_vals import Migration037
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -473,7 +473,7 @@ REMOVE avi:AttributeValueIndexed
         )
 
         migration = Migration037()
-        await migration.execute(db=db, at=Timestamp())
+        await migration.execute(migration_input=MigrationInput(db=db))
 
         await self._verify_all(
             db=db,

--- a/backend/tests/unit/core/migrations/graph/test_037.py
+++ b/backend/tests/unit/core/migrations/graph/test_037.py
@@ -12,6 +12,7 @@ from infrahub.core.migrations.graph.m037_index_attr_vals import Migration037
 from infrahub.core.node import Node
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -472,7 +473,7 @@ REMOVE avi:AttributeValueIndexed
         )
 
         migration = Migration037()
-        await migration.execute(db=db)
+        await migration.execute(db=db, at=Timestamp())
 
         await self._verify_all(
             db=db,

--- a/backend/tests/unit/core/migrations/graph/test_039.py
+++ b/backend/tests/unit/core/migrations/graph/test_039.py
@@ -11,9 +11,9 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m039_ipam_reconcile import Migration039
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -228,7 +228,7 @@ class TestMigration039(TestInfrahubApp):
         branch_address_updates: dict[str, IpAddressDetails],
     ) -> None:
         migration = WrappedMigration039()
-        await migration.execute(db=db, at=Timestamp())
+        await migration.execute(migration_input=MigrationInput(db=db))
 
         # validate that we only reconciled on the branch
         assert set(migration._reconcilers_by_branch.keys()) == {self.branch_name, self.branch_2_name}

--- a/backend/tests/unit/core/migrations/graph/test_039.py
+++ b/backend/tests/unit/core/migrations/graph/test_039.py
@@ -13,6 +13,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m039_ipam_reconcile import Migration039
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -227,7 +228,7 @@ class TestMigration039(TestInfrahubApp):
         branch_address_updates: dict[str, IpAddressDetails],
     ) -> None:
         migration = WrappedMigration039()
-        await migration.execute(db=db)
+        await migration.execute(db=db, at=Timestamp())
 
         # validate that we only reconciled on the branch
         assert set(migration._reconcilers_by_branch.keys()) == {self.branch_name, self.branch_2_name}

--- a/backend/tests/unit/core/migrations/graph/test_040.py
+++ b/backend/tests/unit/core/migrations/graph/test_040.py
@@ -11,6 +11,7 @@ from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import validate_no_duplicate_attributes
 
@@ -37,6 +38,7 @@ class TestMigration040:
                     )
                 ]
                 * 3,
+                at=Timestamp(),
             )
         )
         assert not migration_errors
@@ -79,7 +81,7 @@ class TestMigration040:
         await camry_branch.save(db=db)
 
         migration = Migration040.init(db=db)
-        result = await migration.execute(db=db)
+        result = await migration.execute(db=db, at=Timestamp())
         assert not result.errors
 
         # validate the result

--- a/backend/tests/unit/core/migrations/graph/test_040.py
+++ b/backend/tests/unit/core/migrations/graph/test_040.py
@@ -6,6 +6,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m040_duplicated_attributes import Migration040
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.migrations.schema.tasks import schema_apply_migrations
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.models import SchemaUpdateMigrationInfo
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
@@ -81,7 +82,7 @@ class TestMigration040:
         await camry_branch.save(db=db)
 
         migration = Migration040.init(db=db)
-        result = await migration.execute(db=db, at=Timestamp())
+        result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not result.errors
 
         # validate the result

--- a/backend/tests/unit/core/migrations/graph/test_041/test_041.py
+++ b/backend/tests/unit/core/migrations/graph/test_041/test_041.py
@@ -6,8 +6,8 @@ from infrahub.cli.db import load_export
 from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m041_deleted_dup_edges import Migration041
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import verify_no_duplicate_paths
 
@@ -119,7 +119,7 @@ DETACH DELETE r
         assert set(before_nodes_map.keys()) == set(expected_node_ids)
 
         migration = Migration041()
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
 
         await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_041/test_041.py
+++ b/backend/tests/unit/core/migrations/graph/test_041/test_041.py
@@ -7,6 +7,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m041_deleted_dup_edges import Migration041
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import verify_no_duplicate_paths
 
@@ -118,7 +119,7 @@ DETACH DELETE r
         assert set(before_nodes_map.keys()) == set(expected_node_ids)
 
         migration = Migration041()
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
 
         await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_042.py
+++ b/backend/tests/unit/core/migrations/graph/test_042.py
@@ -9,8 +9,8 @@ from infrahub.core.constants import MetadataOptions
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m042_profile_attrs_in_db import Migration042
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.profiles.node_applier import NodeProfilesApplier
 from tests.helpers.test_app import TestInfrahubApp
@@ -182,14 +182,16 @@ class TestMigration042(TestInfrahubApp):
         deleted_node_branch: Branch,
     ):
         migration = WrappedMigration042()
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors
 
         for branch in [value_branch, priority_branch, deleted_profile_branch, deleted_node_branch]:
             await branch.rebase(db=db)
-            execution_result = await migration.execute_against_branch(db=db, branch=branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=db), branch=branch
+            )
             assert not execution_result.errors
 
         default_crit_low_profile_attrs = [

--- a/backend/tests/unit/core/migrations/graph/test_042.py
+++ b/backend/tests/unit/core/migrations/graph/test_042.py
@@ -10,6 +10,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m042_profile_attrs_in_db import Migration042
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.profiles.node_applier import NodeProfilesApplier
 from tests.helpers.test_app import TestInfrahubApp
@@ -181,14 +182,14 @@ class TestMigration042(TestInfrahubApp):
         deleted_node_branch: Branch,
     ):
         migration = WrappedMigration042()
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
         assert not validation_result.errors
 
         for branch in [value_branch, priority_branch, deleted_profile_branch, deleted_node_branch]:
             await branch.rebase(db=db)
-            execution_result = await migration.execute_against_branch(db=db, branch=branch)
+            execution_result = await migration.execute_against_branch(db=db, branch=branch, at=Timestamp())
             assert not execution_result.errors
 
         default_crit_low_profile_attrs = [

--- a/backend/tests/unit/core/migrations/graph/test_043_044.py
+++ b/backend/tests/unit/core/migrations/graph/test_043_044.py
@@ -16,6 +16,7 @@ from infrahub.core.node import Node
 from infrahub.core.query.node import NodeListGetAttributeQuery
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from tests.helpers.schema import load_schema
@@ -615,7 +616,7 @@ DETACH DELETE attr
         await branch.rebase(db=db)
         async with db.start_session() as dbs:
             migration = Migration043(migrations=[])
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch, at=Timestamp())
             assert not execution_result.errors
 
         branch_schema_branch = SchemaBranch(
@@ -634,7 +635,7 @@ DETACH DELETE attr
 
         async with db.start_session() as dbs:
             migration = Migration044()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch, at=Timestamp())
             assert not execution_result.errors
 
     async def _validate_branch_updates(
@@ -677,7 +678,7 @@ DETACH DELETE attr
         # test adding display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration043(migrations=[])
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)
@@ -686,7 +687,7 @@ DETACH DELETE attr
         # test backfilling display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration044()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_043_044.py
+++ b/backend/tests/unit/core/migrations/graph/test_043_044.py
@@ -12,11 +12,11 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m043_create_hfid_display_label_in_db import Migration043
 from infrahub.core.migrations.graph.m044_backfill_hfid_display_label_in_db import Migration044
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.query.node import NodeListGetAttributeQuery
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from tests.helpers.schema import load_schema
@@ -616,7 +616,9 @@ DETACH DELETE attr
         await branch.rebase(db=db)
         async with db.start_session() as dbs:
             migration = Migration043(migrations=[])
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=dbs), branch=branch
+            )
             assert not execution_result.errors
 
         branch_schema_branch = SchemaBranch(
@@ -635,7 +637,9 @@ DETACH DELETE attr
 
         async with db.start_session() as dbs:
             migration = Migration044()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=dbs), branch=branch
+            )
             assert not execution_result.errors
 
     async def _validate_branch_updates(
@@ -678,7 +682,7 @@ DETACH DELETE attr
         # test adding display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration043(migrations=[])
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)
@@ -687,7 +691,7 @@ DETACH DELETE attr
         # test backfilling display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration044()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)

--- a/backend/tests/unit/core/migrations/graph/test_047.py
+++ b/backend/tests/unit/core/migrations/graph/test_047.py
@@ -6,6 +6,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m047_backfill_or_null_display_label import Migration047
 from infrahub.core.query.node import NodeListGetAttributeQuery
+from infrahub.core.timestamp import Timestamp
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -60,7 +61,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)
@@ -94,7 +95,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
         final_values = await self.get_attribute_values_from_db(
@@ -116,7 +117,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
         first_values = await self.get_attribute_values_from_db(db=db, branch=default_branch, node_ids=node_ids)
@@ -124,7 +125,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
         second_values = await self.get_attribute_values_from_db(db=db, branch=default_branch, node_ids=node_ids)
@@ -159,7 +160,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch)
+            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
             assert not execution_result.errors
 
         branch_final_values = await self.get_attribute_values_from_db(
@@ -192,7 +193,7 @@ class TestMigration047(TestInfrahubApp):
         # Migrate main
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
         main_values = await self.get_attribute_values_from_db(
@@ -206,7 +207,7 @@ class TestMigration047(TestInfrahubApp):
         # Migrate branch
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch)
+            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
             assert not execution_result.errors
 
         branch_values = await self.get_attribute_values_from_db(
@@ -228,7 +229,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs)
+            execution_result = await migration.execute(db=dbs, at=Timestamp())
             assert not execution_result.errors
 
         main_values = await self.get_attribute_values_from_db(
@@ -240,7 +241,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch)
+            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
             assert not execution_result.errors
 
         branch_values = await self.get_attribute_values_from_db(

--- a/backend/tests/unit/core/migrations/graph/test_047.py
+++ b/backend/tests/unit/core/migrations/graph/test_047.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m047_backfill_or_null_display_label import Migration047
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.query.node import NodeListGetAttributeQuery
-from infrahub.core.timestamp import Timestamp
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -61,7 +61,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
             validation_result = await migration.validate_migration(db=dbs)
@@ -95,7 +95,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
         final_values = await self.get_attribute_values_from_db(
@@ -117,7 +117,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
         first_values = await self.get_attribute_values_from_db(db=db, branch=default_branch, node_ids=node_ids)
@@ -125,7 +125,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
         second_values = await self.get_attribute_values_from_db(db=db, branch=default_branch, node_ids=node_ids)
@@ -160,7 +160,9 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=dbs), branch=test_branch
+            )
             assert not execution_result.errors
 
         branch_final_values = await self.get_attribute_values_from_db(
@@ -193,7 +195,7 @@ class TestMigration047(TestInfrahubApp):
         # Migrate main
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
         main_values = await self.get_attribute_values_from_db(
@@ -207,7 +209,9 @@ class TestMigration047(TestInfrahubApp):
         # Migrate branch
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=dbs), branch=test_branch
+            )
             assert not execution_result.errors
 
         branch_values = await self.get_attribute_values_from_db(
@@ -229,7 +233,7 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute(db=dbs, at=Timestamp())
+            execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 
         main_values = await self.get_attribute_values_from_db(
@@ -241,7 +245,9 @@ class TestMigration047(TestInfrahubApp):
 
         async with db.start_session() as dbs:
             migration = Migration047()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=test_branch, at=Timestamp())
+            execution_result = await migration.execute_against_branch(
+                migration_input=MigrationInput(db=dbs), branch=test_branch
+            )
             assert not execution_result.errors
 
         branch_values = await self.get_attribute_values_from_db(

--- a/backend/tests/unit/core/migrations/graph/test_048.py
+++ b/backend/tests/unit/core/migrations/graph/test_048.py
@@ -2,7 +2,7 @@ import pytest
 
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph.m048_undelete_rel_props import Migration048
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import verify_no_duplicate_paths
@@ -421,7 +421,7 @@ RETURN count(e) AS edge_count
 
         # Run the migration
         migration = Migration048.init()
-        execution_result = await migration.execute(db=db, at=Timestamp())
+        execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
 
         # Verify no duplicate paths remain

--- a/backend/tests/unit/core/migrations/graph/test_048.py
+++ b/backend/tests/unit/core/migrations/graph/test_048.py
@@ -2,6 +2,7 @@ import pytest
 
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph.m048_undelete_rel_props import Migration048
+from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from tests.helpers.db_validation import verify_no_duplicate_paths
@@ -420,7 +421,7 @@ RETURN count(e) AS edge_count
 
         # Run the migration
         migration = Migration048.init()
-        execution_result = await migration.execute(db=db)
+        execution_result = await migration.execute(db=db, at=Timestamp())
         assert not execution_result.errors
 
         # Verify no duplicate paths remain

--- a/backend/tests/unit/core/migrations/graph/test_049.py
+++ b/backend/tests/unit/core/migrations/graph/test_049.py
@@ -1,4 +1,5 @@
 from infrahub.core.migrations.graph import Migration049
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.timestamp import current_timestamp
 from infrahub.database import InfrahubDatabase
 
@@ -49,7 +50,7 @@ async def test_migration_049(db: InfrahubDatabase, default_branch, person_john_m
     assert is_visible_count[0].get("is_visible_count") == 4
 
     migration = Migration049()
-    await migration.execute(db=db)
+    await migration.execute(migration_input=MigrationInput(db=db))
     result = await migration.validate_migration(db=db)
     assert result.success
 

--- a/backend/tests/unit/core/migrations/graph/test_050.py
+++ b/backend/tests/unit/core/migrations/graph/test_050.py
@@ -6,6 +6,7 @@ from infrahub.core.constants import BranchSupportType, MetadataOptions, Relation
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m050_backfill_vertex_metadata import Migration050
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -475,7 +476,7 @@ async def test_migration_050(db: InfrahubDatabase, default_branch: Branch, car_p
     # Run the migration first time
     # -------------------------------------------------------------------------
     migration = Migration050()
-    execution_result = await migration.execute(db=db)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors, f"Migration execution failed: {execution_result.errors}"
 
     # -------------------------------------------------------------------------
@@ -494,7 +495,7 @@ async def test_migration_050(db: InfrahubDatabase, default_branch: Branch, car_p
     # Run migration again (idempotency test)
     # -------------------------------------------------------------------------
     migration_again = Migration050()
-    execution_result = await migration_again.execute(db=db)
+    execution_result = await migration_again.execute(migration_input=MigrationInput(db=db))
     assert not execution_result.errors, f"Migration execution failed: {execution_result.errors}"
 
     # -------------------------------------------------------------------------

--- a/backend/tests/unit/core/migrations/schema/test_attribute_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_kind_update.py
@@ -1,0 +1,148 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.migrations.schema.attribute_kind_update import (
+    AttributeKindUpdateMigration,
+    AttributeKindUpdateMigrationQuery,
+)
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
+from tests.helpers.schema import load_schema
+
+CAR_SCHEMA_TEXT = {
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "Car",
+            "namespace": "Test",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+                {"name": "description", "kind": "Text"},  # Text is indexed
+            ],
+        }
+    ],
+}
+
+
+async def check_attribute_value_vertices(db: InfrahubDatabase, value: str) -> tuple[int, int]:
+    """Return number of indexed and non-indexed AttributeValue vertices for a given value."""
+    query = "MATCH (av:AttributeValue) WHERE av.value = $value RETURN 'AttributeValueIndexed' IN labels(av) AS is_indexed, count(av) AS num_vertices"
+    results = await db.execute_query(query=query, params={"value": value})
+    num_indexed, num_non_indexed = 0, 0
+    for result in results:
+        if result["is_indexed"]:
+            num_indexed = result["num_vertices"]
+        else:
+            num_non_indexed = result["num_vertices"]
+    return num_indexed, num_non_indexed
+
+
+async def test_query_indexed_to_not_indexed(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """Test changing attribute kind from indexed (Text) to not indexed (TextArea)."""
+    await load_schema(db=db, schema=SchemaRoot(**CAR_SCHEMA_TEXT))
+    description = "A nice car"
+
+    car = await Node.init(db=db, schema="TestCar")
+    await car.new(db=db, name="Accord", description=description)
+    await car.save(db=db)
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    # Change description from Text (indexed) to TextArea (not indexed)
+    new_attr = new_car_schema.get_attribute(name="description")
+    new_attr.kind = "TextArea"
+
+    # check that only 1 "A nice car" AttributeValue vertex exists
+    num_indexed, num_non_indexed = await check_attribute_value_vertices(db=db, value=description)
+    assert num_indexed == 1
+    assert num_non_indexed == 0
+
+    migration = AttributeKindUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="description"),
+    )
+    query = await AttributeKindUpdateMigrationQuery.init(db=db, branch=default_branch, migration=migration)
+    await query.execute(db=db)
+
+    # Re-execute the query once to ensure that it won't change anything
+    query = await AttributeKindUpdateMigrationQuery.init(db=db, branch=default_branch, migration=migration)
+    await query.execute(db=db)
+
+    # check that a non-indexed "A nice car" AttributeValue vertex was created
+    num_indexed, num_non_indexed = await check_attribute_value_vertices(db=db, value=description)
+    assert num_indexed == 1
+    assert num_non_indexed == 1
+
+
+async def test_migration_no_change_when_same_index_status(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """Test that migration does nothing when attribute indexing status doesn't change."""
+    await load_schema(db=db, schema=SchemaRoot(**CAR_SCHEMA_TEXT))
+
+    car = await Node.init(db=db, schema="TestCar")
+    await car.new(db=db, name="Accord", description="A nice car")
+    await car.save(db=db)
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    # Change description from Text to another indexed type (e.g., Number)
+    new_attr = new_car_schema.get_attribute(name="description")
+    new_attr.kind = "Number"
+
+    migration = AttributeKindUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="description"),
+    )
+
+    # Migration should return early without executing any queries
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 0
+
+
+async def test_migration_edge_timestamps(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """Verify edges created/modified during AttributeKindUpdateMigration use the 'at' timestamp."""
+    await load_schema(db=db, schema=SchemaRoot(**CAR_SCHEMA_TEXT))
+
+    car = await Node.init(db=db, schema="TestCar")
+    await car.new(db=db, name="Accord", description="A nice car")
+    await car.save(db=db)
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    # Change description from Text (indexed) to TextArea (not indexed)
+    new_attr = new_car_schema.get_attribute(name="description")
+    new_attr.kind = "TextArea"
+
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    # 2. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 3. Execute migration
+    migration = AttributeKindUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="description"),
+    )
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    assert not execution_result.errors
+
+    # 4. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)

--- a/backend/tests/unit/core/migrations/schema/test_attribute_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_kind_update.py
@@ -5,6 +5,7 @@ from infrahub.core.migrations.schema.attribute_kind_update import (
     AttributeKindUpdateMigration,
     AttributeKindUpdateMigrationQuery,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
@@ -105,7 +106,7 @@ async def test_migration_no_change_when_same_index_status(db: InfrahubDatabase, 
     )
 
     # Migration should return early without executing any queries
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 0
 
@@ -140,7 +141,7 @@ async def test_migration_edge_timestamps(db: InfrahubDatabase, default_branch: B
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="description"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
 
     # 4. Validate edge timestamps

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -121,7 +121,7 @@ async def test_migration(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
 
     assert execution_result.nbr_migrations_executed == 3

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -166,7 +166,9 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new_color"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+    )
     assert not execution_result.errors
 
     schema_branch = registry.schema.get_schema_branch(name=branch.name)

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -17,6 +17,8 @@ from infrahub.core.path import SchemaPath
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
 async def test_query_default_branch(
@@ -112,22 +114,35 @@ async def test_migration(
     new_attr.name = "new-color"
     new_attr.id = prev_attr.id
 
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    # 2. Count nodes and relationships before migration
     count_attr_node = await count_nodes(db=db, label="Attribute")
     count_rels = await count_relationships(db=db)
 
+    # 3. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 4. Execute migration
     migration = AttributeNameUpdateMigration(
         previous_node_schema=prev_car_schema,
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
     )
-
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
     assert not execution_result.errors
-
     assert execution_result.nbr_migrations_executed == 3
 
+    # 5. Validate nodes and relationships after migration
     assert await count_nodes(db=db, label="Attribute") == count_attr_node + 3
     assert await count_relationships(db=db) == count_rels + 9
+
+    # 6. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
 async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:

--- a/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_name_update.py
@@ -12,6 +12,7 @@ from infrahub.core.migrations.schema.attribute_name_update import (
     AttributeNameUpdateMigration,
     AttributeNameUpdateMigrationQuery01,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.timestamp import Timestamp
@@ -132,7 +133,7 @@ async def test_migration(
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 3
 

--- a/backend/tests/unit/core/migrations/schema/test_attribute_supports_profile.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_supports_profile.py
@@ -8,6 +8,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.attribute_supports_profile import (
     AttributeSupportsProfileUpdateMigration,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.timestamp import Timestamp
@@ -37,7 +38,7 @@ async def test_migration_no_change_when_support_profiles_unchanged(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 0
 
@@ -63,7 +64,7 @@ async def test_migration_no_change_for_new_attribute(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 0
 
@@ -96,7 +97,7 @@ async def test_migration_disable_support_profiles(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
 
     fresh_car_profle = await NodeManager.get_one(db=db, id=car_profile1_main.id)
@@ -135,7 +136,7 @@ async def test_migration_edge_timestamps(
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
 
     # 4. Validate edge timestamps

--- a/backend/tests/unit/core/migrations/schema/test_attribute_supports_profile.py
+++ b/backend/tests/unit/core/migrations/schema/test_attribute_supports_profile.py
@@ -1,0 +1,143 @@
+import uuid
+
+from infrahub.core import registry
+from infrahub.core.attribute import BaseAttribute
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.attribute_supports_profile import (
+    AttributeSupportsProfileUpdateMigration,
+)
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
+
+
+async def test_migration_no_change_when_support_profiles_unchanged(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, car_profile1_main: Node
+) -> None:
+    """Test that migration does nothing when support_profiles doesn't change."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    prev_attr = prev_car_schema.get_attribute(name="nbr_seats")
+    prev_attr.id = str(uuid.uuid4())
+
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="nbr_seats")
+    new_attr.id = prev_attr.id
+    # support_profiles is not changed
+
+    migration = AttributeSupportsProfileUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
+    )
+
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 0
+
+
+async def test_migration_no_change_for_new_attribute(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, car_profile1_main: Node
+) -> None:
+    """Test that migration does nothing for new attributes (no previous ID)."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    # Don't set an ID on previous attribute - indicates this is a new attribute
+
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="nbr_seats")
+    # support_profiles is computed from read_only and optional
+    # To toggle it, we need to change those underlying properties
+    new_attr.read_only = True  # This disables support_profiles
+
+    migration = AttributeSupportsProfileUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
+    )
+
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 0
+
+
+async def test_migration_disable_support_profiles(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, car_profile1_main: Node
+) -> None:
+    """Test disabling support_profiles removes attributes from profile nodes."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    prev_attr = prev_car_schema.get_attribute(name="nbr_seats")
+    prev_attr.id = str(uuid.uuid4())
+
+    nbr_seats_attr = car_profile1_main.get_attribute(name="nbr_seats")
+    assert isinstance(nbr_seats_attr, BaseAttribute), "nbr_seats attribute should exist"
+    nbr_seats_attr.value = 5
+    await car_profile1_main.save(db=db)
+
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="nbr_seats")
+    new_attr.id = prev_attr.id
+    # support_profiles is computed from read_only and optional
+    # Setting read_only=True disables support_profiles
+    new_attr.read_only = True
+
+    migration = AttributeSupportsProfileUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
+    )
+
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    assert not execution_result.errors
+
+    fresh_car_profle = await NodeManager.get_one(db=db, id=car_profile1_main.id)
+    nbr_seats_attr = fresh_car_profle.get_attribute(name="nbr_seats")
+    assert nbr_seats_attr.value is None
+
+
+async def test_migration_edge_timestamps(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, car_profile1_main: Node
+) -> None:
+    """Verify edges created/modified during AttributeSupportsProfileUpdateMigration use the 'at' timestamp."""
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    prev_attr = prev_car_schema.get_attribute(name="nbr_seats")
+    prev_attr.id = str(uuid.uuid4())
+
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="nbr_seats")
+    new_attr.id = prev_attr.id
+    # support_profiles is computed from read_only and optional
+    # Setting read_only=True disables support_profiles
+    new_attr.read_only = True
+
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    # 2. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 3. Execute migration
+    migration = AttributeSupportsProfileUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
+    )
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    assert not execution_result.errors
+
+    # 4. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)

--- a/backend/tests/unit/core/migrations/schema/test_models.py
+++ b/backend/tests/unit/core/migrations/schema/test_models.py
@@ -3,6 +3,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.models import SchemaUpdateMigrationInfo
 from infrahub.core.path import SchemaPath, SchemaPathType
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 
@@ -27,6 +28,7 @@ def test_SchemaApplyMigrationData_serializer(
                 migration_name="node.attribute.add",
             ),
         ],
+        at=Timestamp(),
     )
 
     data_dict = data.model_dump(mode="json")

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -21,6 +21,8 @@ from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes
 from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
 @pytest.fixture
@@ -142,20 +144,36 @@ async def test_query01_re_add(db: InfrahubDatabase, default_branch: Branch, car_
 
 async def test_migration(db: InfrahubDatabase, default_branch, init_database, schema_aware) -> None:
     node = schema_aware
+
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    #  2. Count nodes and relationships before migration
+    assert await count_nodes(db=db, label="TestCar") == 5
+    assert await count_nodes(db=db, label="Attribute") == 0
+
+    # 3. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 4. Execute migration
     migration = NodeAttributeAddMigration(
         new_node_schema=node,
         previous_node_schema=node,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_doors"),
     )
-
-    assert await count_nodes(db=db, label="TestCar") == 5
-    assert await count_nodes(db=db, label="Attribute") == 0
-
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 5
+
+    # 5. Validate nodes and relationships after migration
     assert await count_nodes(db=db, label="TestCar") == 5
     assert await count_nodes(db=db, label="Attribute") == 5
+
+    # 6. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
 async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
@@ -169,7 +187,7 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    await remove_migration.execute(db=db, branch=branch)
+    await remove_migration.execute(db=db, branch=branch, at=Timestamp())
 
     test_user_id = "test-metadata-user"
     migration_time = Timestamp()

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -15,6 +15,7 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
     NodeAttributeRemoveMigration,
     NodeAttributeRemoveMigrationQuery01,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import NodeSchema
@@ -163,7 +164,7 @@ async def test_migration(db: InfrahubDatabase, default_branch, init_database, sc
         previous_node_schema=node,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_doors"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 5
 

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -151,7 +151,7 @@ async def test_migration(db: InfrahubDatabase, default_branch, init_database, sc
     assert await count_nodes(db=db, label="TestCar") == 5
     assert await count_nodes(db=db, label="Attribute") == 0
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 5
     assert await count_nodes(db=db, label="TestCar") == 5

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -188,7 +188,7 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    await remove_migration.execute(db=db, branch=branch, at=Timestamp())
+    await remove_migration.execute(migration_input=MigrationInput(db=db, at=Timestamp()), branch=branch)
 
     test_user_id = "test-metadata-user"
     migration_time = Timestamp()
@@ -198,7 +198,9 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         previous_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+    )
     assert not execution_result.errors
 
     nodes = await NodeManager.get_many(

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -15,6 +15,8 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
 async def test_query_default_branch(
@@ -110,20 +112,35 @@ async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accor
     attr = car_schema.get_attribute(name="color")
     attr.state = HashableModelState.ABSENT
 
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    # 2. Count nodes and relationships before migration
     count_attr_node = await count_nodes(db=db, label="Attribute")
     count_rels = await count_relationships(db=db)
 
+    # 3. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 4. Execute migration
     migration = NodeAttributeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
+
+    # 5. Validate nodes and relationships after migration
     assert await count_nodes(db=db, label="Attribute") == count_attr_node
     assert await count_relationships(db=db) == count_rels + 6
+
+    # 6. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
 async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -160,7 +160,9 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+    )
     assert not execution_result.errors
 
     updated_car = await NodeManager.get_one(

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -119,7 +119,7 @@ async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accor
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
     assert await count_nodes(db=db, label="Attribute") == count_attr_node

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -9,6 +9,7 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
     NodeAttributeRemoveMigration,
     NodeAttributeRemoveMigrationQuery01,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
@@ -130,7 +131,7 @@ async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accor
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
 

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -269,7 +269,9 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+    )
     assert not execution_result.errors
 
     registry.schema.set_schema_branch(name=branch.name, schema=candidate_schema)

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -5,6 +5,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration, NodeKindUpdateMigrationQuery01
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
@@ -93,7 +94,7 @@ async def test_migration_aware_relationship(
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="namespace"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
 
@@ -142,7 +143,7 @@ async def test_migration_agnostic_relationship(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="namespace"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label="TestCar") == 1
@@ -184,7 +185,7 @@ async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch)
         ),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label=TestKind.CONTINENT) == 1
@@ -229,7 +230,7 @@ async def test_inheritance_migration_on_branch_and_main(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="inherit_from"),
     )
 
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
 
@@ -241,7 +242,9 @@ async def test_inheritance_migration_on_branch_and_main(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="inherit_from"),
     )
 
-    execution_result_default = await migration_default.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result_default = await migration_default.execute(
+        migration_input=MigrationInput(db=db), branch=default_branch
+    )
     assert not execution_result_default.errors
 
     await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -83,7 +83,7 @@ async def test_migration_aware_relationship(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="namespace"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
     assert await count_relationships(db=db) == count_rels + 36
@@ -125,7 +125,7 @@ async def test_migration_agnostic_relationship(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="namespace"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label="TestCar") == 1
@@ -167,7 +167,7 @@ async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch)
         ),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label=TestKind.CONTINENT) == 1
@@ -212,7 +212,7 @@ async def test_inheritance_migration_on_branch_and_main(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="inherit_from"),
     )
 
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
 
@@ -224,7 +224,7 @@ async def test_inheritance_migration_on_branch_and_main(
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="inherit_from"),
     )
 
-    execution_result_default = await migration_default.execute(db=db, branch=default_branch)
+    execution_result_default = await migration_default.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result_default.errors
 
     await verify_no_duplicate_paths(db=db)

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -13,7 +13,9 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.constants import TestKind
+from tests.db_snapshot import DbSnapshotter
 from tests.helpers.db_validation import validate_node_relationships, verify_no_duplicate_paths
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import LOCATION_SCHEMA, load_schema
 
 
@@ -72,24 +74,39 @@ async def test_migration_aware_relationship(
     candidate_schema.set(name="Test2NewCar", schema=car_schema)
     assert car_schema.kind == "Test2NewCar"
 
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+
+    # 2. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 3. Count nodes and relationships before migration
     assert await count_nodes(db=db, label="TestCar") == 2
     assert await count_nodes(db=db, label="Test2NewCar") == 0
-
     count_rels = await count_relationships(db=db)
 
+    # 4. Execute migration
     migration = NodeKindUpdateMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="namespace"),
     )
-
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
+
+    # 5. Validate nodes and relationships after migration
     assert await count_relationships(db=db) == count_rels + 36
     assert await count_nodes(db=db, label="TestCar") == 2
     assert await count_nodes(db=db, label="Test2NewCar") == 2
 
+    # 6. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
+
+    # 7. Validate node relationships
     await validate_node_relationships(node=car_accord_main, db=db, branch=default_branch)
     await validate_node_relationships(node=car_camry_main, db=db, branch=default_branch)
 

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -12,6 +12,8 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import load_schema
 from tests.unit.core.migrations.schema.test_node_kind_update import validate_node_relationships
 
@@ -90,22 +92,37 @@ async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car
     candidate_schema = schema.duplicate()
     candidate_schema.delete(name="TestCar")
 
-    assert await count_nodes(db=db, label="TestCar") == 2
+    # 1. Snapshot before migration
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
 
+    # 2. Create explicit timestamp
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 3. Count nodes and relationships before migration
+    assert await count_nodes(db=db, label="TestCar") == 2
     count_rels = await count_relationships(db=db)
 
+    # 4. Execute migration
     migration = NodeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=None,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
-
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
+
+    # 5. Validate nodes and relationships after migration
     assert await count_relationships(db=db) == count_rels + 18
     assert await count_nodes(db=db, label="TestCar") == 2
 
+    # 6. Validate edge timestamps
+    after_snapshot = await snapshotter.snapshot()
+    assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
+
+    # 7. Validate node relationships
     await validate_node_relationships(node=car_accord_main, db=db, branch=default_branch)
     await validate_node_relationships(node=car_camry_main, db=db, branch=default_branch)
 

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -176,7 +176,9 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         new_node_schema=None,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=migration_time, user_id=test_user_id)
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+    )
     assert not execution_result.errors
 
     # Query for the deleted Node and its edge metadata

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -6,6 +6,7 @@ from infrahub.core.migrations.schema.node_remove import (
     NodeRemoveMigrationQueryIn,
     NodeRemoveMigrationQueryOut,
 )
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
@@ -110,7 +111,7 @@ async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car
         new_node_schema=None,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=at)
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
 
@@ -152,7 +153,7 @@ async def test_migration_agnostic_relationship(
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label="TestCar") == 1

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -100,7 +100,7 @@ async def test_migration_aware(db: InfrahubDatabase, default_branch: Branch, car
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 2
     assert await count_relationships(db=db) == count_rels + 18
@@ -135,7 +135,7 @@ async def test_migration_agnostic_relationship(
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
 
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
     assert execution_result.nbr_migrations_executed == 1
     assert await count_nodes(db=db, label="TestCar") == 1

--- a/backend/tests/unit/core/schema_manager/conftest.py
+++ b/backend/tests/unit/core/schema_manager/conftest.py
@@ -259,14 +259,14 @@ def schema_criticality_tag():
                 "relationships": [
                     {
                         "name": "tags",
-                        "peer": InfrahubKind.TAG,
+                        "peer": "TestingTag",
                         "label": "Tags",
                         "optional": True,
                         "cardinality": "many",
                     },
                     {
                         "name": "primary_tag",
-                        "peer": InfrahubKind.TAG,
+                        "peer": "TestingTag",
                         "label": "Primary Tag",
                         "identifier": "primary_tag__criticality",
                         "optional": True,

--- a/backend/tests/unit/core/schema_manager/conftest.py
+++ b/backend/tests/unit/core/schema_manager/conftest.py
@@ -247,7 +247,7 @@ def schema_criticality_tag():
         "nodes": [
             {
                 "name": "Criticality",
-                "namespace": "Builtin",
+                "namespace": "Testing",
                 "default_filter": "name__value",
                 "label": "Criticality",
                 "attributes": [
@@ -276,7 +276,7 @@ def schema_criticality_tag():
             },
             {
                 "name": "Tag",
-                "namespace": "Builtin",
+                "namespace": "Testing",
                 "label": "Tag",
                 "default_filter": "name__value",
                 "attributes": [

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2690,7 +2690,7 @@ async def test_load_node_to_db_node_schema(db: InfrahubDatabase, default_branch:
         ],
         relationships=[RelationshipSchema(name="others", peer="BuiltinCriticality", optional=True, cardinality="many")],
     )
-    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, user_id="user-id")
+    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, at=Timestamp(), user_id="user-id")
 
     node2 = registry.schema.get(name=node.kind, branch=default_branch)
     assert node2.id
@@ -2713,7 +2713,7 @@ async def test_load_node_to_db_generic_schema(db: InfrahubDatabase, default_bran
         ],
     }
     node = GenericSchema(**SCHEMA)
-    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, user_id="user-id")
+    await registry.schema.load_node_to_db(node=node, db=db, branch=default_branch, at=Timestamp(), user_id="user-id")
 
     results = await SchemaManager.query(
         schema="SchemaGeneric", filters={"kind__value": "InfraGenericInterface"}, branch=default_branch, db=db
@@ -2765,7 +2765,9 @@ async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branc
 
     registry.schema = SchemaManager()
     registry.schema.register_schema(schema=SchemaRoot(**internal_schema), branch=default_branch.name)
-    await registry.schema.load_node_to_db(node=NodeSchema(**SCHEMA), db=db, branch=default_branch, user_id="user-id")
+    await registry.schema.load_node_to_db(
+        node=NodeSchema(**SCHEMA), db=db, branch=default_branch, at=Timestamp(), user_id="user-id"
+    )
 
     node = registry.schema.get(name="BuiltinCriticality", branch=default_branch)
 
@@ -2774,7 +2776,9 @@ async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branc
     new_node.default_filter = "kind__value"
     new_node.attributes[0].unique = False
 
-    await registry.schema.update_node_in_db(node=new_node, db=db, branch=default_branch, user_id="user-id")
+    await registry.schema.update_node_in_db(
+        node=new_node, db=db, branch=default_branch, at=Timestamp(), user_id="user-id"
+    )
 
     results = await SchemaManager.get_many(ids=[node.id, new_node.attributes[0].id], db=db)
 
@@ -2786,7 +2790,7 @@ async def test_load_schema_to_db_internal_models(db: InfrahubDatabase, default_b
     schema = SchemaRoot(**internal_schema)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
-    await registry.schema.load_schema_to_db(schema=new_schema, db=db, branch=default_branch.name)
+    await registry.schema.load_schema_to_db(schema=new_schema, db=db, branch=default_branch.name, at=Timestamp())
 
     node_schema = registry.schema.get(name="SchemaNode", branch=default_branch)
     results = await SchemaManager.query(schema=node_schema, db=db)
@@ -2800,7 +2804,7 @@ async def test_load_schema_to_db_core_models(
     schema = SchemaRoot(**core_models)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
-    await registry.schema.load_schema_to_db(schema=new_schema, db=db)
+    await registry.schema.load_schema_to_db(schema=new_schema, db=db, at=Timestamp())
 
     node_schema = registry.schema.get(name="SchemaGeneric")
     results = await SchemaManager.query(schema=node_schema, db=db)
@@ -2814,7 +2818,7 @@ async def test_clean_diff_after_reload_from_db(
     schema = SchemaRoot(**core_models)
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
-    await registry.schema.load_schema_to_db(schema=new_schema, db=db)
+    await registry.schema.load_schema_to_db(schema=new_schema, db=db, at=Timestamp())
 
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     schema_pre = schema_branch.duplicate()

--- a/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
+++ b/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
@@ -25,7 +25,7 @@ def create_updated_schema(branch: Branch) -> SchemaBranch:
     new_schema = current_schema.duplicate()
 
     # Get a duplicate of the Criticality node to modify
-    node = new_schema.get(name="BuiltinCriticality", duplicate=False)
+    node = new_schema.get(name="TestingCriticality", duplicate=False)
 
     # Update node property
     node.label = "Updated Criticality"
@@ -53,7 +53,7 @@ def create_updated_schema(branch: Branch) -> SchemaBranch:
     tags_rel = node.get_relationship(name="tags")
     tags_rel.label = "Updated Tags"
 
-    new_schema.set(name="BuiltinCriticality", schema=node)
+    new_schema.set(name="TestingCriticality", schema=node)
     new_schema.process()
 
     return new_schema
@@ -158,7 +158,7 @@ async def test_schema_load_edges_use_at_timestamp(
 
     schema_with_deletes = update_schema_with_deletes(
         branch=default_branch,
-        node_kind="BuiltinCriticality",
+        node_kind="TestingCriticality",
         attribute_name="priority",  # Delete the attribute we added in step 5
         relationship_name="secondary_tag",  # Delete the relationship we added in step 5
     )

--- a/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
+++ b/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
@@ -7,43 +7,8 @@ from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
-from tests.db_snapshot import DbEdge, DbSnapshot, DbSnapshotter
-
-
-async def assert_edge_timestamps(
-    db: InfrahubDatabase,
-    before_edges_by_id: dict[str, DbEdge],
-    expected_timestamp: str,
-) -> DbSnapshot:
-    """Take a snapshot and verify all new/modified edges use the expected timestamp.
-
-    For new edges: 'from' must equal expected_timestamp
-    For modified edges: changed 'to' must equal expected_timestamp
-    """
-    snapshotter = DbSnapshotter(db)
-    after_snapshot = await snapshotter.snapshot()
-    after_edges_by_id = {e.db_id: e for e in after_snapshot.edge_map.values()}
-
-    for edge_id, after_edge in after_edges_by_id.items():
-        before_edge = before_edges_by_id.get(edge_id)
-
-        if before_edge is None:
-            # New edge - 'from' must equal expected_timestamp
-            from_time = after_edge.properties.get("from")
-            assert from_time == expected_timestamp, (
-                f"New edge {after_edge.edge_type} has from={from_time}, expected {expected_timestamp}"
-            )
-        else:
-            # Check for modified 'to' time (from never changes once set)
-            before_to = before_edge.properties.get("to")
-            after_to = after_edge.properties.get("to")
-
-            if before_to != after_to:
-                assert after_to == expected_timestamp, (
-                    f"Modified edge {after_edge.edge_type} has to={after_to}, expected {expected_timestamp}"
-                )
-
-    return after_snapshot
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
 def create_updated_schema(branch: Branch) -> SchemaBranch:
@@ -154,8 +119,7 @@ async def test_schema_load_edges_use_at_timestamp(
     """
     # 1. Snapshot before loading the schema
     snapshotter = DbSnapshotter(db)
-    before_snapshot = await snapshotter.snapshot()
-    before_edges_by_id = {e.db_id: e for e in before_snapshot.edge_map.values()}
+    snapshot_0 = await snapshotter.snapshot()
 
     # 2. Create explicit timestamp for the 'at' parameter
     at = Timestamp()
@@ -174,8 +138,8 @@ async def test_schema_load_edges_use_at_timestamp(
     )
 
     # 4. Verify all new/modified edges use the 'at' timestamp
-    snapshot_1 = await assert_edge_timestamps(db, before_edges_by_id, at_str)
-    snapshot_1_edges_by_id = {e.db_id: e for e in snapshot_1.edge_map.values()}
+    snapshot_1 = await snapshotter.snapshot()
+    assert_edge_timestamps(snapshot_0, snapshot_1, at_str)
 
     # 5. Load updated schema with new attribute, new relationship, and updated properties
     updated_schema = create_updated_schema(default_branch)
@@ -185,8 +149,8 @@ async def test_schema_load_edges_use_at_timestamp(
     await load_updated_schema(db, default_branch, updated_schema, at_2)
 
     # 6. Verify all new/modified edges (since snapshot_1) use the 'at_2' timestamp
-    snapshot_2 = await assert_edge_timestamps(db, snapshot_1_edges_by_id, at_2_str)
-    snapshot_2_edges_by_id = {e.db_id: e for e in snapshot_2.edge_map.values()}
+    snapshot_2 = await snapshotter.snapshot()
+    assert_edge_timestamps(snapshot_1, snapshot_2, at_2_str)
 
     # 7. Delete an attribute and relationship from the schema
     at_3 = Timestamp()
@@ -201,4 +165,5 @@ async def test_schema_load_edges_use_at_timestamp(
     await load_updated_schema(db, default_branch, schema_with_deletes, at_3)
 
     # 8. Verify all new/modified edges (since snapshot_2) use the 'at_3' timestamp
-    await assert_edge_timestamps(db, snapshot_2_edges_by_id, at_3_str)
+    snapshot_3 = await snapshotter.snapshot()
+    assert_edge_timestamps(snapshot_2, snapshot_3, at_3_str)

--- a/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
+++ b/backend/tests/unit/core/schema_manager/test_schema_load_edge_timestamps.py
@@ -1,0 +1,204 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import HashableModelState, InfrahubKind, RelationshipCardinality
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from tests.db_snapshot import DbEdge, DbSnapshot, DbSnapshotter
+
+
+async def assert_edge_timestamps(
+    db: InfrahubDatabase,
+    before_edges_by_id: dict[str, DbEdge],
+    expected_timestamp: str,
+) -> DbSnapshot:
+    """Take a snapshot and verify all new/modified edges use the expected timestamp.
+
+    For new edges: 'from' must equal expected_timestamp
+    For modified edges: changed 'to' must equal expected_timestamp
+    """
+    snapshotter = DbSnapshotter(db)
+    after_snapshot = await snapshotter.snapshot()
+    after_edges_by_id = {e.db_id: e for e in after_snapshot.edge_map.values()}
+
+    for edge_id, after_edge in after_edges_by_id.items():
+        before_edge = before_edges_by_id.get(edge_id)
+
+        if before_edge is None:
+            # New edge - 'from' must equal expected_timestamp
+            from_time = after_edge.properties.get("from")
+            assert from_time == expected_timestamp, (
+                f"New edge {after_edge.edge_type} has from={from_time}, expected {expected_timestamp}"
+            )
+        else:
+            # Check for modified 'to' time (from never changes once set)
+            before_to = before_edge.properties.get("to")
+            after_to = after_edge.properties.get("to")
+
+            if before_to != after_to:
+                assert after_to == expected_timestamp, (
+                    f"Modified edge {after_edge.edge_type} has to={after_to}, expected {expected_timestamp}"
+                )
+
+    return after_snapshot
+
+
+def create_updated_schema(branch: Branch) -> SchemaBranch:
+    """Create an updated schema with various modifications.
+
+    Modifications include:
+    - A new attribute ("priority" on Criticality)
+    - A new relationship ("secondary_tag" on Criticality)
+    - An updated node property (Criticality label changed)
+    - An attribute with an updated property ("description" label changed)
+    - A relationship with an updated property ("tags" label changed)
+    """
+    current_schema = registry.schema.get_schema_branch(name=branch.name)
+    new_schema = current_schema.duplicate()
+
+    # Get a duplicate of the Criticality node to modify
+    node = new_schema.get(name="BuiltinCriticality", duplicate=False)
+
+    # Update node property
+    node.label = "Updated Criticality"
+
+    # Add new attribute
+    node.attributes.append(AttributeSchema(name="priority", kind="Number", label="Priority", optional=True))
+
+    # Update existing attribute property
+    description_attr = node.get_attribute(name="description")
+    description_attr.label = "Updated Description"
+
+    # Add new relationship
+    node.relationships.append(
+        RelationshipSchema(
+            name="secondary_tag",
+            peer=InfrahubKind.TAG,
+            label="Secondary Tag",
+            identifier="secondary_tag__criticality",
+            optional=True,
+            cardinality=RelationshipCardinality.ONE,
+        )
+    )
+
+    # Update existing relationship property
+    tags_rel = node.get_relationship(name="tags")
+    tags_rel.label = "Updated Tags"
+
+    new_schema.set(name="BuiltinCriticality", schema=node)
+    new_schema.process()
+
+    return new_schema
+
+
+async def load_updated_schema(
+    db: InfrahubDatabase,
+    branch: Branch,
+    new_schema: SchemaBranch,
+    at: Timestamp,
+) -> None:
+    """Load an updated schema using update_schema_branch with a diff."""
+    current_schema = registry.schema.get_schema_branch(name=branch.name)
+
+    # Compute the diff between current and new schema
+    diff = current_schema.diff(other=new_schema)
+
+    # Update the schema with the diff
+    await registry.schema.update_schema_branch(
+        schema=new_schema,
+        db=db,
+        branch=branch,
+        diff=diff,
+        at=at,
+    )
+
+
+def update_schema_with_deletes(
+    branch: Branch,
+    node_kind: str,
+    attribute_name: str,
+    relationship_name: str,
+) -> SchemaBranch:
+    """Create a schema with an attribute and relationship marked as ABSENT (deleted)."""
+    current_schema = registry.schema.get_schema_branch(name=branch.name)
+    new_schema = current_schema.duplicate()
+
+    # Get the node and mark the attribute and relationship as absent
+    node = new_schema.get(name=node_kind, duplicate=False)
+
+    attr = node.get_attribute(name=attribute_name)
+    attr.state = HashableModelState.ABSENT
+
+    rel = node.get_relationship(name=relationship_name)
+    rel.state = HashableModelState.ABSENT
+
+    new_schema.set(name=node_kind, schema=node)
+
+    return new_schema
+
+
+async def test_schema_load_edges_use_at_timestamp(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    schema_criticality_tag: dict,
+) -> None:
+    """Verify that every edge updated during schema load uses the 'at' timestamp.
+
+    When loading a schema via update_schema_branch(), all new edges should have
+    their 'from' time set to the 'at' parameter, and all modified edges should
+    have their 'to' time set to the 'at' parameter.
+    """
+    # 1. Snapshot before loading the schema
+    snapshotter = DbSnapshotter(db)
+    before_snapshot = await snapshotter.snapshot()
+    before_edges_by_id = {e.db_id: e for e in before_snapshot.edge_map.values()}
+
+    # 2. Create explicit timestamp for the 'at' parameter
+    at = Timestamp()
+    at_str = at.to_string()
+
+    # 3. Load schema using update_schema_branch with the explicit 'at' parameter
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    schema_branch.load_schema(schema=SchemaRoot(**schema_criticality_tag))
+    schema_branch.process()
+
+    await registry.schema.update_schema_branch(
+        schema=schema_branch,
+        db=db,
+        branch=default_branch,
+        at=at,
+    )
+
+    # 4. Verify all new/modified edges use the 'at' timestamp
+    snapshot_1 = await assert_edge_timestamps(db, before_edges_by_id, at_str)
+    snapshot_1_edges_by_id = {e.db_id: e for e in snapshot_1.edge_map.values()}
+
+    # 5. Load updated schema with new attribute, new relationship, and updated properties
+    updated_schema = create_updated_schema(default_branch)
+    at_2 = Timestamp()
+    at_2_str = at_2.to_string()
+
+    await load_updated_schema(db, default_branch, updated_schema, at_2)
+
+    # 6. Verify all new/modified edges (since snapshot_1) use the 'at_2' timestamp
+    snapshot_2 = await assert_edge_timestamps(db, snapshot_1_edges_by_id, at_2_str)
+    snapshot_2_edges_by_id = {e.db_id: e for e in snapshot_2.edge_map.values()}
+
+    # 7. Delete an attribute and relationship from the schema
+    at_3 = Timestamp()
+    at_3_str = at_3.to_string()
+
+    schema_with_deletes = update_schema_with_deletes(
+        branch=default_branch,
+        node_kind="BuiltinCriticality",
+        attribute_name="priority",  # Delete the attribute we added in step 5
+        relationship_name="secondary_tag",  # Delete the relationship we added in step 5
+    )
+    await load_updated_schema(db, default_branch, schema_with_deletes, at_3)
+
+    # 8. Verify all new/modified edges (since snapshot_2) use the 'at_3' timestamp
+    await assert_edge_timestamps(db, snapshot_2_edges_by_id, at_3_str)

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -269,7 +269,7 @@ async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     rel_schema = person_schema.get_relationship("tags")
@@ -634,7 +634,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     migrated_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_tags_main.id)
@@ -1099,7 +1099,7 @@ async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     query = await RelationshipGetPeerQuery.init(
@@ -1136,7 +1136,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node_2(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     migrated_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_tags_main.id)
@@ -1178,7 +1178,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node_2(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Builtin2NewTag", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
 
     # delete other tag relationship

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -14,6 +14,7 @@ from infrahub.core.constants import (
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.relationship import (
@@ -269,7 +270,7 @@ async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     rel_schema = person_schema.get_relationship("tags")
@@ -634,7 +635,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     migrated_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_tags_main.id)
@@ -1099,7 +1100,7 @@ async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     query = await RelationshipGetPeerQuery.init(
@@ -1136,7 +1137,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node_2(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     migrated_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_tags_main.id)
@@ -1178,7 +1179,7 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node_2(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Builtin2NewTag", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
 
     # delete other tag relationship

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -1212,7 +1212,7 @@ async def test_query_multiple_filters(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch)
+    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
     assert not execution_result.errors
 
     query05 = """

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -9,6 +9,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import NodeSchema, SchemaRoot
@@ -1212,7 +1213,7 @@ async def test_query_multiple_filters(
             path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
         ),
     )
-    execution_result = await migration.execute(db=db, branch=default_branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
 
     query05 = """

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -7,13 +7,13 @@ from infrahub.core.constants import InfrahubKind, MetadataOptions, RelationshipK
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
@@ -901,7 +901,7 @@ async def test_create_relationship_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -13,6 +13,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
@@ -900,7 +901,7 @@ async def test_create_relationship_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -14,11 +14,11 @@ from infrahub.core.constants import InfrahubKind, MetadataOptions, PermissionAct
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from infrahub.events.models import EventNode
@@ -898,7 +898,7 @@ async def test_relationship_add_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -18,6 +18,7 @@ from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from infrahub.events.models import EventNode
@@ -897,7 +898,7 @@ async def test_relationship_add_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -13,6 +13,7 @@ from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -1249,7 +1250,7 @@ async def test_update_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch)
+    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -9,11 +9,11 @@ from infrahub.core.constants import DiffAction, InfrahubKind, MetadataOptions, S
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -1250,7 +1250,7 @@ async def test_update_for_node_with_migrated_kind(
         new_node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
     )
-    execution_result = await migration.execute(db=db, branch=branch, at=Timestamp())
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
     assert not execution_result.errors
     core_node_schema = schema.get_generic(name="CoreNode")
     core_node_schema.used_by.append(new_person_kind)


### PR DESCRIPTION
part of #6948 

- pass `at` parameter all the way through the schema load/update logic so that everything that is part of a single schema update has the same timestamp (so that we can roll it back if necessary)
- pass required `at` parameter to all migrations, schema and database
  - reviewed all schema migrations to make sure that they are using the `at` parameter when making changes
  - did not update database migrations b/c it did not seem worth the effort, but we should make sure that all changes in a given migration have the same timestamp if possible going forward
- tests for all changes getting the same timestamp during schema save and schema migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration and schema operations now consistently record explicit timestamps, improving audit accuracy for create/update/delete actions.

* **Chores**
  * Migration execution unified to accept a structured context object, streamlining propagation of timing and user metadata across flows.

* **Tests**
  * Added and updated tests and helpers to validate timestamp propagation and edge-timestamp invariants during schema/migration operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->