### PR TITLE
Release 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.6.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.6.3) - 2026-01-07
+
+### Changed
+
+- Changed DiffTreeSummary GraphQL type count fields to be non-optional ([#7778](https://github.com/opsmill/infrahub/issues/7778))
+
+### Fixed
+
+- Stop showing warnings for deprecated attribute schema fields (regex, min_length, max_length) when they are not used ([#7995](https://github.com/opsmill/infrahub/issues/7995))
+
 ## [Infrahub - v1.6.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.6.2) - 2025-12-22
 
 ### Fixed

--- a/changelog/7778.changed.md
+++ b/changelog/7778.changed.md
@@ -1,1 +1,0 @@
-Changed DiffTreeSummary GraphQL type count fields to be non-optional

--- a/changelog/7995.fixed.md
+++ b/changelog/7995.fixed.md
@@ -1,1 +1,0 @@
-Stop showing warnings for deprecated attribute schema fields (regex, min_length, max_length) when they are not used

--- a/docs/docs/release-notes/infrahub/release-1_6_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_6_3.mdx
@@ -1,0 +1,29 @@
+---
+title: Release 1.6.3
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.6.3</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>January 7th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.6.6](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.6.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Changed
+
+- Changed DiffTreeSummary GraphQL type count fields to be non-optional ([#7778](https://github.com/opsmill/infrahub/issues/7778))
+
+### Fixed
+
+<!-- vale off -->
+- Stop showing warnings for deprecated attribute schema fields (regex, min_length, max_length) when they are not used ([#7995](https://github.com/opsmill/infrahub/issues/7995))
+<!-- vale on -->

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -421,6 +421,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_6_3',
             'release-notes/infrahub/release-1_6_2',
             'release-notes/infrahub/release-1_6_1',
             'release-notes/infrahub/release-1_6_0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.6.2"
+version = "1.6.3"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.13"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.6.2"
+version = "1.6.3"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Infrahub v1.6.3

* **Changed**
  * DiffTreeSummary GraphQL type count fields are now non-optional.

* **Fixed**
  * Warnings for deprecated attribute schema fields no longer display when not in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->