### PR TITLE
Add mandatory 'db' attribute to Query objects

### DIFF
--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -56,11 +56,12 @@ class AccountGlobalPermissionQuery(Query):
 
     def __init__(
         self,
+        db: InfrahubDatabase,
         account_id: str,
         branch: Branch | None = None,
         branch_agnostic: bool = False,
     ) -> None:
-        super().__init__(branch=branch, branch_agnostic=branch_agnostic)
+        super().__init__(db=db, branch=branch, branch_agnostic=branch_agnostic)
         self.account_id = account_id
 
         self.params["account_id"] = self.account_id
@@ -296,7 +297,7 @@ class AccountObjectPermissionQuery(Query):
 
 
 async def fetch_permissions(account_id: str, db: InfrahubDatabase, branch: Branch) -> AssignedPermissions:
-    query1 = AccountGlobalPermissionQuery(branch=branch, account_id=account_id, branch_agnostic=True)
+    query1 = AccountGlobalPermissionQuery(db=db, branch=branch, account_id=account_id, branch_agnostic=True)
     await query1.execute(db=db)
     global_permissions = query1.get_permissions()
 

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -345,6 +345,7 @@ class Query:
 
     def __init__(
         self,
+        db: InfrahubDatabase,
         branch: Branch | None = None,
         at: Timestamp | str | None = None,
         limit: int | None = None,
@@ -356,6 +357,7 @@ class Query:
         if branch:
             self.branch = branch
 
+        self.db = db
         self.branch_agnostic = branch_agnostic
 
         if not hasattr(self, "at"):
@@ -398,7 +400,7 @@ class Query:
         offset: int | None = None,
         **kwargs: Any,
     ) -> Self:
-        query = cls(branch=branch, at=at, limit=limit, offset=offset, **kwargs)
+        query = cls(db=db, branch=branch, at=at, limit=limit, offset=offset, **kwargs)
 
         await query.query_init(db=db, **kwargs)
 
@@ -530,10 +532,10 @@ class Query:
         return ":params { " + ", ".join(params) + " }"
 
     @trace.get_tracer(__name__).start_as_current_span("Query.execute")
-    async def execute(self, db: InfrahubDatabase) -> Self:
+    async def execute(self, db: InfrahubDatabase | None = None) -> Self:
         # Ensure all mandatory params have been provided
         # Ensure at least 1 return obj has been defined
-
+        db = db or self.db
         if config.SETTINGS.miscellaneous.print_query_details:
             self.print(include_var=True)
 

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -46,7 +46,7 @@ class DiffQuery(Query):
 
         self.branch_names = branch.get_branches_in_scope()
 
-        super().__init__(branch, **kwargs)
+        super().__init__(branch=branch, **kwargs)
 
 
 class DiffCountChanges(Query):
@@ -55,6 +55,7 @@ class DiffCountChanges(Query):
 
     def __init__(
         self,
+        db: InfrahubDatabase,
         branch_names: list[str],
         diff_from: Timestamp,
         diff_to: Timestamp,
@@ -63,7 +64,7 @@ class DiffCountChanges(Query):
         self.branch_names = branch_names
         self.diff_from = diff_from
         self.diff_to = diff_to
-        super().__init__(**kwargs)
+        super().__init__(db=db, **kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         self.params = {

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -122,13 +122,15 @@ async def test_RelationshipQuery_init(
     assert "Either an instance of Relationship or a valid branch must be provided." in str(exc.value)
 
     # Initialization with the Relationship class
-    rq = DummyRelationshipQuery(source=person_jack_main, rel=Relationship, schema=rel_schema, branch=branch)
+    rq = DummyRelationshipQuery(db=db, source=person_jack_main, rel=Relationship, schema=rel_schema, branch=branch)
     assert rq.schema == rel_schema
     assert rq.branch == branch
     assert rq.source_id == person_jack_main.id
     assert rq.source == person_jack_main
 
-    rq = DummyRelationshipQuery(source_id=person_jack_main.id, rel=Relationship, schema=rel_schema, branch=branch)
+    rq = DummyRelationshipQuery(
+        db=db, source_id=person_jack_main.id, rel=Relationship, schema=rel_schema, branch=branch
+    )
     assert rq.schema == rel_schema
     assert rq.branch == branch
     assert rq.source_id == person_jack_main.id
@@ -136,7 +138,7 @@ async def test_RelationshipQuery_init(
 
     # Initialization with an instance of Relationship
     rel = Relationship(schema=rel_schema, branch=branch, source_kind=person_jack_main.get_kind(), node=person_jack_main)
-    rq = DummyRelationshipQuery(source=person_jack_main, rel=rel)
+    rq = DummyRelationshipQuery(db=db, source=person_jack_main, rel=rel)
     assert rq.schema == rel_schema
     assert rq.branch == branch
 


### PR DESCRIPTION
Add mandatory 'db' param to the Query class prior to migrating other queries away from .init and .query_init methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured database parameter handling across core query classes to ensure consistent database context availability throughout the query lifecycle. Updated query constructors to require explicit database passing during initialization and propagated these changes across query subclasses. Modified the execute method to support optional database parameters with intelligent fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->