### PR TITLE
fix(backend): do not load performance pytest plugin

### DIFF
--- a/changelog/8075.fixed.md
+++ b/changelog/8075.fixed.md
@@ -1,0 +1,1 @@
+Fix failing execution of unit tests within a proposed change pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ infrahubctl = "infrahub_sdk.ctl.cli:app"
 
 [project.entry-points.pytest11]
 "pytest-infrahub" = "infrahub_sdk.pytest_plugin.plugin"
-"pytest-infrahub-performance-test" = "infrahub_testcontainers.plugin"
 
 [project.entry-points."prefect.collections"]
 "infrahubasync" = "infrahub.workers.infrahub_async"


### PR DESCRIPTION
This is not required at all and introduced a regression starting 1.6 because of the uv migration and avoiding the installation of dev dependencies (that include testcontainers).

Fixes #8075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues causing unit tests to fail during pipeline execution

* **Chores**
  * Removed unused testing plugin configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->