### PR TITLE
Ensure we always remove the github-cli archive

### DIFF
--- a/dev/setup-environment.sh
+++ b/dev/setup-environment.sh
@@ -128,10 +128,12 @@ else
             aarch64|arm64) ARCH="arm64" ;;
         esac
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-        curl -sLO "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz" \
-            && tar -xzf "gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz" \
-            && sudo mv "gh_${GH_VERSION}_${OS}_${ARCH}/bin/gh" /usr/local/bin/ \
-            && rm -rf "gh_${GH_VERSION}_${OS}_${ARCH}" "gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz"
+        GH_TARBALL="gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz"
+        GH_DIR="gh_${GH_VERSION}_${OS}_${ARCH}"
+        trap "rm -rf '$GH_DIR' '$GH_TARBALL'" RETURN
+        curl -sLO "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}" \
+            && tar -xzf "$GH_TARBALL" \
+            && sudo mv "$GH_DIR/bin/gh" /usr/local/bin/
     }
     if install_gh; then
         echo "GitHub CLI installed"


### PR DESCRIPTION
Previously, if one of the chained command failed to execute, the archive of the github-cli executable was left in place. This change makes sure that the whatever happens, the archive and directory will be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development setup script: installation now retrieves and extracts a versioned tarball for the GitHub CLI.
  * Cleanup and artifact removal are deferred to an exit trap, ensuring deterministic removal of temporary files after the setup sequence completes or on failure.
  * Minor control-flow adjustments to the setup process for more predictable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->