### PR TITLE
Add link checker for development guidelines

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -10,6 +10,9 @@ development_files: &development_files
   - "development/**"
   - "tasks/**"
 
+dev_guidelines:
+  - "dev/**"
+
 backend_files: &backend_files
   - "backend/**"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       testcontainers: ${{ steps.changes.outputs.testcontainers_files }}
       openapi_schema: ${{ steps.changes.outputs.openapi_schema_all }}
       graphql_schema: ${{ steps.changes.outputs.graphql_schema_all }}
+      dev_guidelines: ${{ steps.changes.outputs.dev_guidelines }}
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"
@@ -814,6 +815,31 @@ jobs:
         run: "uv sync --all-groups"
       - name: "Validate generated documentation"
         run: "uv run invoke docs.validate"
+
+  validate-dev-guideline-links:
+    if: |
+      always() && !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      (needs.files-changed.outputs.python == 'true') ||
+      (needs.files-changed.outputs.dev_guidelines == 'true') ||
+      (needs.files-changed.outputs.javascript == 'true')
+    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 5
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v6"
+        with:
+          submodules: true
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: |
+            --no-progress
+            --config dev/lychee.toml
+            --files-from dev/lychee-files.txt
+          fail: true
 
   validate-documentation-style:
     if: |

--- a/dev/adr/0003-asynchronous-tasks.md
+++ b/dev/adr/0003-asynchronous-tasks.md
@@ -79,10 +79,10 @@ This pattern enables identical code across environments while avoiding Prefect d
 
 Key implementation locations:
 
-- Workflow definitions: [`backend/infrahub/workflows/catalogue.py`](../../../backend/infrahub/workflows/catalogue.py)
-- Workflow models: [`backend/infrahub/workflows/models.py`](../../../backend/infrahub/workflows/models.py)
-- Constants & types: [`backend/infrahub/workflows/constants.py`](../../../backend/infrahub/workflows/constants.py)
-- Initialization: [`backend/infrahub/workflows/initialization.py`](../../../backend/infrahub/workflows/initialization.py)
+- Workflow definitions: [`backend/infrahub/workflows/catalogue.py`](../../backend/infrahub/workflows/catalogue.py)
+- Workflow models: [`backend/infrahub/workflows/models.py`](../../backend/infrahub/workflows/models.py)
+- Constants & types: [`backend/infrahub/workflows/constants.py`](../../backend/infrahub/workflows/constants.py)
+- Initialization: [`backend/infrahub/workflows/initialization.py`](../../backend/infrahub/workflows/initialization.py)
 - Task functions: Various `tasks.py` files across the codebase
 
 See also:

--- a/dev/guidelines/frontend/typescript.md
+++ b/dev/guidelines/frontend/typescript.md
@@ -1,6 +1,6 @@
 # TypeScript Coding Standards
 
-> Part of: `dev/guidelines/frontend/` | Related: [Frontend Architecture](../../knowledge/frontend/architecture.md)
+> Part of: `dev/guidelines/frontend/`
 
 Coding standards for the TypeScript/React frontend.
 
@@ -24,4 +24,3 @@ Follow React best practices and project conventions. See `frontend/app/AGENTS.md
 ## See Also
 
 - `frontend/app/AGENTS.md` - Frontend-specific patterns and structure
-- [Frontend Architecture](../../knowledge/frontend/architecture.md) - Frontend architecture overview

--- a/dev/guides/docs/writing-a-guide.md
+++ b/dev/guides/docs/writing-a-guide.md
@@ -13,7 +13,7 @@ Write a guide when you need to:
 - Address a particular problem or use case
 - Create documentation that can be completed independently by any user
 
-If you're explaining concepts or how something works, write a [topic](../knowledge/) instead.
+If you're explaining concepts or how something works, write a [topic](../../knowledge/) instead.
 
 ## Guide Structure Template
 

--- a/dev/knowledge/backend/architecture.md
+++ b/dev/knowledge/backend/architecture.md
@@ -15,11 +15,11 @@ High-level overview of the Infrahub backend architecture.
 
 ### Schema-Driven Architecture
 
-Everything in Infrahub is defined by schemas. The schema system defines what nodes exist, their attributes, relationships, and constraints. See [schema.md](schema.md).
+Everything in Infrahub is defined by schemas. The schema system defines what nodes exist, their attributes, relationships, and constraints.
 
 ### Git-Like Branching
 
-Infrahub provides version control for infrastructure data. Multiple branches can exist with different data states, and changes can be diffed and merged. See [branching.md](branching.md).
+Infrahub provides version control for infrastructure data. Multiple branches can exist with different data states, and changes can be diffed and merged.
 
 ### Query Pattern
 
@@ -31,7 +31,7 @@ The Neo4j database uses a temporal graph structure with branch support. All vert
 
 ### Proposed Changes
 
-Similar to pull requests, proposed changes allow reviewing and approving data modifications before merging. See [proposed-change.md](proposed-change.md).
+Similar to pull requests, proposed changes allow reviewing and approving data modifications before merging.
 
 ## Layer Responsibilities
 

--- a/dev/lychee-files.txt
+++ b/dev/lychee-files.txt
@@ -1,0 +1,2 @@
+dev/**/*.md
+backend/**/*.md

--- a/dev/lychee.toml
+++ b/dev/lychee.toml
@@ -1,0 +1,1 @@
+offline = true

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764242076,
-        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
           buildInputs = [
             pkgs.git
             pkgs.gh
+            pkgs.lychee
             pkgs.vale
           ];
 
@@ -24,6 +25,7 @@
             echo "Available tools:"
             echo "  - git: $(git --version)"
             echo "  - gh (GitHub CLI): $(gh --version | head -n1)"
+            echo "  - lychee (link checker): $(lychee --version)"
             echo "  - vale (prose linter): $(vale --version)"
           '';
         };

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -29,7 +29,7 @@ from .shared import (
     get_compose_cmd,
     get_env_vars,
 )
-from .utils import ESCAPED_REPO_PATH
+from .utils import ESCAPED_REPO_PATH, check_if_command_available
 
 if TYPE_CHECKING:
     from invoke.context import Context
@@ -65,6 +65,18 @@ def debug(context: Context, database: str = INFRAHUB_DATABASE) -> None:
         compose_cmd = get_compose_cmd(namespace=NAMESPACE)
         command = f"{get_env_vars(context, namespace=NAMESPACE)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME} up"
         execute_command(context=context, command=command)
+
+
+@task()
+def check_links(
+    context: Context,
+) -> None:
+    """Check internal links in the dev folder."""
+    with context.cd(ESCAPED_REPO_PATH):
+        if not check_if_command_available(context=context, command_name="lychee"):
+            print("lychee is not installed or not available in PATH. Please install it to use this task.")
+            return
+        execute_command(context=context, command="lychee -c dev/lychee.toml --files-from dev/lychee-files.txt")
 
 
 @task(optional=["database"])


### PR DESCRIPTION
This PR adds link checking to detect broken links within our dev guidelines directory. It's using [lychee](https://github.com/lycheeverse/lychee), same as we use in the docs website. The PR also updates the local nix flake files to install lychee automatically for whoever uses nix. Other users will have to install it manually if they want to run the link checker.

I've also fixed some of the current violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated link validation to the CI pipeline for development guidelines.
  * Introduced a new development task for checking documentation links.

* **Chores**
  * Enhanced development environment with link validation tooling.
  * Updated documentation structure and internal cross-references.
  * Expanded CI workflow with new validation job for development guidelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->