### PR TITLE
fix deleting branch-aware object with branch-agnostic attribute(s)

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -366,6 +366,24 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         return await self._update(db=db, user_id=user_id, at=save_at)
 
+    def get_branch_for_delete(self) -> Branch:
+        """Get the appropriate branch for explicit attribute delete operations.
+
+        For branch-agnostic attributes on branch-aware nodes, use the current branch
+        to create branch-scoped deletion edges rather than global deletion.
+
+        Returns:
+            Branch: The branch to use for the delete operation
+        """
+        if (
+            self.schema.branch == BranchSupportType.AGNOSTIC
+            and self.node is not None
+            and self.node._schema.branch == BranchSupportType.AWARE
+        ):
+            return self.branch
+
+        return self.get_branch_based_on_support_type()
+
     async def delete(
         self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None
     ) -> AttributeChangelog | None:
@@ -373,7 +391,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
             return None
 
         delete_at = Timestamp(at)
-        branch = self.get_branch_based_on_support_type()
+        branch = self.get_branch_for_delete()
 
         query = await AttributeDeleteQuery.init(db=db, branch=branch, attr=self, user_id=user_id, at=delete_at)
         await query.execute(db=db)

--- a/backend/tests/component/core/migrations/graph/test_043_044.py
+++ b/backend/tests/component/core/migrations/graph/test_043_044.py
@@ -272,15 +272,10 @@ class TestMigration043(TestInfrahubApp):
 
         return NodeDetails(
             node=primary_thing,
-            # a bug in deleting branch-aware nodes with branch-agnostic relationships prevents this from working correctly
-            # https://github.com/opsmill/infrahub/issues/7513
-            # display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
-            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
             human_friendly_id=[
                 str(primary_thing.name.value),
-                # https://github.com/opsmill/infrahub/issues/7513 here too
-                # primary_thing.agnostic_smell.value,
-                None,
+                str(primary_thing.agnostic_smell.value),
                 str(new_secondary_in_node.name.value),
                 str(new_secondary_out_node.size.value),
                 str(new_agnostic_secondary_node.agnostic_smell.value),

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -5,6 +5,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, RelationshipDeleteBehavior
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema.relationship_schema import RelationshipSchema
@@ -237,3 +238,65 @@ class TestDeleteUnidirectionalRelationship(TestInfrahubApp):
         res = await NodeManager.get_many(db=db, ids=[car.id])
         rels = await res[car.id].previous_owner.get_relationships(db=db)
         assert len(rels) == 0
+
+
+async def test_delete_branch_aware_node_with_branch_agnostic_attribute_on_branch(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema_global: None,
+) -> None:
+    """Test that deleting a branch-aware node on a branch does not delete its branch-agnostic attribute on other branches.
+
+    The scenario:
+    - TestCar is branch-aware with a branch-agnostic attribute 'nbr_seats'
+    - Create a car on the default branch
+    - Create new branches (branch2 and branch3)
+    - Delete the car while on branch2
+    - Verify the car and its branch-agnostic attribute still exist on default branch and branch3
+    """
+    # Create a person (owner) on default branch - TestPerson is branch-agnostic in this schema
+    person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person.new(db=db, name="John", height=180)
+    await person.save(db=db)
+
+    # Create a car on default branch with branch-agnostic attribute nbr_seats
+    car = await Node.init(db=db, schema="TestCar", branch=default_branch)
+    await car.new(db=db, name="TestVehicle", nbr_seats=5, color="#FF0000", is_electric=True, owner=person)
+    await car.save(db=db)
+    car_id = car.id
+
+    # Verify initial state on default branch
+    car_on_main = await NodeManager.get_one(db=db, id=car_id, branch=default_branch)
+    assert car_on_main is not None
+    assert car_on_main.nbr_seats.value == 5
+
+    # Create a new branch
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    branch3 = await create_branch(db=db, branch_name="branch3")
+
+    # Get the car on branch2 and delete it
+    car_on_branch2 = await NodeManager.get_one(db=db, id=car_id, branch=branch2)
+    assert car_on_branch2 is not None
+    await car_on_branch2.delete(db=db)
+
+    # Verify the car is deleted on branch2
+    car_on_branch2_after_delete = await NodeManager.get_one(db=db, id=car_id, branch=branch2)
+    assert car_on_branch2_after_delete is None
+
+    # Verify the car still exists on default branch with its branch-agnostic attribute intact
+    car_on_main_after_delete = await NodeManager.get_one(db=db, id=car_id, branch=default_branch)
+    assert car_on_main_after_delete is not None, (
+        "Car should still exist on default branch after being deleted on branch2"
+    )
+    assert car_on_main_after_delete.nbr_seats.value == 5, (
+        "Branch-agnostic attribute 'nbr_seats' should not be deleted on default branch "
+        "when the node is deleted on another branch"
+    )
+
+    # Verify the car still exists on branch3 with its branch-agnostic attribute intact
+    car_on_branch3 = await NodeManager.get_one(db=db, id=car_id, branch=branch3)
+    assert car_on_branch3 is not None
+    assert car_on_branch3.nbr_seats.value == 5, (
+        "Branch-agnostic attribute 'nbr_seats' should not be deleted on branch3 "
+        "when the node is deleted on another branch"
+    )

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -8,6 +8,7 @@ from infrahub.core.constants import BranchSupportType, RelationshipDeleteBehavio
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -317,4 +318,142 @@ async def test_delete_branch_aware_node_with_branch_agnostic_attribute_on_branch
     )
     assert car_on_branch3_after_main_delete.nbr_seats.value == 5, (
         "Branch-agnostic attribute 'nbr_seats' should still exist on branch3 after the node is deleted on main branch"
+    )
+
+
+async def test_delete_branch_aware_node_with_agnostic_relationship(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+) -> None:
+    """Test that deleting a branch-aware node with an explicitly branch-agnostic relationship
+    only deletes the relationship on the specific branch, not globally.
+
+    The scenario:
+    - TestDevice is branch-aware with an explicitly branch-agnostic relationship 'location'
+    - TestLocation is branch-aware
+    - Create a device and location on the default branch
+    - Create new branches (branch2 and branch3)
+    - Delete the device on branch2
+    - Verify the device is deleted on branch2
+    - Verify the device and its relationship to the location still exist on branch3
+    """
+
+    # Create a schema with branch-aware nodes and an explicitly agnostic relationship
+    SCHEMA = {
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": "Test",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+                "relationships": [
+                    # Explicitly set relationship to branch-agnostic
+                    {
+                        "name": "location",
+                        "peer": "TestLocation",
+                        "optional": True,
+                        "cardinality": "one",
+                        "branch": BranchSupportType.AGNOSTIC.value,
+                    },
+                ],
+            },
+            {
+                "name": "Location",
+                "namespace": "Test",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+                "relationships": [
+                    {
+                        "name": "devices",
+                        "peer": "TestDevice",
+                        "cardinality": "many",
+                        "branch": BranchSupportType.AGNOSTIC.value,
+                    },
+                ],
+            },
+        ],
+    }
+
+    schema = SchemaRoot(**SCHEMA)
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+    # Create a location on default branch
+    location = await Node.init(db=db, schema="TestLocation", branch=default_branch)
+    await location.new(db=db, name="DataCenter1")
+    await location.save(db=db)
+    location_id = location.id
+
+    # Create a device on default branch with location relationship
+    device = await Node.init(db=db, schema="TestDevice", branch=default_branch)
+    await device.new(db=db, name="Server1", location=location)
+    await device.save(db=db)
+    device_id = device.id
+
+    # Create new branches
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    branch3 = await create_branch(db=db, branch_name="branch3")
+
+    # Delete the device on branch2
+    device_on_branch2 = await NodeManager.get_one(db=db, id=device_id, branch=branch2)
+    await device_on_branch2.delete(db=db)
+
+    # Verify the device is deleted on branch2
+    device_on_branch2_after_delete = await NodeManager.get_one(db=db, id=device_id, branch=branch2)
+    assert device_on_branch2_after_delete is None, "Device should be deleted on branch2"
+
+    # Verify the device still exists on default branch
+    device_on_main_after_delete = await NodeManager.get_one(db=db, id=device_id, branch=default_branch)
+    assert device_on_main_after_delete is not None, (
+        "Device should still exist on default branch after being deleted on branch2"
+    )
+
+    # Verify the device's location relationship still exists on default branch
+    location_rel = device_on_main_after_delete.get_relationship("location")
+    device_location_on_main = await location_rel.get_peer(db=db)
+    assert device_location_on_main is not None, "Device's location relationship should still exist on default branch"
+    assert device_location_on_main.id == location_id
+
+    # Verify the device still exists on branch3 with its location relationship
+    device_on_branch3 = await NodeManager.get_one(db=db, id=device_id, branch=branch3)
+    assert device_on_branch3 is not None, "Device should still exist on branch3 after being deleted on branch2"
+
+    # Verify the location relationship still exists on branch3
+    location_rel = device_on_branch3.get_relationship("location")
+    device_location_on_branch3 = await location_rel.get_peer(db=db)
+    assert device_location_on_branch3 is not None, (
+        "Device's branch-agnostic location relationship should still exist on branch3 after device deleted on branch2"
+    )
+    assert device_location_on_branch3.id == location_id
+
+    # Now verify from the Location side of the relationship
+
+    # On branch2: location's devices should NOT include the deleted device
+    location_on_branch2 = await NodeManager.get_one(db=db, id=location_id, branch=branch2)
+    assert location_on_branch2 is not None
+    devices_rel_branch2 = location_on_branch2.get_relationship("devices")
+    devices_on_branch2 = await devices_rel_branch2.get_peers(db=db)
+    assert not devices_on_branch2, "Location's devices relationship should be empty on branch2"
+
+    # On default branch: location's devices SHOULD include the device
+    location_on_main = await NodeManager.get_one(db=db, id=location_id, branch=default_branch)
+    assert location_on_main is not None
+    devices_rel_main = location_on_main.get_relationship("devices")
+    devices_on_main = await devices_rel_main.get_peers(db=db)
+    device_ids_on_main = [d.id for d in devices_on_main.values()]
+    assert device_ids_on_main == [device_id], (
+        "Location's devices relationship SHOULD include the device on default branch"
+    )
+
+    # On branch3: location's devices SHOULD include the device
+    location_on_branch3 = await NodeManager.get_one(db=db, id=location_id, branch=branch3)
+    assert location_on_branch3 is not None
+    devices_rel_branch3 = location_on_branch3.get_relationship("devices")
+    devices_on_branch3 = await devices_rel_branch3.get_peers(db=db)
+    device_ids_on_branch3 = [d.id for d in devices_on_branch3.values()]
+    assert device_ids_on_branch3 == [device_id], (
+        "Location's devices relationship SHOULD include the device on branch3 after device deleted on branch2"
     )

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -300,3 +300,21 @@ async def test_delete_branch_aware_node_with_branch_agnostic_attribute_on_branch
         "Branch-agnostic attribute 'nbr_seats' should not be deleted on branch3 "
         "when the node is deleted on another branch"
     )
+
+    # Now delete the car on the main branch
+    car_on_main_to_delete = await NodeManager.get_one(db=db, id=car_id, branch=default_branch)
+    assert car_on_main_to_delete is not None
+    await car_on_main_to_delete.delete(db=db)
+
+    # Verify the car is deleted on main branch
+    car_on_main_after_main_delete = await NodeManager.get_one(db=db, id=car_id, branch=default_branch)
+    assert car_on_main_after_main_delete is None, "Car should be deleted on main branch"
+
+    # Verify the car still exists on branch3 with its branch-agnostic attribute intact
+    car_on_branch3_after_main_delete = await NodeManager.get_one(db=db, id=car_id, branch=branch3)
+    assert car_on_branch3_after_main_delete is not None, (
+        "Car should still exist on branch3 after being deleted on main branch"
+    )
+    assert car_on_branch3_after_main_delete.nbr_seats.value == 5, (
+        "Branch-agnostic attribute 'nbr_seats' should still exist on branch3 after the node is deleted on main branch"
+    )

--- a/changelog/7513.fixed.md
+++ b/changelog/7513.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug that caused branch-agnostic attributes on branch-aware objects to be deleted globally when the object was deleted. Now branch-agnostic attributes on branch-aware objects are only deleted on the branch where the object was deleted.


### PR DESCRIPTION
fixes #7513 

the bug is that deleting a branch-aware Node with branch-agnostic Attribute(s) caused those Attribute(s) to be deleted globally, which is kind of unexpected.

if I delete branch-aware Node `A` from branch `my-branch` and Node `A` includes a branch-agnostic Attribute, say `color`, then the `color` Attribute would be deleted on _all_ branches, including those where `A` still exists

the fix is to only delete the attribute on the branch where it is being deleted if the Node is branch-aware and the Attribute is branch-agnostic.

also adds a test for the same case with Relationships, but we already handle those correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* **Branch-Aware Node Deletion Fix**: Corrected an issue where deleting a branch-aware node would incorrectly remove all branch-agnostic attributes and relationships across all branches. These items are now properly deleted only on the specific branch where the deletion occurs, preserving them on other branches and maintaining proper data isolation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->