### PR TITLE
Add test matrix for Python 3.12 and 3.13 to unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,12 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
-
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.13"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -380,11 +385,11 @@ jobs:
         uses: "actions/checkout@v6"
         with:
           submodules: true
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         id: python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -394,6 +399,7 @@ jobs:
       - name: "Unit Tests"
         run: "uv run invoke backend.test-unit"
       - name: "Coveralls : Unit Tests"
+        if: matrix.python-version == '3.12'
         uses: coverallsapp/github-action@v2
         continue-on-error: true
         env:


### PR DESCRIPTION
Adds a test matrix to the "new" unittests so that we can run the tests against multiple versions of Python. This is mainly as a sanity check during transition periods as I think we'll need to support multiple Python versions to account for issues between customer repos and any requirements they have for third party packages that might not support the latest version of Python.

As I don't expect alternate code paths between Python versions I made a compromise with regards to the test coverage reporting and we only keep the coverage for one of the Python versions. This is to simplify the pipeline a bit and avoid having to compile a carry-forward string or having that string being updated manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline to validate the application across Python 3.12 and 3.13 by executing unit tests in parallel across multiple Python versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->