### PR TITLE
add option to link a diff to a proposed change

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -416,6 +416,7 @@ class EnrichedDiffRootMetadata(BaseSummary):
     tracking_id: TrackingId
     partner_uuid: str | None = field(default=None)
     exists_on_database: bool = field(default=False)
+    proposed_change_id: str | None = field(default=None)
 
     def __hash__(self) -> int:
         return hash(self.uuid)

--- a/backend/infrahub/core/diff/query/diff_get.py
+++ b/backend/infrahub/core/diff/query/diff_get.py
@@ -18,6 +18,9 @@ QUERY_MATCH_NODES = """
     AND ($to_time IS NULL OR diff_root.to_time <= $to_time)
     AND ($tracking_id IS NULL OR diff_root.tracking_id = $tracking_id)
     AND ($diff_ids IS NULL OR diff_root.uuid IN $diff_ids)
+    AND ($proposed_change_id IS NULL OR EXISTS {
+        MATCH (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(:Node {uuid: $proposed_change_id})
+    })
     // get all the nodes attached to the diffs
     OPTIONAL MATCH (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode)
     """
@@ -40,6 +43,7 @@ class EnrichedDiffGetQuery(Query):
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
         diff_ids: list[str] | None = None,
+        proposed_change_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -50,6 +54,7 @@ class EnrichedDiffGetQuery(Query):
         self.max_depth = max_depth
         self.tracking_id = tracking_id
         self.diff_ids = diff_ids
+        self.proposed_change_id = proposed_change_id
         self.filters = filters or EnrichedDiffQueryFilters()
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
@@ -60,6 +65,7 @@ class EnrichedDiffGetQuery(Query):
             "to_time": self.to_time.to_string(),
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "diff_ids": self.diff_ids,
+            "proposed_change_id": self.proposed_change_id,
             "limit": self.limit or config.SETTINGS.database.query_size_limit,
             "offset": self.offset,
         }
@@ -146,6 +152,11 @@ class EnrichedDiffGetQuery(Query):
             diff_node_conflict,
             diff_attributes,
             collect([diff_relationship, diff_rel_element, diff_rel_conflict, diff_rel_property, diff_rel_property_conflict]) AS diff_relationships
+        // -------------------------------------
+        // Retrieve proposed_change_id via edge traversal
+        // -------------------------------------
+        OPTIONAL MATCH (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(pc:Node)
+        WITH *, pc.uuid AS proposed_change_id
         """ % {"max_depth": self.max_depth * 2}
 
         self.add_to_query(query=query_2)
@@ -158,5 +169,6 @@ class EnrichedDiffGetQuery(Query):
             "diff_node_conflict",
             "diff_attributes",
             "diff_relationships",
+            "proposed_change_id",
         ]
         self.order_by = ["diff_root.diff_branch_name ASC", "diff_root.from_time ASC", "diff_node.label ASC"]

--- a/backend/infrahub/core/diff/query/diff_summary.py
+++ b/backend/infrahub/core/diff/query/diff_summary.py
@@ -51,6 +51,7 @@ class DiffSummaryQuery(Query):
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
+        proposed_change_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -60,6 +61,7 @@ class DiffSummaryQuery(Query):
         self.from_time = from_time
         self.to_time = to_time
         self.tracking_id = tracking_id
+        self.proposed_change_id = proposed_change_id
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         if (self.from_time is None or self.to_time is None) and self.tracking_id is None:
@@ -70,6 +72,7 @@ class DiffSummaryQuery(Query):
             "from_time": self.from_time.to_string() if self.from_time else None,
             "to_time": self.to_time.to_string() if self.to_time else None,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+            "proposed_change_id": self.proposed_change_id,
             "diff_ids": None,
         }
 

--- a/backend/infrahub/core/diff/query/link_proposed_change.py
+++ b/backend/infrahub/core/diff/query/link_proposed_change.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+
+class EnrichedDiffLinkProposedChangeQuery(Query):
+    """Links existing DiffRoot nodes to a ProposedChange by their UUIDs."""
+
+    name = "enriched_diff_link_proposed_change"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(
+        self,
+        diff_uuids: list[str],
+        proposed_change_id: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.diff_uuids = diff_uuids
+        self.proposed_change_id = proposed_change_id
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params = {
+            "diff_uuids": self.diff_uuids,
+            "proposed_change_id": self.proposed_change_id,
+        }
+        query = """
+MATCH (pc:Node {uuid: $proposed_change_id})
+MATCH (diff_root:DiffRoot)
+WHERE diff_root.uuid IN $diff_uuids
+MERGE (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(pc)
+        """
+        self.add_to_query(query)

--- a/backend/infrahub/core/diff/query/roots_metadata.py
+++ b/backend/infrahub/core/diff/query/roots_metadata.py
@@ -20,6 +20,7 @@ class EnrichedDiffRootsMetadataQuery(Query):
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
+        proposed_change_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -28,6 +29,7 @@ class EnrichedDiffRootsMetadataQuery(Query):
         self.from_time = from_time
         self.to_time = to_time
         self.tracking_id = tracking_id
+        self.proposed_change_id = proposed_change_id
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params = {
@@ -36,6 +38,7 @@ class EnrichedDiffRootsMetadataQuery(Query):
             "from_time": self.from_time.to_string() if self.from_time else None,
             "to_time": self.to_time.to_string() if self.to_time else None,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+            "proposed_change_id": self.proposed_change_id,
         }
 
         query = """
@@ -46,10 +49,14 @@ class EnrichedDiffRootsMetadataQuery(Query):
         AND ($from_time IS NULL OR diff_root.from_time >= $from_time)
         AND ($to_time IS NULL OR diff_root.to_time <= $to_time)
         AND ($tracking_id IS NULL OR diff_root.tracking_id = $tracking_id)
+        AND ($proposed_change_id IS NULL OR EXISTS {
+            MATCH (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(:Node {uuid: $proposed_change_id})
+        })
+        OPTIONAL MATCH (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(pc:Node)
         """
-        self.return_labels = ["diff_root"]
+        self.return_labels = ["diff_root", "pc.uuid AS proposed_change_id"]
         self.add_to_query(query=query)
 
-    def get_root_nodes_metadata(self) -> Generator[Neo4jNode, None, None]:
+    def get_root_nodes_metadata(self) -> Generator[tuple[Neo4jNode, str | None], None, None]:
         for result in self.get_results():
-            yield result.get_node("diff_root")
+            yield result.get_node("diff_root"), result.get_as_str("proposed_change_id")

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -39,6 +39,25 @@ CALL (diff_root_map) {
     SET diff_root.tracking_id = diff_root_map.tracking_id
     RETURN diff_root
 }
+// -------------------------
+// link the diff root to the proposed change
+// -------------------------
+CALL (diff_root, diff_root_map) {
+    // find the current linked proposed change, if any
+    OPTIONAL MATCH (diff_root)-[current_edge:DIFF_FOR_PROPOSED_CHANGE]->(current_proposed_change)
+    WITH current_edge, current_proposed_change
+    // delete the current link if it is incorrect, including NULL handling
+    WHERE (
+        current_proposed_change.uuid <> diff_root_map.proposed_change_id
+        OR (current_proposed_change IS NULL AND diff_root_map.proposed_change_id IS NOT NULL)
+        OR (current_proposed_change IS NOT NULL AND diff_root_map.proposed_change_id IS NULL)
+    )
+    DELETE current_edge
+    // create the new link
+    WITH diff_root, diff_root_map
+    MATCH (new_proposed_change:Node {uuid: diff_root_map.proposed_change_id})
+    CREATE (diff_root)-[:DIFF_FOR_PROPOSED_CHANGE]->(new_proposed_change)
+}
 WITH DISTINCT diff_root AS diff_root
 WITH collect(diff_root) AS diff_roots
 WHERE SIZE(diff_roots) = 2
@@ -62,6 +81,7 @@ CALL (diff_roots) {
                     "to_time": enriched_diff.to_time.to_string(),
                     "uuid": enriched_diff.uuid,
                     "tracking_id": enriched_diff.tracking_id.serialize() if enriched_diff.tracking_id else None,
+                    "proposed_change_id": enriched_diff.proposed_change_id,
                 }
             )
         return {"diff_root_list": diff_root_list}

--- a/backend/infrahub/core/diff/repository/deserializer.py
+++ b/backend/infrahub/core/diff/repository/deserializer.py
@@ -53,7 +53,9 @@ class EnrichedDiffDeserializer:
         self._parents_path_map[enriched_root].append((node_identifier, parents_path))
 
     async def read_result(self, result: QueryResult, include_parents: bool) -> None:
-        enriched_root = self._deserialize_diff_root(root_node=result.get_node("diff_root"))
+        enriched_root = self._deserialize_diff_root(
+            root_node=result.get_node("diff_root"), proposed_change_id=result.get_as_str("proposed_change_id")
+        )
         node_node = result.get(label="diff_node")
         if not isinstance(node_node, Neo4jNode):
             return
@@ -166,17 +168,19 @@ class EnrichedDiffDeserializer:
         value_raw = node.get(property_name)
         return str(value_raw) if value_raw is not None else None
 
-    def _deserialize_diff_root(self, root_node: Neo4jNode) -> EnrichedDiffRoot:
+    def _deserialize_diff_root(self, root_node: Neo4jNode, proposed_change_id: str | None = None) -> EnrichedDiffRoot:
         root_uuid = str(root_node.get("uuid"))
         if root_uuid in self._diff_root_map:
             return self._diff_root_map[root_uuid]
-        root_empty = self.build_diff_root_metadata(root_node=root_node)
+        root_empty = self.build_diff_root_metadata(root_node=root_node, proposed_change_id=proposed_change_id)
         enriched_root = EnrichedDiffRoot.from_root_metadata(empty_root=root_empty)
         self._diff_root_map[root_uuid] = enriched_root
         return enriched_root
 
     @classmethod
-    def build_diff_root_metadata(cls, root_node: Neo4jNode) -> EnrichedDiffRootMetadata:
+    def build_diff_root_metadata(
+        cls, root_node: Neo4jNode, proposed_change_id: str | None = None
+    ) -> EnrichedDiffRootMetadata:
         from_time = Timestamp(str(root_node.get("from_time")))
         to_time = Timestamp(str(root_node.get("to_time")))
         partner_uuid = cls._get_str_or_none_property_value(node=root_node, property_name="partner_uuid")
@@ -196,6 +200,7 @@ class EnrichedDiffDeserializer:
             num_conflicts=int(root_node.get("num_conflicts", 0)),
             contains_conflict=str(root_node.get("contains_conflict")).lower() == "true",
             exists_on_database=True,
+            proposed_change_id=proposed_change_id,
         )
 
     def _deserialize_diff_node(self, node_node: Neo4jNode, enriched_root: EnrichedDiffRoot) -> EnrichedDiffNode:

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -38,6 +38,7 @@ from ..query.field_specifiers import EnrichedDiffFieldSpecifiersQuery
 from ..query.filters import EnrichedDiffQueryFilters
 from ..query.get_conflict_query import EnrichedDiffConflictQuery
 from ..query.has_conflicts_query import EnrichedDiffHasConflictQuery
+from ..query.link_proposed_change import EnrichedDiffLinkProposedChangeQuery
 from ..query.merge_tracking_id import EnrichedDiffMergedTrackingIdQuery
 from ..query.roots_metadata import EnrichedDiffRootsMetadataQuery
 from ..query.save import EnrichedDiffRootsUpsertQuery, EnrichedNodeBatchCreateQuery, EnrichedNodesLinkQuery
@@ -70,6 +71,7 @@ class DiffRepository:
         max_depth: int | None = None,
         tracking_id: TrackingId | None = None,
         diff_ids: list[str] | None = None,
+        proposed_change_id: str | None = None,
     ) -> list[EnrichedDiffRoot]:
         self.deserializer.initialize()
         final_row_number = None
@@ -91,6 +93,7 @@ class DiffRepository:
                 offset=offset,
                 tracking_id=tracking_id,
                 diff_ids=diff_ids,
+                proposed_change_id=proposed_change_id,
             )
             log.info(f"Beginning enriched diff get query {batch_size_limit=}, {offset=}")
             await get_query.execute(db=self.db)
@@ -118,6 +121,7 @@ class DiffRepository:
         tracking_id: TrackingId | None = None,
         diff_ids: list[str] | None = None,
         include_empty: bool = False,
+        proposed_change_id: str | None = None,
     ) -> list[EnrichedDiffRoot]:
         final_max_depth = config.SETTINGS.database.max_depth_search_hierarchy
         batch_size_limit = int(config.SETTINGS.database.query_size_limit / 10)
@@ -134,6 +138,7 @@ class DiffRepository:
             offset=offset or 0,
             tracking_id=tracking_id,
             diff_ids=diff_ids,
+            proposed_change_id=proposed_change_id,
         )
         if not include_empty:
             diff_roots = [dr for dr in diff_roots if len(dr.nodes) > 0]
@@ -386,6 +391,14 @@ class DiffRepository:
         query = await EnrichedDiffDeleteQuery.init(db=self.db, enriched_diff_root_uuids=diff_root_uuids)
         await query.execute(db=self.db)
 
+    async def link_to_proposed_change(self, diff_uuids: list[str], proposed_change_id: str) -> None:
+        query = await EnrichedDiffLinkProposedChangeQuery.init(
+            db=self.db,
+            diff_uuids=diff_uuids,
+            proposed_change_id=proposed_change_id,
+        )
+        await query.execute(db=self.db)
+
     async def get_time_ranges(
         self,
         base_branch_name: str,
@@ -443,6 +456,7 @@ class DiffRepository:
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
+        proposed_change_id: str | None = None,
     ) -> list[EnrichedDiffRootMetadata]:
         query = await EnrichedDiffRootsMetadataQuery.init(
             db=self.db,
@@ -451,11 +465,14 @@ class DiffRepository:
             from_time=from_time,
             to_time=to_time,
             tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id,
         )
         await query.execute(db=self.db)
         diff_roots = []
-        for neo4j_node in query.get_root_nodes_metadata():
-            diff_roots.append(self.deserializer.build_diff_root_metadata(root_node=neo4j_node))
+        for neo4j_node, pc_id in query.get_root_nodes_metadata():
+            diff_roots.append(
+                self.deserializer.build_diff_root_metadata(root_node=neo4j_node, proposed_change_id=pc_id)
+            )
         return diff_roots
 
     async def diff_has_conflicts(

--- a/backend/tests/component/core/diff/factories.py
+++ b/backend/tests/component/core/diff/factories.py
@@ -106,6 +106,7 @@ class EnrichedRootFactory(DataclassFactory[EnrichedDiffRoot]):
     num_conflicts = 0
     contains_conflict = False
     exists_on_database = False
+    proposed_change_id = None
 
 
 class CalculatedDiffsFactory(DataclassFactory[CalculatedDiffs]): ...

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -1033,6 +1033,245 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert retrieved_diff == saved_diffs.diff_branch_diff
         await verify_no_orphaned_nodes(db=db)
 
+    async def test_save_and_retrieve_with_proposed_change(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test that saving a diff with proposed_change_id creates the DIFF_FOR_PROPOSED_CHANGE edge."""
+        # Create a node that will act as the proposed change
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=NameTrackingId(name="pc-linked-diff"),
+            proposed_change_id=proposed_change_id,
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=NameTrackingId(name="pc-linked-diff"),
+            proposed_change_id=proposed_change_id,
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Verify retrieval via get_roots_metadata
+        metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[self.diff_branch_name, self.base_branch_name],
+            proposed_change_id=proposed_change_id,
+        )
+        assert len(metadata) == 2
+        metadata_uuids = {m.uuid for m in metadata}
+        assert metadata_uuids == {enriched_branch_diff.uuid, enriched_base_diff.uuid}
+        for m in metadata:
+            assert m.proposed_change_id == proposed_change_id
+
+    async def test_update_proposed_change_link(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test that updating a diff's proposed_change_id updates the edge."""
+        # Create two nodes that will act as proposed changes
+        proposed_change_id_1 = str(uuid4())
+        proposed_change_id_2 = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id_1})
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id_2})
+
+        # Save diff with first proposed change
+        tracking_id = NameTrackingId(name="update-pc-diff")
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id_1,
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id_1,
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Update to second proposed change
+        enriched_branch_diff.proposed_change_id = proposed_change_id_2
+        enriched_base_diff.proposed_change_id = proposed_change_id_2
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Verify diffs are linked to proposed change 2 via get_roots_metadata
+        metadatas = await diff_repository.get_roots_metadata(
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id_2,
+        )
+        metadata_uuids = {m.uuid for m in metadatas}
+        assert metadata_uuids == {enriched_branch_diff.uuid, enriched_base_diff.uuid}
+        for m in metadatas:
+            assert m.proposed_change_id == proposed_change_id_2
+
+        # Verify diffs are not linked to proposed change 1 via get_roots_metadata
+        metadatas = await diff_repository.get_roots_metadata(
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id_1,
+        )
+        assert len(metadatas) == 0
+
+    async def test_link_to_proposed_change(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test the link_to_proposed_change method for linking existing diffs."""
+        # Create proposed change node
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        # Save diff without proposed change
+        tracking_id = NameTrackingId(name="link-later-diff")
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=tracking_id,
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=tracking_id,
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Link to proposed change
+        await diff_repository.link_to_proposed_change(
+            diff_uuids=[enriched_branch_diff.uuid],
+            proposed_change_id=proposed_change_id,
+        )
+
+        # Verify diffs are linked to proposed change via get_roots_metadata
+        metadatas = await diff_repository.get_roots_metadata(
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id,
+        )
+        assert len(metadatas) == 1
+        metadatas = metadatas[0]
+        assert metadatas.uuid == enriched_branch_diff.uuid
+        assert metadatas.proposed_change_id == proposed_change_id
+
+        # Verify retrieval via get_roots_metadata
+        metadatas = await diff_repository.get_roots_metadata(tracking_id=tracking_id)
+        metadata_pc_map = {m.uuid: m.proposed_change_id for m in metadatas}
+        assert metadata_pc_map == {enriched_branch_diff.uuid: proposed_change_id, enriched_base_diff.uuid: None}
+
+    async def test_filter_by_proposed_change_id(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test filtering diffs by proposed_change_id."""
+        # Create two proposed changes
+        proposed_change_id_1 = str(uuid4())
+        proposed_change_id_2 = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id_1})
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id_2})
+
+        # Save first diff linked to first proposed change
+        diff_1 = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=NameTrackingId(name="filter-diff-1"),
+            proposed_change_id=proposed_change_id_1,
+        )
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=diff_1, do_summary_counts=False)
+
+        # Save second diff linked to second proposed change
+        diff_2 = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time.add(minutes=30),
+            to_time=self.diff_to_time.add(minutes=30),
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=NameTrackingId(name="filter-diff-2"),
+            proposed_change_id=proposed_change_id_2,
+        )
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=diff_2, do_summary_counts=False)
+
+        # Save third diff with no proposed change
+        diff_3 = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time.add(minutes=60),
+            to_time=self.diff_to_time.add(minutes=60),
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=NameTrackingId(name="filter-diff-3"),
+        )
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=diff_3, do_summary_counts=False)
+
+        # Filter by first proposed change
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            proposed_change_id=proposed_change_id_1,
+        )
+        assert len(retrieved) == 1
+        assert retrieved[0].uuid == diff_1.uuid
+
+        # Filter by second proposed change
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            proposed_change_id=proposed_change_id_2,
+        )
+        assert len(retrieved) == 1
+        assert retrieved[0].uuid == diff_2.uuid
+
+        # No filter should return all 3 diffs
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time.add(hours=1),
+        )
+        assert len(retrieved) == 3
+
 
 async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:
     """Verify that no diff elements have been orphaned"""


### PR DESCRIPTION
IFC-2193

update diff model and queries so that a diff can be linked to a proposed change.
the relationship is 1-to-1, so a diff can be linked to, at most, 1 proposed change and vice versa. technically a pair of diffs can be linked to 1 proposed change at the database level: one for this branch and one for the default branch, but the pair of diffs are treated as a single entity at higher levels

code for actually linking the diffs and proposed changes at the right place will come later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to link and track diffs with their associated proposed changes through a new proposed_change_id field.
  * Added filtering support to retrieve diffs by their associated proposed change ID.
  * Added a new operation to establish or update proposed change associations after diff creation.

* **Tests**
  * Added comprehensive test coverage for proposed change linking, updating associations, and filtering diffs by proposed change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->