### PR TITLE
link diff and pc during pc pipeline

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -440,6 +440,7 @@ class DiffCombiner:
                     to_time=later.to_time,
                     tracking_id=later.tracking_id,
                     nodes=combined_nodes,
+                    proposed_change_id=later.proposed_change_id,
                 )
             )
         base_branch_diff, diff_branch_diff = combined_diffs

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -116,7 +116,9 @@ class DiffCoordinator:
             name=name,
         )
 
-    async def update_branch_diff(self, base_branch: Branch, diff_branch: Branch) -> EnrichedDiffRootMetadata:
+    async def update_branch_diff(
+        self, base_branch: Branch, diff_branch: Branch, proposed_change_id: str | None = None
+    ) -> EnrichedDiffRootMetadata:
         tracking_id = BranchTrackingId(name=diff_branch.name)
         log.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
         existing_incremental_lock = self.diff_locker.get_existing_lock(
@@ -154,6 +156,12 @@ class DiffCoordinator:
                 tracking_id=tracking_id,
                 force_branch_refresh=False,
             )
+
+            # set proposed change IDs
+            if proposed_change_id:
+                enriched_diffs.diff_branch_diff.proposed_change_id = proposed_change_id
+                enriched_diffs.base_branch_diff.proposed_change_id = proposed_change_id
+
             await self.diff_repo.save(
                 enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )
@@ -224,6 +232,10 @@ class DiffCoordinator:
                 await self.conflict_transferer.transfer(
                     earlier=current_branch_diff, later=enriched_diffs.diff_branch_diff
                 )
+
+            # transfer proposed change IDs
+            enriched_diffs.base_branch_diff.proposed_change_id = current_base_diff.proposed_change_id
+            enriched_diffs.diff_branch_diff.proposed_change_id = current_branch_diff.proposed_change_id
 
             await self.diff_repo.save(enriched_diffs=enriched_diffs)
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -296,7 +296,9 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
         component_registry = get_component_registry()
 
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
-        await diff_coordinator.update_branch_diff(base_branch=destination_branch, diff_branch=source_branch)
+        await diff_coordinator.update_branch_diff(
+            base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
+        )
 
 
 @flow(name="proposed-changed-run-generator", flow_run_name="Run generators")
@@ -1095,7 +1097,9 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
         source_branch = await registry.get_branch(db=dbs, branch=model.source_branch)
         component_registry = get_component_registry()
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
-        await diff_coordinator.update_branch_diff(base_branch=destination_branch, diff_branch=source_branch)
+        await diff_coordinator.update_branch_diff(
+            base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
+        )
 
     client = get_client()
 

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -409,3 +409,86 @@ class TestDiffCoordinator:
         assert set(nodes_by_id.keys()) == {person_john_main.id}
         john_diff = nodes_by_id[person_john_main.id]
         assert john_diff.action is DiffAction.REMOVED
+
+    async def test_proposed_change_linked_during_update_branch_diff(
+        self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+    ) -> None:
+        """Test that proposed_change_id is correctly linked to diffs during update_branch_diff."""
+        branch = await create_branch(db=db, branch_name="branch")
+
+        # Create a node that will act as the proposed change
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        # Make a change on the branch
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+        # Update branch diff with proposed_change_id
+        diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch, proposed_change_id=proposed_change_id
+        )
+
+        # Verify the diff is linked to the proposed change
+        assert diff_metadata.proposed_change_id == proposed_change_id
+
+        # Verify via repository retrieval - need to query both branch names since
+        retrieved_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[branch.name, default_branch.name],
+            proposed_change_id=proposed_change_id,
+        )
+        assert len(retrieved_metadata) == 2  # base and diff branch roots
+        for metadata in retrieved_metadata:
+            assert metadata.proposed_change_id == proposed_change_id
+
+    async def test_proposed_change_preserved_during_incremental_diff_update(
+        self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+    ) -> None:
+        """Test that proposed_change_id is preserved when updating an existing diff incrementally."""
+        branch = await create_branch(db=db, branch_name="branch")
+
+        # Create a node that will act as the proposed change
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        # Make initial change on the branch
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+        # First update with proposed_change_id
+        first_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch, proposed_change_id=proposed_change_id
+        )
+        assert first_diff_metadata.proposed_change_id == proposed_change_id
+
+        # Make another change on the branch
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        # Update again with the same proposed_change_id
+        second_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch, proposed_change_id=proposed_change_id
+        )
+
+        # Verify proposed_change_id is still linked
+        assert second_diff_metadata.proposed_change_id == proposed_change_id
+
+        # The diff should have been updated in place (same uuid) or recreated with the link
+        retrieved_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[branch.name, default_branch.name],
+            proposed_change_id=proposed_change_id,
+        )
+        assert len(retrieved_metadata) == 2
+        for metadata in retrieved_metadata:
+            assert metadata.proposed_change_id == proposed_change_id

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -14,12 +14,15 @@ from infrahub_sdk.exceptions import GraphQLError
 from infrahub_sdk.protocols import CoreDataCheck, CoreProposedChange
 
 from infrahub.core.constants import InfrahubKind, ValidatorConclusion
+from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_account, create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.protocols import CoreValidator
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.proposed_change.constants import ProposedChangeState
 from infrahub.utils import get_fixtures_dir
 from tests.constants import TestKind
@@ -30,6 +33,7 @@ from tests.helpers.test_app import TestInfrahubApp
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
+    from infrahub.core.branch import Branch
     from infrahub.core.diff.model.path import EnrichedDiffRoot
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
@@ -141,7 +145,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         await john_branch.save(db=db)
 
     async def test_conflict_pipeline(
-        self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient
+        self, db: InfrahubDatabase, default_branch: Branch, conflict_dataset: None, client: InfrahubClient
     ) -> None:
         proposed_change_create = await client.create(
             kind=CoreProposedChange,
@@ -160,15 +164,26 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         data_integrity = [validator for validator in peers.values() if validator.label.value == "Data Integrity"][0]
         assert data_integrity.conclusion.value.value == ValidatorConclusion.FAILURE.value
 
-        proposed_change_create.state.value = ProposedChangeState.MERGED.value
-
         data_checks = await client.filters(kind=CoreDataCheck, validator__ids=data_integrity.id)
         assert len(data_checks) == 1
         data_check = data_checks[0]
 
+        # Verify that expected diffs are linked to the proposed change
+        component_registry = get_component_registry()
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+        linked_diffs = await diff_repo.get_roots_metadata(
+            proposed_change_id=proposed_change.id,
+        )
+        # Should have both base and diff branch roots linked
+        assert len(linked_diffs) == 2
+        for diff_metadata in linked_diffs:
+            assert diff_metadata.tracking_id == BranchTrackingId(name="conflict_data")
+            assert diff_metadata.proposed_change_id == proposed_change.id
+
         # -------------------------------------------------
         # Try to merge and ensure the proposed change is back to open state
         # -------------------------------------------------
+        proposed_change_create.state.value = ProposedChangeState.MERGED.value
         with pytest.raises(
             GraphQLError, match="Data conflicts found on branch and missing decisions about what branch to keep"
         ):
@@ -201,7 +216,9 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         # as the branch to keep in the data conflict
         assert john.description.value == "Oh boy"  # type: ignore[attr-defined, union-attr]
 
-    async def test_happy_pipeline(self, db: InfrahubDatabase, happy_data_branch: str, client: InfrahubClient) -> None:
+    async def test_happy_pipeline(
+        self, db: InfrahubDatabase, default_branch: Branch, happy_data_branch: str, client: InfrahubClient
+    ) -> None:
         proposed_change_user = await create_account(db=db, name="jimmy-change-user", password="Password123")
         # The state=open part here is to validate that the state check during creation of a
         # proposed change still works if the default "open" state is manually specified
@@ -248,6 +265,19 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
             validator for validator in peers.values() if validator.label.value == "Repository Validator: dealership-car"
         ][0]
         assert repository_merge_conflict.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+
+        # -------------------------------------------------
+        # Verify that diffs are correctly linked to the proposed change
+        # -------------------------------------------------
+        component_registry = get_component_registry()
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+        # Get diffs linked to this proposed change
+        linked_diffs = await diff_repo.get_roots_metadata(proposed_change_id=proposed_change_create.id)
+        # Should have both base and diff branch roots linked
+        assert len(linked_diffs) == 2
+        for diff_metadata in linked_diffs:
+            assert diff_metadata.proposed_change_id == proposed_change_create.id
+            assert diff_metadata.tracking_id == BranchTrackingId(name=happy_data_branch)
 
         tags = await client.all(kind="TestingTag", branch=happy_data_branch)
         # The Generator defined in the repository is expected to have created this tag during the pipeline


### PR DESCRIPTION
IFC-2194

link diff and proposed change during proposed change pipeline
once a proposed change is linked to a diff, they cannot be unlinked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diffs now track and preserve their association with proposed changes during updates and recalculations, improving change management visibility.

* **Tests**
  * Added comprehensive tests verifying proposed change associations are maintained during diff operations and conflict resolution workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->