### PR TITLE
only allow 1 open PC per branch at a time

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -84,7 +84,22 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         if state and state != ProposedChangeState.OPEN.value:
             raise ValidationError(input_value="A proposed change has to be in the open state during creation")
 
+        source_branch_name = data.get("source_branch", {}).get("value")
+
         async with graphql_context.db.start_transaction() as dbt:
+            existing_open_pcs = await NodeManager.query(
+                db=dbt,
+                schema=InfrahubKind.PROPOSEDCHANGE,
+                filters={
+                    "source_branch__value": source_branch_name,
+                    "state__value": ProposedChangeState.OPEN.value,
+                },
+            )
+            if existing_open_pcs:
+                raise ValidationError(
+                    input_value=f"An open proposed change already exists for branch '{source_branch_name}'"
+                )
+
             proposed_change, result = await super().mutate_create(
                 info=info, data=data, branch=branch, database=dbt, override_data=override_data
             )

--- a/backend/tests/component/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/component/graphql/mutations/test_proposed_change.py
@@ -10,11 +10,13 @@ from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.message_bus.types import KVTTL
+from infrahub.proposed_change.constants import ProposedChangeState
 from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
@@ -216,6 +218,96 @@ async def test_create_invalid_state_combinations(
     assert "A proposed change has to be in the open state during creation" in str(closed.errors)
     assert merged.errors
     assert "A proposed change has to be in the open state during creation" in str(merged.errors)
+
+
+async def test_duplicate_open_proposed_change_validation(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    """Validate that we cannot create a second open proposed change for the same source branch,
+    but can create one after the existing one is closed."""
+    branch_name = str(uuid4().hex)
+    source_branch = Branch(name=branch_name)
+    await source_branch.save(db=db)
+
+    account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+    await account.new(db=db, name="user", password="password")
+    await account.save(db=db)
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db,
+        branch=default_branch,
+        account_session=AccountSession(authenticated=False, account_id=account.get_id(), auth_type=AuthType.NONE),
+    )
+
+    # Create first proposed change - should succeed
+    first_pc = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "source": source_branch.name,
+            "destination": "main",
+            "name": "first-proposed-change",
+        },
+    )
+    assert not first_pc.errors
+    first_pc_id = first_pc.data["CoreProposedChangeCreate"]["object"]["id"]
+
+    pcs = await NodeManager.query(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    assert len(pcs) == 1
+    assert pcs[0].source_branch.value == source_branch.name
+    assert pcs[0].state.value.value == ProposedChangeState.OPEN.value
+    assert pcs[0].name.value == "first-proposed-change"
+
+    # Create second proposed change for same branch - should fail
+    second_pc_attempt = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "source": source_branch.name,
+            "destination": "main",
+            "name": "second-proposed-change",
+        },
+    )
+    assert second_pc_attempt.errors
+    assert f"An open proposed change already exists for branch '{source_branch.name}'" in str(second_pc_attempt.errors)
+
+    pcs = await NodeManager.query(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    assert len(pcs) == 1
+
+    # Close the first proposed change
+    close_pc = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "proposed_change": first_pc_id,
+            "state": "closed",
+        },
+    )
+    assert not close_pc.errors
+
+    # Create second proposed change - should succeed now that first is closed
+    second_pc = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "source": source_branch.name,
+            "destination": "main",
+            "name": "second-proposed-change",
+        },
+    )
+    assert not second_pc.errors
+
+    pcs = await NodeManager.query(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    assert len(pcs) == 2
 
 
 class TestTriggerProposedChange(TestInfrahubApp):

--- a/backend/tests/functional/proposed_change/test_comment_counts.py
+++ b/backend/tests/functional/proposed_change/test_comment_counts.py
@@ -92,7 +92,7 @@ class TestProposedChangeTotalComments(TestInfrahubApp):
         """
 
         # Create a branch for the proposed change
-        source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
+        source_branch = await create_branch(branch_name="branch-proposed-change-2", db=db)
 
         # Create a proposed change
         proposed_change = await client.create(

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -1125,44 +1125,6 @@ class TestDiffUpdateConflict(TestInfrahubApp):
             data_check = data_checks_by_conflict_id[tracked_conflict.conflict_id]
             assert data_check.keep_branch.value.value == tracked_conflict.keep_branch.value
 
-    async def test_create_another_proposed_change_data_checks_created(
-        self, db: InfrahubDatabase, initial_dataset, default_branch, client: InfrahubClient
-    ) -> None:
-        # verify duplicate data checks can be created
-        result = await client.execute_graphql(
-            query=PROPOSED_CHANGE_CREATE,
-            variables={
-                "name": PROPOSED_CHANGE_NAME + "2",
-                "source_branch": BRANCH_NAME,
-                "destination_branch": default_branch.name,
-            },
-        )
-        assert result["CoreProposedChangeCreate"]["object"]["id"]
-        pc_id = result["CoreProposedChangeCreate"]["object"]["id"]
-        attribute_value_conflict = self.retrieve_item("attribute_value")
-        peer_conflict = self.retrieve_item("peer_conflict")
-        cardinality_one_property_conflict_a = self.retrieve_item("cardinality_one_property_conflict_a")
-        cardinality_one_property_conflict_b = self.retrieve_item("cardinality_one_property_conflict_b")
-        cardinality_many_property_conflict = self.retrieve_item("cardinality_many_property_conflict")
-
-        pc = await NodeManager.get_one(db=db, id=pc_id)
-        validators = await pc.validations.get_peers(db=db)
-        data_validator = None
-        for v in validators.values():
-            if v.get_kind() == InfrahubKind.DATAVALIDATOR:
-                data_validator = v
-        assert data_validator
-        core_data_checks = await data_validator.checks.get_peers(db=db)  # type: ignore[attr-defined]
-        data_checks_by_conflict_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks.values()}
-        assert set(data_checks_by_conflict_id.keys()) == {
-            attribute_value_conflict.conflict_id,
-            peer_conflict.conflict_id,
-            cardinality_one_property_conflict_a.conflict_id,
-            cardinality_one_property_conflict_b.conflict_id,
-            cardinality_many_property_conflict.conflict_id,
-        }
-        assert len(core_data_checks) == len(data_checks_by_conflict_id)
-
     async def test_merge_proposed_change(
         self,
         db: InfrahubDatabase,

--- a/changelog/8123.fixed.md
+++ b/changelog/8123.fixed.md
@@ -1,0 +1,1 @@
+Prevent opening a proposed change if there is already an open proposed change for the branch.


### PR DESCRIPTION
fixes #8123 
 only allow 1 open proposed change on a given branch at a time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented multiple open proposed changes on the same source branch—attempting to create a second will now raise a validation error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->