### PR TITLE
Run unittests with a single worker

### DIFF
--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -100,12 +100,10 @@ def test_component(context: Context, database: str = INFRAHUB_DATABASE) -> Resul
         return execute_command(context=context, command=f"{exec_cmd}")
 
 
-@task(optional=["database"])
-def test_unit(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
+@task
+def test_unit(context: Context) -> Result | None:
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/unit"
-        if database == "neo4j":
-            exec_cmd += " --neo4j"
+        exec_cmd = f"uv run pytest --cov=infrahub {MAIN_DIRECTORY}/tests/unit"
         print(f"{exec_cmd}")
         return execute_command(context=context, command=f"{exec_cmd}")
 


### PR DESCRIPTION
I saw one of the unittest pipelines fail because the worker tests got mixed up. As the new unittests are a lot faster and doesn't use external services it actually takes longer time to run them when having to start up the additional workers. While this might change in the future it can cause problems today.

Example of when this was problematic: https://github.com/opsmill/infrahub/actions/runs/21036505179/job/60485845937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined backend unit testing configuration by removing database-specific parameters and eliminating parallel worker options, simplifying test execution to focus on coverage metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->