### PR TITLE
fix(docker): switch to official postgres image

### DIFF
--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -37,13 +37,13 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - name: From 1.6.0
-            source_version: 1.6.0
-            neo4j_image: "neo4j:2025.03.0-enterprise"
-            redis_image: "redis:7.2.11"
-            rabbitmq_image: "rabbitmq:3.13.7-management"
-            postgres_image: "postgres:16-alpine"
-            postgres_datadir: "/var/lib/postgresql/data"
+          - name: From 1.7.0
+            source_version: 1.7.0
+            neo4j_image: "neo4j:2025.10.1-enterprise"
+            redis_image: "redis:8.4.0"
+            rabbitmq_image: "rabbitmq:4.2.1-management"
+            postgres_image: "pgautoupgrade/pgautoupgrade:18-alpine"
+            postgres_datadir: "/var/lib/postgresql/18/data"
     name: ${{ matrix.name }}
     runs-on:
       group: huge-runners

--- a/development/docker-compose-deps-nats.yml
+++ b/development/docker-compose-deps-nats.yml
@@ -41,7 +41,7 @@ services:
       - task-manager-db
   task-manager-db:
     profiles: [demo, dev]
-    image: "${POSTGRES_DOCKER_IMAGE:-pgautoupgrade/pgautoupgrade:18-alpine}"
+    image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -43,7 +43,7 @@ services:
       pod: "prefect-server"
   task-manager-db:
     profiles: [demo, dev]
-    image: "${POSTGRES_DOCKER_IMAGE:-pgautoupgrade/pgautoupgrade:18-alpine}"
+    image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
       start_period: 10s
 
   task-manager-db:
-    image: "${POSTGRES_DOCKER_IMAGE:-pgautoupgrade/pgautoupgrade:18-alpine}"
+    image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${INFRAHUB_TASKMANAGER_DB_USER:-postgres}


### PR DESCRIPTION
Now that we have upgraded to postgres, we can remove pgautoupgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated migration test baselines from 1.6.0 to 1.7.0.
  * Updated container dependencies: neo4j (2025.10.1), redis (8.4.0), rabbitmq (4.2.1-management), and postgres (18-alpine).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->