### PR TITLE
Enhance NodeKindUpdateMigration to update pool node references

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
+
+from infrahub.core import registry
+from infrahub.core.constants import infrahubkind
 
 from ..query import MigrationQuery
 from ..query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
-from ..shared import SchemaMigration
+from ..shared import MigrationInput, MigrationResult, SchemaMigration
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+
+
+# Pool kinds and their text attributes that store node kind references
+POOL_NODE_KIND_ATTRIBUTES: list[tuple[str, str]] = [
+    (infrahubkind.NUMBERPOOL, "node"),
+    (infrahubkind.IPADDRESSPOOL, "default_address_type"),
+    (infrahubkind.IPPREFIXPOOL, "default_prefix_type"),
+]
 
 
 class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):
@@ -38,3 +52,40 @@ class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):
 class NodeKindUpdateMigration(SchemaMigration):
     name: str = "node.kind.update"
     queries: Sequence[type[MigrationQuery]] = [NodeKindUpdateMigrationQuery01]  # type: ignore[assignment]
+
+    async def execute_post_queries(
+        self,
+        migration_input: MigrationInput,
+        result: MigrationResult,
+        branch: Branch,
+    ) -> MigrationResult:
+        """Update pool nodes that reference the renamed node kind."""
+        old_kind = self.previous_schema.kind
+        new_kind = self.new_schema.kind
+
+        # Skip if kind hasn't actually changed (e.g., only inherit_from changed)
+        if old_kind == new_kind:
+            return result
+
+        db = migration_input.db
+
+        for pool_kind, attr_name in POOL_NODE_KIND_ATTRIBUTES:
+            # Skip if the pool schema isn't registered (e.g., in test environments)
+            if not registry.schema.has(name=pool_kind, branch=branch.name):
+                continue
+
+            # Query for pool nodes where the attribute value matches the old kind
+            pools = await registry.manager.query(
+                db=db,
+                branch=branch,
+                schema=pool_kind,
+                filters={attr_name: {"value": old_kind}},
+            )
+
+            for pool in pools:
+                attr = pool.get_attribute(name=attr_name)
+                attr.value = new_kind
+                await pool.save(db=db, fields=[attr_name], at=migration_input.at)
+                result.nbr_migrations_executed += 1
+
+        return result

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core import registry
 from infrahub.core.constants import infrahubkind
+from infrahub.core.manager import NodeManager
 
 from ..query import MigrationQuery
 from ..query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
@@ -71,11 +71,11 @@ class NodeKindUpdateMigration(SchemaMigration):
 
         for pool_kind, attr_name in POOL_NODE_KIND_ATTRIBUTES:
             # Skip if the pool schema isn't registered (e.g., in test environments)
-            if not registry.schema.has(name=pool_kind, branch=branch.name):
+            if not db.schema.has(name=pool_kind, branch=branch.name):
                 continue
 
             # Query for pool nodes where the attribute value matches the old kind
-            pools = await registry.manager.query(
+            pools = await NodeManager.query(
                 db=db,
                 branch=branch,
                 schema=pool_kind,
@@ -90,11 +90,16 @@ class NodeKindUpdateMigration(SchemaMigration):
                 attr.value = new_kind
 
                 # Update the pool name if it follows the auto-generated pattern
-                name_attr = pool.get_attribute(name="name")
-                old_prefix = f"{old_kind}."
-                if name_attr.value.startswith(old_prefix):
-                    name_attr.value = f"{new_kind}.{name_attr.value[len(old_prefix) :]}"
-                    fields_to_save.append("name")
+                try:
+                    name_attr = pool.get_attribute(name="name")
+                except ValueError:
+                    pass
+                else:
+                    old_prefix = f"{old_kind}."
+                    new_prefix = f"{new_kind}."
+                    if name_attr.value.startswith(old_prefix):
+                        name_attr.value = name_attr.value.replace(old_prefix, new_prefix, 1)
+                        fields_to_save.append("name")
 
                 await pool.save(db=db, fields=fields_to_save, at=migration_input.at)
                 result.nbr_migrations_executed += 1

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -83,9 +83,20 @@ class NodeKindUpdateMigration(SchemaMigration):
             )
 
             for pool in pools:
+                fields_to_save = [attr_name]
+
+                # Update the kind reference attribute
                 attr = pool.get_attribute(name=attr_name)
                 attr.value = new_kind
-                await pool.save(db=db, fields=[attr_name], at=migration_input.at)
+
+                # Update the pool name if it follows the auto-generated pattern
+                name_attr = pool.get_attribute(name="name")
+                old_prefix = f"{old_kind}."
+                if name_attr.value.startswith(old_prefix):
+                    name_attr.value = f"{new_kind}.{name_attr.value[len(old_prefix):]}"
+                    fields_to_save.append("name")
+
+                await pool.save(db=db, fields=fields_to_save, at=migration_input.at)
                 result.nbr_migrations_executed += 1
 
         return result

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -93,7 +93,7 @@ class NodeKindUpdateMigration(SchemaMigration):
                 name_attr = pool.get_attribute(name="name")
                 old_prefix = f"{old_kind}."
                 if name_attr.value.startswith(old_prefix):
-                    name_attr.value = f"{new_kind}.{name_attr.value[len(old_prefix):]}"
+                    name_attr.value = f"{new_kind}.{name_attr.value[len(old_prefix) :]}"
                     fields_to_save.append("name")
 
                 await pool.save(db=db, fields=fields_to_save, at=migration_input.at)

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pytest
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import (
@@ -15,6 +17,8 @@ from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration, NodeKindUpdateMigrationQuery01
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
+from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
@@ -341,7 +345,10 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
 
 
 async def test_migration_updates_number_pool_node_reference(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that NumberPool.node is updated when the referenced kind is renamed."""
     # 1. Create and register a schema with a NumberPool attribute
@@ -363,8 +370,8 @@ async def test_migration_updates_number_pool_node_reference(
     schema = SchemaRoot(nodes=[device_schema])
     await load_schema(db=db, schema=schema)
 
-    # Register the CoreNumberPool type for pool operations
-    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+    # Register the CoreNumberPool type for pool operations (monkeypatched to avoid shared-state pollution)
+    monkeypatch.setitem(registry.node, InfrahubKind.NUMBERPOOL, CoreNumberPool)
 
     # Create a device to trigger pool creation
     device = await Node.init(db=db, schema="Test2Device")
@@ -420,3 +427,118 @@ async def test_migration_updates_number_pool_node_reference(
     )
     assert len(pools_with_new_name) == 1
     assert pools_with_new_name[0].id == pool_id
+
+
+async def test_migration_updates_ip_address_pool_node_reference(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_schema: SchemaBranch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that CoreIPAddressPool.default_address_type is updated when the referenced kind is renamed."""
+    monkeypatch.setitem(registry.node, InfrahubKind.IPADDRESSPOOL, CoreIPAddressPool)
+
+    # 1. Create an IP namespace and a prefix resource required by the pool
+    ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ns.new(db=db, name="test-ns-addr")
+    await ns.save(db=db)
+
+    prefix = await Node.init(db=db, schema="IpamIPPrefix")
+    await prefix.new(db=db, prefix="192.168.0.0/24", ip_namespace=ns)
+    await prefix.save(db=db)
+
+    # 2. Create a CoreIPAddressPool whose default_address_type points to "IpamIPAddress"
+    pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPADDRESSPOOL, branch=default_branch)
+    pool = await CoreIPAddressPool.init(schema=pool_schema, db=db)
+    await pool.new(
+        db=db,
+        name="IpamIPAddress.test-addr-pool",
+        resources=[prefix],
+        ip_namespace=ns,
+        default_address_type="IpamIPAddress",
+    )
+    await pool.save(db=db)
+    pool_id = pool.id
+
+    # 3. Run NodeKindUpdateMigration to rename IpamIPAddress -> IpamNewIPAddress
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema_branch.duplicate()
+    old_addr_schema = candidate_schema.get(name="IpamIPAddress")
+    candidate_schema.delete(name="IpamIPAddress")
+    old_addr_schema.name = "NewIPAddress"
+    candidate_schema.set(name="IpamNewIPAddress", schema=old_addr_schema)
+    assert old_addr_schema.kind == "IpamNewIPAddress"
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="IpamIPAddress"),
+        new_node_schema=old_addr_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="IpamNewIPAddress", field_name="name"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    # 4. Verify the pool's default_address_type was updated
+    updated_pool = await NodeManager.get_one(db=db, branch=default_branch, id=pool_id)
+    assert updated_pool.default_address_type.value == "IpamNewIPAddress"
+
+    # 5. Verify the pool name was updated (it starts with the old kind prefix)
+    assert updated_pool.name.value.startswith("IpamNewIPAddress.")
+
+
+async def test_migration_updates_ip_prefix_pool_node_reference(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_schema: SchemaBranch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that CoreIPPrefixPool.default_prefix_type is updated when the referenced kind is renamed."""
+    monkeypatch.setitem(registry.node, InfrahubKind.IPPREFIXPOOL, CoreIPPrefixPool)
+
+    # 1. Create an IP namespace and a prefix resource required by the pool
+    ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ns.new(db=db, name="test-ns-prefix")
+    await ns.save(db=db)
+
+    prefix = await Node.init(db=db, schema="IpamIPPrefix")
+    await prefix.new(db=db, prefix="10.0.0.0/8", ip_namespace=ns)
+    await prefix.save(db=db)
+
+    # 2. Create a CoreIPPrefixPool whose default_prefix_type points to "IpamIPPrefix"
+    pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPPREFIXPOOL, branch=default_branch)
+    pool = await CoreIPPrefixPool.init(schema=pool_schema, db=db)
+    await pool.new(
+        db=db,
+        name="IpamIPPrefix.test-prefix-pool",
+        resources=[prefix],
+        ip_namespace=ns,
+        default_prefix_length=24,
+        default_prefix_type="IpamIPPrefix",
+    )
+    await pool.save(db=db)
+    pool_id = pool.id
+
+    # 3. Run NodeKindUpdateMigration to rename IpamIPPrefix -> IpamNewIPPrefix
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema_branch.duplicate()
+    old_prefix_schema = candidate_schema.get(name="IpamIPPrefix")
+    candidate_schema.delete(name="IpamIPPrefix")
+    old_prefix_schema.name = "NewIPPrefix"
+    candidate_schema.set(name="IpamNewIPPrefix", schema=old_prefix_schema)
+    assert old_prefix_schema.kind == "IpamNewIPPrefix"
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="IpamIPPrefix"),
+        new_node_schema=old_prefix_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="IpamNewIPPrefix", field_name="name"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    # 4. Verify the pool's default_prefix_type was updated
+    updated_pool = await NodeManager.get_one(db=db, branch=default_branch, id=pool_id)
+    assert updated_pool.default_prefix_type.value == "IpamNewIPPrefix"
+
+    # 5. Verify the pool name was updated (it starts with the old kind prefix)
+    assert updated_pool.name.value.startswith("IpamNewIPPrefix.")

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -23,7 +23,6 @@ from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
-from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
@@ -351,32 +350,24 @@ async def test_migration_updates_number_pool_node_reference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that NumberPool.node is updated when the referenced kind is renamed."""
-    # 1. Create and register a schema with a NumberPool attribute
-    device_schema = NodeSchema(
-        name="Device",
-        namespace="Test2",
-        attributes=[
-            AttributeSchema(name="name", kind="Text", unique=True),
-            AttributeSchema(
-                name="asset_id",
-                kind="NumberPool",
-                optional=False,
-                unique=True,
-                read_only=True,
-                parameters=NumberPoolParameters(start_range=1000, end_range=9999),
-            ),
-        ],
-    )
-    schema = SchemaRoot(nodes=[device_schema])
-    await load_schema(db=db, schema=schema)
-
     # Register the CoreNumberPool type for pool operations (monkeypatched to avoid shared-state pollution)
     monkeypatch.setitem(registry.node, InfrahubKind.NUMBERPOOL, CoreNumberPool)
 
-    # Create a device to trigger pool creation
-    device = await Node.init(db=db, schema="Test2Device")
-    await device.new(db=db, name="device-01")
-    await device.save(db=db)
+    # 1. Create a CoreNumberPool whose node points to "Test2Device" directly,
+    #    mirroring how IP pool tests create their pool objects.
+    pool_schema = registry.schema.get_node_schema(name=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    pool = await CoreNumberPool.init(schema=pool_schema, db=db)
+    pool_name = "Test2Device.asset_id [test-pool-001]"
+    await pool.new(
+        db=db,
+        name=pool_name,
+        node="Test2Device",
+        node_attribute="asset_id",
+        start_range=1000,
+        end_range=9999,
+    )
+    await pool.save(db=db)
+    pool_id = pool.id
 
     # 2. Verify the NumberPool was created with node="Test2Device"
     pools = await registry.manager.query(
@@ -388,11 +379,26 @@ async def test_migration_updates_number_pool_node_reference(
     assert len(pools) == 1
     original_pool = pools[0]
     assert original_pool.node.value == "Test2Device"
-    pool_id = original_pool.id
     original_pool_name = original_pool.name.value
     assert original_pool_name.startswith("Test2Device.asset_id")
 
-    # 3. Run NodeKindUpdateMigration to rename Test2Device -> Test2NetworkDevice
+    # 3. Register a minimal schema so that NodeKindUpdateMigration has a node to migrate
+    device_schema = NodeSchema(
+        name="Device",
+        namespace="Test2",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+        ],
+    )
+    schema = SchemaRoot(nodes=[device_schema])
+    await load_schema(db=db, schema=schema)
+
+    # Create a device so that the main migration query has exactly 1 node to rename
+    device = await Node.init(db=db, schema="Test2Device")
+    await device.new(db=db, name="device-01")
+    await device.save(db=db)
+
+    # 4. Run NodeKindUpdateMigration to rename Test2Device -> Test2NetworkDevice
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema_branch.duplicate()
     old_device_schema = candidate_schema.get(name="Test2Device")
@@ -408,17 +414,17 @@ async def test_migration_updates_number_pool_node_reference(
     )
     execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
     assert not execution_result.errors
-    # Should have migrated 1 node + 1 pool update
+    # Should have migrated 1 node (the Test2Device instance) + 1 pool update
     assert execution_result.nbr_migrations_executed == 2
 
-    # 4. Verify the NumberPool.node and name attributes were updated
+    # 5. Verify the NumberPool.node and name attributes were updated
     updated_pool = await NodeManager.get_one(db=db, branch=default_branch, id=pool_id)
     assert updated_pool.node.value == "Test2NetworkDevice"
     # Pool name should be updated from "Test2Device.asset_id [...]" to "Test2NetworkDevice.asset_id [...]"
     assert updated_pool.name.value.startswith("Test2NetworkDevice.asset_id")
     assert updated_pool.name.value == original_pool_name.replace("Test2Device.", "Test2NetworkDevice.")
 
-    # 5. Verify pools with new kind name exist
+    # 6. Verify pools with new kind name exist
     pools_with_new_name = await registry.manager.query(
         db=db,
         branch=default_branch,

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -382,6 +382,8 @@ async def test_migration_updates_number_pool_node_reference(
     original_pool = pools[0]
     assert original_pool.node.value == "Test2Device"
     pool_id = original_pool.id
+    original_pool_name = original_pool.name.value
+    assert original_pool_name.startswith("Test2Device.asset_id")
 
     # 3. Run NodeKindUpdateMigration to rename Test2Device -> Test2NetworkDevice
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
@@ -402,9 +404,12 @@ async def test_migration_updates_number_pool_node_reference(
     # Should have migrated 1 node + 1 pool update
     assert execution_result.nbr_migrations_executed == 2
 
-    # 4. Verify the NumberPool.node attribute was updated to "Test2NetworkDevice"
+    # 4. Verify the NumberPool.node and name attributes were updated
     updated_pool = await NodeManager.get_one(db=db, branch=default_branch, id=pool_id)
     assert updated_pool.node.value == "Test2NetworkDevice"
+    # Pool name should be updated from "Test2Device.asset_id [...]" to "Test2NetworkDevice.asset_id [...]"
+    assert updated_pool.name.value.startswith("Test2NetworkDevice.asset_id")
+    assert updated_pool.name.value == original_pool_name.replace("Test2Device.", "Test2NetworkDevice.")
 
     # 5. Verify pools with new kind name exist
     pools_with_new_name = await registry.manager.query(

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -2,16 +2,25 @@ from typing import Any
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SYSTEM_USER_ID, MetadataOptions, RelationshipHierarchyDirection, SchemaPathType
+from infrahub.core.constants import (
+    SYSTEM_USER_ID,
+    InfrahubKind,
+    MetadataOptions,
+    RelationshipHierarchyDirection,
+    SchemaPathType,
+)
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration, NodeKindUpdateMigrationQuery01
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
@@ -329,3 +338,80 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
     )
     assert len(results) == 1, "Expected exactly one deleted edge on old node"
     assert results[0]["from_user_id"] == test_user_id
+
+
+async def test_migration_updates_number_pool_node_reference(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Test that NumberPool.node is updated when the referenced kind is renamed."""
+    # 1. Create and register a schema with a NumberPool attribute
+    device_schema = NodeSchema(
+        name="Device",
+        namespace="Test2",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(
+                name="asset_id",
+                kind="NumberPool",
+                optional=False,
+                unique=True,
+                read_only=True,
+                parameters=NumberPoolParameters(start_range=1000, end_range=9999),
+            ),
+        ],
+    )
+    schema = SchemaRoot(nodes=[device_schema])
+    await load_schema(db=db, schema=schema)
+
+    # Register the CoreNumberPool type for pool operations
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    # Create a device to trigger pool creation
+    device = await Node.init(db=db, schema="Test2Device")
+    await device.new(db=db, name="device-01")
+    await device.save(db=db)
+
+    # 2. Verify the NumberPool was created with node="Test2Device"
+    pools = await registry.manager.query(
+        db=db,
+        branch=default_branch,
+        schema=InfrahubKind.NUMBERPOOL,
+        filters={"node": {"value": "Test2Device"}},
+    )
+    assert len(pools) == 1
+    original_pool = pools[0]
+    assert original_pool.node.value == "Test2Device"
+    pool_id = original_pool.id
+
+    # 3. Run NodeKindUpdateMigration to rename Test2Device -> Test2NetworkDevice
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema_branch.duplicate()
+    old_device_schema = candidate_schema.get(name="Test2Device")
+    candidate_schema.delete(name="Test2Device")
+    old_device_schema.name = "NetworkDevice"
+    candidate_schema.set(name="Test2NetworkDevice", schema=old_device_schema)
+    assert old_device_schema.kind == "Test2NetworkDevice"
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="Test2Device"),
+        new_node_schema=old_device_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NetworkDevice", field_name="name"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+    # Should have migrated 1 node + 1 pool update
+    assert execution_result.nbr_migrations_executed == 2
+
+    # 4. Verify the NumberPool.node attribute was updated to "Test2NetworkDevice"
+    updated_pool = await NodeManager.get_one(db=db, branch=default_branch, id=pool_id)
+    assert updated_pool.node.value == "Test2NetworkDevice"
+
+    # 5. Verify pools with new kind name exist
+    pools_with_new_name = await registry.manager.query(
+        db=db,
+        branch=default_branch,
+        schema=InfrahubKind.NUMBERPOOL,
+        filters={"node": {"value": "Test2NetworkDevice"}},
+    )
+    assert len(pools_with_new_name) == 1
+    assert pools_with_new_name[0].id == pool_id


### PR DESCRIPTION
Fixes: #8160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Node kind renames now automatically update all related pool nodes, including their references and auto-generated names, ensuring data consistency across the system.

* **Tests**
  * Added test coverage validating that pool nodes are correctly updated when their referenced node kind is renamed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->