### PR TITLE
fix deepcopy recursive hash AttributeError

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -269,6 +270,27 @@ class EnrichedDiffRelationship(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.name)
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> EnrichedDiffRelationship:
+        """Custom deepcopy to handle circular references with EnrichedDiffNode.
+
+        The default deepcopy can fail because it may call __hash__ on a partially
+        constructed instance (before 'name' is set) when handling circular references
+        through the nodes -> relationships cycle.
+
+        This implementation ensures 'name' is set and the instance is registered
+        in memo before deepcopying other attributes that may have circular references.
+        """
+        new_obj = object.__new__(EnrichedDiffRelationship)
+        # Set the hashable attribute first (required for __hash__)
+        new_obj.name = self.name
+        # Register in memo BEFORE copying other attributes to handle circular refs
+        memo[id(self)] = new_obj
+        # Deepcopy all other attributes
+        for key, value in self.__dict__.items():
+            if key != "name":
+                setattr(new_obj, key, deepcopy(value, memo))
+        return new_obj
+
     @property
     def num_properties(self) -> int:
         return sum(r.num_properties for r in self.relationships)
@@ -326,6 +348,27 @@ class EnrichedDiffNode(BaseSummary):
 
     def __hash__(self) -> int:
         return hash(self.identifier)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> EnrichedDiffNode:
+        """Custom deepcopy to handle circular references with EnrichedDiffRelationship.
+
+        The default deepcopy can fail because it may call __hash__ on a partially
+        constructed instance (before 'identifier' is set) when handling circular references
+        through the relationships -> nodes cycle.
+
+        This implementation ensures 'identifier' is set and the instance is registered
+        in memo before deepcopying other attributes that may have circular references.
+        """
+        new_obj = object.__new__(EnrichedDiffNode)
+        # Set the hashable attribute first (required for __hash__)
+        new_obj.identifier = deepcopy(self.identifier, memo)
+        # Register in memo BEFORE copying other attributes to handle circular refs
+        memo[id(self)] = new_obj
+        # Deepcopy all other attributes
+        for key, value in self.__dict__.items():
+            if key != "identifier":
+                setattr(new_obj, key, deepcopy(value, memo))
+        return new_obj
 
     @property
     def uuid(self) -> str:

--- a/backend/tests/component/core/diff/test_coordinator_lock.py
+++ b/backend/tests/component/core/diff/test_coordinator_lock.py
@@ -246,7 +246,7 @@ class TestDiffCoordinatorLocks:
             db=db2,
             diff_coordinator=diff_coordinator_2,
             diff_merger=DiffMerger(
-                db=db,
+                db=db2,
                 source_branch=diff_branch,
                 destination_branch=default_branch,
                 diff_repository=diff_repository_2,

--- a/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
+++ b/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
@@ -1,0 +1,104 @@
+"""Tests for deepcopy behavior of EnrichedDiff model classes.
+
+These tests verify that deepcopy works correctly with circular references
+between EnrichedDiffRelationship and EnrichedDiffNode.
+
+The fix: Custom __deepcopy__ methods on EnrichedDiffRelationship and EnrichedDiffNode
+ensure that hashable attributes (name, identifier) are set before the instance is
+registered in the memo dict, preventing AttributeError when __hash__ is called
+during circular reference handling.
+
+Related code: DiffCombiner._combine_relationships calls deepcopy() on
+EnrichedDiffRelationship objects that may have circular node references.
+"""
+
+from copy import deepcopy
+
+from infrahub.core.constants import DiffAction, RelationshipCardinality
+
+from tests.component.core.diff.factories import (
+    EnrichedNodeFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+)
+
+
+class TestEnrichedDiffRelationshipDeepCopy:
+    """Test deepcopy behavior with circular references in EnrichedDiffRelationship.
+
+    The data model has a recursive structure:
+    - EnrichedDiffRelationship.nodes -> set[EnrichedDiffNode]
+    - EnrichedDiffNode.relationships -> set[EnrichedDiffRelationship]
+
+    Custom __deepcopy__ methods handle this by:
+    1. Creating a new instance and setting hashable attributes first
+    2. Registering in memo before copying complex attributes
+    3. Then copying complex attributes that may have circular references
+    """
+
+    def test_deepcopy_relationship_with_circular_node_reference(self) -> None:
+        """Test deepcopy works with circular references starting from a relationship.
+
+        Creates: relationship.nodes -> node.relationships -> relationship
+        """
+        # Create a relationship with a node in its nodes set
+        relationship = EnrichedRelationshipGroupFactory.build(
+            name="parent_relationship",
+            action=DiffAction.ADDED,
+            cardinality=RelationshipCardinality.MANY,
+            relationships={EnrichedRelationshipElementFactory.build(action=DiffAction.ADDED)},
+            nodes=set(),
+        )
+
+        # Create a node that references this relationship
+        node = EnrichedNodeFactory.build(
+            action=DiffAction.ADDED,
+            attributes=set(),
+            relationships={relationship},
+        )
+
+        # Create the circular reference: relationship.nodes contains the node
+        # which has relationship in its relationships set
+        relationship.nodes.add(node)
+
+        # This would fail without the custom __deepcopy__ methods
+        copied = deepcopy(relationship)
+
+        assert copied.name == relationship.name
+        assert copied is not relationship
+        assert len(copied.nodes) == 1
+        # Verify the circular structure is preserved
+        copied_node = next(iter(copied.nodes))
+        assert copied_node is not node
+        assert len(copied_node.relationships) == 1
+        assert next(iter(copied_node.relationships)) is copied
+
+    def test_deepcopy_node_with_circular_relationship_reference(self) -> None:
+        """Test deepcopy works with circular references starting from a node."""
+        relationship = EnrichedRelationshipGroupFactory.build(
+            name="circular_rel",
+            action=DiffAction.UPDATED,
+            cardinality=RelationshipCardinality.ONE,
+            relationships={EnrichedRelationshipElementFactory.build()},
+            nodes=set(),
+        )
+
+        node = EnrichedNodeFactory.build(
+            action=DiffAction.UPDATED,
+            attributes=set(),
+            relationships={relationship},
+        )
+
+        # Create circular reference
+        relationship.nodes.add(node)
+
+        # This would fail without the custom __deepcopy__ methods
+        copied_node = deepcopy(node)
+
+        assert copied_node is not node
+        assert len(copied_node.relationships) == 1
+        copied_rel = next(iter(copied_node.relationships))
+        assert copied_rel.name == relationship.name
+        # Verify the circular structure is preserved
+        assert len(copied_rel.nodes) == 1
+        assert next(iter(copied_rel.nodes)) is copied_node

--- a/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
+++ b/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
@@ -14,13 +14,13 @@ EnrichedDiffRelationship objects that may have circular node references.
 
 from copy import deepcopy
 
-from infrahub.core.constants import DiffAction, RelationshipCardinality
-
 from tests.component.core.diff.factories import (
     EnrichedNodeFactory,
     EnrichedRelationshipElementFactory,
     EnrichedRelationshipGroupFactory,
 )
+
+from infrahub.core.constants import DiffAction, RelationshipCardinality
 
 
 class TestEnrichedDiffRelationshipDeepCopy:

--- a/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
+++ b/backend/tests/unit/core/diff/test_enriched_diff_deepcopy.py
@@ -23,82 +23,54 @@ from tests.component.core.diff.factories import (
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 
 
-class TestEnrichedDiffRelationshipDeepCopy:
+def test_deepcopy_diff_with_circular_reference() -> None:
     """Test deepcopy behavior with circular references in EnrichedDiffRelationship.
 
     The data model has a recursive structure:
     - EnrichedDiffRelationship.nodes -> set[EnrichedDiffNode]
     - EnrichedDiffNode.relationships -> set[EnrichedDiffRelationship]
 
-    Custom __deepcopy__ methods handle this by:
-    1. Creating a new instance and setting hashable attributes first
-    2. Registering in memo before copying complex attributes
-    3. Then copying complex attributes that may have circular references
+    using deepcopy() on an object with a recersive reference to a `set` of its own class could fail
+    depending on the order in which attributes are handled in deepcopy(). custom __deepcopy__ methods
+    ensure the attributes are set in the correct order
     """
+    # Create a relationship with a node in its nodes set
+    relationship = EnrichedRelationshipGroupFactory.build(
+        name="parent_relationship",
+        action=DiffAction.ADDED,
+        cardinality=RelationshipCardinality.MANY,
+        relationships={EnrichedRelationshipElementFactory.build(action=DiffAction.ADDED)},
+        nodes=set(),
+    )
 
-    def test_deepcopy_relationship_with_circular_node_reference(self) -> None:
-        """Test deepcopy works with circular references starting from a relationship.
+    # Create a node that references this relationship
+    node = EnrichedNodeFactory.build(
+        action=DiffAction.ADDED,
+        attributes=set(),
+        relationships={relationship},
+    )
 
-        Creates: relationship.nodes -> node.relationships -> relationship
-        """
-        # Create a relationship with a node in its nodes set
-        relationship = EnrichedRelationshipGroupFactory.build(
-            name="parent_relationship",
-            action=DiffAction.ADDED,
-            cardinality=RelationshipCardinality.MANY,
-            relationships={EnrichedRelationshipElementFactory.build(action=DiffAction.ADDED)},
-            nodes=set(),
-        )
+    # Create the circular reference: relationship.nodes contains the node
+    # which has relationship in its relationships set
+    relationship.nodes.add(node)
 
-        # Create a node that references this relationship
-        node = EnrichedNodeFactory.build(
-            action=DiffAction.ADDED,
-            attributes=set(),
-            relationships={relationship},
-        )
+    # validate copying the relationship works
+    copied = deepcopy(relationship)
+    assert copied.name == relationship.name
+    assert copied is not relationship
+    assert len(copied.nodes) == 1
+    copied_node = next(iter(copied.nodes))
+    assert copied_node is not node
+    assert copied_node.identifier == node.identifier
+    assert len(copied_node.relationships) == 1
+    assert next(iter(copied_node.relationships)) is copied
 
-        # Create the circular reference: relationship.nodes contains the node
-        # which has relationship in its relationships set
-        relationship.nodes.add(node)
-
-        # This would fail without the custom __deepcopy__ methods
-        copied = deepcopy(relationship)
-
-        assert copied.name == relationship.name
-        assert copied is not relationship
-        assert len(copied.nodes) == 1
-        # Verify the circular structure is preserved
-        copied_node = next(iter(copied.nodes))
-        assert copied_node is not node
-        assert len(copied_node.relationships) == 1
-        assert next(iter(copied_node.relationships)) is copied
-
-    def test_deepcopy_node_with_circular_relationship_reference(self) -> None:
-        """Test deepcopy works with circular references starting from a node."""
-        relationship = EnrichedRelationshipGroupFactory.build(
-            name="circular_rel",
-            action=DiffAction.UPDATED,
-            cardinality=RelationshipCardinality.ONE,
-            relationships={EnrichedRelationshipElementFactory.build()},
-            nodes=set(),
-        )
-
-        node = EnrichedNodeFactory.build(
-            action=DiffAction.UPDATED,
-            attributes=set(),
-            relationships={relationship},
-        )
-
-        # Create circular reference
-        relationship.nodes.add(node)
-
-        # This would fail without the custom __deepcopy__ methods
-        copied_node = deepcopy(node)
-
-        assert copied_node is not node
-        assert len(copied_node.relationships) == 1
-        copied_rel = next(iter(copied_node.relationships))
-        assert copied_rel.name == relationship.name
-        # Verify the circular structure is preserved
-        assert len(copied_rel.nodes) == 1
-        assert next(iter(copied_rel.nodes)) is copied_node
+    # validate copying the node works
+    copied_node = deepcopy(node)
+    assert copied_node.identifier == node.identifier
+    assert copied_node is not node
+    assert len(copied_node.relationships) == 1
+    copied_rel = next(iter(copied_node.relationships))
+    assert copied_rel.name == relationship.name
+    assert len(copied_rel.nodes) == 1
+    assert next(iter(copied_rel.nodes)) is copied_node

--- a/changelog/8165.fixed.md
+++ b/changelog/8165.fixed.md
@@ -1,0 +1,1 @@
+Fix diff update logic to prevent crash when copying a diff with recursive relationships


### PR DESCRIPTION
fixes #8164 

it was possible for `DiffCombiner.combine()` (runs during most diff updates) to crash when copying a node that included a recursive relationship. depending on the order in which `deepcopy` copied the attributes of an object, it might try to run `hash` on the object before the attributes required to calculate the hash were set, causing an `AttributeError`

this PR adds new `__deepcopy__` methods to prevent the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes occurring when copying diffs with recursive relationships.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->