### PR TITLE
Display schema when clicking attribute/relationship labels in object details view

### DIFF
--- a/changelog/+schema-shortcut.added.md
+++ b/changelog/+schema-shortcut.added.md
@@ -1,0 +1,1 @@
+Added a shortcut in the object details view: clicking an attribute or relationship label opens the schema viewer modal, directly showing and scrolling to the relevant field definition

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-attribute-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-attribute-row.tsx
@@ -14,12 +14,14 @@ interface ObjectAttributeRowProps {
   attributeSchema: AttributeSchema;
   attributeData: NodeAttributeWithMetadata;
   permission: Permission;
+  objectKind: string;
   onClickMetadata?: (attribute: AttributeSchema) => void;
 }
 
 export function ObjectAttributeRow({
   attributeSchema,
   attributeData,
+  objectKind,
   onClickMetadata,
   permission,
 }: ObjectAttributeRowProps) {
@@ -27,7 +29,8 @@ export function ObjectAttributeRow({
 
   return (
     <ObjectDataRow
-      name={attributeLabel}
+      fieldSchema={attributeSchema}
+      objectKind={objectKind}
       value={
         <>
           <ObjectAttributeValue attributeSchema={attributeSchema} attributeData={attributeData} />

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx
@@ -68,12 +68,15 @@ export function ObjectDataDisplay({
         const fieldData = objectData[fieldName];
         if (!fieldData) return null;
 
+        const objectKind = objectSchema.kind!;
+
         if ("peer" in field) {
           return (
             <ObjectRelationshipRow
               key={fieldName}
               relationshipSchema={field}
               relationshipData={fieldData as NodeRelationshipWithMetadata}
+              objectKind={objectKind}
               permission={permission}
               onClickMetadata={onClickRelationshipMetadata}
             />
@@ -85,6 +88,7 @@ export function ObjectDataDisplay({
             key={fieldName}
             attributeSchema={field}
             attributeData={fieldData as NodeAttributeWithMetadata}
+            objectKind={objectKind}
             permission={permission}
             onClickMetadata={onClickAttributeMetadata}
           />

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
@@ -1,14 +1,46 @@
+import { Icon } from "@iconify-icon/react";
 import type React from "react";
+import { Button, DialogTrigger } from "react-aria-components";
+
+import { classNames } from "@/shared/utils/common";
+
+import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
+import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
+import { SchemaViewerModal } from "@/entities/schema/ui/schema-viewer-modal";
 
 interface ObjectDataRowProps {
-  name: React.ReactNode;
+  fieldSchema: AttributeSchema | RelationshipSchema;
   value: React.ReactNode;
+  objectKind: string;
+  className?: string;
 }
 
-export function ObjectDataRow({ name, value }: ObjectDataRowProps) {
+export function ObjectDataRow({ value, className, objectKind, fieldSchema }: ObjectDataRowProps) {
+  const { schema } = useSchema(objectKind);
+
+  const fieldName = fieldSchema.label ?? fieldSchema.name;
+  const isRelationship = "peer" in fieldSchema;
+  const defaultTab = isRelationship ? "relationships" : "attributes";
+
   return (
-    <div className="grid grid-cols-[200px_auto] gap-4 px-4 py-2 text-xs">
-      <dt className="flex h-8 items-center font-medium text-gray-500">{name}</dt>
+    <div className={classNames("grid grid-cols-[200px_auto] gap-4 px-4 py-2 text-xs", className)}>
+      <dt className="flex h-8 items-center font-medium text-gray-500">
+        {schema ? (
+          <DialogTrigger>
+            <Button
+              className="group flex cursor-pointer items-center outline-hidden hover:text-custom-blue-700"
+              excludeFromTabOrder
+            >
+              {fieldName}
+              <Icon icon="mdi:code-json" className="ml-1 hidden group-hover:inline-block" />
+            </Button>
+
+            <SchemaViewerModal schema={schema} defaultTab={defaultTab} />
+          </DialogTrigger>
+        ) : (
+          fieldName
+        )}
+      </dt>
       <dd className="flex items-center gap-2">{value}</dd>
     </div>
   );

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
@@ -35,7 +35,11 @@ export function ObjectDataRow({ value, className, objectKind, fieldSchema }: Obj
               <Icon icon="mdi:code-json" className="ml-1 hidden group-hover:inline-block" />
             </Button>
 
-            <SchemaViewerModal schema={schema} defaultTab={defaultTab} />
+            <SchemaViewerModal
+              schema={schema}
+              defaultTab={defaultTab}
+              targetField={fieldSchema.name}
+            />
           </DialogTrigger>
         ) : (
           fieldName

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-relationship-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-relationship-row.tsx
@@ -21,6 +21,7 @@ interface ObjectRelationshipRowProps {
   relationshipSchema: RelationshipSchema;
   relationshipData: NodeRelationshipWithMetadata;
   permission: Permission;
+  objectKind: string;
   onClickMetadata?: (relationship: RelationshipSchema) => void;
 }
 
@@ -28,17 +29,16 @@ export function ObjectRelationshipRow({
   relationshipSchema,
   relationshipData,
   permission,
+  objectKind,
   onClickMetadata,
 }: ObjectRelationshipRowProps) {
-  const relationshipLabel = relationshipSchema.label ?? relationshipSchema.name;
-
   if (relationshipSchema.cardinality === "one") {
     return (
       <RelationshipOneRow
         relationshipSchema={relationshipSchema}
         relationshipData={relationshipData as NodeRelationshipOneWithMetadata}
-        relationshipLabel={relationshipLabel}
         permission={permission}
+        objectKind={objectKind}
         onClickMetadata={onClickMetadata}
       />
     );
@@ -47,7 +47,8 @@ export function ObjectRelationshipRow({
   return (
     <RelationshipManyRow
       relationshipData={relationshipData as NodeRelationshipManyWithMetadata}
-      relationshipLabel={relationshipLabel}
+      relationshipSchema={relationshipSchema}
+      objectKind={objectKind}
     />
   );
 }
@@ -55,16 +56,16 @@ export function ObjectRelationshipRow({
 interface RelationshipOneRowProps {
   relationshipSchema: RelationshipSchema;
   relationshipData: NodeRelationshipOneWithMetadata;
-  relationshipLabel: string;
   permission: Permission;
+  objectKind: string;
   onClickMetadata?: (relationship: RelationshipSchema) => void;
 }
 
 function RelationshipOneRow({
   relationshipSchema,
   relationshipData,
-  relationshipLabel,
   permission,
+  objectKind,
   onClickMetadata,
 }: RelationshipOneRowProps) {
   const relatedNode = relationshipData.node;
@@ -72,7 +73,8 @@ function RelationshipOneRow({
 
   return (
     <ObjectDataRow
-      name={relationshipLabel}
+      fieldSchema={relationshipSchema}
+      objectKind={objectKind}
       value={
         <>
           {relatedNode ? (
@@ -93,7 +95,7 @@ function RelationshipOneRow({
                 header={
                   onClickMetadata && (
                     <div className="flex items-center justify-between border-gray-200 border-b p-1 pt-0 pl-2">
-                      <div className="font-semibold">{relationshipLabel}</div>
+                      <div className="font-semibold">{relationshipSchema.label}</div>
 
                       <ButtonWithTooltip
                         variant="ghost"
@@ -123,19 +125,25 @@ function RelationshipOneRow({
 
 interface RelationshipManyRowProps {
   relationshipData: NodeRelationshipManyWithMetadata;
-  relationshipLabel: string;
+  relationshipSchema: RelationshipSchema;
+  objectKind: string;
 }
 
-function RelationshipManyRow({ relationshipData, relationshipLabel }: RelationshipManyRowProps) {
+function RelationshipManyRow({
+  relationshipData,
+  relationshipSchema,
+  objectKind,
+}: RelationshipManyRowProps) {
   const relatedNodeEdges = relationshipData.edges;
 
   if (relatedNodeEdges.length === 0) {
-    return <ObjectDataRow name={relationshipLabel} value="-" />;
+    return <ObjectDataRow fieldSchema={relationshipSchema} objectKind={objectKind} value="-" />;
   }
 
   return (
     <ObjectDataRow
-      name={relationshipLabel}
+      fieldSchema={relationshipSchema}
+      objectKind={objectKind}
       value={
         <dl className="flex flex-col">
           {relatedNodeEdges.map((edge) => {

--- a/frontend/app/src/entities/schema/ui/attribute-display.tsx
+++ b/frontend/app/src/entities/schema/ui/attribute-display.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import { constructPath } from "@/shared/api/rest/fetch";
 import type { components } from "@/shared/api/rest/types.generated";
 import Accordion from "@/shared/components/display/accordion";
@@ -11,11 +13,22 @@ import { AccordionStyled, NullDisplay, PropertyRow, PropertyTitle } from "./styl
 
 export const AttributeDisplay = ({
   attribute,
+  defaultOpen = false,
 }: {
   attribute: components["schemas"]["AttributeSchema-Output"];
+  defaultOpen?: boolean;
 }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (defaultOpen && ref.current) {
+      ref.current.scrollIntoView({ behavior: "instant", block: "start" });
+    }
+  }, [defaultOpen]);
+
   return (
     <AccordionStyled
+      ref={defaultOpen ? ref : undefined}
       title={attribute.label || attribute.name}
       kind={attribute.kind}
       description={attribute.description}
@@ -23,6 +36,7 @@ export const AttributeDisplay = ({
       isUnique={attribute.unique}
       isReadOnly={attribute.read_only}
       isComputed={!!attribute.computed_attribute}
+      defaultOpen={defaultOpen}
     >
       <div>
         <PropertyRow title="ID" value={attribute.id} />

--- a/frontend/app/src/entities/schema/ui/attribute-display.tsx
+++ b/frontend/app/src/entities/schema/ui/attribute-display.tsx
@@ -28,7 +28,7 @@ export const AttributeDisplay = ({
 
   return (
     <AccordionStyled
-      ref={defaultOpen ? ref : undefined}
+      ref={ref}
       title={attribute.label || attribute.name}
       kind={attribute.kind}
       description={attribute.description}

--- a/frontend/app/src/entities/schema/ui/relationship-display.tsx
+++ b/frontend/app/src/entities/schema/ui/relationship-display.tsx
@@ -34,7 +34,7 @@ export const RelationshipDisplay = ({
 
   return (
     <AccordionStyled
-      ref={defaultOpen ? ref : undefined}
+      ref={ref}
       title={relationship.label || relationship.name}
       kind={
         <>

--- a/frontend/app/src/entities/schema/ui/relationship-display.tsx
+++ b/frontend/app/src/entities/schema/ui/relationship-display.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@iconify-icon/react";
+import { useEffect, useRef } from "react";
 
 import type { components } from "@/shared/api/rest/types.generated";
 import { Badge } from "@/shared/components/ui/badge";
@@ -8,7 +9,21 @@ import type { RelationshipSchema } from "@/entities/schema/types";
 
 import { AccordionStyled, ModelDisplay, PropertyRow } from "./styled";
 
-export const RelationshipDisplay = ({ relationship }: { relationship: RelationshipSchema }) => {
+export const RelationshipDisplay = ({
+  relationship,
+  defaultOpen = false,
+}: {
+  relationship: RelationshipSchema;
+  defaultOpen?: boolean;
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (defaultOpen && ref.current) {
+      ref.current.scrollIntoView({ behavior: "instant", block: "start" });
+    }
+  }, [defaultOpen]);
+
   const cardinalityLabel = relationship.cardinality
     ? getLabelForCardinality(relationship.cardinality)
     : null;
@@ -19,6 +34,7 @@ export const RelationshipDisplay = ({ relationship }: { relationship: Relationsh
 
   return (
     <AccordionStyled
+      ref={defaultOpen ? ref : undefined}
       title={relationship.label || relationship.name}
       kind={
         <>
@@ -32,6 +48,7 @@ export const RelationshipDisplay = ({ relationship }: { relationship: Relationsh
       }
       description={relationship.description}
       isOptional={relationship.optional}
+      defaultOpen={defaultOpen}
     >
       <div>
         <PropertyRow title="ID" value={relationship.id} />

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.test.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+
+import { render } from "../../../../tests/components/render";
+import {
+  generateAttributeSchema,
+  generateNodeSchema,
+  generateRelationshipSchema,
+} from "../../../../tests/fake/schema";
+import { SchemaViewerModal } from "./schema-viewer-modal";
+
+describe("SchemaViewerModal Component", () => {
+  test("renders modal with schema information", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Device",
+      namespace: "Infra",
+      label: "Device",
+      description: "A network device",
+    });
+
+    const component = await render(<SchemaViewerModal schema={schema} isOpen />);
+
+    // THEN
+    await expect.element(component.getByRole("dialog")).toBeVisible();
+    await expect.element(component.getByRole("heading", { name: "Device" })).toBeVisible();
+    await expect.element(component.getByRole("paragraph")).toBeVisible();
+    await expect.element(component.getByTestId("schema-viewer")).toBeVisible();
+  });
+
+  test("opens attributes tab by default when defaultTab is 'attributes'", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Device",
+      namespace: "Infra",
+      attributes: [
+        generateAttributeSchema({
+          id: "attr-1",
+          name: "hostname",
+          label: "Hostname",
+          kind: "Text",
+        }),
+      ],
+    });
+
+    const component = await render(
+      <SchemaViewerModal schema={schema} defaultTab="attributes" isOpen />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Hostname Text")).toBeVisible();
+  });
+
+  test("opens relationships tab by default when defaultTab is 'relationships'", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Device",
+      namespace: "Infra",
+      relationships: [
+        generateRelationshipSchema({
+          id: "rel-1",
+          name: "interfaces",
+          label: "Interfaces",
+          peer: "InfraInterface",
+          cardinality: "many",
+        }),
+      ],
+    });
+
+    const component = await render(
+      <SchemaViewerModal schema={schema} defaultTab="relationships" isOpen />
+    );
+
+    // THEN
+    await expect.element(component.getByText("Interfaces")).toBeVisible();
+    await expect.element(component.getByText("InfraInterface")).toBeVisible();
+  });
+
+  test("expands target attribute when targetField matches attribute name", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Device",
+      namespace: "Infra",
+      attributes: [
+        generateAttributeSchema({
+          id: "attr-1",
+          name: "hostname",
+          label: "Hostname",
+          kind: "Text",
+        }),
+        generateAttributeSchema({
+          id: "attr-2",
+          name: "description",
+          label: "Description",
+          kind: "Text",
+        }),
+      ],
+    });
+
+    const component = await render(
+      <SchemaViewerModal schema={schema} defaultTab="attributes" targetField="hostname" isOpen />
+    );
+
+    // THEN - the target attribute should be expanded showing its details
+    await expect.element(component.getByText("attr-1")).toBeVisible();
+  });
+
+  test("expands target relationship when targetField matches relationship name", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Device",
+      namespace: "Infra",
+      relationships: [
+        generateRelationshipSchema({
+          id: "rel-1",
+          name: "interfaces",
+          label: "Interfaces",
+          peer: "InfraInterface",
+        }),
+        generateRelationshipSchema({
+          id: "rel-2",
+          name: "location",
+          label: "Location",
+          peer: "LocationSite",
+        }),
+      ],
+    });
+
+    const component = await render(
+      <SchemaViewerModal
+        schema={schema}
+        defaultTab="relationships"
+        targetField="interfaces"
+        isOpen
+      />
+    );
+
+    // THEN - the target relationship should be expanded showing its details
+    await expect.element(component.getByText("rel-1")).toBeVisible();
+  });
+});

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -18,14 +18,14 @@ export function SchemaViewerModal({
   ...props
 }: SchemaViewerModalProps) {
   return (
-    <Modal aria-label="Schema viewer" className={classNames("w-150", className)} {...props}>
+    <Modal aria-label="Schema viewer" className={classNames("w-150 p-0", className)} {...props}>
       {({ close }) => (
         <SchemaViewer
           schema={schema}
           defaultTab={defaultTab}
           targetField={targetField}
           onClose={close}
-          className="rounded-xl"
+          className="rounded-xl p-3"
         />
       )}
     </Modal>

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -1,17 +1,24 @@
-import { Modal } from "@/shared/components/aria/modal";
+import { Modal, type ModalProps } from "@/shared/components/aria/modal";
+import { classNames } from "@/shared/utils/common";
 
 import type { ModelSchema } from "@/entities/schema/types";
 import { SchemaViewer } from "@/entities/schema/ui/schema-viewer";
 
-interface SchemaViewerModalProps {
+interface SchemaViewerModalProps extends Omit<ModalProps, "children"> {
   schema: ModelSchema;
   defaultTab?: "properties" | "attributes" | "relationships";
   targetField?: string;
 }
 
-export function SchemaViewerModal({ schema, defaultTab, targetField }: SchemaViewerModalProps) {
+export function SchemaViewerModal({
+  schema,
+  defaultTab,
+  targetField,
+  className,
+  ...props
+}: SchemaViewerModalProps) {
   return (
-    <Modal className="w-150">
+    <Modal aria-label="Schema viewer" className={classNames("w-150", className)} {...props}>
       {({ close }) => (
         <SchemaViewer
           schema={schema}

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -1,0 +1,17 @@
+import { Modal } from "@/shared/components/aria/modal";
+
+import type { ModelSchema } from "@/entities/schema/types";
+import { SchemaViewer } from "@/entities/schema/ui/schema-viewer";
+
+interface SchemaViewerModalProps {
+  schema: ModelSchema;
+  defaultTab?: "properties" | "attributes" | "relationships";
+}
+
+export function SchemaViewerModal({ schema, defaultTab }: SchemaViewerModalProps) {
+  return (
+    <Modal className="w-[600px] max-w-[90vw]">
+      {({ close }) => <SchemaViewer schema={schema} defaultTab={defaultTab} onClose={close} />}
+    </Modal>
+  );
+}

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -6,12 +6,20 @@ import { SchemaViewer } from "@/entities/schema/ui/schema-viewer";
 interface SchemaViewerModalProps {
   schema: ModelSchema;
   defaultTab?: "properties" | "attributes" | "relationships";
+  targetField?: string;
 }
 
-export function SchemaViewerModal({ schema, defaultTab }: SchemaViewerModalProps) {
+export function SchemaViewerModal({ schema, defaultTab, targetField }: SchemaViewerModalProps) {
   return (
     <Modal className="w-[600px] max-w-[90vw]">
-      {({ close }) => <SchemaViewer schema={schema} defaultTab={defaultTab} onClose={close} />}
+      {({ close }) => (
+        <SchemaViewer
+          schema={schema}
+          defaultTab={defaultTab}
+          targetField={targetField}
+          onClose={close}
+        />
+      )}
     </Modal>
   );
 }

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -11,13 +11,14 @@ interface SchemaViewerModalProps {
 
 export function SchemaViewerModal({ schema, defaultTab, targetField }: SchemaViewerModalProps) {
   return (
-    <Modal className="w-[600px] max-w-[90vw]">
+    <Modal className="w-150">
       {({ close }) => (
         <SchemaViewer
           schema={schema}
           defaultTab={defaultTab}
           targetField={targetField}
           onClose={close}
+          className="rounded-xl"
         />
       )}
     </Modal>

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -99,7 +99,7 @@ export const SchemaViewer = ({
         <div className="flex items-center gap-2 text-gray-600">
           <SchemaHelpMenu schema={schema} />
 
-          <Button size="icon" variant="ghost" onClick={onClose}>
+          <Button size="icon" variant="ghost" aria-label="Close schema viewer" onClick={onClose}>
             <Icon icon="mdi:close" className="text-xl" />
           </Button>
         </div>

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -71,12 +71,14 @@ export const SchemaViewer = ({
   onClose,
   style,
   defaultTab = "properties",
+  targetField,
 }: {
   className?: string;
   schema: ModelSchema;
   onClose: () => void;
   style?: CSSProperties;
   defaultTab?: "properties" | "attributes" | "relationships";
+  targetField?: string;
 }) => {
   return (
     <section
@@ -105,7 +107,7 @@ export const SchemaViewer = ({
 
       <SchemaViewerTitle schema={schema} />
 
-      <SchemaViewerDetails schema={schema} defaultTab={defaultTab} />
+      <SchemaViewerDetails schema={schema} defaultTab={defaultTab} targetField={targetField} />
     </section>
   );
 };
@@ -131,9 +133,11 @@ const SchemaViewerTitle = ({ schema }: { schema: ModelSchema }) => {
 const SchemaViewerDetails = ({
   schema,
   defaultTab,
+  targetField,
 }: {
   schema: ModelSchema;
   defaultTab: "properties" | "attributes" | "relationships";
+  targetField?: string;
 }) => {
   return (
     <Tabs defaultSelectedKey={defaultTab} className="flex flex-col overflow-y-hidden">
@@ -150,7 +154,11 @@ const SchemaViewerDetails = ({
       <TabPanelStyled id="attributes">
         {schema.attributes && schema.attributes.length > 0 ? (
           schema.attributes?.map((attribute) => (
-            <AttributeDisplay key={attribute.id} attribute={attribute} />
+            <AttributeDisplay
+              key={attribute.id}
+              attribute={attribute}
+              defaultOpen={attribute.name === targetField}
+            />
           ))
         ) : (
           <div className="flex h-32 items-center justify-center">No attribute</div>
@@ -160,7 +168,11 @@ const SchemaViewerDetails = ({
       <TabPanelStyled id="relationships">
         {schema.relationships && schema.relationships.length > 0
           ? schema.relationships?.map((relationship) => (
-              <RelationshipDisplay key={relationship.id} relationship={relationship} />
+              <RelationshipDisplay
+                key={relationship.id}
+                relationship={relationship}
+                defaultOpen={relationship.name === targetField}
+              />
             ))
           : "No relationship"}
       </TabPanelStyled>

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -70,11 +70,13 @@ export const SchemaViewer = ({
   schema,
   onClose,
   style,
+  defaultTab = "properties",
 }: {
   className?: string;
   schema: ModelSchema;
   onClose: () => void;
   style?: CSSProperties;
+  defaultTab?: "properties" | "attributes" | "relationships";
 }) => {
   return (
     <section
@@ -95,15 +97,15 @@ export const SchemaViewer = ({
         <div className="flex items-center gap-2 text-gray-600">
           <SchemaHelpMenu schema={schema} />
 
-          <Button size="icon" variant="ghost">
-            <Icon icon="mdi:close" className="text-xl" onClick={onClose} />
+          <Button size="icon" variant="ghost" onClick={onClose}>
+            <Icon icon="mdi:close" className="text-xl" />
           </Button>
         </div>
       </div>
 
       <SchemaViewerTitle schema={schema} />
 
-      <SchemaViewerDetails schema={schema} />
+      <SchemaViewerDetails schema={schema} defaultTab={defaultTab} />
     </section>
   );
 };
@@ -126,9 +128,15 @@ const SchemaViewerTitle = ({ schema }: { schema: ModelSchema }) => {
   );
 };
 
-const SchemaViewerDetails = ({ schema }: { schema: ModelSchema }) => {
+const SchemaViewerDetails = ({
+  schema,
+  defaultTab,
+}: {
+  schema: ModelSchema;
+  defaultTab: "properties" | "attributes" | "relationships";
+}) => {
   return (
-    <Tabs className="flex flex-col overflow-y-hidden">
+    <Tabs defaultSelectedKey={defaultTab} className="flex flex-col overflow-y-hidden">
       <TabList className="flex">
         <TabStyled id="properties">Properties</TabStyled>
         <TabStyled id="attributes">Attributes</TabStyled>

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -27,7 +27,13 @@ interface ModalProps
   extends Pick<AriaModalOverlayProps, "isOpen" | "onOpenChange" | "isDismissable">,
     DialogProps {}
 
-export function Modal({ isOpen, onOpenChange, className, isDismissable, ...props }: ModalProps) {
+export function Modal({
+  isOpen,
+  onOpenChange,
+  className,
+  isDismissable = true,
+  ...props
+}: ModalProps) {
   return (
     <ModalOverlay isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={isDismissable}>
       <AriaModal

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -39,13 +39,16 @@ export function Modal({
       <AriaModal
         className={classNames(
           "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
-          "no-scrollbar box-border max-h-[calc(var(--visual-viewport-height)*.9)] max-w-[90vw] overflow-auto rounded-xl bg-white p-2",
+          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white p-2",
           "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
           "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
           className
         )}
       >
-        <AriaDialog className="outline-hidden" {...props} />
+        <AriaDialog
+          className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-auto rounded-xl outline-hidden"
+          {...props}
+        />
       </AriaModal>
     </ModalOverlay>
   );

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -23,7 +23,7 @@ export function ModalOverlay({ className, ...props }: AriaModalOverlayProps) {
   );
 }
 
-interface ModalProps
+export interface ModalProps
   extends Pick<AriaModalOverlayProps, "isOpen" | "onOpenChange" | "isDismissable">,
     DialogProps {}
 

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -39,7 +39,7 @@ export function Modal({
       <AriaModal
         className={classNames(
           "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
-          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-stone-50 p-2",
+          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white p-2",
           "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
           "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
           className

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -39,14 +39,14 @@ export function Modal({
       <AriaModal
         className={classNames(
           "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
-          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white p-2",
+          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-stone-50 p-2",
           "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
           "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
           className
         )}
       >
         <AriaDialog
-          className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-auto rounded-xl outline-hidden"
+          className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-auto rounded-xl shadow-lg outline-hidden"
           {...props}
         />
       </AriaModal>

--- a/frontend/app/src/shared/components/display/accordion.tsx
+++ b/frontend/app/src/shared/components/display/accordion.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@iconify-icon/react";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, type Ref, useState } from "react";
 
 import { classNames } from "@/shared/utils/common";
 
@@ -12,6 +12,7 @@ export type AccordionProps = {
   defaultOpen?: boolean;
   style?: CSSProperties;
   hideChevron?: boolean;
+  ref?: Ref<HTMLDivElement>;
 };
 
 export default function Accordion({
@@ -22,6 +23,7 @@ export default function Accordion({
   hideChevron,
   iconClassName,
   titleClassName,
+  ref,
   ...props
 }: AccordionProps) {
   const [isOpen, setIsOpen] = useState<boolean>();
@@ -29,7 +31,7 @@ export default function Accordion({
   const open = isOpen === undefined ? defaultOpen : isOpen;
 
   return (
-    <div className={className} {...props}>
+    <div ref={ref} className={className} {...props}>
       <div className="relative flex cursor-pointer items-center" onClick={() => setIsOpen(!open)}>
         <span
           className={classNames(

--- a/frontend/app/tests/e2e/schema/schema-shortcut.spec.ts
+++ b/frontend/app/tests/e2e/schema/schema-shortcut.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Schema shortcut from object details", () => {
+  test("should open schema modal when clicking on attribute label", async ({ page }) => {
+    await page.goto("/objects/InfraDevice");
+    await page.getByRole("link", { name: "atl1-edge1" }).click();
+
+    await page.getByTestId("object-details").getByRole("button", { name: "Name" }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByTestId("schema-viewer")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Device", exact: true })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Attributes" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    await expect(page.getByText("Namename")).toBeVisible();
+
+    await page.getByRole("button", { name: "Close schema viewer" }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("should open schema modal when clicking on relationship one label", async ({ page }) => {
+    await page.goto("/objects/InfraDevice");
+    await page.getByRole("link", { name: "atl1-edge1" }).click();
+
+    await page.getByTestId("object-details").getByRole("button", { name: "Site" }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByTestId("schema-viewer")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    await expect(page.getByText("Namesite")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("should open schema modal when clicking on relationship many label", async ({ page }) => {
+    await page.goto("/objects/InfraDevice");
+    await page.getByRole("link", { name: "atl1-edge1" }).click();
+
+    await page.getByTestId("object-details").getByRole("button", { name: "Tags" }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByTestId("schema-viewer")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    await expect(page.getByText("Nametags")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+});

--- a/frontend/app/tests/e2e/schema/schema-shortcut.spec.ts
+++ b/frontend/app/tests/e2e/schema/schema-shortcut.spec.ts
@@ -5,54 +5,66 @@ test.describe("Schema shortcut from object details", () => {
     await page.goto("/objects/InfraDevice");
     await page.getByRole("link", { name: "atl1-edge1" }).click();
 
-    await page.getByTestId("object-details").getByRole("button", { name: "Name" }).click();
+    await test.step("open schema modal from attribute", async () => {
+      await page.getByTestId("object-details").getByRole("button", { name: "Name" }).click();
 
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByTestId("schema-viewer")).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Device", exact: true })).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Attributes" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    );
-    await expect(page.getByText("Namename")).toBeVisible();
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByTestId("schema-viewer")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Device", exact: true })).toBeVisible();
+      await expect(page.getByRole("tab", { name: "Attributes" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+      await expect(page.getByText("Namename")).toBeVisible();
+    });
 
-    await page.getByRole("button", { name: "Close schema viewer" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await test.step("close modal with close button", async () => {
+      await page.getByRole("button", { name: "Close schema viewer" }).click();
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
   });
 
   test("should open schema modal when clicking on relationship one label", async ({ page }) => {
     await page.goto("/objects/InfraDevice");
     await page.getByRole("link", { name: "atl1-edge1" }).click();
 
-    await page.getByTestId("object-details").getByRole("button", { name: "Site" }).click();
+    await test.step("open schema modal from relationship one", async () => {
+      await page.getByTestId("object-details").getByRole("button", { name: "Site" }).click();
 
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByTestId("schema-viewer")).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    );
-    await expect(page.getByText("Namesite")).toBeVisible();
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByTestId("schema-viewer")).toBeVisible();
+      await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+      await expect(page.getByText("Namesite")).toBeVisible();
+    });
 
-    await page.keyboard.press("Escape");
-    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await test.step("close modal with Escape key", async () => {
+      await page.keyboard.press("Escape");
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
   });
 
   test("should open schema modal when clicking on relationship many label", async ({ page }) => {
     await page.goto("/objects/InfraDevice");
     await page.getByRole("link", { name: "atl1-edge1" }).click();
 
-    await page.getByTestId("object-details").getByRole("button", { name: "Tags" }).click();
+    await test.step("open schema modal from relationship many", async () => {
+      await page.getByTestId("object-details").getByRole("button", { name: "Tags" }).click();
 
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByTestId("schema-viewer")).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    );
-    await expect(page.getByText("Nametags")).toBeVisible();
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByTestId("schema-viewer")).toBeVisible();
+      await expect(page.getByRole("tab", { name: "Relationships" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+      await expect(page.getByText("Nametags")).toBeVisible();
+    });
 
-    await page.keyboard.press("Escape");
-    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await test.step("close modal with Escape key", async () => {
+      await page.keyboard.press("Escape");
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+    });
   });
 });

--- a/frontend/app/tests/e2e/schema/schema.spec.ts
+++ b/frontend/app/tests/e2e/schema/schema.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { saveScreenshotForDocs } from "../utils";
+import { saveScreenshotForDocs } from "../../utils";
 
 test.describe("/schema - Schema visualizer", () => {
   test("redirect to schema page using object help menu", async ({ page }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable fields open an interactive schema viewer modal.
  * Schema viewer can open on a specific tab and focus a specific field.

* **Improvements**
  * Fields and relationships auto-expand and scroll into view when targeted.
  * Modal layout, dismiss behavior, and scrolling improved.
  * Accordion components accept external refs for programmatic scrolling/focus.

* **Tests**
  * Unit and end-to-end tests added for modal, tab selection, and field focusing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->