### PR TITLE
Improve readability of permission management for read-only  mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -7,8 +7,7 @@ import httpx
 from graphene import Boolean, Field, InputObjectType, Mutation, String
 
 from infrahub import config
-from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import InfrahubKind, MetadataOptions, PermissionAction, PermissionDecision
+from infrahub.core.constants import InfrahubKind, MetadataOptions, PermissionAction
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreReadOnlyRepository
 from infrahub.core.registry import registry
@@ -22,6 +21,7 @@ from infrahub.graphql.types.common import IdentifierInput
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.message_bus.messages.git_repository_connectivity import GitRepositoryConnectivityResponse
+from infrahub.permissions.types import define_object_permission_from_branch
 from infrahub.repositories.create_repository import RepositoryFinalizer
 from infrahub.workflows.catalogue import (
     GIT_READ_ONLY_REPOSITORY_IMPORT_LAST_COMMIT,
@@ -237,18 +237,11 @@ class ReadOnlyRepositoryImportLastCommit(Mutation):
         branch = graphql_context.branch
         repository_id = str(data.id)
 
-        graphql_context.active_permissions.raise_for_permissions(
-            permissions=[
-                ObjectPermission(
-                    namespace="Core",
-                    name="ReadOnlyRepository",
-                    action=PermissionAction.UPDATE.value,
-                    decision=PermissionDecision.ALLOW_DEFAULT.value
-                    if graphql_context.branch.name == registry.default_branch
-                    else PermissionDecision.ALLOW_OTHER.value,
-                ),
-            ]
+        schema = registry.get_node_schema(name=InfrahubKind.READONLYREPOSITORY, branch=branch.name, duplicate=False)
+        permission = define_object_permission_from_branch(
+            schema=schema, action=PermissionAction.UPDATE, branch_name=branch.name
         )
+        graphql_context.active_permissions.raise_for_permission(permission=permission)
 
         repo = await NodeManager.get_one_by_id_or_default_filter(
             db=graphql_context.db,

--- a/backend/infrahub/permissions/types.py
+++ b/backend/infrahub/permissions/types.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
 
-from infrahub.core.constants import GlobalPermissions, InfrahubKind
+from infrahub.core.account import ObjectPermission
+from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
+    GlobalPermissions,
+    InfrahubKind,
+    PermissionAction,
+    PermissionDecision,
+)
+from infrahub.core.registry import registry
 from infrahub.core.schema import NodeSchema
 
 if TYPE_CHECKING:
-    from infrahub.core.account import GlobalPermission, ObjectPermission
+    from infrahub.core.account import GlobalPermission
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.permissions.constants import BranchRelativePermissionDecision
 
@@ -44,3 +52,14 @@ def get_global_permission_for_kind(schema: MainSchemaTypes) -> GlobalPermissions
                 continue
 
     return None
+
+
+def define_object_permission_from_branch(
+    schema: MainSchemaTypes, action: PermissionAction, branch_name: str
+) -> ObjectPermission:
+    if branch_name in (GLOBAL_BRANCH_NAME, registry.default_branch):
+        decision = PermissionDecision.ALLOW_DEFAULT
+    else:
+        decision = PermissionDecision.ALLOW_OTHER
+
+    return ObjectPermission(namespace=schema.namespace, name=schema.name, action=action.value, decision=decision.value)

--- a/backend/tests/component/permissions/test_types.py
+++ b/backend/tests/component/permissions/test_types.py
@@ -1,8 +1,17 @@
+from dataclasses import dataclass
+
 import pytest
 
 from infrahub.core import registry
-from infrahub.core.constants import GlobalPermissions, InfrahubKind
+from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
+    GlobalPermissions,
+    InfrahubKind,
+    PermissionAction,
+    PermissionDecision,
+)
 from infrahub.permissions import get_global_permission_for_kind
+from infrahub.permissions.types import define_object_permission_from_branch
 
 
 @pytest.mark.parametrize(
@@ -23,3 +32,77 @@ def test_get_global_permission_for_kind(
     for kind in kinds:
         schema = registry.schema.get(name=kind)
         assert get_global_permission_for_kind(schema=schema) == permission
+
+
+@dataclass
+class DefineObjectPermissionFromBranchTestCase:
+    name: str
+    kind: str
+    action: PermissionAction
+    branch_name: str
+    expected_decision: PermissionDecision
+
+
+DEFINE_OBJECT_PERMISSION_FROM_BRANCH_TEST_CASES: list[DefineObjectPermissionFromBranchTestCase] = [
+    DefineObjectPermissionFromBranchTestCase(
+        name="global_branch_returns_allow_default",
+        kind=InfrahubKind.TAG,
+        action=PermissionAction.CREATE,
+        branch_name=GLOBAL_BRANCH_NAME,
+        expected_decision=PermissionDecision.ALLOW_DEFAULT,
+    ),
+    DefineObjectPermissionFromBranchTestCase(
+        name="default_branch_returns_allow_default",
+        kind=InfrahubKind.TAG,
+        action=PermissionAction.VIEW,
+        branch_name="main",
+        expected_decision=PermissionDecision.ALLOW_DEFAULT,
+    ),
+    DefineObjectPermissionFromBranchTestCase(
+        name="feature_branch_returns_allow_other",
+        kind=InfrahubKind.TAG,
+        action=PermissionAction.UPDATE,
+        branch_name="feature-branch",
+        expected_decision=PermissionDecision.ALLOW_OTHER,
+    ),
+    DefineObjectPermissionFromBranchTestCase(
+        name="develop_branch_returns_allow_other",
+        kind=InfrahubKind.TAG,
+        action=PermissionAction.DELETE,
+        branch_name="develop",
+        expected_decision=PermissionDecision.ALLOW_OTHER,
+    ),
+    DefineObjectPermissionFromBranchTestCase(
+        name="different_kind_global_branch",
+        kind=InfrahubKind.REPOSITORY,
+        action=PermissionAction.CREATE,
+        branch_name=GLOBAL_BRANCH_NAME,
+        expected_decision=PermissionDecision.ALLOW_DEFAULT,
+    ),
+    DefineObjectPermissionFromBranchTestCase(
+        name="different_kind_feature_branch",
+        kind=InfrahubKind.REPOSITORY,
+        action=PermissionAction.VIEW,
+        branch_name="feature-branch",
+        expected_decision=PermissionDecision.ALLOW_OTHER,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in DEFINE_OBJECT_PERMISSION_FROM_BRANCH_TEST_CASES],
+)
+def test_define_object_permission_from_branch(
+    register_core_models_schema: None, test_case: DefineObjectPermissionFromBranchTestCase
+) -> None:
+    schema = registry.schema.get(name=test_case.kind)
+
+    result = define_object_permission_from_branch(
+        schema=schema, action=test_case.action, branch_name=test_case.branch_name
+    )
+
+    assert result.namespace == schema.namespace
+    assert result.name == schema.name
+    assert result.action == test_case.action.value
+    assert result.decision == test_case.expected_decision.value


### PR DESCRIPTION
Small readability improvements move to singular permission check and move logic for creating a permission based on branch.