### PR TITLE
add exclude_merged param to DiffRepository get methods

### DIFF
--- a/backend/infrahub/core/diff/query/diff_get.py
+++ b/backend/infrahub/core/diff/query/diff_get.py
@@ -11,7 +11,7 @@ from .filters import EnrichedDiffQueryFilters
 QUERY_MATCH_NODES = """
     // get the roots of all diffs in the query
     MATCH (diff_root:DiffRoot)
-    WHERE (diff_root.is_merged IS NULL OR diff_root.is_merged <> TRUE)
+    WHERE ($exclude_merged = FALSE OR diff_root.is_merged IS NULL OR diff_root.is_merged <> TRUE)
     AND diff_root.base_branch = $base_branch
     AND diff_root.diff_branch IN $diff_branches
     AND ($from_time IS NULL OR diff_root.from_time >= $from_time)
@@ -44,6 +44,7 @@ class EnrichedDiffGetQuery(Query):
         tracking_id: TrackingId | None = None,
         diff_ids: list[str] | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -55,6 +56,7 @@ class EnrichedDiffGetQuery(Query):
         self.tracking_id = tracking_id
         self.diff_ids = diff_ids
         self.proposed_change_id = proposed_change_id
+        self.exclude_merged = exclude_merged
         self.filters = filters or EnrichedDiffQueryFilters()
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
@@ -66,6 +68,7 @@ class EnrichedDiffGetQuery(Query):
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "diff_ids": self.diff_ids,
             "proposed_change_id": self.proposed_change_id,
+            "exclude_merged": self.exclude_merged,
             "limit": self.limit or config.SETTINGS.database.query_size_limit,
             "offset": self.offset,
         }

--- a/backend/infrahub/core/diff/query/diff_summary.py
+++ b/backend/infrahub/core/diff/query/diff_summary.py
@@ -52,6 +52,7 @@ class DiffSummaryQuery(Query):
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -62,6 +63,7 @@ class DiffSummaryQuery(Query):
         self.to_time = to_time
         self.tracking_id = tracking_id
         self.proposed_change_id = proposed_change_id
+        self.exclude_merged = exclude_merged
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         if (
@@ -77,6 +79,7 @@ class DiffSummaryQuery(Query):
             "to_time": self.to_time.to_string() if self.to_time else None,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "proposed_change_id": self.proposed_change_id,
+            "exclude_merged": self.exclude_merged,
             "diff_ids": None,
         }
 

--- a/backend/infrahub/core/diff/query/roots_metadata.py
+++ b/backend/infrahub/core/diff/query/roots_metadata.py
@@ -21,6 +21,7 @@ class EnrichedDiffRootsMetadataQuery(Query):
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -30,6 +31,7 @@ class EnrichedDiffRootsMetadataQuery(Query):
         self.to_time = to_time
         self.tracking_id = tracking_id
         self.proposed_change_id = proposed_change_id
+        self.exclude_merged = exclude_merged
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params = {
@@ -39,11 +41,12 @@ class EnrichedDiffRootsMetadataQuery(Query):
             "to_time": self.to_time.to_string() if self.to_time else None,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "proposed_change_id": self.proposed_change_id,
+            "exclude_merged": self.exclude_merged,
         }
 
         query = """
         MATCH (diff_root:DiffRoot)
-        WHERE (diff_root.is_merged IS NULL OR diff_root.is_merged <> TRUE)
+        WHERE ($exclude_merged = FALSE OR diff_root.is_merged IS NULL OR diff_root.is_merged <> TRUE)
         AND ($diff_branch_names IS NULL OR diff_root.diff_branch IN $diff_branch_names)
         AND ($base_branch_names IS NULL OR diff_root.base_branch IN $base_branch_names)
         AND ($from_time IS NULL OR diff_root.from_time >= $from_time)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -72,6 +72,7 @@ class DiffRepository:
         tracking_id: TrackingId | None = None,
         diff_ids: list[str] | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
     ) -> list[EnrichedDiffRoot]:
         self.deserializer.initialize()
         final_row_number = None
@@ -94,6 +95,7 @@ class DiffRepository:
                 tracking_id=tracking_id,
                 diff_ids=diff_ids,
                 proposed_change_id=proposed_change_id,
+                exclude_merged=exclude_merged,
             )
             log.info(f"Beginning enriched diff get query {batch_size_limit=}, {offset=}")
             await get_query.execute(db=self.db)
@@ -122,6 +124,7 @@ class DiffRepository:
         diff_ids: list[str] | None = None,
         include_empty: bool = False,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
     ) -> list[EnrichedDiffRoot]:
         final_max_depth = config.SETTINGS.database.max_depth_search_hierarchy
         batch_size_limit = int(config.SETTINGS.database.query_size_limit / 10)
@@ -139,6 +142,7 @@ class DiffRepository:
             tracking_id=tracking_id,
             diff_ids=diff_ids,
             proposed_change_id=proposed_change_id,
+            exclude_merged=exclude_merged,
         )
         if not include_empty:
             diff_roots = [dr for dr in diff_roots if len(dr.nodes) > 0]
@@ -459,6 +463,7 @@ class DiffRepository:
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
     ) -> list[EnrichedDiffRootMetadata]:
         query = await EnrichedDiffRootsMetadataQuery.init(
             db=self.db,
@@ -468,6 +473,7 @@ class DiffRepository:
             to_time=to_time,
             tracking_id=tracking_id,
             proposed_change_id=proposed_change_id,
+            exclude_merged=exclude_merged,
         )
         await query.execute(db=self.db)
         diff_roots = []

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -375,6 +375,7 @@ class DiffRepository:
         tracking_id: TrackingId | None = None,
         filters: dict | None = None,
         proposed_change_id: str | None = None,
+        exclude_merged: bool = True,
     ) -> DiffSummaryCounters | None:
         query = await DiffSummaryQuery.init(
             db=self.db,
@@ -385,6 +386,7 @@ class DiffRepository:
             to_time=to_time,
             tracking_id=tracking_id,
             proposed_change_id=proposed_change_id,
+            exclude_merged=exclude_merged,
         )
         await query.execute(db=self.db)
         return query.get_summary()

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -563,6 +563,8 @@ class DiffTreeResolver:
             to_time=to_timestamp,
             filters=filters_dict,
             proposed_change_id=proposed_change_id,
+            # include merged diffs if filtering on proposed change
+            exclude_merged=not proposed_change_id,
         )
         if summary is None:
             return None

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -498,6 +498,8 @@ class DiffTreeResolver:
             tracking_id=NameTrackingId(name) if name else None,
             include_empty=True,
             proposed_change_id=proposed_change_id,
+            # include merged diffs if filtering on proposed change
+            exclude_merged=not proposed_change_id,
         )
         if not enriched_diffs:
             return None

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -1326,6 +1326,32 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert merged_diff.uuid in metadata_uuids
         assert unmerged_diff.uuid in metadata_uuids
 
+        # summary(exclude_merged=True) should exclude merged diff
+        summary = await diff_repository.summary(
+            diff_branch_names=[merged_diff.diff_branch_name],
+            base_branch_name=base_branch_name,
+            tracking_id=merged_tracking_id,
+            exclude_merged=True,
+        )
+        assert summary is None
+
+        summary = await diff_repository.summary(
+            diff_branch_names=[unmerged_diff.diff_branch_name],
+            base_branch_name=base_branch_name,
+            tracking_id=unmerged_tracking_id,
+            exclude_merged=True,
+        )
+        assert summary is not None
+
+        # summary(exclude_merged=False) should include merged diff
+        summary = await diff_repository.summary(
+            diff_branch_names=[merged_diff.diff_branch_name],
+            base_branch_name=base_branch_name,
+            tracking_id=merged_tracking_id,
+            exclude_merged=False,
+        )
+        assert summary is not None
+
 
 async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:
     """Verify that no diff elements have been orphaned"""

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -1272,6 +1272,60 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         )
         assert len(retrieved) == 3
 
+    async def test_get_exclude_merged(self, diff_repository: DiffRepository, reset_database) -> None:
+        base_branch_name = "main"
+        # Create two diffs with tracking IDs
+        merged_diff = EnrichedRootFactory.build(base_branch_name=base_branch_name)
+        merged_tracking_id = BranchTrackingId(name=merged_diff.diff_branch_name)
+        merged_diff.tracking_id = merged_tracking_id
+        await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=merged_diff, do_summary_counts=False
+        )
+        await diff_repository.mark_tracking_ids_merged(tracking_ids=[merged_tracking_id])
+
+        unmerged_diff = EnrichedRootFactory.build(base_branch_name=base_branch_name)
+        unmerged_tracking_id = BranchTrackingId(name=unmerged_diff.diff_branch_name)
+        unmerged_diff.tracking_id = unmerged_tracking_id
+        await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=unmerged_diff, do_summary_counts=False
+        )
+
+        # get(exclude_merged=True) should exclude merged diff
+        diffs = await diff_repository.get(
+            diff_branch_names=[merged_diff.diff_branch_name, unmerged_diff.diff_branch_name],
+            base_branch_name=base_branch_name,
+            exclude_merged=True,
+        )
+        assert {d.uuid for d in diffs} == {unmerged_diff.uuid}
+
+        # get(exclude_merged=False) should include both diffs
+        diffs = await diff_repository.get(
+            diff_branch_names=[merged_diff.diff_branch_name, unmerged_diff.diff_branch_name],
+            base_branch_name=base_branch_name,
+            exclude_merged=False,
+        )
+        assert {d.uuid for d in diffs} == {merged_diff.uuid, unmerged_diff.uuid}
+
+        # get_roots_metadata(exclude_merged=True) should exclude merged diff
+        metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[merged_diff.diff_branch_name, unmerged_diff.diff_branch_name],
+            base_branch_names=[base_branch_name],
+            exclude_merged=True,
+        )
+        metadata_uuids = {m.uuid for m in metadata}
+        assert merged_diff.uuid not in metadata_uuids
+        assert unmerged_diff.uuid in metadata_uuids
+
+        # get_roots_metadata(exclude_merged=False) should include both diffs
+        metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[merged_diff.diff_branch_name, unmerged_diff.diff_branch_name],
+            base_branch_names=[base_branch_name],
+            exclude_merged=False,
+        )
+        metadata_uuids = {m.uuid for m in metadata}
+        assert merged_diff.uuid in metadata_uuids
+        assert unmerged_diff.uuid in metadata_uuids
+
 
 async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:
     """Verify that no diff elements have been orphaned"""


### PR DESCRIPTION
we currently exclude all "merged" diffs when retrieving them, but we don't want to do that going forward so that we can display a "merged" diff
this PR adds an `exclude_merged=True` kwarg to the get methods in the DiffRepository to allow retrieving merged diffs while maintaining the existing logic by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filter to control whether merged diffs are shown (default: merged diffs excluded). When viewing a proposed change, merged diffs are included automatically to show complete context.

* **Tests**
  * Added tests validating merged-diff filtering behavior across diff retrieval, summaries, and metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->