### PR TITLE
Ensure that we run e2e tests when we update the SDK commit

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -114,3 +114,4 @@ e2e_all:
   - *ci_config
   - *development_files
   - *infrahub_uv_files
+  - *sdk_files


### PR DESCRIPTION
Currently when we have a PR that only updates the SDK commit we don't run the E2E tests that can cause problems if the test would have failed but we still merge the PR. Changing this to ensure that we always run E2E tests if the SDK commit has been touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing configuration to include SDK files in end-to-end testing aggregation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->