### PR TITLE
Use `dict.get(key, default)` instead of an `if` block

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2040,7 +2040,7 @@ class SchemaBranch:
             for item in template.attributes + template.relationships:
                 if item.order_weight:
                     continue
-                item.order_weight = generic_node_weights[item.name] if item.name in generic_node_weights else None
+                item.order_weight = generic_node_weights.get(item.name)
 
             self.set(name=template.kind, schema=template)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -605,7 +605,6 @@ allow-dunder-method-names = [
     "SIM114",   # Combine `if` branches using logical `or` operator
     "SIM117",   # Use a single `with` statement with multiple contexts
     "SIM118",   # Use `key in dict` instead of `key in dict.keys()`
-    "SIM401",   # Use `dict.get(key, default)` instead of an `if` block
     "SLF001",   # Private member accessed
     "TD",       # flake8-todos
     "TID252",   # Replace relative imports from parent modules with absolute imports


### PR DESCRIPTION
Simplify optional dictionary access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified conditional logic in schema weight assignment using more concise dict access pattern.

* **Chores**
  * Updated linting configuration to enforce stricter code style rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->