### PR TITLE
feat: add stale PRs workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -182,3 +182,7 @@
 - name: "cd/preview"
   description: "Deploy preview branch"
   color: "d77e96"
+
+- name: "stale"
+  description: "Marks stale issues and pull requests"
+  color: "ffffff"

--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -1,0 +1,40 @@
+---
+# yamllint disable rule:truthy
+name: "Manage Stale Pull Requests"
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    if: github.repository == 'opsmill/infrahub'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Only manage PRs, not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # PR configuration
+          days-before-pr-stale: 14
+          days-before-pr-close: -1  # Never close
+
+          stale-pr-label: "stale"
+          stale-pr-message: |
+            This PR has been inactive for 2 weeks and has been marked as stale.
+
+            If you're still working on this, please:
+            - Push new commits, or
+            - Leave a comment to indicate this PR is still active
+
+            The stale label will be removed automatically when there's new activity.
+
+          # Remove stale label on activity
+          remove-stale-when-updated: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated stale pull request management: PRs inactive for 14 days are labeled "stale" (with guidance on reactivation); activity removes the label so PRs remain reactivated. The automation runs daily and can be triggered manually. Also added a visible "stale" label for consistent categorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->