### PR TITLE
Prefer `next(...)` over single element slice

### DIFF
--- a/backend/infrahub/core/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/core/diff/enricher/cardinality_one.py
@@ -111,9 +111,9 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
             element_actions = {element.action for element in diff_relationship.relationships}
             # check if this is a simultaneous update
             if len(diff_relationship.relationships) > 1 and {DiffAction.REMOVED, DiffAction.ADDED} <= element_actions:
-                latest_element = [
+                latest_element = next(
                     element for element in diff_relationship.relationships if element.action is DiffAction.ADDED
-                ][0]
+                )
                 consolidated_element_action = DiffAction.UPDATED
             else:
                 latest_element = max(diff_relationship.relationships, key=lambda elem: elem.changed_at)

--- a/backend/infrahub/core/diff/enricher/hierarchy.py
+++ b/backend/infrahub/core/diff/enricher/hierarchy.py
@@ -134,7 +134,7 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
             log.info(f"Beginning parent enrichment for {kind} node, num_nodes={len(node_identifiers)}...")
             schema_node = self.db.schema.get(name=kind, branch=enriched_diff_root.diff_branch_name, duplicate=False)
 
-            parent_rel = [rel for rel in schema_node.relationships if rel.kind == RelationshipKind.PARENT][0]
+            parent_rel = next(rel for rel in schema_node.relationships if rel.kind == RelationshipKind.PARENT)
             parent_schema = self.db.schema.get(
                 name=parent_rel.peer, branch=enriched_diff_root.diff_branch_name, duplicate=False
             )
@@ -169,7 +169,7 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
             schema_node = self.db.schema.get(
                 name=node.kind, branch=enriched_diff_root.diff_branch_name, duplicate=False
             )
-            parent_rel = [rel for rel in schema_node.relationships if rel.kind == RelationshipKind.PARENT][0]
+            parent_rel = next(rel for rel in schema_node.relationships if rel.kind == RelationshipKind.PARENT)
 
             peer_identifier = NodeIdentifier(
                 uuid=str(peer_parent.peer_id), kind=peer_parent.peer_kind, db_id=peer_parent.peer_db_id

--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -257,7 +257,9 @@ class DiffMergeSerializer:
         }
 
     def _get_actions_and_peers(self, relationship_diff: EnrichedDiffSingleRelationship) -> list[tuple[DiffAction, str]]:
-        is_related_prop = [p for p in relationship_diff.properties if p.property_type is DatabaseEdgeType.IS_RELATED][0]
+        is_related_prop = next(
+            p for p in relationship_diff.properties if p.property_type is DatabaseEdgeType.IS_RELATED
+        )
         actions_and_values = self._get_property_actions_and_values(property_diff=is_related_prop, python_value_type=str)
         actions_and_peers: list[tuple[DiffAction, str]] = []
         for action, peer_id in actions_and_values:

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -28,7 +28,7 @@ class CoreNumberPool(Node):
         """Returns the number of excluded values for the attribute of the number pool."""
 
         pool_node = registry.schema.get(name=self.node.value)  # type: ignore [attr-defined]
-        attribute = [attribute for attribute in pool_node.attributes if attribute.name == self.node_attribute.value][0]  # type: ignore [attr-defined]
+        attribute = next(attribute for attribute in pool_node.attributes if attribute.name == self.node_attribute.value)  # type: ignore [attr-defined]
         if not isinstance(attribute.parameters, NumberAttributeParameters):
             return 0
 

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -352,7 +352,7 @@ class InfrahubMutationMixin:
             # Only the HFID constraint has been violated, it means the node exists and we can update without rerunning constraints
             if len(exc.matching_nodes_ids) > 1:
                 raise RuntimeError(f"Multiple {schema_name} nodes have the same hfid") from exc
-            node_id = list(exc.matching_nodes_ids)[0]
+            node_id = next(iter(exc.matching_nodes_ids))
 
             try:
                 node = await NodeManager.get_one(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -592,7 +592,6 @@ allow-dunder-method-names = [
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
-    "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "RUF052",   # Local dummy variable is accessed
     "S101",     # Use of `assert` detected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal code patterns to use Python's `next()` function instead of list indexing, improving efficiency and code style consistency across the codebase.

* **Chores**
  * Updated linting configuration to enforce preferred patterns for element extraction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->