### PR TITLE
Wait for component tests to finish before running coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1296,6 +1296,7 @@ jobs:
   # ------------------------------------------ Coverall Report  ------------------------------------------
   coverall-report:
     needs:
+      - backend-tests-component
       - backend-tests-integration
       - backend-tests-unit
       - frontend-tests


### PR DESCRIPTION
This change simply adds the backend component tests as a dependency of the coverage report CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include additional test prerequisites before generating coverage reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->