### PR TITLE
add SchemaNode/Generic uniqueness constraints and test

### DIFF
--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -225,7 +225,6 @@ base_node_schema = SchemaNode(
     namespace="Schema",
     branch=BranchSupportType.AWARE.value,
     include_in_menu=False,
-    default_filter="name__value",
     display_labels=["label__value"],
     attributes=[
         SchemaAttribute(
@@ -239,7 +238,7 @@ base_node_schema = SchemaNode(
             name="name",
             kind="Text",
             description="Node name, must be unique within a namespace and must start with an uppercase letter.",
-            unique=True,
+            unique=False,
             regex=str(NODE_NAME_REGEX),
             min_length=DEFAULT_NAME_MIN_LENGTH,
             max_length=DEFAULT_NAME_MAX_LENGTH,
@@ -394,8 +393,8 @@ node_schema = SchemaNode(
     namespace="Schema",
     branch=BranchSupportType.AWARE.value,
     include_in_menu=False,
-    default_filter="name__value",
     display_labels=["label__value"],
+    uniqueness_constraints=[["name__value", "namespace__value"]],
     attributes=base_node_schema.attributes
     + [
         SchemaAttribute(
@@ -898,8 +897,8 @@ generic_schema = SchemaNode(
     namespace="Schema",
     branch=BranchSupportType.AWARE.value,
     include_in_menu=False,
-    default_filter="name__value",
     display_labels=["label__value"],
+    uniqueness_constraints=[["name__value", "namespace__value"]],
     attributes=base_node_schema.attributes
     + [
         SchemaAttribute(

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -182,6 +182,7 @@ class SchemaNode(BaseModel):
     display_label: str | None = None
     display_labels: list[str]
     uniqueness_constraints: list[list[str]] | None = None
+    human_friendly_id: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -199,6 +200,7 @@ class SchemaNode(BaseModel):
             "display_label": self.display_label,
             "display_labels": self.display_labels,
             "uniqueness_constraints": self.uniqueness_constraints,
+            "human_friendly_id": self.human_friendly_id,
         }
 
     def without_duplicates(self, other: SchemaNode) -> SchemaNode:
@@ -394,7 +396,8 @@ node_schema = SchemaNode(
     branch=BranchSupportType.AWARE.value,
     include_in_menu=False,
     display_labels=["label__value"],
-    uniqueness_constraints=[["name__value", "namespace__value"]],
+    human_friendly_id=["namespace__value", "name__value"],
+    uniqueness_constraints=[["namespace__value", "name__value"]],
     attributes=base_node_schema.attributes
     + [
         SchemaAttribute(
@@ -898,7 +901,8 @@ generic_schema = SchemaNode(
     branch=BranchSupportType.AWARE.value,
     include_in_menu=False,
     display_labels=["label__value"],
-    uniqueness_constraints=[["name__value", "namespace__value"]],
+    human_friendly_id=["namespace__value", "name__value"],
+    uniqueness_constraints=[["namespace__value", "name__value"]],
     attributes=base_node_schema.attributes
     + [
         SchemaAttribute(

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -86,6 +86,10 @@ class ConstraintValidatorDeterminer:
         schemas = list(self.schema_branch.get_all(duplicate=False).values())
         # added here to check their uniqueness constraints
         with contextlib.suppress(SchemaNotFoundError):
+            schemas.append(self.schema_branch.get_node(name="SchemaNode", duplicate=False))
+        with contextlib.suppress(SchemaNotFoundError):
+            schemas.append(self.schema_branch.get_node(name="SchemaGeneric", duplicate=False))
+        with contextlib.suppress(SchemaNotFoundError):
             schemas.append(self.schema_branch.get_node(name="SchemaAttribute", duplicate=False))
         with contextlib.suppress(SchemaNotFoundError):
             schemas.append(self.schema_branch.get_node(name="SchemaRelationship", duplicate=False))

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -129,8 +129,8 @@ async def test_get_proposed_change_schema_integrity_constraints(
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 230
-    assert len(non_generate_profile_constraints) == 140
+    assert len(constraints) == 236
+    assert len(non_generate_profile_constraints) == 144
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",

--- a/backend/tests/helpers/schema/__init__.py
+++ b/backend/tests/helpers/schema/__init__.py
@@ -33,13 +33,17 @@ SNOW_TICKET_SCHEMA = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW
 
 
 async def load_schema(
-    db: InfrahubDatabase, schema: SchemaRoot, branch_name: str | None = None, update_db: bool = False
+    db: InfrahubDatabase,
+    schema: SchemaRoot,
+    branch_name: str | None = None,
+    update_db: bool = False,
+    limit: list[str] | None = None,
 ) -> None:
     branch_name = branch_name or registry.default_branch
     branch_schema = registry.schema.get_schema_branch(name=branch_name)
     registry.schema.register_schema(schema=schema, branch=branch_name)
     await registry.schema.update_schema_branch(
-        schema=branch_schema.duplicate(), db=db, branch=branch_name, update_db=update_db
+        schema=branch_schema.duplicate(), db=db, branch=branch_name, limit=limit, update_db=update_db
     )
     branch = registry.get_branch_from_registry(branch_name)
     branch.update_schema_hash()

--- a/backend/tests/integration/schema_lifecycle/test_schema_duplicate_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_duplicate_merge.py
@@ -1,0 +1,82 @@
+"""Test that merging a branch fails when the same schema is loaded on both branches."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core import registry
+from infrahub.core.initialization import create_branch
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestSchemaDuplicateMerge(TestInfrahubApp):
+    """Test that loading the same schema on both main and branch causes merge to fail.
+
+    This test verifies the expected behavior when:
+    1. The base schema (internal + core) is initialized
+    2. A branch is created
+    3. A user schema (CAR_SCHEMA) is loaded on the default branch
+    4. The same user schema is loaded on the created branch
+    5. An attempt to merge the branch should fail due to duplicate schema elements
+    """
+
+    async def test_merge_branch_with_duplicate_schema(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        initialize_registry: None,
+    ) -> None:
+        """Attempt to merge the branch - should fail due to duplicate schema elements."""
+        # Create the branch
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        await registry.schema.update_schema_branch(
+            db=db, schema=schema_branch.duplicate(), branch=default_branch.name, update_db=True
+        )
+
+        branch = await create_branch(db=db, branch_name="schema_duplicate_branch")
+
+        # Load CAR_SCHEMA on the default branch
+        await load_schema(
+            db=db,
+            schema=CAR_SCHEMA.duplicate(),
+            branch_name=default_branch.name,
+            limit=[TestKind.CAR, TestKind.MANUFACTURER, TestKind.PERSON],
+            update_db=True,
+        )
+
+        # Load the same CAR_SCHEMA on the branch
+        await load_schema(
+            db=db,
+            schema=CAR_SCHEMA.duplicate(),
+            branch_name=branch.name,
+            limit=[TestKind.CAR, TestKind.MANUFACTURER, TestKind.PERSON],
+            update_db=True,
+        )
+
+        # Attempt to merge - should fail due to duplicate schema elements
+        with pytest.raises(GraphQLError) as excinfo:
+            await client.branch.merge(branch_name=branch.name)
+
+        # Verify the error mentions uniqueness constraint violation on SchemaNode
+        error_message = str(excinfo.value)
+
+        duplicate_schema_uuids = []
+        for schema_kind in [TestKind.CAR, TestKind.MANUFACTURER, TestKind.PERSON]:
+            for branch_name in [default_branch.name, branch.name]:
+                schema = registry.schema.get_node_schema(name=schema_kind, branch=branch_name, duplicate=False)
+                duplicate_schema_uuids.append(schema.get_id())
+
+        assert "constraint violation on schema 'SchemaNode'" in error_message
+        assert all(uuid in error_message for uuid in duplicate_schema_uuids)

--- a/changelog/8221.fixed.md
+++ b/changelog/8221.fixed.md
@@ -1,0 +1,1 @@
+Prevent creating duplicate schemas on branches and merging them into the default branch


### PR DESCRIPTION
fixes #8221 

adds `[name, namespace]` uniqueness constraints to `SchemaNode` and `SchemaGeneric` so that it is not possible to create the same schemas on different branches and merge them. we assume that each `SchemaNode` and `SchemaGeneric` has a unique namespace-name combination, but we have not actually enforced it when merging a branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate schemas could be created on feature branches and unintentionally duplicated when merging back into the default branch.

* **New Features**
  * Enhanced schema node identification with human_friendly_id for improved lookup operations.
  * Implemented composite uniqueness constraints using namespace and name combinations to ensure schema uniqueness across branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->