### PR TITLE
Closes #8229: Updated shift-click handling of node lists to be the same for select and deselect

### DIFF
--- a/changelog/8229.fixed.md
+++ b/changelog/8229.fixed.md
@@ -1,0 +1,1 @@
+Shift-click range selection now anchors to the last clicked row, with added e2e coverage for range toggling.

--- a/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-toggle-selected-row-handler.ts
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-toggle-selected-row-handler.ts
@@ -3,6 +3,8 @@ import type { PressEvent } from "react-aria-components";
 
 import type { NodeCore } from "@/entities/nodes/types";
 
+const lastSelectedIndexByTable = new WeakMap<object, number>();
+
 export function getToggleSelectedRowHandler<T extends NodeCore>({
   row,
   table,
@@ -10,19 +12,19 @@ export function getToggleSelectedRowHandler<T extends NodeCore>({
   return (e: PressEvent): void => {
     if (!e.shiftKey) {
       row.toggleSelected();
+      lastSelectedIndexByTable.set(table, row.index);
       return;
     }
 
-    const selectedRows = table.getSelectedRowModel().flatRows;
-    const lastSelectedRow = selectedRows.at(-1);
+    const lastSelectedRowIndex = lastSelectedIndexByTable.get(table);
 
-    if (!lastSelectedRow) {
+    if (lastSelectedRowIndex === undefined) {
       row.toggleSelected();
+      lastSelectedIndexByTable.set(table, row.index);
       return;
     }
 
     const currentRowIndex = row.index;
-    const lastSelectedRowIndex = lastSelectedRow.index;
 
     const start = Math.min(currentRowIndex, lastSelectedRowIndex);
     const end = Math.max(currentRowIndex, lastSelectedRowIndex);
@@ -30,5 +32,6 @@ export function getToggleSelectedRowHandler<T extends NodeCore>({
     const rowsToToggle = table.getRowModel().flatRows.slice(start, end + 1);
     const isCellSelected = row.getIsSelected();
     rowsToToggle.forEach((row) => row.toggleSelected(!isCellSelected));
+    lastSelectedIndexByTable.set(table, row.index);
   };
 }

--- a/frontend/app/tests/e2e/objects/list/object-list-select-range.spec.ts
+++ b/frontend/app/tests/e2e/objects/list/object-list-select-range.spec.ts
@@ -103,4 +103,89 @@ test.describe("/objects/:objectKind - Bulk edit some rows", () => {
     await expect(page.getByTestId("identifier-checkbox-cell").nth(4)).not.toBeChecked();
     await expect(page.getByTestId("identifier-checkbox-cell").nth(5)).not.toBeChecked();
   });
+
+  test("should deselect range forward when shift-clicking a selected row", async ({ page }) => {
+    await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+    await page.getByTestId("identifier-checkbox-cell").nth(1).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(4)
+      .click({ modifiers: ["Shift"] });
+
+    await page.getByTestId("identifier-checkbox-cell").nth(1).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(3)
+      .click({ modifiers: ["Shift"] });
+
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(0)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(1)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(2)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(3)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(4)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(5)).not.toBeChecked();
+  });
+
+  test("should deselect range backward when shift-clicking a selected row", async ({ page }) => {
+    await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+    await page.getByTestId("identifier-checkbox-cell").nth(1).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(4)
+      .click({ modifiers: ["Shift"] });
+
+    await page.getByTestId("identifier-checkbox-cell").nth(3).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(1)
+      .click({ modifiers: ["Shift"] });
+
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(0)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(1)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(2)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(3)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(4)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(5)).not.toBeChecked();
+  });
+
+  test("should reset anchor after selecting all rows", async ({ page }) => {
+    await page.goto(`/objects/BuiltinTag?branch=${BRANCH_NAME}`);
+    await expect(page.getByTestId("identifier-checkbox-cell")).toHaveCount(3);
+    await page.getByTestId("select-all-rows").click();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(0)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(1)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(2)).toBeChecked();
+
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(1)
+      .click({ modifiers: ["Shift"] });
+
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(0)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(1)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(2)).toBeChecked();
+  });
+
+  test("should use last click as shift-click anchor", async ({ page }) => {
+    await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+    await page.getByTestId("identifier-checkbox-cell").nth(6).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(2)
+      .click({ modifiers: ["Shift"] });
+
+    await page.getByTestId("identifier-checkbox-cell").nth(4).click();
+    await page
+      .getByTestId("identifier-checkbox-cell")
+      .nth(3)
+      .click({ modifiers: ["Shift"] });
+
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(0)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(1)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(2)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(3)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(4)).not.toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(5)).toBeChecked();
+    await expect(page.getByTestId("identifier-checkbox-cell").nth(6)).toBeChecked();
+  });
 });


### PR DESCRIPTION
Closes #8229 

Updated shift-click handling so that de-selecting a some or all of a selected range behaved as expected.

## Before
![infrahub_shiftclick_before_optimized](https://github.com/user-attachments/assets/b10e3799-4e81-418b-8500-d2325e866586)

## After
![infrahub_shiftclick_after_optimized](https://github.com/user-attachments/assets/4ed77d9b-1783-4c5d-b8e4-fd095fb2cd55)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shift-click range selection behavior in tables to correctly anchor to the last clicked row, improving consistency across forward and backward range selections.

* **Tests**
  * Added end-to-end test coverage for shift-click range selection and toggling, validating behavior across multiple scenarios and object types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->