### PR TITLE
set PC ID on diff even if locks collide

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -440,7 +440,7 @@ class DiffCombiner:
                     to_time=later.to_time,
                     tracking_id=later.tracking_id,
                     nodes=combined_nodes,
-                    proposed_change_id=later.proposed_change_id,
+                    proposed_change_id=earlier.proposed_change_id,
                 )
             )
         base_branch_diff, diff_branch_diff = combined_diffs

--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -440,7 +440,7 @@ class DiffCombiner:
                     to_time=later.to_time,
                     tracking_id=later.tracking_id,
                     nodes=combined_nodes,
-                    proposed_change_id=earlier.proposed_change_id,
+                    proposed_change_id=later.proposed_change_id or earlier.proposed_change_id,
                 )
             )
         base_branch_diff, diff_branch_diff = combined_diffs

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -212,6 +212,10 @@ class DiffCoordinator:
                 force_branch_refresh=False,
             )
 
+            # should never have a proposed change id for an arbitrary diff
+            enriched_diffs.diff_branch_diff.proposed_change_id = None
+            enriched_diffs.base_branch_diff.proposed_change_id = None
+
             await self.diff_repo.save(
                 enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Iterable, Literal, Sequence, overload
 from uuid import uuid4
 
@@ -234,10 +234,12 @@ class DiffCoordinator:
         ):
             log.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
             # Log current diff roots to help debug race conditions
-            current_roots = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+            current_roots = await self.diff_repo.get_roots_metadata(
+                diff_branch_names=[diff_branch.name], exclude_merged=False
+            )
             log.error(
                 f"DiffCoordinator.recalculate for diff_id={diff_id}: current diff roots for branch {diff_branch.name}: "
-                f"{[(dr.uuid, dr.tracking_id.serialize() if dr.tracking_id else None) for dr in current_roots]}"
+                f"{[asdict(dr) for dr in current_roots]}"
             )
             current_branch_diff = await self.diff_repo.get_one(diff_branch_name=diff_branch.name, diff_id=diff_id)
             current_base_diff = await self.diff_repo.get_one(

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable, Literal, Sequence, overload
 from uuid import uuid4
 
@@ -233,14 +233,6 @@ class DiffCoordinator:
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
         ):
             log.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
-            # Log current diff roots to help debug race conditions
-            current_roots = await self.diff_repo.get_roots_metadata(
-                diff_branch_names=[diff_branch.name], exclude_merged=False
-            )
-            log.error(
-                f"DiffCoordinator.recalculate for diff_id={diff_id}: current diff roots for branch {diff_branch.name}: "
-                f"{[asdict(dr) for dr in current_roots]}"
-            )
             current_branch_diff = await self.diff_repo.get_one(diff_branch_name=diff_branch.name, diff_id=diff_id)
             current_base_diff = await self.diff_repo.get_one(
                 diff_branch_name=base_branch.name, diff_id=current_branch_diff.partner_uuid

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -233,6 +233,12 @@ class DiffCoordinator:
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
         ):
             log.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
+            # Log current diff roots to help debug race conditions
+            current_roots = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+            log.error(
+                f"DiffCoordinator.recalculate for diff_id={diff_id}: current diff roots for branch {diff_branch.name}: "
+                f"{[(dr.uuid, dr.tracking_id.serialize() if dr.tracking_id else None) for dr in current_roots]}"
+            )
             current_branch_diff = await self.diff_repo.get_one(diff_branch_name=diff_branch.name, diff_id=diff_id)
             current_base_diff = await self.diff_repo.get_one(
                 diff_branch_name=base_branch.name, diff_id=current_branch_diff.partner_uuid

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -118,18 +118,19 @@ class DiffCoordinator:
 
     async def _link_diff_to_proposed_change(
         self, diff_root: EnrichedDiffRootMetadata, proposed_change_id: str | None
-    ) -> EnrichedDiffRootMetadata:
+    ) -> None:
         """Link a diff root to a proposed change if needed.
 
         Updates the database link and the in-memory object's proposed_change_id.
         """
-        if proposed_change_id and diff_root.proposed_change_id != proposed_change_id:
+        if not proposed_change_id:
+            return
+        if diff_root.proposed_change_id != proposed_change_id:
             diff_uuids = [diff_root.uuid]
             if diff_root.partner_uuid:
                 diff_uuids.append(diff_root.partner_uuid)
             await self.diff_repo.link_to_proposed_change(diff_uuids=diff_uuids, proposed_change_id=proposed_change_id)
         diff_root.proposed_change_id = proposed_change_id
-        return diff_root
 
     async def update_branch_diff(
         self, base_branch: Branch, diff_branch: Branch, proposed_change_id: str | None = None
@@ -146,9 +147,8 @@ class DiffCoordinator:
             ):
                 log.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
-                return await self._link_diff_to_proposed_change(
-                    diff_root=diff_root, proposed_change_id=proposed_change_id
-                )
+                await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+                return diff_root
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
         async with (
@@ -165,9 +165,8 @@ class DiffCoordinator:
                     f"Branch {diff_branch.name} was merged or rebased while waiting for lock, returning latest diff"
                 )
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
-                return await self._link_diff_to_proposed_change(
-                    diff_root=diff_root, proposed_change_id=proposed_change_id
-                )
+                await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+                return diff_root
             log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -116,6 +116,21 @@ class DiffCoordinator:
             name=name,
         )
 
+    async def _link_diff_to_proposed_change(
+        self, diff_root: EnrichedDiffRootMetadata, proposed_change_id: str | None
+    ) -> EnrichedDiffRootMetadata:
+        """Link a diff root to a proposed change if needed.
+
+        Updates the database link and the in-memory object's proposed_change_id.
+        """
+        if proposed_change_id and diff_root.proposed_change_id != proposed_change_id:
+            diff_uuids = [diff_root.uuid]
+            if diff_root.partner_uuid:
+                diff_uuids.append(diff_root.partner_uuid)
+            await self.diff_repo.link_to_proposed_change(diff_uuids=diff_uuids, proposed_change_id=proposed_change_id)
+        diff_root.proposed_change_id = proposed_change_id
+        return diff_root
+
     async def update_branch_diff(
         self, base_branch: Branch, diff_branch: Branch, proposed_change_id: str | None = None
     ) -> EnrichedDiffRootMetadata:
@@ -130,7 +145,10 @@ class DiffCoordinator:
                 target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
             ):
                 log.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
-                return await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
+                diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
+                return await self._link_diff_to_proposed_change(
+                    diff_root=diff_root, proposed_change_id=proposed_change_id
+                )
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
         async with (
@@ -146,7 +164,10 @@ class DiffCoordinator:
                 log.info(
                     f"Branch {diff_branch.name} was merged or rebased while waiting for lock, returning latest diff"
                 )
-                return await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
+                diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
+                return await self._link_diff_to_proposed_change(
+                    diff_root=diff_root, proposed_change_id=proposed_change_id
+                )
             log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,

--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -7,8 +7,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import SchemaNotFoundError
-from infrahub.proposed_change.constants import ProposedChangeState
 
 from .conflicts_extractor import DiffConflictsExtractor
 from .model.diff import DataConflict
@@ -50,60 +48,54 @@ class DiffDataCheckSynchronizer:
     async def synchronize(self, enriched_diff: EnrichedDiffRoot | EnrichedDiffRootMetadata) -> list[Node]:
         self._enriched_conflicts_map = None
         self._data_conflicts = None
-        try:
-            proposed_changes = await NodeManager.query(
-                db=self.db,
-                schema=CoreProposedChange,
-                filters={"source_branch": enriched_diff.diff_branch_name, "state": ProposedChangeState.OPEN},
-            )
-        except SchemaNotFoundError:
-            # if the CoreProposedChange schema does not exist, then there's nothing to do
-            proposed_changes = []
-        if not proposed_changes:
+        if not enriched_diff.proposed_change_id:
             return []
+        pc = await NodeManager.get_one(db=self.db, kind=CoreProposedChange, id=enriched_diff.proposed_change_id)
+        if not pc:
+            return []
+
         all_data_checks = []
         enriched_diff_all_conflicts: EnrichedDiffRoot | None = None
-        for pc in proposed_changes:
-            # if the enriched_diff is EnrichedDiffRootMetadata, then it has no new data in it
-            if not isinstance(enriched_diff, EnrichedDiffRoot):
-                has_validator = bool(await self.conflict_recorder.get_validator(proposed_change=pc))
-                # if this pc has a validator, then the conflicts for this diff have already been synchronized and we can be done
-                if has_validator:
-                    continue
+        # if the enriched_diff is EnrichedDiffRootMetadata, then it has no new data in it
+        if not isinstance(enriched_diff, EnrichedDiffRoot):
+            has_validator = bool(await self.conflict_recorder.get_validator(proposed_change=pc))
+            # if this pc has a validator, then the conflicts for this diff have already been synchronized and we can be done
+            if has_validator:
+                return []
 
-            # we need to get the conflicts for this diff from the database b/c `enriched_diff` might not include all nodes
-            if not enriched_diff_all_conflicts:
-                retrieved_diff_conflicts_only = await self.diff_repository.get_one(
-                    diff_branch_name=enriched_diff.diff_branch_name,
-                    diff_id=enriched_diff.uuid,
-                    filters=EnrichedDiffQueryFilters(only_conflicted=True),
-                )
-                enriched_diff_all_conflicts = retrieved_diff_conflicts_only
-                # if `enriched_diff` is an EnrichedDiffRootsMetadata, then there have been no changes to the diff and
-                # we can use `retrieved_diff_conflicts_only`
-                # otherwise, we need to combine the changes to `enriched_diff` with the conflicts from the database
-                if isinstance(enriched_diff, EnrichedDiffRoot):
-                    self._update_diff_conflicts(updated_diff=enriched_diff, retrieved_diff=enriched_diff_all_conflicts)
-
-            data_conflicts = await self._get_data_conflicts(enriched_diff=enriched_diff_all_conflicts)
-            enriched_conflicts_map = self._get_enriched_conflicts_map(enriched_diff=enriched_diff_all_conflicts)
-            core_data_checks = await self.conflict_recorder.record_conflicts(
-                proposed_change_id=pc.get_id(), conflicts=data_conflicts
+        # we need to get the conflicts for this diff from the database b/c `enriched_diff` might not include all nodes
+        if not enriched_diff_all_conflicts:
+            retrieved_diff_conflicts_only = await self.diff_repository.get_one(
+                diff_branch_name=enriched_diff.diff_branch_name,
+                diff_id=enriched_diff.uuid,
+                filters=EnrichedDiffQueryFilters(only_conflicted=True),
             )
-            all_data_checks.extend(core_data_checks)
-            core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}  # type: ignore[attr-defined]
-            enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts_map.values()}
-            for conflict_id, core_data_check in core_data_checks_by_id.items():
-                enriched_conflict = enriched_conflicts_by_id.get(conflict_id)
-                if not enriched_conflict:
-                    continue
-                expected_keep_branch = self._get_keep_branch_for_enriched_conflict(enriched_conflict=enriched_conflict)
-                expected_keep_branch_value = (
-                    expected_keep_branch.value if isinstance(expected_keep_branch, Enum) else expected_keep_branch
-                )
-                if core_data_check.keep_branch.value != expected_keep_branch_value:  # type: ignore[attr-defined]
-                    core_data_check.keep_branch.value = expected_keep_branch_value  # type: ignore[attr-defined]
-                    await core_data_check.save(db=self.db)
+            enriched_diff_all_conflicts = retrieved_diff_conflicts_only
+            # if `enriched_diff` is an EnrichedDiffRootsMetadata, then there have been no changes to the diff and
+            # we can use `retrieved_diff_conflicts_only`
+            # otherwise, we need to combine the changes to `enriched_diff` with the conflicts from the database
+            if isinstance(enriched_diff, EnrichedDiffRoot):
+                self._update_diff_conflicts(updated_diff=enriched_diff, retrieved_diff=enriched_diff_all_conflicts)
+
+        data_conflicts = await self._get_data_conflicts(enriched_diff=enriched_diff_all_conflicts)
+        enriched_conflicts_map = self._get_enriched_conflicts_map(enriched_diff=enriched_diff_all_conflicts)
+        core_data_checks = await self.conflict_recorder.record_conflicts(
+            proposed_change_id=pc.get_id(), conflicts=data_conflicts
+        )
+        all_data_checks.extend(core_data_checks)
+        core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}  # type: ignore[attr-defined]
+        enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts_map.values()}
+        for conflict_id, core_data_check in core_data_checks_by_id.items():
+            enriched_conflict = enriched_conflicts_by_id.get(conflict_id)
+            if not enriched_conflict:
+                continue
+            expected_keep_branch = self._get_keep_branch_for_enriched_conflict(enriched_conflict=enriched_conflict)
+            expected_keep_branch_value = (
+                expected_keep_branch.value if isinstance(expected_keep_branch, Enum) else expected_keep_branch
+            )
+            if core_data_check.keep_branch.value != expected_keep_branch_value:  # type: ignore[attr-defined]
+                core_data_check.keep_branch.value = expected_keep_branch_value  # type: ignore[attr-defined]
+                await core_data_check.save(db=self.db)
         return all_data_checks
 
     def _get_keep_branch_for_enriched_conflict(

--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -52,7 +52,8 @@ class DiffDataCheckSynchronizer:
         if not enriched_diff.proposed_change_id:
             return []
         pc = await NodeManager.get_one(db=self.db, kind=CoreProposedChange, id=enriched_diff.proposed_change_id)
-        if not pc or pc.state.value != ProposedChangeState.OPEN:
+
+        if not pc or pc.state.value.value != ProposedChangeState.OPEN.value:
             return []
 
         all_data_checks = []

--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -7,6 +7,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange
 from infrahub.database import InfrahubDatabase
+from infrahub.proposed_change.constants import ProposedChangeState
 
 from .conflicts_extractor import DiffConflictsExtractor
 from .model.diff import DataConflict
@@ -51,7 +52,7 @@ class DiffDataCheckSynchronizer:
         if not enriched_diff.proposed_change_id:
             return []
         pc = await NodeManager.get_one(db=self.db, kind=CoreProposedChange, id=enriched_diff.proposed_change_id)
-        if not pc:
+        if not pc or pc.state.value != ProposedChangeState.OPEN:
             return []
 
         all_data_checks = []

--- a/backend/infrahub/core/diff/query/delete_query.py
+++ b/backend/infrahub/core/diff/query/delete_query.py
@@ -22,7 +22,7 @@ class EnrichedDiffDeleteQuery(Query):
         query = """
 MATCH (d_root:DiffRoot)
 %(diff_filter)s
-OPTIONAL MATCH (d_root)-[*]->(diff_thing)
+OPTIONAL MATCH (d_root)-[*]->(diff_thing:DiffRoot|DiffNode|DiffAttribute|DiffRelationship|DiffRelationshipElement|DiffProperty|DiffConflict)
 WITH DISTINCT d_root, diff_thing
 ORDER BY elementId(diff_thing)
 CALL (diff_thing) {

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+
 from prefect import flow
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
@@ -69,7 +71,7 @@ async def refresh_diff_all(branch_name: str, context: InfrahubContext) -> None:
 
         log.error(
             f"DIFF_REFRESH_ALL for branch {branch_name}: found {len(diff_roots_to_refresh)} diff roots: "
-            f"{[(dr.uuid, dr.tracking_id.serialize() if dr.tracking_id else None) for dr in diff_roots_to_refresh]}"
+            f"{[asdict(dr) for dr in diff_roots_to_refresh]}"
         )
 
         for diff_root in diff_roots_to_refresh:

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import asdict
-
 from prefect import flow
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
@@ -68,11 +66,6 @@ async def refresh_diff_all(branch_name: str, context: InfrahubContext) -> None:
         default_branch = registry.get_branch_from_registry()
         diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
         diff_roots_to_refresh = await diff_repository.get_roots_metadata(diff_branch_names=[branch_name])
-
-        log.error(
-            f"DIFF_REFRESH_ALL for branch {branch_name}: found {len(diff_roots_to_refresh)} diff roots: "
-            f"{[asdict(dr) for dr in diff_roots_to_refresh]}"
-        )
 
         for diff_root in diff_roots_to_refresh:
             if diff_root.base_branch_name != diff_root.diff_branch_name:

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -67,6 +67,11 @@ async def refresh_diff_all(branch_name: str, context: InfrahubContext) -> None:
         diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
         diff_roots_to_refresh = await diff_repository.get_roots_metadata(diff_branch_names=[branch_name])
 
+        log.error(
+            f"DIFF_REFRESH_ALL for branch {branch_name}: found {len(diff_roots_to_refresh)} diff roots: "
+            f"{[(dr.uuid, dr.tracking_id.serialize() if dr.tracking_id else None) for dr in diff_roots_to_refresh]}"
+        )
+
         for diff_root in diff_roots_to_refresh:
             if diff_root.base_branch_name != diff_root.diff_branch_name:
                 await get_workflow().submit_workflow(

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -446,6 +446,24 @@ class TestDiffCoordinator:
         for metadata in retrieved_metadata:
             assert metadata.proposed_change_id == proposed_change_id
 
+        # make another change on the branch
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        # update the diff w/ no proposed_change_id
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        # make sure the proposed_change_id sticks
+        assert diff_metadata.proposed_change_id == proposed_change_id
+        retrieved_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[branch.name, default_branch.name],
+            proposed_change_id=proposed_change_id,
+        )
+        assert len(retrieved_metadata) == 2  # base and diff branch roots
+        for metadata in retrieved_metadata:
+            assert metadata.proposed_change_id == proposed_change_id
+
     async def test_proposed_change_preserved_during_incremental_diff_update(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
     ) -> None:

--- a/backend/tests/component/core/diff/test_coordinator_lock.py
+++ b/backend/tests/component/core/diff/test_coordinator_lock.py
@@ -266,3 +266,42 @@ class TestDiffCoordinatorLocks:
         assert results[0].uuid == results[1].uuid
         assert results[0].partner_uuid == results[1].partner_uuid
         assert results[0].tracking_id == results[1].tracking_id
+
+    async def test_proposed_change_linked_when_waiting_for_lock(
+        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
+    ) -> None:
+        """Test that when a diff update with proposed_change_id waits for an in-progress update,
+        the proposed change still gets linked to the diff.
+
+        This tests the race condition scenario:
+        1. Request A starts diff update (acquires lock)
+        2. Request B starts diff update with proposed_change_id, detects lock is held, waits
+        3. Request A completes and releases lock
+        4. Request B should link the proposed_change to the cached diff
+        """
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        # Create a mock proposed change node in the database
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        # Run two concurrent updates - one without proposed_change_id, one with
+        results = await asyncio.gather(
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+            diff_coordinator.update_branch_diff(
+                base_branch=default_branch, diff_branch=diff_branch, proposed_change_id=proposed_change_id
+            ),
+        )
+
+        # Both should return the same diff
+        assert len(results) == 2
+        assert results[0].uuid == results[1].uuid
+        assert results[1].proposed_change_id == proposed_change_id
+
+        # Verify via diff_repository.get_roots_metadata that the diff is linked to the proposed change
+        metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[diff_branch.name], proposed_change_id=proposed_change_id
+        )
+        diff_uuids = {m.uuid for m in metadata}
+        assert results[0].uuid in diff_uuids, "Diff should be retrievable by proposed_change_id"

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -9,26 +9,18 @@ import pytest
 
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.models import Branch
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind
 from infrahub.core.convert_object_type.object_conversion import ConversionFieldInput, ConversionFieldValue
-from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.core.query.delete import DeleteAfterTimeQuery
 from infrahub.core.timestamp import Timestamp
-from infrahub.dependencies.registry import get_component_registry
 from infrahub.git import InfrahubReadOnlyRepository, InfrahubRepository
 from tests.constants.kind import PERSON
-from tests.helpers.test_app import TestInfrahubApp
-
-if TYPE_CHECKING:
-    from infrahub_sdk import InfrahubClient
-
-from typing import TYPE_CHECKING
-
-from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind
-from infrahub.core.manager import NodeManager
+from tests.helpers.db_reset import DatabaseResetter
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -128,12 +120,9 @@ class TestConvertRepository(TestInfrahubApp):
         await people.new(db=db, name="people", members=[john])
         await people.save(db=db)
 
-    async def reset_to_time(self, db: InfrahubDatabase, default_branch: Branch, reset_time: Timestamp):
-        component_registry = get_component_registry()
-        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
-        await diff_repository.delete_all_diff_roots()
-        query_delete = await DeleteAfterTimeQuery.init(db=db, timestamp=reset_time)
-        await query_delete.execute(db=db)
+    async def reset_to_time(self, db: InfrahubDatabase, reset_time: Timestamp):
+        db_resetter = DatabaseResetter(db=db)
+        await db_resetter.reset_to_time(reset_time=reset_time)
 
     async def test_convert_repo_to_read_only(
         self,
@@ -271,7 +260,7 @@ class TestConvertRepository(TestInfrahubApp):
             original_commit=repository.commit.value,
         )
 
-        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
+        await self.reset_to_time(db=db, reset_time=start_time)
 
     async def test_convert_read_only_to_read_write(
         self,
@@ -405,7 +394,7 @@ class TestConvertRepository(TestInfrahubApp):
             original_commit=repository.commit.value,
         )
 
-        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
+        await self.reset_to_time(db=db, reset_time=start_time)
 
     async def _validate_rebase(
         self, branch_name: str, client: InfrahubClient, db: InfrahubDatabase, new_repo_id: str, original_commit: str
@@ -542,7 +531,7 @@ class TestConvertRepository(TestInfrahubApp):
             original_commit=repository.commit.value,
         )
 
-        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
+        await self.reset_to_time(db=db, reset_time=start_time)
 
     async def _validate_repo_groups(self, db: InfrahubDatabase, repository: CoreGenericRepository):
         # Make sure old repository groups has been deleted

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -10,10 +10,12 @@ import pytest
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.models import Branch
 from infrahub.core.convert_object_type.object_conversion import ConversionFieldInput, ConversionFieldValue
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.query.delete import DeleteAfterTimeQuery
 from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.git import InfrahubReadOnlyRepository, InfrahubRepository
 from tests.constants.kind import PERSON
 from tests.helpers.test_app import TestInfrahubApp
@@ -126,6 +128,13 @@ class TestConvertRepository(TestInfrahubApp):
         await people.new(db=db, name="people", members=[john])
         await people.save(db=db)
 
+    async def reset_to_time(self, db: InfrahubDatabase, default_branch: Branch, reset_time: Timestamp):
+        component_registry = get_component_registry()
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+        await diff_repository.delete_all_diff_roots()
+        query_delete = await DeleteAfterTimeQuery.init(db=db, timestamp=reset_time)
+        await query_delete.execute(db=db)
+
     async def test_convert_repo_to_read_only(
         self,
         client: InfrahubClient,
@@ -187,12 +196,12 @@ class TestConvertRepository(TestInfrahubApp):
 
         # We want to test unidirectional relationship coming from validators towards a repository,
         # so we create a proposed change that would create validators attached to this repo.
-        branch_2_name = "branch_2"
-        _ = await create_branch(branch_name=branch_2_name, db=db)
+        branch_name = "branch_2"
+        _ = await create_branch(branch_name=branch_name, db=db)
         await self._create_proposed_change_and_wait_for_validators(
             repository_id=repository.id,
             client=client,
-            source_branch=branch_2_name,
+            source_branch=branch_name,
             target_branch=default_branch.name,
             db=db,
         )
@@ -252,20 +261,17 @@ class TestConvertRepository(TestInfrahubApp):
 
         await self._validate_repo_groups(db=db, repository=repository)
 
-        await self._validate_branches_status(
-            db=db, branch_2_name=branch_2_name, default_branch_name=default_branch.name
-        )
+        await self._validate_branches_status(db=db, branch_2_name=branch_name, default_branch_name=default_branch.name)
 
         await self._validate_rebase(
-            branch_name=branch_2_name,
+            branch_name=branch_name,
             client=client,
             db=db,
             new_repo_id=new_repo_id,
             original_commit=repository.commit.value,
         )
 
-        query_delete = await DeleteAfterTimeQuery.init(db=db, timestamp=start_time)
-        await query_delete.execute(db=db)
+        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
 
     async def test_convert_read_only_to_read_write(
         self,
@@ -333,12 +339,12 @@ class TestConvertRepository(TestInfrahubApp):
 
         # We want to test unidirectional relationship coming from validators towards a repository,
         # so we create a proposed change that would create validators attached to this repo.
-        branch_2_name = "branch_2"
-        _ = await create_branch(branch_name=branch_2_name, db=db)
+        branch_name = "branch_3"
+        _ = await create_branch(branch_name=branch_name, db=db)
         await self._create_proposed_change_and_wait_for_validators(
             repository_id=repository.id,
             client=client,
-            source_branch=branch_2_name,
+            source_branch=branch_name,
             target_branch=default_branch.name,
             db=db,
         )
@@ -389,20 +395,17 @@ class TestConvertRepository(TestInfrahubApp):
 
         await self._validate_repo_groups(db=db, repository=repository)
 
-        await self._validate_branches_status(
-            db=db, branch_2_name=branch_2_name, default_branch_name=default_branch.name
-        )
+        await self._validate_branches_status(db=db, branch_2_name=branch_name, default_branch_name=default_branch.name)
 
         await self._validate_rebase(
-            branch_name=branch_2_name,
+            branch_name=branch_name,
             client=client,
             db=db,
             new_repo_id=new_repo_id,
             original_commit=repository.commit.value,
         )
 
-        query_delete = await DeleteAfterTimeQuery.init(db=db, timestamp=start_time)
-        await query_delete.execute(db=db)
+        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
 
     async def _validate_rebase(
         self, branch_name: str, client: InfrahubClient, db: InfrahubDatabase, new_repo_id: str, original_commit: str
@@ -465,8 +468,8 @@ class TestConvertRepository(TestInfrahubApp):
             }
         }
 
-        branch_2_name = "branch_test"
-        _ = await create_branch(branch_name=branch_2_name, db=db)
+        branch_name = "branch_4"
+        _ = await create_branch(branch_name=branch_name, db=db)
 
         with patch("infrahub.git.tasks.lock"):
             client_repository = await client.create(
@@ -529,20 +532,17 @@ class TestConvertRepository(TestInfrahubApp):
 
         await self._validate_repo_groups(db=db, repository=repository)
 
-        await self._validate_branches_status(
-            db=db, branch_2_name=branch_2_name, default_branch_name=default_branch.name
-        )
+        await self._validate_branches_status(db=db, branch_2_name=branch_name, default_branch_name=default_branch.name)
 
         await self._validate_rebase(
-            branch_name=branch_2_name,
+            branch_name=branch_name,
             client=client,
             db=db,
             new_repo_id=new_repo_id,
             original_commit=repository.commit.value,
         )
 
-        query_delete = await DeleteAfterTimeQuery.init(db=db, timestamp=start_time)
-        await query_delete.execute(db=db)
+        await self.reset_to_time(db=db, default_branch=default_branch, reset_time=start_time)
 
     async def _validate_repo_groups(self, db: InfrahubDatabase, repository: CoreGenericRepository):
         # Make sure old repository groups has been deleted

--- a/backend/tests/helpers/db_reset.py
+++ b/backend/tests/helpers/db_reset.py
@@ -1,0 +1,28 @@
+from infrahub.core import registry
+from infrahub.core.branch.models import Branch
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.query.delete import DeleteAfterTimeQuery
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+class DatabaseResetter:
+    def __init__(self, db: InfrahubDatabase) -> None:
+        self.db = db
+
+    async def get_diff_repository(self) -> DiffRepository:
+        default_branch = await Branch.get_by_name(db=self.db, name=registry.default_branch)
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=self.db, branch=default_branch)
+
+    async def reset_to_time(self, reset_time: Timestamp) -> None:
+        # delete any diff that covers a time period after the to_time
+        diff_repository = await self.get_diff_repository()
+        all_diff_metadatas = await diff_repository.get_roots_metadata(exclude_merged=False)
+        diff_uuids_to_delete = [d.uuid for d in all_diff_metadatas if d.to_time > reset_time]
+        await diff_repository.delete_diff_roots(diff_uuids_to_delete)
+
+        # remove any changes from the database after the to_time
+        query_delete = await DeleteAfterTimeQuery.init(db=self.db, timestamp=reset_time)
+        await query_delete.execute(db=self.db)


### PR DESCRIPTION
if 2 different requests to update a diff come in at the same-ish time, the later request waits for the earlier request to complete and then just returns the diff generated by the earlier request.

this won't work correctly in the case where the earlier request does not include a proposed change ID (b/c it came from the branch view of the UI) and the later request _does_ include a proposed change ID (b/c it came from the PC view). in this case, we need the second diff request to link the diff to the correct proposed change, which is what this PR does

also
- cleans up a test that was not resetting data correctly: `test_convert_repositories.py`
- simplifies `DiffDataCheckSynchronizer.synchronize` now that we have a direct link from diff to proposed change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure proposed-change IDs stay linked to diffs across concurrent updates, lock waits, and subsequent branch mutations.
  * Narrow deletion targets to avoid removing unrelated nodes and reduce unnecessary conflict/check updates; limit redundant writes.

* **Tests**
  * Added tests covering proposed-change linkage during lock contention and across branch mutations.
  * Updated tests to use a time-reset helper for more reliable state setup.

* **Chores**
  * Added a test database reset utility to restore state to a given point in time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->