### PR TITLE
fix(frontend): use variables for graphql pagination

### DIFF
--- a/frontend/app/src/entities/ipam/ip-addresses/api/get-ip-address-list-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/api/get-ip-address-list-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import {
@@ -22,20 +22,22 @@ export interface GetIpAddressListGraphQLQueryParams extends PaginationParams {
 }
 
 export function getIpAddressListWithAvailabilityGraphQLQuery({
-  limit,
-  offset,
   filters,
   objectKind,
   attributes,
   relationships,
-}: GetIpAddressListGraphQLQueryParams) {
+}: Omit<GetIpAddressListGraphQLQueryParams, "limit" | "offset">) {
   return jsonToGraphQLQuery({
     query: {
       __name: `GetObjects${objectKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [IP_ADDRESS_GENERIC]: {
         __args: {
-          limit,
-          offset,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
           include_available: true,
           ...(objectKind !== IP_ADDRESS_GENERIC ? { kinds: [objectKind] } : {}),
           ...(filters ? addFiltersToRequest(filters) : {}),
@@ -72,22 +74,24 @@ export function getIpAddressListWithAvailabilityGraphQLQuery({
 }
 
 export function getIpAddressListWithoutAvailabilityGraphQLQuery({
-  limit,
-  offset,
   filters,
   objectKind,
   attributes,
   relationships,
-}: GetIpAddressListGraphQLQueryParams) {
+}: Omit<GetIpAddressListGraphQLQueryParams, "limit" | "offset">) {
   const cleanedFilters = dropIncludeAvailableWhenFalse(filters);
 
   return jsonToGraphQLQuery({
     query: {
       __name: `GetObjects${objectKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [objectKind]: {
         __args: {
-          limit,
-          offset,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
           ...(cleanedFilters?.length ? addFiltersToRequest(cleanedFilters) : {}),
         },
         edges: {
@@ -111,12 +115,15 @@ export interface getIpAddressListFromApiParams
 export function getIpAddressListWithAvailabilityFromApi({
   branchName,
   atDate,
+  limit,
+  offset,
   ...params
 }: getIpAddressListFromApiParams) {
   const graphqlQuery = getIpAddressListWithAvailabilityGraphQLQuery(params);
 
   return graphqlClient.query({
     query: gql(graphqlQuery),
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,
@@ -127,12 +134,15 @@ export function getIpAddressListWithAvailabilityFromApi({
 export function getIpAddressListWithoutAvailabilityFromApi({
   branchName,
   atDate,
+  limit,
+  offset,
   ...params
 }: getIpAddressListFromApiParams) {
   const graphqlQuery = getIpAddressListWithoutAvailabilityGraphQLQuery(params);
 
   return graphqlClient.query({
     query: gql(graphqlQuery),
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/ipam/ip-namespaces/api/get-ip-namespace-list-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-namespaces/api/get-ip-namespace-list-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { addFiltersToRequest } from "@/shared/api/graphql/utils";
@@ -24,10 +24,14 @@ export async function getIpNamespaceListFromApi({
     jsonToGraphQLQuery({
       query: {
         __name: `GetObjects${IP_NAMESPACE_GENERIC}`,
+        __variables: {
+          limit: "Int",
+          offset: "Int",
+        },
         [IP_NAMESPACE_GENERIC]: {
           __args: {
-            limit,
-            offset,
+            limit: new VariableType("limit"),
+            offset: new VariableType("offset"),
             ...(filters ? addFiltersToRequest(filters) : {}),
           },
           edges: {
@@ -59,6 +63,7 @@ export async function getIpNamespaceListFromApi({
 
   return graphqlClient.query({
     query,
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import {
@@ -42,8 +42,6 @@ export async function getIpPrefixListFromApi({
       ? buildGetIpPrefixListWithoutAvailabilityQuery
       : buildGetIpPrefixListWithAvailabilityQuery
   )({
-    limit,
-    offset,
     filters,
     objectKind,
     attributes,
@@ -53,6 +51,7 @@ export async function getIpPrefixListFromApi({
   const query = gql(queryString);
   return graphqlClient.query({
     query,
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,
@@ -81,22 +80,24 @@ export const IP_PREFIX_KIND_DETAILS_FRAGMENT = {
 };
 
 export function buildGetIpPrefixListWithoutAvailabilityQuery({
-  limit,
-  offset,
   filters,
   objectKind,
   attributes,
   relationships,
-}: BuildGetIpPrefixListQueryParams) {
+}: Omit<BuildGetIpPrefixListQueryParams, "limit" | "offset">) {
   const cleanedFilters = dropIncludeAvailableWhenFalse(filters);
 
   return jsonToGraphQLQuery({
     query: {
       __name: `GetObjects${objectKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [objectKind]: {
         __args: {
-          limit,
-          offset,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
           ...(cleanedFilters?.length ? addFiltersToRequest(cleanedFilters) : {}),
         },
         edges: {
@@ -115,20 +116,22 @@ export function buildGetIpPrefixListWithoutAvailabilityQuery({
 }
 
 export function buildGetIpPrefixListWithAvailabilityQuery({
-  limit,
-  offset,
   filters,
   objectKind,
   attributes,
   relationships,
-}: BuildGetIpPrefixListQueryParams) {
+}: Omit<BuildGetIpPrefixListQueryParams, "limit" | "offset">) {
   return jsonToGraphQLQuery({
     query: {
       __name: `GetObjects${objectKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [IP_PREFIX_GENERIC]: {
         __args: {
-          limit,
-          offset,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
           [AVAILABLE_IP_FILTER_NAME]: true,
           ...(objectKind !== IP_PREFIX_GENERIC ? { kinds: [objectKind] } : {}),
           ...(filters ? addFiltersToRequest(filters) : {}),

--- a/frontend/app/src/entities/navigation/api/search-from-api.ts
+++ b/frontend/app/src/entities/navigation/api/search-from-api.ts
@@ -4,8 +4,8 @@ import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { ContextParams } from "@/shared/api/types";
 
 const SEARCH = graphql(`
-  query Search($search: String!, $caseSensitive: Boolean) {
-    InfrahubSearchAnywhere(q: $search, limit: 4, partial_match: true, case_sensitive: $caseSensitive) {
+  query Search($search: String!, $limit: Int, $caseSensitive: Boolean) {
+    InfrahubSearchAnywhere(q: $search, limit: $limit, partial_match: true, case_sensitive: $caseSensitive) {
       count
       edges {
         node {
@@ -25,6 +25,7 @@ const SEARCH = graphql(`
 
 export interface SearchAnywhereFromApiParams extends ContextParams {
   search: string;
+  limit?: number;
   caseSensitive?: boolean;
 }
 
@@ -32,11 +33,12 @@ export function searchAnywhereFromApi({
   search,
   branchName,
   atDate,
+  limit = 4,
   caseSensitive,
 }: SearchAnywhereFromApiParams) {
   return graphqlClient.query({
     query: SEARCH,
-    variables: { search, caseSensitive },
+    variables: { search, limit, caseSensitive },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/hierarchy/api/get-object-ancestors-from-api.ts
+++ b/frontend/app/src/entities/nodes/hierarchy/api/get-object-ancestors-from-api.ts
@@ -18,10 +18,11 @@ export const getObjectAncestorsFromApi = async ({
   branchName,
   atDate,
 }: GetObjectAncestorsFromApiParams) => {
-  const query = getObjectAncestorsQuery({ objectKind, objectId });
+  const query = getObjectAncestorsQuery({ objectKind });
 
   return graphqlClient.query({
     query: gql(query),
+    variables: { ids: [objectId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/hierarchy/api/get-object-ancestors.query.ts
+++ b/frontend/app/src/entities/nodes/hierarchy/api/get-object-ancestors.query.ts
@@ -1,4 +1,4 @@
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 export type GetObjectAncestorsQueryParams = {
   objectKind: string;
@@ -7,14 +7,16 @@ export type GetObjectAncestorsQueryParams = {
 
 export function getObjectAncestorsQuery({
   objectKind,
-  objectId,
-}: GetObjectAncestorsQueryParams): string {
+}: Omit<GetObjectAncestorsQueryParams, "objectId">): string {
   return jsonToGraphQLQuery({
     query: {
       __name: `Get${objectKind}Ancestors`,
+      __variables: {
+        ids: "[ID]",
+      },
       [objectKind]: {
         __args: {
-          ids: [objectId],
+          ids: new VariableType("ids"),
         },
         edges: {
           node: {

--- a/frontend/app/src/entities/nodes/hierarchy/api/get-tree-nodes-by-parent-from-api.ts
+++ b/frontend/app/src/entities/nodes/hierarchy/api/get-tree-nodes-by-parent-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { ContextParams, PaginationParams } from "@/shared/api/types";
@@ -12,17 +12,22 @@ export interface GetTreeNodesByParentQueryParams extends PaginationParams {
 export function GetTreeNodesByParentQuery({
   objectKind,
   parentObjectId,
-  limit,
-  offset,
-}: GetTreeNodesByParentQueryParams) {
+}: Omit<GetTreeNodesByParentQueryParams, "limit" | "offset">) {
   return jsonToGraphQLQuery({
     query: {
       __name: `GetTreeNodesByParent_${objectKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+        ...(parentObjectId ? { parentIds: "[ID]" } : {}),
+      },
       [objectKind]: {
         __args: {
-          limit,
-          offset,
-          ...(parentObjectId ? { parent__ids: parentObjectId } : { parent__isnull: true }),
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
+          ...(parentObjectId
+            ? { parent__ids: new VariableType("parentIds") }
+            : { parent__isnull: true }),
         },
         edges: {
           node: {
@@ -46,10 +51,17 @@ export interface GetTreeNodesByParentFromApiParams
 export function GetTreeNodesByParentFromApi({
   branchName,
   atDate,
+  limit,
+  offset,
   ...params
 }: GetTreeNodesByParentFromApiParams) {
   return graphqlClient.query({
     query: gql(GetTreeNodesByParentQuery(params)),
+    variables: {
+      limit,
+      offset,
+      ...(params.parentObjectId ? { parentIds: [params.parentObjectId] } : {}),
+    },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/object-item-edit/api/get-object-for-editing-from-api.ts
+++ b/frontend/app/src/entities/nodes/object-item-edit/api/get-object-for-editing-from-api.ts
@@ -19,10 +19,11 @@ export async function getObjectForEditingFromApi({
   branchName,
   atDate,
 }: GetObjectForEditingFromApiParams) {
-  const queryString = generateObjectEditFormQuery({ schema, objectId, extraRelationshipNames });
+  const queryString = generateObjectEditFormQuery({ schema, extraRelationshipNames });
 
   return graphqlClient.query({
     query: gql(queryString),
+    variables: { ids: [objectId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/object-item-edit/generateObjectEditFormQuery.ts
+++ b/frontend/app/src/entities/nodes/object-item-edit/generateObjectEditFormQuery.ts
@@ -1,4 +1,4 @@
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import { nodeCoreFragment } from "@/shared/api/graphql/fragments";
 import { addAttributesToRequest, addRelationshipsToRequest } from "@/shared/api/graphql/utils";
@@ -10,11 +10,9 @@ import { isTemplateSchema } from "@/entities/schema/utils/is-template-schema";
 
 export const generateObjectEditFormQuery = ({
   schema,
-  objectId,
   extraRelationshipNames = [],
 }: {
   schema: NodeSchema | ProfileSchema;
-  objectId: string;
   extraRelationshipNames?: string[];
 }): string => {
   let objectSchema = schema;
@@ -34,9 +32,12 @@ export const generateObjectEditFormQuery = ({
   const request = {
     query: {
       __name: "GetObjectForEditForm",
+      __variables: {
+        ids: "[ID]",
+      },
       [schema.kind as string]: {
         __args: {
-          ids: [objectId],
+          ids: new VariableType("ids"),
         },
         edges: {
           node: {

--- a/frontend/app/src/entities/nodes/object/api/get-display-label-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-display-label-from-api.ts
@@ -1,16 +1,17 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { ContextParams } from "@/shared/api/types";
 
-const getNodeLabelQuery = ({ objectId, kind }: { objectId?: string | null; kind: string }) => {
+const getNodeLabelQuery = ({ hasObjectId, kind }: { hasObjectId: boolean; kind: string }) => {
   const request = {
     query: {
       __name: "GET_DISPLAY_LABEL",
+      ...(hasObjectId ? { __variables: { ids: "[ID]" } } : {}),
       [kind]: {
         __args: {
-          ...(objectId ? { ids: [objectId] } : {}),
+          ...(hasObjectId ? { ids: new VariableType("ids") } : {}),
         },
         edges: {
           node: {
@@ -34,7 +35,8 @@ export function getNodeLabelFromApi({
   kind: string;
 } & ContextParams) {
   return graphqlClient.query({
-    query: gql(getNodeLabelQuery({ objectId, kind })),
+    query: gql(getNodeLabelQuery({ hasObjectId: Boolean(objectId), kind })),
+    ...(objectId ? { variables: { ids: [objectId] } } : {}),
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-node-metadata-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import { nodeMetadataFragment } from "@/shared/api/graphql/fragments";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
@@ -10,13 +10,16 @@ export interface GetNodeMetadataQueryParams {
   objectKind: string;
 }
 
-const getNodeMetadataQuery = ({ objectId, objectKind }: GetNodeMetadataQueryParams) => {
+const getNodeMetadataQuery = ({ objectKind }: Omit<GetNodeMetadataQueryParams, "objectId">) => {
   const query = {
     query: {
       __name: `GetNodeMetadata${objectKind}`,
+      __variables: {
+        ids: "[ID]",
+      },
       [objectKind]: {
         __args: {
-          ids: [objectId],
+          ids: new VariableType("ids"),
         },
         edges: nodeMetadataFragment,
       },
@@ -38,7 +41,8 @@ export const getNodeMetadataFromApi = async ({
   atDate,
 }: GetNodeMetadataFromApiParams) => {
   return graphqlClient.query({
-    query: getNodeMetadataQuery({ objectId, objectKind }),
+    query: getNodeMetadataQuery({ objectKind }),
+    variables: { ids: [objectId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/object/api/get-object-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-object-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import { nodeCoreFragment } from "@/shared/api/graphql/fragments";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
@@ -18,18 +18,20 @@ interface GetObjectQueryParams {
 
 const getObjectQuery = ({
   schemaKind,
-  objectId,
   attributes,
   relationships,
   relationshipFragment,
-}: GetObjectQueryParams) => {
+}: Omit<GetObjectQueryParams, "objectId">) => {
   return gql(
     jsonToGraphQLQuery({
       query: {
         __name: `GetObject${schemaKind}`,
+        __variables: {
+          ids: "[ID]",
+        },
         [schemaKind]: {
           __args: {
-            ids: [objectId],
+            ids: new VariableType("ids"),
           },
           edges: {
             node: {
@@ -61,11 +63,11 @@ export async function getObjectFromApi({
   return graphqlClient.query({
     query: getObjectQuery({
       schemaKind,
-      objectId,
       attributes,
       relationships,
       relationshipFragment,
     }),
+    variables: { ids: [objectId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import { nodeCoreFragment } from "@/shared/api/graphql/fragments";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
@@ -18,8 +18,6 @@ interface GetObjectsQueryParams {
   schemaKind: string;
   attributes: AttributeSchema[];
   relationships: RelationshipSchema[];
-  limit?: number;
-  offset?: number;
   filters?: Array<Filter>;
   attributesOptions?: AddAttributesToRequestOptions;
   relationshipsOptions?: AddAttributesToRequestOptions;
@@ -29,8 +27,6 @@ const getObjectsQuery = ({
   schemaKind,
   attributes,
   relationships,
-  limit,
-  offset,
   filters,
   attributesOptions,
   relationshipsOptions,
@@ -39,10 +35,14 @@ const getObjectsQuery = ({
     jsonToGraphQLQuery({
       query: {
         __name: `GetObjects${schemaKind}`,
+        __variables: {
+          limit: "Int",
+          offset: "Int",
+        },
         [schemaKind]: {
           __args: {
-            limit,
-            offset,
+            limit: new VariableType("limit"),
+            offset: new VariableType("offset"),
             ...(filters ? addFiltersToRequest(filters) : {}),
           },
           edges: {
@@ -80,12 +80,11 @@ export async function getObjectsFromApi({
       schemaKind,
       attributes,
       relationships,
-      limit,
-      offset,
       filters,
       attributesOptions,
       relationshipsOptions,
     }),
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
@@ -4,27 +4,23 @@ import type { PaginationParams } from "@/shared/api/types";
 
 export type GenerateRelationshipListQueryParams = PaginationParams & {
   peer: string;
-  parent?: { name?: string; value?: string };
   search?: string;
   filterQuery?: Record<string, string | number | boolean | string[]>;
 };
 
+export const isIdFilter = (filterName: string): boolean =>
+  filterName === "ids" || filterName.endsWith("__ids");
+
 export const generateRelationshipListQuery = ({
   peer,
-  parent,
   filterQuery = {},
-}: Omit<GenerateRelationshipListQueryParams, "limit" | "offset" | "search">): string => {
-  const defaultArgs = {
-    limit: new VariableType("limit"),
-    offset: new VariableType("offset"),
-    any__value: new VariableType("search"),
-    partial_match: true,
-  };
-
-  const args =
-    parent?.name && parent?.value
-      ? { ...defaultArgs, [`${parent.name}__ids`]: [parent.value] }
-      : { ...defaultArgs };
+}: Pick<GenerateRelationshipListQueryParams, "peer" | "filterQuery">): string => {
+  const filterArgs = Object.fromEntries(
+    Object.entries(filterQuery).map(([filterName, value]) => [
+      filterName,
+      isIdFilter(filterName) ? new VariableType(filterName) : value,
+    ])
+  );
 
   const request = {
     query: {
@@ -33,11 +29,19 @@ export const generateRelationshipListQuery = ({
         limit: "Int",
         offset: "Int",
         search: "String",
+        ...Object.fromEntries(
+          Object.keys(filterQuery)
+            .filter(isIdFilter)
+            .map((filterName) => [filterName, "[ID]"])
+        ),
       },
       [peer]: {
         __args: {
-          ...args,
-          ...filterQuery,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
+          any__value: new VariableType("search"),
+          partial_match: true,
+          ...filterArgs,
         },
         edges: {
           node: {

--- a/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
@@ -21,9 +21,10 @@ export const generateRelationshipListQuery = ({
     partial_match: true,
   };
 
-  const args = parent?.value
-    ? { ...defaultArgs, [`${parent.name}__ids`]: [parent.value] }
-    : { ...defaultArgs };
+  const args =
+    parent?.name && parent?.value
+      ? { ...defaultArgs, [`${parent.name}__ids`]: [parent.value] }
+      : { ...defaultArgs };
 
   const request = {
     query: {

--- a/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/generate-relationship-list.query.ts
@@ -1,10 +1,10 @@
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import type { PaginationParams } from "@/shared/api/types";
 
 export type GenerateRelationshipListQueryParams = PaginationParams & {
   peer: string;
-  parent?: { name: string; value: string };
+  parent?: { name?: string; value?: string };
   search?: string;
   filterQuery?: Record<string, string | number | boolean | string[]>;
 };
@@ -12,12 +12,14 @@ export type GenerateRelationshipListQueryParams = PaginationParams & {
 export const generateRelationshipListQuery = ({
   peer,
   parent,
-  limit = 0,
-  offset = 0,
-  search = "",
   filterQuery = {},
-}: GenerateRelationshipListQueryParams): string => {
-  const defaultArgs = { limit, offset, any__value: search, partial_match: true };
+}: Omit<GenerateRelationshipListQueryParams, "limit" | "offset" | "search">): string => {
+  const defaultArgs = {
+    limit: new VariableType("limit"),
+    offset: new VariableType("offset"),
+    any__value: new VariableType("search"),
+    partial_match: true,
+  };
 
   const args = parent?.value
     ? { ...defaultArgs, [`${parent.name}__ids`]: [parent.value] }
@@ -26,6 +28,11 @@ export const generateRelationshipListQuery = ({
   const request = {
     query: {
       __name: "GetRelationshipList" + peer,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+        search: "String",
+      },
       [peer]: {
         __args: {
           ...args,

--- a/frontend/app/src/entities/nodes/relationships/api/get-object-relationships-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-object-relationships-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import {
@@ -27,10 +27,8 @@ const generateObjectRelationshipsQuery = ({
   parentId,
   relationshipName,
   relationshipSchema,
-  limit = 0,
-  offset = 0,
   filters,
-}: GenerateObjectRelationshipsQueryParams) => {
+}: Omit<GenerateObjectRelationshipsQueryParams, "limit" | "offset">) => {
   const { kind: relationshipKind, attributes = [], relationships = [] } = relationshipSchema;
   const attributesVisible = getAttributesVisibleInListView(attributes);
   const relationshipsVisible = getRelationshipsVisibleInListView(relationships);
@@ -38,6 +36,10 @@ const generateObjectRelationshipsQuery = ({
   const request = {
     query: {
       __name: `Get${parentKind}Relationships${relationshipKind}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [parentKind]: {
         __args: {
           ids: [parentId],
@@ -46,18 +48,14 @@ const generateObjectRelationshipsQuery = ({
           node: {
             [relationshipName]: {
               __args: {
-                limit,
-                offset,
+                limit: new VariableType("limit"),
+                offset: new VariableType("offset"),
                 ...(filters ? addFiltersToRequest(filters) : {}),
               },
               edges: {
                 node: {
                   __on: {
                     __typeName: relationshipKind,
-                    __args: {
-                      limit,
-                      offset,
-                    },
                     id: true,
                     hfid: true,
                     display_label: true,
@@ -82,12 +80,15 @@ export type GetObjectRelationshipsFromApiParams = ContextParams &
 export const getObjectRelationshipsFromApi = ({
   branchName,
   atDate,
+  limit,
+  offset,
   ...params
 }: GetObjectRelationshipsFromApiParams) => {
   const query = gql(generateObjectRelationshipsQuery(params));
 
   return graphqlClient.query({
     query,
+    variables: { limit, offset },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/get-object-relationships-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-object-relationships-from-api.ts
@@ -24,11 +24,10 @@ type GenerateObjectRelationshipsQueryParams = PaginationParams & {
 
 const generateObjectRelationshipsQuery = ({
   parentKind,
-  parentId,
   relationshipName,
   relationshipSchema,
   filters,
-}: Omit<GenerateObjectRelationshipsQueryParams, "limit" | "offset">) => {
+}: Omit<GenerateObjectRelationshipsQueryParams, "limit" | "offset" | "parentId">) => {
   const { kind: relationshipKind, attributes = [], relationships = [] } = relationshipSchema;
   const attributesVisible = getAttributesVisibleInListView(attributes);
   const relationshipsVisible = getRelationshipsVisibleInListView(relationships);
@@ -37,12 +36,13 @@ const generateObjectRelationshipsQuery = ({
     query: {
       __name: `Get${parentKind}Relationships${relationshipKind}`,
       __variables: {
+        parentIds: "[ID]",
         limit: "Int",
         offset: "Int",
       },
       [parentKind]: {
         __args: {
-          ids: [parentId],
+          ids: new VariableType("parentIds"),
         },
         edges: {
           node: {
@@ -82,13 +82,14 @@ export const getObjectRelationshipsFromApi = ({
   atDate,
   limit,
   offset,
+  parentId,
   ...params
 }: GetObjectRelationshipsFromApiParams) => {
   const query = gql(generateObjectRelationshipsQuery(params));
 
   return graphqlClient.query({
     query,
-    variables: { limit, offset },
+    variables: { parentIds: [parentId], limit, offset },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/get-relationship-count-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-relationship-count-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { ContextParams } from "@/shared/api/types";
@@ -13,16 +13,18 @@ export type getRelationshipCountQueryParams = {
 
 const getRelationshipCountQuery = ({
   objectKind,
-  objectId,
   relationshipName,
   queryFilter,
-}: getRelationshipCountQueryParams) => {
+}: Omit<getRelationshipCountQueryParams, "objectId">) => {
   const query = {
     query: {
       __name: `getRelationshipCount_${objectKind}_${relationshipName}`,
+      __variables: {
+        ids: "[ID]",
+      },
       [objectKind]: {
         __args: {
-          [queryFilter ?? "ids"]: [objectId],
+          [queryFilter ?? "ids"]: new VariableType("ids"),
         },
         edges: {
           node: {
@@ -45,10 +47,12 @@ export interface GetRelationshipCountFromApiParams
 export const getRelationshipCountFromApi = async ({
   branchName,
   atDate,
+  objectId,
   ...params
 }: GetRelationshipCountFromApiParams) => {
   return graphqlClient.query({
     query: getRelationshipCountQuery(params),
+    variables: { ids: [objectId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/get-relationship-properties-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-relationship-properties-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
@@ -12,22 +12,24 @@ type GenerateObjectRelationshipsQueryParams = {
 
 const generateRelationshipPropertiesQuery = ({
   parentKind,
-  parentId,
   relationshipName,
-  relationshipId,
-}: GenerateObjectRelationshipsQueryParams) => {
+}: Omit<GenerateObjectRelationshipsQueryParams, "parentId" | "relationshipId">) => {
   const request = {
     query: {
       __name: `Get${parentKind}${relationshipName}RelationshipProperties`,
+      __variables: {
+        parentIds: "[ID]",
+        relationshipIds: "[ID]",
+      },
       [parentKind]: {
         __args: {
-          ids: [parentId],
+          ids: new VariableType("parentIds"),
         },
         edges: {
           node: {
             [relationshipName]: {
               __args: {
-                ids: [relationshipId],
+                ids: new VariableType("relationshipIds"),
               },
               edges: {
                 properties: {
@@ -63,12 +65,15 @@ export type GetObjectRelationshipsFromApiParams = GenerateObjectRelationshipsQue
 export const getRelationshipPropertiesFromApi = ({
   branchName,
   atDate,
+  parentId,
+  relationshipId,
   ...params
 }: GetObjectRelationshipsFromApiParams) => {
   const query = gql(generateRelationshipPropertiesQuery(params));
 
   return graphqlClient.query({
     query,
+    variables: { parentIds: [parentId], relationshipIds: [relationshipId] },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/get-relationships-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-relationships-from-api.ts
@@ -20,10 +20,11 @@ export const getRelationshipsFromApi = async ({
   atDate,
   filterQuery,
 }: getRelationshipsFromApiParams) => {
-  const query = gql(generateRelationshipListQuery({ peer, limit, offset, search, filterQuery }));
+  const query = gql(generateRelationshipListQuery({ peer, filterQuery }));
 
   return graphqlClient.query({
     query,
+    variables: { limit, offset, search },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/nodes/relationships/api/get-relationships-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-relationships-from-api.ts
@@ -6,10 +6,10 @@ import type { ContextParams } from "@/shared/api/types";
 import {
   type GenerateRelationshipListQueryParams,
   generateRelationshipListQuery,
+  isIdFilter,
 } from "@/entities/nodes/relationships/api/generate-relationship-list.query";
 
-export type getRelationshipsFromApiParams = ContextParams &
-  Omit<GenerateRelationshipListQueryParams, "parent">;
+export type getRelationshipsFromApiParams = ContextParams & GenerateRelationshipListQueryParams;
 
 export const getRelationshipsFromApi = async ({
   peer,
@@ -22,9 +22,13 @@ export const getRelationshipsFromApi = async ({
 }: getRelationshipsFromApiParams) => {
   const query = gql(generateRelationshipListQuery({ peer, filterQuery }));
 
+  const idFilterVariables = Object.fromEntries(
+    Object.entries(filterQuery ?? {}).filter(([filterName]) => isIdFilter(filterName))
+  );
+
   return graphqlClient.query({
     query,
-    variables: { limit, offset, search },
+    variables: { limit, offset, search, ...idFilterVariables },
     context: {
       branch: branchName,
       date: atDate,

--- a/frontend/app/src/entities/path-traversal/api/get-path-traversal-from-api.ts
+++ b/frontend/app/src/entities/path-traversal/api/get-path-traversal-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
@@ -58,8 +58,11 @@ export async function getPathTraversalFromApi(params: GetPathTraversalParams) {
   const queryString = jsonToGraphQLQuery({
     query: {
       __name: "GetPathTraversal",
+      __variables: {
+        data: "PathTraversalInput!",
+      },
       InfrahubPathTraversal: {
-        __args: { data: dataArgs },
+        __args: { data: new VariableType("data") },
         paths: pathFields,
         source: nodeFields,
         destination: nodeFields,
@@ -71,6 +74,7 @@ export async function getPathTraversalFromApi(params: GetPathTraversalParams) {
 
   return graphqlClient.query<{ InfrahubPathTraversal: PathTraversalResponse }>({
     query: gql(queryString),
+    variables: { data: dataArgs },
     context: { branch: branchName, date: atDate },
   });
 }

--- a/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
+++ b/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
@@ -54,8 +54,11 @@ export async function getReachableNodesFromApi(params: GetReachableNodesParams) 
   const queryString = jsonToGraphQLQuery({
     query: {
       __name: "GetReachableNodes",
+      __variables: {
+        data: "ReachableNodesInput!",
+      },
       InfrahubReachableNodes: {
-        __args: { data: dataArgs },
+        __args: { data: new VariableType("data") },
         source: nodeFields,
         dependencies: {
           node: nodeFields,
@@ -69,6 +72,7 @@ export async function getReachableNodesFromApi(params: GetReachableNodesParams) 
 
   return graphqlClient.query<{ InfrahubReachableNodes: ReachableNodesResponse }>({
     query: gql(queryString),
+    variables: { data: dataArgs },
     context: { branch: branchName, date: atDate },
   });
 }

--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
@@ -26,7 +26,7 @@ export interface ProposedChangesFromApiParams extends PaginationParams {
 export const getProposedChangesFromApi = async ({
   schema,
   limit = DEFAULT_PAGE_SIZE,
-  offset,
+  offset = 0,
   filters,
   getAttributesVisible = getAttributesVisibleInListView,
   getRelationshipsVisible = getRelationshipsVisibleInListView,

--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { EnumType, jsonToGraphQLQuery } from "json-to-graphql-query";
+import { EnumType, jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import {
@@ -39,10 +39,14 @@ export const getProposedChangesFromApi = async ({
   const queryString = jsonToGraphQLQuery({
     query: {
       __name: `Get${PROPOSED_CHANGE_OBJECT}`,
+      __variables: {
+        limit: "Int",
+        offset: "Int",
+      },
       [schemaKindToQuery]: {
         __args: {
-          limit,
-          offset,
+          limit: new VariableType("limit"),
+          offset: new VariableType("offset"),
           order: {
             by: [{ field: "node_metadata__created_at", direction: new EnumType("DESC") }],
           },
@@ -87,5 +91,6 @@ export const getProposedChangesFromApi = async ({
   const query = gql(queryString);
   return graphqlClient.query({
     query,
+    variables: { limit, offset },
   });
 };


### PR DESCRIPTION
Small optimization...
This leverages graphql caching in the backend as introduced in #8102.

The backend caches parsed GraphQL documents in an LRU keyed on the exact query string (`backend/infrahub/graphql/execution.py`), so any per-request value inlined into a query document produces a distinct document per request and defeats the cache. Beyond the original pagination migration (`limit`/`offset`/`search` as variables), this PR converts the remaining per-request values in generated queries to GraphQL variables:

- object ids (`ids`, `*__ids`) in the object detail, edit form, metadata, display label, ancestors, tree nodes, relationship count/properties/list queries
- id-typed `filterQuery` entries in the relationship list query (UUID search, breadcrumbs, hierarchical pickers)
- the path-traversal payloads (`$data: PathTraversalInput!` / `ReachableNodesInput!`)

Still inlined, left as follow-up: filter values built by `addFiltersToRequest` and non-id `filterQuery` entries (need a per-filter GraphQL type mapping in the shared util), and mutation `data` payloads. The rule and pattern are documented in `dev/knowledge/frontend/entities-structure.md`.

## Note for the next stable → develop sync

develop restructured some of the files this PR touches, so the merge will not carry every fix by itself:

- `entities/nodes/object-item-edit/` no longer exists on develop; the edit-form query lives at `frontend/app/src/entities/nodes/object/api/get-object-for-editing-from-api.ts` and still inlines `ids: [objectId]` — the fix must be re-applied there during the merge.
- `generate-relationship-list.query.ts` and `get-object-ancestors.query.ts` were absorbed into their `*-from-api.ts` files on develop; expect modify/delete conflicts and resolve them by porting the `__variables` + Apollo `variables` pattern into the merged files.
- The remaining files exist at identical paths on develop and merge through normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now support configurable pagination limits
  * Relationship selectors dynamically refresh when pagination or search criteria change

* **Improvements**
  * Enhanced pagination query handling across IP address and prefix management features
  * Optimized GraphQL query execution for relationship lookups

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
