### PR TITLE
Single line breaks in TextArea are now rendered correctly

### DIFF
--- a/changelog/+IFC-1859.fixed.md
+++ b/changelog/+IFC-1859.fixed.md
@@ -1,0 +1,1 @@
+Single line breaks in text fields are now rendered correctly.

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -70,6 +70,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "react-toastify": "^9.1.3",
         "recharts": "^3.6.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remeda": "^2.33.4",
         "sha1": "^1.1.1",
@@ -12114,6 +12115,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "license": "MIT",
@@ -13982,6 +13997,21 @@
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -88,6 +88,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "react-toastify": "^9.1.3",
     "recharts": "^3.6.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remeda": "^2.33.4",
     "sha1": "^1.1.1",

--- a/frontend/app/src/shared/components/editor/markdown/markdown-render.test.tsx
+++ b/frontend/app/src/shared/components/editor/markdown/markdown-render.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+
+import { render } from "../../../../../tests/components/render";
+import { MarkdownRender } from "./markdown-render";
+
+describe("MarkdownRender Component", () => {
+  test("renders markdown text correctly", async () => {
+    // GIVEN
+    const markdownText = "**bold** and *italic*";
+
+    // WHEN
+    const component = await render(<MarkdownRender markdownText={markdownText} />);
+
+    // THEN
+    await expect.element(component.getByText("bold")).toBeVisible();
+    await expect.element(component.getByText("italic")).toBeVisible();
+  });
+
+  test("renders single newlines as line breaks", async () => {
+    // GIVEN
+    const markdownText = "line one\nline two\nline three";
+
+    // WHEN
+    const component = await render(<MarkdownRender markdownText={markdownText} />);
+
+    // THEN
+    const brElements = component.container.querySelectorAll("br");
+    expect(brElements.length).toBe(2);
+  });
+
+  test("renders empty string without errors", async () => {
+    // GIVEN
+    const markdownText = "";
+
+    // WHEN
+    const component = await render(<MarkdownRender markdownText={markdownText} />);
+
+    // THEN
+    const markdownDiv = component.container.querySelector(".markdown");
+    expect(markdownDiv).not.toBeNull();
+  });
+
+  test("applies custom className", async () => {
+    // GIVEN
+    const className = "custom-class";
+
+    // WHEN
+    const component = await render(<MarkdownRender markdownText="test" className={className} />);
+
+    // THEN
+    const markdownDiv = component.container.querySelector(".markdown");
+    expect(markdownDiv?.classList.contains("custom-class")).toBe(true);
+  });
+});

--- a/frontend/app/src/shared/components/editor/markdown/markdown-render.tsx
+++ b/frontend/app/src/shared/components/editor/markdown/markdown-render.tsx
@@ -2,6 +2,7 @@ import "@/app/styles/markdown.css";
 
 import type { FC } from "react";
 import Markdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 import { classNames } from "@/shared/utils/common";
@@ -13,6 +14,6 @@ type MarkdownRenderProps = {
 
 export const MarkdownRender: FC<MarkdownRenderProps> = ({ className = "", markdownText = "" }) => (
   <div className={classNames("markdown", className)}>
-    <Markdown remarkPlugins={[remarkGfm]}>{markdownText}</Markdown>
+    <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{markdownText}</Markdown>
   </div>
 );


### PR DESCRIPTION
Fix: https://github.com/opsmill/infrahub/issues/7253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single line breaks in text fields now render correctly.

* **Tests**
  * Added test suite validating markdown rendering functionality, including line break handling, bold and italic formatting, empty content states, and custom styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->