### PR TITLE
docs: capitalize Generators consistently across documentation

### DIFF
--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -17,7 +17,7 @@ Infrahub is an open-source platform that enables infrastructure as code by provi
 - Unified Storage: Version control for data and files
 - Versioning: Track current state and future intended state of the infrastructure with built-in peer review and a CI pipeline for validation.
 - Immutable Database: Go back in time to view the state of infrastructure at any point.
-- Artifact Generation: Transform infrastructure data into any format (text configurations, XML, JSON, etc.) using generators and templates.
+- Artifact Generation: Transform infrastructure data into any format (text configurations, XML, JSON, etc.) using Generators and templates.
 - Data Lineage: View the source and owner for each piece of infrastructure data.
 - Multiple interfaces for each team and need:
   - Web UI: View and manage all infrastructure data, configurations, and CI/CD pipelines through a user interface.

--- a/docs/docs/getting-started/concepts.mdx
+++ b/docs/docs/getting-started/concepts.mdx
@@ -75,7 +75,7 @@ These transformations allow for flexible and powerful data manipulation, making 
 
 Generators in Infrahub are tools that automatically create infrastructure objects based on predefined templates and user inputs. They serve as a way to streamline the process of setting up complex infrastructure stacks while allowing for customization.
 
-Key aspects of generators include:
+Key aspects of Generators include:
 
 1. Template-based: Generators use templates as a starting point for creating infrastructure configurations.
 
@@ -83,15 +83,15 @@ Key aspects of generators include:
 
 3. Automation: Generators automate repetitive tasks in infrastructure setup, reducing manual effort and potential errors.
 
-4. Consistency: By using generators, teams can ensure consistent infrastructure setups across different projects or environments.
+4. Consistency: By using Generators, teams can ensure consistent infrastructure setups across different projects or environments.
 
-5. Customization: While based on templates, generators allow for significant customization to meet specific project requirements.
+5. Customization: While based on templates, Generators allow for significant customization to meet specific project requirements.
 
 6. Versioning: Infrahub supports versioning of generator outputs, enabling users to track changes over time.
 
 7. Integration: Generators can be integrated into workflows and CI/CD pipelines for automated infrastructure provisioning.
 
-8. Extensibility: Advanced users can create custom generators to suit their organization's specific needs.
+8. Extensibility: Advanced users can create custom Generators to suit their organization's specific needs.
 
 <ReferenceLink title="Learn more about generator" url="../topics/generator" />
 

--- a/docs/docs/getting-started/next-steps.mdx
+++ b/docs/docs/getting-started/next-steps.mdx
@@ -78,7 +78,7 @@ infrahubctl object load city_data.yml
 
 The git repository will be used to store any files needed to capture the intended state of your infrastructure, such as the schema, templates, Python scripts, etc.
 
-Infrahub offers a native integration with git, allowing you to connect your repository and consume the files to run data transformations, generators, and more.
+Infrahub offers a native integration with git, allowing you to connect your repository and consume the files to run data transformations, Generators, and more.
 
 The most important file is the `.infrahub.yml` file, which defines how Infrahub should behave and what files to consume.
 
@@ -109,7 +109,7 @@ From here, depending on your use case and goals, you can:
 
 - [**Create your own schema**](../guides/create-schema.mdx) - Extend the existing schema to fit your organization's needs.
 - [**Generate artifacts**](../guides/artifact.mdx) - Use transformations to create meaningful files from your data such as startup configurations, documentation, cabling plans and more.
-- [**Build generators**](../guides/generator.mdx) - Automate the creation of infrastructure objects based on templates and user inputs.
+- [**Build Generators**](../guides/generator.mdx) - Automate the creation of infrastructure objects based on templates and user inputs.
 - [**Deploy artifacts to the field using Ansible**]($(base_url)ansible) - Deploy outputs where they're needed and apply your intended state to your infrastructure. You can also use other tools like [Nornir]($(base_url)nornir) to deploy your artifacts.
 
 If you need guidance with which feature to explore next or how to implement a specific use case, feel free to reach out to the community on our [Discord server](https://discord.gg/opsmill) or book a meeting with OpsMill.

--- a/docs/docs/getting-started/quick-start.mdx
+++ b/docs/docs/getting-started/quick-start.mdx
@@ -57,7 +57,7 @@ Below is the current list of available demos developed and maintained by OpsMill
 A bundle is an end-to-end reference implementation you can actually learn from. This bundle includes:
 
 - Schema-driven modelling — spine-leaf fabrics, VxLAN/EVPN overlays, POPs, security zones, load balancers
-- Design-driven automation — create a topology design, watch generators spawn all the devices, interfaces, IPs, BGP peers (the otters do the work)
+- Design-driven automation — create a topology design, watch Generators spawn all the devices, interfaces, IPs, BGP peers (the otters do the work)
 - Branch-based workflows — proposed changes with diffs, validation checks, artifact regeneration before merge
 - Firewall policy abstracted from vendor implementations
 - Multi-vendor configuration generation — Arista, Juniper, Cisco, SONiC templates included

--- a/docs/docs/guides/generator.mdx
+++ b/docs/docs/guides/generator.mdx
@@ -361,7 +361,7 @@ For a complete explanation of the `.infrahub.yml` file format, see the [infrahub
 
 2. Verify the configuration
 
-Check that your `.infrahub.yml` file is correctly formatted by listing available generators:
+Check that your `.infrahub.yml` file is correctly formatted by listing available Generators:
 
 ```shell
 infrahubctl generator --list
@@ -514,8 +514,8 @@ You should see three new resources (`widget3-1`, `widget3-2`, and `widget3-3`) a
 
 Now that you've created a basic generator, you can:
 
-- Create generators that handle a full object lifecycle, including creation, updates, and deletions
-- Build idempotent generators that can be run multiple times without creating duplicate data
+- Create Generators that handle a full object lifecycle, including creation, updates, and deletions
+- Build idempotent Generators that can be run multiple times without creating duplicate data
 - Add unit tests to your generator to ensure it behaves as expected
 - Harden your generator by adding error handling and logging
 

--- a/docs/docs/guides/resource-manager.mdx
+++ b/docs/docs/guides/resource-manager.mdx
@@ -273,7 +273,7 @@ In the mutation we passed additional data to the allocated resource, in this cas
 
 :::success Idempotent allocation of an IP address
 
-You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](../topics/generator.mdx).
+You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../topics/generator.mdx).
 
 Execute this mutation twice, note the identifier. The resulting IP address should be the same, as well as the id. Replace the id with the id of the `CoreIPAddressPool` we created previously.
 
@@ -451,7 +451,7 @@ Allocate an IP address directly from the pool:
   }
   ```
 
-  This is essential for [generators](../topics/generator.mdx) and automated workflows.
+  This is essential for [Generators](../topics/generator.mdx) and automated workflows.
 
   :::
 
@@ -793,7 +793,7 @@ This feature is not yet available directly via the Web Interface.
   }
   ```
 
-  This is essential for [generators](../topics/generator.mdx) and automated workflows.
+  This is essential for [Generators](../topics/generator.mdx) and automated workflows.
 
   :::
 
@@ -802,7 +802,7 @@ This feature is not yet available directly via the Web Interface.
 
 :::success
 
-You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](../topics/generator.mdx).
+You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../topics/generator.mdx).
 
 Execute this mutation twice, note the identifier. The resulting IP prefix should be the same, as well as the id. Replace the id with the id of the `CoreIPPrefixPool` we created previously.
 

--- a/docs/docs/home.mdx
+++ b/docs/docs/home.mdx
@@ -70,7 +70,7 @@ import HomePageCard from "../src/components/HomePage/card.tsx";
     />
     <HomePageCard title="Generators"
         svgPath="/img/infrahub-logo.svg"
-        description="Create consistent infrastructure objects using generators."
+        description="Create consistent infrastructure objects using Generators."
         link="topics/generator"
     />
 </div>

--- a/docs/docs/release-notes/infrahub/release-0_13.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_13.mdx
@@ -88,7 +88,7 @@ infrahub db index --help
 A Generator is a generic plugin that can be used apply your own logic to create new nodes and relationships.
 Generator are expected to be idempotent and should be able to run multiple times and always produce the same result.
 
-One use case for the generators is to be able to manage technical objects derived from a higher level definition of a service.
+One use case for the Generators is to be able to manage technical objects derived from a higher level definition of a service.
 
 Generators are associated with some input data identified by a GraphQL query.
 Similar to the Transforms & Artifacts, Generator will be automatically executed as part of the CI Pipeline if the data associated with a given generator has changed.

--- a/docs/docs/release-notes/infrahub/release-0_15_2.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_15_2.mdx
@@ -47,7 +47,7 @@ We are thrilled to announce the latest release of Infrahub (0.15.2).
 - Fix OpenAPI documentation of schema load endpoint @dgarros (#3911)
 - Fix return code when trying to use a restricted namespace @dgarros (#3912)
 - Validate HFID and uniqueness constraints format when loading a schema @gmazoyer (#3972)
-- Run artifact refresh after generators in proposed changes pipeline @ajtmccarty (#3897)
+- Run artifact refresh after Generators in proposed changes pipeline @ajtmccarty (#3897)
 - Fix button covering GraphQL query view @bilalabbad (#3964)
 - Fix dot on tree being hidden when there is a very long text, also improve CSS for the tree @bilalabbad (#3958)
 - Fix branch details page open correctly when the branch name contains a `/` @bilalabbad (#3917)

--- a/docs/docs/release-notes/infrahub/release-0_16_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_16_0.mdx
@@ -164,7 +164,7 @@ The complete list of changes can always be found in the `CHANGELOG.md` file in t
 - Comment input is not cleared upon submission of Proposed Change form. ([#3942](https://github.com/opsmill/infrahub/issues/3942))
 - Can not assign Profile when editing Node in the web UI. ([#3999](https://github.com/opsmill/infrahub/issues/3999))
 - Allow users to add a new generic to an existing node. ([#4051](https://github.com/opsmill/infrahub/issues/4051))
-- Allow users to run artifacts and generators on nodes without name attribute ([#4062](https://github.com/opsmill/infrahub/issues/4062))
+- Allow users to run artifacts and Generators on nodes without name attribute ([#4062](https://github.com/opsmill/infrahub/issues/4062))
 - Allow bare Git URL and automatically add `.git`. ([#4070](https://github.com/opsmill/infrahub/issues/4070))
 - Schema diff view not functioning in branch detail page. ([#4093](https://github.com/opsmill/infrahub/issues/4093))
 - Removed erroneous approval button on Diff view. ([#4094](https://github.com/opsmill/infrahub/issues/4094))

--- a/docs/docs/release-notes/infrahub/release-1_0_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_0_0.mdx
@@ -202,7 +202,7 @@ Stay tuned for more information and more exciting features around task managemen
 - Add ability to import repositories with default branch other than 'main' ([#3435](https://github.com/opsmill/infrahub/issues/3435))
 - Disable approve/merge/close buttons for merged Proposed Changes ([#3495](https://github.com/opsmill/infrahub/issues/3495))
 - Fixed regex validation for List type attributes ([#3929](https://github.com/opsmill/infrahub/issues/3929))
-- Allow users to run artifacts and generators on nodes without name attribute ([#4062](https://github.com/opsmill/infrahub/issues/4062))
+- Allow users to run artifacts and Generators on nodes without name attribute ([#4062](https://github.com/opsmill/infrahub/issues/4062))
 - In the schema, properly delete inherited attribute and relationship on Node when the original attribute or relationship are being deleted on the Generic ([#4301](https://github.com/opsmill/infrahub/issues/4301))
 - "Retry All" button for checks is bigger ([#4315](https://github.com/opsmill/infrahub/issues/4315))
 - Add a size restriction on common attribute kinds. Only TextArea and JSON support large values ([#4432](https://github.com/opsmill/infrahub/issues/4432))

--- a/docs/docs/release-notes/infrahub/release-1_5_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_5_0.mdx
@@ -32,9 +32,9 @@ Finally, we've ensured Webhooks are more consistent by aligning custom webhook d
 
 ## Disable generator in Infrahub's CI pipeline and after a branch merge operation
 
-To provide a cleaner experience when setting up event-based generators, we've introduced the capability to selectively disable generators during specific lifecycle events: CI pipeline execution and branch merge operations.
+To provide a cleaner experience when setting up event-based Generators, we've introduced the capability to selectively disable Generators during specific lifecycle events: CI pipeline execution and branch merge operations.
 
-Previously, generators could be triggered multiple times, leading to redundant processing: once by their configured event trigger rules, again during the Proposed Change (CI) phase, and finally after merging into the main branch.
+Previously, Generators could be triggered multiple times, leading to redundant processing: once by their configured event trigger rules, again during the Proposed Change (CI) phase, and finally after merging into the main branch.
 
 You can now prevent this overlap by optionally disabling generator execution on a per-generator basis directly within your repository configuration file, `.infrahub.yml`. This ensures your automation runs only when you explicitly intend it to, giving you finer control over when your generation logic executes.
 

--- a/docs/docs/release-notes/infrahub/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_6_0.mdx
@@ -104,7 +104,7 @@ See which Infrahub edition you're using in the account menu alongside the versio
 
 ⚠ **BREAKING CHANGE**
 
-When using `convert_query_response` with nested relationships in Python transforms and generators, queries must now include `id` and `__typename` fields on all nodes. This fixes a bug where objects were only converted one level deep.
+When using `convert_query_response` with nested relationships in Python transforms and Generators, queries must now include `id` and `__typename` fields on all nodes. This fixes a bug where objects were only converted one level deep.
 
 If you are not using `convert_query_response` or if the queries that you are using with this feature aren't deeply nested, then you don't have to change anything.
 

--- a/docs/docs/topics/community-vs-enterprise.mdx
+++ b/docs/docs/topics/community-vs-enterprise.mdx
@@ -137,7 +137,7 @@ Both Community and Enterprise provide identical capabilities for fundamental inf
 
 - **Template-based configuration**: Generate configuration artifacts from infrastructure data
 - **Multiple transformation options**: Use Jinja2 templates or Python transforms
-- **Extensible framework**: Create custom generators for specific needs
+- **Extensible framework**: Create custom Generators for specific needs
 - **Automation integration**: Connect with external automation tools and platforms
 
 ### Performance and scalability

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -25,9 +25,9 @@ To initialize a new Infrahub repository, run the following command (replace `<pr
 uv tool run --from 'copier' copier copy https://github.com/opsmill/infrahub-template <project-name>
 ```
 
-This uses [copier](https://copier.readthedocs.io/) to create a new Infrahub repository from the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template). The command will guide you through interactive prompts to customize your repository (such as including example generators, transforms, and scripts). No separate installation is needed as `uv tool run` handles everything automatically.
+This uses [copier](https://copier.readthedocs.io/) to create a new Infrahub repository from the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template). The command will guide you through interactive prompts to customize your repository (such as including example Generators, transforms, and scripts). No separate installation is needed as `uv tool run` handles everything automatically.
 
-Once complete, your new repository will be ready for you to add schemas, transforms, and generators.
+Once complete, your new repository will be ready for you to add schemas, transforms, and Generators.
 
 <details>
   <summary>Recommended file structure for manually creating an Infrahub repository</summary>

--- a/docs/docs/topics/generator.mdx
+++ b/docs/docs/topics/generator.mdx
@@ -26,7 +26,7 @@ Running a generator definition will create new nodes as defined by the generator
 
 The targets point to a [group](./groups.mdx) that will consist of objects that are impacted by the generator. The members of this group can be any type of object within your schema, service objects, devices, contracts or anything you want the generator to act upon. Generator groups (`CoreGeneratorGroup`) serve as target collections that define which objects trigger generator execution, while the actual tracking of generated objects is handled by individual generator instances.
 
-The [GraphQL query](graphql) defines the data that will be collected when running the generator. Any object identified in this step is added as a member to a GraphQL query [group](./groups.mdx) (`CoreGraphQLQueryGroup`). The membership in these groups are then used to determine which generators need to be executed as part of a proposed change during the pipeline run.
+The [GraphQL query](graphql) defines the data that will be collected when running the generator. Any object identified in this step is added as a member to a GraphQL query [group](./groups.mdx) (`CoreGraphQLQueryGroup`). The membership in these groups are then used to determine which Generators need to be executed as part of a proposed change during the pipeline run.
 
 The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Just like [transforms](transformation) and [checks](check), the Generators are user defined.
 
@@ -43,13 +43,13 @@ Generators can be executed in several ways, depending on your workflow and where
    When you open a Proposed Change that affects the generator’s targets, the generator runs as part of Infrahub’s CI checks. Review the results in the Checks and Data tabs of the Proposed Change. This behavior can also be disabled per generator in the repository configuration file.
 4. Automatically via Events and Actions
 
-   You can configure Infrahub Event rules and Actions to trigger generators automatically based on changes in your data. This enables fully automated execution aligned with your workflows.
+   You can configure Infrahub Event rules and Actions to trigger Generators automatically based on changes in your data. This enables fully automated execution aligned with your workflows.
 
 ## Video guides
 
-In this video series we’re diving into the concept of generators and services, exploring their significance, structure, and how they can streamline processes for teams. Whether you’re a developer or just curious about automation in IT, this guide will provide you with a comprehensive understanding of generators and their applications.
+In this video series we're diving into the concept of Generators and services, exploring their significance, structure, and how they can streamline processes for teams. Whether you’re a developer or just curious about automation in IT, this guide will provide you with a comprehensive understanding of generators and their applications.
 
-The first video will highlight what generators are and how they can be used to deliver services.
+The first video will highlight what Generators are and how they can be used to deliver services.
 
 <center>
   <VideoPlayer url='https://www.youtube.com/watch?v=TSqY0caGb0A' light />

--- a/docs/docs/topics/infrahub-yml.mdx
+++ b/docs/docs/topics/infrahub-yml.mdx
@@ -8,7 +8,7 @@ The `.infrahub.yml` file serves as the central manifest that defines how Infrahu
 
 ## Why `.infrahub.yml` exists
 
-Infrastructure automation requires both structured data (device inventories, network topologies) and executable code (templates, validation scripts, generators). The `.infrahub.yml` file solves the fundamental challenge of bridging these two worlds by:
+Infrastructure automation requires both structured data (device inventories, network topologies) and executable code (templates, validation scripts, Generators). The `.infrahub.yml` file solves the fundamental challenge of bridging these two worlds by:
 
 - **Declaring intent**: Explicitly stating what resources from a Git repository should be imported into Infrahub
 - **Enabling selective integration**: Allowing fine-grained control over which files and resources are processed
@@ -30,7 +30,7 @@ Rather than scanning the entire repository and making assumptions about file pur
 
 The configuration organizes resources into distinct categories based on their purpose and processing requirements:
 
-- **Executable code**: Python transformations, generators, and checks
+- **Executable code**: Python transformations, Generators, and checks
 - **Templates**: Jinja2 templates for configuration generation
 - **Schema definitions**: Data models for infrastructure representation
 - **Data definitions**: Object files for storing infrastructure data
@@ -59,7 +59,7 @@ Infrahub processes configuration sections in a specific order to handle dependen
 1. **Schemas**: Loaded first to establish the data model
 2. **GraphQL queries**: Loaded before resources that depend on them
 3. **Objects**: Loaded to populate initial data
-4. **Python files**: Check definitions, Python transformations, and generators are loaded together
+4. **Python files**: Check definitions, Python transformations, and Generators are loaded together
 5. **Jinja2 transformations**: Loaded after their required queries are available
 6. **Artifact definitions**: Loaded last to reference existing transformations
 

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -31,7 +31,7 @@ A proposed change in Infrahub offers a more sophisticated approach by integratin
 
 - **Data differences**: See precisely what objects were added, modified, or deleted, along with the specific attribute changes.
 - **Schema differences**: Identify changes to the underlying data models that define your infrastructure.
-- **File differences**: Track modifications to implementation files like transforms, generators, and templates.
+- **File differences**: Track modifications to implementation files like transforms, Generators, and templates.
 - **Artifact differences**: Compare the [artifacts](artifact) generated to understand output changes.
 
 This multi-dimensional diffing provides a "single pane of glass" view, enabling reviewers to fully understand the scope and impact of changes before approval. This comprehensive visibility is especially valuable for complex infrastructure changes.
@@ -67,9 +67,9 @@ Learn more about [transformations](transformation) and [artifacts](artifact).
 
 ### Generator integration
 
-Infrahub will automatically run generators as part of the proposed change workflow.
+Infrahub will automatically run Generators as part of the proposed change workflow.
 
-Learn more about [generators](generator).
+Learn more about [Generators](generator).
 
 ## Conflict management and resolution
 

--- a/docs/docs/topics/repository.mdx
+++ b/docs/docs/topics/repository.mdx
@@ -6,7 +6,7 @@ import ReferenceLink from "../../src/components/Card";
 
 # Understanding Git repositories in Infrahub
 
-Infrahub integrates with external Git repositories to enable comprehensive version-controlled infrastructure management. This integration allows you to store and manage transformations, queries, generators, and other automation resources alongside your infrastructure data. This topic explains how Infrahub's Git integration works, the available repository types, and the architectural decisions behind these features.
+Infrahub integrates with external Git repositories to enable comprehensive version-controlled infrastructure management. This integration allows you to store and manage transformations, queries, Generators, and other automation resources alongside your infrastructure data. This topic explains how Infrahub's Git integration works, the available repository types, and the architectural decisions behind these features.
 
 ## Why Git integration matters
 

--- a/docs/docs/topics/resource-manager.mdx
+++ b/docs/docs/topics/resource-manager.mdx
@@ -197,9 +197,9 @@ Infrahub provides comprehensive visibility into resource utilization:
 
 ## Integration patterns
 
-### With generators
+### With Generators
 
-Resource managers integrate seamlessly with [generators](./generator.mdx) to create fully automated provisioning workflows:
+Resource managers integrate seamlessly with [Generators](./generator.mdx) to create fully automated provisioning workflows:
 
 - Template configurations with dynamically allocated IPs
 - Generate DNS records based on allocations

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -96,7 +96,7 @@ A TransformPython can be rendered with 2 different methods:
 
 ## Using transformations with groups
 
-Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [generators](./generator.mdx), which combine a transformation with a [group](./groups.mdx) of targets.
+Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a transformation with a [group](./groups.mdx) of targets.
 
 This design enables powerful patterns:
 
@@ -104,7 +104,7 @@ This design enables powerful patterns:
 - **Bulk processing**: Artifact definitions automatically apply the transformation to all members of the target group
 - **Dynamic targeting**: Adding or removing objects from groups automatically changes which objects the transformation processes
 
-The transformation logic remains group-agnostic, while artifact definitions and generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
+The transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
 
 ## Unit testing for transformation
 


### PR DESCRIPTION
Standardize capitalization of "Generators" when referring to the Infrahub Generators feature throughout the documentation. This change affects 21 files across FAQ, guides, release notes, topics, and getting-started sections.

Lowercase "generators" is preserved in file paths and directory references (e.g., generators/, generators/widget_generator.py).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for consistency, including standardized capitalization of "Generators" as a product feature throughout guides, release notes, and conceptual topics.
  * Refined descriptive text in documentation for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->