### PR TITLE
docs: standardize Transformation terminology in documentation

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -76,6 +76,7 @@ file_path
 frontend
 generator_definitions
 GitHub
+Grafana
 Graphql
 GraphQL
 GraphQL's

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,7 +33,8 @@ Infrahub documentation is organized using the [Diataxis framework](https://diata
   - `tutorials/` – Learning tutorials
   - `media/` – Images and screenshots
   - `development/` – Developer documentation
-    - `docs.mdx` – Full documentation guide with linting rules
+    - `docs.mdx` – Documentation guide with linting rules
+    - `style-guide.mdx` – **Writing style and terminology rules**
 - `sidebars.ts` – Navigation configuration
 
 ## Commands
@@ -67,6 +68,7 @@ For step-by-step instructions on writing documentation:
 
 For detailed markdown formatting rules, see `dev/guidelines/markdown.md`.
 For documentation writing guidelines, see `dev/guidelines/documentation.md`.
+For the complete style guide including terminology, see `docs/development/style-guide.mdx`.
 
 ### Voice and Tone
 
@@ -74,6 +76,21 @@ For documentation writing guidelines, see `dev/guidelines/documentation.md`.
 - **Imperative mood** for guides: "Click **New Branch**"
 - **Present tense**: "Infrahub uses branches to isolate changes"
 - **Professional but approachable**: Avoid "simple", "easy", or "just"
+
+### Infrahub Terminology
+
+Capitalize these Infrahub-specific terms when referring to the feature:
+
+| Term | Capitalize? | Example |
+|------|-------------|---------|
+| Generator(s) | Yes | "Infrahub **Generators** convert service models into objects." |
+| Transformation(s) | Yes | "**Transformations** convert graph data into artifacts." |
+| Profile(s) | Yes | "Create **Profiles** for your devices." |
+| Resource Manager | Yes (singular) | "Use **Resource Manager** to allocate IPs." |
+| artifact(s) | No | "The **artifact** is stored in object storage." |
+| transform (verb) | No | "Use this to **transform** data into vendor formats." |
+
+**Never use "transform" or "transforms" as a noun.** Always use "Transformation" or "Transformations".
 
 ## Documentation Workflow
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,143 @@
+# Infrahub Documentation Style Guide
+
+This guide defines capitalization and grammar rules for Infrahub documentation.
+
+## Core Principle
+
+> **Capitalize nouns that represent first-class, named Infrahub capabilities with defined behavior and APIs.**
+> **Do not capitalize generic industry concepts, even when Infrahub produces or uses them.**
+
+## Capitalization Rules
+
+### Generators
+
+**Always capitalize** when referring to the Infrahub feature.
+
+Generator is not a widely established industry term. In Infrahub, a Generator is a named system concept with specific semantics (idempotent, service-model-driven, graph-aware).
+
+| Usage | Correct | Incorrect |
+|-------|---------|-----------|
+| Feature reference | "Infrahub **Generators** convert service models into objects." | "Infrahub generators convert..." |
+| Plural | "Configure your **Generators** in the repository." | "Configure your generators..." |
+
+### Transformations
+
+**Always capitalize** when referring to the Infrahub feature. Use "transform" only as a verb, never as a noun.
+
+While "transformation" is a common word, Infrahub Transformations have a specific execution model, defined inputs (GraphQL queries), and defined outputs (artifacts).
+
+| Usage | Correct | Incorrect |
+|-------|---------|-----------|
+| Feature reference | "**Transformations** convert graph data into artifacts." | "transformations convert..." |
+| As a verb | "Use this to **transform** data into vendor formats." | "Use this Transform to..." |
+| Noun form | "Create a **Transformation** for config generation." | "Create a transform for..." |
+
+**Never use "transform" or "transforms" as a noun.** Always use "Transformation" or "Transformations".
+
+### Artifacts
+
+**Do NOT capitalize** unless it starts a sentence or is at the beginning of a bullet point where other items are also capitalized.
+
+Artifact is a broadly accepted industry term. Infrahub artifacts are not conceptually novel in the same way Generators or Transformations are.
+
+| Usage | Correct | Incorrect |
+|-------|---------|-----------|
+| Mid-sentence | "The **artifact** is stored in object storage." | "The Artifact is stored..." |
+| Start of sentence | "**Artifacts** are generated automatically." | "artifacts are generated..." |
+| In a capitalized list | "- **Artifacts**: Generated outputs..." | "- **artifacts**: Generated outputs..." (if other items start capitalized) |
+
+### Profiles
+
+**Always capitalize** when referring to the Infrahub feature.
+
+| Usage | Correct | Incorrect |
+|-------|---------|-----------|
+| Feature reference | "Infrahub **Profiles** allow you to..." | "Infrahub profiles allow..." |
+| Plural | "Create **Profiles** for your devices." | "Create profiles for..." |
+
+### Resource Manager
+
+**Always capitalize** and **always use singular form**.
+
+| Usage | Correct | Incorrect |
+|-------|---------|-----------|
+| Feature reference | "Use **Resource Manager** to allocate IPs." | "Use Resource Managers..." |
+| Plural context | "Configure **Resource Manager** instances." | "Configure Resource Managers." |
+
+## Bullet Point Lists
+
+When a word appears at the start of a bullet point in a list where other items begin with capitalized words, capitalize it for consistency.
+
+**Correct:**
+```markdown
+- **Caching**: Generated artifacts are stored...
+- **Traceability**: Past values remain available...
+- **Peer Review**: Artifacts are automatically part of...
+- **Database**: Artifact nodes are stored...
+```
+
+**Incorrect:**
+```markdown
+- **Caching**: Generated artifacts are stored...
+- **Traceability**: Past values remain available...
+- **Peer Review**: artifacts are automatically part of...  <!-- Should be capitalized -->
+- **Database**: artifact nodes are stored...               <!-- Should be capitalized -->
+```
+
+## Link Text in Lists
+
+When a word appears as link text at the start of a bullet point in a list where other items begin with capitalized words, capitalize it.
+
+**Correct:**
+```markdown
+- [Version control](version-control): Understand how branches work...
+- [Schema](schema): Learn about data models...
+- [Artifacts](artifact): Explore generated outputs...
+- [Generators](generator): Learn about code generation...
+```
+
+**Incorrect:**
+```markdown
+- [Version control](version-control): Understand how branches work...
+- [Schema](schema): Learn about data models...
+- [artifacts](artifact): Explore generated outputs...  <!-- Should be capitalized -->
+- [generators](generator): Learn about code generation...  <!-- Should be capitalized -->
+```
+
+## Quick Reference Table
+
+| Term | Capitalize? | Notes |
+|------|-------------|-------|
+| Generator(s) | Yes | Infrahub-specific primitive |
+| Transformation(s) | Yes | First-class capability (noun form) |
+| transform | No | Verb only |
+| artifact(s) | No | Generic industry term (capitalize at sentence/list start) |
+| Profile(s) | Yes | Infrahub-specific feature |
+| Resource Manager | Yes | Always singular, system-level capability |
+
+## Product and Technology Names
+
+Always use correct capitalization for these terms:
+
+- Ansible
+- Docker, DockerHub
+- GitHub, GitLab, GitPod
+- Grafana
+- GraphQL
+- InfluxDB
+- Infrahub
+- Jinja2
+- K3s, K8s, Kubernetes
+- MySQL
+- Neo4j
+- NGINX
+- Node.js
+- OpenAPI, OpenConfig
+- OpsMill
+- PostgreSQL
+- Prometheus
+- Python
+- RabbitMQ
+- Terraform
+- Ubuntu
+- VS Code

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -134,7 +134,7 @@ Infrahub uses [Vale](https://vale.sh) to check grammar, style, and word usage. Y
 
 [Markdownlint](https://github.com/DavidAnson/markdownlint) is used to encourage consistent markdown files, and Infrahub's configuration is located at `.markdownlint.yaml`.
 
-Most Vale warnings match up with the [style guide](#style-guide) explanations below. Other warnings often fall into the `Infrahub.spelling` rule. These are caused by misspellings, product names, names of people, or otherwise unknown technical terms. See the [procedures for updating rules](#spelling-errors) below for details on adding terms to the approved list.
+Most Vale warnings match up with the [style guide](./style-guide.mdx) explanations. Other warnings often fall into the `Infrahub.spelling` rule. These are caused by misspellings, product names, names of people, or otherwise unknown technical terms. See the [procedures for updating rules](#spelling-errors) below for details on adding terms to the approved list.
 
 ### Install VS Code linting extensions
 
@@ -365,130 +365,6 @@ You can also organize your screenshots using folders, by specifying the folder n
 ```ts
 await saveScreenshotForDocs(page, "my-folder/my-screenshot-name" );
 ```
-
-## Style guide
-
-As a general rule, prefer consistency and simplicity when possible. This guide should help in making choices, but it is a living document and should evolve as the needs of the project evolve. For anything not answered below, reference the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).
-
-General tips:
-<!-- vale off -->
-- Avoid words like *easy*, *just*, or *simple* to describe how to do something or how "easy" a task is.
-<!-- vale on -->
-- If a sentence looks too long, it probably is. Try and simplify it or break it into multiple sentences.
-- Avoid jargon unless you are sure the reader knows the term.
-- Don't hesitate to link between pages and concepts.
-- Avoid repeating information when possible, and instead link out to topic or reference pages.
-
-### Language
-
-We use American English for most standard text. Unique technical terms are [included below](#common-external-words), or in the [Microsoft A-Z word list](https://learn.microsoft.com/en-us/style-guide/welcome/).
-
-### Trailing commas
-
-Use a trailing comma when listing multiple items. This is commonly known as the Oxford comma or serial comma.
-
-**:x: Don't do this:** There are devices, organizations, and users.
-
-**:white_check_mark: Do this:** There are devices, organizations, and users.
-
-### Headings and titles
-
-Headings and titles should capitalize the first word only and end with no punctuation. The exception being any proper noun.
-
-**:x: Don't do this**: Getting Started!
-
-**:white_check_mark: Do this**: Getting started
-
-Every page should have a top-level heading. Additional heading tiers can only exist if a higher tier has been used.
-
-**:x: Don't do this**:
-
-```markdown
-<!-- This is missing an h2 -->
-# Page title
-
-### Smaller heading
-```
-
-### Avoid over-capitalization
-
-It is tempting to want to capitalize all feature names. Unless the term is a named marketing feature, avoid capitalization.
-
-**:x: Don't do this**: Git Repository, API Server, User Management
-
-**:white_check_mark: Do this**: Git repository, API server, user management
-
-### Lists
-
-Capitalize the first letter of each list item. If an item is a complete sentence, give it a period at the end. If it's not, it is okay to omit punctuation. The [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/scannable-content/lists) has a good explanation of how to handle list punctuation.
-
-When listing items and descriptions, prefer the use of a colon (:) instead of a dash (-).
-
-```markdown
-<!-- Don't do this -->
-- Not - this
-- Or - this
-
-<!-- Do this -->
-- Do: this
-- And: this
-```
-
-### Colons
-
-Avoid extra spaces before a colon.
-
-```markdown
-<!-- Don't do this -->
-Feature : Explanation of feature
-
-<!-- Do this -->
-
-Feature: Explanation of feature
-```
-
-### Code blocks
-
-When creating a code block or snippet with three backticks, make sure to include a language designation.
-<!-- markdownlint-disable -->
-~~~md
-```shell
-this is a shell script
-```
-~~~
-<!-- markdownlint-restore -->
-
-### Marking code items
-
-Sometimes you need to mention a `function` or `ModelName`. To do so, use the inline code backticks in markdown.
-
-### Excalidraw diagrams
-
-You can attach `.excalidraw` diagrams to visually explain concepts, workflows, or processes within the documentation.
-
-:::warning
-Always save Excalidraw files with the "Embed Scene" option checked to maintain the ability to edit in VS Code.
-:::
-
-### Use i.e. for examples
-
-Prefer `i.e.` over `e.g.` or `ex.`. In a sentence, `i.e.` is surrounded by commas.
-
-For example: *Select the current branch, i.e., 'main'.*
-
-It's also acceptable and clearer to use "for example" or "such as".
-
-### Common external words
-
-Refer to external brand guidelines for capitalization rules. Here are some common spellings and uses for brands found in the Infrahub docs. Additional terms can be found in `.vale/styles/Infrahub/branded-terms-case-swap.yml`.
-
-- GitHub
-- GitLab
-- Git
-- RabbitMQ
-- GraphQL
-- MacOS
-- Linux
 
 ## Documentation release checklist
 

--- a/docs/docs/development/style-guide.mdx
+++ b/docs/docs/development/style-guide.mdx
@@ -1,13 +1,24 @@
-# Infrahub Documentation Style Guide
+---
+title: Documentation style guide
+---
 
-This guide defines capitalization and grammar rules for Infrahub documentation.
+# Documentation style guide
 
-## Core Principle
+This guide defines writing style, capitalization, and grammar rules for Infrahub documentation. As a general rule, prefer consistency and simplicity when possible. For anything not answered below, reference the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).
+
+General tips:
+<!-- vale off -->
+- Avoid words like *easy*, *just*, or *simple* to describe how to do something or how "easy" a task is.
+<!-- vale on -->
+- If a sentence looks too long, it probably is. Try and simplify it or break it into multiple sentences.
+- Avoid jargon unless you are sure the reader knows the term.
+- Don't hesitate to link between pages and concepts.
+- Avoid repeating information when possible, and instead link out to topic or reference pages.
+
+## Infrahub terminology
 
 > **Capitalize nouns that represent first-class, named Infrahub capabilities with defined behavior and APIs.**
 > **Do not capitalize generic industry concepts, even when Infrahub produces or uses them.**
-
-## Capitalization Rules
 
 ### Generators
 
@@ -30,7 +41,7 @@ While "transformation" is a common word, Infrahub Transformations have a specifi
 |-------|---------|-----------|
 | Feature reference | "**Transformations** convert graph data into artifacts." | "transformations convert..." |
 | As a verb | "Use this to **transform** data into vendor formats." | "Use this Transform to..." |
-| Noun form | "Create a **Transformation** for config generation." | "Create a transform for..." |
+| Noun form | "Create a **Transformation** for configuration generation." | "Create a transform for..." |
 
 **Never use "transform" or "transforms" as a noun.** Always use "Transformation" or "Transformations".
 
@@ -64,7 +75,73 @@ Artifact is a broadly accepted industry term. Infrahub artifacts are not concept
 | Feature reference | "Use **Resource Manager** to allocate IPs." | "Use Resource Managers..." |
 | Plural context | "Configure **Resource Manager** instances." | "Configure Resource Managers." |
 
-## Bullet Point Lists
+### Quick reference table
+
+| Term | Capitalize? | Notes |
+|------|-------------|-------|
+| Generator(s) | Yes | Infrahub-specific primitive |
+| Transformation(s) | Yes | First-class capability (noun form) |
+| transform | No | Verb only |
+| artifact(s) | No | Generic industry term (capitalize at sentence/list start) |
+| Profile(s) | Yes | Infrahub-specific feature |
+| Resource Manager | Yes | Always singular, system-level capability |
+
+## Language
+
+We use American English for most standard text. Unique technical terms are [included below](#product-and-technology-names), or in the [Microsoft A-Z word list](https://learn.microsoft.com/en-us/style-guide/welcome/).
+
+## Trailing commas
+
+Use a trailing comma when listing multiple items. This is commonly known as the Oxford comma or serial comma.
+
+**:x: Don't do this:** There are devices, organizations, and users.
+
+**:white_check_mark: Do this:** There are devices, organizations, and users.
+
+## Headings and titles
+
+Headings and titles should capitalize the first word only and end with no punctuation. The exception being any proper noun.
+
+**:x: Don't do this**: Getting Started!
+
+**:white_check_mark: Do this**: Getting started
+
+Every page should have a top-level heading. Additional heading tiers can only exist if a higher tier has been used.
+
+**:x: Don't do this**:
+
+```markdown
+<!-- This is missing an h2 -->
+# Page title
+
+### Smaller heading
+```
+
+## Avoid over-capitalization
+
+It is tempting to want to capitalize all feature names. Unless the term is a named marketing feature, avoid capitalization.
+
+**:x: Don't do this**: Git Repository, API Server, User Management
+
+**:white_check_mark: Do this**: Git repository, API server, user management
+
+## Lists
+
+Capitalize the first letter of each list item. If an item is a complete sentence, give it a period at the end. If it's not, it is okay to omit punctuation. The [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/scannable-content/lists) has a good explanation of how to handle list punctuation.
+
+When listing items and descriptions, prefer the use of a colon (:) instead of a dash (-).
+
+```markdown
+<!-- Don't do this -->
+- Not - this
+- Or - this
+
+<!-- Do this -->
+- Do: this
+- And: this
+```
+
+### Bullet point lists
 
 When a word appears at the start of a bullet point in a list where other items begin with capitalized words, capitalize it for consistency.
 
@@ -84,7 +161,7 @@ When a word appears at the start of a bullet point in a list where other items b
 - **Database**: artifact nodes are stored...               <!-- Should be capitalized -->
 ```
 
-## Link Text in Lists
+### Link text in lists
 
 When a word appears as link text at the start of a bullet point in a list where other items begin with capitalized words, capitalize it.
 
@@ -104,23 +181,57 @@ When a word appears as link text at the start of a bullet point in a list where 
 - [generators](generator): Learn about code generation...  <!-- Should be capitalized -->
 ```
 
-## Quick Reference Table
+## Colons
 
-| Term | Capitalize? | Notes |
-|------|-------------|-------|
-| Generator(s) | Yes | Infrahub-specific primitive |
-| Transformation(s) | Yes | First-class capability (noun form) |
-| transform | No | Verb only |
-| artifact(s) | No | Generic industry term (capitalize at sentence/list start) |
-| Profile(s) | Yes | Infrahub-specific feature |
-| Resource Manager | Yes | Always singular, system-level capability |
+Avoid extra spaces before a colon.
 
-## Product and Technology Names
+```markdown
+<!-- Don't do this -->
+Feature : Explanation of feature
+
+<!-- Do this -->
+
+Feature: Explanation of feature
+```
+
+## Code blocks
+
+When creating a code block or snippet with three backticks, make sure to include a language designation.
+<!-- markdownlint-disable -->
+~~~md
+```shell
+this is a shell script
+```
+~~~
+<!-- markdownlint-restore -->
+
+## Marking code items
+
+Sometimes you need to mention a `function` or `ModelName`. To do so, use the inline code backticks in markdown.
+
+## Excalidraw diagrams
+
+You can attach `.excalidraw` diagrams to visually explain concepts, workflows, or processes within the documentation.
+
+:::warning
+Always save Excalidraw files with the "Embed Scene" option checked to maintain the ability to edit in VS Code.
+:::
+
+## Use i.e. for examples
+
+Prefer `i.e.` over `e.g.` or `ex.`. In a sentence, `i.e.` is surrounded by commas.
+
+For example: *Select the current branch, i.e., 'main'.*
+
+It's also acceptable and clearer to use "for example" or "such as".
+
+## Product and technology names
 
 Always use correct capitalization for these terms:
 
 - Ansible
 - Docker, DockerHub
+- Git
 - GitHub, GitLab, GitPod
 - Grafana
 - GraphQL
@@ -128,6 +239,8 @@ Always use correct capitalization for these terms:
 - Infrahub
 - Jinja2
 - K3s, K8s, Kubernetes
+- Linux
+- MacOS
 - MySQL
 - Neo4j
 - NGINX
@@ -141,3 +254,5 @@ Always use correct capitalization for these terms:
 - Terraform
 - Ubuntu
 - VS Code
+
+Additional terms can be found in `.vale/styles/Infrahub/branded-terms-case-swap.yml`.

--- a/docs/docs/getting-started/concepts.mdx
+++ b/docs/docs/getting-started/concepts.mdx
@@ -61,15 +61,15 @@ A recording of a livestream that covers:
   <VideoPlayer url='https://www.youtube.com/live/0Z_SBoPmGws' light />
 </center>
 
-## Data transformations
+## Data Transformations
 
 ![Transformations](./../media/overview-transformations.excalidraw.svg)
 
 Transformations in Infrahub are operations that allow users to extract and export their infrastructure data in a structured and repeatable way. It involves converting data retrieved via GraphQL queries into a desired format, using either Jinja2 templates or Python code.
 
-These transformations allow for flexible and powerful data manipulation, making it easier to integrate and utilize data in various applications and workflows.
+These Transformations allow for flexible and powerful data manipulation, making it easier to integrate and utilize data in various applications and workflows.
 
-<ReferenceLink title="Learn more about transformation" url="../topics/transformation" />
+<ReferenceLink title="Learn more about Transformations" url="../topics/transformation" />
 
 ## Generators
 
@@ -138,7 +138,7 @@ Downstream objects are linked to the generator. If a business service needs upda
 For example, when deploying a new service:
     - A branch is created to stage the changes
     - A generator runs and creates the needed objects according to the business logic
-    - A transformation runs to create the needed configuration files
+    - A Transformation runs to create the needed configuration files
     - The changes are reviewed and eventually merged in a proposed change
 
 :::success

--- a/docs/docs/guides/computed-attributes.mdx
+++ b/docs/docs/guides/computed-attributes.mdx
@@ -149,7 +149,7 @@ Once completed, you can load this schema into Infrahub.
 
 :::note
 
-You can specify a Transformation that doesn't yet exist in Infrahub, attribute will just remain empty. Once the Transformation is loaded, Infrahub will automatically catch up and compute the value of this attribute.
+You can specify a Transformation that doesn't yet exist in Infrahub, and the attribute remains empty. Once the Transformation is loaded, Infrahub automatically catches up and computes the value of this attribute.
 
 :::
 

--- a/docs/docs/guides/computed-attributes.mdx
+++ b/docs/docs/guides/computed-attributes.mdx
@@ -7,11 +7,11 @@ title: Creating a computed attribute
 Infrahub supports two different types of computed attributes:
 
 - [**Jinja2**](../topics/computed-attributes.mdx#jinja-computed-attribute) uses a concise Jinja2 template directly within the schema definition.
-- [**Python**](../topics/computed-attributes.mdx#python-computed-attribute) leverages Infrahub's [Python transform](../topics/transformation.mdx) feature to offer endless possibilities.
+- [**Python**](../topics/computed-attributes.mdx#python-computed-attribute) leverages Infrahub's [Python Transformation](../topics/transformation.mdx) feature to offer endless possibilities.
 
 ## Recommendations
 
-- We recommend to keep Python transforms straightforward to not impact system performance.
+- We recommend to keep Python Transformations straightforward to not impact system performance.
 - Use `Jinja2` when the calculation logic is straightforward and concise.
 
 ## Adding a Jinja2 computed attribute
@@ -79,7 +79,7 @@ You can now load this schema into your Infrahub instance. For more details, refe
 Creating a Python computed attribute is a two-step process:
 
 1. Add the attribute to the schema.
-2. Prepare a Python Transform to implement the logic.
+2. Prepare a Python Transformation to implement the logic.
 
 In the following example we will create a computed attribute `description` for our `InfraCircuit` node. The value will be a combination of all endpoints locations.
 
@@ -149,13 +149,13 @@ Once completed, you can load this schema into Infrahub.
 
 :::note
 
-You can specify a Transform that doesn't yet exist in Infrahub, attribute will just remain empty. Once the Transform is loaded, Infrahub will automatically catch up and compute the value of this attribute.
+You can specify a Transformation that doesn't yet exist in Infrahub, attribute will just remain empty. Once the Transformation is loaded, Infrahub will automatically catch up and compute the value of this attribute.
 
 :::
 
-### Create the Python transform
+### Create the Python Transformation
 
-Please refer to the [Python Transform guide](./python-transform.mdx) for further details.
+Please refer to the [Python Transformation guide](./python-transform.mdx) for further details.
 
 1. First we prepare a GraphQL query that returns the data we need
 
@@ -244,7 +244,7 @@ queries:
     file_path: computed_circuit_description.gql
 ```
 
-At this stage you should be able to test your Transform using `infrahubctl`
+At this stage you should be able to test your Transformation using `infrahubctl`
 
 :::note
 
@@ -256,7 +256,7 @@ To create a meaningful test, you may want to create: two sites, one circuit, and
 "site1::endpoint-a <- circuit1 -> site2::endpoint-b"
 ```
 
-4. Load the Transform in Infrahub
+4. Load the Transformation in Infrahub
 
 You need to commit these files to a Git repository and link the repository to Infrahub. Please refer to the [adding a repository to Infrahub](../guides/repository.mdx) guide.
 

--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -307,7 +307,7 @@ Verify your restoration was successful:
    Logs should show normal operation without errors.
 
 4. **Test artifact retrieval:**
-   Access the Infrahub UI and verify that stored artifacts (transforms, queries) are accessible.
+   Access the Infrahub UI and verify that stored artifacts (Transformations, queries) are accessible.
 
 ## Backup and restore Neo4j clusters <EnterpriseBadge />
 

--- a/docs/docs/guides/jinja2-transform.mdx
+++ b/docs/docs/guides/jinja2-transform.mdx
@@ -1,20 +1,20 @@
 ---
-title: Creating a Jinja transform
+title: Creating a Jinja Transformation
 ---
 
-# Creating a Jinja rendered file (transform)
+# Creating a Jinja rendered file (Transformation)
 
-Within Infrahub a [Transform](../topics/transformation.mdx) is defined in an [external repository](../topics/repository.mdx). However, during development and troubleshooting it is easiest to start from your local computer and run the render using [infrahubctl render]($(base_url)infrahubctl/infrahubctl-render).
+Within Infrahub a [Transformation](../topics/transformation.mdx) is defined in an [external repository](../topics/repository.mdx). However, during development and troubleshooting it is easiest to start from your local computer and run the render using [infrahubctl render]($(base_url)infrahubctl/infrahubctl-render).
 
-The goal of this guide is to develop a Jinja Transform and add it to Infrahub, we will achieve this by following these steps.
+The goal of this guide is to develop a Jinja Transformation and add it to Infrahub, we will achieve this by following these steps.
 
 1. Identify the relevant data you want to extract from the database using a [GraphQL query](../topics/graphql.mdx), that can take an input parameter to filter the data
 2. Write a Jinja2 file that use the GraphQL query to read information from the system and render the data into a new format
-3. Create an entry for the Jinja2 Transform within an .infrahub.yml file.
+3. Create an entry for the Jinja2 Transformation within an .infrahub.yml file.
 4. Create a Git repository
-5. Test the Transform rendering with infrahubctl
+5. Test the Transformation rendering with infrahubctl
 6. Add the repository to Infrahub as an external repository
-7. Validate that the Transform works by using the render API endpoint
+7. Validate that the Transformation works by using the render API endpoint
 
 ## 1. Loading a schema
 
@@ -128,7 +128,7 @@ Response to the tags query:
 }
 ```
 
-While it would be possible to create a Transform that targets all of these devices, for example if you want to create a report, the goal for us is to be able to focus on one of these objects. For this reason we need to modify the query from above to take an input parameter so that we can filter the result to what we want.
+While it would be possible to create a Transformation that targets all of these devices, for example if you want to create a report, the goal for us is to be able to focus on one of these objects. For this reason we need to modify the query from above to take an input parameter so that we can filter the result to what we want.
 
 Create a local directory on your computer.
 
@@ -189,15 +189,15 @@ For more information, please consult the [SDK Templating Reference]($(base_url)p
 
 ## 4. Create a .infrahub.yml file
 
-In the .infrahub.yml file you define what transforms you have in your repository that you want to make available for Infrahub.
+In the .infrahub.yml file you define what Transformations you have in your repository that you want to make available for Infrahub.
 
 Create a .infrahub.yml file in the root of the directory.
 
 ```yaml
 ---
 jinja2_transforms:
-  - name: device_config_transform             # Unique name for your transform
-    description: "device config transform"    # (optional)
+  - name: device_config_transform             # Unique name for your Transformation
+    description: "device config Transformation"    # (optional)
     query: "device_config_query"              # Name or ID of the GraphQLQuery
     template_path: "device_config.j2"         # Path to the main Jinja2 template
 
@@ -208,7 +208,7 @@ queries:
 
 > The main Jinja2 template can import other templates
 
-Three parts here are required, first the `name` of the Transform which should be unique across Infrahub, `query` the GraphqlQuery linked to our Transform and also the `template_path` that should point to the Jinja2 file within the repository.
+Three parts here are required, first the `name` of the Transformation which should be unique across Infrahub, `query` the GraphqlQuery linked to our Transformation and also the `template_path` that should point to the Jinja2 file within the repository.
 
 ## 5. Create a Git repository
 
@@ -216,9 +216,9 @@ Within the `device_config_render` folder you should now have tree files:
 
 * device_config.gql: Contains the GraphQL query
 * device_config.j2: Contains the Jinja2 Template
-* .infrahub.yml: Contains the definition for the transform
+* .infrahub.yml: Contains the definition for the Transformation
 
-Before we can test our Transform we must add the files to a local Git repository.
+Before we can test our Transformation we must add the files to a local Git repository.
 
 ```shell
 git init --initial-branch=main
@@ -228,13 +228,13 @@ git commit -m "First commit"
 
 ## 6. Test the render using infrahubctl
 
-Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available transforms.
+Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available Transformations.
 
 ```shell
 
  Usage: infrahubctl render [OPTIONS] TRANSFORM_NAME [VARIABLES]...
 
- Render a local Jinja2 Transform for debugging purpose.
+ Render a local Jinja2 Transformation for debugging purpose.
 
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────╮
 │ *    transform_name      TEXT            [default: None] [required]                             │
@@ -243,7 +243,7 @@ Using infrahubctl you can first verify that the `.infrahub.yml` file is formatte
 │                                          [default: None]                                        │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --branch                       TEXT  Branch on which to render the transform. [default: None]   │
+│ --branch                       TEXT  Branch on which to render the Transformation. [default: None]   │
 │ --debug          --no-debug          [default: no-debug]                                        │
 │ --config-file                  TEXT  [env var: INFRAHUBCTL_CONFIG] [default: infrahubctl.toml]  │
 │ --help                               Show this message and exit.                                │
@@ -266,9 +266,9 @@ If `--branch` is not provided it will automatically use the name of the local br
 
 In order to avoid having the same instructions over and over please refer to the guide [adding a repository to Infrahub](../guides/repository.mdx) in order to sync the repository you created and make it available within Infrahub.
 
-## 8. Accessing the Transform from the API
+## 8. Accessing the Transformation from the API
 
-A Transform can be rendered on demand via the REST API with the endpoint: `https://<host>/api/transform/jinja2/<transform name or ID>`
+A Transformation can be rendered on demand via the REST API with the endpoint: `https://<host>/api/transform/jinja2/<transform name or ID>`
 
 This endpoint is branch-aware and it accepts the name of the branch and/or the time as URL parameters.
 

--- a/docs/docs/guides/jinja2-transform.mdx
+++ b/docs/docs/guides/jinja2-transform.mdx
@@ -212,7 +212,7 @@ Three parts here are required, first the `name` of the Transformation which shou
 
 ## 5. Create a Git repository
 
-Within the `device_config_render` folder you should now have tree files:
+Within the `device_config_render` folder you should now have three files:
 
 * device_config.gql: Contains the GraphQL query
 * device_config.j2: Contains the Jinja2 Template

--- a/docs/docs/guides/jinja2-transform.mdx
+++ b/docs/docs/guides/jinja2-transform.mdx
@@ -2,7 +2,7 @@
 title: Creating a Jinja Transformation
 ---
 
-# Creating a Jinja rendered file (Transformation)
+# Creating a Jinja-rendered file (Transformation)
 
 Within Infrahub a [Transformation](../topics/transformation.mdx) is defined in an [external repository](../topics/repository.mdx). However, during development and troubleshooting it is easiest to start from your local computer and run the render using [infrahubctl render]($(base_url)infrahubctl/infrahubctl-render).
 

--- a/docs/docs/guides/python-transform.mdx
+++ b/docs/docs/guides/python-transform.mdx
@@ -1,26 +1,26 @@
 ---
-title: Creating a Python transform
+title: Creating a Python Transformation
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Creating a Python transform
+# Creating a Python Transformation
 
-Within Infrahub a [Transform](../topics/transformation.mdx) is defined in an [external repository](../topics/repository.mdx). However, during development and troubleshooting it is easiest to start from your local computer and run the Transform using [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform).
+Within Infrahub a [Transformation](../topics/transformation.mdx) is defined in an [external repository](../topics/repository.mdx). However, during development and troubleshooting it is easiest to start from your local computer and run the Transformation using [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform).
 
-The goal of this guide is to develop a Python Transform and add it to Infrahub, we will achieve this by following these steps.
+The goal of this guide is to develop a Python Transformation and add it to Infrahub, we will achieve this by following these steps.
 
 1. Identify the relevant data you want to extract from the database using a [GraphQL query](../topics/graphql.mdx), that can take an input parameter to filter the data
-2. Write a Python script that use the GraphQL query to read information from the system and transforms the data into a new format
-3. Create an entry for the Transform within an .infrahub.yml file.
+2. Write a Python script that use the GraphQL query to read information from the system and transform the data into a new format
+3. Create an entry for the Transformation within an .infrahub.yml file.
 4. Create a Git repository
-5. Test the Transform with infrahubctl
+5. Test the Transformation with infrahubctl
 6. Add the repository to Infrahub as an external repository
-7. Validate that the Transform works by using the Transform API endpoint
+7. Validate that the Transformation works by using the Transformation API endpoint
 
 ## 1. Loading a schema
 
-In this guide we are going to work with a very simplistic network device model. It won't provide a transform that is very useful, the goal is instead to show how the transforms are created. Once you have mastered the basics you will be ready to go on to create more advanced transforms.
+In this guide we are going to work with a very simplistic network device model. It won't provide a Transformation that is very useful, the goal is instead to show how Transformations are created. Once you have mastered the basics you will be ready to go on to create more advanced Transformations.
 
 ```yaml
 ---
@@ -213,7 +213,7 @@ Response to the query:
   </TabItem>
 </Tabs>
 
-While it would be possible to create a transform that targets all of these devices, for example if you want to create a report, the goal for us is to be able to focus on one of these objects. For this reason we need to modify the query from above to take an input parameter so that we can filter the result to what we want.
+While it would be possible to create a Transformation that targets all of these devices, for example if you want to create a report, the goal for us is to be able to focus on one of these objects. For this reason we need to modify the query from above to take an input parameter so that we can filter the result to what we want.
 
 Create a local directory on your computer.
 
@@ -231,9 +231,9 @@ The query will require an input parameter called `$name` what will refer to the 
 }
 ```
 
-## 3. Create the Python transform file
+## 3. Create the Python Transformation file
 
-The next step is to create the actual Python transform. The transform is a Python class that inherits from InfrahubTransform from the [Python SDK]($(base_url)python-sdk/introduction). Create a file called `device_config_render/device_config.py`:
+The next step is to create the actual Python Transformation. The Transformation is a Python class that inherits from InfrahubTransform from the [Python SDK]($(base_url)python-sdk/introduction). Create a file called `device_config_render/device_config.py`:
 
 <Tabs groupId="convertResponse">
   <TabItem value="Non-converted query response">
@@ -269,7 +269,7 @@ class DeviceConfigTransform(InfrahubTransform):
   </TabItem>
 </Tabs>
 
-The example is simplistic in terms of what we do with the data, but all of the important parts of a Transform exist here.
+The example is simplistic in terms of what we do with the data, but all of the important parts of a Transformation exist here.
 
 1. We import the InfrahubTransform class.
 
@@ -293,9 +293,9 @@ Here we need to note the name of the class as we will need it later, optionally 
 
 The query part refers to the the query that we will define in the `.infrahub.yml` repository configuration file later in the guide.
 
-With this configuration, the endpoint of our transform will be [http://localhost:8000/api/transform/python/device_config_transform](http://localhost:8000/api/transform/python/device_config_transform).
+With this configuration, the endpoint of our Transformation will be [http://localhost:8000/api/transform/python/device_config_transform](http://localhost:8000/api/transform/python/device_config_transform).
 
-4. The Transform method
+4. The Transformation method
 
 <Tabs groupId="convertResponse">
   <TabItem value="Non-converted query response">
@@ -327,13 +327,13 @@ async def transform(self, data):
   </TabItem>
 </Tabs>
 
-When running the transform, the `data` input variable will consist of the response to the query we created or the webhook payload if using the transform with a [Custom Webhook](../topics/webhooks.mdx).
+When running the Transformation, the `data` input variable will consist of the response to the query we created or the webhook payload if using the Transformation with a [Custom Webhook](../topics/webhooks.mdx).
 
-In this case, the transform returns a JSON object consisting of two keys `device_hostname` and `device_description` where we have modified the data in some way. Here you would return data in the format you need.
+In this case, the Transformation returns a JSON object consisting of two keys `device_hostname` and `device_description` where we have modified the data in some way. Here you would return data in the format you need.
 
 :::info
 
-If you are unsure of the format of the data you can set a debug marker when testing the Transform with infrahubctl:
+If you are unsure of the format of the data you can set a debug marker when testing the Transformation with infrahubctl:
 
 ```python
     async def transform(self, data):
@@ -347,7 +347,7 @@ If you are unsure of the format of the data you can set a debug marker when test
 
 ## 4. Create an .infrahub.yml file
 
-The [.infrahub.yml](../topics/infrahub-yml.mdx) file allows you to define both the transform and query.
+The [.infrahub.yml](../topics/infrahub-yml.mdx) file allows you to define both the Transformation and query.
 
 :::info Convert query to Infrahub SDK objects
 We provide `convert_query_response` option to be toggled to be able to access objects from the GraphQL query as Infrahub SDK objects rather than the raw dictionary response.
@@ -395,8 +395,8 @@ queries:
 </Tabs>
 
 <Tabs>
-  <TabItem value="Python transform" default>
-    Two parts here are required, first the `name` of the Transform which should be unique across Infrahub and also the `file_path` that should point to the Python file within the repository. In this example we have also defined `class_name`, the reason for this is that we gave our class the name `DeviceConfigTransform` instead of the default `Transform`.
+  <TabItem value="Python Transformation" default>
+    Two parts here are required, first the `name` of the Transformation which should be unique across Infrahub and also the `file_path` that should point to the Python file within the repository. In this example we have also defined `class_name`, the reason for this is that we gave our class the name `DeviceConfigTransform` instead of the default `Transform`.
   </TabItem>
   <TabItem value="Queries">
     Here the `name` refers to the query's name and `file_path` should point to the GraphQL file within the repository.
@@ -405,17 +405,17 @@ queries:
 
 See [this topic](../topics/infrahub-yml.mdx) for a full explanation of everything that can be defined in the `.infrahub.yml` file.
 
-## 5. Test the Transform using infrahubctl
+## 5. Test the Transformation using infrahubctl
 
-Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available transforms.
+Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available Transformations.
 
 ```shell title="❯ infrahubctl transform --list"
-Python transforms defined in repository: 1
+Python Transformations defined in repository: 1
 device_config_transform (device_config.py::DeviceConfigTransform)
 ```
 
 :::info
-Trying to run the transform with just the transform name will produce an error.
+Trying to run the Transformation with just the Transformation name will produce an error.
 
 ```shell title="❯ infrahubctl transform device_config_transform"
 {'message': "Variable '$name' of required type 'String!' was not provided.", 'locations': [{'line': 1, 'column': 19}]}
@@ -425,7 +425,7 @@ Here we can see that our query is missing the required input for `$name` which i
 
 :::
 
-Run the Transform and specify the variable name along with the tag we want to target.
+Run the Transformation and specify the variable name along with the tag we want to target.
 
 ```json title="❯ infrahubctl transform device_config_transform name=switch2"
 {
@@ -434,17 +434,17 @@ Run the Transform and specify the variable name along with the tag we want to ta
 }
 ```
 
-We have now successfully created a transform. Most of the transforms you will create would be more complex than this, however the main building blocks will always remain the same. It could be that you need the output in OpenConfig format, as Terraform input variables or any other kind of format.
+We have now successfully created a Transformation. Most of the Transformations you will create would be more complex than this, however the main building blocks will always remain the same. It could be that you need the output in OpenConfig format, as Terraform input variables or any other kind of format.
 
 ## 6. Create a Git repository
 
 Within the `device_config_render` folder you should now have 3 files:
 
 * `device_config_render/device_config.gql`: Contains the GraphQL query
-* `device_config_render/device_config.py`: Contains the Python code for the transform
-* `.infrahub.yml`: Contains the definition for the transform
+* `device_config_render/device_config.py`: Contains the Python code for the Transformation
+* `.infrahub.yml`: Contains the definition for the Transformation
 
-Before we can test our transform we must add the files to a local Git repository.
+Before we can test our Transformation we must add the files to a local Git repository.
 
 ```shell
 git init --initial-branch=main
@@ -456,9 +456,9 @@ git commit -m "First commit"
 
 In order to avoid having the same instructions over and over please refer to the guide [adding a repository to Infrahub](../guides/repository.mdx) in order to sync the repository you created and make it available within Infrahub.
 
-## 8. Accessing the transform from the API
+## 8. Accessing the Transformation from the API
 
-Once the repository is synced to Infrahub you can access the Transform from the API:
+Once the repository is synced to Infrahub you can access the Transformation from the API:
 
 ```json title="❯ curl http://localhost:8000/api/transform/python/device_config_transform?name=switch2"
 {

--- a/docs/docs/guides/webhooks.mdx
+++ b/docs/docs/guides/webhooks.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 Infrahub supports two different types of webhooks:
 
 - `Standard Webhook` sends event information to an external endpoint.
-- `Custom Webhook` allows the ability to tie events to a [transformation](../topics/transformation.mdx) to configure the payload being sent to an external endpoint.
+- `Custom Webhook` allows the ability to tie events to a [Transformation](../topics/transformation.mdx) to configure the payload being sent to an external endpoint.
 
 # Managing webhooks
 
@@ -48,21 +48,21 @@ mutation {
   </TabItem>
 </Tabs>
 
-# Creating a custom webhook with a transform
+# Creating a custom webhook with a Transformation
 
 Custom webhooks allow you to transform event data before sending it to an external endpoint. This is useful when the receiving system expects a specific payload format, such as Slack, Microsoft Teams, GitHub Actions, or other third-party APIs.
 
-For general information about Python transforms, see the [Python transform guide](./python-transform.mdx). For details about webhook events and payloads, see the [webhooks topic](../topics/webhooks.mdx).
+For general information about Python Transformations, see the [Python Transformation guide](./python-transform.mdx). For details about webhook events and payloads, see the [webhooks topic](../topics/webhooks.mdx).
 
 :::note
 
-When using a transform with a webhook, the transform receives the webhook event data directly instead of executing its GraphQL query. The `query` attribute is still required on the transform class but is not used. See [GitHub issue #6650](https://github.com/opsmill/infrahub/issues/6650) for updates on this requirement.
+When using a Transformation with a webhook, the Transformation receives the webhook event data directly instead of executing its GraphQL query. The `query` attribute is still required on the Transformation class but is not used. See [GitHub issue #6650](https://github.com/opsmill/infrahub/issues/6650) for updates on this requirement.
 
 :::
 
-## 1. Create the Python transform
+## 1. Create the Python Transformation
 
-Create a Python file with a transform class that processes webhook event data. The transform receives a dictionary containing the event information:
+Create a Python file with a Transformation class that processes webhook event data. The Transformation receives a dictionary containing the event information:
 
 ```python title="transforms/slack_webhook.py"
 from typing import Any
@@ -110,7 +110,7 @@ See the [webhooks topic](../topics/webhooks.mdx) for example event payloads.
 
 ## 2. Create a placeholder GraphQL query
 
-Create a GraphQL query file. This query is required but not executed for webhook transforms:
+Create a GraphQL query file. This query is required but not executed for webhook Transformations:
 
 ```graphql title="queries/placeholder.gql"
 query PlaceholderQuery {
@@ -124,7 +124,7 @@ query PlaceholderQuery {
 
 ## 3. Configure .infrahub.yml
 
-Add the transform and query to your repository configuration:
+Add the Transformation and query to your repository configuration:
 
 ```yaml title=".infrahub.yml"
 # yaml-language-server: $schema=https://schema.infrahub.app/python-sdk/repository-config/latest.json
@@ -141,7 +141,7 @@ queries:
 
 ## 4. Add the repository to Infrahub
 
-Add your repository containing the transform to Infrahub. See the [repository guide](./repository.mdx) for instructions.
+Add your repository containing the Transformation to Infrahub. See the [repository guide](./repository.mdx) for instructions.
 
 ## 5. Create the custom webhook
 
@@ -163,7 +163,7 @@ Add your repository containing the transform to Infrahub. See the [repository gu
 
   <TabItem value="graphql" label="Via the GraphQL Interface">
 
-First, get the transform ID:
+First, get the Transformation ID:
 
 ```graphql
 query GetTransform {
@@ -207,4 +207,4 @@ mutation CreateCustomWebhook {
 1. Make a change that triggers the configured event. For example, update a node if using `infrahub.node.updated`.
 2. Check that your external endpoint received the transformed payload.
 
-For troubleshooting, check the Infrahub logs for webhook delivery status and any transform errors.
+For troubleshooting, check the Infrahub logs for webhook delivery status and any Transformation errors.

--- a/docs/docs/reference/infrahub-tests.mdx
+++ b/docs/docs/reference/infrahub-tests.mdx
@@ -4,7 +4,7 @@ title: Tests configuration file
 
 # Tests configuration file
 
-The tests configuration file allows you to define multiple tests for Infrahub resources such as Jinja2 transforms, Python transforms, checks and GraphQL queries.
+The tests configuration file allows you to define multiple tests for Infrahub resources such as Jinja2 Transformations, Python Transformations, checks and GraphQL queries.
 
 The file should be formatted as a YAML file, have a filename prefixed with `test_` like `test_all.yml` and should be stored somewhere in the [repository](../topics/repository.mdx).
 

--- a/docs/docs/topics/artifact.mdx
+++ b/docs/docs/topics/artifact.mdx
@@ -27,12 +27,12 @@ The following MIME types or formats are supported and will be rendered properly 
 
 :::
 
-While it's always possible to generate [Transformations](./transformation.mdx) on demand via the API, having an Artifact provide some additional benefits:
+While it's always possible to generate [Transformations](./transformation.mdx) on demand via the API, having an artifact provide some additional benefits:
 
 - **Caching**: Generated artifacts are stored in the internal [object storage](./object-storage.mdx). For resource intensive transformations, it will significantly reduce the load of the system if an artifact can be serve from the cache instead of regenerating each time.
 - **Traceability**: Past values of an artifact remain available. In a future release, it will be possible to compare the value of an artifact over time.
-- **Peer Review**: Artifacts are automatically part of the [Proposed Change](./proposed-change.mdx) review process.
-- **Database**: Artifact nodes are stored in the database and other nodes can optionally have a relationship with them, which makes it possible to perform certain artifact related queries.
+- **Peer Review**: artifacts are automatically part of the [Proposed Change](./proposed-change.mdx) review process.
+- **Database**: artifact nodes are stored in the database and other nodes can optionally have a relationship with them, which makes it possible to perform certain artifact related queries.
 
 While the content of an artifact can change, its identifier will remain the same over time.
 
@@ -59,9 +59,9 @@ From an **artifact definition** artifact nodes are created, for each target whic
 
 ## CoreArtifactTarget
 
-A node for which you want to generate an Artifact, must inherit from the `CoreArtifactTarget` generic.
+A node for which you want to generate an artifact, must inherit from the `CoreArtifactTarget` generic.
 
-As a result of this, an Artifacts tab will show up in the node's detailed view in the UI, which allows you to access all of the artifacts that have been generated for this node.
+As a result of this, an artifacts tab will show up in the node's detailed view in the UI, which allows you to access all of the artifacts that have been generated for this node.
 
 ![artifact tab](../media/topics/artifact/node_detail_view_artifact_tab.png)
 

--- a/docs/docs/topics/artifact.mdx
+++ b/docs/docs/topics/artifact.mdx
@@ -31,8 +31,8 @@ While it's always possible to generate [Transformations](./transformation.mdx) o
 
 - **Caching**: Generated artifacts are stored in the internal [object storage](./object-storage.mdx). For resource intensive transformations, it will significantly reduce the load of the system if an artifact can be serve from the cache instead of regenerating each time.
 - **Traceability**: Past values of an artifact remain available. In a future release, it will be possible to compare the value of an artifact over time.
-- **Peer Review**: artifacts are automatically part of the [Proposed Change](./proposed-change.mdx) review process.
-- **Database**: artifact nodes are stored in the database and other nodes can optionally have a relationship with them, which makes it possible to perform certain artifact related queries.
+- **Peer Review**: Artifacts are automatically part of the [Proposed Change](./proposed-change.mdx) review process.
+- **Database**: Artifact nodes are stored in the database and other nodes can optionally have a relationship with them, which makes it possible to perform certain artifact related queries.
 
 While the content of an artifact can change, its identifier will remain the same over time.
 

--- a/docs/docs/topics/community-vs-enterprise.mdx
+++ b/docs/docs/topics/community-vs-enterprise.mdx
@@ -136,7 +136,7 @@ Both Community and Enterprise provide identical capabilities for fundamental inf
 #### Artifact generation
 
 - **Template-based configuration**: Generate configuration artifacts from infrastructure data
-- **Multiple transformation options**: Use Jinja2 templates or Python transforms
+- **Multiple Transformation options**: Use Jinja2 templates or Python Transformations
 - **Extensible framework**: Create custom generators for specific needs
 - **Automation integration**: Connect with external automation tools and platforms
 

--- a/docs/docs/topics/community-vs-enterprise.mdx
+++ b/docs/docs/topics/community-vs-enterprise.mdx
@@ -138,8 +138,6 @@ Both Community and Enterprise provide identical capabilities for fundamental inf
 - **Template-based configuration**: Generate configuration artifacts from infrastructure data
 - **Multiple Transformation options**: Use Jinja2 templates or Python Transformations
 - **Extensible framework**: Create custom generators for specific needs
-- **Multiple transformation options**: Use Jinja2 templates or Python transforms
-- **Extensible framework**: Create custom Generators for specific needs
 - **Automation integration**: Connect with external automation tools and platforms
 
 ### Performance and scalability

--- a/docs/docs/topics/computed-attributes.mdx
+++ b/docs/docs/topics/computed-attributes.mdx
@@ -35,7 +35,7 @@ See the [guide](../guides/computed-attributes.mdx) for instructions on creating 
 
 ## Python computed attributes {#python-computed-attribute}
 
-Python computed attributes leverage Infrahub's [Python transform](./transformation.mdx) feature. Users can define which transformation to apply directly within the schema. The computation of the value is delegated to workers as asynchronous tasks, which may cause the value to take a few seconds to update.
+Python computed attributes leverage Infrahub's [Python Transformation](./transformation.mdx) feature. Users can define which Transformation to apply directly within the schema. The computation of the value is delegated to workers as asynchronous tasks, which may cause the value to take a few seconds to update.
 
 Python scripts do not have the limitations of Jinja2 computed attributes and can include more complex logic, including relationships with cardinality `many` and nested relationships.
 

--- a/docs/docs/topics/database-backup.mdx
+++ b/docs/docs/topics/database-backup.mdx
@@ -26,7 +26,7 @@ Infrahub's data is distributed across multiple systems, each serving a specific 
 The core of Infrahub's data model, storing all infrastructure relationships, schemas, and configuration data. This uses Neo4j's transactional graph database engine, which maintains ACID compliance and supports point-in-time recovery through transaction logs.
 
 **Artifact storage**
-Transforms, queries, and other generated artifacts are stored separately from the graph database. This can be either an S3-compatible object store or local filesystem, depending on your deployment configuration. The separation allows for efficient storage of large files without impacting database performance.
+Transformations, queries, and other generated artifacts are stored separately from the graph database. This can be either an S3-compatible object store or local filesystem, depending on your deployment configuration. The separation allows for efficient storage of large files without impacting database performance.
 
 **Task management database**
 Prefect's PostgreSQL database contains task execution history, logs, and workflow state. While not critical for data recovery, this information is valuable for auditing and troubleshooting past operations. The infrahubops tool backs this up using `pg_dump` with the custom format (`-Fc`) for efficient compression and restoration.

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -9,7 +9,7 @@ This guide provides best practices to help you develop robust, efficient, and ma
 
 The following features in Infrahub are based on user provided code :
 
-- [**Transforms** (Python and Jinja2)](./transformation.mdx): Used to generate [Artifacts](./artifact.mdx) and define [Computed Attributes](./computed-attributes.mdx).
+- [**Transformations** (Python and Jinja2)](./transformation.mdx): Used to generate [Artifacts](./artifact.mdx) and define [Computed Attributes](./computed-attributes.mdx).
 - [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
 - [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
 
@@ -25,9 +25,9 @@ To initialize a new Infrahub repository, run the following command (replace `<pr
 uv tool run --from 'copier' copier copy https://github.com/opsmill/infrahub-template <project-name>
 ```
 
-This uses [copier](https://copier.readthedocs.io/) to create a new Infrahub repository from the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template). The command will guide you through interactive prompts to customize your repository (such as including example generators, transforms, and scripts). No separate installation is needed as `uv tool run` handles everything automatically.
+This uses [copier](https://copier.readthedocs.io/) to create a new Infrahub repository from the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template). The command will guide you through interactive prompts to customize your repository (such as including example generators, Transformations, and scripts). No separate installation is needed as `uv tool run` handles everything automatically.
 
-Once complete, your new repository will be ready for you to add schemas, transforms, and generators.
+Once complete, your new repository will be ready for you to add schemas, Transformations, and generators.
 
 <details>
   <summary>Recommended file structure for manually creating an Infrahub repository</summary>
@@ -81,8 +81,8 @@ Refer to the command documentation for details:
 
 | Command                        | Description                                                  |
 |--------------------------------|--------------------------------------------------------------|
-| [`infrahubctl transform`]($(base_url)infrahubctl/infrahubctl-transform) | Execute Python transforms locally.                          |
-| [`infrahubctl render`]($(base_url)infrahubctl/infrahubctl-render)       | Render Jinja2 transforms locally.                           |
+| [`infrahubctl transform`]($(base_url)infrahubctl/infrahubctl-transform) | Execute Python Transformations locally.                          |
+| [`infrahubctl render`]($(base_url)infrahubctl/infrahubctl-render)       | Render Jinja2 Transformations locally.                           |
 | [`infrahubctl generator`]($(base_url)infrahubctl/infrahubctl-generator) | Test custom generators.                                     |
 | [`infrahubctl check`]($(base_url)infrahubctl/infrahubctl-check)         | Run local checks                                            |
 

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -9,7 +9,7 @@ This guide provides best practices to help you develop robust, efficient, and ma
 
 The following features in Infrahub are based on user provided code :
 
-- [**Transformations** (Python and Jinja2)](./transformation.mdx): Used to generate [Artifacts](./artifact.mdx) and define [Computed Attributes](./computed-attributes.mdx).
+- [**Transformations** (Python and Jinja2)](./transformation.mdx): Used to generate [artifacts](./artifact.mdx) and define [Computed Attributes](./computed-attributes.mdx).
 - [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
 - [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
 

--- a/docs/docs/topics/generator.mdx
+++ b/docs/docs/topics/generator.mdx
@@ -28,7 +28,7 @@ The targets point to a [group](./groups.mdx) that will consist of objects that a
 
 The [GraphQL query](graphql) defines the data that will be collected when running the generator. Any object identified in this step is added as a member to a GraphQL query [group](./groups.mdx) (`CoreGraphQLQueryGroup`). The membership in these groups are then used to determine which generators need to be executed as part of a proposed change during the pipeline run.
 
-The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Just like [transforms](transformation) and [checks](check), the Generators are user defined.
+The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Just like [Transformations](transformation) and [checks](check), the Generators are user defined.
 
 Generators can be executed in several ways, depending on your workflow and where you are in the lifecycle (local development vs. in Infrahub):
 

--- a/docs/docs/topics/groups.mdx
+++ b/docs/docs/topics/groups.mdx
@@ -101,5 +101,5 @@ Validation checks can target groups, running the same validation logic across al
 
 - [How to organize objects with groups](../guides/groups.mdx) - Practical guide for creating and managing groups
 - [Groups schema reference](../reference/schema/groups.mdx) - Technical reference for group attributes and relationships
-- [Artifact definitions](./artifact.mdx) - How groups integrate with artifact generation
+- [artifact definitions](./artifact.mdx) - How groups integrate with artifact generation
 - [Transformations](./transformation.mdx) - Using groups as transformation targets

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -183,7 +183,7 @@ The proposed change functionality interconnects with several other key concepts 
 
 - [Version control](version-control): Understand how branches and commits work in Infrahub, which form the foundation of proposed changes
 - [Schema](schema): Learn about the data models that define your infrastructure objects and are subject to review in proposed changes
-- [artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
+- [Artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
 - [Checks](check): Discover how validation checks ensure the quality and compliance of proposed changes
 - [Transformations](transformation): Understand how Transformations are managed and reviewed within proposed changes
 - [generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -186,6 +186,6 @@ The proposed change functionality interconnects with several other key concepts 
 - [Artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
 - [Checks](check): Discover how validation checks ensure the quality and compliance of proposed changes
 - [Transformations](transformation): Understand how Transformations are managed and reviewed within proposed changes
-- [generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
+- [Generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
 - [Permissions and roles](permissions-roles): Understand the access controls that govern who can create, review, and merge proposed changes
 - [Change Management Workflow Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -31,7 +31,7 @@ A proposed change in Infrahub offers a more sophisticated approach by integratin
 
 - **Data differences**: See precisely what objects were added, modified, or deleted, along with the specific attribute changes.
 - **Schema differences**: Identify changes to the underlying data models that define your infrastructure.
-- **File differences**: Track modifications to implementation files like transforms, generators, and templates.
+- **File differences**: Track modifications to implementation files like Transformations, generators, and templates.
 - **Artifact differences**: Compare the [artifacts](artifact) generated to understand output changes.
 
 This multi-dimensional diffing provides a "single pane of glass" view, enabling reviewers to fully understand the scope and impact of changes before approval. This comprehensive visibility is especially valuable for complex infrastructure changes.
@@ -61,9 +61,9 @@ Learn more about [checks](check) and how to implement custom validation logic.
 
 ### Artifact generation
 
-Infrahub will automatically run transformations and generate artifacts as part of the proposed change workflow.
+Infrahub will automatically run Transformations and generate artifacts as part of the proposed change workflow.
 
-Learn more about [transformations](transformation) and [artifacts](artifact).
+Learn more about [Transformations](transformation) and [artifacts](artifact).
 
 ### Generator integration
 
@@ -184,7 +184,7 @@ The proposed change functionality interconnects with several other key concepts 
 - [Schema](schema): Learn about the data models that define your infrastructure objects and are subject to review in proposed changes
 - [Artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
 - [Checks](check): Discover how validation checks ensure the quality and compliance of proposed changes
-- [Transformations](transformation): Understand how data transformations are managed and reviewed within proposed changes
-- [Generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
+- [Transformations](transformation): Understand how Transformations are managed and reviewed within proposed changes
+- [generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
 - [Permissions and roles](permissions-roles): Understand the access controls that govern who can create, review, and merge proposed changes
 - [Change Management Workflow Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -183,7 +183,7 @@ The proposed change functionality interconnects with several other key concepts 
 
 - [Version control](version-control): Understand how branches and commits work in Infrahub, which form the foundation of proposed changes
 - [Schema](schema): Learn about the data models that define your infrastructure objects and are subject to review in proposed changes
-- [Artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
+- [artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
 - [Checks](check): Discover how validation checks ensure the quality and compliance of proposed changes
 - [Transformations](transformation): Understand how Transformations are managed and reviewed within proposed changes
 - [generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes

--- a/docs/docs/topics/resources-testing-framework.mdx
+++ b/docs/docs/topics/resources-testing-framework.mdx
@@ -6,7 +6,7 @@ title: Resources testing framework
 
 ## Summary
 
-Infrahub allows users to define tests to ensure that [transformations](../topics/transformation.mdx) and [checks](../topics/check.mdx) are working as intended. This can be an important step while writing Infrahub related resources as it makes sure that they keep returning the same expected values over time and version bumps.
+Infrahub allows users to define tests to ensure that [Transformations](../topics/transformation.mdx) and [checks](../topics/check.mdx) are working as intended. This can be an important step while writing Infrahub related resources as it makes sure that they keep returning the same expected values over time and version bumps.
 
 These tests are based on [pytest](https://docs.pytest.org/) but do not require users to write any Python code. Tests can be run via a command line and the `pytest` executable but they are also integrated within the CI pipelines of [proposed changes](../topics/proposed-change.mdx).
 
@@ -31,7 +31,7 @@ infrahub_tests:
 
 The `version: "1.0"` line defines the version of the test declaration file. The syntax of this file is subject to changes in the future as the testing framework gets improved.
 
-All Jinja2 transforms, Python transforms, checks and GraphQL queries declared in a repository [configuration file](../reference/dotinfrahub.mdx) can be tested.
+All Jinja2 Transformations, Python Transformations, checks and GraphQL queries declared in a repository [configuration file](../reference/dotinfrahub.mdx) can be tested.
 
 Tests are declared using a two level hierarchy, they are grouped by resources like:
 
@@ -51,7 +51,7 @@ All available keys and their values are listed in the tests configuration file [
 
 In this section, we will take a look at what test definitions look like for a given Infrahub repository configuration.
 
-In the following Infrahub repository configuration example, we declare a schema, a Jinja2 Transform to render the base configuration of devices, a check to verify that a MPLS RSVP configuration is complete and a Python Transform giving details about layer 2 circuit services. These are resources that we defined to run our network operations, though they are not tested, and we cannot know for sure that they work like we would expect them to.
+In the following Infrahub repository configuration example, we declare a schema, a Jinja2 Transformation to render the base configuration of devices, a check to verify that a MPLS RSVP configuration is complete and a Python Transformation giving details about layer 2 circuit services. These are resources that we defined to run our network operations, though they are not tested, and we cannot know for sure that they work like we would expect them to.
 
 ```yaml
 ---

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -91,6 +91,9 @@ This can be accomplished by using the `self.root_directory` that points to the r
 A TransformPython can be rendered with 2 different methods:
 
 - On demand via the REST API
+- As part of an [artifact](./artifact.mdx)
+- Via the CLI for development and troubleshooting: [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform)
+
 ## Using Transformations with groups
 
 Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a Transformation with a [group](./groups.mdx) of targets.

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -91,7 +91,7 @@ This can be accomplished by using the `self.root_directory` that points to the r
 A TransformPython can be rendered with 2 different methods:
 
 - On demand via the REST API
-- As part of an [Artifact](./artifact.mdx)
+- As part of an [artifact](./artifact.mdx)
 - Via the CLI for development and troubleshooting: [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform)
 
 ## Using Transformations with groups
@@ -102,7 +102,7 @@ Transformations themselves are generic pieces of logic that process data and pro
 This design enables powerful patterns:
 
 - **Reusable logic**: A single Transformation can be applied to different groups through multiple artifact definitions
-- **Bulk processing**: Artifact definitions automatically apply the Transformation to all members of the target group
+- **Bulk processing**: artifact definitions automatically apply the Transformation to all members of the target group
 - **Dynamic targeting**: Adding or removing objects from groups automatically changes which objects the Transformation processes
 
 The Transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -6,8 +6,8 @@ title: Transformation
 
 A `Transformation` is a generic plugin to transform a dataset into a different format to simplify it's ingestion by third-party systems.
 
-The output of a transformation can be either in JSON or any text based format.
->*Currently transformations must be written in Python or Jinja2, but in the future more languages could be supported.*
+The output of a Transformation can be either in JSON or any text based format.
+>*Currently Transformations must be written in Python or Jinja2, but in the future more languages could be supported.*
 
 :::note Examples
 
@@ -18,14 +18,14 @@ The output of a transformation can be either in JSON or any text based format.
 
 ## High level design
 
-A transformation is composed of 2 main components:
+A Transformation is composed of 2 main components:
 
 - A **GraphQL query** that will define what the input data is.
 - A **Transformation logic** that will process the data and transform it.
 
 ![Transformation diagram](../media/transformation.excalidraw.svg)
 
-The transformation will automatically inherit the parameters (variables) defined by the GraphQL query. Depending on how the GraphQL query has been constructed, a transformation can be static or work for multiple objects.
+The Transformation will automatically inherit the parameters (variables) defined by the GraphQL query. Depending on how the GraphQL query has been constructed, a Transformation can be static or work for multiple objects.
 
 <details>
   <summary>Common parameters</summary>
@@ -42,24 +42,24 @@ The transformation will automatically inherit the parameters (variables) defined
 
 </details>
 
-## Available transformations
+## Available Transformations
 
 | Namespace | Transformation      | Description                            | Language | Output Format |
 | --------- | ------------------- | -------------------------------------- | -------- | ------------- |
 | Core      | **TransformJinja2** | A file rendered from a Jinja2 template | Jinja2   | Plain Text    |
-| Core      | **TransformPython** | A transform function written in Python | Python   | JSON          |
+| Core      | **TransformPython** | A Transformation function written in Python | Python   | JSON          |
 
 ### Rendered file (Jinja2 plugin)
 
 Infrahub can natively render any Jinja templates dynamically. Internally it's referred to as `TransformJinja2`. It can generate any file in plain text format and must be composed of 1 main Jinja2 template and 1 GraphQL query.
 
-#### Create a Jinja rendered transform
+#### Create a Jinja rendered Transformation
 
-Please refer to the guide [Creating a Jinja Rendered Transform](../guides/jinja2-transform.mdx) for more information.
+Please refer to the guide [Creating a Jinja Rendered Transformation](../guides/jinja2-transform.mdx) for more information.
 
-#### Render a Jinja2 transform
+#### Render a Jinja2 Transformation
 
-A Jinja2 Transform can be rendered with 3 different methods:
+A Jinja2 Transformation can be rendered with 3 different methods:
 
 - On demand via the REST API
 - As part of an [artifact](./artifact.mdx)
@@ -67,15 +67,15 @@ A Jinja2 Transform can be rendered with 3 different methods:
 
 ### TransformPython (Python plugin)
 
-A `TransformPython` is a transformation plugin written in Python. It can generate any dataset in JSON format and must be composed of 1 main Python Class and 1 GraphQL Query.
+A `TransformPython` is a Transformation plugin written in Python. It can generate any dataset in JSON format and must be composed of 1 main Python Class and 1 GraphQL Query.
 
-#### Create a Python transform
+#### Create a Python Transformation
 
 A TransformPython must be written as a Python class that inherits from `InfrahubTransform` and it must implement one `transform` method. The transform method must accept a dict and return one.
 
-Please refer to the guide [Creating a Python transform](../guides/python-transform.mdx) for more information.
+Please refer to the guide [Creating a Python Transformation](../guides/python-transform.mdx) for more information.
 
-##### Python transform accessing local files
+##### Python Transformation accessing local files
 
 There may be times that you want to access files that are stored within the Git repository such as Jinja2 templates.
 
@@ -94,22 +94,22 @@ A TransformPython can be rendered with 2 different methods:
 - As part of an [Artifact](./artifact.mdx)
 - Via the CLI for development and troubleshooting: [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform)
 
-## Using transformations with groups
+## Using Transformations with groups
 
-Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [generators](./generator.mdx), which combine a transformation with a [group](./groups.mdx) of targets.
+Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a Transformation with a [group](./groups.mdx) of targets.
 
 This design enables powerful patterns:
 
-- **Reusable logic**: A single transformation can be applied to different groups through multiple artifact definitions
-- **Bulk processing**: Artifact definitions automatically apply the transformation to all members of the target group
-- **Dynamic targeting**: Adding or removing objects from groups automatically changes which objects the transformation processes
+- **Reusable logic**: A single Transformation can be applied to different groups through multiple artifact definitions
+- **Bulk processing**: Artifact definitions automatically apply the Transformation to all members of the target group
+- **Dynamic targeting**: Adding or removing objects from groups automatically changes which objects the Transformation processes
 
-The transformation logic remains group-agnostic, while artifact definitions and generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
+The Transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
 
-## Unit testing for transformation
+## Unit testing for Transformations
 
-Infrahub provide a framework to create unit tests for your transformations with very minimal code/configuration.
+Infrahub provide a framework to create unit tests for your Transformations with very minimal code/configuration.
 
-The tests can be executed locally for development purpose and they will also be executed as part of the CI Pipeline when the platform identify a change that could potentially impact your transformation.
+The tests can be executed locally for development purpose and they will also be executed as part of the CI Pipeline when the platform identify a change that could potentially impact your Transformation.
 
 For more information, please check out the [Resource Testing Framework](../topics/resources-testing-framework.mdx) page.

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -91,22 +91,17 @@ This can be accomplished by using the `self.root_directory` that points to the r
 A TransformPython can be rendered with 2 different methods:
 
 - On demand via the REST API
-- As part of an [artifact](./artifact.mdx)
-- Via the CLI for development and troubleshooting: [infrahubctl transform]($(base_url)infrahubctl/infrahubctl-transform)
-
 ## Using Transformations with groups
 
 Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a Transformation with a [group](./groups.mdx) of targets.
-Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a transformation with a [group](./groups.mdx) of targets.
 
 This design enables powerful patterns:
 
 - **Reusable logic**: A single Transformation can be applied to different groups through multiple artifact definitions
-- **Bulk processing**: artifact definitions automatically apply the Transformation to all members of the target group
+- **Bulk processing**: Artifact definitions automatically apply the Transformation to all members of the target group
 - **Dynamic targeting**: Adding or removing objects from groups automatically changes which objects the Transformation processes
 
 The Transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
-The transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [organizing objects with groups](../guides/groups.mdx) for details on creating target groups.
 
 ## Unit testing for Transformations
 

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -6,7 +6,7 @@ title: Transformation
 
 A `Transformation` is a generic plugin to transform a dataset into a different format to simplify it's ingestion by third-party systems.
 
-The output of a Transformation can be either in JSON or any text based format.
+The output of a Transformation can be either in JSON or any text-based format.
 >*Currently Transformations must be written in Python or Jinja2, but in the future more languages could be supported.*
 
 :::note Examples

--- a/docs/docs/tutorials/getting-started/git-integration.mdx
+++ b/docs/docs/tutorials/getting-started/git-integration.mdx
@@ -53,7 +53,7 @@ After adding the `infrahub-demo-edge` repository you will be able to see several
 
 - 2 Jinja Rendered File under [Jinja2 Transformation](http://localhost:8000/objects/CoreTransformJinja2/) (Menu > Actions > Transformation)
 - 2 Python Transformation under [Python Transformation](http://localhost:8000/objects/CoreTransformPython) (Menu > Actions > Transformation)
-- 2 [Artifact Definition](http://localhost:8000/objects/CoreArtifactDefinition) (Menu > Actions > Artifact Definition)
+- 2 [artifact definitions](http://localhost:8000/objects/CoreArtifactDefinition) (Menu > Actions > Artifact Definition)
 - 9 GraphQL [Queries](../../topics/graphql.mdx) under [Objects / GraphQL Query](http://localhost:8000/objects/CoreGraphQLQuery/) (Menu > Object Management > GraphQL Query)
 
 :::note Troubleshooting

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -402,7 +402,8 @@ const sidebars: SidebarsConfig = {
             'development/frontend/testing-guidelines',
           ],
         },
-        'development/docs'
+        'development/docs',
+        'development/style-guide'
       ],
     },
     {


### PR DESCRIPTION
- Capitalize "Transformation/Transformations" when referring to the Infrahub feature
- Use lowercase "transformation" only for generic/non-feature usage
- Standardize on "Transformation" as a noun instead of "transform"
- Keep "transform" only as a verb form
- Preserve class names, imports, file paths, and release notes unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized terminology across documentation with consistent capitalization and naming (Transform → Transformation)
  * Added comprehensive style guide documenting Infrahub terminology standards and documentation best practices

* **Chores**
  * Updated documentation configuration and spelling exceptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->