### PR TITLE
docs(vale): add branded term rules for Infrahub primitives

### DIFF
--- a/.vale/styles/Infrahub/branded-terms-case-swap.yml
+++ b/.vale/styles/Infrahub/branded-terms-case-swap.yml
@@ -7,15 +7,19 @@ action:
   name: replace
 swap:
   (?<![\.|/|#])ansible[\.!]?\s: Ansible
+  (?<=\s)Artifact[\.!]?\s: artifact
+  (?<=\s)Artifacts[\.!]?\s: artifacts
   (?<![\.|/|#])docker[\.!]?\s: Docker
   (?<![\.|/|#])[Dd]ockerhub[\.!]?\s: DockerHub
+  (?<![\.|/|#])generator[\.!]?\s: Generator
+  (?<![\.|/|#])generators[\.!]?\s: Generators
   (?<![\.|/|#])[Gg]ithub[\.!]?\s: GitHub
   (?<![\.|/|#])[Gg]itlab[\.!]?\s: GitLab
   (?:gitpod): GitPod
   (?:grafana): Grafana
   (?:[^/.][Gg]raphql): GraphQL
-  (?:[Ii]nflux[Dd]b): InfluxDB
   (?<![\.|/|#])infrahub[\.!]?\s: Infrahub
+  (?:[Ii]nflux[Dd]b): InfluxDB
   (?:jinja2): Jinja2
   (?:k3s): K3s
   (?<![\.|/|#])k8s[\.!]?\s: K8s
@@ -28,9 +32,18 @@ swap:
   (?:Openconfig): OpenConfig
   (?<![\.|/|#])opsmill[\.!]?\s: OpsMill
   (?:[Pp]ostgre[Ss]ql): PostgreSQL
+  (?<![\.|/|#])profile[\.!]?\s: Profile
+  (?<![\.|/|#])profiles[\.!]?\s: Profiles
   (?:[^/]prometheus): Prometheus
   (?<![\.|/|#])python[\.!]?\s: Python
   (?<![\.|/|#])[Rr]abbitmq[\.!]?\s: RabbitMQ
+  relatioinship: relationship
+  Relatioinship: Relationship
+  (?<![\.|/|#])resource manager[\.!]?\s: Resource Manager
+  (?<![\.|/|#])[Rr]esource [Mm]anagers[\.!]?\s: Resource Manager
   (?:[^/]terraform): Terraform
+  (?<![\.|/|#])transformation[\.!]?\s: Transformation
+  (?<![\.|/|#])transformations[\.!]?\s: Transformations
+  (?<![\.|/|#])[Tt]ransforms[\.!]?\s: Transformations
   (?:ubuntu): Ubuntu
   (?:[Vv]s\W?[Cc]ode): VS Code

--- a/.vale/styles/Infrahub/branded-terms-case-swap.yml
+++ b/.vale/styles/Infrahub/branded-terms-case-swap.yml
@@ -39,7 +39,7 @@ swap:
   (?<![\.|/|#])[Rr]abbitmq[\.!]?\s: RabbitMQ
   relatioinship: relationship
   Relatioinship: Relationship
-  (?<![\.|/|#])resource manager[\.!]?\s: Resource Manager
+  (?<![\.|/|#])[Rr]esource [Mm]anager[\.!]?\s: Resource Manager
   (?<![\.|/|#])[Rr]esource [Mm]anagers[\.!]?\s: Resource Manager
   (?:[^/]terraform): Terraform
   (?<![\.|/|#])transformation[\.!]?\s: Transformation


### PR DESCRIPTION
Add Vale rules for consistent capitalization of Infrahub-specific terms:
- Generators: always capitalize
- Transformations: always capitalize as noun
- Profiles: always capitalize
- Resource Manager: always capitalize, always singular
- artifacts: lowercase mid-sentence (generic industry term)
- Fix "relatioinship" typo

Sort all rules alphabetically by replacement text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded branded terminology validation with numerous new and adjusted term mappings to improve consistent casing of technical terms across docs.
  * Retained core branded terms while broadening coverage for platform and tooling names.

* **Chores**
  * Reorganized a mapping entry (position updated) to refine term processing order.
  * Added a small auxiliary file related to repository maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->