### PR TITLE
Fixed misleading schema loading error pointing to the wrong attribute

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -6,10 +6,10 @@ import os
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, NoReturn, overload
 
 from infrahub_sdk.utils import compare_lists, intersection
-from pydantic import ConfigDict, field_validator
+from pydantic import ConfigDict, ValidationError, field_validator
 
 from infrahub.core.constants import HashableModelState, RelationshipCardinality, RelationshipKind
 from infrahub.core.models import HashableModel, HashableModelDiff
@@ -73,6 +73,19 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
     model_config = ConfigDict(extra="forbid", json_schema_extra=_json_schema_extra)
 
+    @staticmethod
+    def _enhance_attribute_validation_error(exc: ValidationError, attr_name: str, idx: int) -> NoReturn:
+        """Enhance validation error with attribute name and correct index in location path."""
+        errors = []
+        for error in exc.errors():
+            error_copy = error.copy()
+            # Insert the correct list index at the start of the location path
+            error_copy["loc"] = (idx,) + error["loc"]
+            nested_path = ".".join(str(item) for item in error["loc"])
+            error_copy["input"] = f"[{attr_name}.{nested_path}]: {error.get('input', 'N/A')}"
+            errors.append(error_copy)
+        raise ValidationError.from_exception_data(title=exc.title, line_errors=errors) from exc
+
     @property
     def is_schema_node(self) -> bool:
         """Tell if this node represent a part of the schema. Not to confuse this with `is_node_schema`."""
@@ -124,19 +137,27 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
         if not isinstance(raw_attributes, list):
             return raw_attributes
         attribute_schemas_with_types: list[Any] = []
-        for raw_attr in raw_attributes:
+        for idx, raw_attr in enumerate(raw_attributes):
             if not isinstance(raw_attr, (dict, AttributeSchema)):
                 attribute_schemas_with_types.append(raw_attr)
                 continue
             if isinstance(raw_attr, dict):
-                kind = raw_attr.get("kind")
+                kind = raw_attr["kind"]
+                attr_name = raw_attr["name"]
                 attribute_type_class = get_attribute_schema_class_for_kind(kind=kind)
-                attribute_schemas_with_types.append(attribute_type_class(**raw_attr))
+                try:
+                    attribute_schemas_with_types.append(attribute_type_class(**raw_attr))
+                except ValidationError as exc:
+                    cls._enhance_attribute_validation_error(exc, attr_name, idx)
                 continue
 
+            attr_name = raw_attr.name
             expected_attr_schema_class = get_attribute_schema_class_for_kind(kind=raw_attr.kind)
             if not isinstance(raw_attr, expected_attr_schema_class):
-                final_attr = expected_attr_schema_class(**raw_attr.model_dump())
+                try:
+                    final_attr = expected_attr_schema_class(**raw_attr.model_dump())
+                except ValidationError as exc:
+                    cls._enhance_attribute_validation_error(exc, attr_name, idx)
             else:
                 final_attr = raw_attr
             attribute_schemas_with_types.append(final_attr)

--- a/backend/tests/component/core/test_schema.py
+++ b/backend/tests/component/core/test_schema.py
@@ -440,6 +440,50 @@ def test_dropdown_choice_sort() -> None:
     assert active < passive
 
 
+def test_dropdown_validation_error_with_invalid_choice_name() -> None:
+    """Test that validation errors for dropdown choices include attribute name and nested path.
+
+    This simulates the issue from IFC-2089 where YAML parsing converts 'off' to boolean False,
+    and the error message should clearly indicate which attribute and which choice field has the problem.
+    """
+    SCHEMA_WITH_INVALID_CHOICE: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "SDP",
+                "namespace": "Infra",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "label": "SDP ID", "optional": False},
+                    {
+                        "name": "signaling",
+                        "kind": "Dropdown",
+                        "label": "Signaling",
+                        "optional": False,
+                        "choices": [
+                            {"name": "tldp", "label": "TLDP"},
+                            {"name": False, "label": "Off"},  # Boolean instead of string - simulates YAML 'off'
+                            {"name": "bgp", "label": "BGP"},
+                        ],
+                        "default_value": "tldp",
+                    },
+                ],
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError) as exc:
+        SchemaRoot(**SCHEMA_WITH_INVALID_CHOICE)
+
+    # The error should have the attribute name and nested path in the input field
+    errors = exc.value.errors()
+    assert len(errors) == 1, "Should have exactly one validation error"
+    error = errors[0]
+    input_value = str(error.get("input", ""))
+    assert "signaling" in input_value, f"Input should contain attribute name 'signaling': {input_value}"
+    assert "choices" in input_value, f"Input should contain 'choices': {input_value}"
+    assert "name" in input_value, f"Input should contain 'name': {input_value}"
+    assert "[signaling.choices.1.name]" in input_value, f"Input should show nested path: {input_value}"
+
+
 def test_validate_python_keywords_with_attribute_and_relationship() -> None:
     """Test that validate_python_keywords rejects Python keywords in attribute and relationship names."""
     # Test schema with 'from' keyword as attribute name

--- a/changelog/+13729495.fixed.md
+++ b/changelog/+13729495.fixed.md
@@ -1,0 +1,1 @@
+Fixed confusing issue when "off" was converted to boolean 'false' due to issues with Yaml. The bug was that if "off" or something that Yaml parses as a boolean was used as the name of a Dropdown the incorrect attribute was highlighted in the schema error. When this happened troubleshooting was harder due to misleading errors pointing to another attribute.


### PR DESCRIPTION
This PR fixes an issue related to the backend highlighting an incorrect index for attributes when there is a problem with a schema that users are loading. The issue is reported in IFC-2089. The root cause was that we had a schema with an attribute that looked like this:

```yaml
      - name: name
        kind: Text
      - name: description
        kind: Text
      - name: signaling
        kind: Dropdown
        label: "Signaling"
        optional: false
        choices:
          - name: tldp
            label: "TLDP"
          - name: off (due to yaml issues this needs to be "off")
            label: "Off"
          - name: bgp
            label: "BGP"
        default_value: tldp
```

The problem here is that the yaml parser reads the name "off" as a boolean and a boolean is an invalid type for a name. This coupled with the `.set_attribute_type()` validator modifies the attributes during validation and mixes up the ordering so we loose information about the index of the attributes within the error message. When combined with `infrahubctl` the above error would show up on attribute index 1 i.e. the second attribute of the node (i.e. "description"). This is because "off" is the second dropdown. However since the attribute index was lost the error message got very confusing. As such the error indicated that something was incorrect with the "description" attribute. The change in this PR is to ensure that the correct order of the attributes are preserved when there is an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation error messages to preserve exact location (list index and attribute name) for nested/mis-typed attributes, fixing misleading highlights for Dropdown names parsed as booleans (e.g., "off").
* **Tests**
  * Added a test to ensure Dropdown choice-name validation errors include the attribute name and nested path.
* **Documentation**
  * Added changelog entry describing the fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->