### PR TITLE
docs: remove is_visible metadata references

### DIFF
--- a/changelog/+remove-is-visible-docs.removed.md
+++ b/changelog/+remove-is-visible-docs.removed.md
@@ -1,0 +1,1 @@
+Removed references to the deprecated `is_visible` metadata property from documentation.

--- a/docs/docs/topics/graphql.mdx
+++ b/docs/docs/topics/graphql.mdx
@@ -81,7 +81,7 @@ At the object level, there are mainly 3 types of resources that can be accessed,
 Each attribute is its own object in GraphQL to expose the value and all the metadata.
 
 In the query below, to access the attribute **name** of the object the query must be `CoreRepository` > `edges` > `node` > `name` > `value`.
-At the same level all the metadata of the attribute are also available example: `is_protected`, `is_visible`, `source` & `owner`
+At the same level all the metadata of the attribute are also available, for example: `is_protected`, `source` & `owner`
 
 ```graphql {6-14} title="Example query to access the value and the properties of the attribute 'name'"
 query {
@@ -92,7 +92,6 @@ query {
         name {              # TextAttribute object
           value
           is_protected
-          is_visible
           source {
             id
             display_label
@@ -116,8 +115,7 @@ query {
       node {
         account {
           properties {
-            is_visible
-            is_propected
+            is_protected
             source {
               id
               display_label

--- a/docs/docs/topics/metadata.mdx
+++ b/docs/docs/topics/metadata.mdx
@@ -19,7 +19,6 @@ The current supported metadata are:
 - **Source**: Where is the data coming from. (By default, it can be an `Account` or a `Repository`)
 - **Owner**: Who is the owner of this data (By default, it be a `Group`, an `Account` or a `Repository`)
 - **Is Protected**: Flag to indicate if a value should be protected or not
-- **Is Visible**: An attribute that is not visible, won't show up in the frontend but it will remain available via GraphQL
 
 :::info
 
@@ -41,7 +40,7 @@ Note that accounts defined with the role of `admin` can always update protected 
 
 In addition to attribute and relationship metadata, Infrahub automatically tracks **object-level metadata** for every node in your infrastructure data. This provides complete audit trails and accountability, enabling you to determine who created or modified an object and when.
 
-Object-level metadata is distinct from the attribute-level metadata described above (Source, Owner, Is Protected, Is Visible). While attribute metadata tracks lineage for individual data points, object-level metadata tracks the lifecycle of the entire object.
+Object-level metadata is distinct from the attribute-level metadata described above (Source, Owner, Is Protected). While attribute metadata tracks lineage for individual data points, object-level metadata tracks the lifecycle of the entire object.
 
 The following fields are available on every object:
 

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -145,13 +145,6 @@ Here are some example payloads of some events that may be sent.
           "name": "name",
           "value": "Google Fibre",
           "properties": {
-            "is_visible": {
-              "name": "is_visible",
-              "value": true,
-              "value_type": "Boolean",
-              "value_previous": null,
-              "value_update_status": "added"
-            },
             "is_protected": {
               "name": "is_protected",
               "value": false,
@@ -168,13 +161,6 @@ Here are some example payloads of some events that may be sent.
           "name": "description",
           "value": "Google Fibre",
           "properties": {
-            "is_visible": {
-              "name": "is_visible",
-              "value": true,
-              "value_type": "Boolean",
-              "value_previous": null,
-              "value_update_status": "added"
-            },
             "is_protected": {
               "name": "is_protected",
               "value": false,


### PR DESCRIPTION
The is_visible metadata property was removed from Infrahub in a previous release (1.5.0). This updates the documentation to reflect that change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed references to the deprecated "Is Visible" metadata from metadata docs, GraphQL examples, and webhook payload samples.
  * Updated object- and attribute-level metadata descriptions and example queries to reflect the change.
  * Corrected a spelling error in the relationship example (is_protected).

* **Chores**
  * Added a changelog entry documenting the removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->