### PR TITLE
docs: capitalize 'Profiles' when referring to Infrahub feature

### DIFF
--- a/docs/docs/guides/object-template.mdx
+++ b/docs/docs/guides/object-template.mdx
@@ -309,23 +309,23 @@ When viewing your newly created device object, navigate to the Interfaces tab to
 
 :::
 
-## Using profiles with templates
+## Using Profiles with templates
 
-When both `generate_template` and `generate_profile` are configured on a schema node, you can assign profiles to templates to enable bulk configuration updates. Objects created from templates automatically inherit the profiles assigned to those templates, allowing you to update values in bulk by modifying the profile.
+When both `generate_template` and `generate_profile` are configured on a schema node, you can assign Profiles to templates to enable bulk configuration updates. Objects created from templates automatically inherit the Profiles assigned to those templates, allowing you to update values in bulk by modifying the Profile.
 
 :::info Profile and template integration
 
-When a profile is assigned to a template:
+When a Profile is assigned to a template:
 
-- Objects created from the template automatically inherit the template's profiles
-- Template values (when explicitly configured) take precedence over profile values
+- Objects created from the template automatically inherit the template's Profiles
+- Template values (when explicitly configured) take precedence over Profile values
 - Profiles provide values for attributes not explicitly set on the template
-- Multiple profiles can be assigned to a template with proper priority handling
+- Multiple Profiles can be assigned to a template with proper priority handling
 - This enables consistent configuration management across templated objects
 
 :::
 
-For more information about profiles and templates, see:
+For more information about Profiles and templates, see:
 
-- [Creating and assigning profiles](../guides/profiles.mdx) - Guide for working with profiles
-- [Understanding profiles in Infrahub](../topics/profiles.mdx) - Deep dive into profile concepts
+- [Creating and assigning Profiles](../guides/profiles.mdx) - Guide for working with Profiles
+- [Understanding Profiles in Infrahub](../topics/profiles.mdx) - Deep dive into Profile concepts

--- a/docs/docs/guides/profiles.mdx
+++ b/docs/docs/guides/profiles.mdx
@@ -1,31 +1,31 @@
 ---
-title: Creating and assigning profiles
+title: Creating and assigning Profiles
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide shows you how to create and apply profiles to ensure consistent configuration across multiple nodes in Infrahub. Profiles help you maintain standardized configurations and reduce repetitive work when managing similar objects.
+This guide shows you how to create and apply Profiles to ensure consistent configuration across multiple nodes in Infrahub. Profiles help you maintain standardized configurations and reduce repetitive work when managing similar objects.
 
 ## What you'll achieve
 
 By following this guide, you'll:
 
-- Create a profile that defines standard configuration for network interfaces
-- Apply the profile to multiple interfaces to ensure consistency
-- Learn how to override profile values for specific interfaces
-- Understand how profile inheritance works in Infrahub
+- Create a Profile that defines standard configuration for network interfaces
+- Apply the Profile to multiple interfaces to ensure consistency
+- Learn how to override Profile values for specific interfaces
+- Understand how Profile inheritance works in Infrahub
 
 ## Prerequisites
 
 - Infrahub instance running and accessible
-- Schema loaded with nodes that support profiles
+- Schema loaded with nodes that support Profiles
 - Basic understanding of GraphQL mutations and queries
 
 ## Load the schema
 
 :::warning Schema creation
-This step is only necessary if you don't already have a schema with profile-enabled nodes in your instance.
+This step is only necessary if you don't already have a schema with Profile-enabled nodes in your instance.
 :::
 
 1. Create a `schema.yml` file in the schemas directory of your repository:
@@ -150,13 +150,13 @@ You should see: `schema 'schema.yml' loaded successfully`
 
 :::
 
-## Step 1: Creating a profile
+## Step 1: Creating a Profile
 
-### Create an interface profile
+### Create an interface Profile
 
-Let's create a profile that defines the standard configuration for end-user interfaces. This profile will set common attributes that should be applied consistently across multiple interfaces.
+Let's create a Profile that defines the standard configuration for end-user interfaces. This Profile will set common attributes that should be applied consistently across multiple interfaces.
 
-The profile will define these standard settings:
+The Profile will define these standard settings:
 
 - **Speed**: 1000 Mbps
 - **Status**: active (interface is operational)
@@ -167,9 +167,9 @@ The profile will define these standard settings:
 - **Role**: end_user
 - **Untagged VLAN**: 10 (this is the default VLAN for end-user devices)
 
-:::info Relationships in profiles
+:::info Relationships in Profiles
 
-From Infrahub 1.7 relationships can also be defined in profiles. If you are using an earlier version, you can skip the untagged VLAN part. Learn more in the [Understanding profiles in Infrahub](../topics/profiles#relationships-in-profiles) topic.
+From Infrahub 1.7 relationships can also be defined in Profiles. If you are using an earlier version, you can skip the untagged VLAN part. Learn more in the [Understanding Profiles in Infrahub](../topics/profiles#relationships-in-profiles) topic.
 
 :::
 
@@ -185,8 +185,8 @@ From Infrahub 1.7 relationships can also be defined in profiles. If you are usin
 5. Click **Save** to create the VLAN
 6. Navigate to **Object Management** → **Profiles**
 7. Click on **Add Profile**
-8. Select **InfraInterface** as the profile type
-9. Fill in the profile details as follows:
+8. Select **InfraInterface** as the Profile type
+9. Fill in the Profile details as follows:
     - **Profile Name**: end-user-interface
     - **Speed**: 1000
     - **Auto Negotiation**: true
@@ -196,7 +196,7 @@ From Infrahub 1.7 relationships can also be defined in profiles. If you are usin
     - **Status**: active
     - **Role**: end_user
     - **Untagged VLAN**: VLAN 10
-10. Click **Save** to create the profile
+10. Click **Save** to create the Profile
 
 </TabItem>
 <TabItem value="graphql" label="GraphQL">
@@ -242,15 +242,15 @@ mutation {
 </TabItem>
 </Tabs>
 
-### Verify the profile was created
+### Verify the Profile was created
 
-Query Infrahub to confirm the profile exists:
+Query Infrahub to confirm the Profile exists:
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Object Management** → **Profiles**
-2. Locate the **end-user-interface** profile in the list and click on it
+2. Locate the **end-user-interface** Profile in the list and click on it
 
 </TabItem>
 <TabItem value="graphql" label="GraphQL">
@@ -290,14 +290,14 @@ query {
 </Tabs>
 
 :::success
-You should see the profile with all attributes set to your specified values.
+You should see the Profile with all attributes set to your specified values.
 :::
 
-## Step 2: Using the profile
+## Step 2: Using the Profile
 
-### Create interfaces using the profile
+### Create interfaces using the Profile
 
-Now that we have a profile, let's create multiple interfaces that inherit configuration from it. When using profiles, you only need to specify the unique attributes (like name) and reference the profile for all standardized values.
+Now that we have a Profile, let's create multiple interfaces that inherit configuration from it. When using Profiles, you only need to specify the unique attributes (like name) and reference the Profile for all standardized values.
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -309,7 +309,7 @@ Now that we have a profile, let's create multiple interfaces that inherit config
     - **Interface Name**: GigabitEthernet0/0/0
 
 :::note
-You should see interface field values automatically populated when selecting the profile.
+You should see interface field values automatically populated when selecting the Profile.
 :::
 
 4. Click **Save** to create the interface
@@ -392,9 +392,9 @@ The query should return the IDs of the created interfaces:
 </TabItem>
 </Tabs>
 
-### Verify profile inheritance
+### Verify Profile inheritance
 
-Now let's verify that the interfaces have properly inherited values from the profile. Infrahub's metadata shows which values came from profiles, giving you complete transparency about data origin.
+Now let's verify that the interfaces have properly inherited values from the Profile. Infrahub's metadata shows which values came from Profiles, giving you complete transparency about data origin.
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -405,9 +405,9 @@ Now let's verify that the interfaces have properly inherited values from the pro
 
 :::success
 
-You should see that the MTU value is inherited from the profile.
+You should see that the MTU value is inherited from the Profile.
 
-![Check profile inheritance in metadata](../media/guides/profiles/metadata.png)
+![Check Profile inheritance in metadata](../media/guides/profiles/metadata.png)
 
 :::
 
@@ -439,7 +439,7 @@ query {
 
 :::success
 
-You should see that the MTU value is inherited from the profile.
+You should see that the MTU value is inherited from the Profile.
 
 ```json
 {
@@ -475,13 +475,13 @@ You should see that the MTU value is inherited from the profile.
 </TabItem>
 </Tabs>
 
-## Step 3: Override profile values
+## Step 3: Override Profile values
 
-While profiles ensure consistency, you sometimes need exceptions for specific devices or interfaces. Infrahub lets you override profile values when needed.
+While Profiles ensure consistency, you sometimes need exceptions for specific devices or interfaces. Infrahub lets you override Profile values when needed.
 
 ### Create an interface with custom MTU
 
-Create an interface with a custom MTU value that overrides the profile default:
+Create an interface with a custom MTU value that overrides the Profile default:
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -519,7 +519,7 @@ mutation {
 
 ### Verify the override
 
-Confirm that the MTU was overridden while other values still come from the profile:
+Confirm that the MTU was overridden while other values still come from the Profile:
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -530,7 +530,7 @@ Confirm that the MTU was overridden while other values still come from the profi
 
 :::success
 
-You should see that the MTU value is **not** inherited from the profile (source is empty).
+You should see that the MTU value is **not** inherited from the Profile (source is empty).
 
 :::
 
@@ -554,7 +554,7 @@ query {
 
 :::success
 
-You should see that the MTU value is **not** inherited from the profile.
+You should see that the MTU value is **not** inherited from the Profile.
 
 ```json {9}
 {
@@ -580,20 +580,20 @@ You should see that the MTU value is **not** inherited from the profile.
 </TabItem>
 </Tabs>
 
-## Step 4: Updating a profile
+## Step 4: Updating a Profile
 
-One of the key benefits of profiles is that when you update a profile, all nodes using it automatically inherit the changes. This provides a powerful way to update configurations across your infrastructure.
+One of the key benefits of Profiles is that when you update a Profile, all nodes using it automatically inherit the changes. This provides a powerful way to update configurations across your infrastructure.
 
-### Updating the profile
+### Updating the Profile
 
-We will change the `end-user-interface` profile to set a new default **MTU** of `9000` instead of `1500`.
+We will change the `end-user-interface` Profile to set a new default **MTU** of `9000` instead of `1500`.
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
 
 1. Open the **Infrahub UI** in your browser
 2. Navigate to **Object Management** → **Profiles**
-3. Locate the **end-user-interface** profile in the list and click on it
+3. Locate the **end-user-interface** Profile in the list and click on it
 4. Click **Edit Profile Interface**
 5. Change the **MTU** value to `9000`
 6. Click **Save** to apply the changes
@@ -654,36 +654,36 @@ You should see that the MTU value is now `9000` for all the interfaces.
 
 ## Conclusion
 
-You've successfully set up profiles for your interfaces in Infrahub. Here's what you've accomplished:
+You've successfully set up Profiles for your interfaces in Infrahub. Here's what you've accomplished:
 
-- Created a standardized profile for end-user interfaces
-- Applied the profile to multiple interfaces to ensure consistent configuration
-- Verified how values are inherited from profiles using metadata
-- Overridden specific profile values for individual interfaces when needed
-- Updated a profile and observed changes propagate automatically
-- Worked with multiple profiles and understood inheritance priority
+- Created a standardized Profile for end-user interfaces
+- Applied the Profile to multiple interfaces to ensure consistent configuration
+- Verified how values are inherited from Profiles using metadata
+- Overridden specific Profile values for individual interfaces when needed
+- Updated a Profile and observed changes propagate automatically
+- Worked with multiple Profiles and understood inheritance priority
 
 ## Advanced usage
 
-### Using multiple profiles
+### Using multiple Profiles
 
-Infrahub lets you assign multiple profiles to a single node, giving you powerful composition capabilities. When multiple profiles define the same attribute, the `profile_priority` value controls which takes precedence (lower number = higher priority).
+Infrahub lets you assign multiple Profiles to a single node, giving you powerful composition capabilities. When multiple Profiles define the same attribute, the `profile_priority` value controls which takes precedence (lower number = higher priority).
 
-Learn more about profile priorities in the [Understanding profiles in Infrahub](../topics/profiles.mdx) topic.
+Learn more about Profile priorities in the [Understanding Profiles in Infrahub](../topics/profiles.mdx) topic.
 
-#### Step 1: Creating another profile
+#### Step 1: Creating another Profile
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Object Management** → **Profiles**
 2. Click on **Add Profile**
-3. Select **InfraInterface** as the profile type
-4. Fill in the profile details as follows:
+3. Select **InfraInterface** as the Profile type
+4. Fill in the Profile details as follows:
     - **Profile Name**: high-speed-interface
     - **MTU**: 9000
     - **Speed**: 10000
-5. Click **Save** to create the profile
+5. Click **Save** to create the Profile
 
 </TabItem>
 <TabItem value="graphql" label="GraphQL">
@@ -706,7 +706,7 @@ mutation {
 </TabItem>
 </Tabs>
 
-#### Step 2: Assigning multiple profiles to an interface
+#### Step 2: Assigning multiple Profiles to an interface
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -717,10 +717,10 @@ mutation {
     - **Profile**: `end-user-interface` and `high-speed-interface`
     - **Interface Name**: GigabitEthernet0/0/4
 
-![Apply multiple profiles form](../media/guides/profiles/form-profiles.png)
+![Apply multiple Profiles form](../media/guides/profiles/form-profiles.png)
 
 :::note
-You should see interface field values automatically populated when selecting the profiles.
+You should see interface field values automatically populated when selecting the Profiles.
 :::
 
 4. Click **Save** to create the interface
@@ -747,9 +747,9 @@ mutation {
 </TabItem>
 </Tabs>
 
-#### Step 3: Validating profile inheritance with multiple profiles
+#### Step 3: Validating Profile inheritance with multiple Profiles
 
-Let's check which profile values are being applied when multiple profiles define the same attribute:
+Let's check which Profile values are being applied when multiple Profiles define the same attribute:
 
 <Tabs groupId="method">
 <TabItem value="web" label="Web interface">
@@ -841,44 +841,44 @@ query {
 
 You should see that:
 
-- The **Speed** value (10000) is inherited from the `high-speed-interface` profile
-- The **Status** value (active) is inherited from the `end-user-interface` profile
+- The **Speed** value (10000) is inherited from the `high-speed-interface` Profile
+- The **Status** value (active) is inherited from the `end-user-interface` Profile
 
 :::
 
-## Using profiles with templates
+## Using Profiles with templates
 
-When both `generate_template` and `generate_profile` are configured on a schema node, you can assign profiles to templates for powerful configuration management. This allows you to:
+When both `generate_template` and `generate_profile` are configured on a schema node, you can assign Profiles to templates for powerful configuration management. This allows you to:
 
 - **Define structure with templates**: Templates define which components exist (i.e., which interfaces are present)
-- **Configure values with profiles**: Profiles define the configuration settings for those components
-- **Bulk updates**: Modify profile values to update all objects created from templates using those profiles
+- **Configure values with Profiles**: Profiles define the configuration settings for those components
+- **Bulk updates**: Modify Profile values to update all objects created from templates using those Profiles
 
-### How template-profile integration works
+### How template-Profile integration works
 
-When you assign a profile to a template and then create objects from that template:
+When you assign a Profile to a template and then create objects from that template:
 
 1. The object is created based on the template structure
-2. The template's profiles are automatically assigned to the created object
-3. Template values (when explicitly configured) take precedence over profile values
+2. The template's Profiles are automatically assigned to the created object
+3. Template values (when explicitly configured) take precedence over Profile values
 4. Profiles provide values for attributes not explicitly set on the template
-5. You can assign multiple profiles to a template with proper priority handling
+5. You can assign multiple Profiles to a template with proper priority handling
 
-This enables you to update configuration values in bulk by modifying the profile, while the template ensures structural consistency and can override specific values when needed.
+This enables you to update configuration values in bulk by modifying the Profile, while the template ensures structural consistency and can override specific values when needed.
 
 For more information, see:
 
 - [Creating an object template guide](../guides/object-template.mdx) - Step-by-step guide for creating templates
-- [Object templates topic](../topics/object-template.mdx) - Understanding template and profile integration
+- [Object templates topic](../topics/object-template.mdx) - Understanding template and Profile integration
 
 ## Related resources
 
-- [Understanding profiles in Infrahub](../topics/profiles.mdx) - Detailed explanation of profile concepts, inheritance rules, and design decisions
+- [Understanding Profiles in Infrahub](../topics/profiles.mdx) - Detailed explanation of Profile concepts, inheritance rules, and design decisions
 - [Metadata](../topics/metadata.mdx) - Learn how Infrahub tracks data lineage and attribute sources
-- [Creating a schema](../guides/create-schema.mdx) - Learn to create schemas that generate profile support
-- [Creating an object template](../guides/object-template.mdx) - Learn how to combine templates with profiles for powerful configuration management
-- [Object templates topic](../topics/object-template.mdx) - Understanding how profiles integrate with templates
+- [Creating a schema](../guides/create-schema.mdx) - Learn to create schemas that generate Profile support
+- [Creating an object template](../guides/object-template.mdx) - Learn how to combine templates with Profiles for powerful configuration management
+- [Object templates topic](../topics/object-template.mdx) - Understanding how Profiles integrate with templates
 - [Node schema reference](../reference/schema/node.mdx) - Complete reference for node configuration including the `generate_profile` option
 - [Schema validation](../reference/schema-validation.mdx) - Validate your schemas before loading
 - [GraphQL API](../topics/graphql.mdx) - Overview of Infrahub's GraphQL API
-- [Python SDK documentation]($(base_url)python-sdk/introduction) - Full SDK reference for programmatic profile operations
+- [Python SDK documentation]($(base_url)python-sdk/introduction) - Full SDK reference for programmatic Profile operations

--- a/docs/docs/release-notes/infrahub/release-0_13.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_13.mdx
@@ -50,10 +50,10 @@ More information about IPAM is available in the [Documentation](../../topics/ipa
 
 #### Profiles
 
-A profile in Infrahub allow you to define a common set of attributes that should be applied to nodes.
+A Profile in Infrahub allows you to define a common set of attributes that should be applied to nodes.
 
-A node that has a profile assigned, will get the values of its attributes inherited from the assigned profile, if no value is defined for the attribute at the node, or if the default value is used.
-The attribute values of a node that were inherited from a profile can be overridden, by defining them at the node.
+A node that has a Profile assigned, will get the values of its attributes inherited from the assigned Profile, if no value is defined for the attribute at the node, or if the default value is used.
+The attribute values of a node that were inherited from a Profile can be overridden, by defining them at the node.
 
 More information about Profiles is available in the [Documentation](../../topics/profiles.mdx).
 

--- a/docs/docs/release-notes/infrahub/release-0_15_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_15_0.mdx
@@ -33,9 +33,9 @@ This release focuses on enhancing the user experience and laying the groundwork 
 
 #### Profiles enhancements
 
-- You can now create profiles on a Generic, in addition to Nodes.
-- A node inheriting from multiple Generics can utilize any profiles associated with these Generics.
-- Introduced a new attribute `generate_profile` in the schema for more precise control over which nodes should have profiles generated or supported.
+- You can now create Profiles on a Generic, in addition to Nodes.
+- A node inheriting from multiple Generics can utilize any Profiles associated with these Generics.
+- Introduced a new attribute `generate_profile` in the schema for more precise control over which nodes should have Profiles generated or supported.
 - Profiles have been disabled on most core models.
 
 ### Schema

--- a/docs/docs/release-notes/infrahub/release-0_15_1.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_15_1.mdx
@@ -34,11 +34,11 @@ We are thrilled to announce the latest release of Infrahub (0.15.1).
 
 ### Frontend
 
-#### Multi profiles
+#### Multi Profiles
 
-We can now select multiple profiles when creating and editing an object.
+We can now select multiple Profiles when creating and editing an object.
 
-The `profile_priority` value from the profile schema is used to understand which value is used for the fields (the lower the number is, the higher the priority is).
+The `profile_priority` value from the Profile schema is used to understand which value is used for the fields (the lower the number is, the higher the priority is).
 
 #### Generic relationship select fixes
 

--- a/docs/docs/release-notes/infrahub/release-1_5_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_5_0.mdx
@@ -91,14 +91,14 @@ In the documentation you can find [specific instructions to migrate existing sch
 
 Today, in some places in the UI, we are using the HFID of objects to display them with useful context. This was mostly done to overcome the restriction of not supporting relationships in the `display_label`. In a future release we will use the `display_label` for this instead.
 
-## Refactor profiles
+## Refactor Profiles
 
 Profiles have been reworked for performance and future flexibility.
-Previously, attribute values derived from profiles were resolved dynamically at read time, which could impact performance at scale. With 1.5.0:
+Previously, attribute values derived from Profiles were resolved dynamically at read time, which could impact performance at scale. With 1.5.0:
 
-- Attribute values influenced by profiles are now computed and stored at write time (create/update object or profile).
+- Attribute values influenced by Profiles are now computed and stored at write time (create/update object or Profile).
 - Reads no longer have to compute derived values, improving query performance and predictability.
-- This refactor lays groundwork to expand profile capabilities, such as adding relationships to profiles in future versions of Infrahub.
+- This refactor lays groundwork to expand Profile capabilities, such as adding relationships to Profiles in future versions of Infrahub.
 
 ## Memory optimizations
 

--- a/docs/docs/release-notes/infrahub/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_6_0.mdx
@@ -39,7 +39,7 @@ We've replaced the static landing page with an interactive dashboard so you can 
 
 ## Use Profiles in Object Templates
 
-You can now define profiles in Object Templates so they're automatically applied when objects are created, ensuring consistency without manual post-creation steps.
+You can now define Profiles in Object Templates so they're automatically applied when objects are created, ensuring consistency without manual post-creation steps.
 
 ## Selective branch synchronization filter for Git repositories
 

--- a/docs/docs/release-notes/infrahub/release-1_7_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_7_0.mdx
@@ -46,16 +46,16 @@ The `created_by` and `updated_by` metadata will be set for objects that have bee
 
 Profiles now support relationships in addition to attributes, enabling you to define complete, reusable templates for entire classes of objects.
 
-Previously, profiles could only set attribute values, limiting their usefulness and adoption. Now you can:
+Previously, Profiles could only set attribute values, limiting their usefulness and adoption. Now you can:
 
-- Define relationships within a profile alongside attributes
+- Define relationships within a Profile alongside attributes
 - Create comprehensive templates that capture both data and connections
 - Enforce data consistency across large inventories with less manual work
 - Apply complete object configurations at scale
 
-Additionally profiles now support required attributes and relationships, as long as they are not part of a uniqueness constraint.
+Additionally Profiles now support required attributes and relationships, as long as they are not part of a uniqueness constraint.
 
-For example, you can now create a "Production Server Interface" profile that captures configurations, such as the speed and MTU and mode, but also automatically connect it to a specific VLAN.
+For example, you can now create a "Production Server Interface" Profile that captures configurations, such as the speed and MTU and mode, but also automatically connect it to a specific VLAN.
 
 This reduces manual configuration, minimizes errors when scaling automation projects, and ensures that relationships are consistently applied across your infrastructure data model.
 
@@ -85,10 +85,10 @@ Groups management:
 
 Profiles management:
 
-- New section shows all profiles currently applied to the object
-- Manage profile assignments directly from the object detail view
+- New section shows all Profiles currently applied to the object
+- Manage Profile assignments directly from the object detail view
 
-These changes make it faster to understand an object's context (its metadata, groups, and profiles) without switching between multiple views.
+These changes make it faster to understand an object's context (its metadata, groups, and Profiles) without switching between multiple views.
 
 ![Object detail view](../../media/release_notes/release_1_7_0/object_detail_page.jpg)
 

--- a/docs/docs/topics/object-template.mdx
+++ b/docs/docs/topics/object-template.mdx
@@ -18,18 +18,18 @@ When creating a new object instance, users can optionally select a template. If 
 
 See the [object-template guide](../guides/object-template.mdx) for more information.
 
-## Integration with profiles
+## Integration with Profiles
 
-When both `generate_template` and `generate_profile` are configured on a schema node, profiles can be assigned to templates. This integration enables powerful configuration management workflows:
+When both `generate_template` and `generate_profile` are configured on a schema node, Profiles can be assigned to templates. This integration enables powerful configuration management workflows:
 
-- **Bulk configuration**: Assign profiles to templates to define common configuration that applies to all objects created from that template
-- **Automatic inheritance**: Objects created from a template automatically inherit the profiles assigned to that template
-- **Value precedence**: Template values (when explicitly configured) take precedence over profile values, while profiles provide values for attributes not set on the template
-- **Multiple profiles**: Templates support multiple profile assignments with proper priority handling
+- **Bulk configuration**: Assign Profiles to templates to define common configuration that applies to all objects created from that template
+- **Automatic inheritance**: Objects created from a template automatically inherit the Profiles assigned to that template
+- **Value precedence**: Template values (when explicitly configured) take precedence over Profile values, while Profiles provide values for attributes not set on the template
+- **Multiple Profiles**: Templates support multiple Profile assignments with proper priority handling
 
-This combination allows you to use templates for structural definition (which ports exist) while profiles handle configuration values (port settings), enabling updates to values in bulk by modifying the profile rather than individual objects. Templates can still override specific profile values when needed.
+This combination allows you to use templates for structural definition (which ports exist) while Profiles handle configuration values (port settings), enabling updates to values in bulk by modifying the Profile rather than individual objects. Templates can still override specific Profile values when needed.
 
-For more details, see the [Creating and assigning profiles guide](../guides/profiles.mdx).
+For more details, see the [Creating and assigning Profiles guide](../guides/profiles.mdx).
 
 ## Component relationship
 

--- a/docs/docs/topics/profiles.mdx
+++ b/docs/docs/topics/profiles.mdx
@@ -2,15 +2,15 @@
 title: Profiles
 ---
 
-This topic explains the concept of profiles in Infrahub, their purpose in the system architecture, and how they enable configuration consistency across your infrastructure. You'll gain a deeper understanding of profile inheritance, priority mechanisms, and the design decisions behind this feature.
+This topic explains the concept of Profiles in Infrahub, their purpose in the system architecture, and how they enable configuration consistency across your infrastructure. You'll gain a deeper understanding of Profile inheritance, priority mechanisms, and the design decisions behind this feature.
 
-## What are profiles?
+## What are Profiles?
 
 Profiles in Infrahub are configuration templates that define common attribute and relationship values for objects. They represent a fundamental approach to managing configuration at scale by separating the definition of common settings from individual object instances.
 
-Think of profiles as reusable configuration blueprints. Just as a class in object-oriented programming defines properties that instances inherit, profiles define attribute values that objects inherit. This design pattern promotes consistency while maintaining flexibility for exceptions.
+Think of Profiles as reusable configuration blueprints. Just as a class in object-oriented programming defines properties that instances inherit, Profiles define attribute values that objects inherit. This design pattern promotes consistency while maintaining flexibility for exceptions.
 
-## Why profiles matter
+## Why Profiles matter
 
 ### The configuration consistency challenge
 
@@ -20,20 +20,20 @@ In infrastructure management, you often have hundreds or thousands of similar co
 - **BGP sessions**: Internal BGP peers share common timers, authentication, and policy settings
 - **Server configurations**: Groups of servers require identical monitoring, logging, and security settings
 
-Without profiles, you would need to:
+Without Profiles, you would need to:
 
 - Manually set the same values on each node
 - Risk configuration drift when standards change
 - Lack visibility into which nodes follow which standards
 - Struggle to update configurations consistently
 
-### How profiles solve these challenges
+### How Profiles solve these challenges
 
 Profiles address these issues through:
 
 1. **Centralized definition**: Define configuration once, apply everywhere
-2. **Automatic inheritance**: Objects automatically receive profile values
-3. **Dynamic updates**: Changes to profiles propagate to all associated objects
+2. **Automatic inheritance**: Objects automatically receive Profile values
+3. **Dynamic updates**: Changes to Profiles propagate to all associated objects
 4. **Override capability**: Individual objects can still have exceptions
 5. **Data lineage**: Track where each configuration value originated
 
@@ -41,21 +41,21 @@ Profiles address these issues through:
 
 ### Dynamic schema generation
 
-Infrahub automatically generates profile schemas based on your node schemas. This design decision ensures:
+Infrahub automatically generates Profile schemas based on your node schemas. This design decision ensures:
 
 - **Type safety**: Profiles always match their corresponding node type
 - **Schema evolution**: Profile schemas update automatically when node schemas change
-- **No manual maintenance**: You never need to define profile schemas separately
+- **No manual maintenance**: You never need to define Profile schemas separately
 
 For every node type with `generate_profile: true` (the default), Infrahub creates:
 
-- A profile schema named `Profile<Namespace><NodeName>`
-- GraphQL queries and mutations for profile operations
-- Validation logic ensuring profile-node compatibility
+- A Profile schema named `Profile<Namespace><NodeName>`
+- GraphQL queries and mutations for Profile operations
+- Validation logic ensuring Profile-node compatibility
 
 ### Profile components
 
-Each profile contains:
+Each Profile contains:
 
 1. **Core attributes** (inherited from `CoreProfile`):
    - `profile_name`: Unique identifier (3-32 characters)
@@ -72,17 +72,17 @@ Profile inheritance follows a sophisticated model:
 ```text
 Node Creation/Update
        ↓
-Check if profiles assigned (If created from a template, inherit its profiles)
+Check if Profiles assigned (If created from a template, inherit its Profiles)
        ↓
 For each attribute/relationship:
   - Is value explicitly set on node? → Use node value
-  - Is default value being used? → Check profiles
+  - Is default value being used? → Check Profiles
        ↓
-Check profiles by priority (lowest number first)
+Check Profiles by priority (lowest number first)
        ↓
-Use first profile-defined value found
+Use first Profile-defined value found
        ↓
-If no profile defines it → Use schema default
+If no Profile defines it → Use schema default
 ```
 
 This mechanism ensures predictable behavior while maintaining flexibility.
@@ -105,7 +105,7 @@ Inheritance order: B → A → C
 
 ### Priority in practice
 
-Consider a node with three profiles defining MTU:
+Consider a node with three Profiles defining MTU:
 
 - Base profile (priority 1000): MTU = 1500
 - Department profile (priority 500): MTU = 9000
@@ -118,8 +118,8 @@ The node inherits MTU = 9000 from the department profile (highest priority).
 The priority system enables:
 
 - **Hierarchical configuration**: Organization-wide → Department → Team → Special cases
-- **Controlled overrides**: Higher-priority profiles override lower-priority ones
-- **Flexible composition**: Combine multiple profiles without conflicts
+- **Controlled overrides**: Higher-priority Profiles override lower-priority ones
+- **Flexible composition**: Combine multiple Profiles without conflicts
 
 ## Data lineage and metadata
 
@@ -142,17 +142,17 @@ attribute = {
 This metadata enables:
 
 - **Audit trails**: Know exactly where each value came from
-- **Impact analysis**: Understand which nodes would be affected by profile changes
+- **Impact analysis**: Understand which nodes would be affected by Profile changes
 - **Troubleshooting**: Quickly identify why a node has specific values
 
 ### Metadata properties explained
 
-- `is_from_profile`: Boolean indicating inheritance from a profile
+- `is_from_profile`: Boolean indicating inheritance from a Profile
 - `is_default`: Boolean indicating use of schema default value
-- `source`: Reference to the specific profile providing the value
+- `source`: Reference to the specific Profile providing the value
 - `is_protected`: (Future) Will indicate if value is locked from changes
 
-## Relationships in profiles
+## Relationships in Profiles
 
 :::info Infrahub Version
 
@@ -160,25 +160,25 @@ Available since Infrahub 1.7!
 
 :::
 
-Starting with Infrahub 1.7, profiles can define relationship values in addition to attributes. This enables you to set relationships that objects inherit when assigned to a profile.
+Starting with Infrahub 1.7, Profiles can define relationship values in addition to attributes. This enables you to set relationships that objects inherit when assigned to a Profile.
 
 ### How relationship inheritance works
 
-Relationship inheritance in profiles follows the same principles as attribute inheritance:
+Relationship inheritance in Profiles follows the same principles as attribute inheritance:
 
 1. **Cardinality support**: Both `one` and `many` cardinality relationships are supported:
-   - For cardinality `one` relationships, the profile defines a single related object
-   - For cardinality `many` relationships, the profile defines a set of related objects that the inheriting object will be connected to
+   - For cardinality `one` relationships, the Profile defines a single related object
+   - For cardinality `many` relationships, the Profile defines a set of related objects that the inheriting object will be connected to
 
-2. **Priority-based resolution**: When multiple profiles define the same relationship, the profile with the highest priority (lowest priority number) takes precedence.
+2. **Priority-based resolution**: When multiple Profiles define the same relationship, the Profile with the highest priority (lowest priority number) takes precedence.
 
 3. **Override capability**: Just like attributes, relationship values can be overridden on individual objects when exceptions are needed.
 
-4. **Metadata tracking**: Relationship values inherited from profiles include metadata indicating their source, enabling full data lineage tracking.
+4. **Metadata tracking**: Relationship values inherited from Profiles include metadata indicating their source, enabling full data lineage tracking.
 
 ### Example use cases
 
-- **VLAN assignment**: Define a profile that sets the untagged VLAN for all end-user interfaces
+- **VLAN assignment**: Define a Profile that sets the untagged VLAN for all end-user interfaces
 - **Default location assignment**: Set a default location or site for objects of a specific type
 
 ## Profile constraints and limitations
@@ -194,13 +194,13 @@ Relationship inheritance in profiles follows the same principles as attribute in
 
 3. **Assignment limitations**:
    - Static assignment only (no dynamic rules yet)
-   - No conditional logic (if X then apply profile Y)
-   - No profile composition (profile extending another profile)
+   - No conditional logic (if X then apply Profile Y)
+   - No Profile composition (Profile extending another Profile)
 
 4. **Scope boundaries**:
    - Profiles are node-type specific
-   - Cannot share profiles across different node types
-   - No global or cross-schema profiles
+   - Cannot share Profiles across different node types
+   - No global or cross-schema Profiles
 
 ### Design rationale for constraints
 
@@ -208,11 +208,11 @@ These constraints exist to:
 
 - Maintain data integrity (unique constraints)
 - Ensure predictable behavior (static assignment)
-- Simplify mental model (type-specific profiles)
+- Simplify mental model (type-specific Profiles)
 - Preserve hierarchy integrity (hierarchical relationships excluded)
 - Enable future enhancements without breaking changes
 
-## Mental models for profiles
+## Mental models for Profiles
 
 ### Object-oriented inheritance
 
@@ -231,7 +231,7 @@ class UserInterface(InterfaceProfile):
 
 ### CSS-like cascading
 
-Similar to CSS, profiles cascade with priority:
+Similar to CSS, Profiles cascade with priority:
 
 ```css
 /* Lower priority */
@@ -248,23 +248,23 @@ Similar to CSS, profiles cascade with priority:
 
 Profiles implement policy-based management where:
 
-- Policies (profiles) define desired state
+- Policies (Profiles) define desired state
 - Nodes subscribe to policies
-- Changes to policies automatically propagate
+- Changes to Profiles automatically propagate
 - Exceptions are explicitly documented
 
 ## Future directions
 
 ### Planned enhancements
 
-1. **Dynamic assignment**: Rules-based profile application
+1. **Dynamic assignment**: Rules-based Profile application
 
    ```yaml
    if: node.location == "datacenter-1"
    then: apply_profile("dc1-standards")
    ```
 
-2. **Profile composition**: Profiles extending other profiles
+2. **Profile composition**: Profiles extending other Profiles
 
    ```yaml
    profile: edge-interface
@@ -279,34 +279,34 @@ The profile system is designed to evolve toward:
 
 - More sophisticated inheritance models
 - Integration with external configuration systems
-- Event-driven profile updates
-- Multi-tenancy with profile isolation
+- Event-driven Profile updates
+- Multi-tenancy with Profile isolation
 
 ## Conclusion
 
-Profiles in Infrahub represent a thoughtful approach to configuration management that balances consistency with flexibility. By understanding the inheritance model, priority system, and design constraints, you can effectively use profiles to manage infrastructure at scale while maintaining clear configuration lineage and enabling controlled exceptions.
+Profiles in Infrahub represent a thoughtful approach to configuration management that balances consistency with flexibility. By understanding the inheritance model, priority system, and design constraints, you can effectively use Profiles to manage infrastructure at scale while maintaining clear configuration lineage and enabling controlled exceptions.
 
-The system's design anticipates future needs while providing immediate value through reduced configuration drift, improved consistency, and clear audit trails. As Infrahub evolves, profiles will become even more powerful while maintaining backward compatibility with current usage patterns.
+The system's design anticipates future needs while providing immediate value through reduced configuration drift, improved consistency, and clear audit trails. As Infrahub evolves, Profiles will become even more powerful while maintaining backward compatibility with current usage patterns.
 
 ## Related resources
 
 ### Guides
 
-- [How to use profiles for consistent configuration](../guides/profiles.mdx) - Step-by-step guide for creating and using profiles
-- [Creating a schema](../guides/create-schema.mdx) - Learn how to create schemas that support profiles
-- [Managing groups](../guides/groups.mdx) - Understand how groups complement profiles for organization
-- [Creating an object template](../guides/object-template.mdx) - Learn how templates can be combined with profiles
+- [How to use Profiles for consistent configuration](../guides/profiles.mdx) - Step-by-step guide for creating and using Profiles
+- [Creating a schema](../guides/create-schema.mdx) - Learn how to create schemas that support Profiles
+- [Managing groups](../guides/groups.mdx) - Understand how groups complement Profiles for organization
+- [Creating an object template](../guides/object-template.mdx) - Learn how templates can be combined with Profiles
 
 ### Topics
 
-- [Schema](../topics/schema.mdx) - Deep dive into schema design and how profiles are generated
-- [GraphQL](../topics/graphql.mdx) - Understanding Infrahub's GraphQL API for profile operations
+- [Schema](../topics/schema.mdx) - Deep dive into schema design and how Profiles are generated
+- [GraphQL](../topics/graphql.mdx) - Understanding Infrahub's GraphQL API for Profile operations
 - [Metadata](../topics/metadata.mdx) - Learn about metadata tracking and data lineage
-- [Version control](../topics/version-control.mdx) - How profiles work with branches and version control
-- [Object templates](../topics/object-template.mdx) - How profiles integrate with templates for powerful configuration management
+- [Version control](../topics/version-control.mdx) - How Profiles work with branches and version control
+- [Object templates](../topics/object-template.mdx) - How Profiles integrate with templates for powerful configuration management
 
 ### Reference
 
-- [Node schema reference](../reference/schema/node.mdx) - Complete node schema options including profile generation
-- [Generic schema reference](../reference/schema/generic.mdx) - How profiles work with generic schemas
-- [Schema validation](../reference/schema-validation.mdx) - Validate schemas that generate profiles
+- [Node schema reference](../reference/schema/node.mdx) - Complete node schema options including Profile generation
+- [Generic schema reference](../reference/schema/generic.mdx) - How Profiles work with generic schemas
+- [Schema validation](../reference/schema-validation.mdx) - Validate schemas that generate Profiles


### PR DESCRIPTION
Standardize capitalization of 'Profiles' throughout documentation. As a first-class Infrahub capability with defined behavior and APIs, 'Profiles' should be capitalized when referring to the feature.

Updated files:
- topics/profiles.mdx
- topics/object-template.mdx
- guides/profiles.mdx
- guides/object-template.mdx
- Release notes (0.13, 0.15.0, 0.15.1, 1.5.0, 1.6.0, 1.7.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation consistency throughout guides, release notes, and topics through standardized terminology, capitalization, and improved formatting conventions.
  * Refined phrasing and presentation standards across the entire documentation suite for improved clarity, readability, and professional appearance.
  * Updated all documentation materials to ensure consistent terminology usage and clearer communication of concepts, features, and functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->