### PR TITLE
Add sticky footer row with object count to DataTable

### DIFF
--- a/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-table.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-table.tsx
@@ -6,6 +6,7 @@ import type { Filter } from "@/shared/hooks/useFilters";
 import { IP_ADDRESS_AVAILABLE_KIND } from "@/entities/ipam/constants";
 import { useGetIpAddressList } from "@/entities/ipam/ip-addresses/domain/get-ip-address-list.query";
 import { getIpAddressTableColumns } from "@/entities/ipam/ip-addresses/utils/get-ip-address-table-columns";
+import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/utils/get-object-actions-column";
@@ -18,10 +19,17 @@ export interface IpAddressTableProps {
 
 export function IpAddressTable({ baseFilters = [] }: IpAddressTableProps) {
   const { filters, selectedSchema, permission } = useObjectTableContext();
+  const allFilters = [...baseFilters, ...filters];
+
+  const { data: count } = useObjectsCount({
+    objectKind: selectedSchema.kind!,
+    filters: allFilters,
+  });
+
   const { isPending, isFetchingNextPage, data, error, fetchNextPage, hasNextPage } =
     useGetIpAddressList({
       schema: selectedSchema,
-      filters: [...baseFilters, ...filters],
+      filters: allFilters,
     });
 
   if (error) {
@@ -36,6 +44,7 @@ export function IpAddressTable({ baseFilters = [] }: IpAddressTableProps) {
       <DataTable
         columnOrder={IP_ADDRESS_TABLE_COLUMN_ORDER}
         columns={columns}
+        count={count}
         data={flatData}
         enableRowSelection={(row) => row.original.__typename !== IP_ADDRESS_AVAILABLE_KIND}
         isLoading={isPending || isFetchingNextPage}

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-table.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-table.tsx
@@ -6,6 +6,7 @@ import type { Filter } from "@/shared/hooks/useFilters";
 import { IP_PREFIX_AVAILABLE_KIND } from "@/entities/ipam/constants";
 import { useGetIpPrefixList } from "@/entities/ipam/ip-prefixes/domain/get-ip-prefix-list.query";
 import { getIpPrefixTableColumns } from "@/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns";
+import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/utils/get-object-actions-column";
@@ -26,11 +27,17 @@ export interface IpPrefixTableProps {
 
 export function IpPrefixTable({ baseFilters = [] }: IpPrefixTableProps) {
   const { filters, selectedSchema, permission } = useObjectTableContext();
+  const allFilters = [...baseFilters, ...filters];
+
+  const { data: count } = useObjectsCount({
+    objectKind: selectedSchema.kind!,
+    filters: allFilters,
+  });
 
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } =
     useGetIpPrefixList({
       schema: selectedSchema,
-      filters: [...baseFilters, ...filters],
+      filters: allFilters,
     });
 
   if (error) {
@@ -45,6 +52,7 @@ export function IpPrefixTable({ baseFilters = [] }: IpPrefixTableProps) {
       <DataTable
         columnOrder={IP_PREFIX_TABLE_COLUMN_ORDER}
         columns={columns}
+        count={count}
         data={flatData}
         enableRowSelection={(row) => row.original.__typename !== IP_PREFIX_AVAILABLE_KIND}
         isLoading={isPending || isFetchingNextPage}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
@@ -37,7 +37,7 @@ export function TableIdentifierCell({
         variant="ghost"
         size="sm"
         to={getObjectDetailsUrl(objectKind, objectId)}
-        className="truncate rounded-full px-2.5 text-custom-blue-700 hover:bg-custom-blue-700/10 hover:underline"
+        className="-mx-1 truncate rounded-xl px-2 text-custom-blue-700 hover:underline"
       >
         {label}
       </LinkButton>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -3,7 +3,6 @@ import { DataTable } from "@/shared/components/table/data-table";
 import { InfiniteScroll } from "@/shared/components/utils/infinite-scroll";
 
 import { useObjects } from "@/entities/nodes/object/domain/get-objects.query";
-import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/utils/get-object-actions-column";
@@ -12,15 +11,10 @@ import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/u
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
 
-  const { data: count } = useObjectsCount({
-    objectKind: selectedSchema.kind!,
+  const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
+    schema: selectedSchema,
     filters,
   });
-
-  const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects(
-    { schema: selectedSchema, filters },
-    { enabled: count !== undefined }
-  );
 
   if (error) {
     return <ErrorScreen message={error.message} />;

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -27,6 +27,7 @@ export const ObjectTable = () => {
     <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
       <DataTable
         columns={columns}
+        count={count}
         data={flatData}
         isLoading={isPending || isFetchingNextPage}
         renderEmpty={() => <ObjectTableEmpty schema={selectedSchema} />}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -3,6 +3,7 @@ import { DataTable } from "@/shared/components/table/data-table";
 import { InfiniteScroll } from "@/shared/components/utils/infinite-scroll";
 
 import { useObjects } from "@/entities/nodes/object/domain/get-objects.query";
+import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/utils/get-object-actions-column";
@@ -10,6 +11,11 @@ import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/u
 
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
+
+  const { data: count } = useObjectsCount({
+    objectKind: selectedSchema.kind!,
+    filters,
+  });
 
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
     schema: selectedSchema,

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -3,6 +3,7 @@ import { DataTable } from "@/shared/components/table/data-table";
 import { InfiniteScroll } from "@/shared/components/utils/infinite-scroll";
 
 import { useObjects } from "@/entities/nodes/object/domain/get-objects.query";
+import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/utils/get-object-actions-column";
@@ -11,10 +12,15 @@ import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/u
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
 
-  const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
-    schema: selectedSchema,
+  const { data: count } = useObjectsCount({
+    objectKind: selectedSchema.kind!,
     filters,
   });
+
+  const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects(
+    { schema: selectedSchema, filters },
+    { enabled: count !== undefined }
+  );
 
   if (error) {
     return <ErrorScreen message={error.message} />;

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
@@ -9,6 +9,7 @@ import {
   type UseObjectRelationshipsParams,
   useObjectRelationships,
 } from "@/entities/nodes/relationships/domain/get-object-relationships/get-object-relationships.query";
+import { useGetRelationshipCount } from "@/entities/nodes/relationships/domain/get-relationship-count/get-relationship-count.query";
 import { getRelationshipActionsColumn } from "@/entities/nodes/relationships/ui/relationship-table/get-relationship-actions-column";
 import { ToolbarDissociateAction } from "@/entities/nodes/relationships/ui/relationship-table/toolbar-dissociate-action";
 import { canDissociateRelationship } from "@/entities/nodes/relationships/utils/can-dissociate-relationship";
@@ -26,6 +27,12 @@ export function RelationshipTable({
 }: RelationshipTableProps) {
   const { schema: parentSchema } = useSchema(parentKind);
   const [filters] = useFilters();
+  const { data: count } = useGetRelationshipCount({
+    objectKind: parentKind,
+    objectId: parentId,
+    relationshipName,
+  });
+
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } =
     useObjectRelationships({
       relationshipSchema,
@@ -65,6 +72,7 @@ export function RelationshipTable({
     <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
       <DataTable
         columns={columns}
+        count={count}
         data={flatData}
         isLoading={isLoading}
         renderEmpty={() => <ObjectTableEmpty schema={relationshipSchema} />}

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -8,6 +8,10 @@ import {
 } from "@tanstack/react-table";
 import React from "react";
 
+import { Row } from "@/shared/components/container";
+import { cellFooterStyle, cellsStyle } from "@/shared/components/table/style";
+import { classNames } from "@/shared/utils/common";
+
 import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { ObjectTableSkeleton } from "@/entities/nodes/object/ui/object-table/object-table-skeleton";
 import {
@@ -19,6 +23,7 @@ import type { NodeCore } from "@/entities/nodes/types";
 export interface DataTableProps<T> extends React.HTMLAttributes<HTMLDivElement> {
   columnOrder?: ColumnOrderState;
   columns: ColumnDef<T>[];
+  count?: number;
   data: Array<T>;
   isLoading?: boolean;
   renderEmpty?: () => React.ReactNode;
@@ -33,6 +38,7 @@ const defaultGridTemplateColumns = (columnCount: number) =>
 export function DataTable<T extends NodeCore>({
   columnOrder,
   columns,
+  count,
   data,
   isLoading,
   renderEmpty,
@@ -101,6 +107,24 @@ export function DataTable<T extends NodeCore>({
       {!isLoading && allRows.length === 0 && renderEmpty?.()}
 
       {isLoading && <ObjectTableSkeleton headerCount={allHeaders.length} />}
+
+      {!!count &&
+        Array.from({ length: allHeaders.length }).map((_, index) => (
+          <div
+            key={index}
+            className={classNames(cellsStyle, cellFooterStyle, index === 0 && "left-0 z-10")}
+          >
+            {index === 0 && (
+              <>
+                <Row className="gap-1">
+                  <span className="font-medium">{count}</span>
+                  <span className="text-gray-500">count{count && count > 1 && "s"}</span>
+                </Row>
+                <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-gradient-to-r from-gray-500/10" />
+              </>
+            )}
+          </div>
+        ))}
     </div>
   );
 }

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -109,7 +109,7 @@ export function DataTable<T extends NodeCore>({
 
       {isLoading && <ObjectTableSkeleton headerCount={allHeaders.length} />}
 
-      {!!count &&
+      {count !== undefined &&
         Array.from({ length: allHeaders.length }).map((_, index) => (
           <div
             key={index}
@@ -119,7 +119,7 @@ export function DataTable<T extends NodeCore>({
               <>
                 <Row className="gap-1">
                   <span className="font-medium">{formatNumberDisplay(count)}</span>
-                  <span className="text-gray-500">count{count && count > 1 && "s"}</span>
+                  <span className="text-gray-500">count{count > 1 && "s"}</span>
                 </Row>
                 <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-linear-to-r from-gray-500/10" />
               </>

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { Row } from "@/shared/components/container";
 import { cellFooterStyle, cellsStyle } from "@/shared/components/table/style";
 import { classNames } from "@/shared/utils/common";
+import { formatNumberDisplay } from "@/shared/utils/number";
 
 import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { ObjectTableSkeleton } from "@/entities/nodes/object/ui/object-table/object-table-skeleton";
@@ -117,10 +118,10 @@ export function DataTable<T extends NodeCore>({
             {index === 0 && (
               <>
                 <Row className="gap-1">
-                  <span className="font-medium">{count}</span>
+                  <span className="font-medium">{formatNumberDisplay(count)}</span>
                   <span className="text-gray-500">count{count && count > 1 && "s"}</span>
                 </Row>
-                <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-gradient-to-r from-gray-500/10" />
+                <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-linear-to-r from-gray-500/10" />
               </>
             )}
           </div>

--- a/frontend/app/src/shared/components/table/style.tsx
+++ b/frontend/app/src/shared/components/table/style.tsx
@@ -5,4 +5,7 @@ export const cellHeaderStyle =
 
 export const cellBodyStyle = "bg-gray-50 border-r border-b border-gray-200";
 
+export const cellFooterStyle =
+  "sticky bottom-0 -mt-px h-9 border-gray-200 px-2.5 border-t border-r";
+
 export const cellMutedStyle = "bg-gray-50 text-gray-400";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables now show total item counts in footer rows for objects, IP addresses, IP prefixes, and relationships.

* **Style**
  * Updated identifier button styling with adjusted spacing and rounded corners for a cleaner, consistent look.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->