### PR TITLE
e2e disappearing diff bug

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -118,6 +118,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         component_registry = get_component_registry()
         diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=obj)
+        diff_coordinator.set_logger(log)
         diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=obj)
         initial_from_time = Timestamp(obj.get_branched_from())
         merger = BranchMerger(

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -148,6 +148,15 @@ class DiffCoordinator:
                 log.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+
+                roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+                log.info(
+                    f"update_branch_diff returning (lock already held): "
+                    f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
+                    f"proposed_change_id={proposed_change_id}, "
+                    f"roots_metadata={[repr(r) for r in roots_metadata]}"
+                )
+
                 return diff_root
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
@@ -166,6 +175,15 @@ class DiffCoordinator:
                 )
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+
+                roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+                log.info(
+                    f"update_branch_diff returning (branch merged/rebased): "
+                    f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
+                    f"proposed_change_id={proposed_change_id}, "
+                    f"roots_metadata={[repr(r) for r in roots_metadata]}"
+                )
+
                 return diff_root
             log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
@@ -187,6 +205,15 @@ class DiffCoordinator:
             )
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             log.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
+
+            roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+            log.info(
+                f"update_branch_diff returning (success): "
+                f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
+                f"proposed_change_id={proposed_change_id}, "
+                f"roots_metadata={[repr(r) for r in roots_metadata]}"
+            )
+
         return enriched_diffs.diff_branch_diff
 
     async def create_or_update_arbitrary_timeframe_diff(
@@ -264,6 +291,14 @@ class DiffCoordinator:
             await self.diff_repo.save(enriched_diffs=enriched_diffs)
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             log.info(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
+
+            roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
+            log.info(
+                f"recalculate returning: "
+                f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, diff_id={diff_id}, "
+                f"roots_metadata={[repr(r) for r in roots_metadata]}"
+            )
+
         return enriched_diffs.diff_branch_diff
 
     def _get_ordered_diff_pairs(

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -204,7 +204,6 @@ class DiffCoordinator:
                 force_branch_refresh=False,
             )
 
-            # set proposed change IDs
             if proposed_change_id:
                 enriched_diffs.diff_branch_diff.proposed_change_id = proposed_change_id
                 enriched_diffs.base_branch_diff.proposed_change_id = proposed_change_id
@@ -214,7 +213,8 @@ class DiffCoordinator:
                 span.set_attribute("diff_branch_name", diff_branch.name)
                 span.set_attribute("from_time", from_time.to_string())
                 span.set_attribute("to_time", to_time.to_string())
-                span.set_attribute("proposed_change_id", proposed_change_id or "null")
+                current_proposed_change_id = enriched_diffs.diff_branch_diff.proposed_change_id
+                span.set_attribute("proposed_change_id", current_proposed_change_id or "null")
                 diff_uuids = [enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]
                 span.set_attribute("diff_uuids", str(diff_uuids))
 

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable, Literal, Sequence, overload
 from uuid import uuid4
 
+from opentelemetry import trace
 from prefect import flow
 
 from infrahub.core.branch import Branch
@@ -208,9 +209,18 @@ class DiffCoordinator:
                 enriched_diffs.diff_branch_diff.proposed_change_id = proposed_change_id
                 enriched_diffs.base_branch_diff.proposed_change_id = proposed_change_id
 
-            await self.diff_repo.save(
-                enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
-            )
+            with trace.get_tracer(__name__).start_as_current_span("diff_update_save") as span:
+                span.set_attribute("base_branch_name", base_branch.name)
+                span.set_attribute("diff_branch_name", diff_branch.name)
+                span.set_attribute("from_time", from_time.to_string())
+                span.set_attribute("to_time", to_time.to_string())
+                span.set_attribute("proposed_change_id", proposed_change_id or "null")
+                diff_uuids = [enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]
+                span.set_attribute("diff_uuids", str(diff_uuids))
+
+                await self.diff_repo.save(
+                    enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
+                )
 
             self.logger.error(
                 f"Saved diff roots {[enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]}"
@@ -434,7 +444,14 @@ class DiffCoordinator:
                 diff_uuids_to_delete.append(diff_pair.diff_branch_diff.uuid)
 
         if diff_uuids_to_delete:
-            await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
+            with trace.get_tracer(__name__).start_as_current_span("diff_update_delete") as span:
+                span.set_attribute("base_branch_name", base_branch.name)
+                span.set_attribute("diff_branch_name", diff_branch.name)
+                span.set_attribute("from_time", from_time.to_string())
+                span.set_attribute("to_time", to_time.to_string())
+                span.set_attribute("uuids_to_delete", str(diff_uuids_to_delete))
+
+                await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
 
             self.logger.error(f"Deleted diff roots {diff_uuids_to_delete}")
 

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -211,6 +211,11 @@ class DiffCoordinator:
             await self.diff_repo.save(
                 enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )
+
+            self.logger.error(
+                f"Saved diff roots {[enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]}"
+            )
+
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             self.logger.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
 
@@ -430,6 +435,8 @@ class DiffCoordinator:
 
         if diff_uuids_to_delete:
             await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
+
+            self.logger.error(f"Deleted diff roots {diff_uuids_to_delete}")
 
         # this is an EnrichedDiffsMetadata, so there are no nodes to enrich
         if not isinstance(aggregated_enriched_diffs, EnrichedDiffs):

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -150,7 +150,7 @@ class DiffCoordinator:
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
 
                 roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                log.info(
+                log.error(
                     f"update_branch_diff returning (lock already held): "
                     f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                     f"proposed_change_id={proposed_change_id}, "
@@ -177,7 +177,7 @@ class DiffCoordinator:
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
 
                 roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                log.info(
+                log.error(
                     f"update_branch_diff returning (branch merged/rebased): "
                     f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                     f"proposed_change_id={proposed_change_id}, "
@@ -207,7 +207,7 @@ class DiffCoordinator:
             log.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
 
             roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            log.info(
+            log.error(
                 f"update_branch_diff returning (success): "
                 f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                 f"proposed_change_id={proposed_change_id}, "
@@ -293,7 +293,7 @@ class DiffCoordinator:
             log.info(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
 
             roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            log.info(
+            log.error(
                 f"recalculate returning: "
                 f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, diff_id={diff_id}, "
                 f"roots_metadata={[repr(r) for r in roots_metadata]}"

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -25,6 +25,10 @@ from .model.path import (
 )
 
 if TYPE_CHECKING:
+    import logging
+
+    from structlog.stdlib import BoundLogger
+
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
 
@@ -39,7 +43,7 @@ if TYPE_CHECKING:
     from .repository.repository import DiffRepository
 
 
-log = get_logger()
+default_log = get_logger()
 
 
 @dataclass
@@ -84,6 +88,10 @@ class DiffCoordinator:
         self.data_check_synchronizer = data_check_synchronizer
         self.conflict_transferer = conflict_transferer
         self.diff_locker = diff_locker
+        self.logger: logging.Logger | logging.LoggerAdapter[logging.Logger] | BoundLogger = default_log
+
+    def set_logger(self, logger: logging.Logger | logging.LoggerAdapter[logging.Logger] | BoundLogger) -> None:
+        self.logger = logger
 
     async def run_update(
         self,
@@ -136,21 +144,21 @@ class DiffCoordinator:
         self, base_branch: Branch, diff_branch: Branch, proposed_change_id: str | None = None
     ) -> EnrichedDiffRootMetadata:
         tracking_id = BranchTrackingId(name=diff_branch.name)
-        log.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
+        self.logger.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
         existing_incremental_lock = self.diff_locker.get_existing_lock(
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
         )
         if existing_incremental_lock and await existing_incremental_lock.locked():
-            log.info(f"Branch diff update for {base_branch.name} - {diff_branch.name} already in progress")
+            self.logger.info(f"Branch diff update for {base_branch.name} - {diff_branch.name} already in progress")
             async with self.diff_locker.acquire_lock(
                 target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
             ):
-                log.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
+                self.logger.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
 
                 roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                log.error(
+                self.logger.error(
                     f"update_branch_diff returning (lock already held): "
                     f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                     f"proposed_change_id={proposed_change_id}, "
@@ -170,14 +178,14 @@ class DiffCoordinator:
         ):
             refreshed_branch = await Branch.get_by_name(db=self.db, name=diff_branch.name)
             if refreshed_branch.get_branched_from() != diff_branch.get_branched_from():
-                log.info(
+                self.logger.info(
                     f"Branch {diff_branch.name} was merged or rebased while waiting for lock, returning latest diff"
                 )
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
 
                 roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                log.error(
+                self.logger.error(
                     f"update_branch_diff returning (branch merged/rebased): "
                     f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                     f"proposed_change_id={proposed_change_id}, "
@@ -185,7 +193,7 @@ class DiffCoordinator:
                 )
 
                 return diff_root
-            log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
@@ -204,10 +212,10 @@ class DiffCoordinator:
                 enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
-            log.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
 
             roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            log.error(
+            self.logger.error(
                 f"update_branch_diff returning (success): "
                 f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
                 f"proposed_change_id={proposed_change_id}, "
@@ -228,7 +236,7 @@ class DiffCoordinator:
         async with self.diff_locker.acquire_lock(
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
         ):
-            log.info(f"Acquired lock to run arbitrary diff update for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Acquired lock to run arbitrary diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
@@ -246,7 +254,7 @@ class DiffCoordinator:
                 enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
-            log.info(f"Arbitrary diff update complete for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Arbitrary diff update complete for {base_branch.name} - {diff_branch.name}")
         return enriched_diffs.diff_branch_diff
 
     async def recalculate(
@@ -258,7 +266,7 @@ class DiffCoordinator:
         async with self.diff_locker.acquire_lock(
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
         ):
-            log.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
             current_branch_diff = await self.diff_repo.get_one(diff_branch_name=diff_branch.name, diff_id=diff_id)
             current_base_diff = await self.diff_repo.get_one(
                 diff_branch_name=base_branch.name, diff_id=current_branch_diff.partner_uuid
@@ -290,10 +298,10 @@ class DiffCoordinator:
 
             await self.diff_repo.save(enriched_diffs=enriched_diffs)
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
-            log.info(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
+            self.logger.info(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
 
             roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            log.error(
+            self.logger.error(
                 f"recalculate returning: "
                 f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, diff_id={diff_id}, "
                 f"roots_metadata={[repr(r) for r in roots_metadata]}"
@@ -472,7 +480,7 @@ class DiffCoordinator:
         if partial_enriched_diffs is not None and not aggregated_enriched_diffs:
             ordered_diffs = self._get_ordered_diff_pairs(diff_pairs=partial_enriched_diffs, allow_overlap=False)
             ordered_diff_reprs = [repr(d) for d in ordered_diffs]
-            log.info(f"Ordered diffs for aggregation: {ordered_diff_reprs}")
+            self.logger.info(f"Ordered diffs for aggregation: {ordered_diff_reprs}")
             incremental_diffs_and_requests: list[EnrichedDiffsMetadata | EnrichedDiffRequest | None] = []
             current_time = diff_request.from_time
             while current_time < diff_request.to_time:
@@ -488,7 +496,7 @@ class DiffCoordinator:
                 else:
                     end_time = diff_request.to_time
                 # if there are no changes on either branch in this time range, then there cannot be a diff
-                log.info(
+                self.logger.info(
                     f"Checking number of changes on branches for {diff_request!r}, from_time={current_time}, to_time={end_time}"
                 )
                 num_changes_by_branch = await get_num_changes_in_time_range_by_branch(
@@ -497,7 +505,7 @@ class DiffCoordinator:
                     to_time=end_time,
                     db=self.db,
                 )
-                log.info(f"Number of changes: {num_changes_by_branch}")
+                self.logger.info(f"Number of changes: {num_changes_by_branch}")
                 might_have_changes_in_time_range = any(num_changes_by_branch.values())
                 if not might_have_changes_in_time_range:
                     incremental_diffs_and_requests.append(None)
@@ -553,11 +561,13 @@ class DiffCoordinator:
         for diff_or_request in diff_or_request_list:
             if isinstance(diff_or_request, EnrichedDiffRequest):
                 if previous_diff_pair:
-                    log.info(f"Getting node field specifiers diff uuid={previous_diff_pair.diff_branch_diff.uuid}")
+                    self.logger.info(
+                        f"Getting node field specifiers diff uuid={previous_diff_pair.diff_branch_diff.uuid}"
+                    )
                     node_field_specifiers = await self.diff_repo.get_node_field_specifiers(
                         diff_id=previous_diff_pair.diff_branch_diff.uuid,
                     )
-                    log.info(f"Number node field specifiers: {len(node_field_specifiers)}")
+                    self.logger.info(f"Number node field specifiers: {len(node_field_specifiers)}")
                     diff_or_request.node_field_specifiers = node_field_specifiers
                 is_incremental_diff = diff_or_request.from_time != full_diff_request.from_time
                 calculated_diff = await self._calculate_enriched_diff(
@@ -576,13 +586,13 @@ class DiffCoordinator:
                 previous_diff_pair = single_enriched_diffs
                 continue
 
-            log.info("Combining diffs...")
+            self.logger.info("Combining diffs...")
             previous_diff_pair = await self._combine_diffs(
                 earlier=previous_diff_pair,
                 later=single_enriched_diffs,
                 node_identifiers=updated_node_identifiers,
             )
-            log.info("Diffs combined.")
+            self.logger.info("Diffs combined.")
 
         node_identifiers_to_drop: set[NodeIdentifier] = set()
         if isinstance(previous_diff_pair, EnrichedDiffs):
@@ -597,8 +607,8 @@ class DiffCoordinator:
         later: EnrichedDiffs | EnrichedDiffsMetadata,
         node_identifiers: set[NodeIdentifier],
     ) -> EnrichedDiffs | EnrichedDiffsMetadata:
-        log.info(f"Earlier diff to combine: {earlier!r}")
-        log.info(f"Later diff to combine: {later!r}")
+        self.logger.info(f"Earlier diff to combine: {earlier!r}")
+        self.logger.info(f"Later diff to combine: {later!r}")
         # if one of the diffs is hydrated and has no data, we can combine them without hydrating the other
         if isinstance(earlier, EnrichedDiffs) and earlier.is_empty:
             later.base_branch_diff.from_time = earlier.base_branch_diff.from_time
@@ -611,17 +621,17 @@ class DiffCoordinator:
 
         # hydrate the diffs to combine, if necessary
         if not isinstance(earlier, EnrichedDiffs):
-            log.info("Hydrating earlier diff...")
+            self.logger.info("Hydrating earlier diff...")
             earlier = await self.diff_repo.hydrate_diff_pair(
                 enriched_diffs_metadata=earlier, node_identifiers=node_identifiers
             )
-            log.info("Earlier diff hydrated.")
+            self.logger.info("Earlier diff hydrated.")
         if not isinstance(later, EnrichedDiffs):
-            log.info("Hydrating later diff...")
+            self.logger.info("Hydrating later diff...")
             later = await self.diff_repo.hydrate_diff_pair(
                 enriched_diffs_metadata=later, node_identifiers=node_identifiers
             )
-            log.info("Later diff hydrated.")
+            self.logger.info("Later diff hydrated.")
 
         return await self.diff_combiner.combine(earlier_diffs=earlier, later_diffs=later)
 
@@ -631,7 +641,7 @@ class DiffCoordinator:
     async def _calculate_enriched_diff(
         self, diff_request: EnrichedDiffRequest, is_incremental_diff: bool
     ) -> EnrichedDiffs:
-        log.info(f"Calculating diff for {diff_request!r}, include_unchanged={is_incremental_diff}")
+        self.logger.info(f"Calculating diff for {diff_request!r}, include_unchanged={is_incremental_diff}")
         calculated_diff_pair = await self.diff_calculator.calculate_diff(
             base_branch=diff_request.base_branch,
             diff_branch=diff_request.diff_branch,
@@ -640,9 +650,9 @@ class DiffCoordinator:
             include_unchanged=is_incremental_diff,
             previous_node_specifiers=diff_request.node_field_specifiers,
         )
-        log.info("Calculation complete. Enriching diff...")
+        self.logger.info("Calculation complete. Enriching diff...")
         enriched_diff_pair = await self.diff_enricher.enrich(
             calculated_diffs=calculated_diff_pair, tracking_id=diff_request.tracking_id
         )
-        log.info("Enrichment complete")
+        self.logger.info("Enrichment complete")
         return enriched_diff_pair

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable, Literal, Sequence, overload
 from uuid import uuid4
 
-from opentelemetry import trace
 from prefect import flow
 
 from infrahub.core.branch import Branch
@@ -157,15 +156,6 @@ class DiffCoordinator:
                 self.logger.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
-
-                roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                self.logger.error(
-                    f"update_branch_diff returning (lock already held): "
-                    f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
-                    f"proposed_change_id={proposed_change_id}, "
-                    f"roots_metadata={[repr(r) for r in roots_metadata]}"
-                )
-
                 return diff_root
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
@@ -184,15 +174,6 @@ class DiffCoordinator:
                 )
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
                 await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
-
-                roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-                self.logger.error(
-                    f"update_branch_diff returning (branch merged/rebased): "
-                    f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
-                    f"proposed_change_id={proposed_change_id}, "
-                    f"roots_metadata={[repr(r) for r in roots_metadata]}"
-                )
-
                 return diff_root
             self.logger.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
@@ -208,34 +189,12 @@ class DiffCoordinator:
                 enriched_diffs.diff_branch_diff.proposed_change_id = proposed_change_id
                 enriched_diffs.base_branch_diff.proposed_change_id = proposed_change_id
 
-            with trace.get_tracer(__name__).start_as_current_span("diff_update_save") as span:
-                span.set_attribute("base_branch_name", base_branch.name)
-                span.set_attribute("diff_branch_name", diff_branch.name)
-                span.set_attribute("from_time", from_time.to_string())
-                span.set_attribute("to_time", to_time.to_string())
-                current_proposed_change_id = enriched_diffs.diff_branch_diff.proposed_change_id
-                span.set_attribute("proposed_change_id", current_proposed_change_id or "null")
-                diff_uuids = [enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]
-                span.set_attribute("diff_uuids", str(diff_uuids))
-
-                await self.diff_repo.save(
-                    enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
-                )
-
-            self.logger.error(
-                f"Saved diff roots {[enriched_diffs.base_branch_diff.uuid, enriched_diffs.diff_branch_diff.uuid]}"
+            await self.diff_repo.save(
+                enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
             )
 
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             self.logger.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
-
-            roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            self.logger.error(
-                f"update_branch_diff returning (success): "
-                f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, "
-                f"proposed_change_id={proposed_change_id}, "
-                f"roots_metadata={[repr(r) for r in roots_metadata]}"
-            )
 
         return enriched_diffs.diff_branch_diff
 
@@ -314,14 +273,6 @@ class DiffCoordinator:
             await self.diff_repo.save(enriched_diffs=enriched_diffs)
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             self.logger.info(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
-
-            roots_metadata = await self.diff_repo.get_roots_metadata(diff_branch_names=[diff_branch.name])
-            self.logger.error(
-                f"recalculate returning: "
-                f"base_branch={base_branch.name}, diff_branch={diff_branch.name}, diff_id={diff_id}, "
-                f"roots_metadata={[repr(r) for r in roots_metadata]}"
-            )
-
         return enriched_diffs.diff_branch_diff
 
     def _get_ordered_diff_pairs(
@@ -444,16 +395,7 @@ class DiffCoordinator:
                 diff_uuids_to_delete.append(diff_pair.diff_branch_diff.uuid)
 
         if diff_uuids_to_delete:
-            with trace.get_tracer(__name__).start_as_current_span("diff_update_delete") as span:
-                span.set_attribute("base_branch_name", base_branch.name)
-                span.set_attribute("diff_branch_name", diff_branch.name)
-                span.set_attribute("from_time", from_time.to_string())
-                span.set_attribute("to_time", to_time.to_string())
-                span.set_attribute("uuids_to_delete", str(diff_uuids_to_delete))
-
-                await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
-
-            self.logger.error(f"Deleted diff roots {diff_uuids_to_delete}")
+            await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
 
         # this is an EnrichedDiffsMetadata, so there are no nodes to enrich
         if not isinstance(aggregated_enriched_diffs, EnrichedDiffs):

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from prefect import flow
+from prefect import flow, get_run_logger
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
@@ -33,6 +33,7 @@ async def update_diff(model: RequestDiffUpdate) -> None:
 
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
 
+        diff_coordinator.set_logger(get_run_logger())
         await diff_coordinator.run_update(
             base_branch=base_branch,
             diff_branch=diff_branch,

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import Argument, Boolean, DateTime, Field, InputObjectType, Int, List, NonNull, ObjectType, String
 from graphene import Enum as GrapheneEnum
+from opentelemetry import trace
 
 from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
@@ -488,27 +489,28 @@ class DiffTreeResolver:
         elif root_node_uuids:
             filters_dict["ids"] = root_node_uuids
 
-        t = Timestamp()
-        log.error(f"Retrieving diffs for {branch} at {t.to_string()}")
+        with trace.get_tracer(__name__).start_as_current_span("diff_tree_request") as span:
+            span.set_attribute("base_branch_name", base_branch.name)
+            span.set_attribute("diff_branch_name", diff_branch.name)
+            span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
+            span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
+            span.set_attribute("proposed_change_id", proposed_change_id or "null")
 
-        enriched_diffs = await diff_repo.get(
-            base_branch_name=base_branch.name,
-            diff_branch_names=[diff_branch.name],
-            from_time=from_timestamp,
-            to_time=to_timestamp,
-            filters=EnrichedDiffQueryFilters(**filters_dict),
-            include_parents=include_parents,
-            limit=limit,
-            offset=offset,
-            tracking_id=NameTrackingId(name) if name else None,
-            include_empty=True,
-            proposed_change_id=proposed_change_id,
-            # include merged diffs if filtering on proposed change
-            exclude_merged=not proposed_change_id,
-        )
-
-        t = Timestamp()
-        log.error(f"Diffs retrieved for {branch} at {t.to_string()}")
+            enriched_diffs = await diff_repo.get(
+                base_branch_name=base_branch.name,
+                diff_branch_names=[diff_branch.name],
+                from_time=from_timestamp,
+                to_time=to_timestamp,
+                filters=EnrichedDiffQueryFilters(**filters_dict),
+                include_parents=include_parents,
+                limit=limit,
+                offset=offset,
+                tracking_id=NameTrackingId(name) if name else None,
+                include_empty=True,
+                proposed_change_id=proposed_change_id,
+                # include merged diffs if filtering on proposed change
+                exclude_merged=not proposed_change_id,
+            )
 
         if not enriched_diffs:
             return None

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -10,6 +10,7 @@ from opentelemetry import trace
 from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
 from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.diff_locker import DiffLocker
 from infrahub.core.diff.model.path import NameTrackingId
 from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
 from infrahub.core.diff.repository.repository import DiffRepository
@@ -489,28 +490,43 @@ class DiffTreeResolver:
         elif root_node_uuids:
             filters_dict["ids"] = root_node_uuids
 
-        with trace.get_tracer(__name__).start_as_current_span("diff_tree_request") as span:
-            span.set_attribute("base_branch_name", base_branch.name)
-            span.set_attribute("diff_branch_name", diff_branch.name)
-            span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
-            span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
-            span.set_attribute("proposed_change_id", proposed_change_id or "null")
+        # ensure any ongoing diff updates complete before we try to retrieve them
+        diff_locker = DiffLocker()
 
-            enriched_diffs = await diff_repo.get(
-                base_branch_name=base_branch.name,
-                diff_branch_names=[diff_branch.name],
-                from_time=from_timestamp,
-                to_time=to_timestamp,
-                filters=EnrichedDiffQueryFilters(**filters_dict),
-                include_parents=include_parents,
-                limit=limit,
-                offset=offset,
-                tracking_id=NameTrackingId(name) if name else None,
-                include_empty=True,
-                proposed_change_id=proposed_change_id,
-                # include merged diffs if filtering on proposed change
-                exclude_merged=not proposed_change_id,
-            )
+        lock_request_time = Timestamp()
+        async with (
+            diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+            ),
+            diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+            ),
+        ):
+            lock_acquired_time = Timestamp()
+            with trace.get_tracer(__name__).start_as_current_span("diff_tree_request") as span:
+                span.set_attribute("base_branch_name", base_branch.name)
+                span.set_attribute("diff_branch_name", diff_branch.name)
+                span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
+                span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
+                span.set_attribute("proposed_change_id", proposed_change_id or "null")
+                span.set_attribute("lock_request_time", lock_request_time.to_string())
+                span.set_attribute("lock_acquired_time", lock_acquired_time.to_string())
+
+                enriched_diffs = await diff_repo.get(
+                    base_branch_name=base_branch.name,
+                    diff_branch_names=[diff_branch.name],
+                    from_time=from_timestamp,
+                    to_time=to_timestamp,
+                    filters=EnrichedDiffQueryFilters(**filters_dict),
+                    include_parents=include_parents,
+                    limit=limit,
+                    offset=offset,
+                    tracking_id=NameTrackingId(name) if name else None,
+                    include_empty=True,
+                    proposed_change_id=proposed_change_id,
+                    # include merged diffs if filtering on proposed change
+                    exclude_merged=not proposed_change_id,
+                )
 
         if not enriched_diffs:
             return None
@@ -567,16 +583,26 @@ class DiffTreeResolver:
 
         filters_dict = dict(filters or {})
 
-        summary = await diff_repo.summary(
-            base_branch_name=base_branch.name,
-            diff_branch_names=[diff_branch.name],
-            from_time=from_timestamp,
-            to_time=to_timestamp,
-            filters=filters_dict,
-            proposed_change_id=proposed_change_id,
-            # include merged diffs if filtering on proposed change
-            exclude_merged=not proposed_change_id,
-        )
+        # ensure any ongoing diff updates complete before we try to retrieve them
+        diff_locker = DiffLocker()
+        async with (
+            diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+            ),
+            diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+            ),
+        ):
+            summary = await diff_repo.summary(
+                base_branch_name=base_branch.name,
+                diff_branch_names=[diff_branch.name],
+                from_time=from_timestamp,
+                to_time=to_timestamp,
+                filters=filters_dict,
+                proposed_change_id=proposed_change_id,
+                # include merged diffs if filtering on proposed change
+                exclude_merged=not proposed_change_id,
+            )
         if summary is None:
             return None
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import Argument, Boolean, DateTime, Field, InputObjectType, Int, List, NonNull, ObjectType, String
 from graphene import Enum as GrapheneEnum
-from opentelemetry import trace
 
 from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
@@ -19,7 +18,6 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.graphql.enums import ConflictSelection as GraphQLConflictSelection
 from infrahub.graphql.field_extractor import extract_graphql_fields
-from infrahub.log import get_logger
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -40,7 +38,6 @@ if TYPE_CHECKING:
 
 GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
 GrapheneCardinalityEnum = GrapheneEnum.from_enum(RelationshipCardinality)
-log = get_logger()
 
 
 @dataclass
@@ -492,8 +489,6 @@ class DiffTreeResolver:
 
         # ensure any ongoing diff updates complete before we try to retrieve them
         diff_locker = DiffLocker()
-
-        lock_request_time = Timestamp()
         async with (
             diff_locker.acquire_lock(
                 target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
@@ -502,31 +497,21 @@ class DiffTreeResolver:
                 target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
             ),
         ):
-            lock_acquired_time = Timestamp()
-            with trace.get_tracer(__name__).start_as_current_span("diff_tree_request") as span:
-                span.set_attribute("base_branch_name", base_branch.name)
-                span.set_attribute("diff_branch_name", diff_branch.name)
-                span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
-                span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
-                span.set_attribute("proposed_change_id", proposed_change_id or "null")
-                span.set_attribute("lock_request_time", lock_request_time.to_string())
-                span.set_attribute("lock_acquired_time", lock_acquired_time.to_string())
-
-                enriched_diffs = await diff_repo.get(
-                    base_branch_name=base_branch.name,
-                    diff_branch_names=[diff_branch.name],
-                    from_time=from_timestamp,
-                    to_time=to_timestamp,
-                    filters=EnrichedDiffQueryFilters(**filters_dict),
-                    include_parents=include_parents,
-                    limit=limit,
-                    offset=offset,
-                    tracking_id=NameTrackingId(name) if name else None,
-                    include_empty=True,
-                    proposed_change_id=proposed_change_id,
-                    # include merged diffs if filtering on proposed change
-                    exclude_merged=not proposed_change_id,
-                )
+            enriched_diffs = await diff_repo.get(
+                base_branch_name=base_branch.name,
+                diff_branch_names=[diff_branch.name],
+                from_time=from_timestamp,
+                to_time=to_timestamp,
+                filters=EnrichedDiffQueryFilters(**filters_dict),
+                include_parents=include_parents,
+                limit=limit,
+                offset=offset,
+                tracking_id=NameTrackingId(name) if name else None,
+                include_empty=True,
+                proposed_change_id=proposed_change_id,
+                # include merged diffs if filtering on proposed change
+                exclude_merged=not proposed_change_id,
+            )
 
         if not enriched_diffs:
             return None

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -17,6 +17,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.graphql.enums import ConflictSelection as GraphQLConflictSelection
 from infrahub.graphql.field_extractor import extract_graphql_fields
+from infrahub.log import get_logger
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
 
 GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
 GrapheneCardinalityEnum = GrapheneEnum.from_enum(RelationshipCardinality)
+log = get_logger()
 
 
 @dataclass
@@ -486,6 +488,9 @@ class DiffTreeResolver:
         elif root_node_uuids:
             filters_dict["ids"] = root_node_uuids
 
+        t = Timestamp()
+        log.error(f"Retrieving diffs for {branch} at {t.to_string()}")
+
         enriched_diffs = await diff_repo.get(
             base_branch_name=base_branch.name,
             diff_branch_names=[diff_branch.name],
@@ -501,6 +506,10 @@ class DiffTreeResolver:
             # include merged diffs if filtering on proposed change
             exclude_merged=not proposed_change_id,
         )
+
+        t = Timestamp()
+        log.error(f"Diffs retrieved for {branch} at {t.to_string()}")
+
         if not enriched_diffs:
             return None
         if len(enriched_diffs) > 0:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -297,6 +297,7 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
         component_registry = get_component_registry()
 
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
+        diff_coordinator.set_logger(get_run_logger())
         await diff_coordinator.update_branch_diff(
             base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
         )
@@ -1099,6 +1100,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
         source_branch = await registry.get_branch(db=dbs, branch=model.source_branch)
         component_registry = get_component_registry()
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
+        diff_coordinator.set_logger(get_run_logger())
         await diff_coordinator.update_branch_diff(
             base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
         )


### PR DESCRIPTION
example https://github.com/opsmill/infrahub/actions/runs/21471686819/job/61845671547?pr=8265

an E2E test to retrieve a diff in the UI was failing b/c the backend was returning an empty diff for a branch with data and a diff that had already been calculated.

this issue just started following some recent changes to link a diff to a proposed change, but it was not actually caused by these changes. the recent changes seem to have affected the timing of calculating/saving/retrieving a diff specifically for the E2E test, which is operating the UI at speeds no regular person ever would. this revealed (after much troubleshooting and logging) that it is possible to request the diff for a branch while the diff is being updated, which can result in no diff being found in the database.

the fix is to use the same locking used in the components that update the diff inside of the `DiffTree.resolver` method to ensure that all updates to the diff are complete before trying to retrieve it

I also made some changes to how logging works in DiffCoordinator to get logs to show up in the E2E tests while troubleshooting this, but they seem mildly helpful, so I will leave them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced logging visibility in background operations for improved task tracking and debugging.
  * Improved synchronization of change data operations to prevent race conditions during concurrent updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->