### PR TITLE
fix(devcontainer): disable moby

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,10 @@
   "postCreateCommand": "./.devcontainer/postCreateCommand.sh",
   "postAttachCommand": "./.devcontainer/postAttachCommand.sh",
   "features": {
-    "docker-in-docker": "latest",
+    "docker-in-docker": {
+      "version": "latest",
+      "moby": false
+    },
     "github-cli": "latest"
   },
   "hostRequirements": {


### PR DESCRIPTION
This is because moby is not available with Debian trixie.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker-in-Docker configuration in the development environment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->