### PR TITLE
freeze diff for a closed proposed change

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from infrahub.core.constants import (
     BranchSupportType,
@@ -41,7 +41,7 @@ class TrackingId:
         return f"{self.prefix}{self.delimiter}{self.name}"
 
     @classmethod
-    def deserialize(cls, id_string: str) -> TrackingId:
+    def deserialize(cls, id_string: str) -> Self:
         if not id_string.startswith(cls.prefix):
             raise ValueError(
                 f"Cannot deserialize TrackingId with incorrect prefix '{id_string}', expected prefix '{cls.prefix}{cls.delimiter}'"

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -71,8 +71,12 @@ class NameTrackingId(TrackingId):
     prefix = "name"
 
 
+class FrozenTrackingId(TrackingId):
+    prefix = "frozen"
+
+
 def deserialize_tracking_id(tracking_id_str: str) -> TrackingId:
-    for tracking_id_class in (BranchTrackingId, NameTrackingId):
+    for tracking_id_class in (BranchTrackingId, NameTrackingId, FrozenTrackingId):
         try:
             return tracking_id_class.deserialize(id_string=tracking_id_str)
         except ValueError:
@@ -460,6 +464,7 @@ class EnrichedDiffRootMetadata(BaseSummary):
     partner_uuid: str | None = field(default=None)
     exists_on_database: bool = field(default=False)
     proposed_change_id: str | None = field(default=None)
+    is_frozen: bool = field(default=False, kw_only=True)
 
     def __hash__(self) -> int:
         return hash(self.uuid)

--- a/backend/infrahub/core/diff/query/delete_query.py
+++ b/backend/infrahub/core/diff/query/delete_query.py
@@ -9,15 +9,28 @@ class EnrichedDiffDeleteQuery(Query):
     type = QueryType.WRITE
     insert_return = False
 
-    def __init__(self, enriched_diff_root_uuids: list[str] | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        enriched_diff_root_uuids: list[str] | None = None,
+        include_frozen: bool = False,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.enriched_diff_root_uuids = enriched_diff_root_uuids
+        self.include_frozen = include_frozen
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
-        diff_filter = ""
+        diff_filters = []
+        self.params = {}
         if self.enriched_diff_root_uuids:
-            self.params = {"diff_root_uuids": self.enriched_diff_root_uuids}
-            diff_filter = "WHERE d_root.uuid IN $diff_root_uuids"
+            self.params["diff_root_uuids"] = self.enriched_diff_root_uuids
+            diff_filters.append("d_root.uuid IN $diff_root_uuids")
+        if not self.include_frozen:
+            diff_filters.append("(d_root.is_frozen IS NULL OR d_root.is_frozen <> TRUE)")
+
+        diff_filter = ""
+        if diff_filters:
+            diff_filter = "WHERE " + " AND ".join(diff_filters)
 
         query = """
 MATCH (d_root:DiffRoot)

--- a/backend/infrahub/core/diff/query/freeze_by_proposed_change.py
+++ b/backend/infrahub/core/diff/query/freeze_by_proposed_change.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from infrahub.core.diff.model.path import FrozenTrackingId
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+
+class EnrichedDiffFreezeByProposedChangeQuery(Query):
+    """Freezes DiffRoot nodes linked to a ProposedChange.
+
+    Sets is_frozen=TRUE and updates tracking_id to 'frozen.{proposed_change_id}'
+    for all DiffRoots linked via DIFF_FOR_PROPOSED_CHANGE relationship.
+    """
+
+    name = "enriched_diff_freeze_by_proposed_change"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(
+        self,
+        proposed_change_id: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.proposed_change_id = proposed_change_id
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        frozen_tracking_id = FrozenTrackingId(name=self.proposed_change_id)
+        self.params = {
+            "proposed_change_id": self.proposed_change_id,
+            "frozen_tracking_id": frozen_tracking_id.serialize(),
+        }
+        query = """
+MATCH (diff_root:DiffRoot)-[:DIFF_FOR_PROPOSED_CHANGE]->(pc:Node {uuid: $proposed_change_id})
+SET diff_root.is_frozen = TRUE
+SET diff_root.tracking_id = $frozen_tracking_id
+        """
+        self.add_to_query(query)

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -37,6 +37,7 @@ CALL (diff_root_map) {
     SET diff_root.from_time = diff_root_map.from_time
     SET diff_root.to_time = diff_root_map.to_time
     SET diff_root.tracking_id = diff_root_map.tracking_id
+    SET diff_root.is_frozen = diff_root_map.is_frozen
     RETURN diff_root
 }
 // -------------------------
@@ -82,6 +83,7 @@ CALL (diff_roots) {
                     "uuid": enriched_diff.uuid,
                     "tracking_id": enriched_diff.tracking_id.serialize() if enriched_diff.tracking_id else None,
                     "proposed_change_id": enriched_diff.proposed_change_id,
+                    "is_frozen": enriched_diff.is_frozen,
                 }
             )
         return {"diff_root_list": diff_root_list}

--- a/backend/infrahub/core/diff/repository/deserializer.py
+++ b/backend/infrahub/core/diff/repository/deserializer.py
@@ -186,6 +186,7 @@ class EnrichedDiffDeserializer:
         partner_uuid = cls._get_str_or_none_property_value(node=root_node, property_name="partner_uuid")
         tracking_id_str = str(root_node.get("tracking_id"))
         tracking_id = deserialize_tracking_id(tracking_id_str=tracking_id_str)
+        is_frozen = str(root_node.get("is_frozen", False)).lower() == "true"
         return EnrichedDiffRootMetadata(
             base_branch_name=str(root_node.get("base_branch")),
             diff_branch_name=str(root_node.get("diff_branch")),
@@ -201,6 +202,7 @@ class EnrichedDiffDeserializer:
             contains_conflict=str(root_node.get("contains_conflict")).lower() == "true",
             exists_on_database=True,
             proposed_change_id=proposed_change_id,
+            is_frozen=is_frozen,
         )
 
     def _deserialize_diff_node(self, node_node: Neo4jNode, enriched_root: EnrichedDiffRoot) -> EnrichedDiffNode:

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -36,6 +36,7 @@ from ..query.diff_get import EnrichedDiffGetQuery
 from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
 from ..query.field_specifiers import EnrichedDiffFieldSpecifiersQuery
 from ..query.filters import EnrichedDiffQueryFilters
+from ..query.freeze_by_proposed_change import EnrichedDiffFreezeByProposedChangeQuery
 from ..query.get_conflict_query import EnrichedDiffConflictQuery
 from ..query.has_conflicts_query import EnrichedDiffHasConflictQuery
 from ..query.link_proposed_change import EnrichedDiffLinkProposedChangeQuery
@@ -392,17 +393,27 @@ class DiffRepository:
         return query.get_summary()
 
     async def delete_all_diff_roots(self) -> None:
-        query = await EnrichedDiffDeleteQuery.init(db=self.db)
+        query = await EnrichedDiffDeleteQuery.init(db=self.db, include_frozen=True)
         await query.execute(db=self.db)
 
-    async def delete_diff_roots(self, diff_root_uuids: list[str]) -> None:
-        query = await EnrichedDiffDeleteQuery.init(db=self.db, enriched_diff_root_uuids=diff_root_uuids)
+    async def delete_diff_roots(self, diff_root_uuids: list[str], include_frozen: bool = False) -> None:
+        query = await EnrichedDiffDeleteQuery.init(
+            db=self.db, enriched_diff_root_uuids=diff_root_uuids, include_frozen=include_frozen
+        )
         await query.execute(db=self.db)
 
     async def link_to_proposed_change(self, diff_uuids: list[str], proposed_change_id: str) -> None:
         query = await EnrichedDiffLinkProposedChangeQuery.init(
             db=self.db,
             diff_uuids=diff_uuids,
+            proposed_change_id=proposed_change_id,
+        )
+        await query.execute(db=self.db)
+
+    async def freeze_diffs_for_proposed_change(self, proposed_change_id: str) -> None:
+        """Freeze diffs linked to a PC by setting is_frozen and updating tracking_id to FrozenTrackingId."""
+        query = await EnrichedDiffFreezeByProposedChangeQuery.init(
+            db=self.db,
             proposed_change_id=proposed_change_id,
         )
         await query.execute(db=self.db)

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -15,9 +15,11 @@ from infrahub.core.constants import (
     MetadataOptions,
     PermissionDecision,
 )
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.manager import NodeManager
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.events import (
     EventMeta,
     ProposedChangeApprovalRevokedEvent,
@@ -180,6 +182,13 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         proposed_change, result = await super().mutate_update(
             info=info, data=data, branch=branch, database=graphql_context.db, node=obj
         )
+
+        if updated_state == ProposedChangeState.CLOSED:
+            component_registry = get_component_registry()
+            diff_repository = await component_registry.get_component(
+                DiffRepository, db=graphql_context.db, branch=branch
+            )
+            await diff_repository.freeze_diffs_for_proposed_change(proposed_change_id=proposed_change.id)
 
         if updated_state == ProposedChangeState.MERGED:
             await graphql_context.service.workflow.execute_workflow(

--- a/backend/tests/component/core/diff/factories.py
+++ b/backend/tests/component/core/diff/factories.py
@@ -107,6 +107,7 @@ class EnrichedRootFactory(DataclassFactory[EnrichedDiffRoot]):
     contains_conflict = False
     exists_on_database = False
     proposed_change_id = None
+    is_frozen = False
 
 
 class CalculatedDiffsFactory(DataclassFactory[CalculatedDiffs]): ...

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -13,6 +13,7 @@ from infrahub.core.diff.model.path import (
     BranchTrackingId,
     EnrichedDiffRoot,
     EnrichedDiffs,
+    FrozenTrackingId,
     NameTrackingId,
     NodeDiffFieldSummary,
 )
@@ -1351,6 +1352,215 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             exclude_merged=False,
         )
         assert summary is not None
+
+    async def test_freeze_diffs_for_proposed_change(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test freezing diffs linked to a proposed change."""
+        # Create proposed change node
+        proposed_change_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": proposed_change_id})
+
+        # Save diff with proposed change (is_frozen defaults to False)
+        tracking_id = BranchTrackingId(name=str(uuid4()))
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id,
+            is_frozen=False,
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=tracking_id,
+            proposed_change_id=proposed_change_id,
+            is_frozen=False,
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Verify diffs are not frozen initially
+        metadata = await diff_repository.get_roots_metadata(proposed_change_id=proposed_change_id)
+        assert len(metadata) == 2
+        for m in metadata:
+            assert m.is_frozen is False
+            assert isinstance(m.tracking_id, BranchTrackingId)
+
+        # Freeze diffs
+        await diff_repository.freeze_diffs_for_proposed_change(proposed_change_id=proposed_change_id)
+
+        # Verify diffs are frozen with FrozenTrackingId
+        metadata = await diff_repository.get_roots_metadata(proposed_change_id=proposed_change_id)
+        assert len(metadata) == 2
+        for m in metadata:
+            assert m.is_frozen is True
+            assert isinstance(m.tracking_id, FrozenTrackingId)
+            assert m.tracking_id.name == proposed_change_id
+
+    async def test_delete_frozen_diff_protection(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test that frozen diffs are protected from deletion unless include_frozen=True."""
+        # Create proposed change nodes
+        frozen_pc_id = str(uuid4())
+        unfrozen_pc_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": frozen_pc_id})
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": unfrozen_pc_id})
+
+        # Create diff that will be frozen
+        frozen_tracking_id = NameTrackingId(name=str(uuid4()))
+        frozen_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
+            tracking_id=frozen_tracking_id,
+            proposed_change_id=frozen_pc_id,
+            is_frozen=False,
+        )
+        frozen_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=frozen_tracking_id,
+            proposed_change_id=frozen_pc_id,
+            is_frozen=False,
+        )
+        frozen_base_diff.partner_uuid = frozen_branch_diff.uuid
+        frozen_branch_diff.partner_uuid = frozen_base_diff.uuid
+        frozen_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=frozen_base_diff,
+            diff_branch_diff=frozen_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=frozen_diffs, do_summary_counts=False)
+        await diff_repository.freeze_diffs_for_proposed_change(proposed_change_id=frozen_pc_id)
+
+        # Create unfrozen diff
+        unfrozen_tracking_id = NameTrackingId(name=str(uuid4()))
+        unfrozen_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time.add(minutes=30),
+            to_time=self.diff_to_time.add(minutes=30),
+            nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
+            tracking_id=unfrozen_tracking_id,
+            proposed_change_id=unfrozen_pc_id,
+            is_frozen=False,
+        )
+        unfrozen_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time.add(minutes=30),
+            to_time=self.diff_to_time.add(minutes=30),
+            nodes=set(),
+            tracking_id=unfrozen_tracking_id,
+            proposed_change_id=unfrozen_pc_id,
+            is_frozen=False,
+        )
+        unfrozen_base_diff.partner_uuid = unfrozen_branch_diff.uuid
+        unfrozen_branch_diff.partner_uuid = unfrozen_base_diff.uuid
+        unfrozen_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=unfrozen_base_diff,
+            diff_branch_diff=unfrozen_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=unfrozen_diffs, do_summary_counts=False)
+
+        # Verify both diffs exist before deletion
+        frozen_metadata_before = await diff_repository.get_roots_metadata(proposed_change_id=frozen_pc_id)
+        assert len(frozen_metadata_before) == 2
+        unfrozen_metadata_before = await diff_repository.get_roots_metadata(proposed_change_id=unfrozen_pc_id)
+        assert len(unfrozen_metadata_before) == 2
+
+        # Delete with include_frozen=False: only unfrozen diffs should be deleted
+        await diff_repository.delete_diff_roots(
+            diff_root_uuids=[frozen_branch_diff.uuid, unfrozen_branch_diff.uuid],
+            include_frozen=False,
+        )
+
+        # Verify frozen diff still exists
+        frozen_metadata = await diff_repository.get_roots_metadata(proposed_change_id=frozen_pc_id)
+        frozen_uuids = {m.uuid for m in frozen_metadata}
+        assert frozen_branch_diff.uuid in frozen_uuids
+
+        # Verify unfrozen diff is deleted
+        unfrozen_metadata = await diff_repository.get_roots_metadata(proposed_change_id=unfrozen_pc_id)
+        unfrozen_uuids = {m.uuid for m in unfrozen_metadata}
+        assert unfrozen_branch_diff.uuid not in unfrozen_uuids
+
+        # Delete with include_frozen=True: frozen diffs should now be deleted
+        await diff_repository.delete_diff_roots(
+            diff_root_uuids=[frozen_branch_diff.uuid],
+            include_frozen=True,
+        )
+
+        # Verify frozen diff is now deleted
+        frozen_metadata_after = await diff_repository.get_roots_metadata(proposed_change_id=frozen_pc_id)
+        frozen_uuids_after = {m.uuid for m in frozen_metadata_after}
+        assert frozen_branch_diff.uuid not in frozen_uuids_after
+
+    async def test_save_and_retrieve_is_frozen(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ) -> None:
+        """Test that is_frozen property is saved and retrieved correctly."""
+        # Create diff with is_frozen=True
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=self._build_nodes(num_nodes=2, num_sub_fields=1),
+            tracking_id=FrozenTrackingId(name="frozen-tracking-test"),
+            is_frozen=True,
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=FrozenTrackingId(name="frozen-tracking-test"),
+            is_frozen=True,
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+        await diff_repository.save(enriched_diffs=enriched_diffs, do_summary_counts=False)
+
+        # Retrieve and verify
+        metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[self.diff_branch_name, self.base_branch_name],
+            tracking_id=FrozenTrackingId(name="frozen-tracking-test"),
+        )
+        assert len(metadata) == 2
+        for m in metadata:
+            assert m.is_frozen is True
+            assert isinstance(m.tracking_id, FrozenTrackingId)
 
 
 async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:

--- a/backend/tests/helpers/db_reset.py
+++ b/backend/tests/helpers/db_reset.py
@@ -21,7 +21,7 @@ class DatabaseResetter:
         diff_repository = await self.get_diff_repository()
         all_diff_metadatas = await diff_repository.get_roots_metadata(exclude_merged=False)
         diff_uuids_to_delete = [d.uuid for d in all_diff_metadatas if d.to_time > reset_time]
-        await diff_repository.delete_diff_roots(diff_uuids_to_delete)
+        await diff_repository.delete_diff_roots(diff_uuids_to_delete, include_frozen=True)
 
         # remove any changes from the database after the to_time
         query_delete = await DeleteAfterTimeQuery.init(db=self.db, timestamp=reset_time)

--- a/backend/tests/integration/diff/test_diff_freeze.py
+++ b/backend/tests/integration/diff/test_diff_freeze.py
@@ -218,3 +218,129 @@ class TestDiffFreeze(TestInfrahubApp):
             diff_branch_name=BRANCH_NAME,
         )
         assert frozen_diff_after_delete.uuid == frozen_diff.uuid
+
+    async def test_branch_diff_update_using_frozen_diff(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, Node],
+        client: InfrahubClient,
+    ) -> None:
+        """Test a branch-tracking diff using a previous frozen diff
+
+        This validates the scenario where:
+        1. Create a branch
+        2. Make changes
+        3. Create a proposed change and link the diff
+        4. Close the proposed change, freezing the diff
+        5. Make more changes on the branch
+        6. Refresh the diff for the branch (without creating a new PC)
+        7. Frozen diff still exists and is linked to the closed PC
+        8. New BranchTrackingId diff has latest data and is NOT linked to any PC
+        """
+        branch_name = "freeze-persist-test-branch"
+
+        # Step 1: Create branch
+        branch = await create_branch(db=db, branch_name=branch_name)
+
+        # Step 2: Make initial changes on branch
+        carol = await Node.init(schema=TestKind.PERSON, db=db, branch=branch.name)
+        await carol.new(db=db, name="Carol", height=170, description="First person on persist test")
+        await carol.save(db=db)
+
+        # Step 3: Run DiffUpdate to create initial diff
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_name})
+        assert result["DiffUpdate"]["ok"]
+
+        # Create proposed change
+        pc_result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_CREATE,
+            variables={
+                "name": "PC-persist-test",
+                "source_branch": branch_name,
+                "destination_branch": default_branch.name,
+            },
+        )
+        pc_id = pc_result["CoreProposedChangeCreate"]["object"]["id"]
+
+        # Verify diff is linked to the PC and has BranchTrackingId
+        component_registry = get_component_registry()
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+        diff_before_close = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=branch_name),
+            diff_branch_name=branch_name,
+        )
+        assert diff_before_close.proposed_change_id == pc_id
+        assert diff_before_close.is_frozen is False
+        assert isinstance(diff_before_close.tracking_id, BranchTrackingId)
+        assert len(diff_before_close.nodes) == 1
+        assert any(n.label == "Carol" for n in diff_before_close.nodes)
+        diff_before_close_to_time = diff_before_close.to_time
+
+        # Step 4: Close the proposed change (this freezes the diff)
+        await client.execute_graphql(
+            query=PROPOSED_CHANGE_UPDATE,
+            variables={"proposed_change_id": pc_id, "state": ProposedChangeState.CLOSED.value},
+        )
+
+        # Verify diff is now frozen and linked to closed PC
+        frozen_diff_metadata_list = await diff_repo.get_roots_metadata(proposed_change_id=pc_id)
+        assert len(frozen_diff_metadata_list) == 2  # branch diff + base diff
+        for frozen_diff_metadata in frozen_diff_metadata_list:
+            assert frozen_diff_metadata.is_frozen is True
+            assert isinstance(frozen_diff_metadata.tracking_id, FrozenTrackingId)
+            assert frozen_diff_metadata.tracking_id.name == pc_id
+            assert frozen_diff_metadata.proposed_change_id == pc_id
+
+        # Step 5: Make more changes on the branch
+        diff_branch = registry.get_branch_from_registry(branch=branch_name)
+        dave = await Node.init(schema=TestKind.PERSON, db=db, branch=diff_branch.name)
+        await dave.new(db=db, name="Dave", height=185, description="Second person on persist test")
+        await dave.save(db=db)
+        second_change_time = Timestamp()
+
+        # Step 6: Refresh the diff for the branch (no new PC created)
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_name})
+        assert result["DiffUpdate"]["ok"]
+
+        # Step 7: Validate frozen diff still exists and is linked to closed PC
+        frozen_diff = await diff_repo.get_one(
+            tracking_id=FrozenTrackingId(name=pc_id),
+            diff_branch_name=branch_name,
+        )
+        assert frozen_diff.uuid == next(m.uuid for m in frozen_diff_metadata_list if m.diff_branch_name == branch_name)
+        assert frozen_diff.is_frozen is True
+        assert isinstance(frozen_diff.tracking_id, FrozenTrackingId)
+        assert frozen_diff.tracking_id.name == pc_id
+        assert frozen_diff.proposed_change_id == pc_id
+        # Frozen diff should have same time range as before it was closed
+        assert frozen_diff.to_time == diff_before_close_to_time
+        assert frozen_diff.to_time < second_change_time
+        # Frozen diff should only have original changes (Carol, not Dave)
+        assert len(frozen_diff.nodes) == 1
+        frozen_nodes_by_label = {n.label: n for n in frozen_diff.nodes}
+        assert "Carol" in frozen_nodes_by_label
+        assert "Dave" not in frozen_nodes_by_label
+
+        # Step 8: Validate the new BranchTrackingId diff has latest data and is NOT linked to any PC
+        current_diff = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=branch_name),
+            diff_branch_name=branch_name,
+        )
+        # Current diff should be different from frozen diff
+        assert current_diff.uuid != frozen_diff.uuid
+        # Current diff should NOT be frozen
+        assert current_diff.is_frozen is False
+        # Current diff should have BranchTrackingId
+        assert isinstance(current_diff.tracking_id, BranchTrackingId)
+        assert current_diff.tracking_id.name == branch_name
+        # Current diff should NOT be linked to any proposed change
+        assert current_diff.proposed_change_id is None
+        # Current diff should have latest data (both Carol and Dave)
+        assert len(current_diff.nodes) == 2
+        current_nodes_by_label = {n.label: n for n in current_diff.nodes}
+        assert "Carol" in current_nodes_by_label
+        assert "Dave" in current_nodes_by_label
+        # Current diff should have updated time range
+        assert current_diff.from_time == frozen_diff.from_time  # Same branch creation time
+        assert current_diff.to_time >= second_change_time

--- a/backend/tests/integration/diff/test_diff_freeze.py
+++ b/backend/tests/integration/diff/test_diff_freeze.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.diff.model.path import BranchTrackingId, FrozenTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.proposed_change.constants import ProposedChangeState
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+BRANCH_NAME = "freeze-test-branch"
+
+DIFF_UPDATE_QUERY = """
+mutation DiffUpdate($branch_name: String!) {
+    DiffUpdate(data: { branch: $branch_name }, wait_until_completion: true) {
+        ok
+    }
+}
+"""
+
+PROPOSED_CHANGE_CREATE = """
+mutation ProposedChange(
+  $name: String!,
+  $source_branch: String!,
+  $destination_branch: String!,
+) {
+  CoreProposedChangeCreate(
+    data: {
+      name: {value: $name},
+      source_branch: {value: $source_branch},
+      destination_branch: {value: $destination_branch}
+    }
+  ) {
+    object {
+      id
+    }
+  }
+}
+"""
+
+PROPOSED_CHANGE_UPDATE = """
+mutation UpdateProposedChange(
+    $proposed_change_id: String!,
+    $state: String
+  ) {
+  CoreProposedChangeUpdate(data:
+    {
+      id: $proposed_change_id,
+      state: {value: $state}
+    }
+  ) {
+    ok
+  }
+}
+"""
+
+
+class TestDiffFreeze(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+        prefect_test_fixture: None,
+    ) -> dict[str, Node]:
+        await load_schema(db, schema=CAR_SCHEMA)
+
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, description="Original person")
+        await john.save(db=db)
+
+        return {"john": john}
+
+    async def test_freeze_diff_on_proposed_change_close(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, Node],
+        client: InfrahubClient,
+    ) -> None:
+        """Test that closing a proposed change freezes its diff and allows new diffs on the same branch."""
+        # Step 1: Create branch
+        branch = await create_branch(db=db, branch_name=BRANCH_NAME)
+
+        # Step 2: Make initial changes on branch
+        alice = await Node.init(schema=TestKind.PERSON, db=db, branch=branch.name)
+        await alice.new(db=db, name="Alice", height=165, description="First person added")
+        await alice.save(db=db)
+
+        # Step 3: Run DiffUpdate to create initial diff
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": BRANCH_NAME})
+        assert result["DiffUpdate"]["ok"]
+
+        # Step 4: Create first proposed change (PC1)
+        pc1_result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_CREATE,
+            variables={
+                "name": "PC1-freeze-test",
+                "source_branch": BRANCH_NAME,
+                "destination_branch": default_branch.name,
+            },
+        )
+        pc1_id = pc1_result["CoreProposedChangeCreate"]["object"]["id"]
+
+        # Get the diff before closing PC1
+        component_registry = get_component_registry()
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+        diff_before_close = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=BRANCH_NAME),
+            diff_branch_name=BRANCH_NAME,
+        )
+        assert len(diff_before_close.nodes) == 1
+        nodes_by_label = {n.label: n for n in diff_before_close.nodes}
+        assert "Alice" in nodes_by_label
+        assert diff_before_close.is_frozen is False
+        diff_before_close_to_time = diff_before_close.to_time
+
+        # Step 5: Close PC1 (this should freeze the diff)
+        await client.execute_graphql(
+            query=PROPOSED_CHANGE_UPDATE,
+            variables={"proposed_change_id": pc1_id, "state": ProposedChangeState.CLOSED.value},
+        )
+
+        # Verify the diff is now frozen with FrozenTrackingId
+        frozen_diff_metadata = await diff_repo.get_roots_metadata(proposed_change_id=pc1_id)
+        assert len(frozen_diff_metadata) == 2  # branch diff + base diff
+        for metadata in frozen_diff_metadata:
+            assert metadata.is_frozen is True
+            assert isinstance(metadata.tracking_id, FrozenTrackingId)
+            assert metadata.tracking_id.name == pc1_id
+            assert metadata.proposed_change_id == pc1_id
+
+        # Get the frozen branch diff
+        frozen_branch_metadata = next(m for m in frozen_diff_metadata if m.diff_branch_name == BRANCH_NAME)
+
+        # Step 6: Create second proposed change (PC2)
+        pc2_result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_CREATE,
+            variables={
+                "name": "PC2-freeze-test",
+                "source_branch": BRANCH_NAME,
+                "destination_branch": default_branch.name,
+            },
+        )
+        pc2_id = pc2_result["CoreProposedChangeCreate"]["object"]["id"]
+
+        # Step 7: Make more changes on branch
+        diff_branch = registry.get_branch_from_registry(branch=BRANCH_NAME)
+        bob = await Node.init(schema=TestKind.PERSON, db=db, branch=diff_branch.name)
+        await bob.new(db=db, name="Bob", height=180, description="Second person added")
+        await bob.save(db=db)
+        second_change_time = Timestamp()
+
+        # Step 8: Run DiffUpdate again
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": BRANCH_NAME})
+        assert result["DiffUpdate"]["ok"]
+
+        # Step 9: Validate frozen diff for PC1 still has original changes and time range
+        frozen_diff = await diff_repo.get_one(
+            tracking_id=FrozenTrackingId(name=pc1_id),
+            diff_branch_name=BRANCH_NAME,
+        )
+        assert frozen_diff.uuid == frozen_branch_metadata.uuid
+        # Frozen diff should have same time range as before it was closed
+        assert frozen_diff.to_time == diff_before_close_to_time
+        assert frozen_diff.to_time < second_change_time
+        assert len(frozen_diff.nodes) == 1
+        frozen_nodes_by_label = {n.label: n for n in frozen_diff.nodes}
+        assert "Alice" in frozen_nodes_by_label
+        assert "Bob" not in frozen_nodes_by_label
+
+        # Step 10: Validate diff for PC2 has all changes and correct time range
+        pc2_diff_metadata = await diff_repo.get_roots_metadata(proposed_change_id=pc2_id)
+        assert len(pc2_diff_metadata) == 2  # branch diff + base diff
+        pc2_branch_metadata = next(m for m in pc2_diff_metadata if m.diff_branch_name == BRANCH_NAME)
+        assert pc2_branch_metadata.is_frozen is False
+        assert isinstance(pc2_branch_metadata.tracking_id, BranchTrackingId)
+
+        current_diff = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=BRANCH_NAME),
+            diff_branch_name=BRANCH_NAME,
+        )
+        assert current_diff.uuid == pc2_branch_metadata.uuid
+        # Current diff should have same from_time as frozen diff (branch creation time)
+        assert current_diff.from_time == frozen_diff.from_time
+        assert current_diff.to_time >= second_change_time
+        assert len(current_diff.nodes) == 2
+        current_nodes_by_label = {n.label: n for n in current_diff.nodes}
+        assert "Alice" in current_nodes_by_label
+        assert "Bob" in current_nodes_by_label
+
+        # Verify both diffs coexist - frozen diff is distinct from current diff
+        assert frozen_diff.uuid != current_diff.uuid
+
+        # Step 11: Verify frozen diff cannot be deleted by normal delete operations
+        await diff_repo.delete_diff_roots(diff_root_uuids=[frozen_diff.uuid], include_frozen=False)
+        # Frozen diff should still exist
+        frozen_diff_after_delete = await diff_repo.get_one(
+            tracking_id=FrozenTrackingId(name=pc1_id),
+            diff_branch_name=BRANCH_NAME,
+        )
+        assert frozen_diff_after_delete.uuid == frozen_diff.uuid


### PR DESCRIPTION
IFC-2224

adds support for "freezing" a diff when the proposed change it is associated with is closed to allow users to view the diff of the changes up to the point that the PC was closed and to prevent it from being updated

"freezing" a diff entails setting `is_frozen=True` on the `:DiffRoot` vertex in the database and updating the tracking_id to be a `FrozenTrackingId` instead of a `BranchTrackingId` b/c a `BranchTrackingId` implies that it is tracking all of the changes for the lifecycle of the branch and that is not the case once it is frozen

TODO:
- [x] test closing a PC and then viewing the diff in the branch to confirm that still works as expected
  - this actually fails, but it's a frontend issue and I've let them know 
- [x] test proposed change link is correctly removed when updating a branch diff with an earlier frozen diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposed-change closure now freezes associated diffs; frozen diffs preserve historical tracking and remain queryable.
  * Repository API supports an option to include frozen diffs when deleting; bulk deletes can opt into removing frozen items.
  * Diff save/retrieve flows propagate and expose an is_frozen flag.

* **Tests**
  * New unit and integration tests validate freezing, protected deletion, coexistence of frozen and active diffs, and related tracking IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->