### PR TITLE
allow retrieving a diff for a PC on a deleted branch

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -183,7 +183,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             info=info, data=data, branch=branch, database=graphql_context.db, node=obj
         )
 
-        if updated_state == ProposedChangeState.CLOSED:
+        if updated_state in (ProposedChangeState.CLOSED, ProposedChangeState.CANCELED):
             component_registry = get_component_registry()
             diff_repository = await component_registry.get_component(
                 DiffRepository, db=graphql_context.db, branch=branch

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -16,6 +16,7 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.query.diff import DiffCountChanges
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.enums import ConflictSelection as GraphQLConflictSelection
 from infrahub.graphql.field_extractor import extract_graphql_fields
 
@@ -431,7 +432,7 @@ class DiffTreeResolver:
         self,
         from_time: datetime | None,
         to_time: datetime | None,
-        branch_start_timestamp: Timestamp,
+        branch_start_timestamp: Timestamp | None,
         at: Timestamp,
         proposed_change_id: str | None,
     ) -> tuple[Timestamp | None, Timestamp | None]:
@@ -451,6 +452,28 @@ class DiffTreeResolver:
             to_timestamp = at
         return from_timestamp, to_timestamp
 
+    async def _get_branch_and_from_time(
+        self,
+        db: InfrahubDatabase,
+        branch: str | None,
+        proposed_change_id: str | None,
+    ) -> tuple[str, Timestamp | None]:
+        try:
+            diff_branch = await registry.get_branch(db=db, branch=branch)
+            diff_branch_name: str | None = diff_branch.name
+            branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
+        except BranchNotFoundError:
+            # case for a request with a deleted branch and a proposed change ID
+            if not proposed_change_id:
+                raise
+            diff_branch_name = branch  # Use the requested branch name for the query
+            branch_start_timestamp = None
+
+        if not diff_branch_name:
+            raise ValidationError("Must include the branch or proposed_change_id argument")
+
+        return diff_branch_name, branch_start_timestamp
+
     async def resolve(
         self,
         root: dict,  # noqa: ARG002
@@ -469,9 +492,12 @@ class DiffTreeResolver:
         component_registry = get_component_registry()
         graphql_context: GraphqlContext = info.context
         base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
-        diff_branch = await registry.get_branch(db=graphql_context.db, branch=branch)
-        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=diff_branch)
-        branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
+
+        diff_branch_name, branch_start_timestamp = await self._get_branch_and_from_time(
+            db=graphql_context.db, branch=branch, proposed_change_id=proposed_change_id
+        )
+
+        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=base_branch)
         from_timestamp, to_timestamp = self._get_timestamp(
             from_time=from_time,
             to_time=to_time,
@@ -491,15 +517,15 @@ class DiffTreeResolver:
         diff_locker = DiffLocker()
         async with (
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=True
             ),
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=False
             ),
         ):
             enriched_diffs = await diff_repo.get(
                 base_branch_name=base_branch.name,
-                diff_branch_names=[diff_branch.name],
+                diff_branch_names=[diff_branch_name],
                 from_time=from_timestamp,
                 to_time=to_timestamp,
                 filters=EnrichedDiffQueryFilters(**filters_dict),
@@ -538,7 +564,7 @@ class DiffTreeResolver:
                 diff_response=diff_tree,
                 from_time=enriched_diff.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,
-                diff_branch_name=diff_branch.name if need_branch_changes else None,
+                diff_branch_name=diff_branch_name if need_branch_changes else None,
             )
         return await self.to_graphql(fields=full_fields, diff_object=diff_tree)
 
@@ -555,9 +581,12 @@ class DiffTreeResolver:
         component_registry = get_component_registry()
         graphql_context: GraphqlContext = info.context
         base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
-        diff_branch = await registry.get_branch(db=graphql_context.db, branch=branch)
-        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=diff_branch)
-        branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
+
+        diff_branch_name, branch_start_timestamp = await self._get_branch_and_from_time(
+            db=graphql_context.db, branch=branch, proposed_change_id=proposed_change_id
+        )
+
+        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=base_branch)
         from_timestamp, to_timestamp = self._get_timestamp(
             from_time=from_time,
             to_time=to_time,
@@ -572,15 +601,15 @@ class DiffTreeResolver:
         diff_locker = DiffLocker()
         async with (
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=True
             ),
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=False
             ),
         ):
             summary = await diff_repo.summary(
                 base_branch_name=base_branch.name,
-                diff_branch_names=[diff_branch.name],
+                diff_branch_names=[diff_branch_name],
                 from_time=from_timestamp,
                 to_time=to_timestamp,
                 filters=filters_dict,
@@ -593,7 +622,7 @@ class DiffTreeResolver:
 
         diff_tree_summary = DiffTreeSummary(
             base_branch=base_branch.name,
-            diff_branch=diff_branch.name,
+            diff_branch=diff_branch_name,
             from_time=summary.from_time.to_datetime(),
             to_time=summary.to_time.to_datetime(),
             **summary.model_dump(exclude={"from_time", "to_time"}),
@@ -607,7 +636,7 @@ class DiffTreeResolver:
                 diff_response=diff_tree_summary,
                 from_time=summary.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,
-                diff_branch_name=diff_branch.name if need_branch_changes else None,
+                diff_branch_name=diff_branch_name if need_branch_changes else None,
             )
         return diff_tree_summary
 

--- a/backend/tests/integration/diff/test_diff_freeze.py
+++ b/backend/tests/integration/diff/test_diff_freeze.py
@@ -70,6 +70,28 @@ mutation UpdateProposedChange(
 }
 """
 
+BRANCH_DELETE = """
+mutation BranchDelete($branch_name: String!) {
+  BranchDelete(data: {name: $branch_name}, wait_until_completion: true) {
+    ok
+  }
+}
+"""
+
+DIFF_TREE_QUERY = """
+query DiffTree($branch_name: String!, $proposed_change_id: String!) {
+  DiffTree(
+    branch: $branch_name
+    proposed_change_id: $proposed_change_id
+  ) {
+    num_added
+    num_updated
+    num_removed
+    num_conflicts
+  }
+}
+"""
+
 
 class TestDiffFreeze(TestInfrahubApp):
     @pytest.fixture(scope="class")
@@ -218,6 +240,91 @@ class TestDiffFreeze(TestInfrahubApp):
             diff_branch_name=BRANCH_NAME,
         )
         assert frozen_diff_after_delete.uuid == frozen_diff.uuid
+
+    async def test_freeze_diff_on_branch_delete(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, Node],
+        client: InfrahubClient,
+    ) -> None:
+        """Test that deleting a branch freezes diffs for open proposed changes associated with that branch."""
+        branch_name = "branch-delete-freeze-test"
+
+        # Step 1: Create branch
+        branch = await create_branch(db=db, branch_name=branch_name)
+
+        # Step 2: Make changes on branch
+        eve = await Node.init(schema=TestKind.PERSON, db=db, branch=branch.name)
+        await eve.new(db=db, name="Eve", height=160, description="Person for branch delete test")
+        await eve.save(db=db)
+
+        # Step 3: Run DiffUpdate to create diff
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_name})
+        assert result["DiffUpdate"]["ok"]
+
+        # Step 4: Create proposed change linked to the branch
+        pc_result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_CREATE,
+            variables={
+                "name": "PC-branch-delete-freeze-test",
+                "source_branch": branch_name,
+                "destination_branch": default_branch.name,
+            },
+        )
+        pc_id = pc_result["CoreProposedChangeCreate"]["object"]["id"]
+
+        # Verify diff is linked to PC and not frozen
+        component_registry = get_component_registry()
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+        diff_before_delete = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=branch_name),
+            diff_branch_name=branch_name,
+        )
+        assert diff_before_delete.proposed_change_id == pc_id
+        assert diff_before_delete.is_frozen is False
+        assert isinstance(diff_before_delete.tracking_id, BranchTrackingId)
+        assert len(diff_before_delete.nodes) == 1
+        assert any(n.label == "Eve" for n in diff_before_delete.nodes)
+
+        # Step 5: Delete the branch
+        result = await client.execute_graphql(query=BRANCH_DELETE, variables={"branch_name": branch_name})
+        assert result["BranchDelete"]["ok"]
+
+        # Step 6: Verify diffs are now frozen with FrozenTrackingId
+        frozen_diff_metadata = await diff_repo.get_roots_metadata(proposed_change_id=pc_id)
+        assert len(frozen_diff_metadata) == 2  # branch diff + base diff
+        for metadata in frozen_diff_metadata:
+            assert metadata.is_frozen is True
+            assert isinstance(metadata.tracking_id, FrozenTrackingId)
+            assert metadata.tracking_id.name == pc_id
+            assert metadata.proposed_change_id == pc_id
+
+        # Verify the frozen diff still has the original data
+        frozen_branch_metadata = next(m for m in frozen_diff_metadata if m.diff_branch_name == branch_name)
+        frozen_diff = await diff_repo.get_one(
+            tracking_id=FrozenTrackingId(name=pc_id),
+            diff_branch_name=branch_name,
+        )
+        assert frozen_diff.uuid == frozen_branch_metadata.uuid
+        assert frozen_diff.is_frozen is True
+        assert len(frozen_diff.nodes) == 1
+        frozen_nodes_by_label = {n.label: n for n in frozen_diff.nodes}
+        assert "Eve" in frozen_nodes_by_label
+
+        # Step 7: Verify frozen diff can be retrieved via DiffTree GraphQL query
+        # even after the branch is deleted
+        diff_tree_result = await client.execute_graphql(
+            query=DIFF_TREE_QUERY,
+            variables={"branch_name": branch_name, "proposed_change_id": pc_id},
+        )
+        assert "DiffTree" in diff_tree_result
+        assert diff_tree_result["DiffTree"] is not None
+        # Verify it shows the added node
+        assert diff_tree_result["DiffTree"]["num_added"] == 1
+        assert diff_tree_result["DiffTree"]["num_updated"] == 0
+        assert diff_tree_result["DiffTree"]["num_removed"] == 0
+        assert diff_tree_result["DiffTree"]["num_conflicts"] == 0
 
     async def test_branch_diff_update_using_frozen_diff(
         self,


### PR DESCRIPTION
IFC-1451

tested and found that we did not allow getting a diff linked to a proposed change if the branch had been deleted

- update DiffTree[<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diffs are now properly frozen when proposed changes are canceled, in addition to when closed.

* **Improvements**
  * Enhanced branch resolution in diff queries with robust error handling for deleted branches, improving system stability and reliability during diff operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->] GraphQL queries to allow retrieving a diff for a deleted branch if the request includes a proposed_change_id
- updated proposed change diff-freezing logic to include CANCELED PCs too