### PR TITLE
Fix invalid import

### DIFF
--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -7,7 +7,7 @@ from prefect.events import emit_event
 
 if TYPE_CHECKING:
     from infrahub.events import InfrahubEvent
-    from infrahub.services import InfrahubMessageBus
+    from infrahub.services.adapters.message_bus import InfrahubMessageBus
 
 
 class InfrahubEventService:


### PR DESCRIPTION
Previously InfrahubMessageBus would have been available directly under Infrahub.services, this is no longer the case.