### PR TITLE
Add demo schema using `CoreFileObject`

### DIFF
--- a/models/base/dcim.yml
+++ b/models/base/dcim.yml
@@ -545,13 +545,21 @@ nodes:
         cardinality: one
         kind: Attribute
         order_weight: 1
+      - name: contracts
+        label: "Contracts"
+        identifier: circuit__contracts
+        peer: InfraCircuitContract
+        optional: true
+        cardinality: many
+        kind: Generic
+        order_weight: 2
       - name: tenant
         identifier: circuit__tenant
         peer: OrganizationTenant
         optional: true
         cardinality: one
         kind: Attribute
-        order_weight: 2
+        order_weight: 3
       - name: endpoints
         peer: InfraCircuitEndpoint
         optional: true
@@ -587,6 +595,40 @@ nodes:
         optional: false
         cardinality: one
         kind: Parent
+  - name: CircuitContract
+    namespace: Infra
+    description: "A Circuit Contract represents the contractual agreement for a circuit provided by a vendor"
+    label: "Circuit Contract"
+    icon: "mdi:file-document-outline"
+    include_in_menu: true
+    inherit_from:
+      - CoreFileObject
+    display_label: contract_number__value
+    human_friendly_id:
+      - contract_number__value
+    order_by:
+      - contract_number__value
+    attributes:
+      - name: contract_number
+        kind: Text
+        unique: true
+      - name: vendor
+        kind: Text
+      - name: start_date
+        kind: Text
+      - name: end_date
+        kind: Text
+      - name: monthly_cost
+        kind: Number
+        optional: true
+    relationships:
+      - name: circuit
+        label: "Circuit"
+        identifier: circuit__contracts
+        peer: InfraCircuit
+        optional: true
+        cardinality: one
+        kind: Attribute
   # --------------------  MLAG  --------------------
   - name: MlagDomain
     namespace: Infra

--- a/models/base_menu.yml
+++ b/models/base_menu.yml
@@ -119,7 +119,6 @@ spec:
             kind: InfraPlatform
             icon: "mdi:application-cog-outline"
 
-
     - namespace: Infra
       name: CircuitMenu
       label: Circuit Management
@@ -131,6 +130,11 @@ spec:
             label: "Circuit"
             icon: "mdi:cable-data"
             kind: InfraCircuit
+          - name: CircuitContract
+            namespace: Infra
+            label: "Circuit Contract"
+            icon: "mdi:file-document-box-multiple-outline"
+            kind: InfraCircuitContract
 
     - namespace: Infra
       name: NetworkMenu


### PR DESCRIPTION
This change simply adds a `InfraCircuitContract` schema node that inherits `CoreFileObject` into the demo schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Circuit Contract Management: Added ability to create and track circuit contracts with vendor information, service dates, and monthly costs. Link contracts directly to circuits for streamlined infrastructure documentation and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->