### PR TITLE
prep release 1.7.4

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -168,6 +168,8 @@ RabbitMQ
 rebase
 Rebase
 rebased
+Rebased
+rebasing
 Rebasing
 redis
 Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.7.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.4) - 2026-02-03
+
+### Removed
+
+- Removed references to the deprecated `is_visible` metadata property from documentation.
+
+### Fixed
+
+- Fix bug in computed attribute calculation that prevented having a computed attribute on a branch if there were no computed attributes on the default branch ([#8270](https://github.com/opsmill/infrahub/issues/8270))
+- Add migration to allow rebasing branches created before #8221 was fixed so that the uniqueness constraint on SchemaNode.name and SchemaGeneric.name is removed
+- Fixed branch merge failing to include relationships to AGNOSTIC nodes (e.g., CoreIPAddressPool) by including the global branch in the peer node lookup query.
+- Fixed confusing issue when "off" was converted to boolean 'false' due to issues with Yaml. The bug was that if "off" or something that Yaml parses as a boolean was used as the name of a Dropdown the incorrect attribute was highlighted in the schema error. When this happened troubleshooting was harder due to misleading errors pointing to another attribute.
+
 ## [Infrahub - v1.7.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.3) - 2026-01-28
 
 ### Security

--- a/changelog/+13729495.fixed.md
+++ b/changelog/+13729495.fixed.md
@@ -1,1 +1,0 @@
-Fixed confusing issue when "off" was converted to boolean 'false' due to issues with Yaml. The bug was that if "off" or something that Yaml parses as a boolean was used as the name of a Dropdown the incorrect attribute was highlighted in the schema error. When this happened troubleshooting was harder due to misleading errors pointing to another attribute.

--- a/changelog/+7896-fix-agnostic-peer-merge.fixed.md
+++ b/changelog/+7896-fix-agnostic-peer-merge.fixed.md
@@ -1,1 +1,0 @@
-Fixed branch merge failing to include relationships to AGNOSTIC nodes (e.g., CoreIPAddressPool) by including the global branch in the peer node lookup query.

--- a/changelog/+c89a0b41.fixed.md
+++ b/changelog/+c89a0b41.fixed.md
@@ -1,1 +1,0 @@
-Add migration to allow rebasing branches created before #8221 was fixed so that the uniqueness constraint on SchemaNode.name and SchemaGeneric.name is removed

--- a/changelog/+remove-is-visible-docs.removed.md
+++ b/changelog/+remove-is-visible-docs.removed.md
@@ -1,1 +1,0 @@
-Removed references to the deprecated `is_visible` metadata property from documentation.

--- a/changelog/8270.fixed.md
+++ b/changelog/8270.fixed.md
@@ -1,1 +1,0 @@
-Fix bug in computed attribute calculation that prevented having a computed attribute on a branch if there were no computed attributes on the default branch

--- a/docs/docs/release-notes/infrahub/release-1_7_4.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_7_4.mdx
@@ -1,0 +1,30 @@
+---
+title: Release 1.7.4
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.7.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>February 3rd, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.7.4](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.7.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Removed
+
+- Removed references to the deprecated `is_visible` metadata property from documentation.
+
+### Fixed
+
+- Fix bug in computed attribute calculation that prevented having a computed attribute on a branch if there were no computed attributes on the default branch ([#8270](https://github.com/opsmill/infrahub/issues/8270))
+- Add migration to allow rebasing branches created before ([#8221](https://github.com/opsmill/infrahub/issues/8221)) was fixed so that the uniqueness constraint on SchemaNode.name and SchemaGeneric.name is removed
+- Fixed branch merge failing to include relationships to AGNOSTIC nodes (e.g., CoreIPAddressPool) by including the global branch in the peer node lookup query.
+- Fixed confusing issue when "off" was converted to boolean 'false' due to issues with Yaml. The bug was that if "off" or something that Yaml parses as a boolean was used as the name of a Dropdown the incorrect attribute was highlighted in the schema error. When this happened troubleshooting was harder due to misleading errors pointing to another attribute.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -421,6 +421,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_7_4',
             'release-notes/infrahub/release-1_7_3',
             'release-notes/infrahub/release-1_7_2',
             'release-notes/infrahub/release-1_7_1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.7.3"
+version = "1.7.4"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.14"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.7.3"
+version = "1.7.4"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.7.3"
+version = "1.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.7.3"
+version = "1.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed**
  * Removed deprecated is_visible metadata references from documentation.

* **Bug Fixes**
  * Corrected computed-attribute behavior on non-default branches.
  * Ensured branch merges include relationships to AGNOSTIC nodes.
  * Fixed Dropdown error highlighting when YAML-parsed booleans (e.g., "off") were used as names.
  * Added migration support to enable rebasing older branches by addressing uniqueness constraints.

* **Documentation**
  * Added release notes for Infrahub v1.7.4 and updated release listing.

* **Chores**
  * Bumped project version to v1.7.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->