### PR TITLE
Pass along context from user when saving PC during merge

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -123,6 +123,7 @@ if TYPE_CHECKING:
 async def _proposed_change_transition_state(
     state: ProposedChangeState,
     database: InfrahubDatabase,
+    user_id: str,
     proposed_change: InternalCoreProposedChange | None = None,
     proposed_change_id: str | None = None,
 ) -> None:
@@ -133,7 +134,7 @@ async def _proposed_change_transition_state(
             )
         if proposed_change:
             proposed_change.state.value = state.value  # type: ignore[misc]
-            await proposed_change.save(db=db)
+            await proposed_change.save(db=db, user_id=user_id)
 
 
 # async def proposed_change_transition_merged(flow: Flow, flow_run: FlowRun, state: State) -> None:
@@ -186,7 +187,10 @@ async def merge_proposed_change(
             )
         except ValueError as exc:
             await _proposed_change_transition_state(
-                proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
+                proposed_change=proposed_change,
+                state=ProposedChangeState.OPEN,
+                database=db,
+                user_id=context.account.account_id,
             )
             return Failed(message=str(exc))
 
@@ -200,7 +204,10 @@ async def merge_proposed_change(
             ):
                 # Ignoring Data integrity checks as they are handled again later
                 await _proposed_change_transition_state(
-                    proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
+                    proposed_change=proposed_change,
+                    state=ProposedChangeState.OPEN,
+                    database=db,
+                    user_id=context.account.account_id,
                 )
                 return Failed(message="Unable to merge proposed change containing failing checks")
             if validator_kind == InfrahubKind.DATAVALIDATOR:
@@ -208,7 +215,10 @@ async def merge_proposed_change(
                 for check in data_checks.values():
                     if check.conflicts.value and not check.keep_branch.value:
                         await _proposed_change_transition_state(
-                            proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
+                            proposed_change=proposed_change,
+                            state=ProposedChangeState.OPEN,
+                            database=db,
+                            user_id=context.account.account_id,
                         )
                         return Failed(
                             message="Data conflicts found on branch and missing decisions about what branch to keep"
@@ -219,14 +229,20 @@ async def merge_proposed_change(
             await merge_branch(branch=source_branch.name, context=context, proposed_change_id=proposed_change_id)
         except MergeFailedError as exc:
             await _proposed_change_transition_state(
-                proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
+                proposed_change=proposed_change,
+                state=ProposedChangeState.OPEN,
+                database=db,
+                user_id=context.account.account_id,
             )
             return Failed(message=f"Merge failure when trying to merge {exc.message}")
 
         log.info(f"Branch {source_branch.name} has been merged successfully")
 
         await _proposed_change_transition_state(
-            proposed_change=proposed_change, state=ProposedChangeState.MERGED, database=db
+            proposed_change=proposed_change,
+            state=ProposedChangeState.MERGED,
+            database=db,
+            user_id=context.account.account_id,
         )
 
         current_user = await NodeManager.get_one_by_id_or_default_filter(

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -260,8 +260,12 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         proposed_change_create.state.value = ProposedChangeState.MERGED.value
         await proposed_change_create.save()
 
-        proposed_change_after = await client.get(kind=CoreProposedChange, id=proposed_change_create.id)
+        proposed_change_after = await client.get(
+            kind=CoreProposedChange, id=proposed_change_create.id, include_metadata=True
+        )
         assert proposed_change_after.state.value == ProposedChangeState.MERGED.value
+        assert proposed_change_after.state.updated_by.id == proposed_change_user.id
+        assert proposed_change_after.state.updated_by.display_label == "Jimmy-Change-User"
 
         for _ in range(10):
             merge_event = await client.execute_graphql(

--- a/changelog/+05d00859.fixed.md
+++ b/changelog/+05d00859.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue where system user showed as the last user changing a proposed change after merge


### PR DESCRIPTION
This PR doesn't really fix the feature request listed in #8308, but the feature request highlights a bug with regards to the latest user to update a proposed change. When a proposed change is merged we first update the state to "merging" and then in the background from a prefect worker it will transition to the "merged" state or back to "open", when this happens in the background the last change currently gets recorded as being done by a "system user". This is a bug and the change should be recorded as being done by the user who tried to merge the proposed change. The PR updates the behaviour of this secondary save operation to ensure that use the user id from the context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the system user was incorrectly recorded as the last user who modified a proposed change after merging.

* **Tests**
  * Enhanced test coverage to validate user attribution is correctly tracked during proposed change state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->