### PR TITLE
prevent using resource pools in profile relationships

### DIFF
--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -12,6 +12,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.relationship.constraints.profiles_removal import RelationshipProfileRemovalConstraint
 from infrahub.core.schema import ProfileSchema
 from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import ValidationError
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_logger
 from infrahub.profiles.node_applier import NodeProfilesApplier
@@ -48,6 +49,35 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         _meta.schema = schema
 
         super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    def _validate_no_resource_pools_in_data(cls, data: InputObjectType) -> None:
+        """Validate that no relationships in the data use from_pool.
+
+        Profiles cannot use resource pools as the source for relationship values.
+
+        Raises:
+            ValidationError: If any relationship data contains from_pool.
+        """
+        schema: ProfileSchema = cls._meta.active_schema  # type: ignore[assignment]
+        for rel_schema in schema.relationships:
+            rel_name = rel_schema.name
+            if rel_name not in data:
+                continue
+
+            rel_data = data[rel_name]
+            if rel_data is None:
+                continue
+
+            # Handle both single relationships and lists
+            items = [rel_data] if not isinstance(rel_data, list) else rel_data
+            for item in items:
+                # Check if from_pool is present and has a non-None value
+                # (graphene InputObjectType may include keys with None values for unset fields)
+                if isinstance(item, dict) and item.get("from_pool") is not None:
+                    raise ValidationError(
+                        {rel_name: "Resource pools cannot be used as the source for relationship values in Profiles"}
+                    )
 
     @classmethod
     async def _send_profile_refresh_workflows(
@@ -95,6 +125,8 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         database: InfrahubDatabase | None = None,
         override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
+        cls._validate_no_resource_pools_in_data(data)
+
         graphql_context: GraphqlContext = info.context
         db = database or graphql_context.db
         workflow_service = graphql_context.active_service.workflow
@@ -118,6 +150,8 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         obj: Node,
         skip_uniqueness_check: bool = False,
     ) -> tuple[Node, Self]:
+        cls._validate_no_resource_pools_in_data(data)
+
         workflow_service = info.context.active_service.workflow
         original_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
 

--- a/backend/tests/component/graphql/mutations/test_profile_resource_pool_validation.py
+++ b/backend/tests/component/graphql/mutations/test_profile_resource_pool_validation.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
+from infrahub.core.schema import SchemaRoot
+from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from tests.helpers.graphql import graphql
+from tests.helpers.schema import load_schema
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+SITE_SCHEMA_WITH_PROFILE: dict[str, Any] = {
+    "nodes": [
+        {
+            "name": "SiteWithProfile",
+            "namespace": "Test",
+            "description": "A site with an optional relationship to a prefix",
+            "generate_profile": True,
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+            ],
+            "relationships": [
+                {
+                    "name": "prefix",
+                    "peer": "IpamIPPrefix",
+                    "kind": "Attribute",
+                    "optional": True,
+                    "cardinality": "one",
+                },
+            ],
+        },
+    ],
+}
+
+
+@pytest.fixture
+async def site_schema_with_profile(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_extended_schema: SchemaBranch,
+) -> None:
+    """Set up a schema with a node that has generate_profile=True and a relationship to an IP prefix."""
+    schema = SchemaRoot(**SITE_SCHEMA_WITH_PROFILE)
+    await load_schema(db=db, schema=schema)
+
+
+@pytest.fixture
+async def prefix_pool(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_ipnamespace: Node,
+    register_ipam_extended_schema: SchemaBranch,
+    init_nodes_registry,
+    ip_dataset_prefix_v4,
+) -> CoreIPPrefixPool:
+    """Create an IP prefix pool for testing."""
+    ns1 = ip_dataset_prefix_v4["ns1"]
+    net140 = ip_dataset_prefix_v4["net140"]
+
+    prefix_pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPPREFIXPOOL, branch=default_branch)
+
+    pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db, branch=default_branch)
+    await pool.new(
+        db=db,
+        name="test-pool",
+        default_prefix_length=24,
+        default_prefix_type="IpamIPPrefix",
+        resources=[net140],
+        ip_namespace=ns1,
+    )
+    await pool.save(db=db)
+    return pool
+
+
+async def test_create_profile_with_from_pool_fails(
+    db: InfrahubDatabase, default_branch: Branch, site_schema_with_profile: None, prefix_pool: CoreIPPrefixPool
+) -> None:
+    """Test that creating a profile with from_pool in a relationship fails with a validation error."""
+    query = """
+    mutation CreateProfile($pool_id: String!) {
+        ProfileTestSiteWithProfileCreate(data: {
+            profile_name: { value: "test-profile" }
+            prefix: {
+                from_pool: {
+                    id: $pool_id
+                }
+            }
+        }) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"pool_id": prefix_pool.id},
+    )
+
+    assert result.errors
+    assert "Resource pools cannot be used as the source for relationship values in Profiles" in str(result.errors[0])
+
+
+async def test_update_profile_with_from_pool_fails(
+    db: InfrahubDatabase, default_branch: Branch, site_schema_with_profile: None, prefix_pool: CoreIPPrefixPool
+) -> None:
+    """Test that updating a profile with from_pool in a relationship fails with a validation error."""
+    # First, create a profile without a prefix
+    profile_schema = registry.schema.get_profile_schema(name="ProfileTestSiteWithProfile", branch=default_branch)
+    profile = await Node.init(db=db, schema=profile_schema, branch=default_branch)
+    await profile.new(db=db, profile_name="test-profile")
+    await profile.save(db=db)
+
+    # Now try to update the profile with a from_pool relationship
+    query = """
+    mutation UpdateProfile($id: String!, $pool_id: String!) {
+        ProfileTestSiteWithProfileUpdate(data: {
+            id: $id
+            prefix: {
+                from_pool: {
+                    id: $pool_id
+                }
+            }
+        }) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": profile.id, "pool_id": prefix_pool.id},
+    )
+
+    assert result.errors
+    assert "Resource pools cannot be used as the source for relationship values in Profiles" in str(result.errors[0])
+
+
+async def test_create_profile_with_direct_peer_succeeds(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    site_schema_with_profile: None,
+    ip_dataset_prefix_v4,
+) -> None:
+    """Test that creating a profile with a direct peer reference (not from_pool) still works."""
+    net142 = ip_dataset_prefix_v4["net142"]
+
+    query = """
+    mutation CreateProfile($prefix_id: String!) {
+        ProfileTestSiteWithProfileCreate(data: {
+            profile_name: { value: "test-profile-direct" }
+            prefix: {
+                id: $prefix_id
+            }
+        }) {
+            ok
+            object {
+                id
+                profile_name {
+                    value
+                }
+            }
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"prefix_id": net142.id},
+    )
+
+    assert not result.errors
+    assert result.data
+    assert result.data["ProfileTestSiteWithProfileCreate"]["ok"]
+    assert result.data["ProfileTestSiteWithProfileCreate"]["object"]["profile_name"]["value"] == "test-profile-direct"


### PR DESCRIPTION
IFC-2250

prevent using `from_pool` when creating/updating relationships on a Profile. we don't support these correctly so we should prevent them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented validation to prevent resource pools from being used as the source for relationship values in profiles. This improves data integrity by ensuring configuration consistency and preventing invalid relationship patterns.

* **Tests**
  * Added comprehensive test coverage for profile resource pool validation scenarios, including profile creation, updates, and direct peer relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->