### PR TITLE
Fix permission report for admins on merged branches

### DIFF
--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -26,13 +26,15 @@ def get_permission_report(  # noqa: PLR0911
     action: str,
     global_permission_report: dict[GlobalPermissions, bool],
 ) -> BranchRelativePermissionDecision:
-    if global_permission_report[GlobalPermissions.SUPER_ADMIN]:
-        return BranchRelativePermissionDecision.ALLOW
-
     # Block mutations on merged branches
     # Note: Branch delete is allowed via middleware, this covers node permissions
+    # We want this check about the super admin permission as not even an admin account
+    # should be able to modify merged branches or those that need a rebase
     if branch.status in (BranchStatus.MERGED, BranchStatus.NEED_REBASE) and action != "view":
         return BranchRelativePermissionDecision.DENY
+
+    if global_permission_report[GlobalPermissions.SUPER_ADMIN]:
+        return BranchRelativePermissionDecision.ALLOW
 
     if action != "view":
         if node.kind in (InfrahubKind.ACCOUNTGROUP, InfrahubKind.ACCOUNTROLE, InfrahubKind.GENERICACCOUNT) or (

--- a/backend/tests/unit/permissions/test_merged_branch_permissions.py
+++ b/backend/tests/unit/permissions/test_merged_branch_permissions.py
@@ -64,8 +64,8 @@ class TestMergedBranchPermissions:
         assert result == BranchRelativePermissionDecision.DENY
         mock_manager.report_object_permission.assert_not_called()
 
-    def test_super_admin_bypasses_merged_check(self) -> None:
-        """Test that super admin can still perform actions on merged branches."""
+    def test_super_admin_doesnt_bypass_merged_check(self) -> None:
+        """Test that super admin can't perform actions on merged branches."""
         mock_branch = _create_branch(BranchStatus.MERGED)
         mock_node = _create_node()
         mock_manager = MagicMock()
@@ -77,7 +77,7 @@ class TestMergedBranchPermissions:
             action="create",
             global_permission_report=_create_global_permission_report(super_admin=True),
         )
-        assert result == BranchRelativePermissionDecision.ALLOW
+        assert result == BranchRelativePermissionDecision.DENY
         mock_manager.report_object_permission.assert_not_called()
 
     @patch("infrahub.permissions.report.registry")
@@ -143,8 +143,8 @@ class TestNeedRebaseBranchPermissions:
         assert result == BranchRelativePermissionDecision.DENY
         mock_manager.report_object_permission.assert_not_called()
 
-    def test_super_admin_bypasses_need_rebase_check(self) -> None:
-        """Test that super admin can still perform actions on branches needing rebase."""
+    def test_super_admin_doesnt_bypass_need_rebase_check(self) -> None:
+        """Test that super admin can't perform actions on branches needing rebase."""
         mock_manager = MagicMock()
 
         result = get_permission_report(
@@ -154,7 +154,7 @@ class TestNeedRebaseBranchPermissions:
             action="create",
             global_permission_report=_create_global_permission_report(super_admin=True),
         )
-        assert result == BranchRelativePermissionDecision.ALLOW
+        assert result == BranchRelativePermissionDecision.DENY
         mock_manager.report_object_permission.assert_not_called()
 
     @patch("infrahub.permissions.report.registry")


### PR DESCRIPTION
# Why

The permission report assumes that an account with the super admin permission would always be allowed an action. However this should not be true for modifications on branches that have already been merged or those that are in a need of a rebase.

## What changed

Switches the order of the admin and merged/rebase branch checks so that a modify action is reported as being denied for any user when the query is on a merged branch or one in the need of a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Super-admin users are now subject to permission restrictions on merged or needs-rebase branches. Previously, super-admin status would bypass these branch status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->