### PR TITLE
fix: use compact json encoding for webhook payload signature calculation

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -135,7 +135,7 @@ class Webhook(BaseModel):
         if self.shared_key:
             message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"
             timestamp = str(at.to_timestamp()) if at else str(Timestamp().to_timestamp())
-            payload = json.dumps(self._payload or {})
+            payload = json.dumps(self._payload or {}, separators=(",", ":"))
             unsigned_data = f"{message_id}.{timestamp}.{payload}".encode()
             signature = self._sign(data=unsigned_data)
             self._headers["webhook-id"] = message_id

--- a/changelog/+webhook_signature.fixed.md
+++ b/changelog/+webhook_signature.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where Infrahub was calculating the wrong authentication signature caused by HTTPX v0.28.0 switching to compact JSON payload encoding.


### PR DESCRIPTION
# Why

httpx dependency was updated from version 0.27.2 to 0.28.1 in Infrahub v1.7.0.
httpx seems to use compact json encoding since 0.28.0, which caused Infrahub to send an invalid signature for webhooks, breaking webhook authentication.

Goal: use compact json encoding for the webhook payload so that we calculate and set a correct signature for webhooks.

## Checklist

- [-] Tests added/updated
- [X] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [-] External docs updated (if user-facing or ops-facing change)
- [-] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed webhook authentication signature calculation to correctly handle compact JSON payload encoding in signature generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->