### PR TITLE
Add docs for import latest commit

### DIFF
--- a/docs/docs/guides/repository.mdx
+++ b/docs/docs/guides/repository.mdx
@@ -232,9 +232,14 @@ After creation, your new repository should appear under **Integrations > Git Rep
 
 ### Update a read-only repository with remote changes
 
-Unlike fully integrated repositories which sync automatically, read-only repositories must be manually updated by changing the `ref` value when you want to pull in new changes.
+Unlike fully integrated repositories which sync automatically, read-only repositories require manual action to pull in new changes. There are two ways to do this:
+
+- **Change the `ref` property**: Point the repository to a different branch, tag, or commit hash
+- **Import latest commit**: Fetch the latest commit from the remote for the current ref and re-import resources
 
 For more details on how each repository type tracks changes, refer to the [Repository Topic](../topics/repository.mdx#read-only-vs-core).
+
+#### Change the ref
 
 <Tabs>
 <TabItem value="Via the Web Interface" default>
@@ -285,6 +290,60 @@ After updating the ref, the repository will begin synchronizing. You can monitor
 
 :::
 
+#### Import latest commit
+
+If the remote repository has new commits on the same ref that your read-only repository is already tracking, you can pull the latest commit without changing the ref. This fetches from the remote, resolves the latest commit for the tracked ref, and re-imports all resources.
+
+<Tabs>
+<TabItem value="Via the Web Interface" default>
+
+1. Log in to the Infrahub UI
+2. Go to **Integrations > Git Repositories**
+3. Click on the `CoreReadOnlyRepository` record you want to update
+4. Click the **More** menu
+5. Select **Import latest commit**
+
+The repository will fetch the latest changes from the remote, update to the most recent commit on the tracked ref, and re-import resources.
+
+</TabItem>
+<TabItem value="Via the GraphQL Interface">
+
+1. Open the **GraphQL Interface**
+
+:::note GraphQL Sandbox
+
+Access the sandbox by clicking your user icon in the bottom left corner and selecting **GraphQL Sandbox**.
+
+:::
+
+2. Execute the import mutation with the repository ID:
+
+```graphql
+mutation {
+  InfrahubReadOnlyRepositoryImportLastCommit(
+    data: {
+      id: "REPOSITORY_ID"
+    }
+  ) {
+    ok
+    task {
+      id
+    }
+  }
+}
+```
+
+The mutation returns a task ID that you can use to monitor the progress of the import operation.
+
+</TabItem>
+</Tabs>
+
+:::success Check synchronization status
+
+After triggering the import, the repository will fetch from the remote and re-import resources. You can monitor the process by checking the repository's sync status and the commit field, which will update to reflect the latest commit from the tracked ref.
+
+:::
+
 ### Troubleshoot repository connections
 
 If you encounter issues with your repository connections, you can use the following steps to diagnose and resolve them:
@@ -305,7 +364,8 @@ If you encounter issues with your repository connections, you can use the follow
 3. Use repository actions for advanced troubleshooting:
    - From the repository detail view, click the **More** menu
    - Select **Check connectivity** to verify authentication and connection
-   - Select **Reimport last commit** to force reimport without changing the reference
+   - Select **Reimport current commit** to force reimport without changing the reference
+   - For read-only repositories, select **Import latest commit** to fetch and import the latest commit from the remote for the tracked ref
 
 :::success Validation
 A healthy repository connection should show `Online` for operational status and `In sync` for sync status once all operations complete.

--- a/docs/docs/topics/repository.mdx
+++ b/docs/docs/topics/repository.mdx
@@ -91,7 +91,8 @@ This separation ensures that Git operations don't block API requests and enables
 **For Read-only Repositories:**
 
 - No automatic synchronization occurs
-- Updates require manual modification of the `ref` property
+- Updates can be triggered by modifying the `ref` property to point to a different branch, tag, or commit
+- Alternatively, use the **Import latest commit** action to fetch the latest commit for the current ref from the remote without changing the ref
 - Each update fetches the specified commit and imports resources according to configuration
 
 ### Merging branches
@@ -150,7 +151,8 @@ Indicates the state of data synchronization:
 Beyond basic synchronization, repositories support administrative actions for troubleshooting and maintenance:
 
 - **Check connectivity**: Validates network access and authentication without modifying data
-- **Reimport last commit**: Forces re-processing of the current commit without fetching new changes, useful for recovering from import errors
+- **Reimport current commit**: Forces re-processing of the current commit without fetching new changes, useful for recovering from import errors
+- **Import latest commit** (read-only repositories only): Fetches the latest commit from the remote for the tracked ref and imports its resources. This is useful when the remote repository has new changes and you want to pull them without manually updating the `ref` property. Unlike changing the `ref`, this operation keeps the same ref but updates to whatever commit that ref currently points to on the remote
 
 ## Design trade-offs and constraints
 


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

Docs needed updating for new feature of importing latest commit from remote. 

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

## What changed

Added docs for importing latest commit

### Suggested review order
1. Start with clone repo
2. invoke docs.build
3. invoke docs.serve

## How to review

1. Start with clone repo
2. invoke docs.build
3. invoke docs.serve

## How to test

load the docs

```bash
1. Start with clone repo
2. invoke docs.build
3. invoke docs.serve
```

<!-- Expected outputs, screenshots, or links to CI results -->

## Impact & rollout

<!-- Delete items that don't apply -->

- **Backward compatibility:** <!-- any breaking changes or migration steps -->
- **Performance:** <!-- implications, measurements if relevant -->
- **Config/env changes:** <!-- new settings, feature flags, env vars -->
- **Deployment notes:** <!-- "safe to deploy" vs "requires coordinated release" -->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [x] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for updating read-only repositories with two distinct workflows: "Import latest commit" to fetch the latest remote commit without changing the ref, and "Change the ref" to update the tracked branch/tag/commit.
  * Updated terminology from "Reimport last commit" to "Reimport current commit" for clarity.
  * Added detailed steps for both Web Interface and GraphQL operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->