### PR TITLE
Update SDK commit to include Jinja2 bugfix

### DIFF
--- a/changelog/8311.fixed.md
+++ b/changelog/8311.fixed.md
@@ -1,0 +1,1 @@
+Fixed error reporting on invalid Jinja2 templates for display_labels


### PR DESCRIPTION
# Why

Introduce a bug fix from the SDK

Closes #8311

## What changed

Updates the SDK commit to the latest commit in the `infrahub-develop` branch, the purpose is to include this fix: https://github.com/opsmill/infrahub-sdk-python/pull/798

## How to review

There is not much to review here, the tests are located on the SDK side and the change is that we raise our own internal error instead of letting errors from Jinja2 be raised without catching them which made the error messages unfriendly for the users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for invalid Jinja2 templates used with display_labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->