### PR TITLE
Ignore mypy issues from the SDK when adding py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ module = "infrahub.*"
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
+module = "infrahub_sdk.*"
+follow_imports = "skip" # Added to ignore typing issues from the SDK when introducing a py.typed file
+
+[[tool.mypy.overrides]]
 module = "tests.conftest"
 disallow_untyped_defs = false
 


### PR DESCRIPTION
# Why

We will be adding a `py.typed` file to the Python SDK to indicate that typing is available within that project. However, currently there's a high number of typing violations that arise because of this. As such we're ignoring the errors that will arise in order to later break them apart and address them at a suitable pace.


## What changed

Update mypy rules to ignore violations that would have come when we add the `py.typed` file to the Python SDK.