### PR TITLE
fix: IFC-2264 CI documentation check should also be triggered when vale files are modifed

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -44,6 +44,10 @@ e2e_test_files:
 demo_files: &demo_files
   - "models/**"
 
+vale_files: &vale_files
+  - ".vale/**"
+  - ".vale.ini"
+
 doc_files: &doc_files
   - "docs/**"
   - package.json
@@ -87,6 +91,7 @@ documentation_all:
   - *development_files
   - *doc_files
   - *markdown_all
+  - *vale_files
 
 documentation_generated_all:
   - *infrahub_reference_generated


### PR DESCRIPTION
# Why

**Problem Statement**: This PR broke the stable CI pipeline (https://github.com/opsmill/infrahub/pull/8257). This is because the documentation check only gets triggered when development, documentation, or Markdown files are modified.

**Goal**: to make the CI documentation vale check trigger when modifying vale files.


Closes IFC-2264

## What changed

Added vale files to the file perimeter that triggers `documentation_all` check.


## How to test

I think that this PR is a good test. I have pushed a commit modifying one vale file, and the documentation CI check occurred. 

Other check are also triggered when modifying the CI files (as `backend_all`), but this is not the case of `documentation_all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation file filtering configuration to include Vale-related documentation assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->