### PR TITLE
IFC-2255 Add support for `NumberPool` in templates

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -360,6 +360,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         # Templates should not allocate from pools - just store the reference
         # Actual allocation happens when creating objects from the template
         if isinstance(self._schema, TemplateSchema):
+            if attribute.from_pool:
+                attribute.source = attribute.from_pool["id"]
             return
 
         if not attribute.from_pool or not allocate_resources:

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from infrahub import lock
 from infrahub.core import registry
-from infrahub.core.constants import SYSTEM_USER_ID, InfrahubKind, RelationshipCardinality, RelationshipKind
+from infrahub.core.constants import (
+    SYSTEM_USER_ID,
+    InfrahubKind,
+    MetadataOptions,
+    RelationshipCardinality,
+    RelationshipKind,
+)
 from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.node import Node
@@ -30,7 +36,9 @@ async def get_template_relationship_peers(
     """For a given relationship on the template, fetch the related peers."""
     template_relationship_manager: RelationshipManager = getattr(template, relationship.name)
     if relationship.cardinality == RelationshipCardinality.MANY:
-        return await template_relationship_manager.get_peers(db=db, peer_type=CoreObjectTemplate)
+        return await template_relationship_manager.get_peers(
+            db=db, peer_type=CoreObjectTemplate, include_metadata=MetadataOptions.SOURCE
+        )
 
     peers: dict[str, CoreObjectTemplate] = {}
     template_relationship_peer = await template_relationship_manager.get_peer(db=db, peer_type=CoreObjectTemplate)
@@ -49,7 +57,10 @@ async def extract_peer_data(
     obj_peer_data: dict[str, Any] = {}
 
     for attr_name in template_peer.get_schema().attribute_names:
-        template_attr = getattr(template_peer, attr_name)
+        if attr_name not in obj_peer_schema.attribute_names:
+            continue
+
+        template_attr = template_peer.get_attribute(name=attr_name)
 
         # NumberPool from_pool handling requires two code paths:
         # 1. Template just created in-memory: from_pool is set but not yet persisted
@@ -58,7 +69,7 @@ async def extract_peer_data(
             obj_peer_data[attr_name] = {"from_pool": template_attr.from_pool}
             continue
 
-        if template_attr.value is None and template_attr.source_id:
+        if template_attr.value is None and template_attr.source_id:  # type: ignore
             source = await template_attr.get_source(db=db)
             if source and source.get_kind() == InfrahubKind.NUMBERPOOL:
                 obj_peer_data[attr_name] = {"from_pool": {"id": source.id}}
@@ -76,7 +87,7 @@ async def extract_peer_data(
 
         # If the template attribute comes from a profile, preserve the profile as the source
         # Otherwise, use the template itself as the source
-        source_id = template_attr.source_id or template_peer.id
+        source_id = template_attr.source_id or template_peer.id  # type: ignore
         attr_data = {"value": template_attr.value, "source": source_id}
         if template_attr.is_from_profile:
             attr_data["is_from_profile"] = True

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from infrahub import lock
 from infrahub.core import registry
-from infrahub.core.constants import SYSTEM_USER_ID, RelationshipCardinality, RelationshipKind
+from infrahub.core.constants import SYSTEM_USER_ID, InfrahubKind, RelationshipCardinality, RelationshipKind
 from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.node import Node
@@ -50,6 +50,20 @@ async def extract_peer_data(
 
     for attr_name in template_peer.get_schema().attribute_names:
         template_attr = getattr(template_peer, attr_name)
+
+        # NumberPool from_pool handling requires two code paths:
+        # 1. Template just created in-memory: from_pool is set but not yet persisted
+        # 2. Template loaded from DB: from_pool is not persisted, must reconstruct from source
+        if template_attr.from_pool:
+            obj_peer_data[attr_name] = {"from_pool": template_attr.from_pool}
+            continue
+
+        if template_attr.value is None and template_attr.source_id:
+            source = await template_attr.get_source(db=db)
+            if source and source.get_kind() == InfrahubKind.NUMBERPOOL:
+                obj_peer_data[attr_name] = {"from_pool": {"id": source.id}}
+                continue
+
         if template_attr.value is None:
             continue
         if template_attr.is_default:

--- a/backend/infrahub/templates/node_applier.py
+++ b/backend/infrahub/templates/node_applier.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from infrahub.core.constants import (
     OBJECT_TEMPLATE_NAME_ATTR,
     OBJECT_TEMPLATE_RELATIONSHIP_NAME,
+    InfrahubKind,
     RelationshipCardinality,
     RelationshipKind,
 )
@@ -46,10 +47,18 @@ class NodeTemplateApplier:
 
             attr = template.get_attribute(name=attr_name)
 
-            # Propagate from_pool reference for NumberPool attributes
+            # NumberPool from_pool handling requires two code paths:
+            # 1. Template just created in-memory: from_pool is set but not yet persisted
+            # 2. Template loaded from DB: from_pool is not persisted, must reconstruct from source
             if attr.from_pool:
                 fields[attr_name] = {"from_pool": attr.from_pool}
                 continue
+
+            if attr.value is None and attr.source_id:  # type: ignore[attr-defined]
+                source = await attr.get_source(db=self.db)
+                if source and source.get_kind() == InfrahubKind.NUMBERPOOL:
+                    fields[attr_name] = {"from_pool": {"id": source.id}}
+                    continue
 
             if attr.value is not None:
                 # source_id is dynamically set by NodePropertyMixin._init_node_property_mixin hence the type hint ignore

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -7,11 +7,13 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipCardinality
+from infrahub.core.initialization import initialize_registry
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
-from infrahub.core.schema import RelationshipSchema, SchemaRoot
-from infrahub.exceptions import PoolExhaustedError
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.schema import AttributeSchema, RelationshipSchema, SchemaRoot
+from infrahub.exceptions import PoolExhaustedError, ValidationError
 from tests.constants import TestKind
 from tests.helpers.schema.device import DEVICE, INTERFACE, INTERFACE_HOLDER
 
@@ -265,6 +267,168 @@ async def test_object_from_template_raises_validation_error_when_pool_exhausted(
         await create_node(
             data={
                 "name": "device-should-fail",
+                "manufacturer": "Acme",
+                "weight": 10,
+                "airflow": "Front to rear",
+                "object_template": {"id": template.id},
+            },
+            db=db,
+            branch=default_branch,
+            schema=node_schema,
+        )
+
+
+@pytest.fixture
+async def device_with_rack_unit_schema(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, init_nodes_registry: None
+) -> None:
+    device = copy.deepcopy(DEVICE)
+    device.attributes.append(AttributeSchema(name="rack_unit", kind="Number", optional=True))
+    schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    await initialize_registry(db=db)
+
+
+@pytest.fixture
+async def number_pool(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
+) -> CoreNumberPool:
+    pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+    await pool.new(
+        db=db, name="rack-unit-pool", node=TestKind.DEVICE, node_attribute="rack_unit", start_range=1, end_range=48
+    )
+    await pool.save(db=db)
+    return pool
+
+
+async def test_template_with_number_pool_attribute_does_not_allocate(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
+) -> None:
+    """Template with from_pool attribute should store reference but not allocate."""
+    template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    await template.new(
+        db=db, template_name="device-template-with-pool-attr", rack_unit={"from_pool": {"id": number_pool.id}}
+    )
+    await template.save(db=db)
+
+    assert template.id is not None
+    assert template.rack_unit.value is None
+
+    source = await template.rack_unit.get_source(db=db)
+    assert source is not None
+    assert source.id == number_pool.id
+
+
+async def test_object_from_template_with_number_pool_allocates_value(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
+) -> None:
+    """Object created from template should allocate from the NumberPool."""
+    template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
+    node_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    await template.new(
+        db=db, template_name="device-template-for-number-allocation", rack_unit={"from_pool": {"id": number_pool.id}}
+    )
+    await template.save(db=db)
+
+    device = await create_node(
+        data={
+            "name": "device-from-template-with-pool",
+            "manufacturer": "Acme",
+            "weight": 10,
+            "airflow": "Front to rear",
+            "object_template": {"id": template.id},
+        },
+        db=db,
+        branch=default_branch,
+        schema=node_schema,
+    )
+
+    assert device.id is not None
+    assert device.name.value == "device-from-template-with-pool"
+    assert device.rack_unit.value is not None
+    assert 1 <= device.rack_unit.value <= 48
+
+    source = await device.rack_unit.get_source(db=db)
+    assert source is not None
+    assert source.id == number_pool.id
+
+
+async def test_object_from_template_with_explicit_value_uses_explicit(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
+) -> None:
+    """Object created with explicit value should use it instead of pool allocation."""
+    template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
+    node_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    await template.new(
+        db=db, template_name="device-template-explicit-override", rack_unit={"from_pool": {"id": number_pool.id}}
+    )
+    await template.save(db=db)
+
+    device = await create_node(
+        data={
+            "name": "device-with-explicit-rack-unit",
+            "manufacturer": "Acme",
+            "weight": 10,
+            "airflow": "Front to rear",
+            "object_template": {"id": template.id},
+            "rack_unit": 99,
+        },
+        db=db,
+        branch=default_branch,
+        schema=node_schema,
+    )
+
+    assert device.id is not None
+    assert device.rack_unit.value == 99
+    source = await device.rack_unit.get_source(db=db)
+    assert source is None
+
+
+async def test_object_from_template_raises_error_when_number_pool_exhausted(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
+) -> None:
+    """Creating object from template should raise PoolExhaustedError when NumberPool is exhausted."""
+    small_pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+    await small_pool.new(
+        db=db, name="small-rack-unit-pool", node=TestKind.DEVICE, node_attribute="rack_unit", start_range=1, end_range=2
+    )
+    await small_pool.save(db=db)
+
+    template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
+    node_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    await template.new(
+        db=db, template_name="device-template-small-number-pool", rack_unit={"from_pool": {"id": small_pool.id}}
+    )
+    await template.save(db=db)
+
+    # Allocate everything from the pool
+    for i in range(2):
+        device = await create_node(
+            data={
+                "name": f"device-exhaust-number-{i}",
+                "manufacturer": "Acme",
+                "weight": 10,
+                "airflow": "Front to rear",
+                "object_template": {"id": template.id},
+            },
+            db=db,
+            branch=default_branch,
+            schema=node_schema,
+        )
+        assert device.id is not None
+
+    with pytest.raises(ValidationError, match=r"The pool (.*) is exhausted"):
+        await create_node(
+            data={
+                "name": "device-should-fail-number",
                 "manufacturer": "Acme",
                 "weight": 10,
                 "airflow": "Front to rear",

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -393,7 +393,7 @@ async def test_object_from_template_with_explicit_value_uses_explicit(
 async def test_object_from_template_raises_error_when_number_pool_exhausted(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
 ) -> None:
-    """Creating object from template should raise PoolExhaustedError when NumberPool is exhausted."""
+    """Creating object from template raises ValidationError when NumberPool is exhausted."""
     small_pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
     await small_pool.new(
         db=db, name="small-rack-unit-pool", node=TestKind.DEVICE, node_attribute="rack_unit", start_range=1, end_range=2

--- a/backend/tests/component/templates/test_template_applier.py
+++ b/backend/tests/component/templates/test_template_applier.py
@@ -8,9 +8,11 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipCardinality
+from infrahub.core.initialization import initialize_registry
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
-from infrahub.core.schema import RelationshipSchema, SchemaRoot
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.schema import AttributeSchema, RelationshipSchema, SchemaRoot
 from infrahub.pools.allocator import PoolAllocator
 from infrahub.pools.default_allocator import DefaultPoolAllocator
 from infrahub.templates.node_applier import NodeTemplateApplier
@@ -468,3 +470,93 @@ class TestNodeTemplateApplierPoolRelationships:
         )
 
         _validate_template_fields(fields=fields, user_fields=user_fields, excluded_fields=["primary_ip"])
+
+
+class TestNodeTemplateApplierNumberPoolAttributes:
+    @pytest.fixture
+    async def device_with_rack_unit_schema(
+        self, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+    ) -> None:
+        """Device schema with a rack_unit attribute for number pool testing."""
+        device = copy.deepcopy(DEVICE)
+        device.attributes.append(AttributeSchema(name="rack_unit", kind="Number", optional=True))
+        schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
+        await load_schema(db=db, schema=schema)
+        await initialize_registry(db=db)
+
+    @pytest.fixture
+    async def number_pool(
+        self, db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
+    ) -> CoreNumberPool:
+        """A number pool for rack_unit attribute."""
+        pool = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
+        await pool.new(
+            db=db, name="rack-unit-pool", node="TestingDevice", node_attribute="rack_unit", start_range=1, end_range=48
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture
+    async def device_template_with_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        device_with_rack_unit_schema: None,
+        number_pool: CoreNumberPool,
+    ) -> Node:
+        """A device template with from_pool reference for rack_unit."""
+        template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
+        template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+        await template.new(
+            db=db,
+            template_name="device-with-rack-unit-template",
+            manufacturer="Acme",
+            rack_unit={"from_pool": {"id": number_pool.id}},
+        )
+        await template.save(db=db)
+        return template
+
+    async def test_applier_passes_from_pool_to_target(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        device_with_rack_unit_schema: None,
+        number_pool: CoreNumberPool,
+        device_template_with_pool: Node,
+    ) -> None:
+        """Applier should pass from_pool reference to target fields for later allocation."""
+        applier = NodeTemplateApplier(db=db, branch=default_branch, pool_allocator=NoOpPoolAllocator())
+        target_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+        user_fields: dict[str, Any] = {"name": "my-device", "weight": 100, "airflow": "Front to rear"}
+
+        fields = await applier.apply(
+            template=device_template_with_pool,
+            target_schema=target_schema,
+            target_id="new-device-id",
+            user_fields=user_fields,
+        )
+
+        _validate_template_fields(fields=fields, user_fields=user_fields)
+        assert fields["rack_unit"] == {"from_pool": {"id": number_pool.id}}
+
+    async def test_applier_preserves_user_value_over_pool_reference(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        device_with_rack_unit_schema: None,
+        number_pool: CoreNumberPool,
+        device_template_with_pool: Node,
+    ) -> None:
+        """Applier should preserve user-provided value instead of pool reference."""
+        applier = NodeTemplateApplier(db=db, branch=default_branch, pool_allocator=NoOpPoolAllocator())
+        target_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+        user_fields: dict[str, Any] = {"name": "my-device", "weight": 100, "airflow": "Front to rear", "rack_unit": 99}
+
+        fields = await applier.apply(
+            template=device_template_with_pool,
+            target_schema=target_schema,
+            target_id="new-device-id",
+            user_fields=user_fields,
+        )
+
+        _validate_template_fields(fields=fields, user_fields=user_fields)

--- a/backend/tests/component/templates/test_template_applier.py
+++ b/backend/tests/component/templates/test_template_applier.py
@@ -489,7 +489,7 @@ class TestNodeTemplateApplierNumberPoolAttributes:
         self, db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
     ) -> CoreNumberPool:
         """A number pool for rack_unit attribute."""
-        pool = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
+        pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
         await pool.new(
             db=db, name="rack-unit-pool", node="TestingDevice", node_attribute="rack_unit", start_range=1, end_range=48
         )

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ipaddress import ip_network
+from ipaddress import IPv4Interface, IPv4Network, IPv6Interface, IPv6Network, ip_network
 from typing import TYPE_CHECKING
 
 import pytest
@@ -418,3 +418,274 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
         assert retrieved1.slot_id.value is not None
         assert retrieved2.slot_id.value is not None
         assert retrieved1.slot_id.value != retrieved2.slot_id.value
+
+
+class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
+    """End-to-end test for pool allocations in templates with nested component relationships.
+
+    Schema:
+    - Device: has management IP (from IP address pool) and rack_unit (from number pool)
+    - Interface: component of Device, has VLAN (from number pool) and prefix (from prefix pool)
+
+    Template:
+    - Device template with 8 interface templates
+    - Creates multiple devices and verifies all allocations are unique with correct sources
+    """
+
+    @pytest.fixture(scope="class")
+    async def load_schema(self, db: InfrahubDatabase, initialize_registry: None, client: InfrahubClient) -> None:
+        schema = {
+            "version": "1.0",
+            "nodes": [
+                {"name": "IPAddress", "namespace": "Ipam", "inherit_from": ["BuiltinIPAddress"]},
+                {"name": "IPPrefix", "namespace": "Ipam", "inherit_from": ["BuiltinIPPrefix"]},
+                {
+                    "name": "Device",
+                    "namespace": "Infra",
+                    "generate_template": True,
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                        {"name": "rack_unit", "kind": "Number", "optional": True},
+                    ],
+                    "relationships": [
+                        {
+                            "name": "mgmt_address",
+                            "peer": "IpamIPAddress",
+                            "cardinality": "one",
+                            "optional": True,
+                        },
+                        {
+                            "name": "interfaces",
+                            "peer": "InfraInterface",
+                            "cardinality": "many",
+                            "kind": "Component",
+                            "optional": True,
+                        },
+                    ],
+                },
+                {
+                    "name": "Interface",
+                    "namespace": "Infra",
+                    "attributes": [
+                        {"name": "name", "kind": "Text"},
+                        {"name": "vlan_id", "kind": "Number", "optional": True},
+                    ],
+                    "relationships": [
+                        {
+                            "name": "device",
+                            "peer": "InfraDevice",
+                            "cardinality": "one",
+                            "kind": "Parent",
+                            "optional": False,
+                        },
+                        {
+                            "name": "prefix",
+                            "peer": "IpamIPPrefix",
+                            "cardinality": "one",
+                            "optional": True,
+                        },
+                    ],
+                },
+            ],
+        }
+        response = await client.schema.load(schemas=[schema])
+        assert response.schema_updated
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def ip_namespace(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        ns = await client.create(kind=InfrahubKind.NAMESPACE, name="all-pools-namespace")
+        await ns.save()
+        return ns
+
+    @pytest.fixture(scope="class")
+    async def mgmt_prefix(self, client: InfrahubClient, ip_namespace: InfrahubNode) -> InfrahubNode:
+        """Management IP prefix: 10.0.0.0/24 for device management addresses."""
+        prefix = await client.create(kind="IpamIPPrefix", prefix="10.0.0.0/24", ip_namespace=ip_namespace.id)
+        await prefix.save()
+        return prefix
+
+    @pytest.fixture(scope="class")
+    async def mgmt_address_pool(
+        self, client: InfrahubClient, ip_namespace: InfrahubNode, mgmt_prefix: InfrahubNode
+    ) -> InfrahubNode:
+        """IP Address Pool for device management IPs."""
+        pool = await client.create(
+            kind=InfrahubKind.IPADDRESSPOOL,
+            name="mgmt-address-pool",
+            resources=[mgmt_prefix.id],
+            ip_namespace=ip_namespace.id,
+            default_address_type="IpamIPAddress",
+        )
+        await pool.save()
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def interface_supernet(self, client: InfrahubClient, ip_namespace: InfrahubNode) -> InfrahubNode:
+        """Supernet for interface prefixes: 172.16.0.0/16."""
+        prefix = await client.create(
+            kind="IpamIPPrefix", prefix="172.16.0.0/16", ip_namespace=ip_namespace.id, is_pool=True
+        )
+        await prefix.save()
+        return prefix
+
+    @pytest.fixture(scope="class")
+    async def interface_prefix_pool(
+        self, client: InfrahubClient, ip_namespace: InfrahubNode, interface_supernet: InfrahubNode
+    ) -> InfrahubNode:
+        """IP Prefix Pool for interface /30 prefixes."""
+        pool = await client.create(
+            kind=InfrahubKind.IPPREFIXPOOL,
+            name="interface-prefix-pool",
+            resources=[interface_supernet.id],
+            ip_namespace=ip_namespace.id,
+            default_prefix_length=30,
+            default_prefix_type="IpamIPPrefix",
+        )
+        await pool.save()
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def vlan_pool(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        """Number Pool for VLAN IDs (100-999)."""
+        pool = await client.create(
+            kind=InfrahubKind.NUMBERPOOL,
+            name="vlan-pool",
+            node="InfraInterface",
+            node_attribute="vlan_id",
+            start_range=100,
+            end_range=999,
+        )
+        await pool.save()
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def rack_unit_pool(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        """Number Pool for device rack units (1-48)."""
+        pool = await client.create(
+            kind=InfrahubKind.NUMBERPOOL,
+            name="rack-unit-pool",
+            node="InfraDevice",
+            node_attribute="rack_unit",
+            start_range=1,
+            end_range=48,
+        )
+        await pool.save()
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def device_template_with_interfaces(
+        self,
+        client: InfrahubClient,
+        mgmt_address_pool: InfrahubNode,
+        interface_prefix_pool: InfrahubNode,
+        vlan_pool: InfrahubNode,
+        rack_unit_pool: InfrahubNode,
+    ) -> InfrahubNode:
+        """Device template with 8 interface templates, all using pool allocations."""
+        device_template = await client.create(
+            kind="TemplateInfraDevice",
+            template_name="device-with-8-interfaces",
+            mgmt_address_from_resource_pool=mgmt_address_pool.id,
+            rack_unit=rack_unit_pool,
+        )
+        await device_template.save()
+
+        for i in range(8):
+            interface_template = await client.create(
+                kind="TemplateInfraInterface",
+                template_name=f"interface-eth{i}",
+                name=f"eth{i}",
+                vlan_id=vlan_pool,
+                device=device_template.id,
+                prefix_from_resource_pool=interface_prefix_pool.id,
+            )
+            await interface_template.save()
+
+        return device_template
+
+    async def test_templates_store_pool_references_not_values(
+        self, device_template_with_interfaces: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        """Templates should store pool references without allocating values."""
+        device_template = await client.get(kind="TemplateInfraDevice", id=device_template_with_interfaces.id)
+        assert device_template.rack_unit.value is None, "Device template should not have allocated rack_unit"
+
+        interface_templates = await client.all(kind="TemplateInfraInterface")
+        assert len(interface_templates) == 8
+        for iface_template in interface_templates:
+            assert iface_template.vlan_id.value is None, "Interface template should not have allocated vlan_id"
+
+    async def test_devices_from_template_get_unique_allocations(
+        self,
+        device_template_with_interfaces: InfrahubNode,
+        mgmt_address_pool: InfrahubNode,
+        rack_unit_pool: InfrahubNode,
+        vlan_pool: InfrahubNode,
+        interface_prefix_pool: InfrahubNode,
+        client: InfrahubClient,
+    ) -> None:
+        """Each device from template should get unique allocations from all pool types."""
+        device_ids = []
+        for i in range(3):
+            device = await client.create(
+                kind="InfraDevice",
+                name=f"device-all-pools-{i}",
+                object_template=device_template_with_interfaces.id,
+            )
+            await device.save()
+            device_ids.append(device.id)
+
+        # Collect all allocated values across devices and interfaces
+        mgmt_addresses: set[IPv4Interface | IPv6Interface] = set()
+        rack_units: set[int] = set()
+        vlans: set[int] = set()
+        prefixes: set[IPv4Network | IPv6Network] = set()
+
+        for device_id in device_ids:
+            device = await client.get(kind="InfraDevice", id=device_id, include=["rack_unit"], property=True)
+
+            # Device management address from IP pool
+            await device.mgmt_address.fetch()
+            assert device.mgmt_address.peer is not None, "Device should have management address from IP pool"
+            assert device.mgmt_address.source == mgmt_address_pool.id, (
+                f"Management address source should be the IP address pool, got {device.mgmt_address.source}"
+            )
+            mgmt_addr = await client.get(kind="IpamIPAddress", id=device.mgmt_address.peer.id)
+            mgmt_addresses.add(mgmt_addr.address.value)
+
+            # Device rack_unit from number pool (attribute source is NodeProperty with .id)
+            assert device.rack_unit.value is not None, "Device should have rack_unit from number pool"
+            assert device.rack_unit.source.id == rack_unit_pool.id, (
+                f"rack_unit source should be the number pool, got {device.rack_unit.source}"
+            )
+            rack_units.add(device.rack_unit.value)
+
+            # Interface attributes from pools
+            interfaces = await client.filters(kind="InfraInterface", device__ids=[device_id], property=True)
+            assert len(interfaces) == 8, "Device should have 8 interfaces from template"
+
+            for iface in interfaces:
+                # Interface VLAN from number pool (attribute source is NodeProperty with .id)
+                assert iface.vlan_id.value is not None, "Interface should have vlan_id from number pool"
+                assert iface.vlan_id.source.id == vlan_pool.id, (
+                    f"vlan_id source should be the VLAN number pool, got {iface.vlan_id.source}"
+                )
+                vlans.add(iface.vlan_id.value)
+
+                # Interface prefix from IP prefix pool
+                await iface.prefix.fetch()
+                assert iface.prefix.peer is not None, "Interface should have prefix from IP prefix pool"
+                assert iface.prefix.source == interface_prefix_pool.id, (
+                    f"Interface prefix source should be the IP prefix pool, got {iface.prefix.source}"
+                )
+                prefix = await client.get(kind="IpamIPPrefix", id=iface.prefix.peer.id)
+                prefixes.add(prefix.prefix.value)
+
+        # Each device gets unique allocations
+        assert len(mgmt_addresses) == 3, "Each device should have unique management address"
+        assert len(rack_units) == 3, "Each device should have unique rack_unit"
+
+        # Each interface across all devices gets unique allocations
+        assert len(vlans) == 24, "Each interface should have unique VLAN (3 devices x 8 interfaces)"
+        assert len(prefixes) == 24, "Each interface should have unique prefix (3 devices x 8 interfaces)"

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -360,14 +360,16 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
     async def test_rack_from_template_with_static_slot(
         self, template_with_static_slot: InfrahubNode, client: InfrahubClient
     ) -> None:
+        """Static value from template should have the template as source."""
         rack = await client.create(
             kind="InfraRack", name="rack-from-static-template", object_template=template_with_static_slot.id
         )
         await rack.save()
 
-        retrieved = await client.get(kind="InfraRack", id=rack.id)
+        retrieved = await client.get(kind="InfraRack", id=rack.id, include=["slot_id"], property=True)
         assert retrieved.name.value == "rack-from-static-template"
         assert retrieved.slot_id.value == 50
+        assert retrieved.slot_id.source.id == template_with_static_slot.id
 
     async def test_rack_from_template_with_pool_allocates_slot(
         self, template_with_pool_slot: InfrahubNode, slot_pool: InfrahubNode, client: InfrahubClient
@@ -378,10 +380,11 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
         )
         await rack.save()
 
-        retrieved = await client.get(kind="InfraRack", id=rack.id, include=["slot_id"])
+        retrieved = await client.get(kind="InfraRack", id=rack.id, include=["slot_id"], property=True)
         assert retrieved.name.value == "rack-from-pool-template"
         assert retrieved.slot_id.value is not None
         assert 1 <= retrieved.slot_id.value <= 100
+        assert retrieved.slot_id.source.id == slot_pool.id
 
     async def test_rack_explicit_slot_overrides_pool_template(
         self, template_with_pool_slot: InfrahubNode, client: InfrahubClient

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -86,14 +86,6 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
         return address
 
     @pytest.fixture(scope="class")
-    async def template_without_address(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
-        template = await client.create(
-            kind="TemplateInfraDevice", template_name="device-no-address", description="Template without address"
-        )
-        await template.save()
-        return template
-
-    @pytest.fixture(scope="class")
     async def template_with_static_address(
         self, client: InfrahubClient, static_ip_address: InfrahubNode, load_schema: None
     ) -> InfrahubNode:
@@ -134,24 +126,6 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
         assert pool_rel.peer == InfrahubKind.IPADDRESSPOOL
         assert pool_rel.optional
 
-    async def test_template_without_address_created(
-        self, template_without_address: InfrahubNode, client: InfrahubClient
-    ) -> None:
-        retrieved = await client.get(kind="TemplateInfraDevice", id=template_without_address.id)
-        assert retrieved.template_name.value == "device-no-address"
-        assert retrieved.description.value == "Template without address"
-        assert retrieved.primary_address.id is None
-
-    async def test_template_with_static_address_created(
-        self, template_with_static_address: InfrahubNode, static_ip_address: InfrahubNode, client: InfrahubClient
-    ) -> None:
-        retrieved = await client.get(kind="TemplateInfraDevice", id=template_with_static_address.id)
-        assert retrieved.template_name.value == "device-static-address"
-
-        await retrieved.primary_address.fetch()
-        assert retrieved.primary_address.peer is not None
-        assert retrieved.primary_address.peer.id == static_ip_address.id
-
     async def test_template_with_pool_created(
         self, template_with_pool: InfrahubNode, ip_address_pool: InfrahubNode, client: InfrahubClient
     ) -> None:
@@ -161,19 +135,6 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
         await retrieved.primary_address_from_resource_pool.fetch()
         assert retrieved.primary_address_from_resource_pool.peer is not None
         assert retrieved.primary_address_from_resource_pool.peer.id == ip_address_pool.id
-        assert retrieved.primary_address.id is None
-
-    async def test_device_from_template_without_address(
-        self, template_without_address: InfrahubNode, client: InfrahubClient
-    ) -> None:
-        device = await client.create(
-            kind="InfraDevice", name="device-from-no-address-template", object_template=template_without_address.id
-        )
-        await device.save()
-
-        retrieved = await client.get(kind="InfraDevice", id=device.id)
-        assert retrieved.name.value == "device-from-no-address-template"
-        assert retrieved.description.value == "Template without address"
         assert retrieved.primary_address.id is None
 
     async def test_device_from_template_with_static_address(
@@ -333,3 +294,127 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
             await retrieved.update()
 
         assert "Templates can only use one of: direct relationship or resource pool allocation" in str(exc.value)
+
+
+class TestTemplateNumberPoolAttributes(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def load_schema(self, db: InfrahubDatabase, initialize_registry: None, client: InfrahubClient) -> None:
+        schema = {
+            "version": "1.0",
+            "nodes": [
+                {
+                    "name": "Rack",
+                    "namespace": "Infra",
+                    "generate_template": True,
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                        {"name": "location", "kind": "Text", "optional": True},
+                        {"name": "slot_id", "kind": "Number", "optional": True},
+                    ],
+                },
+            ],
+        }
+        response = await client.schema.load(schemas=[schema])
+        assert response.schema_updated
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def slot_pool(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        pool = await client.create(
+            kind=InfrahubKind.NUMBERPOOL,
+            name="slot-pool",
+            node="InfraRack",
+            node_attribute="slot_id",
+            start_range=1,
+            end_range=100,
+        )
+        await pool.save()
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def template_with_static_slot(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        template = await client.create(
+            kind="TemplateInfraRack", template_name="rack-static-slot", location="datacenter-1", slot_id=50
+        )
+        await template.save()
+        return template
+
+    @pytest.fixture(scope="class")
+    async def template_with_pool_slot(
+        self, client: InfrahubClient, slot_pool: InfrahubNode, load_schema: None
+    ) -> InfrahubNode:
+        template = await client.create(
+            kind="TemplateInfraRack", template_name="rack-pool-slot", location="datacenter-1", slot_id=slot_pool
+        )
+        await template.save()
+        return template
+
+    async def test_template_with_pool_stores_reference_not_value(
+        self, template_with_pool_slot: InfrahubNode, slot_pool: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        """Template with from_pool should store reference without allocating a value."""
+        retrieved = await client.get(kind="TemplateInfraRack", id=template_with_pool_slot.id)
+        assert retrieved.template_name.value == "rack-pool-slot"
+        assert retrieved.slot_id.value is None
+
+    async def test_rack_from_template_with_static_slot(
+        self, template_with_static_slot: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        rack = await client.create(
+            kind="InfraRack", name="rack-from-static-template", object_template=template_with_static_slot.id
+        )
+        await rack.save()
+
+        retrieved = await client.get(kind="InfraRack", id=rack.id)
+        assert retrieved.name.value == "rack-from-static-template"
+        assert retrieved.slot_id.value == 50
+
+    async def test_rack_from_template_with_pool_allocates_slot(
+        self, template_with_pool_slot: InfrahubNode, slot_pool: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        """Object created from template should allocate from pool."""
+        rack = await client.create(
+            kind="InfraRack", name="rack-from-pool-template", object_template=template_with_pool_slot.id
+        )
+        await rack.save()
+
+        retrieved = await client.get(kind="InfraRack", id=rack.id, include=["slot_id"])
+        assert retrieved.name.value == "rack-from-pool-template"
+        assert retrieved.slot_id.value is not None
+        assert 1 <= retrieved.slot_id.value <= 100
+
+    async def test_rack_explicit_slot_overrides_pool_template(
+        self, template_with_pool_slot: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        """User-provided slot value should override pool allocation."""
+        rack = await client.create(
+            kind="InfraRack",
+            name="rack-with-explicit-slot",
+            object_template=template_with_pool_slot.id,
+            slot_id=999,
+        )
+        await rack.save()
+
+        retrieved = await client.get(kind="InfraRack", id=rack.id)
+        assert retrieved.slot_id.value == 999
+
+    async def test_multiple_racks_from_pool_template_get_unique_slots(
+        self, template_with_pool_slot: InfrahubNode, client: InfrahubClient
+    ) -> None:
+        """Multiple objects from same pool template should get unique slot allocations."""
+        rack1 = await client.create(
+            kind="InfraRack", name="rack-pool-unique-1", object_template=template_with_pool_slot.id
+        )
+        await rack1.save()
+
+        rack2 = await client.create(
+            kind="InfraRack", name="rack-pool-unique-2", object_template=template_with_pool_slot.id
+        )
+        await rack2.save()
+
+        retrieved1 = await client.get(kind="InfraRack", id=rack1.id)
+        retrieved2 = await client.get(kind="InfraRack", id=rack2.id)
+
+        assert retrieved1.slot_id.value is not None
+        assert retrieved2.slot_id.value is not None
+        assert retrieved1.slot_id.value != retrieved2.slot_id.value


### PR DESCRIPTION
# Why

Add support to reference `NumberPool`s in templates without allocating numbers from them while still allocating numbers when creating objects from those templates.

**Goal:** Enable templates to properly use `NumberPool` attributes that allocate unique values when objects are created, with proper source tracking.

## What changed

### Behavioral changes
- Templates with `NumberPool` attributes now correctly pass pool references to objects created from them

### Implementation notes

**`backend/infrahub/core/node/__init__.py`**
- `handle_pool()`: Added source assignment for templates - when a template has a `from_pool` reference, the source is now set to the pool ID

**`backend/infrahub/core/node/create.py`**
- `get_template_relationship_peers()`: Added `include_metadata=MetadataOptions.SOURCE` when fetching MANY cardinality relationship peers. This ensures `source_id` is loaded on template attributes, which is required for NumberPool handling in `extract_peer_data()`
- `extract_peer_data()`: Added filter to skip attributes that don't exist on the target schema (prevents `template_name` from being passed to non-template objects)

### What stayed the same
- IPAddressPool and IPPrefixPool relationship allocation (already worked)
- Template creation behavior (pools still don't allocate on template save)
- API contract unchanged

## How to review

1. Start with `backend/infrahub/core/node/__init__.py` - the `handle_pool()` change is small but critical
2. Then `backend/infrahub/core/node/create.py` - the `MetadataOptions.SOURCE` fix for nested templates
3. Tests in `backend/tests/functional/templates/test_template_resource_pool.py` demonstrate all scenarios

**Key insight:** The `source_id` on template attributes must be loaded to detect NumberPool references. Without `include_metadata=MetadataOptions.SOURCE`, the code path that reconstructs `from_pool` from `source_id` never triggers. There is also a repeated logic for two code paths, which is expected as there is one code path for the top-level template and another for sub-level templates.

## How to test

```bash
# Run all template resource pool tests
uv run pytest backend/tests/component/core/node/test_template_pool_allocation.py -v
uv run backend/tests/component/templates/test_template_applier.py -v
uv run pytest backend/tests/functional/templates/test_template_resource_pool.py -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can reference number-based resource pools; when applied, objects record pool sources and allocate values from pools while still honoring explicit user-provided values.

* **Tests**
  * Expanded unit and functional tests covering pool-backed attributes, unique allocations across instances, explicit-override precedence, exhaustion handling, and source tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->