### PR TITLE
fix(docs): HA examples redis misconfig

### DIFF
--- a/development/deploy.tf
+++ b/development/deploy.tf
@@ -408,7 +408,7 @@ resource "kubernetes_deployment_v1" "redis_sentinel_proxy_deployment" {
             "-listen",
             ":6379",
             "-sentinel",
-            "cache:26379",
+            "redis:26379",
           ]
           port {
             container_port = 6379
@@ -431,7 +431,7 @@ resource "helm_release" "cache_ha" {
 
   values = [
     <<EOT
-nameOverride: cache
+nameOverride: redis
 image:
   repository: bitnamilegacy/redis
   tag: 8.2.1-debian-12-r0

--- a/development/k8s/redis-sentinel-proxy-deploy.yaml
+++ b/development/k8s/redis-sentinel-proxy-deploy.yaml
@@ -32,7 +32,7 @@ spec:
             - "-listen"
             - ":6379"
             - "-sentinel"
-            - "cache:26379"
+            - "redis:26379"
           ports:
             - containerPort: 6379
               name: redis

--- a/development/k8s/redis-values.yaml
+++ b/development/k8s/redis-values.yaml
@@ -1,5 +1,5 @@
 ---
-nameOverride: cache
+nameOverride: redis
 image:
   repository: bitnamilegacy/redis
   tag: 8.2.1-debian-12-r0


### PR DESCRIPTION
This is to ensure the cache's service name doesn't conflict with Infrahub's env config keys.

When using "cache" as the fullnameOverride and "infrahub" as the Helm deployment name, the service name is created as "infrahub-cache".
Kubernetes then populates containers with env vars related to the services, such as "INFRAHUB_CACHE_PORT" which conflcits with Infrahub's own settings... thus preventing it from starting correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis infrastructure configuration to improve service naming consistency and deployment alignment across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->