### PR TITLE
Add fallback for files that can't be previewed

### DIFF
--- a/frontend/app/biome.jsonc
+++ b/frontend/app/biome.jsonc
@@ -102,7 +102,6 @@
         "useExhaustiveDependencies": "off",
         "useHookAtTopLevel": "off",
         "useImportExtensions": "off",
-        "noSwitchDeclarations": "off",
         "useUniqueElementIds": "off"
       },
       "nursery": {

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -1,3 +1,4 @@
+import { EyeOffIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Col, Row } from "@/shared/components/container";
@@ -44,24 +45,22 @@ function DataViewerContent({
   content: string;
 }) {
   switch (contentType) {
-    case "text/markdown": {
+    case "text/markdown":
       return <MarkdownViewer>{content}</MarkdownViewer>;
-    }
-    case "image/svg+xml": {
+
+    case "image/svg+xml":
       return (
         <Svg value={content} className="grow rounded-lg border border-neutral-700 shadow-sm" />
       );
-    }
 
-    case "text/csv": {
+    case "text/csv":
       return (
         <ScrollArea scrollX scrollBarClassName="bg-transparent">
           <CsvTable content={content} />
         </ScrollArea>
       );
-    }
 
-    case "application/pdf": {
+    case "application/pdf":
       return (
         <iframe
           src={`data:application/pdf;base64,${content}`}
@@ -69,14 +68,13 @@ function DataViewerContent({
           className="h-150 w-full rounded-lg border border-neutral-700"
         />
       );
-    }
 
     case "image/png":
     case "image/jpeg":
     case "image/gif":
     case "image/webp":
     case "image/bmp":
-    case "image/x-icon": {
+    case "image/x-icon":
       return (
         <div className="flex justify-center rounded-lg border border-neutral-700 bg-white p-4">
           <img
@@ -86,26 +84,52 @@ function DataViewerContent({
           />
         </div>
       );
-    }
 
-    default: {
-      // Treat all text-based and unknown content types as plain text
+    case "application/json":
+    case "application/yaml":
+    case "application/x-yaml":
+    case "application/hcl":
+    case "application/graphql":
+    case "application/xml":
+    case "application/javascript":
+    case "application/typescript":
+    case "application/x-sh":
+    case "application/x-python":
+    case "application/toml":
+    case "application/x-toml":
+    case "text/plain":
+      return <TextViewer content={content} language={getTextLanguage(contentType)} />;
+
+    default:
+      if (contentType.startsWith("text/")) {
+        return <TextViewer content={content} language="text" />;
+      }
+
       return (
-        <ScrollArea
-          scrollX
-          className="grow rounded-lg border border-neutral-700 shadow-sm"
-          scrollBarClassName="bg-transparent"
-        >
-          <CodeViewer language={getTextLanguage(contentType)} customStyle={{ margin: 0 }}>
-            {content}
-          </CodeViewer>
-        </ScrollArea>
+        <div className="flex grow flex-col items-center justify-center gap-2 rounded-lg border border-neutral-700 p-8 text-neutral-400">
+          <EyeOffIcon className="size-8" />
+          <p>This file can&#39;t be previewed</p>
+          <p className="text-sm">{contentType}</p>
+        </div>
       );
-    }
   }
 }
 
-function getTextLanguage(contentType: DataViewerContentType): string {
+function TextViewer({ content, language }: { content: string; language: string }) {
+  return (
+    <ScrollArea
+      scrollX
+      className="grow rounded-lg border border-neutral-700 shadow-sm"
+      scrollBarClassName="bg-transparent"
+    >
+      <CodeViewer language={language} customStyle={{ margin: 0 }}>
+        {content}
+      </CodeViewer>
+    </ScrollArea>
+  );
+}
+
+function getTextLanguage(contentType: string): string {
   switch (contentType) {
     case "application/json":
       return "json";
@@ -118,6 +142,17 @@ function getTextLanguage(contentType: DataViewerContentType): string {
       return "graphql";
     case "application/xml":
       return "xml";
+    case "application/javascript":
+      return "javascript";
+    case "application/typescript":
+      return "typescript";
+    case "application/x-sh":
+      return "bash";
+    case "application/x-python":
+      return "python";
+    case "application/toml":
+    case "application/x-toml":
+      return "toml";
     default:
       return "text";
   }

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -45,22 +45,25 @@ function DataViewerContent({
   content: string;
 }) {
   switch (contentType) {
-    case "text/markdown":
+    case "text/markdown": {
       return <MarkdownViewer>{content}</MarkdownViewer>;
+    }
 
-    case "image/svg+xml":
+    case "image/svg+xml": {
       return (
         <Svg value={content} className="grow rounded-lg border border-neutral-700 shadow-sm" />
       );
+    }
 
-    case "text/csv":
+    case "text/csv": {
       return (
         <ScrollArea scrollX scrollBarClassName="bg-transparent">
           <CsvTable content={content} />
         </ScrollArea>
       );
+    }
 
-    case "application/pdf":
+    case "application/pdf": {
       return (
         <iframe
           src={`data:application/pdf;base64,${content}`}
@@ -68,13 +71,14 @@ function DataViewerContent({
           className="h-150 w-full rounded-lg border border-neutral-700"
         />
       );
+    }
 
     case "image/png":
     case "image/jpeg":
     case "image/gif":
     case "image/webp":
     case "image/bmp":
-    case "image/x-icon":
+    case "image/x-icon": {
       return (
         <div className="flex justify-center rounded-lg border border-neutral-700 bg-white p-4">
           <img
@@ -84,6 +88,7 @@ function DataViewerContent({
           />
         </div>
       );
+    }
 
     case "application/json":
     case "application/yaml":
@@ -97,10 +102,11 @@ function DataViewerContent({
     case "application/x-python":
     case "application/toml":
     case "application/x-toml":
-    case "text/plain":
+    case "text/plain": {
       return <TextViewer content={content} language={getTextLanguage(contentType)} />;
+    }
 
-    default:
+    default: {
       if (contentType.startsWith("text/")) {
         return <TextViewer content={content} language="text" />;
       }
@@ -112,6 +118,7 @@ function DataViewerContent({
           <p className="text-sm">{contentType}</p>
         </div>
       );
+    }
   }
 }
 
@@ -131,29 +138,40 @@ function TextViewer({ content, language }: { content: string; language: string }
 
 function getTextLanguage(contentType: string): string {
   switch (contentType) {
-    case "application/json":
+    case "application/json": {
       return "json";
+    }
     case "application/yaml":
-    case "application/x-yaml":
+    case "application/x-yaml": {
       return "yaml";
-    case "application/hcl":
+    }
+    case "application/hcl": {
       return "hcl";
-    case "application/graphql":
+    }
+    case "application/graphql": {
       return "graphql";
-    case "application/xml":
+    }
+    case "application/xml": {
       return "xml";
-    case "application/javascript":
+    }
+    case "application/javascript": {
       return "javascript";
-    case "application/typescript":
+    }
+    case "application/typescript": {
       return "typescript";
-    case "application/x-sh":
+    }
+    case "application/x-sh": {
       return "bash";
-    case "application/x-python":
+    }
+    case "application/x-python": {
       return "python";
+    }
     case "application/toml":
-    case "application/x-toml":
+    case "application/x-toml": {
       return "toml";
-    default:
+    }
+    default: {
       return "text";
+    }
   }
 }

--- a/frontend/app/src/shared/components/data-viewer/types.ts
+++ b/frontend/app/src/shared/components/data-viewer/types.ts
@@ -31,8 +31,13 @@ export type PdfContentType = "application/pdf";
 
 /**
  * All supported content types for DataViewer.
+ * Includes well-known types plus any arbitrary MIME type string.
  */
-export type DataViewerContentType = TextContentType | ImageContentType | PdfContentType;
+export type DataViewerContentType =
+  | TextContentType
+  | ImageContentType
+  | PdfContentType
+  | (string & {});
 
 export function getExtensionFromContentType(contentType?: string): string {
   switch (contentType) {


### PR DESCRIPTION
<img width="866" height="511" alt="image" src="https://github.com/user-attachments/assets/2e564b70-4f3a-481e-8c28-c8559b2aeac6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded file preview to include JSON, YAML, HCL, GraphQL, XML, JavaScript, TypeScript, Shell, Python, and TOML with improved syntax highlighting.
  * Added a clear placeholder when a file cannot be previewed.

* **Refactor**
  * Reworked text-based preview system for more consistent rendering and easier future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->