### PR TITLE
Refactor: compute pool prop in getFormFieldFromRelationship + fix pool allocation from relationship tabs

### DIFF
--- a/changelog/+pool-relationship.fixed.md
+++ b/changelog/+pool-relationship.fixed.md
@@ -1,0 +1,1 @@
+Fixed adding a relationship from a resource pool within relationship tabs in the object detail view

--- a/frontend/app/src/entities/nodes/object-item-details/action-buttons/relationships-buttons.tsx
+++ b/frontend/app/src/entities/nodes/object-item-details/action-buttons/relationships-buttons.tsx
@@ -18,6 +18,7 @@ import { objectQueryKeys } from "@/entities/nodes/object/domain/object.query-key
 import { useAddRelationships } from "@/entities/nodes/relationships/domain/add-relationships/add-relationships.mutation";
 import type { NodeObject } from "@/entities/nodes/types";
 import type { Permission } from "@/entities/permission/types";
+import { getPoolKindFromSchema } from "@/entities/resource-manager/utils/get-pool-kind-from-schema";
 import { genericSchemasAtom, nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
 import type { ModelSchema, RelationshipSchema } from "@/entities/schema/types";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
@@ -51,6 +52,8 @@ export function RelationshipsButtons({
   const peerRelationshipSchema = peerSchema.schema?.relationships?.find((r) => {
     return r.peer === objectKind;
   });
+
+  const poolKind = peerSchema.schema ? getPoolKindFromSchema(peerSchema.schema) : null;
 
   const [showAddDrawer, setShowAddDrawer] = useState(false);
 
@@ -86,9 +89,13 @@ export function RelationshipsButtons({
     const { relation } = data;
 
     if (relation?.id || relation?.from_pool) {
+      const relationshipId = relation.from_pool
+        ? { from_pool: { id: relation.from_pool.id } }
+        : relation.id;
+
       await addRelationship({
         objectId,
-        relationshipIds: [relation.id],
+        relationshipIds: [relationshipId],
         relationshipName: relationshipSchema!.name,
       });
 
@@ -163,6 +170,13 @@ export function RelationshipsButtons({
                     inherited: true,
                   } as RelationshipSchema,
                   options,
+                  pool:
+                    poolKind && peerSchema.schema
+                      ? {
+                          kind: poolKind,
+                          defaultAllocatedObjectKind: peerSchema.schema.kind as string,
+                        }
+                      : undefined,
                 },
               ]}
               onSubmit={async ({ relation }) => {

--- a/frontend/app/src/entities/nodes/relationships/domain/add-relationships/add-relationships.ts
+++ b/frontend/app/src/entities/nodes/relationships/domain/add-relationships/add-relationships.ts
@@ -3,10 +3,8 @@ import {
   addRelationshipsToApi,
 } from "@/entities/nodes/relationships/api/add-relationships-from-api";
 
-type RelationshipId = string | { from_pool: { id: string } };
-
 export type AddRelationshipsParams = Omit<AddRelationshipsToApiParams, "relationshipIds"> & {
-  relationshipIds: Array<RelationshipId>;
+  relationshipIds: Array<string | { from_pool: { id: string } }>;
 };
 
 export type AddRelationships = (params: AddRelationshipsParams) => Promise<void>;

--- a/frontend/app/src/entities/nodes/relationships/domain/add-relationships/add-relationships.ts
+++ b/frontend/app/src/entities/nodes/relationships/domain/add-relationships/add-relationships.ts
@@ -3,8 +3,10 @@ import {
   addRelationshipsToApi,
 } from "@/entities/nodes/relationships/api/add-relationships-from-api";
 
+type RelationshipId = string | { from_pool: { id: string } };
+
 export type AddRelationshipsParams = Omit<AddRelationshipsToApiParams, "relationshipIds"> & {
-  relationshipIds: Array<string>;
+  relationshipIds: Array<RelationshipId>;
 };
 
 export type AddRelationships = (params: AddRelationshipsParams) => Promise<void>;
@@ -18,7 +20,9 @@ export const addRelationships: AddRelationships = async ({
   await addRelationshipsToApi({
     objectId,
     relationshipName,
-    relationshipIds: relationshipIds.map((id) => ({ id })),
+    relationshipIds: relationshipIds.map((entry) =>
+      typeof entry === "string" ? { id: entry } : { from_pool: entry.from_pool }
+    ),
     branchName,
   });
 };

--- a/frontend/app/src/shared/components/form/fields/relationships/regular-relationship.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/relationships/regular-relationship.field.tsx
@@ -16,8 +16,6 @@ import { FormField, FormInput, FormMessage } from "@/shared/components/ui/form";
 
 import type { Node } from "@/entities/nodes/getObjectItemDisplayValue";
 import { useDefaultParent } from "@/entities/nodes/relationships/domain/get-default-parent.query";
-import { getPoolKindFromSchema } from "@/entities/resource-manager/utils/get-pool-kind-from-schema";
-import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
 export interface RegularRelationshipFieldProps extends DynamicRelationshipFieldProps {
   parentDisabled?: boolean;
@@ -36,6 +34,7 @@ export const NodeRelationshipField = ({
   type,
   options,
   parent,
+  pool,
   shouldUnregister,
   ...props
 }: RegularRelationshipFieldProps) => {
@@ -116,8 +115,6 @@ export const NodeRelationshipField = ({
           const fieldData: FormRelationshipValue = field.value;
 
           const { peer } = relationship;
-          const { schema: peerSchema } = useSchema(peer);
-          const poolKind = peerSchema ? getPoolKindFromSchema(peerSchema) : null;
           const selectedPoolId = fieldData?.source?.type === "pool" ? fieldData.source.id : null;
 
           const onChange = (newValue: Node | PoolValue | null) => {
@@ -150,10 +147,10 @@ export const NodeRelationshipField = ({
                   />
                 </FormInput>
 
-                {poolKind && peerSchema && (
+                {pool && (
                   <PoolSelect
-                    poolKind={poolKind}
-                    poolDefaultAllocatedObjectKind={peerSchema.kind as string}
+                    poolKind={pool.kind}
+                    poolDefaultAllocatedObjectKind={pool.defaultAllocatedObjectKind}
                     selectedPoolId={selectedPoolId}
                     onChange={onChange}
                   />

--- a/frontend/app/src/shared/components/form/fields/relationships/relationship-hierarchical.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/relationships/relationship-hierarchical.field.tsx
@@ -17,8 +17,6 @@ import {
   RelationshipHierarchicalManyInput,
 } from "@/entities/nodes/relationships/ui/relationship-hierarchical-input";
 import type { NodeCore } from "@/entities/nodes/types";
-import { getPoolKindFromSchema } from "@/entities/resource-manager/utils/get-pool-kind-from-schema";
-import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
 export interface RelationshipHierarchicalFieldProps
   extends Omit<DynamicRelationshipFieldProps, "type"> {}
@@ -33,6 +31,7 @@ export default function RelationshipHierarchicalField({
   rules,
   unique,
   shouldUnregister,
+  pool,
 }: RelationshipHierarchicalFieldProps) {
   return (
     <FormField
@@ -52,8 +51,6 @@ export default function RelationshipHierarchicalField({
             : fieldData.value;
 
         const { peer } = relationship;
-        const { schema: peerSchema } = useSchema(peer);
-        const poolKind = peerSchema ? getPoolKindFromSchema(peerSchema) : null;
         const selectedPoolId = fieldData?.source?.type === "pool" ? fieldData.source.id : null;
 
         const onChange = (newValue: NodeCore | NodeCore[] | PoolValue | null) => {
@@ -89,10 +86,10 @@ export default function RelationshipHierarchicalField({
                 )}
               </FormInput>
 
-              {relationship.cardinality === "one" && poolKind && peerSchema && (
+              {relationship.cardinality === "one" && pool && (
                 <PoolSelect
-                  poolKind={poolKind}
-                  poolDefaultAllocatedObjectKind={peerSchema.kind as string}
+                  poolKind={pool.kind}
+                  poolDefaultAllocatedObjectKind={pool.defaultAllocatedObjectKind}
                   selectedPoolId={selectedPoolId}
                   onChange={onChange}
                 />

--- a/frontend/app/src/shared/components/form/utils/getFormFieldFromRelationship.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldFromRelationship.ts
@@ -11,6 +11,8 @@ import { isRequired } from "@/shared/components/form/utils/validation";
 
 import type { AuthContextType } from "@/entities/authentication/ui/useAuth";
 import type { NodeFieldsWithMetadata, NodeObject, NodeRelationship } from "@/entities/nodes/types";
+import { getPoolKindFromSchema } from "@/entities/resource-manager/utils/get-pool-kind-from-schema";
+import { getSchema } from "@/entities/schema/domain/get-schema";
 import type { ModelSchema, RelationshipSchema } from "@/entities/schema/types";
 import { validateRelationshipMany } from "@/entities/schema/utils/validation/validate-relationship-many";
 
@@ -70,10 +72,17 @@ export const getFormFieldFromRelationship = ({
     | NodeRelationship
     | undefined;
 
+  const { schema: peerSchema } = getSchema(relationshipSchema.peer);
+  const poolKind = peerSchema ? getPoolKindFromSchema(peerSchema) : null;
+
   return {
     type: type ?? "relationship",
     name: name ?? relationshipSchema.name,
     label,
+    pool:
+      poolKind && peerSchema
+        ? { kind: poolKind, defaultAllocatedObjectKind: peerSchema.kind as string }
+        : undefined,
     defaultValue: getRelationshipDefaultValue({
       objectData,
       objectTemplate,

--- a/frontend/app/tests/e2e/objects/object-relationships.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-relationships.spec.ts
@@ -148,7 +148,10 @@ test.describe("/objects/:objectKind/:objectId - relationship tab", () => {
       await page.getByText("Ip Addresses0").click();
       await page.getByTestId("open-relationship-form-button").click();
       await page.getByTestId("select-open-pool-option-button").click();
-      await expect(page.getByRole("option", { name: "Loopbacks pool" })).toBeVisible();
+      await page.getByRole("option", { name: "Loopbacks pool" }).click();
+      await expect(page.getByTestId("source-pool-badge")).toContainText("Loopbacks pool");
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Association with IpamIPAddress added")).toBeVisible();
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relationship creation now supports selecting a resource pool when adding relationships.

* **Bug Fixes**
  * Fixed adding a relationship from a resource pool within relationship tabs in the object detail view.

* **Refactor**
  * Relationship fields now receive pool information directly, reducing runtime lookups and improving selector reliability and performance.

* **Tests**
  * End-to-end tests updated to verify pool selection, badge display, and successful save flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->