### PR TITLE
Allow setting `from_pool: null` for template attribute

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -620,7 +620,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
             if value_to_set != self.value:
                 self.value = value_to_set
                 changed = True
-        elif "from_pool" in data:
+        if "from_pool" in data:
             self.from_pool = data["from_pool"]
             if process_pools:
                 await self.node.handle_pool(db=db, attribute=self, errors=[])

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -362,6 +362,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if isinstance(self._schema, TemplateSchema):
             if attribute.from_pool:
                 attribute.source = attribute.from_pool["id"]
+                attribute.value = None
+            elif attribute.from_pool is None:
+                attribute.clear_source()
             return
 
         if not attribute.from_pool or not allocate_resources:

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -562,6 +562,72 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
         assert rack2.slot_id.value is not None
         assert rack1.slot_id.value != rack2.slot_id.value
 
+    async def test_template_can_swap_pool_to_static_value(
+        self, db: InfrahubDatabase, slot_pool: Node, client: InfrahubClient, device_schema: None
+    ) -> None:
+        """Swapping from pool to static value should set the value and clear the pool source."""
+        sdk_pool = await client.get(kind=InfrahubKind.NUMBERPOOL, id=slot_pool.id)
+        template = await client.create(
+            kind="TemplateInfraRack", template_name="rack-pool-to-static", location="datacenter-1", slot_id=sdk_pool
+        )
+        await template.save()
+
+        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        assert tmpl.slot_id.value is None
+        assert tmpl.slot_id.source_id == slot_pool.id
+
+        await client.execute_graphql(
+            query="""
+            mutation SwapPoolToStatic($id: String!, $slot_id: BigInt!) {
+                TemplateInfraRackUpdate(
+                    data: {
+                        id: $id
+                        slot_id: { value: $slot_id, from_pool: null }
+                    }
+                ) {
+                    ok
+                }
+            }
+            """,
+            variables={"id": template.id, "slot_id": 42},
+        )
+
+        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        assert tmpl.slot_id.value == 42
+        assert tmpl.slot_id.source_id is None
+
+    async def test_template_can_swap_static_value_to_pool(
+        self, db: InfrahubDatabase, slot_pool: Node, client: InfrahubClient, device_schema: None
+    ) -> None:
+        """Swapping from static value to pool should clear the value and set pool as source."""
+        template = await Node.init(db=db, schema="TemplateInfraRack")
+        await template.new(db=db, template_name="rack-static-to-pool", location="datacenter-1", slot_id=75)
+        await template.save(db=db)
+
+        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        assert tmpl.slot_id.value == 75
+        assert tmpl.slot_id.source_id is None
+
+        await client.execute_graphql(
+            query="""
+            mutation SwapStaticToPool($id: String!, $pool_id: String!) {
+                TemplateInfraRackUpdate(
+                    data: {
+                        id: $id
+                        slot_id: { from_pool: { id: $pool_id } }
+                    }
+                ) {
+                    ok
+                }
+            }
+            """,
+            variables={"id": template.id, "pool_id": slot_pool.id},
+        )
+
+        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        assert tmpl.slot_id.value is None
+        assert tmpl.slot_id.source_id == slot_pool.id
+
 
 class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
     """End-to-end test for pool allocations in templates with nested component relationships.


### PR DESCRIPTION
# Why

If a template uses a pool for an attribute, setting that attribute back to a static value was not clearing the source of the attribute. This change allows to support this by accepting `from_pool: null` in addition to the value to replace.

Also in this change, 2 more tests to validate that we can swap a static value to a pool and vice versa.

## What changed

- Process the `from_pool` data even if a `value` is provided.
- Clear the source of an attribute when `from_pool` is null for templates only.

## How to test

```bash
uv run pytest -vvvv backend/tests/functional/templates/test_template_resource_pool.py
```

## Checklist

- [x] Tests added/updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Template attributes can now be swapped between pool-backed sources and static values for flexible resource allocation.

* **Bug Fixes**
  * Improved handling of pool-based attribute allocations in templates to properly manage source relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->