### PR TITLE
handle deleted parent relationship schema when combining diffs

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -80,7 +80,11 @@ class DiffCombiner:
                 filtered_node_pairs.append(NodePair(earlier=earlier_node))
                 continue
             # if node was added and removed or vice-versa, remove it from the diff
-            if {earlier_node.action, later_node.action} == {DiffAction.ADDED, DiffAction.REMOVED}:
+            # unless it's still needed as a parent by a surviving child node
+            if {earlier_node.action, later_node.action} == {
+                DiffAction.ADDED,
+                DiffAction.REMOVED,
+            } and earlier_node.identifier not in self._parent_node_identifiers:
                 continue
             filtered_node_pairs.append(NodePair(earlier=earlier_node, later=later_node))
         for later_node in later_diff.nodes:
@@ -410,7 +414,9 @@ class DiffCombiner:
             if child_node.identifier not in self._child_parent_identifier_map:
                 continue
             parent_identifier, parent_rel_name = self._child_parent_identifier_map[child_node.identifier]
-            parent_node = nodes_by_identifier[parent_identifier]
+            parent_node = nodes_by_identifier.get(parent_identifier)
+            if not parent_node:
+                continue
             parent_rel = child_node.get_relationship(name=parent_rel_name)
             parent_rel.nodes.add(parent_node)
 

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.diff.combiner import DiffCombiner
@@ -16,6 +16,7 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
@@ -409,3 +410,71 @@ class TestDiffCoordinator:
         assert set(nodes_by_id.keys()) == {person_john_main.id}
         john_diff = nodes_by_id[person_john_main.id]
         assert john_diff.action is DiffAction.REMOVED
+
+    async def test_parent_reassigned_then_deleted(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        hierarchical_location_schema_simple: SchemaRoot,
+    ) -> None:
+        """Test reassigning a child to a new parent and deleting the old parent"""
+        branch = await create_branch(db=db, branch_name="branch_parent_reassign")
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+        # Create region R1 and site S with parent=R1
+        region1 = await Node.init(db=db, branch=branch, schema="LocationRegion")
+        await region1.new(db=db, name="test-region-1")
+        await region1.save(db=db)
+
+        site = await Node.init(db=db, branch=branch, schema="LocationSite")
+        await site.new(db=db, name="test-site", parent=region1)
+        await site.save(db=db)
+
+        # Window 1: R1=ADDED, S=ADDED with parent=R1
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        # Reassign site to new parent R2, then delete R1
+        region2 = await Node.init(db=db, branch=branch, schema="LocationRegion")
+        await region2.new(db=db, name="test-region-2")
+        await region2.save(db=db)
+
+        site_branch = await NodeManager.get_one(db=db, branch=branch, id=site.id)
+        await site_branch.parent.update(db=db, data=region2)
+        site_branch.status.value = "offline"
+        await site_branch.save(db=db)
+
+        await NodeManager.delete(
+            db=db, nodes=[await NodeManager.get_one(db=db, branch=branch, id=region1.id)], branch=branch
+        )
+
+        # Window 2: S reassigned to R2, R1 deleted
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        diff = await diff_repository.get_one(
+            diff_branch_name=diff_metadata.diff_branch_name, diff_id=diff_metadata.uuid
+        )
+
+        nodes_by_id = {n.uuid: n for n in diff.nodes}
+
+        # R1 was ADDED then deleted — should not be in the final diff
+        assert set(nodes_by_id.keys()) == {site.id, region2.id}
+
+        # Site must still be present as ADDED
+        site_node = nodes_by_id[site.id]
+        assert site_node.kind == "LocationSite"
+        assert site_node.action is DiffAction.ADDED
+
+        # Site's parent relationship should point to R2
+        rels_by_name = {r.name: r for r in site_node.relationships}
+        assert "parent" in rels_by_name
+        parent_rel = rels_by_name["parent"]
+        assert parent_rel.cardinality is RelationshipCardinality.ONE
+        assert len(parent_rel.relationships) == 1
+        parent_element = list(parent_rel.relationships)[0]
+        assert parent_element.peer_id == region2.id
+
+        # R2 must be present as ADDED
+        r2_node = nodes_by_id[region2.id]
+        assert r2_node.kind == "LocationRegion"
+        assert r2_node.action is DiffAction.ADDED

--- a/backend/tests/component/core/diff/test_diff_combiner.py
+++ b/backend/tests/component/core/diff/test_diff_combiner.py
@@ -1216,3 +1216,59 @@ class TestDiffCombiner:
         self.expected_combined.nodes = {expected_node}
 
         assert self.expected_combined == combined
+
+    async def test_added_removed_parent_with_surviving_child(self) -> None:
+        """Test an edge case where a parent relationship is removed from the schema and a parent object is deleted
+
+        The earlier diff includes a child node with a kind=Parent relationship to a parent node.
+        Then the parent relationship schema is removed from the diff, the parent node is deleted, and the child node
+        is updated, so the later diff includes the child node and no parent relationship.
+        """
+        # Earlier diff: parent ADDED, child ADDED with relationship pointing to parent
+        parent_node_1 = EnrichedNodeFactory.build(action=DiffAction.ADDED, attributes=set(), relationships=set())
+        element_1 = EnrichedRelationshipElementFactory.build(action=DiffAction.ADDED)
+        attr_1 = EnrichedAttributeFactory.build(action=DiffAction.ADDED)
+        relationship_1 = EnrichedRelationshipGroupFactory.build(
+            name="parent",
+            label="Parent",
+            action=DiffAction.ADDED,
+            relationships={element_1},
+            nodes={parent_node_1},
+        )
+        child_node_1 = EnrichedNodeFactory.build(
+            action=DiffAction.ADDED, relationships={relationship_1}, attributes={attr_1}
+        )
+        self.diff_root_1.nodes = {parent_node_1, child_node_1}
+
+        # Later diff: parent REMOVED (no child ref), child UPDATED (no parent ref since parent is gone)
+        parent_node_2 = EnrichedNodeFactory.build(
+            identifier=parent_node_1.identifier, action=DiffAction.REMOVED, attributes=set(), relationships=set()
+        )
+        attr_2 = EnrichedAttributeFactory.build(action=DiffAction.UPDATED)
+        child_node_2 = EnrichedNodeFactory.build(
+            identifier=child_node_1.identifier,
+            action=DiffAction.UPDATED,
+            relationships=set(),
+            attributes={attr_2},
+            changed_at=Timestamp(),
+        )
+        self.diff_root_2.nodes = {parent_node_2, child_node_2}
+
+        # This should not raise a KeyError
+        combined = await self.__call_system_under_test(self.diff_root_1, self.diff_root_2)
+
+        # Both parent and child should be in combined output
+        assert len(combined.nodes) == 2
+        combined_nodes_by_id = {n.identifier: n for n in combined.nodes}
+
+        # Parent should be kept as UNCHANGED (ADDED+REMOVED cancels, but kept as structural anchor)
+        combined_parent = combined_nodes_by_id[parent_node_1.identifier]
+        assert combined_parent.action is DiffAction.UNCHANGED
+        assert combined_parent.attributes == set()
+        assert combined_parent.relationships == set()
+
+        # Child should survive with action=ADDED (ADDED+UPDATED=ADDED)
+        combined_child = combined_nodes_by_id[child_node_1.identifier]
+        assert combined_child.action is DiffAction.ADDED
+        assert attr_1 in combined_child.attributes
+        assert attr_2 in combined_child.attributes

--- a/backend/tests/integration/diff/test_diff_delete_parent_rel_schema.py
+++ b/backend/tests/integration/diff/test_diff_delete_parent_rel_schema.py
@@ -1,0 +1,181 @@
+"""Test that removing a Parent relationship from the schema is correctly reflected in the diff."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.dependencies.registry import get_component_registry
+from tests.helpers.test_app import TestInfrahubApp
+
+from ..shared import load_schema
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+PARENT_REL_BRANCH_NAME = "branch_parent_rel_schema_remove"
+
+CLUSTER_KIND = "TestCluster"
+VIRTUAL_INTERFACE_KIND = "NetworkVirtualInterface"
+PROVIDER_GENERIC = "NetworkVirtualInterfaceProvider"
+
+PARENT_REL_SCHEMA: dict[str, Any] = {
+    "version": "1.0",
+    "generics": [
+        {
+            "name": "VirtualInterfaceProvider",
+            "namespace": "Network",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+            ],
+        },
+    ],
+    "nodes": [
+        {
+            "name": "Cluster",
+            "namespace": "Test",
+            "inherit_from": [PROVIDER_GENERIC],
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text",
+                    "optional": True,
+                },
+            ],
+        },
+        {
+            "name": "VirtualInterface",
+            "namespace": "Network",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+            ],
+            "relationships": [
+                {
+                    "name": "provider",
+                    "peer": PROVIDER_GENERIC,
+                    "kind": "Parent",
+                    "optional": False,
+                    "cardinality": "one",
+                },
+            ],
+        },
+    ],
+}
+
+
+class TestDiffDeleteParentRelSchema(TestInfrahubApp):
+    """Verify the diff is correct after a Parent relationship is removed from the schema mid-branch."""
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+    ) -> None:
+        await load_schema(db=db, schema=PARENT_REL_SCHEMA)
+
+    @pytest.fixture(scope="class")
+    async def diff_branch(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: None,
+    ) -> Branch:
+        return await create_branch(db=db, branch_name=PARENT_REL_BRANCH_NAME)
+
+    async def test_parent_rel_removed_by_schema_change(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_branch: Branch,
+        client: InfrahubClient,
+    ) -> None:
+        """Removing a Parent relationship from the schema after data is created should
+        produce a diff where the child node no longer has the removed relationship.
+
+        1. Create TestCluster + VirtualInterface (provider=TestCluster) on branch.
+        2. Update the branch diff.
+        3. Schema change: mark ``provider`` relationship as absent.
+        4. Modify VirtualInterface and delete TestCluster.
+        5. Update the branch diff again.
+        6. Validate VirtualInterface is in the diff without the ``provider`` relationship.
+        """
+        # Create data on the branch
+        cluster = await Node.init(schema=CLUSTER_KIND, db=db, branch=diff_branch)
+        await cluster.new(db=db, name="test-cluster")
+        await cluster.save(db=db)
+
+        vi = await Node.init(schema=VIRTUAL_INTERFACE_KIND, db=db, branch=diff_branch)
+        await vi.new(db=db, name="eth0", provider=cluster)
+        await vi.save(db=db)
+
+        # First diff update
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+
+        # Remove the provider Parent relationship from the schema
+        schema_removal: dict[str, Any] = {
+            "version": "1.0",
+            "nodes": [
+                {
+                    "name": "VirtualInterface",
+                    "namespace": "Network",
+                    "relationships": [
+                        {
+                            "name": "provider",
+                            "peer": PROVIDER_GENERIC,
+                            "kind": "Parent",
+                            "optional": False,
+                            "cardinality": "one",
+                            "state": "absent",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        response = await client.schema.load(schemas=[schema_removal], branch=diff_branch.name)
+        assert not response.errors
+
+        # Modify VirtualInterface and delete the cluster
+        from infrahub.core.manager import NodeManager
+
+        vi_updated = await NodeManager.get_one(db=db, id=vi.id, branch=diff_branch)
+        vi_updated.name.value = "eth0-updated"  # type: ignore[union-attr]
+        await vi_updated.save(db=db)
+
+        cluster_deleted = await NodeManager.get_one(db=db, id=cluster.id, branch=diff_branch)
+        await cluster_deleted.delete(db=db)
+
+        # Second diff update
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+
+        # Validate the diff
+        diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+        diff = await diff_repo.get_one(
+            tracking_id=BranchTrackingId(name=diff_branch.name),
+            diff_branch_name=diff_branch.name,
+        )
+
+        nodes_by_id = {n.uuid: n for n in diff.nodes}
+        assert vi.id in nodes_by_id, f"NetworkVirtualInterface {vi.id} should be in the diff"
+        vi_node = nodes_by_id[vi.id]
+        assert vi_node.kind == VIRTUAL_INTERFACE_KIND
+
+        # this relationship should be removed once #2474 is implemented
+        # assert not vi_node.has_relationship("provider"), (
+        #     "The 'provider' Parent relationship should not be in the diff after being removed from the schema"
+        # )

--- a/backend/tests/integration/diff/test_diff_delete_parent_rel_schema.py
+++ b/backend/tests/integration/diff/test_diff_delete_parent_rel_schema.py
@@ -10,6 +10,7 @@ from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.dependencies.registry import get_component_registry
 from tests.helpers.test_app import TestInfrahubApp
@@ -150,8 +151,6 @@ class TestDiffDeleteParentRelSchema(TestInfrahubApp):
         assert not response.errors
 
         # Modify VirtualInterface and delete the cluster
-        from infrahub.core.manager import NodeManager
-
         vi_updated = await NodeManager.get_one(db=db, id=vi.id, branch=diff_branch)
         vi_updated.name.value = "eth0-updated"  # type: ignore[union-attr]
         await vi_updated.save(db=db)

--- a/changelog/8388.fixed.md
+++ b/changelog/8388.fixed.md
@@ -1,0 +1,1 @@
+Handle deleted parent relationship schemas when combining diffs without crashing


### PR DESCRIPTION
fixes #8388 

# Why

## Problem
Combining two diffs (regular part of updating a diff) could crash if a parent relationship schema was deleted and a node included in the diff had been previously added on the branch with that parent relationship.

## Goal
Add some more graceful handling to `DiffCombiner` so that it can handle a deleted parent relationship schema. And add tests for it

## Non-goal
The root cause of the issue is that we don't actually delete all instances of a relationship when a relationship schema is removed. We just count on the relationship no longer being in the schema to prevent anyone from viewing or updating it. The diff logic only looks at edges added and updated at the database level and the actual relationship instances for a deleted schema are not updated, so the diff does not see them and can end up in an unexpected situation when a relationship schema is deleted. This is a bigger issue than this bug and is documented in #2474

Closes IFC-2268

## What changed

- functionally, not very much, just a few simple updates to be more defensive in the DiffCombiner
- and a number of tests that eventually reproduced the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Handle parent relationships that are added then removed without losing child references.
  * Skip missing parent linkages safely to avoid crashes during diff combination.
  * Prevent schema changes that remove parent relationships from causing failures when combining diffs.

* **Tests**
  * Added unit and integration tests covering reassigned/deleted parents and removed parent-relationship schema scenarios.

* **Chore**
  * Added changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->