### PR TITLE
Add missing return statements in tests

### DIFF
--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -1,3 +1,6 @@
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
+
 import pytest
 from fast_depends import Provider
 from fastapi.testclient import TestClient
@@ -15,7 +18,7 @@ from infrahub.workflows.initialization import setup_task_manager
 
 
 @pytest.fixture
-def client(dependency_provider: Provider, nats, redis):
+def client(dependency_provider: Provider, nats, redis) -> Generator[TestClient, None, None]:
     # In order to mock some methods later we can't load app by default because it will automatically load all import in main.py as well
     from infrahub.server import app
 
@@ -27,17 +30,17 @@ def client(dependency_provider: Provider, nats, redis):
 
 
 @pytest.fixture
-def client_headers():
+def client_headers() -> dict[str, str]:
     return {"Authorization": "Token XXXX"}
 
 
 @pytest.fixture
-def admin_headers():
+def admin_headers() -> dict[str, str]:
     return {"X-INFRAHUB-KEY": "admin-security"}
 
 
 @pytest.fixture
-def rpc_bus(helper, dependency_provider):
+def rpc_bus(helper, dependency_provider) -> Generator[Any, None, None]:
     original = config.OVERRIDE.message_bus
     bus = helper.get_message_bus_rpc()
     config.OVERRIDE.message_bus = bus
@@ -47,7 +50,7 @@ def rpc_bus(helper, dependency_provider):
 
 
 @pytest.fixture
-async def workflow_local(dependency_provider):
+async def workflow_local(dependency_provider) -> AsyncGenerator[WorkflowLocalExecution, None]:
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     await setup_task_manager()
@@ -144,7 +147,9 @@ async def car_person_data(
 
 
 @pytest.fixture
-async def car_person_data_generic_diff(db: InfrahubDatabase, default_branch, car_person_data_generic, first_account):
+async def car_person_data_generic_diff(
+    db: InfrahubDatabase, default_branch, car_person_data_generic, first_account
+) -> dict[str, Any]:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     # Time After Creation of branch2
@@ -233,7 +238,9 @@ async def car_person_data_generic_diff(db: InfrahubDatabase, default_branch, car
 
 
 @pytest.fixture
-async def car_person_data_artifact_diff(db: InfrahubDatabase, default_branch, car_person_data_generic_diff):
+async def car_person_data_artifact_diff(
+    db: InfrahubDatabase, default_branch, car_person_data_generic_diff
+) -> dict[str, Any]:
     query = """
     query {
         TestPerson {
@@ -360,7 +367,9 @@ async def car_person_data_artifact_diff(db: InfrahubDatabase, default_branch, ca
 
 
 @pytest.fixture
-async def data_diff_attribute(db: InfrahubDatabase, default_branch, car_person_data_generic, first_account):
+async def data_diff_attribute(
+    db: InfrahubDatabase, default_branch, car_person_data_generic, first_account
+) -> dict[str, Any]:
     branch2 = await create_branch(branch_name="branch2", db=db)
 
     # Time After Creation of branch2

--- a/backend/tests/component/api/test_15_diff.py
+++ b/backend/tests/component/api/test_15_diff.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from infrahub import config
@@ -92,7 +94,7 @@ async def test_get_display_labels_with_branch(db: InfrahubDatabase, default_bran
 
 
 @pytest.fixture
-async def r1_update_01(data_diff_attribute):
+async def r1_update_01(data_diff_attribute) -> dict[str, Any]:
     r1 = data_diff_attribute["r1"]
 
     expected_response = {

--- a/backend/tests/component/api/test_50_internals.py
+++ b/backend/tests/component/api/test_50_internals.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -72,7 +74,7 @@ async def test_info_endpoint_anonymous_account(
 
 
 @pytest.fixture
-def override_search_index_path():
+def override_search_index_path() -> Generator[None, None, None]:
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
     config.SETTINGS.main.docs_index_path = get_fixtures_dir() / "docs" / "search-index.json"
@@ -83,7 +85,7 @@ def override_search_index_path():
 
 
 @pytest.fixture
-def no_search_index_path():
+def no_search_index_path() -> Generator[None, None, None]:
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
     config.SETTINGS.main.docs_index_path = get_fixtures_dir() / "docs" / "no-index.json"

--- a/backend/tests/component/cli/test_migrate.py
+++ b/backend/tests/component/cli/test_migrate.py
@@ -27,7 +27,7 @@ class Migration001(GraphMigration):
     minimum_version: int = 0
     queries: list = []
 
-    async def validate_migration(self, db: InfrahubDatabase):
+    async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         return MigrationResult()
 
 
@@ -38,7 +38,7 @@ class Migration042(GraphMigration):
     minimum_version: int = 41
     queries: list = []
 
-    async def validate_migration(self, db: InfrahubDatabase):
+    async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         return MigrationResult()
 
 
@@ -78,7 +78,7 @@ class TestDoMigrate:
         db: InfrahubDatabase,
         default_branch: Branch,
         test_case: DoMigrateTestCase,
-    ):
+    ) -> None:
         """Test that check=True prevents migrations from running."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version
@@ -108,7 +108,7 @@ class TestDoMigrate:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         """Test that no changes occur when no migrations are applicable."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version
@@ -137,7 +137,7 @@ class TestDoMigrate:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         """Test that update_graph_version=True when no specific migration is requested."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version
@@ -166,7 +166,7 @@ class TestDoMigrate:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         """Test that update_graph_version=False when a specific migration is requested."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version
@@ -203,7 +203,7 @@ class TestDoMigrate:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         """Test that migration_number selects the correct migration."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version
@@ -233,7 +233,7 @@ class TestDoMigrate:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         """Test that a specific migration can be re-run even if already applied."""
         root_node = await get_root_node(db=db)
         initial_version = root_node.graph_version

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -12,6 +12,7 @@ from fast_depends import Provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.hydration.v1.hydration_handler import _GraphHydrator
 from prefect.settings import get_current_settings
 from prefect.testing.utilities import prefect_test_harness
 from pytest_httpx import HTTPXMock
@@ -78,7 +79,7 @@ def load_component_dependency_registry() -> None:
 
 
 @pytest.fixture(scope="session")
-def neo4j_factory():
+def neo4j_factory() -> _GraphHydrator:
     """Return a Hydration Scope from Neo4j used to generate fake
     Node and Relationship object.
 
@@ -91,7 +92,7 @@ def neo4j_factory():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def prefect_test_fixture():
+def prefect_test_fixture() -> Generator[None, None, None]:
     def _run_uvicorn_command(self) -> subprocess.Popen[Any]:
         """Patched version of prefect method to call the test server, pointing at the Infrahub entrypoint instead"""
         # used to turn off serving the UI
@@ -1116,7 +1117,9 @@ async def car_person_schema_global(
 
 
 @pytest.fixture
-async def car_person_data_generic(db: InfrahubDatabase, register_core_models_schema, car_person_schema_generics):
+async def car_person_data_generic(
+    db: InfrahubDatabase, register_core_models_schema, car_person_schema_generics
+) -> dict[str, Node]:
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -1768,7 +1771,7 @@ def do_criticality_schema(branch: Branch, schema_root: SchemaRoot) -> NodeSchema
 
 
 @pytest.fixture
-async def criticality_protocol():
+async def criticality_protocol() -> type[CoreNode]:
     class TestCriticality(CoreNode):
         name: String
         label: StringOptional
@@ -1788,7 +1791,7 @@ async def criticality_protocol():
 
 
 @pytest.fixture
-async def criticality_low(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def criticality_low(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> Node:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="low", level=4)
     await obj.save(db=db)
@@ -1797,7 +1800,7 @@ async def criticality_low(db: InfrahubDatabase, default_branch: Branch, critical
 
 
 @pytest.fixture
-async def criticality_medium(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def criticality_medium(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> Node:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="medium", level=3, description="My desc", color="#333333")
     await obj.save(db=db)
@@ -1805,7 +1808,7 @@ async def criticality_medium(db: InfrahubDatabase, default_branch: Branch, criti
 
 
 @pytest.fixture
-async def criticality_high(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def criticality_high(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> Node:
     obj = await Node.init(db=db, schema=criticality_schema)
     await obj.new(db=db, name="high", level=2, description="My other desc", color="#333333")
     await obj.save(db=db)
@@ -2606,7 +2609,7 @@ async def session_second_account(db: InfrahubDatabase, second_account) -> Accoun
 
 
 @pytest.fixture
-async def repos_in_main(db: InfrahubDatabase, register_core_models_schema):
+async def repos_in_main(db: InfrahubDatabase, register_core_models_schema) -> dict[str, Node]:
     repo01 = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
     await repo01.new(
         db=db,
@@ -2631,7 +2634,7 @@ async def repos_in_main(db: InfrahubDatabase, register_core_models_schema):
 
 
 @pytest.fixture
-async def read_only_repos_in_main(db: InfrahubDatabase, register_core_models_schema):
+async def read_only_repos_in_main(db: InfrahubDatabase, register_core_models_schema) -> dict[str, Node]:
     repo01 = await Node.init(db=db, schema=InfrahubKind.READONLYREPOSITORY)
     await repo01.new(
         db=db,
@@ -2675,7 +2678,7 @@ async def ip_dataset_01(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> dict[str, Any]:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -2772,7 +2775,7 @@ async def ip_dataset_prefix_v4(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> dict[str, Any]:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -2884,7 +2887,7 @@ async def prefix_pool_01(
     init_nodes_registry,
     person_ip_schema,
     ip_dataset_prefix_v4,
-):
+) -> dict[str, Any]:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 
@@ -2907,7 +2910,7 @@ async def prefix_pool_01(
 
 
 @pytest.fixture
-def workflow_local(dependency_provider: Provider):
+def workflow_local(dependency_provider: Provider) -> Generator[WorkflowLocalExecution, None, None]:
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     config.OVERRIDE.workflow = workflow

--- a/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
@@ -91,7 +91,9 @@ async def car_person_schema_generics_simple(db: InfrahubDatabase, default_branch
 
 
 @pytest.fixture
-async def car_person_generic_data(db: InfrahubDatabase, car_person_schema_generics_simple, default_branch: Branch):
+async def car_person_generic_data(
+    db: InfrahubDatabase, car_person_schema_generics_simple, default_branch: Branch
+) -> dict[str, Node]:
     p_1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await p_1.new(db=db, name="P1")
     await p_1.save(db=db)

--- a/backend/tests/component/core/diff/query/test_read.py
+++ b/backend/tests/component/core/diff/query/test_read.py
@@ -86,7 +86,9 @@ class TestDiffReadQuery(TestInfrahub):
         registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
     @pytest.fixture(scope="class")
-    async def hierarchical_data(self, db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema):
+    async def hierarchical_data(
+        self, db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema
+    ) -> dict[str, Node]:
         REGIONS = (
             ("north-america",),
             ("europe",),
@@ -128,7 +130,7 @@ class TestDiffReadQuery(TestInfrahub):
         return nodes
 
     @pytest.fixture(scope="class")
-    async def load_data(self, db: InfrahubDatabase, default_branch: Branch, hierarchical_data):
+    async def load_data(self, db: InfrahubDatabase, default_branch: Branch, hierarchical_data) -> dict[str, Any]:
         rack1_main = hierarchical_data["paris-r1"]
         rack2_main = hierarchical_data["paris-r2"]
 

--- a/backend/tests/component/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/component/core/diff/test_calculate_artifact_diff.py
@@ -15,7 +15,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.fixture
 async def car_person_data_artifact_diff(
     db: InfrahubDatabase, default_branch: Branch, car_person_data_generic: dict[str, Node]
-):
+) -> dict[str, Node | Branch]:
     g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
     await g1.new(db=db, name="group1", members=[car_person_data_generic["c1"], car_person_data_generic["c2"]])
     await g1.save(db=db)

--- a/backend/tests/component/core/diff/test_conflict_transferer.py
+++ b/backend/tests/component/core/diff/test_conflict_transferer.py
@@ -20,7 +20,7 @@ from .factories import (
 
 class TestDiffConflictsTransferer:
     @pytest.fixture
-    async def conflict_transferer(self):
+    async def conflict_transferer(self) -> DiffConflictTransferer:
         return DiffConflictTransferer(diff_combiner=DiffCombiner())
 
     async def test_node_conflicts(self, conflict_transferer: DiffConflictTransferer) -> None:

--- a/backend/tests/component/core/diff/test_diff_and_merge.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge.py
@@ -2443,7 +2443,7 @@ class TestDiffAndMerge:
         car_camry_main: Node,
         person_jane_main: Node,
         person_john_main: Node,
-    ):
+    ) -> None:
         car_accord_created_at = car_accord_main._get_created_at()
         car_camry_created_at = car_camry_main._get_created_at()
         original_car_owner = person_john_main

--- a/backend/tests/component/core/diff/test_diff_calculator.py
+++ b/backend/tests/component/core/diff/test_diff_calculator.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Generator
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(autouse=True)
-def parallel_runtime(db: InfrahubDatabase):
+def parallel_runtime(db: InfrahubDatabase) -> Generator[None, None, None]:
     original = db.default_neo4j_runtime
     db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
 
@@ -39,7 +40,7 @@ def parallel_runtime(db: InfrahubDatabase):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def low_query_size_limit():
+def low_query_size_limit() -> Generator[None, None, None]:
     original = config.SETTINGS.database.query_size_limit
     config.SETTINGS.database.query_size_limit = 5
 
@@ -4385,7 +4386,7 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
     person_jane_main,
     person_alfred_main,
     person_albert_main,
-):
+) -> None:
     """Test that when a schema kind is migrated on the default branch, relationships to instances
     of the migrated node can be updated on a branch before the diff is calculated."""
     # Migrate TestPerson kind on default branch

--- a/backend/tests/component/core/diff/test_diff_task.py
+++ b/backend/tests/component/core/diff/test_diff_task.py
@@ -11,7 +11,7 @@ from infrahub.dependencies.registry import get_component_registry
 
 
 class DummyComponentRegistry:
-    async def get_component(self, *args, **kwargs):
+    async def get_component(self, *args, **kwargs) -> AsyncMock:
         mock_component = AsyncMock()
         # Needed so .run_update can be awaited and does nothing
         mock_component.run_update = AsyncMock()

--- a/backend/tests/component/core/ipam/conftest.py
+++ b/backend/tests/component/core/ipam/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -79,7 +80,7 @@ async def ip_dataset_01_load(
     default_ipnamespace: Node,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> dict[str, Node]:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -177,7 +178,7 @@ async def diff_repository(db: InfrahubDatabase, default_branch: Branch) -> DiffR
 
 
 @pytest.fixture(scope="module")
-def start_time():
+def start_time() -> Timestamp:
     return Timestamp()
 
 
@@ -188,7 +189,7 @@ async def ip_dataset_01(
     ip_dataset_01_load,
     diff_repository: DiffRepository,
     start_time: Timestamp,
-):
+) -> Generator[dict[str, Node], None, None]:
     yield ip_dataset_01_load
 
     all_diff_roots = await diff_repository.get_roots_metadata()

--- a/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
@@ -753,7 +753,7 @@ async def test_reconcile_query_on_migrated_kind_node(
 
 async def test_reconcile_query_for_address_with_prefix_added_on_branch_and_merged(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
-):
+) -> None:
     """
     Test for bug that could cause an IP address to be its own parent after an update on a branch was merged
     """

--- a/backend/tests/component/core/migrations/graph/test_041/test_041.py
+++ b/backend/tests/component/core/migrations/graph/test_041/test_041.py
@@ -27,7 +27,7 @@ class TestMigration041:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-    ):
+    ) -> None:
         export_dir = Path(__file__).parent / ("data_export")
         await load_export(db=db, export_dir=export_dir)
         # set default branch on the import Root node
@@ -89,7 +89,7 @@ DETACH DELETE r
         """
         await db.execute_query(query=query)
 
-    async def test_migration_041(self, db: InfrahubDatabase, load_bad_data, car_person_schema: SchemaBranch):
+    async def test_migration_041(self, db: InfrahubDatabase, load_bad_data, car_person_schema: SchemaBranch) -> None:
         for schema_name in car_person_schema.node_names:
             if schema_name == "TestCar":
                 car_schema = car_person_schema.get(name=schema_name, duplicate=False)

--- a/backend/tests/component/core/migrations/graph/test_042.py
+++ b/backend/tests/component/core/migrations/graph/test_042.py
@@ -180,7 +180,7 @@ class TestMigration042(TestInfrahubApp):
         priority_branch: Branch,
         deleted_profile_branch: Branch,
         deleted_node_branch: Branch,
-    ):
+    ) -> None:
         migration = WrappedMigration042()
         execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -39,7 +39,7 @@ async def car_person_schema(
 
 
 @pytest.fixture
-async def schema_aware():
+async def schema_aware() -> NodeSchema:
     SCHEMA = {
         "name": "Car",
         "namespace": "Test",

--- a/backend/tests/component/core/profiles/test_node_applier.py
+++ b/backend/tests/component/core/profiles/test_node_applier.py
@@ -719,7 +719,7 @@ async def test_template_profile_application(
     criticality_schema: NodeSchema,
     criticality_low: Node,
     branch: Branch,
-):
+) -> None:
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=branch)
     template_schema = registry.schema.get("TemplateTestCriticality", branch=branch)
 
@@ -766,7 +766,7 @@ async def test_template_with_multiple_profiles(
     db: InfrahubDatabase,
     criticality_schema: NodeSchema,
     branch: Branch,
-):
+) -> None:
     """Test that templates can have multiple profiles with correct priority handling."""
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=branch)
     template_schema = registry.schema.get("TemplateTestCriticality", branch=branch)
@@ -823,7 +823,7 @@ async def test_template_profile_manual_values_precedence(
     db: InfrahubDatabase,
     criticality_schema: NodeSchema,
     branch: Branch,
-):
+) -> None:
     """Test that template's own values take precedence over profile values.
 
     When a template has a manually configured value, profile values should not override it.
@@ -871,7 +871,7 @@ async def test_node_from_template_with_profile_precedence(
     db: InfrahubDatabase,
     criticality_schema: NodeSchema,
     branch: Branch,
-):
+) -> None:
     """Test that when creating a node from a template with profiles,
     template's manually defined values take precedence over profile values,
     while profile values are used for attributes not set on the template."""

--- a/backend/tests/component/core/schema/test_check_dup_schema_fields_cmd.py
+++ b/backend/tests/component/core/schema/test_check_dup_schema_fields_cmd.py
@@ -104,7 +104,7 @@ class TestCheckDuplicateSchemaFields:
         default_branch: Branch,
         load_main_schema: dict[str, Node],
         branch: Branch,
-    ):
+    ) -> None:
         node_schema = load_main_schema["node_schema"]
         generic_schema = load_main_schema["generic_schema"]
 

--- a/backend/tests/component/core/schema/test_check_inheritance_cmd.py
+++ b/backend/tests/component/core/schema/test_check_inheritance_cmd.py
@@ -24,7 +24,7 @@ class DatabaseNodeWithLabels:
 
 
 class TestCheckInheritance:
-    async def get_database_nodes_with_labels(self, db: InfrahubDatabase):
+    async def get_database_nodes_with_labels(self, db: InfrahubDatabase) -> set[DatabaseNodeWithLabels]:
         query = """
 MATCH (n:TestPerson)-[e:IS_PART_OF]->(:Root)
 WITH DISTINCT n, e.branch AS branch

--- a/backend/tests/component/core/schema_manager/conftest.py
+++ b/backend/tests/component/core/schema_manager/conftest.py
@@ -92,7 +92,7 @@ async def animal_person_schema_dict() -> dict:
 
 
 @pytest.fixture
-def schema_all_in_one():
+def schema_all_in_one() -> dict[str, Any]:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -242,7 +242,7 @@ def schema_all_in_one():
 
 
 @pytest.fixture
-def schema_criticality_tag():
+def schema_criticality_tag() -> dict[str, Any]:
     FULL_SCHEMA = {
         "nodes": [
             {
@@ -355,7 +355,7 @@ def schema_parent_component() -> dict:
 
 
 @pytest.fixture
-def schema_diff_attr_inheritance_types():
+def schema_diff_attr_inheritance_types() -> dict[str, Any]:
     """Two generics with the same attribute but different types and a single node implementation."""
     FULL_SCHEMA = {
         "generics": [

--- a/backend/tests/component/core/test_node_query.py
+++ b/backend/tests/component/core/test_node_query.py
@@ -472,7 +472,7 @@ async def test_query_NodeListGetRelationshipsQuery_hierarchical(
 
 async def test_query_NodeListGetRelationshipsQuery_pagination_and_parallel_runtime(
     db: InfrahubDatabase, default_branch: Branch, person_tag_schema, query_limit_of_one, neo4j_runtime_parallel
-):
+) -> None:
     """
     Test all expected results are returned with pagination and parallel runtime
     """

--- a/backend/tests/component/core/test_relationship_metadata.py
+++ b/backend/tests/component/core/test_relationship_metadata.py
@@ -21,7 +21,7 @@ class RelationshipMetadata:
 
 
 class TestRelationshipMetadata:
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.person_id = None
         self.black_tag_id = None
         self.red_tag_id = None

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -2,7 +2,7 @@ import re
 import shutil
 import tarfile
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator
 
 import anyio
 import pytest
@@ -33,7 +33,7 @@ def client() -> InfrahubClient:
 
 
 @pytest.fixture
-def branch01():
+def branch01() -> BranchData:
     return BranchData(
         id="6c915158-d8ef-4169-9b00-59f94716b8c3 ",
         name="branch01",
@@ -46,7 +46,7 @@ def branch01():
 
 
 @pytest.fixture
-def branch02():
+def branch02() -> BranchData:
     return BranchData(
         id="7708dcea-f7b4-4f5a-b5e9-a0605d4c11ba",
         name="branch02",
@@ -59,7 +59,7 @@ def branch02():
 
 
 @pytest.fixture
-def branch99():
+def branch99() -> BranchData:
     return BranchData(
         id="2e933717-086c-47cf-8242-21421dd3c2bb",
         name="branch99",
@@ -734,7 +734,7 @@ async def check_definition_data_01() -> dict:
 
 
 @pytest.fixture
-async def gql_query_data_03():
+async def gql_query_data_03() -> dict[str, Any]:
     # QUERY
     query_string = """
     query {
@@ -833,7 +833,7 @@ async def mock_upload_content(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 
 @pytest.fixture
-async def artifact_definition_data_01():
+async def artifact_definition_data_01() -> dict[str, Any]:
     data = {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
@@ -875,7 +875,7 @@ async def artifact_definition_node_01(client, schema_02: ClientSchemaRoot, artif
 
 
 @pytest.fixture
-async def artifact_definition_data_02():
+async def artifact_definition_data_02() -> dict[str, Any]:
     data = {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
@@ -917,7 +917,7 @@ async def artifact_definition_node_02(client, schema_02: ClientSchemaRoot, artif
 
 
 @pytest.fixture
-async def artifact_data_01():
+async def artifact_data_01() -> dict[str, Any]:
     data = {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": "CoreArtifact",
@@ -950,7 +950,7 @@ async def artifact_node_01(client, schema_02: ClientSchemaRoot, artifact_data_01
 
 
 @pytest.fixture
-async def artifact_data_02():
+async def artifact_data_02() -> dict[str, Any]:
     data = {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACT,
@@ -1184,7 +1184,7 @@ async def mock_create_branch_git_repo_03(db: InfrahubDatabase, default_branch: B
 
 
 @pytest.fixture
-def git_use_explicit_merge_commit_config():
+def git_use_explicit_merge_commit_config() -> Generator[None, None, None]:
     initial_use_explicit_merge_commit = config.SETTINGS.git.use_explicit_merge_commit
     config.SETTINGS.git.use_explicit_merge_commit = True
     yield

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1131,7 +1131,7 @@ async def test_get_filtered_remote_branches__no_import_sync_branch_names(git_rep
 
 async def test_repo_merge_use_explicit_merge_commit(
     git_repo_01: InfrahubRepository, branch02: BranchData, git_user_config, git_use_explicit_merge_commit_config
-):
+) -> None:
     repo = git_repo_01
     await repo.create_branch_in_git(branch_name=branch02.name, branch_id=branch02.id)
     response = await repo.merge(source_branch=branch02.name, dest_branch="main")

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, AsyncMock, patch
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
@@ -58,7 +61,7 @@ class AsyncContextManagerMock:
 
 class TestAddRepository:
     @pytest.fixture
-    async def setup(self, dependency_provider):
+    async def setup(self, dependency_provider) -> AsyncGenerator[None, None]:
         self.default_branch_name = "default-branch"
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
@@ -216,7 +219,7 @@ async def test_git_rpc_diff(
 
 class TestAddReadOnly:
     @pytest.fixture
-    async def setup(self, dependency_provider):
+    async def setup(self, dependency_provider) -> AsyncGenerator[None, None]:
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
@@ -270,7 +273,7 @@ class TestAddReadOnly:
 
 class TestPullReadOnly:
     @pytest.fixture
-    async def setup(self, dependency_provider):
+    async def setup(self, dependency_provider) -> AsyncGenerator[None, None]:
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
         self.workflow = WorkflowLocalExecution()

--- a/backend/tests/component/git/test_git_transform.py
+++ b/backend/tests/component/git/test_git_transform.py
@@ -11,7 +11,7 @@ from infrahub.transformations.tasks import transform_python, transform_render_ji
 
 
 @pytest.fixture
-async def init_service():
+async def init_service() -> InfrahubServices:
     return await InfrahubServices.new(client=InfrahubClient(), workflow=WorkflowLocalExecution())
 
 

--- a/backend/tests/component/git/test_utils.py
+++ b/backend/tests/component/git/test_utils.py
@@ -10,7 +10,7 @@ from infrahub.git.utils import get_repositories_commit_per_branch
 
 
 @pytest.fixture
-async def repository_01(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch):
+async def repository_01(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch) -> Node:
     repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY, branch=default_branch)
     await repo.new(db=db, name="repo01", default_branch=default_branch.name, commit="commit01", location="location01")
     await repo.save(db=db)
@@ -18,7 +18,7 @@ async def repository_01(db: InfrahubDatabase, register_core_models_schema, defau
 
 
 @pytest.fixture
-async def repository_02(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch):
+async def repository_02(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch) -> Node:
     repo = await Node.init(db=db, schema=InfrahubKind.READONLYREPOSITORY, branch=default_branch)
     await repo.new(db=db, name="repo02", ref=default_branch.name, commit="commit02", location="location02")
     await repo.save(db=db)

--- a/backend/tests/component/graphql/mutations/test_branch.py
+++ b/backend/tests/component/graphql/mutations/test_branch.py
@@ -422,7 +422,7 @@ async def test_branch_merge_wrong_branch(
 
 async def test_branch_merge_need_upgrade_rebase(
     db: InfrahubDatabase, base_dataset_02, register_core_models_schema, session_admin, local_services: InfrahubServices
-):
+) -> None:
     branch = await create_branch(db=db, branch_name="branch_to_upgrade")
     branch.status = BranchStatus.NEED_UPGRADE_REBASE
     await branch.save(db=db)

--- a/backend/tests/component/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/component/graphql/mutations/test_proposed_change.py
@@ -559,7 +559,7 @@ async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_m
 
 async def test_merge_proposed_change_with_branch_upgrade_rebase_status(
     db: InfrahubDatabase, register_core_models_schema: None
-):
+) -> None:
     branch_name = "upgrade-rebase-status-proposed-change"
     source_branch = Branch(name=branch_name)
     source_branch.status = BranchStatus.NEED_UPGRADE_REBASE

--- a/backend/tests/component/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/component/graphql/mutations/test_resource_manager.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from infrahub.core import registry
@@ -24,7 +26,7 @@ async def prefix_pool_01(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_prefix_v4,
-):
+) -> dict[str, Any]:
     ns1 = ip_dataset_prefix_v4["ns1"]
     net140 = ip_dataset_prefix_v4["net140"]
 

--- a/backend/tests/component/graphql/queries/test_branch.py
+++ b/backend/tests/component/graphql/queries/test_branch.py
@@ -36,7 +36,7 @@ query($name: String, $partial_match: Boolean = false) {
 """
 
 
-def test_check_branch_type_has_corresponding_infrahub_branch_value_field():
+def test_check_branch_type_has_corresponding_infrahub_branch_value_field() -> None:
     exempted_fields = ("id", "created_at", "node_metadata")
     for field_name, field_value in BranchType._meta.fields.items():
         if field_name in exempted_fields:

--- a/backend/tests/component/graphql/queries/test_event.py
+++ b/backend/tests/component/graphql/queries/test_event.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -397,7 +398,7 @@ async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
     return [str(event.meta.id) for event in events_data.values()]
 
 
-def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]):
+def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]) -> dict[str, Any]:
     """
     Because we can't guarantee that Prefect is empty at the start of the test easily
     we need to exclude all events not created by this test suite.
@@ -407,7 +408,7 @@ def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]):
 
 
 @pytest.fixture(scope="module")
-async def prefect_client(prefect_test_fixture):
+async def prefect_client(prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
     async with get_client(sync_client=False) as client:
         yield client
 

--- a/backend/tests/component/graphql/queries/test_ipam.py
+++ b/backend/tests/component/graphql/queries/test_ipam.py
@@ -21,7 +21,7 @@ async def ip_dataset_01(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> dict[str, Any]:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
     # -----------------------
@@ -82,7 +82,7 @@ async def ip_dataset_02(
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
     register_ipam_schema: SchemaBranch,
-):
+) -> dict[str, Any]:
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -253,7 +253,9 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         return schema_branch
 
     @pytest.fixture(scope="class")
-    async def ip_dataset_ranges(self, db: InfrahubDatabase, default_branch: Branch, register_ipam_schema: SchemaBranch):
+    async def ip_dataset_ranges(
+        self, db: InfrahubDatabase, default_branch: Branch, register_ipam_schema: SchemaBranch
+    ) -> dict[str, Any]:
         prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
         address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -337,7 +339,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def ip_dataset_available_prefixes(
         self, db: InfrahubDatabase, default_branch: Branch, register_ipam_schema: SchemaBranch
-    ):
+    ) -> dict[str, Any]:
         prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
 
         ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -413,7 +415,7 @@ class TestIpamAvailableNodes(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def ip_dataset_range_various_kinds(
         self, db: InfrahubDatabase, default_branch: Branch, register_ipam_schema: SchemaBranch
-    ):
+    ) -> dict[str, Any]:
         prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
         address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
         alternative_address_schema = registry.schema.get_node_schema(name="TestIPAddress", branch=default_branch)

--- a/backend/tests/component/graphql/queries/test_resource_pool.py
+++ b/backend/tests/component/graphql/queries/test_resource_pool.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from infrahub.core import registry
@@ -25,7 +27,7 @@ async def prefix_pools_02(
     register_ipam_extended_schema: SchemaBranch,
     init_nodes_registry,
     ip_dataset_01,
-):
+) -> dict[str, Any]:
     ns1 = ip_dataset_01["ns1"]
     ipv6_prefix_resource = ip_dataset_01["net161"]
     ipv4_prefix_resource = ip_dataset_01["net144"]

--- a/backend/tests/component/graphql/queries/test_task.py
+++ b/backend/tests/component/graphql/queries/test_task.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -138,7 +139,7 @@ async def tag_red(db: InfrahubDatabase, default_branch: Branch) -> Node:
 
 
 @pytest.fixture
-async def prefect_client(prefect_test_fixture):
+async def prefect_client(prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
     async with get_client(sync_client=False) as client:
         yield client
 

--- a/backend/tests/component/message_bus/operations/event/test_branch.py
+++ b/backend/tests/component/message_bus/operations/event/test_branch.py
@@ -26,7 +26,7 @@ from tests.adapters.message_bus import BusRecorder
 
 
 @pytest.fixture
-async def init_service():
+async def init_service() -> InfrahubServices:
     recorder = BusRecorder()
     database = MagicMock()
     workflow = WorkflowLocalExecution()
@@ -35,7 +35,7 @@ async def init_service():
 
 
 @pytest.fixture
-def context():
+def context() -> InfrahubContext:
     return InfrahubContext(
         account=AccountSession(account_id="123", auth_type=AuthType.NONE),
         branch=BranchContext(name="main", id="placeholder"),

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -97,7 +97,7 @@ def branch_diff_01_summary() -> list[NodeDiff]:
 
 
 @pytest.fixture
-async def branch2(db: InfrahubDatabase):
+async def branch2(db: InfrahubDatabase) -> Branch:
     return await create_branch(branch_name=SOURCE_BRANCH_A, db=db)
 
 

--- a/backend/tests/component/task_manager/test_event.py
+++ b/backend/tests/component/task_manager/test_event.py
@@ -1,5 +1,6 @@
 import uuid
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
 
 import pytest
 from prefect.client.orchestration import PrefectClient, get_client
@@ -27,7 +28,7 @@ query {
 """
 
 
-def filter_outofscope_events(events: dict, in_scope_ids: list[str]):
+def filter_outofscope_events(events: dict, in_scope_ids: list[str]) -> dict[str, Any]:
     """
     Because we can't guarantee that Prefect is empty at the start of the test easily
     we need to exclude all events not created by this test suite.
@@ -37,7 +38,7 @@ def filter_outofscope_events(events: dict, in_scope_ids: list[str]):
 
 
 @pytest.fixture(scope="module")
-async def prefect_client(prefect_test_fixture: Generator[None]):
+async def prefect_client(prefect_test_fixture: Generator[None]) -> AsyncGenerator[PrefectClient, None]:
     async with get_client(sync_client=False) as client:
         yield client
 

--- a/backend/tests/component/trigger/test_tasks.py
+++ b/backend/tests/component/trigger/test_tasks.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 
 import pytest
 from prefect.client.orchestration import PrefectClient, get_client
@@ -10,7 +10,7 @@ from infrahub.workflows.initialization import setup_deployments, setup_worker_po
 
 
 @pytest.fixture
-async def prefect_client(prefect_test_fixture: Generator):
+async def prefect_client(prefect_test_fixture: Generator) -> AsyncGenerator[PrefectClient, None]:
     async with get_client(sync_client=False) as prefect_client:
         yield prefect_client
 

--- a/backend/tests/scale/common/protocols.py
+++ b/backend/tests/scale/common/protocols.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 from urllib.parse import urlparse
 
 from infrahub_sdk import Config, InfrahubClientSync
@@ -11,7 +12,7 @@ class LocustInfrahubClient(InfrahubClientSync):
         super().__init__(address=address, config=config)
         self._request_event = request_event
 
-    def execute_graphql(self, *args, **kwargs):
+    def execute_graphql(self, *args, **kwargs) -> Any:
         request_meta = {
             "request_type": "InfrahubClient",
             "name": kwargs.get("tracker", "graphql_query"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -898,7 +898,6 @@ allow-dunder-method-names = [
     "ANN001",   # Missing type annotation for function argument
     "ANN002",   # Missing type annotation for `*args`
     "ANN003",   # Missing type annotation for `**kwargs`
-    "ANN201",   # Missing return type annotation for public function
     "ANN202",   # Missing return type annotation for private function
     "LOG015",   # `info()` call on root logger
     "PLR0913",  # Too many arguments in function definition
@@ -929,7 +928,6 @@ allow-dunder-method-names = [
     ##################################################################################################
     "ANN002",   # Missing type annotation for `*args`
     "ANN003",   # Missing type annotation for `**kwargs`
-    "ANN201",   # Missing return type annotation for public function
     "ANN202",   # Missing return type annotation for private function
     "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
     "ASYNC240", # Async functions should not use pathlib.Path methods


### PR DESCRIPTION
# Why

Improve typing throughout tests and prevent future violations from being introduced.

## What changed

* ruff rules in pyproject.toml
* Return statements in tests and test functions
* Minor formatting fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixtures and functions with explicit type annotations across the testing suite to improve type safety and code clarity.

* **Chores**
  * Updated code linting configuration to enforce stricter return type annotation requirements for public functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->