### PR TITLE
link PC to diff if an open PC exists for branch diff being updated

### DIFF
--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -8,8 +8,8 @@ from opentelemetry import trace
 from prefect import flow
 
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import ValidationError
 from infrahub.log import get_logger
@@ -132,7 +132,7 @@ class DiffCoordinator:
         """Look up the ID of an OPEN CoreProposedChange for the given source branch."""
         open_proposed_changes = await NodeManager.query(
             db=self.db,
-            schema=InfrahubKind.PROPOSEDCHANGE,
+            schema=CoreProposedChange,
             filters={
                 "source_branch__value": branch_name,
                 "state__value": ProposedChangeState.OPEN.value,

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -8,9 +8,12 @@ from opentelemetry import trace
 from prefect import flow
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import ValidationError
 from infrahub.log import get_logger
+from infrahub.proposed_change.constants import ProposedChangeState
 
 from ..query.diff import get_num_changes_in_time_range_by_branch
 from .model.field_specifiers_map import NodeFieldSpecifierMap
@@ -125,21 +128,45 @@ class DiffCoordinator:
             name=name,
         )
 
+    async def _get_proposed_change_id_for_branch(self, branch_name: str) -> str | None:
+        """Look up the ID of an OPEN CoreProposedChange for the given source branch."""
+        open_proposed_changes = await NodeManager.query(
+            db=self.db,
+            schema=InfrahubKind.PROPOSEDCHANGE,
+            filters={
+                "source_branch__value": branch_name,
+                "state__value": ProposedChangeState.OPEN.value,
+            },
+        )
+        if open_proposed_changes:
+            return open_proposed_changes[0].id
+        return None
+
     async def _link_diff_to_proposed_change(
-        self, diff_root: EnrichedDiffRootMetadata, proposed_change_id: str | None
-    ) -> None:
+        self,
+        diff_root: EnrichedDiffRootMetadata,
+        proposed_change_id: str | None,
+        diff_branch_name: str,
+    ) -> str | None:
         """Link a diff root to a proposed change if needed.
 
+        If proposed_change_id is not provided, attempts to find an OPEN
+        CoreProposedChange for the given diff_branch_name.
+
         Updates the database link and the in-memory object's proposed_change_id.
+        Returns the resolved proposed_change_id (may be None).
         """
         if not proposed_change_id:
-            return
+            proposed_change_id = await self._get_proposed_change_id_for_branch(diff_branch_name)
+        if not proposed_change_id:
+            return None
         if diff_root.proposed_change_id != proposed_change_id:
             diff_uuids = [diff_root.uuid]
             if diff_root.partner_uuid:
                 diff_uuids.append(diff_root.partner_uuid)
             await self.diff_repo.link_to_proposed_change(diff_uuids=diff_uuids, proposed_change_id=proposed_change_id)
         diff_root.proposed_change_id = proposed_change_id
+        return proposed_change_id
 
     async def update_branch_diff(
         self, base_branch: Branch, diff_branch: Branch, proposed_change_id: str | None = None
@@ -156,7 +183,11 @@ class DiffCoordinator:
             ):
                 self.logger.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
                 diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
-                await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+                await self._link_diff_to_proposed_change(
+                    diff_root=diff_root,
+                    proposed_change_id=proposed_change_id,
+                    diff_branch_name=diff_branch.name,
+                )
                 return diff_root
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
@@ -178,7 +209,11 @@ class DiffCoordinator:
                         f"Branch {diff_branch.name} was merged or rebased while waiting for lock, returning latest diff"
                     )
                     diff_root = await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
-                    await self._link_diff_to_proposed_change(diff_root=diff_root, proposed_change_id=proposed_change_id)
+                    await self._link_diff_to_proposed_change(
+                        diff_root=diff_root,
+                        proposed_change_id=proposed_change_id,
+                        diff_branch_name=diff_branch.name,
+                    )
                     return diff_root
                 self.logger.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
                 enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
@@ -190,6 +225,8 @@ class DiffCoordinator:
                     force_branch_refresh=False,
                 )
 
+                if not proposed_change_id and not enriched_diffs.diff_branch_diff.proposed_change_id:
+                    proposed_change_id = await self._get_proposed_change_id_for_branch(diff_branch.name)
                 if proposed_change_id:
                     enriched_diffs.diff_branch_diff.proposed_change_id = proposed_change_id
                     enriched_diffs.base_branch_diff.proposed_change_id = proposed_change_id

--- a/backend/tests/component/core/changelog/test_diff.py
+++ b/backend/tests/component/core/changelog/test_diff.py
@@ -36,7 +36,12 @@ async def test_events_from_diff(
     assert len(changelogs) == 2
 
 
-async def test_merge_diff_changelogs(db: InfrahubDatabase, default_branch: Branch, car_person_schema: None) -> None:
+async def test_merge_diff_changelogs(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
     p1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await p1.new(db=db, name="John", height=180)
     await p1.save(db=db)
@@ -160,6 +165,10 @@ async def test_merge_diff_changelogs(db: InfrahubDatabase, default_branch: Branc
 
 
 class TestConflict:
+    @pytest.fixture(autouse=True)
+    async def _setup_proposed_change_schema(self, register_simplified_proposed_change_schema: SchemaBranch) -> None:
+        return
+
     async def _get_diff_coordinator(self, db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
         component_registry = get_component_registry()
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)

--- a/backend/tests/component/core/diff/query/test_read.py
+++ b/backend/tests/component/core/diff/query/test_read.py
@@ -18,10 +18,15 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
+from tests.conftest import do_register_simplified_proposed_change_schema
 from tests.helpers.test_app import TestInfrahub
 
 
 class TestDiffReadQuery(TestInfrahub):
+    @pytest.fixture(scope="class", autouse=True)
+    async def _setup_core_schema(self, default_branch: Branch) -> None:
+        do_register_simplified_proposed_change_schema(branch=default_branch)
+
     @pytest.fixture(scope="class")
     async def hierarchical_location_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         SCHEMA: dict[str, Any] = {

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -3,6 +3,8 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import pytest
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, InfrahubKind
@@ -16,7 +18,6 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
@@ -25,6 +26,10 @@ from infrahub.proposed_change.constants import ProposedChangeState
 
 
 class TestDiffCoordinator:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema) -> None:
+        return
+
     async def get_wrapped_diff_coordinator(
         self,
         db: InfrahubDatabase,
@@ -376,7 +381,6 @@ class TestDiffCoordinator:
     async def test_schema_deleted_on_source_and_target_branches(
         self,
         db: InfrahubDatabase,
-        register_internal_models_schema,
         default_branch: Branch,
         person_john_main,
     ) -> None:
@@ -516,7 +520,6 @@ class TestDiffCoordinator:
     async def test_open_proposed_change_discovered_when_not_provided(
         self,
         db: InfrahubDatabase,
-        register_core_models_schema: SchemaBranch,
         default_branch: Branch,
         person_john_main: Node,
     ) -> None:
@@ -561,7 +564,6 @@ class TestDiffCoordinator:
     async def test_non_open_proposed_changes_not_discovered(
         self,
         db: InfrahubDatabase,
-        register_core_models_schema: SchemaBranch,
         default_branch: Branch,
         person_john_main: Node,
     ) -> None:

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -18,8 +18,8 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
-from infrahub.core.validators.schema_branch.interface import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import SchemaNotFoundError

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -19,6 +19,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
+from infrahub.core.validators.schema_branch.interface import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import SchemaNotFoundError
@@ -27,7 +28,7 @@ from infrahub.proposed_change.constants import ProposedChangeState
 
 class TestDiffCoordinator:
     @pytest.fixture(autouse=True)
-    async def _setup_core_schema(self, register_core_models_schema) -> None:
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
         return
 
     async def get_wrapped_diff_coordinator(

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import DiffAction, InfrahubKind
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.diff.combiner import DiffCombiner
@@ -16,10 +16,12 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import SchemaNotFoundError
+from infrahub.proposed_change.constants import ProposedChangeState
 
 
 class TestDiffCoordinator:
@@ -510,3 +512,84 @@ class TestDiffCoordinator:
         assert len(retrieved_metadata) == 2
         for metadata in retrieved_metadata:
             assert metadata.proposed_change_id == proposed_change_id
+
+    async def test_open_proposed_change_discovered_when_not_provided(
+        self,
+        db: InfrahubDatabase,
+        register_core_models_schema: SchemaBranch,
+        default_branch: Branch,
+        person_john_main: Node,
+    ) -> None:
+        """When update_branch_diff is called without proposed_change_id but an OPEN
+        CoreProposedChange exists for the branch, the diff should be linked to it."""
+        branch = await create_branch(db=db, branch_name="branch")
+
+        # Create a real OPEN CoreProposedChange for this branch
+        proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE, branch=default_branch)
+        await proposed_change.new(
+            db=db,
+            name="test-pc",
+            source_branch=branch.name,
+            destination_branch=default_branch.name,
+        )
+        await proposed_change.save(db=db)
+
+        # Make a change on the branch so the diff has content
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+        # Update branch diff WITHOUT providing proposed_change_id
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        # The diff should have discovered and linked the open proposed change
+        assert diff_metadata.proposed_change_id == proposed_change.id
+
+        # Verify both diff roots are linked via the repository
+        retrieved_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[branch.name, default_branch.name],
+            proposed_change_id=proposed_change.id,
+        )
+        assert len(retrieved_metadata) == 2
+        for metadata in retrieved_metadata:
+            assert metadata.proposed_change_id == proposed_change.id
+
+    async def test_non_open_proposed_changes_not_discovered(
+        self,
+        db: InfrahubDatabase,
+        register_core_models_schema: SchemaBranch,
+        default_branch: Branch,
+        person_john_main: Node,
+    ) -> None:
+        """Diffs should not be linked to CLOSED, CANCELED, or MERGED proposed changes."""
+        branch = await create_branch(db=db, branch_name="branch")
+
+        # Create proposed changes in non-open states for this branch
+        for state in (ProposedChangeState.CLOSED, ProposedChangeState.CANCELED, ProposedChangeState.MERGED):
+            pc = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE, branch=default_branch)
+            await pc.new(
+                db=db,
+                name=f"pc-{state.value}",
+                source_branch=branch.name,
+                destination_branch=default_branch.name,
+                state=state.value,
+            )
+            await pc.save(db=db)
+
+        # Make a change on the branch so the diff has content
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        person_john_branch.height.value += 1
+        await person_john_branch.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+
+        # Update branch diff WITHOUT providing proposed_change_id
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        # The diff should NOT be linked to any of the non-open proposed changes
+        assert diff_metadata.proposed_change_id is None

--- a/backend/tests/component/core/diff/test_coordinator_lock.py
+++ b/backend/tests/component/core/diff/test_coordinator_lock.py
@@ -14,6 +14,7 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import get_component_registry
@@ -21,11 +22,13 @@ from infrahub.dependencies.registry import get_component_registry
 
 class TestDiffCoordinatorLocks:
     @pytest.fixture(autouse=True)
-    async def _setup_core_schema(self, register_core_models_schema) -> None:
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
         return
 
     @pytest.fixture
-    async def branch_with_data(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> Branch:
+    async def branch_with_data(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
+    ) -> Branch:
         lock.initialize_lock(local_only=True)
         branch_1 = await create_branch(branch_name="branch_1", db=db)
         for _ in range(10):

--- a/backend/tests/component/core/diff/test_coordinator_lock.py
+++ b/backend/tests/component/core/diff/test_coordinator_lock.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 import pytest
 
 from infrahub import config, lock
-from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.diff_locker import DiffLocker
@@ -15,15 +14,16 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot
-from infrahub.core.schema.definitions.core.repository import core_read_only_repository, core_repository
-from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import get_component_registry
 
 
 class TestDiffCoordinatorLocks:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema) -> None:
+        return
+
     @pytest.fixture
     async def branch_with_data(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> Branch:
         lock.initialize_lock(local_only=True)
@@ -43,26 +43,6 @@ class TestDiffCoordinatorLocks:
     async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
         component_registry = get_component_registry()
         return await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
-
-    @pytest.fixture
-    async def dummy_repository_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
-        dummy_repository = NodeSchema(
-            name=core_repository.name,
-            namespace=core_repository.namespace,
-        )
-        schema = SchemaRoot(nodes=[dummy_repository])
-        registry.schema.register_schema(schema=schema, branch=default_branch.name)
-        default_branch.update_schema_hash()
-        await default_branch.save(db=db)
-
-        dummy_repository = NodeSchema(
-            name=core_read_only_repository.name,
-            namespace=core_read_only_repository.namespace,
-        )
-        schema = SchemaRoot(nodes=[dummy_repository])
-        registry.schema.register_schema(schema=schema, branch=default_branch.name)
-        default_branch.update_schema_hash()
-        await default_branch.save(db=db)
 
     async def get_diff_coordinator(self, db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
         config.SETTINGS.database.max_depth_search_hierarchy = 10
@@ -195,7 +175,6 @@ class TestDiffCoordinatorLocks:
         default_branch: Branch,
         diff_repository: DiffRepository,
         branch_with_data: Branch,
-        dummy_repository_schema: None,
     ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
@@ -230,7 +209,6 @@ class TestDiffCoordinatorLocks:
         default_branch: Branch,
         diff_repository: DiffRepository,
         branch_with_data: Branch,
-        dummy_repository_schema: None,
     ) -> None:
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)

--- a/backend/tests/component/core/diff/test_diff_and_merge.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge.py
@@ -44,7 +44,7 @@ from .get_one_node import get_one_diff_node
 
 class TestDiffAndMerge:
     @pytest.fixture(autouse=True)
-    async def _setup_core_schema(self, register_core_models_schema) -> None:
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
         return
 
     @pytest.fixture

--- a/backend/tests/component/core/diff/test_diff_and_merge.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge.py
@@ -43,6 +43,10 @@ from .get_one_node import get_one_diff_node
 
 
 class TestDiffAndMerge:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema) -> None:
+        return
+
     @pytest.fixture
     async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
         component_registry = get_component_registry()
@@ -104,7 +108,6 @@ class TestDiffAndMerge:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        register_core_models_schema: SchemaBranch,
         car_person_schema: SchemaBranch,
     ) -> None:
         schema_main = registry.schema.get_schema_branch(name=default_branch.name)
@@ -1861,8 +1864,6 @@ class TestDiffAndMerge:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        register_internal_models_schema: SchemaBranch,
-        register_core_models_schema: SchemaBranch,
         car_person_schema: SchemaBranch,
         car_accord_main: Node,
         car_camry_main: Node,
@@ -2122,8 +2123,6 @@ class TestDiffAndMerge:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        register_internal_models_schema: SchemaBranch,
-        register_core_models_schema: SchemaBranch,
         car_person_schema_generics: SchemaBranch,
     ) -> None:
         # schema with multiple generics
@@ -2436,8 +2435,6 @@ class TestDiffAndMerge:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        register_internal_models_schema: SchemaBranch,
-        register_core_models_schema: SchemaBranch,
         car_person_schema: SchemaBranch,
         car_accord_main: Node,
         car_camry_main: Node,

--- a/backend/tests/component/core/test_branch_rebase.py
+++ b/backend/tests/component/core/test_branch_rebase.py
@@ -106,6 +106,7 @@ async def test_branch_rebase_diff_conflict(
     default_branch: Branch,
     workflow_local: WorkflowLocalExecution,
     dependency_provider: Provider,
+    register_simplified_proposed_change_schema: SchemaBranch,
     car_person_schema: SchemaBranch,
     car_camry_main: Node,
 ) -> None:

--- a/backend/tests/component/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_query.py
@@ -460,6 +460,7 @@ async def test_diff_tree_one_attr_change(
 async def test_diff_tree_one_relationship_change(
     db: InfrahubDatabase,
     default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
     car_person_schema: SchemaBranch,
     car_accord_main: Node,
     person_john_main: Node,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -42,6 +42,7 @@ from infrahub.core.schema.definitions.core import (
     core_generic_account,
     core_profile_schema_definition,
 )
+from infrahub.core.schema.definitions.core.propose_change import core_proposed_change
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
@@ -294,6 +295,28 @@ async def do_register_core_models_schema(branch: Branch) -> SchemaBranch:
     schema_branch = registry.schema.register_schema(schema=schema, branch=branch.name)
     branch.update_schema_hash()
     return schema_branch
+
+
+def do_register_simplified_proposed_change_schema(branch: Branch) -> SchemaBranch:
+    """Register a minimal CoreProposedChange schema with only the attributes needed for queries."""
+
+    minimal_pc = NodeSchema(
+        name=core_proposed_change.name,
+        namespace=core_proposed_change.namespace,
+        branch=core_proposed_change.branch,
+        attributes=[
+            attr for attr in core_proposed_change.attributes if attr.name in {"name", "source_branch", "state"}
+        ],
+    )
+    schema = SchemaRoot(nodes=[minimal_pc])
+    schema_branch = registry.schema.register_schema(schema=schema, branch=branch.name)
+    branch.update_schema_hash()
+    return schema_branch
+
+
+@pytest.fixture
+async def register_simplified_proposed_change_schema(default_branch: Branch) -> SchemaBranch:
+    return do_register_simplified_proposed_change_schema(branch=default_branch)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->
Intermittently failing E2E test revealed that there is a race condition if you create a proposed change for a branch and then refresh the diff on that proposed change as fast as possible, it is possible to end up temporarily not linking the new proposed change to the diff

<!-- Goal: what outcome does this PR achieve? -->
PRs adds a check for an opened proposed change on the branch for the diff being updated and links the diff to the PC, but only if the diff being updated is set to track the whole branch


And update some tests that now require the `CoreProposedChange` schema to be registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Branch diffs now automatically discover and link open proposed changes for the source branch, improving change-tracking accuracy during diffs and merges.
* **Tests**
  * Expanded test coverage and added fixtures to validate proposed-change discovery and linking behavior across diff and merge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->