### PR TITLE
IFC-2297 / Partial fix of issue #7036 : Identifier is not retrieved when queried from the Number Pools related requests

### DIFF
--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -19,14 +19,6 @@ class NumberPoolIdentifierData:
     value: int
     identifier: str
 
-    @classmethod
-    def from_db(cls, result: QueryResult) -> NumberPoolIdentifierData:
-        """Convert raw QueryResult to typed dataclass."""
-        return cls(
-            value=result.get_as_type("value", return_type=int),
-            identifier=result.get_as_type("identifier", return_type=str),
-        )
-
 
 @dataclass(frozen=True)
 class PoolIdentifierResult:
@@ -304,7 +296,13 @@ class NumberPoolGetReserved(Query):
         Returns:
             List of NumberPoolIdentifierData containing value and identifier.
         """
-        return [NumberPoolIdentifierData.from_db(result) for result in self.get_results()]
+        return [
+            NumberPoolIdentifierData(
+                value=result.get_as_type("value", return_type=int),
+                identifier=result.get_as_type("identifier", return_type=str),
+            )
+            for result in self.get_results()
+        ]
 
     def get_reservations(self) -> Generator[NumberPoolIdentifierData]:
         """Yield reservations as typed dataclass instances.
@@ -435,7 +433,10 @@ class NumberPoolGetUsed(Query):
             NumberPoolIdentifierData for each used value in the pool.
         """
         for result in self.get_results():
-            yield NumberPoolIdentifierData.from_db(result)
+            yield NumberPoolIdentifierData(
+                value=result.get_as_type("value", return_type=int),
+                identifier=result.get_as_type("identifier", return_type=str),
+            )
 
 
 class NumberPoolGetFree(Query):

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -205,6 +205,10 @@ class NumberPoolGetAllocated(Query):
             MATCH (a)-[hs_int:HAS_SOURCE]->(pool)
             WHERE hs_int.status = "active"
                 AND hs_int.to IS NULL
+                AND NOT EXISTS {
+                    MATCH (a)-[hs_deleted:HAS_SOURCE {branch: hs_int.branch, status: "deleted"}]->(pool)
+                    WHERE hs_deleted.from > hs_int.from
+                }
             RETURN true AS hs_active
             LIMIT 1
         }

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -60,6 +60,9 @@ class NumberPoolAllocatedResult:
     value: int
     """The allocated number value."""
 
+    identifier: str
+    """Identifier used for the reservation."""
+
     @classmethod
     def from_db(cls, result: QueryResult) -> NumberPoolAllocatedResult:
         """Convert raw QueryResult to typed dataclass."""

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -198,24 +198,42 @@ class NumberPoolGetAllocated(Query):
         )
         self.params.update(branch_params)
 
+        hs_branch_filter, hs_branch_params = self.branch.get_query_filter_path(
+            at=self.at.to_string(), branch_agnostic=self.branch_agnostic, variable_name="hs_int"
+        )
+        self.params.update(hs_branch_params)
+
         query = """
         MATCH (n:%(node)s)-[ha:HAS_ATTRIBUTE]-(a:Attribute {name: $node_attribute})-[hv:HAS_VALUE]-(av:AttributeValueIndexed)
         MATCH (a)-[hs:HAS_SOURCE]-(pool:%(number_pool_kind)s)-[ir:IS_RESERVED]->(av)
+        CALL (a) {
+            MATCH (a)-[hs_int:HAS_SOURCE]->(pool:%(number_pool_kind)s)
+            WHERE (%(hs_branch_filter)s) AND hs_int.status = "active"
+            RETURN true AS hs_active
+            LIMIT 1
+        }
+        WITH n, ha, a, hv, av, hs, pool, ir, hs_active
         WHERE
-            pool.uuid = $pool_id
+            hs_active = TRUE
+            AND pool.uuid = $pool_id
             AND av.value >= $start_range and av.value <= $end_range
             AND all(r in [ha, hv, hs] WHERE (%(branch_filter)s))
             AND ha.status = "active"
             AND hv.status = "active"
-            AND hs.status = "active"
         """ % {
             "node": self.pool.node.value,
             "number_pool_kind": InfrahubKind.NUMBERPOOL,
             "branch_filter": branch_filter,
+            "hs_branch_filter": hs_branch_filter,
         }
         self.add_to_query(query)
 
-        self.return_labels = ["n.uuid as id", "hv.branch as branch", "av.value as value", "ir.identifier as identifier"]
+        self.return_labels = [
+            "DISTINCT n.uuid as id",
+            "hv.branch as branch",
+            "av.value as value",
+            "ir.identifier as identifier",
+        ]
         self.order_by = ["av.value"]
 
     def get_data(self) -> list[NumberPoolAllocatedResult]:

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -198,17 +198,17 @@ class NumberPoolGetAllocated(Query):
         )
         self.params.update(branch_params)
 
-        hs_branch_filter, hs_branch_params = self.branch.get_query_filter_path(
-            at=self.at.to_string(), branch_agnostic=self.branch_agnostic, variable_name="hs_int"
-        )
-        self.params.update(hs_branch_params)
-
         query = """
         MATCH (n:%(node)s)-[ha:HAS_ATTRIBUTE]-(a:Attribute {name: $node_attribute})-[hv:HAS_VALUE]-(av:AttributeValueIndexed)
         MATCH (a)-[hs:HAS_SOURCE]-(pool:%(number_pool_kind)s)-[ir:IS_RESERVED]->(av)
-        CALL (a) {
-            MATCH (a)-[hs_int:HAS_SOURCE]->(pool:%(number_pool_kind)s)
-            WHERE (%(hs_branch_filter)s) AND hs_int.status = "active"
+        CALL (a, pool) {
+            MATCH (a)-[hs_int:HAS_SOURCE]->(pool)
+            WHERE hs_int.status = "active"
+                AND hs_int.to IS NULL
+                AND NOT EXISTS {
+                    MATCH (a)-[hs_deleted:HAS_SOURCE {branch: hs_int.branch, status: "deleted"}]->(pool)
+                    WHERE hs_deleted.from > hs_int.from
+                }
             RETURN true AS hs_active
             LIMIT 1
         }
@@ -224,7 +224,6 @@ class NumberPoolGetAllocated(Query):
             "node": self.pool.node.value,
             "number_pool_kind": InfrahubKind.NUMBERPOOL,
             "branch_filter": branch_filter,
-            "hs_branch_filter": hs_branch_filter,
         }
         self.add_to_query(query)
 

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -63,16 +63,6 @@ class NumberPoolAllocatedResult:
     identifier: str
     """Identifier used for the reservation."""
 
-    @classmethod
-    def from_db(cls, result: QueryResult) -> NumberPoolAllocatedResult:
-        """Convert raw QueryResult to typed dataclass."""
-        return cls(
-            id=result.get_as_type("id", str),
-            branch=result.get_as_type("branch", str),
-            value=result.get_as_type("value", int),
-            identifier=result.get_as_type("identifier", str),
-        )
-
 
 @dataclass(frozen=True)
 class NumberPoolFreeData:
@@ -242,7 +232,15 @@ class NumberPoolGetAllocated(Query):
         Returns:
             List of NumberPoolAllocatedResult containing allocated number info.
         """
-        return [NumberPoolAllocatedResult.from_db(result) for result in self.get_results()]
+        return [
+            NumberPoolAllocatedResult(
+                id=result.get_as_type("id", str),
+                branch=result.get_as_type("branch", str),
+                value=result.get_as_type("value", int),
+                identifier=result.get_as_type("identifier", str),
+            )
+            for result in self.get_results()
+        ]
 
 
 class NumberPoolGetReserved(Query):

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -70,6 +70,7 @@ class NumberPoolAllocatedResult:
             id=result.get_as_type("id", str),
             branch=result.get_as_type("branch", str),
             value=result.get_as_type("value", int),
+            identifier=result.get_as_type("identifier", str),
         )
 
 
@@ -217,7 +218,7 @@ class NumberPoolGetAllocated(Query):
 
         query = """
         MATCH (n:%(node)s)-[ha:HAS_ATTRIBUTE]-(a:Attribute {name: $node_attribute})-[hv:HAS_VALUE]-(av:AttributeValueIndexed)
-        MATCH (a)-[hs:HAS_SOURCE]-(pool:%(number_pool_kind)s)
+        MATCH (a)-[hs:HAS_SOURCE]-(pool:%(number_pool_kind)s)-[ir:IS_RESERVED]->(av)
         WHERE
             pool.uuid = $pool_id
             AND av.value >= $start_range and av.value <= $end_range
@@ -232,7 +233,7 @@ class NumberPoolGetAllocated(Query):
         }
         self.add_to_query(query)
 
-        self.return_labels = ["n.uuid as id", "hv.branch as branch", "av.value as value"]
+        self.return_labels = ["n.uuid as id", "hv.branch as branch", "av.value as value", "ir.identifier as identifier"]
         self.order_by = ["av.value"]
 
     def get_data(self) -> list[NumberPoolAllocatedResult]:

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -205,10 +205,6 @@ class NumberPoolGetAllocated(Query):
             MATCH (a)-[hs_int:HAS_SOURCE]->(pool)
             WHERE hs_int.status = "active"
                 AND hs_int.to IS NULL
-                AND NOT EXISTS {
-                    MATCH (a)-[hs_deleted:HAS_SOURCE {branch: hs_int.branch, status: "deleted"}]->(pool)
-                    WHERE hs_deleted.from > hs_int.from
-                }
             RETURN true AS hs_active
             LIMIT 1
         }

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -292,6 +292,7 @@ async def resolve_number_pool_allocation(
                     "kind": pool.node.value,  # type: ignore[attr-defined]
                     "branch": item.branch,
                     "display_label": item.value,
+                    "identifier": item.identifier,
                 }
             }
             edges.append(node)

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -191,11 +191,7 @@ async def test_NumberPoolGetAllocated_includes_allocation_active_on_other_branch
     default_branch: Branch,
     run_number_pool_validation: None,
 ) -> None:
-    """When a node created on main is deleted on a branch, NumberPoolGetAllocated still returns it.
-
-    The allocation is still active on main (HAS_SOURCE edge remains active there),
-    so it should appear in the allocated list regardless of the branch-local deletion.
-    """
+    """When a node created on main is deleted on a branch, NumberPoolGetAllocated still returns it."""
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
     incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
     pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
@@ -223,13 +219,7 @@ async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_on
     default_branch: Branch,
     run_number_pool_validation: None,
 ) -> None:
-    """When HAS_SOURCE is cleared on a branch, the allocation still appears because it is active on main.
-
-    Setup: 3 incidents allocated on default branch → values [1, 2, 3].
-    Then on br1, clear the source of incident #2's number attribute.
-    The default branch still has an active HAS_SOURCE edge for incident #2,
-    so the allocation remains visible — it is still allocated from the pool's perspective.
-    """
+    """When HAS_SOURCE is cleared on a branch, the allocation still appears because it is active on main."""
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
     incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
     pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -1,8 +1,13 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -15,7 +20,9 @@ from infrahub.core.query.resource_manager import (
 )
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
 from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 
@@ -379,6 +386,48 @@ class TestNumberPoolGetAllocated:
         assert allocated_values == [1, 2, 3], (
             f"Expected allocation (value=2) to be counted after being re-assigned to the pool on br1; "
             f"got {allocated_values}"
+        )
+
+    async def test_NumberPoolGetAllocated_excludes_allocation_after_merging_cleared_source(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """Fork a branch from main, clear the source on forked branch. Merge the forked branch back into main. The value
+        should not be allocated anymore."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        # Fork br1 and clear the source on br1.
+        br1 = await create_branch(db=db, branch_name="br1-clear-then-merge")
+        incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+        incident2_on_br1.get_attribute("number").clear_source()
+        await incident2_on_br1.save(db=db)
+
+        # Merge br1 back into main.
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=br1)
+        diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=br1)
+        diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=br1)
+        await diff_merger.merge_graph(at=Timestamp())
+
+        query = await NumberPoolGetAllocated.init(
+            db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True
+        )
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 3], (
+            f"Expected allocation (value=2) to be excluded after merging the HAS_SOURCE removal "
+            f"from br1 into main; got {allocated_values}"
         )
 
 

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -337,6 +337,50 @@ class TestNumberPoolGetAllocated:
         allocated_values = sorted([r.value for r in results])
         assert allocated_values == [1, 3], f"Expected allocation (value=2) to be excluded. Got {allocated_values}."
 
+    async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_then_reassigned_on_branch(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """Scenario: on a child branch, source=pool -> source=null -> source=pool again; then the
+        main-branch active edge is closed so that it cannot satisfy the query on its own."""
+
+        # Step 1: creation on main.
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        # Step 2: fork br1 and clear the source on br1
+        br1 = await create_branch(db=db, branch_name="br1")
+        incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+        incident2_on_br1.get_attribute("number").clear_source()
+        await incident2_on_br1.save(db=db)
+
+        # Step 3: re-assign the source back to the pool on br1
+        incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+        incident2_on_br1.get_attribute("number").set_source(incident_pool.get_id())
+        await incident2_on_br1.save(db=db)
+
+        # Step 4: close the main-branch active edge by clearing the source on main
+        incident2_on_main = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+        incident2_on_main.get_attribute("number").clear_source()
+        await incident2_on_main.save(db=db)
+
+        query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=br1, branch_agnostic=True)
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 2, 3], (
+            f"Expected allocation (value=2) to be counted after being re-assigned to the pool on br1; "
+            f"got {allocated_values}"
+        )
+
 
 class TestPoolChangeReserved:
     async def test_PoolChangeReserved(

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -89,250 +89,285 @@ async def get_reservations(db: InfrahubDatabase, pool: CoreNumberPool, branch: B
     return {item.identifier: item.value for item in query1.get_reservations()}
 
 
-async def test_NumberPoolGetUsed(
-    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
-) -> None:
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
+class TestNumberPoolGetUsed:
+    async def test_NumberPoolGetUsed(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
 
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
 
-    # Identify the NumberPool for each model
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    assert len(pools) == 2
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+        # Identify the NumberPool for each model
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        assert len(pools) == 2
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
-    # Validate that the incident NumberPool has 3 used values
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+        # Validate that the incident NumberPool has 3 used values
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
 
-    # Create a new branch and add more incidents
-    # Ensure the query returns all used numbers across branches
-    branch2 = await create_branch(db=db, branch_name="branch2")
-    await create_objects(db=db, schema=incident_schema, branch=branch2.name, start=4, end=7)
+        # Create a new branch and add more incidents
+        # Ensure the query returns all used numbers across branches
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        await create_objects(db=db, schema=incident_schema, branch=branch2.name, start=4, end=7)
 
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6, 7]
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6, 7]
 
-    # Delete the branch and validate that the numbers allocated previously are available
-    await branch2.delete(db=db)
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+        # Delete the branch and validate that the numbers allocated previously are available
+        await branch2.delete(db=db)
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
 
-    # Create a new branch and add more incidents
-    # to ensure the query returns all used numbers across branches
-    branch3 = await create_branch(db=db, branch_name="branch3")
-    await create_objects(db=db, schema=incident_schema, branch=branch3.name, start=11, end=13)
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6]
+        # Create a new branch and add more incidents
+        # to ensure the query returns all used numbers across branches
+        branch3 = await create_branch(db=db, branch_name="branch3")
+        await create_objects(db=db, schema=incident_schema, branch=branch3.name, start=11, end=13)
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6]
 
-    # Delete the branch and validate that the numbers allocated previously are available
-    await branch3.delete(db=db)
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+        # Delete the branch and validate that the numbers allocated previously are available
+        await branch3.delete(db=db)
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
 
-    # Delete nodes in main and ensure the numbers are reallocated
-    await incidents[1].delete(db=db)
-    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 3]
-
-
-async def test_NumberPoolGetAllocated_returns_identifier(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
-
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
-
-    # Act
-    await query.execute(db=db)
-    results = query.get_data()
-
-    assert len(results) == 3
-    # Build a lookup by allocated value
-    results_by_value = {r.value: r for r in results}
-
-    # Each allocated result should have the identifier set to the node UUID
-    for idx, incident in enumerate(incidents, start=1):
-        result = results_by_value[idx]
-        assert result.identifier == incident.get_id()
+        # Delete nodes in main and ensure the numbers are reallocated
+        await incidents[1].delete(db=db)
+        assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 3]
 
 
-async def test_NumberPoolGetAllocated_excludes_deleted(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """When a node is deleted on main branch, NumberPoolGetAllocated should not return it."""
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+class TestNumberPoolGetAllocated:
+    async def test_NumberPoolGetAllocated_returns_identifier(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
-    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
-    await incident2.delete(db=db)
+        query = await NumberPoolGetAllocated.init(
+            db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True
+        )
 
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
-    await query.execute(db=db)
-    results = query.get_data()
+        # Act
+        await query.execute(db=db)
+        results = query.get_data()
 
-    allocated_values = sorted([r.value for r in results])
-    assert allocated_values == [1, 3], (
-        f"Expected deleted allocation (value=2) to be excluded on branch, got {allocated_values}"
-    )
+        assert len(results) == 3
+        # Build a lookup by allocated value
+        results_by_value = {r.value: r for r in results}
+
+        # Each allocated result should have the identifier set to the node UUID
+        for idx, incident in enumerate(incidents, start=1):
+            result = results_by_value[idx]
+            assert result.identifier == incident.get_id()
+
+    async def test_NumberPoolGetAllocated_excludes_deleted(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """When a node is deleted on main branch which is the only branch having this allocated value,
+        NumberPoolGetAllocated should not return it."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+        await incident2.delete(db=db)
+
+        query = await NumberPoolGetAllocated.init(
+            db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True
+        )
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 3], (
+            f"Expected deleted allocation (value=2) to be excluded on branch, got {allocated_values}"
+        )
+
+    async def test_NumberPoolGetAllocated_includes_allocation_active_on_other_branch(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """When a node created on main is deleted on a branch, NumberPoolGetAllocated still returns it."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        # Create a branch and delete incident #2 on that branch
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=branch2)
+        await incident2.delete(db=db)
+
+        # Query on branch2 — the allocation is still active on main, so it should appear
+        query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=branch2, branch_agnostic=True)
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 2, 3], (
+            f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
+        )
+
+    async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_on_branch(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """When HAS_SOURCE is cleared on a branch, the allocation still appears because it is active on main."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        # Create a branch and clear the source on incident #2's number attribute
+        br1 = await create_branch(db=db, branch_name="br1")
+        incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+        incident2.get_attribute("number").clear_source()
+        await incident2.save(db=db)
+
+        # Query on br1 — the allocation is still active on main, so it should appear
+        query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=br1, branch_agnostic=True)
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 2, 3], (
+            f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
+        )
+
+    async def test_NumberPoolGetAllocated_excludes_allocation_when_source_cleared_on_same_branch(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """When HAS_SOURCE is cleared on the same branch it was created on and there are no additional branches which contain
+        this allocation, the allocation must not appear."""
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+        incident2.get_attribute("number").clear_source()
+        await incident2.save(db=db)
+
+        query = await NumberPoolGetAllocated.init(
+            db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True
+        )
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 3], (
+            f"Expected allocation (value=2) to be excluded after HAS_SOURCE was cleared on the same branch, "
+            f"got {allocated_values}"
+        )
+
+    async def test_NumberPoolGetAllocated_requires_to_is_null_after_cross_branch_and_same_branch_clear(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        """
+        1. Create incidents on main
+        2. Fork br1 and clear the source on br1
+        3. Clear the source on main
+        """
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+        br1 = await create_branch(db=db, branch_name="br1")
+
+        incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+        incident2_on_br1.get_attribute("number").clear_source()
+        await incident2_on_br1.save(db=db)
+
+        incident2_on_main = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+        incident2_on_main.get_attribute("number").clear_source()
+        await incident2_on_main.save(db=db)
+
+        # Resulting state for incident #2's number attribute:
+        #  - main edge:  status="active", to=<cleared_at>
+        #  - br1 edge:   status="deleted", to=NULL
+
+        query = await NumberPoolGetAllocated.init(
+            db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True
+        )
+        await query.execute(db=db)
+        results = query.get_data()
+
+        allocated_values = sorted([r.value for r in results])
+        assert allocated_values == [1, 3], f"Expected allocation (value=2) to be excluded. Got {allocated_values}."
 
 
-async def test_NumberPoolGetAllocated_includes_allocation_active_on_other_branch(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """When a node created on main is deleted on a branch, NumberPoolGetAllocated still returns it."""
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+class TestPoolChangeReserved:
+    async def test_PoolChangeReserved(
+        self,
+        db: InfrahubDatabase,
+        register_test_schema: SchemaBranch,
+        default_branch: Branch,
+        run_number_pool_validation: None,
+    ) -> None:
+        incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+        request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
 
-    # Create a branch and delete incident #2 on that branch
-    branch2 = await create_branch(db=db, branch_name="branch2")
-    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=branch2)
-    await incident2.delete(db=db)
+        incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+        await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
+        incident = incidents[1]
 
-    # Query on branch2 — the allocation is still active on main, so it should appear
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=branch2, branch_agnostic=True)
-    await query.execute(db=db)
-    results = query.get_data()
+        pools: list[CoreNumberPool] = await NodeManager.query(
+            db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch
+        )
+        assert len(pools) == 2
+        incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
-    allocated_values = sorted([r.value for r in results])
-    assert allocated_values == [1, 2, 3], (
-        f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
-    )
+        reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
+        assert len(reservations_before) == 3
+        assert reservations_before[incident.get_id()] == 2
 
+        query = await PoolChangeReserved.init(
+            db=db, existing_identifier=incident.get_id(), new_identifier="new_id", branch=default_branch
+        )
+        await query.execute(db=db)
 
-async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_on_branch(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """When HAS_SOURCE is cleared on a branch, the allocation still appears because it is active on main."""
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
-
-    # Create a branch and clear the source on incident #2's number attribute
-    br1 = await create_branch(db=db, branch_name="br1")
-    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
-    incident2.get_attribute("number").clear_source()
-    await incident2.save(db=db)
-
-    # Query on br1 — the allocation is still active on main, so it should appear
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=br1, branch_agnostic=True)
-    await query.execute(db=db)
-    results = query.get_data()
-
-    allocated_values = sorted([r.value for r in results])
-    assert allocated_values == [1, 2, 3], (
-        f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
-    )
-
-
-async def test_NumberPoolGetAllocated_excludes_allocation_when_source_cleared_on_same_branch(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """When HAS_SOURCE is cleared on the same branch it was created on and there are no additional branches which contain
-    this allocation, the allocation must not appear."""
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
-
-    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
-    incident2.get_attribute("number").clear_source()
-    await incident2.save(db=db)
-
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
-    await query.execute(db=db)
-    results = query.get_data()
-
-    allocated_values = sorted([r.value for r in results])
-    assert allocated_values == [1, 3], (
-        f"Expected allocation (value=2) to be excluded after HAS_SOURCE was cleared on the same branch, "
-        f"got {allocated_values}"
-    )
-
-
-async def test_NumberPoolGetAllocated_requires_to_is_null_after_cross_branch_and_same_branch_clear(
-    db: InfrahubDatabase,
-    register_test_schema: SchemaBranch,
-    default_branch: Branch,
-    run_number_pool_validation: None,
-) -> None:
-    """
-      1. Create incidents on main
-      2. Fork br1 and clear the source on br1
-      3. Clear the source on main
-     """
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
-
-    br1 = await create_branch(db=db, branch_name="br1")
-
-    incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
-    incident2_on_br1.get_attribute("number").clear_source()
-    await incident2_on_br1.save(db=db)
-
-    incident2_on_main = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
-    incident2_on_main.get_attribute("number").clear_source()
-    await incident2_on_main.save(db=db)
-
-    # Resulting state for incident #2's number attribute:
-    #  - main edge:  status="active", to=<cleared_at>
-    #  - br1 edge:   status="deleted", to=NULL
-
-    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
-    await query.execute(db=db)
-    results = query.get_data()
-
-    allocated_values = sorted([r.value for r in results])
-    assert allocated_values == [1, 3], (
-        f"Expected allocation (value=2) to be excluded. Got {allocated_values}."
-    )
-
-
-async def test_PoolChangeReserved(
-    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
-) -> None:
-    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-    request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
-
-    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
-    incident = incidents[1]
-
-    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
-    assert len(pools) == 2
-    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
-
-    reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
-    assert len(reservations_before) == 3
-    assert reservations_before[incident.get_id()] == 2
-
-    query = await PoolChangeReserved.init(
-        db=db, existing_identifier=incident.get_id(), new_identifier="new_id", branch=default_branch
-    )
-    await query.execute(db=db)
-
-    reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
-    assert len(reservations_before) == 3
-    assert reservations_before["new_id"] == 2
+        reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
+        assert len(reservations_before) == 3
+        assert reservations_before["new_id"] == 2

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -134,7 +134,10 @@ async def test_NumberPoolGetUsed(
 
 
 async def test_NumberPoolGetAllocated_returns_identifier(
-    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
 ) -> None:
     """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -137,11 +137,8 @@ async def test_NumberPoolGetAllocated_returns_identifier(
     db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
 ) -> None:
     """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
-    # Arrange
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
-
     incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-
     pools: list[CoreNumberPool] = await registry.schema.query(
         db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
     )
@@ -153,9 +150,7 @@ async def test_NumberPoolGetAllocated_returns_identifier(
     await query.execute(db=db)
     results = query.get_data()
 
-    # Assert
     assert len(results) == 3
-
     # Build a lookup by allocated value
     results_by_value = {r.value: r for r in results}
 

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -242,6 +242,74 @@ async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_on
     )
 
 
+async def test_NumberPoolGetAllocated_excludes_allocation_when_source_cleared_on_same_branch(
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
+) -> None:
+    """When HAS_SOURCE is cleared on the same branch it was created on and there are no additional branches which contain
+    this allocation, the allocation must not appear."""
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+    incident2.get_attribute("number").clear_source()
+    await incident2.save(db=db)
+
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
+    await query.execute(db=db)
+    results = query.get_data()
+
+    allocated_values = sorted([r.value for r in results])
+    assert allocated_values == [1, 3], (
+        f"Expected allocation (value=2) to be excluded after HAS_SOURCE was cleared on the same branch, "
+        f"got {allocated_values}"
+    )
+
+
+async def test_NumberPoolGetAllocated_requires_to_is_null_after_cross_branch_and_same_branch_clear(
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
+) -> None:
+    """
+      1. Create incidents on main
+      2. Fork br1 and clear the source on br1
+      3. Clear the source on main
+     """
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+    br1 = await create_branch(db=db, branch_name="br1")
+
+    incident2_on_br1 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+    incident2_on_br1.get_attribute("number").clear_source()
+    await incident2_on_br1.save(db=db)
+
+    incident2_on_main = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+    incident2_on_main.get_attribute("number").clear_source()
+    await incident2_on_main.save(db=db)
+
+    # Resulting state for incident #2's number attribute:
+    #  - main edge:  status="active", to=<cleared_at>
+    #  - br1 edge:   status="deleted", to=NULL
+
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
+    await query.execute(db=db)
+    results = query.get_data()
+
+    allocated_values = sorted([r.value for r in results])
+    assert allocated_values == [1, 3], (
+        f"Expected allocation (value=2) to be excluded. Got {allocated_values}."
+    )
+
+
 async def test_PoolChangeReserved(
     db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
 ) -> None:

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -6,7 +6,12 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
-from infrahub.core.query.resource_manager import NumberPoolGetReserved, NumberPoolGetUsed, PoolChangeReserved
+from infrahub.core.query.resource_manager import (
+    NumberPoolGetAllocated,
+    NumberPoolGetReserved,
+    NumberPoolGetUsed,
+    PoolChangeReserved,
+)
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -126,6 +131,38 @@ async def test_NumberPoolGetUsed(
     # Delete nodes in main and ensure the numbers are reallocated
     await incidents[1].delete(db=db)
     assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 3]
+
+
+async def test_NumberPoolGetAllocated_returns_identifier(
+    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+) -> None:
+    """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
+    # Arrange
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+
+    pools: list[CoreNumberPool] = await registry.schema.query(
+        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
+    )
+    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
+
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
+
+    # Act
+    await query.execute(db=db)
+    results = query.get_data()
+
+    # Assert
+    assert len(results) == 3
+
+    # Build a lookup by allocated value
+    results_by_value = {r.value: r for r in results}
+
+    # Each allocated result should have the identifier set to the node UUID
+    for idx, incident in enumerate(incidents, start=1):
+        result = results_by_value[idx]
+        assert result.identifier == incident.get_id()
 
 
 async def test_PoolChangeReserved(

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -4,6 +4,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.query.resource_manager import (
@@ -98,11 +99,9 @@ async def test_NumberPoolGetUsed(
     await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
 
     # Identify the NumberPool for each model
-    pools: list[CoreNumberPool] = await registry.schema.query(
-        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
-    )
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
     assert len(pools) == 2
-    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
     # Validate that the incident NumberPool has 3 used values
     assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
@@ -142,10 +141,8 @@ async def test_NumberPoolGetAllocated_returns_identifier(
     """Test that NumberPoolGetAllocated returns the identifier (node UUID) from the IS_RESERVED relationship."""
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
     incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
-    pools: list[CoreNumberPool] = await registry.schema.query(
-        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
-    )
-    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
     query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
 
@@ -163,6 +160,98 @@ async def test_NumberPoolGetAllocated_returns_identifier(
         assert result.identifier == incident.get_id()
 
 
+async def test_NumberPoolGetAllocated_excludes_deleted(
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
+) -> None:
+    """When a node is deleted on main branch, NumberPoolGetAllocated should not return it."""
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=default_branch)
+    await incident2.delete(db=db)
+
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=default_branch, branch_agnostic=True)
+    await query.execute(db=db)
+    results = query.get_data()
+
+    allocated_values = sorted([r.value for r in results])
+    assert allocated_values == [1, 3], (
+        f"Expected deleted allocation (value=2) to be excluded on branch, got {allocated_values}"
+    )
+
+
+async def test_NumberPoolGetAllocated_includes_allocation_active_on_other_branch(
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
+) -> None:
+    """When a node created on main is deleted on a branch, NumberPoolGetAllocated still returns it.
+
+    The allocation is still active on main (HAS_SOURCE edge remains active there),
+    so it should appear in the allocated list regardless of the branch-local deletion.
+    """
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+    # Create a branch and delete incident #2 on that branch
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=branch2)
+    await incident2.delete(db=db)
+
+    # Query on branch2 — the allocation is still active on main, so it should appear
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=branch2, branch_agnostic=True)
+    await query.execute(db=db)
+    results = query.get_data()
+
+    allocated_values = sorted([r.value for r in results])
+    assert allocated_values == [1, 2, 3], (
+        f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
+    )
+
+
+async def test_NumberPoolGetAllocated_includes_allocation_when_source_cleared_on_branch(
+    db: InfrahubDatabase,
+    register_test_schema: SchemaBranch,
+    default_branch: Branch,
+    run_number_pool_validation: None,
+) -> None:
+    """When HAS_SOURCE is cleared on a branch, the allocation still appears because it is active on main.
+
+    Setup: 3 incidents allocated on default branch → values [1, 2, 3].
+    Then on br1, clear the source of incident #2's number attribute.
+    The default branch still has an active HAS_SOURCE edge for incident #2,
+    so the allocation remains visible — it is still allocated from the pool's perspective.
+    """
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
+
+    # Create a branch and clear the source on incident #2's number attribute
+    br1 = await create_branch(db=db, branch_name="br1")
+    incident2 = await NodeManager.get_one(db=db, id=incidents[1].get_id(), branch=br1)
+    incident2.get_attribute("number").clear_source()
+    await incident2.save(db=db)
+
+    # Query on br1 — the allocation is still active on main, so it should appear
+    query = await NumberPoolGetAllocated.init(db=db, pool=incident_pool, branch=br1, branch_agnostic=True)
+    await query.execute(db=db)
+    results = query.get_data()
+
+    allocated_values = sorted([r.value for r in results])
+    assert allocated_values == [1, 2, 3], (
+        f"Expected allocation (value=2) to remain visible (active on main), got {allocated_values}"
+    )
+
+
 async def test_PoolChangeReserved(
     db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
 ) -> None:
@@ -173,11 +262,9 @@ async def test_PoolChangeReserved(
     await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
     incident = incidents[1]
 
-    pools: list[CoreNumberPool] = await registry.schema.query(
-        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
-    )
+    pools: list[CoreNumberPool] = await NodeManager.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch)
     assert len(pools) == 2
-    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
+    incident_pool = next(pool for pool in pools if pool.get_attribute("node").value == INCIDENT.kind)
 
     reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
     assert len(reservations_before) == 3

--- a/backend/tests/component/graphql/queries/test_resource_pool.py
+++ b/backend/tests/component/graphql/queries/test_resource_pool.py
@@ -858,7 +858,9 @@ async def test_number_pool_utilization(
     assert first.data
     assert second.data
     assert third.data
+    first_id = first.data["TestingTicketCreate"]["object"]["id"]
     second_id = second.data["TestingTicketCreate"]["object"]["id"]
+    third_id = third.data["TestingTicketCreate"]["object"]["id"]
 
     utilization = await graphql(
         schema=gql_params.schema,
@@ -895,6 +897,15 @@ async def test_number_pool_utilization(
     assert allocation.data["InfrahubResourcePoolAllocated"]["count"] == 3
     numbers = [entry["node"]["display_label"] for entry in allocation.data["InfrahubResourcePoolAllocated"]["edges"]]
     assert sorted(numbers) == ["1", "2", "3"]
+
+    # Validate that each allocation has the node UUID as identifier
+    allocations_by_value = {
+        str(entry["node"]["display_label"]): entry["node"]
+        for entry in allocation.data["InfrahubResourcePoolAllocated"]["edges"]
+    }
+    assert allocations_by_value["1"]["identifier"] == first_id
+    assert allocations_by_value["2"]["identifier"] == second_id
+    assert allocations_by_value["3"]["identifier"] == third_id
 
     remove_two = await graphql(
         schema=gql_params.schema,

--- a/changelog/+identifier-number-pool-queries.fixed.md
+++ b/changelog/+identifier-number-pool-queries.fixed.md
@@ -1,0 +1,1 @@
+Fix identifier not being returned when querying number pool allocations via GraphQL API.


### PR DESCRIPTION
# Why
**Problems statement:** 

1. When querying attributes whose value has been allocated by a `NumberPool`, the identifier is not returned.

### Query


```graphql
query MyQuery($resource_id: String = "") {
  InfrahubResourcePoolAllocated(
    pool_id: "185b9728-1b76-dda7-d13d-106529b1bcd9"
    resource_id: $resource_id
  ) {
    count
    edges {
      node {
        branch
        display_label
        id
        identifier
        kind
      }
    }
  }
}
```

### Reponse

```
"edges": [
  {
    "node": 
    {
      "branch": "test",
      "display_label": "100",
      "id": "185b972f-4c29-7b92-d13d-1065bc2cab68",
      "identifier": null,
      "kind": "InfraVLAN"
    }
  }
]
```

This query `infrahub.core.query.resource_manager.NumberPoolSetReserved.query_init` sets an identifier into the IS_RESERVED relationship , which can be either a custom identifier or the uuid.

Currently, when one runs the `InfrahubResourcePoolAllocated` GraphQL query, no identifier is returned `infrahub.core.query.resource_manager.NumberPoolGetAllocated.query_init`.

**Goal:** Add the IS_RESERVED identifier to the return of the Cypher query used to retrieve information from the NumberPools allocations.

### What is not included

Custom identifiers management on the number pool allocations.

Closes [IFC-2297]
Partially fix https://github.com/opsmill/infrahub/issues/7036

## What changed

1. `infrahub.core.query.resource_manager.NumberPoolGetAllocated` Cypher query, which matchs an additional relationship in order to return the identifier attached to this relationship.

## How to review

- Cypher query: `infrahub.core.query.resource_manager.NumberPoolGetAllocated` alongside with performance consideration
- Impact on the resolver `infrahub.graphql.queries.resource_manager.PoolAllocated.resolve`

## How to test

<!-- Make it runnable and specific -->

```bash
uv run invoke backend.test-unit --path backend/tests/component/graphql/queries/test_resource_pool.py::test_number_pool_utilization                                                                           
   
uv run invoke backend.test-unit --path backend/tests/component/core/resource_manager/test_number_pool_query.py::test_NumberPoolGetAllocated_returns_identifier  
```

## Impact & rollout

- **Performance:** Additional relationships are matched in the query.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)


[IFC-2297]: https://opsmill.atlassian.net/browse/IFC-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL number-pool allocation responses now include resource identifiers so allocated items display the correct identifier.

* **Tests**
  * Added comprehensive tests validating allocation queries, identifier correctness after delete/reallocate, empty-state behavior, and cross-branch scenarios.

* **Chore**
  * Added changelog entry noting the identifier fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->