### PR TITLE
Fix template crash with core Component peers 

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -412,5 +412,13 @@ DEFAULT_REL_IDENTIFIER_LENGTH = 128
 
 OBJECT_TEMPLATE_RELATIONSHIP_NAME = "object_template"
 OBJECT_TEMPLATE_NAME_ATTR = "template_name"
+# Kinds that cannot be auto-generated as subtemplates. When used as COMPONENT/PARENT peers,
+# the template relationship points to the original node instead of a template version.
+SUBTEMPLATE_EXCLUDED_KINDS = [
+    InfrahubKind.NUMBERPOOL,
+    InfrahubKind.IPADDRESSPOOL,
+    InfrahubKind.IPPREFIXPOOL,
+    InfrahubKind.RESOURCEPOOL,
+]
 PROFILE_NODE_RELATIONSHIP_IDENTIFIER = "node__profile"
 PROFILE_TEMPLATE_RELATIONSHIP_IDENTIFIER = "template__profile"

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2548,16 +2548,12 @@ class SchemaBranch:
                 continue
 
             peer_schema = self.get(name=relationship.peer, duplicate=False)
-            if (
-                relationship.kind in [RelationshipKind.COMPONENT, RelationshipKind.PARENT]
-                and peer_schema.namespace in RESTRICTED_NAMESPACES
-            ):
-                continue
+            peer_in_restricted_ns = peer_schema.namespace in RESTRICTED_NAMESPACES
 
             rel_template_peer = (
-                self._get_object_template_kind(node_kind=relationship.peer)
-                if relationship.kind not in [RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC]
-                else relationship.peer
+                relationship.peer
+                if relationship.kind in [RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC] or peer_in_restricted_ns
+                else self._get_object_template_kind(node_kind=relationship.peer)
             )
 
             is_optional = (

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2547,6 +2547,13 @@ class SchemaBranch:
             ]:
                 continue
 
+            peer_schema = self.get(name=relationship.peer, duplicate=False)
+            if (
+                relationship.kind in [RelationshipKind.COMPONENT, RelationshipKind.PARENT]
+                and peer_schema.namespace in RESTRICTED_NAMESPACES
+            ):
+                continue
+
             rel_template_peer = (
                 self._get_object_template_kind(node_kind=relationship.peer)
                 if relationship.kind not in [RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC]
@@ -2688,13 +2695,23 @@ class SchemaBranch:
         self, node_schema: NodeSchema | GenericSchema, identified: set[NodeSchema | GenericSchema]
     ) -> set[NodeSchema]:
         """Identify all templates required to turn a given node into a template."""
-        if node_schema in identified or node_schema.state == HashableModelState.ABSENT:
+        if (
+            node_schema in identified
+            or node_schema.state == HashableModelState.ABSENT
+            or node_schema.namespace in RESTRICTED_NAMESPACES
+        ):
             return identified
 
         identified.add(node_schema)
 
-        if node_schema.is_node_schema:
-            identified.update([self.get(name=kind, duplicate=False) for kind in node_schema.inherit_from])
+        if isinstance(node_schema, NodeSchema):
+            identified.update(
+                [
+                    schema
+                    for schema in (self.get(name=kind, duplicate=False) for kind in node_schema.inherit_from)
+                    if isinstance(schema, NodeSchema | GenericSchema) and schema.namespace not in RESTRICTED_NAMESPACES
+                ]
+            )
 
         for relationship in node_schema.relationships:
             if (

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -23,6 +23,7 @@ from infrahub.core.constants import (
     RESERVED_ATTR_GEN_NAMES,
     RESERVED_ATTR_REL_NAMES,
     RESTRICTED_NAMESPACES,
+    SUBTEMPLATE_EXCLUDED_KINDS,
     BranchSupportType,
     ComputedAttributeKind,
     HashableModelState,
@@ -2547,12 +2548,10 @@ class SchemaBranch:
             ]:
                 continue
 
-            peer_schema = self.get(name=relationship.peer, duplicate=False)
-            peer_in_restricted_ns = peer_schema.namespace in RESTRICTED_NAMESPACES
-
             rel_template_peer = (
                 relationship.peer
-                if relationship.kind in [RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC] or peer_in_restricted_ns
+                if relationship.kind in [RelationshipKind.ATTRIBUTE, RelationshipKind.GENERIC]
+                or relationship.peer in SUBTEMPLATE_EXCLUDED_KINDS
                 else self._get_object_template_kind(node_kind=relationship.peer)
             )
 
@@ -2694,7 +2693,7 @@ class SchemaBranch:
         if (
             node_schema in identified
             or node_schema.state == HashableModelState.ABSENT
-            or node_schema.namespace in RESTRICTED_NAMESPACES
+            or node_schema.kind in SUBTEMPLATE_EXCLUDED_KINDS
         ):
             return identified
 
@@ -2705,7 +2704,7 @@ class SchemaBranch:
                 [
                     schema
                     for schema in (self.get(name=kind, duplicate=False) for kind in node_schema.inherit_from)
-                    if isinstance(schema, NodeSchema | GenericSchema) and schema.namespace not in RESTRICTED_NAMESPACES
+                    if isinstance(schema, NodeSchema | GenericSchema) and schema.kind not in SUBTEMPLATE_EXCLUDED_KINDS
                 ]
             )
 

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -4623,8 +4623,8 @@ async def test_identify_object_templates_with_generics() -> None:
     }
 
 
-async def test_manage_object_templates_component_relationship_to_core_node() -> None:
-    """Template generation must skip core nodes reached via Component relationships."""
+async def test_manage_object_templates_component_relationship_to_excluded_kind() -> None:
+    """Template generation must not create subtemplates for excluded kinds like resource pools."""
     car_schema = copy.deepcopy(CAR_SCHEMA)
     car = car_schema.get(name=TestKind.CAR)
     car.generate_template = True

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -4654,3 +4654,8 @@ async def test_manage_object_templates_component_relationship_to_core_node() -> 
 
     with pytest.raises(SchemaNotFoundError):
         schema_branch.get(name="TemplateCoreNumberPool", duplicate=False)
+
+    # The template should still have the relationship, pointing to the original core node
+    template = schema_branch.get(name=f"Template{TestKind.CAR}", duplicate=False)
+    pool_rel = template.get_relationship(name="number_pools")
+    assert pool_rel.peer == InfrahubKind.NUMBERPOOL

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -45,7 +45,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from tests.conftest import TestHelper
 from tests.constants import TestKind
-from tests.helpers.schema import CHILD, DEVICE, DEVICE_SCHEMA, THING
+from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING
 from tests.helpers.schema.device import LAG_INTERFACE
 
 from .conftest import _get_schema_by_kind
@@ -4621,3 +4621,36 @@ async def test_identify_object_templates_with_generics() -> None:
         TestKind.SFP,
         TestKind.VIRTUAL_INTERFACE,
     }
+
+
+async def test_manage_object_templates_component_relationship_to_core_node() -> None:
+    """Template generation must skip core nodes reached via Component relationships."""
+    car_schema = copy.deepcopy(CAR_SCHEMA)
+    car = car_schema.get(name=TestKind.CAR)
+    car.generate_template = True
+    car.relationships.append(
+        RelationshipSchema(
+            name="number_pools",
+            peer=InfrahubKind.NUMBERPOOL,
+            cardinality=RelationshipCardinality.MANY,
+            optional=True,
+            kind=RelationshipKind.COMPONENT,
+        ),
+    )
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(**core_models).merge(schema=car_schema))
+    schema_branch.process_inheritance()
+
+    # CoreNumberPool is a core node and should NOT be identified as needing a template, even though it is a COMPONENT peer
+    identified = schema_branch.identify_required_object_templates(
+        node_schema=schema_branch.get(name=TestKind.CAR, duplicate=False), identified=set()
+    )
+    identified_kinds = {n.kind for n in identified}
+    assert InfrahubKind.NUMBERPOOL not in identified_kinds
+
+    schema_branch.manage_object_template_schemas()
+    schema_branch.manage_object_template_relationships()
+
+    with pytest.raises(SchemaNotFoundError):
+        schema_branch.get(name="TemplateCoreNumberPool", duplicate=False)

--- a/changelog/7903.fixed.md
+++ b/changelog/7903.fixed.md
@@ -1,0 +1,1 @@
+Fixed schema loading crash when a node with `generate_template=True` has a Component relationship to a core node like `CoreNumberPool`

--- a/changelog/7903.fixed.md
+++ b/changelog/7903.fixed.md
@@ -1,1 +1,1 @@
-Fixed schema loading crash when a node with `generate_template=True` has a Component relationship to a core node like `CoreNumberPool`
+Fixed schema loading crash when a node with `generate_template=True` has a Component relationship to `CoreNumberPool`


### PR DESCRIPTION
# Why

When a user-defined node with `generate_template=True` has a Component relationship to a core/restricted namespace node like `CoreNumberPool`, the template generation pipeline incorrectly identifies the core node as needing a template.

Closes #7903

## What changed

- `identify_required_object_templates()` now returns early when it encounters a node that cannot be used to generate subtemplates, preventing some nodes from being pulled into the template set via Component relationships
- `inherit_from` expansion now filters out schemas that are not allowed to become subtemplates
- `add_relationships_to_template()` now keeps COMPONENT/PARENT relationships to peers but points them to the original node (e.g., `CoreNumberPool`) instead of a template

## How to test

```bash
uv run pytest backend/tests/component/core/schema_manager/test_manager_schema.py -x
```

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema loading when a node with template generation references certain core kinds via component relationships; template generation now preserves relationships to the original core nodes instead of creating invalid templates.

* **Chores**
  * Added a public setting that lists kinds which must not be auto-generated as subtemplates (e.g., number pool, IP address/prefix pools, resource pool).

* **Tests**
  * Added a test to verify component-to-excluded-core-kind relationships are handled correctly during template management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->