### PR TITLE
prevent CoreNumberPool duplicates

### DIFF
--- a/backend/infrahub/branch/tasks.py
+++ b/backend/infrahub/branch/tasks.py
@@ -26,4 +26,9 @@ async def branch_merged(
         branch_name=target_branch, component=service.component, db=service.database, log=log
     )
 
-    await validate_schema_number_pools(branch_name=target_branch, context=context, service=service)
+    updated_branches = await validate_schema_number_pools(branch_name=target_branch, context=context, service=service)
+
+    if updated_branches:
+        await wait_for_schema_to_converge(
+            branch_name=target_branch, component=service.component, db=service.database, log=log
+        )

--- a/backend/infrahub/core/migrations/graph/__init__.py
+++ b/backend/infrahub/core/migrations/graph/__init__.py
@@ -64,6 +64,7 @@ from .m059_recompute_permission_display_labels import Migration059
 from .m060_template_number_pool_cleanup import Migration060
 from .m061_template_ip_pool_relationship_cleanup import Migration061
 from .m062_remove_generic_generate_template import Migration062
+from .m063_consolidate_duplicate_number_pools import Migration063
 
 if TYPE_CHECKING:
     from ..shared import MigrationTypes
@@ -132,6 +133,7 @@ MIGRATIONS: list[type[MigrationTypes]] = [
     Migration060,
     Migration061,
     Migration062,
+    Migration063,
 ]
 
 

--- a/backend/infrahub/core/migrations/graph/m063_consolidate_duplicate_number_pools.py
+++ b/backend/infrahub/core/migrations/graph/m063_consolidate_duplicate_number_pools.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from infrahub.core.migrations.shared import (
+    ArbitraryMigration,
+    MigrationInput,
+    MigrationResult,
+    get_migration_console,
+)
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+console = get_migration_console()
+
+
+@dataclass
+class DuplicatePoolGroup:
+    node: str
+    node_attribute: str
+    survivor_uuid: str
+    duplicate_uuids: list[str] = field(default_factory=list)
+
+
+class Migration063(ArbitraryMigration):
+    """Consolidate duplicate CoreNumberPool instances with pool_type='Schema'
+    that share the same node + node_attribute combination.
+
+    Keeps the earliest pool (by creation timestamp) and moves all
+    IS_RESERVED and HAS_SOURCE relationships to it. Hard-deletes the duplicate pools
+    Updates any NumberPoolParameters on SchemaAttributes that reference a deleted CoreNumberPool
+    """
+
+    name: str = "063_consolidate_duplicate_number_pools"
+    minimum_version: int = 62
+
+    async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
+        return MigrationResult()
+
+    async def execute(self, migration_input: MigrationInput) -> MigrationResult:
+        db = migration_input.db
+        async with db.start_transaction() as dbt:
+            try:
+                duplicate_groups = await self._find_duplicate_groups(db=dbt)
+                if not duplicate_groups:
+                    console.log("No duplicate CoreNumberPool instances found.")
+                    return MigrationResult()
+
+                console.log(f"Found {len(duplicate_groups)} duplicate pool group(s) to consolidate.")
+
+                pool_id_map: dict[str, str] = {}
+                for group in duplicate_groups:
+                    console.log(
+                        f"Consolidating pools for node={group.node}, "
+                        f"node_attribute={group.node_attribute}: "
+                        f"keeping {group.survivor_uuid}, removing {group.duplicate_uuids}"
+                    )
+
+                    await self._reassign_is_reserved(
+                        db=dbt, survivor_uuid=group.survivor_uuid, duplicate_uuids=group.duplicate_uuids
+                    )
+                    await self._reassign_has_source(
+                        db=dbt, survivor_uuid=group.survivor_uuid, duplicate_uuids=group.duplicate_uuids
+                    )
+                    await self._delete_duplicate_pools(db=dbt, duplicate_uuids=group.duplicate_uuids)
+
+                    for dup_uuid in group.duplicate_uuids:
+                        pool_id_map[dup_uuid] = group.survivor_uuid
+
+                await self._update_schema_parameters(db=dbt, pool_id_map=pool_id_map)
+
+            except Exception as exc:
+                error_msg = str(exc) or f"{type(exc).__name__}: {repr(exc)}"
+                return MigrationResult(errors=[error_msg])
+
+        return MigrationResult()
+
+    async def _find_duplicate_groups(self, db: InfrahubDatabase) -> list[DuplicatePoolGroup]:
+        """Find groups of duplicate Schema-type CoreNumberPools sharing the same node + node_attribute."""
+        query = """
+        MATCH (pool:CoreNumberPool)
+
+        // -------------------------------------------
+        // Get latest IS_PART_OF edge; skip pool if deleted
+        // -------------------------------------------
+        CALL (pool) {
+            MATCH (pool)-[r_ipo:IS_PART_OF]->(root:Root)
+            RETURN r_ipo
+            ORDER BY r_ipo.from DESC
+            LIMIT 1
+        }
+        WITH pool, r_ipo
+        WHERE r_ipo.status = "active"
+
+        // -------------------------------------------
+        // Get latest pool_type; skip if deleted or not "Schema"
+        // -------------------------------------------
+        CALL (pool) {
+            MATCH (pool)-[r1:HAS_ATTRIBUTE]->(attr_pt:Attribute {name: "pool_type"})-[r2:HAS_VALUE]->(av_pt)
+            RETURN r1.status = "active" AND r2.status= "active" AS is_active, av_pt.value AS pool_type
+            ORDER BY r1.from DESC, r1.status ASC, r2.from DESC, r2.status ASC
+            LIMIT 1
+        }
+        WITH pool, r_ipo, is_active, pool_type
+        WHERE is_active AND pool_type = "Schema"
+
+        // -------------------------------------------
+        // Get latest node and node_attribute values
+        // almost no filtering is required
+        // b/c the schema is branch-agnostic and the attribute is mandatory
+        // -------------------------------------------
+        CALL (pool) {
+            MATCH (pool)-[r1:HAS_ATTRIBUTE]->(attr_n:Attribute {name: "node"})-[r2:HAS_VALUE]->(av_n)
+            RETURN av_n.value AS node_value
+            ORDER BY r1.from DESC, r2.from DESC
+            LIMIT 1
+        }
+        CALL (pool) {
+            MATCH (pool)-[r1:HAS_ATTRIBUTE]->(attr_n:Attribute {name: "node_attribute"})-[r2:HAS_VALUE]->(av_na)
+            RETURN av_na.value AS node_attribute_value
+            ORDER BY r1.from DESC, r2.from DESC
+            LIMIT 1
+        }
+
+        WITH pool.uuid AS pool_uuid,
+            r_ipo.from AS created_at,
+            node_value,
+            node_attribute_value
+        ORDER BY node_value, node_attribute_value, created_at ASC
+
+        WITH node_value,
+            node_attribute_value,
+            collect(pool_uuid) AS chronological_pool_ids
+        WHERE size(chronological_pool_ids) > 1
+
+        RETURN node_value,
+               node_attribute_value,
+               chronological_pool_ids[0] AS survivor_uuid,
+               chronological_pool_ids[1..] AS duplicate_uuids
+        """
+
+        results = await db.execute_query(query=query, name="find_duplicate_number_pools")
+
+        return [
+            DuplicatePoolGroup(
+                node=record["node_value"],
+                node_attribute=record["node_attribute_value"],
+                survivor_uuid=record["survivor_uuid"],
+                duplicate_uuids=list(record["duplicate_uuids"]),
+            )
+            for record in results
+        ]
+
+    async def _reassign_is_reserved(self, db: InfrahubDatabase, survivor_uuid: str, duplicate_uuids: list[str]) -> None:
+        """Move IS_RESERVED relationships from duplicate pools to the surviving pool."""
+        query = """
+        MATCH (survivor:CoreNumberPool {uuid: $survivor_uuid})
+        MATCH (dup_pool:CoreNumberPool)-[old_res:IS_RESERVED]->(target)
+        WHERE dup_pool.uuid IN $duplicate_uuids
+
+        CREATE (survivor)-[new_res:IS_RESERVED]->(target)
+        SET new_res = properties(old_res)
+        DELETE old_res
+
+        RETURN count(new_res) AS moved_count
+        """
+
+        results = await db.execute_query(
+            query=query,
+            params={"survivor_uuid": survivor_uuid, "duplicate_uuids": duplicate_uuids},
+            name="reassign_is_reserved",
+        )
+
+        if results and results[0]["moved_count"]:
+            console.log(f"  Moved {results[0]['moved_count']} IS_RESERVED relationship(s) to survivor pool.")
+
+    async def _reassign_has_source(self, db: InfrahubDatabase, survivor_uuid: str, duplicate_uuids: list[str]) -> None:
+        """Move HAS_SOURCE relationships from duplicate pools to the surviving pool."""
+        query = """
+        MATCH (survivor:CoreNumberPool {uuid: $survivor_uuid})
+        MATCH (attr:Attribute)-[old_hs:HAS_SOURCE]->(dup_pool:CoreNumberPool)
+        WHERE dup_pool.uuid IN $duplicate_uuids
+
+        CREATE (attr)-[new_hs:HAS_SOURCE]->(survivor)
+        SET new_hs = properties(old_hs)
+        DELETE old_hs
+
+        RETURN count(new_hs) AS moved_count
+        """
+
+        results = await db.execute_query(
+            query=query,
+            params={"survivor_uuid": survivor_uuid, "duplicate_uuids": duplicate_uuids},
+            name="reassign_has_source",
+        )
+
+        if results and results[0]["moved_count"]:
+            console.log(f"  Moved {results[0]['moved_count']} HAS_SOURCE relationship(s) to survivor pool.")
+
+    async def _update_schema_parameters(self, db: InfrahubDatabase, pool_id_map: dict[str, str]) -> None:
+        """Update SchemaAttribute parameters JSON where number_pool_id matches a deleted pool.
+
+        Args:
+            pool_id_map: Mapping of {duplicate_uuid: survivor_uuid} for all pools to replace.
+        """
+        query = """
+        // -------------------------------------------
+        // no edge filtering required b/c we can count on the CONTAINS UUID filter
+        // -------------------------------------------
+        UNWIND $replacements AS replacement
+        WITH replacement.dup_uuid AS dup_uuid, replacement.survivor_uuid AS survivor_uuid
+
+        CALL (dup_uuid, survivor_uuid) {
+            MATCH (sa:SchemaAttribute)-[:HAS_ATTRIBUTE]->(kind_attr:Attribute {name: "kind"})
+                -[:HAS_VALUE]->(kind_val:AttributeValue {value: "NumberPool"})
+            MATCH (sa)-[:HAS_ATTRIBUTE]->(param_attr:Attribute {name: "parameters"})
+                -[:HAS_VALUE]->(param_val:AttributeValue)
+            WHERE param_val.value CONTAINS dup_uuid
+
+            SET param_val.value = replace(param_val.value, dup_uuid, survivor_uuid)
+            RETURN 1 AS _dummy
+        }
+
+        RETURN count(*) AS updated_count
+        """
+
+        replacements = [{"dup_uuid": dup, "survivor_uuid": surv} for dup, surv in pool_id_map.items()]
+
+        results = await db.execute_query(
+            query=query,
+            params={"replacements": replacements},
+            name="update_schema_params_pool_id",
+        )
+
+        if results and results[0]["updated_count"]:
+            console.log(f"  Updated {results[0]['updated_count']} SchemaAttribute parameter(s).")
+
+    async def _delete_duplicate_pools(self, db: InfrahubDatabase, duplicate_uuids: list[str]) -> None:
+        """Hard-delete duplicate pool nodes and their attribute sub-graphs."""
+        query = """
+        // ---------------------
+        // only Attribute deletes are necessary b/c CoreNumberPool has no Relatonships
+        // ---------------------
+        MATCH (pool:CoreNumberPool)
+        WHERE pool.uuid IN $duplicate_uuids
+        OPTIONAL MATCH (pool)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+
+        DETACH DELETE attr, pool
+        """
+
+        await db.execute_query(
+            query=query,
+            params={"duplicate_uuids": duplicate_uuids},
+            name="delete_duplicate_pools",
+        )
+
+        console.log(f"  Hard-deleted {len(duplicate_uuids)} duplicate pool node(s).")

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core import registry
-from infrahub.core.node import Node
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.log import get_logger
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from infrahub.tasks.registry import update_branch_registry
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
@@ -13,12 +14,14 @@ from ..query.attribute_add import AttributeAddQuery
 from ..shared import AttributeSchemaMigration, MigrationInput, MigrationResult
 
 if TYPE_CHECKING:
-    from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+    from infrahub.core.node import Node
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.attribute_schema import AttributeSchema
     from infrahub.database import InfrahubDatabase
 
     from ...branch import Branch
+
+log = get_logger()
 
 
 class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuery):
@@ -83,12 +86,16 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         db = migration_input.db
         at = migration_input.at
 
-        number_pool: CoreNumberPool = await Node.fetch_or_create_number_pool(
+        upserter = SchemaNumberPoolUpserter(
             db=db,
-            branch=branch,
-            schema_node=self.new_schema,  # type: ignore
-            schema_attribute=self.new_attribute_schema,
+            schema_manager=registry.schema,
+        )
+        number_pool = await upserter.upsert_number_pool(
+            schema_node=self.new_schema,
+            attribute=self.new_attribute_schema,
+            branch_name=branch.name,
             at=at,
+            user_id=migration_input.user_id,
         )
 
         await update_branch_registry(db=db, branch=branch)
@@ -99,12 +106,12 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
 
         async def allocate_numbers(db: InfrahubDatabase) -> None:
             for node in nodes:
-                number = await number_pool.get_resource(
+                number = await number_pool.get_resource(  # type: ignore[attr-defined]
                     db=db, branch=branch, node=node, attribute=self.new_attribute_schema, at=at
                 )
                 attr = node.get_attribute(name=self.new_attribute_schema.name)
                 attr.value = number
-                attr.set_source(number_pool)
+                attr.set_source(number_pool.get_id())
 
                 await node.save(db=db, fields=[self.new_attribute_schema.name], at=at)
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Sequence, TypeVar, overload
 from infrahub_sdk.utils import is_valid_uuid
 from infrahub_sdk.uuidt import UUIDT
 
-from infrahub import lock
 from infrahub.computed_attribute.jinja2 import InfrahubJinja2Template
 from infrahub.core import registry
 from infrahub.core.changelog.models import NodeChangelog
@@ -17,7 +16,6 @@ from infrahub.core.constants import (
     BranchSupportType,
     ComputedAttributeKind,
     InfrahubKind,
-    NumberPoolType,
     RelationshipCardinality,
     RelationshipKind,
 )
@@ -28,7 +26,6 @@ from infrahub.core.protocols import CoreNumberPool, CoreObjectTemplate
 from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery, NodeUpdateMetadataQuery
 from infrahub.core.schema import (
     AttributeSchema,
-    GenericSchema,
     NodeSchema,
     NonGenericSchemaTypes,
     ProfileSchema,
@@ -39,7 +36,6 @@ from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError, NodeNotFoundError, PoolExhaustedError, ValidationError
 from infrahub.pools.default_allocator import DefaultPoolAllocator
-from infrahub.pools.models import NumberPoolLockDefinition
 from infrahub.profiles.mandatory_fields_checker import ProfilesMandatoryFieldGetter
 from infrahub.templates.node_applier import NodeTemplateApplier
 from infrahub.types import ATTRIBUTE_TYPES
@@ -351,12 +347,11 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         This method only works on number pools, currently Integer is the only type that has the from_pool
         within the create code.
+
+        Supports two cases:
+        1. Schema-defined NumberPool attributes (kind="NumberPool" with number_pool_id in parameters)
+        2. User-specified from_pool (user explicitly passes {"from_pool": {"id": pool_id}} to a Number attribute)
         """
-
-        if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
-            attribute.from_pool = {"id": attribute.schema.parameters.number_pool_id}
-            attribute.is_default = False
-
         # Templates should not allocate from pools - just store the reference
         # Actual allocation happens when creating objects from the template
         if isinstance(self._schema, TemplateSchema):
@@ -367,26 +362,41 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 attribute.clear_source()
             return
 
-        if not attribute.from_pool or not allocate_resources:
-            return
-
-        try:
-            number_pool = await registry.manager.get_one_by_id_or_default_filter(
-                db=db, id=attribute.from_pool["id"], kind=CoreNumberPool
-            )
-        except NodeNotFoundError:
-            if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
-                number_pool = await self.fetch_or_create_number_pool(
-                    db=db, schema_node=self._schema, schema_attribute=attribute.schema, branch=self._branch
-                )
-
-            else:
+        number_pool_id: str | None = None
+        # Case 1: Schema-defined NumberPool attribute
+        if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
+            number_pool_id = attribute.schema.parameters.number_pool_id
+            if not number_pool_id:
                 errors.append(
                     ValidationError(
-                        {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
+                        {f"{attribute.name}": f"The pool for {attribute.name} has not been provisioned yet."}
                     )
                 )
                 return
+            attribute.from_pool = {"id": number_pool_id}
+            attribute.is_default = False
+        # Case 2: User-specified from_pool on a regular Number attribute
+        elif attribute.from_pool:
+            number_pool_id = attribute.from_pool.get("id")
+            if not number_pool_id:
+                errors.append(ValidationError({f"{attribute.name}.from_pool": "No pool ID specified in from_pool."}))
+                return
+
+        if not allocate_resources or not number_pool_id:
+            # no pool allocation necessary
+            return
+
+        try:
+            number_pool = await registry.manager.get_one(
+                db=db, id=number_pool_id, kind=CoreNumberPool, raise_on_error=True
+            )
+        except NodeNotFoundError:
+            errors.append(
+                ValidationError(
+                    {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
+                )
+            )
+            return
 
         if (
             number_pool.node.value in [self._schema.kind] + self._schema.inherit_from
@@ -412,69 +422,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     }
                 )
             )
-
-    @staticmethod
-    async def fetch_or_create_number_pool(
-        db: InfrahubDatabase,
-        schema_node: NodeSchema | GenericSchema,
-        schema_attribute: AttributeSchema,
-        branch: Branch | None = None,
-        at: Timestamp | None = None,
-    ) -> CoreNumberPool:
-        """Fetch or create a number pool based on the schema attribute parameters.
-
-        Warning, ideally this method should be outside of the Node class, but it is itself using the Node class to create the pool node.
-        """
-
-        if (
-            schema_attribute.kind != "NumberPool"
-            or not schema_attribute.parameters
-            or not isinstance(schema_attribute.parameters, NumberPoolParameters)
-        ):
-            raise ValueError("Attribute is not of type NumberPool")
-
-        number_pool_from_db: CoreNumberPool | None = None
-        number_pool_parameters: NumberPoolParameters = schema_attribute.parameters
-
-        lock_definition = NumberPoolLockDefinition(pool_id=str(number_pool_parameters.number_pool_id))
-        async with lock.registry.get(
-            name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False
-        ):
-            try:
-                number_pool_from_db = await registry.manager.get_one_by_id_or_default_filter(
-                    db=db, id=str(number_pool_parameters.number_pool_id), kind=CoreNumberPool
-                )
-                return number_pool_from_db  # type: ignore[return-value]
-
-            except NodeNotFoundError:
-                schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
-
-                pool_node = schema_node.kind
-                if schema_attribute.inherited:
-                    for generic_name in schema_node.inherit_from:
-                        generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
-                        if schema_attribute.name in generic_node.attribute_names:
-                            pool_node = generic_node.kind
-                            break
-
-                number_pool = await Node.init(db=db, schema=schema, branch=branch)
-                await number_pool.new(
-                    db=db,
-                    id=number_pool_parameters.number_pool_id,
-                    name=f"{pool_node}.{schema_attribute.name} [{number_pool_parameters.number_pool_id}]",
-                    node=pool_node,
-                    node_attribute=schema_attribute.name,
-                    start_range=number_pool_parameters.start_range,
-                    end_range=number_pool_parameters.end_range,
-                    pool_type=NumberPoolType.SCHEMA.value,
-                )
-                await number_pool.save(db=db, at=at)
-
-                # Do a lookup of the number pool to get the correct mapped type from the registry
-                # without this we don't get access to the .get_resource() method.
-                return await registry.manager.get_one_by_id_or_default_filter(
-                    db=db, id=number_pool.id, kind=CoreNumberPool
-                )
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -194,7 +194,7 @@ class NumberPoolParameters(AttributeParameters):
     )
     number_pool_id: str | None = Field(
         default=None,
-        description="The ID of the numberpool associated with this attribute",
+        description="The ID of the numberpool associated with this attribute. Only set after the number pool has been provisioned.",
         json_schema_extra={"update": UpdateSupport.NOT_SUPPORTED.value},
     )
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -7,7 +7,6 @@ import keyword
 from collections import defaultdict
 from itertools import chain, combinations
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
 from infrahub_sdk.template.exceptions import JinjaTemplateError, JinjaTemplateOperationViolationError
 from infrahub_sdk.topological_sort import DependencyCycleExistsError, topological_sort
@@ -56,7 +55,6 @@ from infrahub.core.schema import (
 )
 from infrahub.core.schema.attribute_parameters import (
     ListAttributeParameters,
-    NumberPoolParameters,
     TextAttributeParameters,
 )
 from infrahub.core.schema.attribute_schema import get_attribute_schema_class_for_kind
@@ -1235,27 +1233,13 @@ class SchemaBranch:
                             ) from None
 
     def validate_attribute_parameters(self) -> None:
-        for name in self.generics.keys():
-            generic_schema = self.get_generic(name=name, duplicate=False)
-            for attribute in generic_schema.attributes:
-                if (
-                    attribute.kind == "NumberPool"
-                    and isinstance(attribute.parameters, NumberPoolParameters)
-                    and not attribute.parameters.number_pool_id
-                ):
-                    attribute.parameters.number_pool_id = str(uuid4())
-
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
-                if attribute.kind == "NumberPool" and isinstance(attribute.parameters, NumberPoolParameters):
-                    self._validate_number_pool_parameters(
-                        node_schema=node_schema, attribute=attribute, number_pool_parameters=attribute.parameters
-                    )
+                if attribute.kind == "NumberPool":
+                    self._validate_number_pool_parameters(node_schema=node_schema, attribute=attribute)
 
-    def _validate_number_pool_parameters(
-        self, node_schema: NodeSchema, attribute: AttributeSchema, number_pool_parameters: NumberPoolParameters
-    ) -> None:
+    def _validate_number_pool_parameters(self, node_schema: NodeSchema, attribute: AttributeSchema) -> None:
         if attribute.optional:
             raise ValidationError(f"{node_schema.kind}.{attribute.name} is a NumberPool it can't be optional")
 
@@ -1264,30 +1248,26 @@ class SchemaBranch:
                 f"{node_schema.kind}.{attribute.name} is a NumberPool it has to be a read_only attribute"
             )
 
-        if attribute.inherited and not number_pool_parameters.number_pool_id:
+        if attribute.inherited:
+            # Validate that the attribute isn't inherited from multiple generics
             generics_with_attribute = []
             for generic_name in node_schema.inherit_from:
                 generic_schema = self.get_generic(name=generic_name, duplicate=False)
                 if attribute.name in generic_schema.attribute_names:
-                    generic_attribute = generic_schema.get_attribute(name=attribute.name)
                     generics_with_attribute.append(generic_schema)
-                    if isinstance(generic_attribute.parameters, NumberPoolParameters):
-                        number_pool_parameters.number_pool_id = generic_attribute.parameters.number_pool_id
 
             if len(generics_with_attribute) > 1:
+                generic_kinds = [g.kind for g in generics_with_attribute]
                 raise ValidationError(
-                    f"{node_schema.kind}.{attribute.name} is a NumberPool inherited from more than one generic"
+                    f"{node_schema.kind}.{attribute.name} is a NumberPool inherited from more than one generic: {generic_kinds}"
                 )
-        elif not attribute.inherited:
+        else:
             for generic_name in node_schema.inherit_from:
                 generic_schema = self.get_generic(name=generic_name, duplicate=False)
                 if attribute.name in generic_schema.attribute_names:
                     raise ValidationError(
                         f"Overriding '{node_schema.kind}.{attribute.name}' NumberPool attribute from generic '{generic_name}' is not supported"
                     )
-
-            if not number_pool_parameters.number_pool_id:
-                number_pool_parameters.number_pool_id = str(uuid4())
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()

--- a/backend/infrahub/pools/models.py
+++ b/backend/infrahub/pools/models.py
@@ -3,11 +3,12 @@ from dataclasses import dataclass
 
 @dataclass
 class NumberPoolLockDefinition:
-    pool_id: str
+    schema_kind: str
+    attribute_name: str
 
     @property
     def lock_name(self) -> str:
-        return f"number-pool-creation-{self.pool_id}"
+        return f"number-pool-creation-{self.schema_kind}-{self.attribute_name}"
 
     @property
     def namespace_name(self) -> str:

--- a/backend/infrahub/pools/registration.py
+++ b/backend/infrahub/pools/registration.py
@@ -10,7 +10,7 @@ def get_branches_with_schema_number_pool(kind: str, attribute_name: str) -> list
 
     for active_branch in active_branches:
         try:
-            schema = registry.schema.get(name=kind, branch=active_branch)
+            schema = registry.schema.get(name=kind, branch=active_branch, duplicate=False)
         except SchemaNotFoundError:
             continue
 

--- a/backend/infrahub/pools/schema_number_pool_synchronizer.py
+++ b/backend/infrahub/pools/schema_number_pool_synchronizer.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from infrahub.core.constants import SYSTEM_USER_ID, NumberPoolType
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreNumberPool
+from infrahub.core.registry import registry
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.log import get_logger
+from infrahub.pools.registration import get_branches_with_schema_number_pool
+
+if TYPE_CHECKING:
+    from logging import Logger, LoggerAdapter
+
+    from structlog.stdlib import BoundLogger
+
+    from infrahub.core.schema import GenericSchema, NodeSchema
+    from infrahub.core.schema.manager import SchemaManager
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+    from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
+
+default_log = get_logger()
+
+
+class SchemaNumberPoolSynchronizer:
+    """Synchronizes schema-defined number pools.
+
+    This class handles the lifecycle of CoreNumberPool instances that are defined
+    via NumberPool attributes in the schema. It ensures pools are created, updated,
+    or deleted as the schema changes across branches.
+
+    Args:
+        db: Database connection.
+        log: Logger instance.
+        schema_manager: Schema manager for looking up schemas.
+    """
+
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        schema_manager: SchemaManager,
+        upserter: SchemaNumberPoolUpserter,
+        log: Logger | LoggerAdapter | BoundLogger | None = None,
+    ) -> None:
+        self.db = db
+        self.log = log or default_log
+        self.schema_manager = schema_manager
+        self.upserter = upserter
+
+    async def run(self, user_id: str = SYSTEM_USER_ID) -> set[str]:
+        """Execute the full synchronization process.
+
+        Returns:
+            Set of branch names where schema changes were persisted.
+        """
+        await self._sync_existing_pools_with_schema(user_id=user_id)
+        return await self._process_all_branches(user_id=user_id)
+
+    async def _sync_existing_pools_with_schema(self, user_id: str) -> None:
+        """Update or delete existing pools based on current schema definitions."""
+        schema_number_pools = await NodeManager.query(
+            db=self.db,
+            schema=CoreNumberPool,
+            filters={"pool_type__value": NumberPoolType.SCHEMA.value},
+            branch_agnostic=True,
+        )
+        for schema_number_pool in schema_number_pools:
+            defined_on_branches = get_branches_with_schema_number_pool(
+                kind=schema_number_pool.node.value, attribute_name=schema_number_pool.node_attribute.value
+            )
+            if registry.default_branch in defined_on_branches:
+                await self._update_pool_from_schema(schema_number_pool, user_id=user_id)
+            elif not defined_on_branches:
+                self.log.info(
+                    f"Deleting number pool (id={schema_number_pool.id}) as it is no longer defined in the schema"
+                )
+                await schema_number_pool.delete(db=self.db, user_id=user_id)
+
+    async def _update_pool_from_schema(self, schema_number_pool: CoreNumberPool, user_id: str = SYSTEM_USER_ID) -> None:
+        """Update a pool's range parameters if they differ from the schema."""
+        schema = self.schema_manager.get(
+            name=schema_number_pool.node.value, branch=registry.default_branch, duplicate=False
+        )
+        attribute = schema.get_attribute(name=schema_number_pool.node_attribute.value)
+        number_pool_updated = False
+
+        if isinstance(attribute.parameters, NumberPoolParameters):
+            if schema_number_pool.start_range.value != attribute.parameters.start_range:
+                schema_number_pool.start_range.value = attribute.parameters.start_range
+                number_pool_updated = True
+            if schema_number_pool.end_range.value != attribute.parameters.end_range:
+                schema_number_pool.end_range.value = attribute.parameters.end_range
+                number_pool_updated = True
+
+        if number_pool_updated:
+            self.log.info(
+                f"Updating NumberPool={schema_number_pool.id} based on changes in the schema on {registry.default_branch}"
+            )
+            await schema_number_pool.save(db=self.db, user_id=user_id)
+
+    async def _process_all_branches(self, user_id: str) -> set[str]:
+        """Process all branches to create any missing number pools.
+
+        Returns:
+            Set of branch names where schema changes were persisted.
+        """
+        updated_branches: set[str] = set()
+
+        for branch_name in self.schema_manager.get_branches():
+            schemas_to_update: list[str] = []
+            schema_branch = self.schema_manager.get_schema_branch(name=branch_name)
+
+            # Process generics first so their pool IDs are available for inheriting nodes
+            for generic_name in schema_branch.generic_names:
+                generic_schema = schema_branch.get_generic(name=generic_name, duplicate=False)
+                updated_schema = await self._process_schema_node(
+                    schema_node=generic_schema,
+                    branch_name=branch_name,
+                    schema_branch=schema_branch,
+                    user_id=user_id,
+                )
+                if updated_schema:
+                    schema_branch.set(name=generic_schema.kind, schema=updated_schema)
+                    schemas_to_update.append(generic_schema.kind)
+
+            # Process nodes after generics - inherited attributes will look up pool IDs from generics
+            for node_name in schema_branch.node_names:
+                node_schema = schema_branch.get_node(name=node_name, duplicate=False)
+                updated_schema = await self._process_schema_node(
+                    schema_node=node_schema,
+                    branch_name=branch_name,
+                    schema_branch=schema_branch,
+                    user_id=user_id,
+                )
+                if updated_schema:
+                    schema_branch.set(name=node_schema.kind, schema=updated_schema)
+                    schemas_to_update.append(node_schema.kind)
+
+            if schemas_to_update:
+                self.log.info(f"Persisting schema changes to the database on {branch_name}")
+                await self.schema_manager.update_schema_branch(
+                    db=self.db, branch=branch_name, schema=schema_branch, limit=schemas_to_update, update_db=True
+                )
+                updated_branches.add(branch_name)
+
+        return updated_branches
+
+    async def _process_schema_node(
+        self,
+        schema_node: NodeSchema | GenericSchema,
+        branch_name: str,
+        schema_branch: SchemaBranch,
+        user_id: str,
+    ) -> NodeSchema | GenericSchema | None:
+        """Process NumberPool attributes for a schema node, creating pools as needed.
+
+        Args:
+            schema_node: The schema node to process.
+            branch_name: The branch name for schema lookups.
+            schema_branch: The SchemaBranch for schema lookups.
+            user_id: The user ID for any save operations.
+
+        Returns a NodeSchema or GenericSchema if the schema was updated.
+        """
+        updated_schema: NodeSchema | GenericSchema | None = None
+
+        for attribute_name in schema_node.attribute_names:
+            attribute = schema_node.get_attribute(name=attribute_name)
+            if not isinstance(attribute.parameters, NumberPoolParameters):
+                continue
+
+            if attribute.parameters.number_pool_id:
+                # Pool ID already exists, so the pool exists, move on
+                continue
+
+            # Try to get existing pool ID
+            new_pool_id = await self.upserter.get_existing_number_pool_id(
+                schema_node=schema_node,
+                attribute=attribute,
+                branch_name=branch_name,
+                schema_branch=schema_branch,
+            )
+
+            # If no pool ID, create one
+            if not new_pool_id:
+                new_pool = await self.upserter.upsert_number_pool(
+                    schema_node=schema_node,
+                    attribute=attribute,
+                    branch_name=branch_name,
+                    schema_branch=schema_branch,
+                    user_id=user_id,
+                )
+                new_pool_id = new_pool.id
+
+            self.log.info(f"Setting {schema_node.kind}.{attribute_name} number_pool_id to {new_pool_id}")
+            if not updated_schema:
+                updated_schema = schema_node.duplicate()
+            updated_attribute = updated_schema.get_attribute(name=attribute_name)
+            attribute_parameters = cast("NumberPoolParameters", updated_attribute.parameters)
+            attribute_parameters.number_pool_id = new_pool_id
+
+        return updated_schema

--- a/backend/infrahub/pools/schema_number_pool_upserter.py
+++ b/backend/infrahub/pools/schema_number_pool_upserter.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from infrahub import lock
+from infrahub.core.constants import SYSTEM_USER_ID, InfrahubKind, NumberPoolType
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.protocols import CoreNumberPool
+from infrahub.core.registry import registry
+from infrahub.core.schema import NodeSchema
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.pools.models import NumberPoolLockDefinition
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.attribute_schema import AttributeSchema
+    from infrahub.core.schema.manager import SchemaManager
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class InheritedPoolInfo:
+    pool_id: str | None
+    generic_kind: str
+
+
+class SchemaNumberPoolUpserter:
+    """Gets or creates CoreNumberPool instances for schema-defined number pools.
+
+    This class provides two main public methods:
+    - get_existing_number_pool_id: Returns the ID of an existing pool, or None
+    - upsert_number_pool: Returns a CoreNumberPool, creating it if necessary
+
+    It handles inherited attributes by looking up the pool from the generic
+    that defines the attribute.
+
+    Args:
+        db: Database connection.
+        schema_manager: Schema manager for looking up schemas.
+    """
+
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        schema_manager: SchemaManager,
+    ) -> None:
+        self.db = db
+        self.schema_manager = schema_manager
+        self._cache: dict[str, CoreNumberPool] = {}
+
+    async def get_existing_number_pool_id(
+        self,
+        schema_node: MainSchemaTypes,
+        attribute: AttributeSchema,
+        branch_name: str,
+        schema_branch: SchemaBranch | None = None,
+    ) -> str | None:
+        """Get the ID of an existing CoreNumberPool for a NumberPool attribute.
+
+        Handles inheritance by checking the generic that defines the attribute.
+
+        Args:
+            schema_node: The schema containing the NumberPool attribute.
+            attribute: The NumberPool attribute schema.
+            branch_name: Branch name for schema lookups.
+            schema_branch: Optional SchemaBranch to use for lookups (avoids re-fetching).
+
+        Returns:
+            The pool ID if found, None otherwise.
+        """
+        # If pool_id is already set on the attribute, return it
+        if isinstance(attribute.parameters, NumberPoolParameters) and attribute.parameters.number_pool_id:
+            return attribute.parameters.number_pool_id
+
+        # For inherited attributes on nodes, check the generic first
+        if attribute.inherited and isinstance(schema_node, NodeSchema):
+            inherited_info = self.get_inherited_pool_info(
+                node_schema=schema_node,
+                attribute_name=attribute.name,
+                branch_name=branch_name,
+                schema_branch=schema_branch,
+            )
+            if inherited_info and inherited_info.pool_id:
+                return inherited_info.pool_id
+
+        return None
+
+    async def upsert_number_pool(
+        self,
+        schema_node: MainSchemaTypes,
+        attribute: AttributeSchema,
+        branch_name: str,
+        at: Timestamp | None = None,
+        user_id: str = SYSTEM_USER_ID,
+        schema_branch: SchemaBranch | None = None,
+    ) -> CoreNumberPool:
+        """Get or create a CoreNumberPool for a NumberPool attribute.
+
+        Check for an existing pool.
+        If found, retrieves the pool using registry.manager.get_one().
+        If not found, creates a new pool with appropriate node and node_attribute values.
+
+        Args:
+            schema_node: The schema containing the NumberPool attribute.
+            attribute: The NumberPool attribute schema.
+            branch_name: Branch name for schema lookups.
+            at: Optional timestamp for pool creation (used for consistency in migrations).
+            user_id: The user ID to use for save operations.
+            schema_branch: Optional SchemaBranch to use for lookups (avoids re-fetching).
+
+        Returns:
+            The CoreNumberPool instance.
+
+        Raises:
+            ValueError: If the attribute is not a NumberPool type.
+        """
+        if not isinstance(attribute.parameters, NumberPoolParameters):
+            raise ValueError(f"Attribute {attribute.name} on {schema_node.kind} is not a NumberPool type")
+
+        # Check for existing pool
+        pool_id = await self.get_existing_number_pool_id(
+            schema_node=schema_node,
+            attribute=attribute,
+            branch_name=branch_name,
+            schema_branch=schema_branch,
+        )
+
+        if pool_id:
+            # Pool exists, retrieve it
+            return await self._get_by_id(pool_id)
+
+        # No existing pool, create one with distributed lock to prevent race conditions
+        pool_kind = self._get_pool_kind(schema_node, attribute, branch_name, schema_branch=schema_branch)
+        lock_definition = NumberPoolLockDefinition(schema_kind=pool_kind, attribute_name=attribute.name)
+
+        async with lock.registry.get(
+            name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False
+        ):
+            # Double-check after acquiring lock (race condition protection)
+            existing_pools = await NodeManager.query(
+                db=self.db,
+                schema=CoreNumberPool,
+                filters={
+                    "node__value": pool_kind,
+                    "node_attribute__value": attribute.name,
+                    "pool_type__value": NumberPoolType.SCHEMA.value,
+                },
+                branch_agnostic=True,
+            )
+
+            if existing_pools:
+                pool = existing_pools[0]
+                self._cache[pool.id] = pool
+                return pool
+
+            # Create new pool
+            number_pool_id = str(uuid4())
+            number_pool = await Node.init(db=self.db, schema=InfrahubKind.NUMBERPOOL)
+            await number_pool.new(
+                db=self.db,
+                id=number_pool_id,
+                name=f"{pool_kind}.{attribute.name} [{number_pool_id}]",
+                node=pool_kind,
+                node_attribute=attribute.name,
+                start_range=attribute.parameters.start_range,
+                end_range=attribute.parameters.end_range,
+                pool_type=NumberPoolType.SCHEMA.value,
+            )
+            await number_pool.save(db=self.db, at=at, user_id=user_id)
+
+            # Re-fetch using _get_by_id to get the proper CoreNumberPool instance with its methods
+            return await self._get_by_id(number_pool_id)
+
+    def get_inherited_pool_info(
+        self,
+        node_schema: MainSchemaTypes,
+        attribute_name: str,
+        branch_name: str,
+        schema_branch: SchemaBranch | None = None,
+    ) -> InheritedPoolInfo | None:
+        """Look up pool info from the generic that defines this inherited attribute.
+
+        Args:
+            node_schema: The node schema with the inherited attribute.
+            attribute_name: The name of the inherited attribute.
+            branch_name: The branch name to look up generics from.
+            schema_branch: Optional SchemaBranch to use for lookups (avoids re-fetching).
+
+        Returns:
+            InheritedPoolInfo if the generic is found, None otherwise.
+            The pool_id may be None if the generic hasn't been assigned a pool yet.
+        """
+        if not isinstance(node_schema, NodeSchema):
+            return None
+        if schema_branch is None:
+            schema_branch = self.schema_manager.get_schema_branch(name=branch_name)
+        for generic_name in node_schema.inherit_from:
+            generic_schema = schema_branch.get_generic(name=generic_name, duplicate=False)
+            if attribute_name in generic_schema.attribute_names:
+                generic_attr = generic_schema.get_attribute(name=attribute_name)
+                if isinstance(generic_attr.parameters, NumberPoolParameters):
+                    return InheritedPoolInfo(
+                        pool_id=generic_attr.parameters.number_pool_id, generic_kind=generic_schema.kind
+                    )
+
+        return None
+
+    def _get_pool_kind(
+        self,
+        schema_node: MainSchemaTypes,
+        attribute: AttributeSchema,
+        branch_name: str,
+        schema_branch: SchemaBranch | None = None,
+    ) -> str:
+        """Determine the kind to use for pool creation/lookup.
+
+        For inherited attributes on NodeSchema, returns the generic kind.
+        Otherwise returns the schema_node's kind.
+        """
+        if attribute.inherited and isinstance(schema_node, NodeSchema):
+            inherited_info = self.get_inherited_pool_info(
+                node_schema=schema_node,
+                attribute_name=attribute.name,
+                branch_name=branch_name,
+                schema_branch=schema_branch,
+            )
+            if inherited_info:
+                return inherited_info.generic_kind
+        return schema_node.kind
+
+    async def _get_by_id(self, pool_id: str) -> CoreNumberPool:
+        """Retrieve a CoreNumberPool by its ID.
+
+        Args:
+            pool_id: The ID of the CoreNumberPool to retrieve.
+
+        Returns:
+            The CoreNumberPool instance.
+
+        Raises:
+            NodeNotFoundError: If pool not found.
+        """
+        if pool_id in self._cache:
+            return self._cache[pool_id]
+
+        pool = await registry.manager.get_one(
+            db=self.db,
+            id=pool_id,
+            kind=CoreNumberPool,
+            branch_agnostic=True,
+            raise_on_error=True,
+        )
+
+        self._cache[pool_id] = pool
+        return pool

--- a/backend/infrahub/pools/tasks.py
+++ b/backend/infrahub/pools/tasks.py
@@ -3,124 +3,41 @@ from __future__ import annotations
 from prefect import flow
 from prefect.logging import get_run_logger
 
-from infrahub import lock
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
-from infrahub.core.constants import InfrahubKind, NumberPoolType
-from infrahub.core.manager import NodeManager
-from infrahub.core.node import Node
-from infrahub.core.protocols import CoreNumberPool
+from infrahub.core.branch.models import Branch
 from infrahub.core.registry import registry
-from infrahub.core.schema.attribute_parameters import NumberPoolParameters
-from infrahub.exceptions import NodeNotFoundError
-from infrahub.pools.models import NumberPoolLockDefinition
-from infrahub.pools.registration import get_branches_with_schema_number_pool
+from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 
 
 @flow(
     name="validate-schema-number-pools",
-    flow_run_name="Validate schema number pools on {branch_name}",
+    flow_run_name="Validate schema number pools",
 )
 async def validate_schema_number_pools(
     branch_name: str,  # noqa: ARG001
-    context: InfrahubContext,  # noqa: ARG001
+    context: InfrahubContext,
     service: InfrahubServices,
-) -> None:
+) -> set[str]:
     log = get_run_logger()
+    synchronizer = SchemaNumberPoolSynchronizer(
+        db=service.database,
+        schema_manager=registry.schema,
+        upserter=SchemaNumberPoolUpserter(db=service.database, schema_manager=registry.schema),
+        log=log,
+    )
+    updated_branches = await synchronizer.run(user_id=context.account.account_id)
 
-    async with service.database.start_session() as dbs:
-        schema_number_pools = await NodeManager.query(
-            db=dbs, schema=CoreNumberPool, filters={"pool_type__value": NumberPoolType.SCHEMA.value}
-        )
+    if updated_branches:
+        for updated_branch_name in updated_branches:
+            branch = await Branch.get_by_name(db=service.database, name=updated_branch_name)
+            branch.update_schema_hash()
+            await branch.save(db=service.database, user_id=context.account.account_id)
+            log.info(f"Updated schema hash for branch {updated_branch_name} after number pool synchronization")
 
-    for schema_number_pool in list(schema_number_pools):
-        defined_on_branches = get_branches_with_schema_number_pool(
-            kind=schema_number_pool.node.value, attribute_name=schema_number_pool.node_attribute.value
-        )
-        if registry.default_branch in defined_on_branches:
-            schema = registry.schema.get(name=schema_number_pool.node.value, branch=registry.default_branch)
-            attribute = schema.get_attribute(name=schema_number_pool.node_attribute.value)
-            number_pool_updated = False
-            if isinstance(attribute.parameters, NumberPoolParameters):
-                if schema_number_pool.start_range.value != attribute.parameters.start_range:
-                    schema_number_pool.start_range.value = attribute.parameters.start_range
-                    number_pool_updated = True
-                if schema_number_pool.end_range.value != attribute.parameters.end_range:
-                    schema_number_pool.end_range.value = attribute.parameters.end_range
-                    number_pool_updated = True
+        await service.component.refresh_schema_hash(branches=list(updated_branches))
+        await service.message_bus.send(RefreshRegistryBranches())
 
-            if number_pool_updated:
-                log.info(
-                    f"Updating NumberPool={schema_number_pool.id} based on changes in the schema on {registry.default_branch}"
-                )
-                await schema_number_pool.save(db=service.database)
-
-        elif not defined_on_branches:
-            log.info(f"Deleting number pool (id={schema_number_pool.id}) as it is no longer defined in the schema")
-            await schema_number_pool.delete(db=service.database)
-
-    existing_pool_ids = [pool.id for pool in schema_number_pools]
-    for registry_branch in registry.schema.get_branches():
-        schema_branch = service.database.schema.get_schema_branch(name=registry_branch)
-
-        for generic_name in schema_branch.generic_names:
-            generic_node = schema_branch.get_generic(name=generic_name, duplicate=False)
-            for attribute_name in generic_node.attribute_names:
-                attribute = generic_node.get_attribute(name=attribute_name)
-                if isinstance(attribute.parameters, NumberPoolParameters) and attribute.parameters.number_pool_id:
-                    if attribute.parameters.number_pool_id not in existing_pool_ids:
-                        await _create_number_pool(
-                            service=service,
-                            number_pool_id=attribute.parameters.number_pool_id,
-                            pool_node=generic_node.kind,
-                            pool_attribute=attribute_name,
-                            start_range=attribute.parameters.start_range,
-                            end_range=attribute.parameters.end_range,
-                        )
-                        existing_pool_ids.append(attribute.parameters.number_pool_id)
-
-        for node_name in schema_branch.node_names:
-            node = schema_branch.get_node(name=node_name, duplicate=False)
-            for attribute_name in node.attribute_names:
-                attribute = node.get_attribute(name=attribute_name)
-                if isinstance(attribute.parameters, NumberPoolParameters) and attribute.parameters.number_pool_id:
-                    if attribute.parameters.number_pool_id not in existing_pool_ids:
-                        await _create_number_pool(
-                            service=service,
-                            number_pool_id=attribute.parameters.number_pool_id,
-                            pool_node=node.kind,
-                            pool_attribute=attribute_name,
-                            start_range=attribute.parameters.start_range,
-                            end_range=attribute.parameters.end_range,
-                        )
-                        existing_pool_ids.append(attribute.parameters.number_pool_id)
-
-
-async def _create_number_pool(
-    service: InfrahubServices,
-    number_pool_id: str,
-    pool_node: str,
-    pool_attribute: str,
-    start_range: int,
-    end_range: int,
-) -> None:
-    lock_definition = NumberPoolLockDefinition(pool_id=number_pool_id)
-    async with lock.registry.get(name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False):
-        async with service.database.start_session() as dbs:
-            try:
-                await registry.manager.get_one_by_id_or_default_filter(
-                    db=dbs, id=str(number_pool_id), kind=CoreNumberPool
-                )
-            except NodeNotFoundError:
-                number_pool = await Node.init(db=dbs, schema=InfrahubKind.NUMBERPOOL, branch=registry.default_branch)
-                await number_pool.new(
-                    db=dbs,
-                    id=number_pool_id,
-                    name=f"{pool_node}.{pool_attribute} [{number_pool_id}]",
-                    node=pool_node,
-                    node_attribute=pool_attribute,
-                    start_range=start_range,
-                    end_range=end_range,
-                    pool_type=NumberPoolType.SCHEMA.value,
-                )
-                await number_pool.save(db=dbs)
+    return updated_branches

--- a/backend/infrahub/schema/tasks.py
+++ b/backend/infrahub/schema/tasks.py
@@ -24,4 +24,9 @@ async def schema_updated(
         branch_name=branch_name, component=service.component, db=service.database, log=log
     )
 
-    await validate_schema_number_pools(branch_name=branch_name, context=context, service=service)
+    updated_branches = await validate_schema_number_pools(branch_name=branch_name, context=context, service=service)
+
+    if updated_branches:
+        await wait_for_schema_to_converge(
+            branch_name=branch_name, component=service.component, db=service.database, log=log
+        )

--- a/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
@@ -16,6 +16,8 @@ from infrahub.core.validators.attribute.number_pool import (
 from infrahub.core.validators.enum import ConstraintIdentifier
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
 
 
@@ -24,6 +26,10 @@ async def snow_incident_01(db: InfrahubDatabase, default_branch: Branch, registe
     schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
     registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+    await snps.run()
 
     incident_1 = await Node.init(db=db, schema="SnowIncident", branch=default_branch)
     await incident_1.new(db=db, title="The first issue")

--- a/backend/tests/component/core/migrations/graph/test_063_consolidate_duplicate_number_pools.py
+++ b/backend/tests/component/core/migrations/graph/test_063_consolidate_duplicate_number_pools.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import InfrahubKind, MetadataOptions, NumberPoolType
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.graph.m063_consolidate_duplicate_number_pools import Migration063
+from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.query.resource_manager import NumberPoolGetReserved
+from infrahub.core.schema import SchemaRoot
+from infrahub.exceptions import NodeNotFoundError
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestMigration063:
+    @pytest.fixture
+    async def duplicate_pool_setup(
+        self, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+    ) -> dict:
+        """Load the same schema with duplicate CoreNumberPools on 3 branches.
+
+        For each branch: create a CoreNumberPool, then load a TestDevice schema whose
+        serial_number attribute references that pool via number_pool_id. Creating a device
+        on each branch allocates from the pool, producing IS_RESERVED and HAS_SOURCE edges.
+        This mirrors the real bug where loading the same schema on multiple branches
+        creates separate pools for the same node + node_attribute.
+        """
+        # Create all branches BEFORE loading any schemas
+        branches = []
+        for i in range(3):
+            branch = await create_branch(db=db, branch_name=f"pool-branch-{i}")
+            branches.append(branch)
+
+        pool_uuids = []
+        device_ids = []
+
+        for branch in branches:
+            # Create a CoreNumberPool (mimics the pool auto-created per-branch in the real bug)
+            pool = await Node.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+            await pool.new(
+                db=db,
+                name=f"pool-{branch.name}",
+                node="TestDevice",
+                node_attribute="serial_number",
+                start_range=1,
+                end_range=1000,
+                pool_type=NumberPoolType.SCHEMA.value,
+            )
+            await pool.save(db=db)
+            pool_uuids.append(pool.id)
+
+            # Load a TestDevice schema with serial_number referencing this pool
+            device_schema_dict: dict = {
+                "nodes": [
+                    {
+                        "name": "Device",
+                        "namespace": "Test",
+                        "default_filter": "name__value",
+                        "display_labels": ["name__value"],
+                        "attributes": [
+                            {"name": "name", "kind": "Text", "unique": True},
+                            {
+                                "name": "serial_number",
+                                "kind": "NumberPool",
+                                "read_only": True,
+                                "unique": True,
+                                "parameters": {
+                                    "number_pool_id": pool.id,
+                                    "start_range": 1,
+                                    "end_range": 1000,
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+            schema = SchemaRoot(**device_schema_dict)
+            schema_branch = registry.schema.register_schema(schema=schema, branch=branch.name)
+            await registry.schema.load_schema_to_db(schema=schema_branch, db=db, branch=branch, limit=["TestDevice"])
+
+            # Creating a device allocates from the pool (IS_RESERVED + HAS_SOURCE edges)
+            device = await Node.init(db=db, schema="TestDevice", branch=branch)
+            await device.new(db=db, name=f"device-{branch.name}")
+            await device.save(db=db)
+            device_ids.append(device.id)
+
+        return {
+            "branches": branches,
+            "pool_uuids": pool_uuids,
+            "device_ids": device_ids,
+        }
+
+    async def _validate_consolidation(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        branches: list[Branch],
+        pool_uuids: list[str],
+        device_ids: list[str],
+    ) -> None:
+        """Assert that only the oldest pool survives and all references point to it."""
+        oldest_uuid = pool_uuids[0]
+
+        # Only the oldest pool should survive
+        survivor = await NodeManager.get_one(db=db, id=oldest_uuid, branch_agnostic=True, raise_on_error=True)
+        assert survivor is not None
+        for deleted_uuid in pool_uuids[1:]:
+            with pytest.raises(NodeNotFoundError):
+                await NodeManager.get_one(db=db, id=deleted_uuid, branch_agnostic=True, raise_on_error=True)
+
+        # All IS_RESERVED edges should now be on the survivor pool
+        query = await NumberPoolGetReserved.init(
+            db=db, branch=default_branch, pool_id=oldest_uuid, branch_agnostic=True
+        )
+        await query.execute(db=db)
+        reservations = query.get_data()
+        assert {r.identifier for r in reservations} == set(device_ids)
+
+        # All HAS_SOURCE edges should now point to the oldest pool
+        for branch, device_id in zip(branches, device_ids, strict=True):
+            device = await NodeManager.get_one(
+                db=db, id=device_id, branch=branch, include_metadata=MetadataOptions.LINKED_NODES, raise_on_error=True
+            )
+            assert device.get_attribute("serial_number").source_id == oldest_uuid
+
+        # SchemaAttribute parameters should all reference the oldest pool
+        for branch in branches:
+            fresh_schema = await registry.schema.load_schema_from_db(db=db, branch=branch, validate_schema=False)
+            test_device = fresh_schema.get_node(name="TestDevice")
+            attr = test_device.get_attribute(name="serial_number")
+            assert attr.parameters.number_pool_id == oldest_uuid
+
+    async def test_consolidates_duplicate_pools(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        duplicate_pool_setup: dict,
+    ) -> None:
+        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+        branches = duplicate_pool_setup["branches"]
+        pool_uuids = duplicate_pool_setup["pool_uuids"]
+        device_ids = duplicate_pool_setup["device_ids"]
+
+        # First run
+        async with db.start_session() as dbs:
+            migration = Migration063()
+            result = await migration.execute(migration_input=MigrationInput(db=dbs))
+            assert not result.errors
+
+        await self._validate_consolidation(
+            db=db,
+            default_branch=default_branch,
+            branches=branches,
+            pool_uuids=pool_uuids,
+            device_ids=device_ids,
+        )
+
+        # Second run (idempotency) — should succeed with no changes
+        async with db.start_session() as dbs:
+            migration = Migration063()
+            result = await migration.execute(migration_input=MigrationInput(db=dbs))
+            assert not result.errors
+
+        await self._validate_consolidation(
+            db=db,
+            default_branch=default_branch,
+            branches=branches,
+            pool_uuids=pool_uuids,
+            device_ids=device_ids,
+        )
+
+    async def test_no_duplicates_is_noop(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+    ) -> None:
+        """When there are no duplicates, migration should complete successfully with no changes."""
+        pool = await Node.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+        await pool.new(
+            db=db,
+            name="solo-pool",
+            node="SoloDevice",
+            node_attribute="solo_attr",
+            start_range=1,
+            end_range=100,
+            pool_type=NumberPoolType.SCHEMA.value,
+        )
+        await pool.save(db=db)
+
+        async with db.start_session() as dbs:
+            migration = Migration063()
+            result = await migration.execute(migration_input=MigrationInput(db=dbs))
+            assert not result.errors
+
+        # Pool should still exist
+        existing = await NodeManager.query(
+            db=db,
+            schema=InfrahubKind.NUMBERPOOL,
+            filters={"name__value": "solo-pool"},
+        )
+        assert len(existing) == 1

--- a/backend/tests/component/core/migrations/graph/test_063_consolidate_duplicate_number_pools.py
+++ b/backend/tests/component/core/migrations/graph/test_063_consolidate_duplicate_number_pools.py
@@ -35,6 +35,7 @@ class TestMigration063:
         This mirrors the real bug where loading the same schema on multiple branches
         creates separate pools for the same node + node_attribute.
         """
+        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
         # Create all branches BEFORE loading any schemas
         branches = []
         for i in range(3):
@@ -146,7 +147,6 @@ class TestMigration063:
         default_branch: Branch,
         duplicate_pool_setup: dict,
     ) -> None:
-        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
         branches = duplicate_pool_setup["branches"]
         pool_uuids = duplicate_pool_setup["pool_uuids"]
         device_ids = duplicate_pool_setup["device_ids"]

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -4,7 +4,15 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SYSTEM_USER_ID, HashableModelState, MetadataOptions, SchemaPathType
+from infrahub.core.constants import (
+    SYSTEM_USER_ID,
+    BranchSupportType,
+    HashableModelState,
+    InfrahubKind,
+    MetadataOptions,
+    NumberPoolType,
+    SchemaPathType,
+)
 from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_add import (
@@ -17,8 +25,10 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
 )
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.path import SchemaPath
-from infrahub.core.schema import NodeSchema, SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.definitions.core.template import core_object_template
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
@@ -257,3 +267,152 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
     assert attr._get_created_by() == test_user_id
     assert attr._get_updated_at() == migration_time
     assert attr._get_updated_by() == test_user_id
+
+
+# -----------------------------------------------------------------------------
+# NumberPool Attribute Add Tests
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def server_schema_without_numberpool() -> NodeSchema:
+    """Return a TestServer schema without the NumberPool attribute."""
+    return NodeSchema(
+        name="Server",
+        namespace="Test",
+        default_filter="name__value",
+        branch=BranchSupportType.AWARE,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True, branch=BranchSupportType.AWARE),
+        ],
+    )
+
+
+@pytest.fixture
+async def server_schema_with_numberpool() -> NodeSchema:
+    """Return a TestServer schema with a NumberPool attribute."""
+    return NodeSchema(
+        name="Server",
+        namespace="Test",
+        default_filter="name__value",
+        branch=BranchSupportType.AWARE,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True, branch=BranchSupportType.AWARE),
+            AttributeSchema(
+                name="rack_unit",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                branch=BranchSupportType.AWARE,
+                parameters=NumberPoolParameters(start_range=1, end_range=100),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+async def servers_in_db(
+    db: InfrahubDatabase,
+    branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    server_schema_without_numberpool: NodeSchema,
+) -> list[Node]:
+    """Create test servers without the rack_unit attribute."""
+    # Register CoreNumberPool implementation class in registry for get_resource method
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    # Register the schema without NumberPool
+    schema = SchemaRoot(nodes=[server_schema_without_numberpool])
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+
+    servers = []
+    for i in range(3):
+        server = await Node.init(db=db, schema="TestServer", branch=branch)
+        await server.new(db=db, name=f"server-{i}")
+        await server.save(db=db)
+        servers.append(server)
+    return servers
+
+
+async def test_migration_numberpool_attribute(
+    db: InfrahubDatabase,
+    branch: Branch,
+    server_schema_with_numberpool: NodeSchema,
+    servers_in_db: list[Node],
+) -> None:
+    """Test that adding a NumberPool attribute creates the pool, allocates unique values, and sets the source."""
+    # Get the current schema (without NumberPool)
+    current_schema = registry.schema.get_node_schema(name="TestServer", branch=branch)
+
+    # Verify initial state
+    num_server_objects = await NodeManager.count(db=db, schema="TestServer", branch=branch)
+    assert num_server_objects == 3
+    initial_pool_count = len(
+        await NodeManager.query(
+            db=db,
+            schema="CoreNumberPool",
+            filters={"pool_type__value": NumberPoolType.SCHEMA.value},
+            branch_agnostic=True,
+        )
+    )
+    assert initial_pool_count == 0
+
+    # Verify the new schema has parameters
+    new_attr = server_schema_with_numberpool.get_attribute(name="rack_unit")
+    assert isinstance(new_attr.parameters, NumberPoolParameters)
+
+    # Run the migration
+    at = Timestamp()
+    migration = NodeAttributeAddMigration(
+        previous_node_schema=current_schema,
+        new_node_schema=server_schema_with_numberpool,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestServer", field_name="rack_unit"),
+    )
+
+    # Register the new schema before executing the migration
+    registry.schema.set(name="TestServer", schema=server_schema_with_numberpool, branch=branch.name)
+    registry.schema.process_schema_branch(name=branch.name)
+
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=branch)
+    assert not execution_result.errors
+
+    # Verify a CoreNumberPool was created
+    pools = await NodeManager.query(
+        db=db,
+        schema="CoreNumberPool",
+        filters={
+            "node__value": "TestServer",
+            "node_attribute__value": "rack_unit",
+            "pool_type__value": NumberPoolType.SCHEMA.value,
+        },
+        branch_agnostic=True,
+    )
+    assert len(pools) == 1
+    number_pool = pools[0]
+
+    # Verify pool parameters
+    assert number_pool.get_attribute("start_range").value == 1
+    assert number_pool.get_attribute("end_range").value == 100
+
+    # Query servers and verify they have unique rack_unit values
+    servers_map = await NodeManager.get_many(
+        db=db, branch=branch, ids=[s.get_id() for s in servers_in_db], include_metadata=MetadataOptions.SOURCE
+    )
+    assert len(servers_map) == 3
+
+    rack_unit_values = [server.get_attribute("rack_unit").value for server in servers_map.values()]
+
+    # All values should be assigned (not None)
+    assert all(v is not None for v in rack_unit_values), "All servers should have rack_unit values assigned"
+
+    # All values should be unique
+    assert len(set(rack_unit_values)) == 3, "All rack_unit values should be unique"
+
+    # All values should be within the pool range
+    assert all(1 <= v <= 100 for v in rack_unit_values), "All rack_unit values should be within range 1-100"
+
+    # Verify the source is set to the pool for all servers
+    for server in servers_map.values():
+        source = await server.get_attribute("rack_unit").get_source(db=db)
+        assert source is not None, "rack_unit should have a source set"
+        assert source.id == number_pool.id, f"rack_unit source should be the pool {number_pool.id}"

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -10,6 +10,8 @@ from infrahub.core.query.resource_manager import NumberPoolGetReserved, NumberPo
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 
 REQUEST = NodeSchema(
     name="Request",
@@ -46,6 +48,17 @@ async def register_test_schema(default_branch: Branch, register_core_models_sche
     return schema_branch
 
 
+@pytest.fixture
+async def run_number_pool_validation(db: InfrahubDatabase) -> None:
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    snps = SchemaNumberPoolSynchronizer(
+        db=db,
+        schema_manager=registry.schema,
+        upserter=upserter,
+    )
+    await snps.run()
+
+
 async def create_objects(db: InfrahubDatabase, schema: NodeSchema, branch: str, start: int, end: int) -> list[Node]:
     """Helper function to create incidents."""
     nodes = []
@@ -71,7 +84,7 @@ async def get_reservations(db: InfrahubDatabase, pool: CoreNumberPool, branch: B
 
 
 async def test_NumberPoolGetUsed(
-    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
 ) -> None:
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
     request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
@@ -116,7 +129,7 @@ async def test_NumberPoolGetUsed(
 
 
 async def test_PoolChangeReserved(
-    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch, run_number_pool_validation: None
 ) -> None:
     incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
     request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -7,9 +7,11 @@ import pytest
 
 from infrahub import config
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, NumberPoolType
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.protocols import CoreNumberPool as CoreNumberPoolProtocol
 from infrahub.core.registry import registry
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import (
@@ -23,7 +25,15 @@ from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
+
+
+def build_synchronizer(db: InfrahubDatabase) -> SchemaNumberPoolSynchronizer:
+    """Helper to build a SchemaNumberPoolSynchronizer with its dependencies."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    return SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
 
 
 def test_number_pool_with_range() -> None:
@@ -173,24 +183,6 @@ def test_number_pool_override_generic() -> None:
         schema_branch.process()
 
 
-def test_number_pool_assign_from_generics() -> None:
-    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
-    schema_branch = SchemaBranch(cache={})
-    schema_branch.load_schema(schema=schema)
-    schema_branch.process()
-
-    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
-    snow_request = schema_branch.get_node(name="SnowRequest", duplicate=False)
-
-    incident_attribute = snow_incident.get_attribute(name="number")
-    request_attribute = snow_request.get_attribute(name="number")
-
-    assert isinstance(incident_attribute.parameters, NumberPoolParameters)
-    assert isinstance(request_attribute.parameters, NumberPoolParameters)
-    assert incident_attribute.parameters.number_pool_id
-    assert incident_attribute.parameters.number_pool_id == request_attribute.parameters.number_pool_id
-
-
 def test_number_pool_fail_on_multiple_generics() -> None:
     alternate_base = deepcopy(SNOW_TASK)
     alternate_base.name = "OtherTask"
@@ -215,6 +207,10 @@ async def test_create_nodes_from_generic_numberpools(
 ) -> None:
     schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
     schema_branch = registry.schema.register_schema(schema=schema)
+
+    snps = build_synchronizer(db)
+    await snps.run()
+
     snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
     incident_attribute = snow_incident.get_attribute(name="number")
     assert isinstance(incident_attribute.parameters, NumberPoolParameters)
@@ -244,6 +240,162 @@ async def test_create_nodes_from_generic_numberpools(
     assert request_1.identifier.value == "REQ2"
     assert request_2.number.value == 3
     assert request_2.identifier.value == "REQ3"
+
+
+async def test_synchronizer_assigns_shared_pool_for_inherited_attributes(
+    db: InfrahubDatabase, register_core_models_schema: SchemaBranch
+) -> None:
+    """Test that inherited NumberPool attributes share the same pool after synchronization.
+
+    Given:
+      - GenericSchema 'SnowTask' with NumberPool attribute 'number'
+      - NodeSchema 'SnowIncident' inherits from 'SnowTask'
+      - NodeSchema 'SnowRequest' inherits from 'SnowTask'
+
+    When:
+      - SchemaNumberPoolSynchronizer.run() is called
+
+    Then:
+      - One pool ID is assigned to the generic
+      - Both inheriting nodes share that same pool ID
+    """
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
+    schema_branch = registry.schema.register_schema(schema=schema)
+
+    # Before synchronizer runs, pool IDs should be None
+    snow_task = schema_branch.get_generic(name="SnowTask", duplicate=False)
+    task_attr = snow_task.get_attribute(name="number")
+    assert isinstance(task_attr.parameters, NumberPoolParameters)
+    assert task_attr.parameters.number_pool_id is None
+
+    # Run the synchronizer
+    snps = build_synchronizer(db)
+    await snps.run()
+
+    # After synchronizer runs, get the updated schemas
+    updated_schema_branch = registry.schema.get_schema_branch(name=registry.default_branch)
+    snow_task = updated_schema_branch.get_generic(name="SnowTask", duplicate=False)
+    snow_incident = updated_schema_branch.get_node(name="SnowIncident", duplicate=False)
+    snow_request = updated_schema_branch.get_node(name="SnowRequest", duplicate=False)
+
+    task_attr = snow_task.get_attribute(name="number")
+    incident_attr = snow_incident.get_attribute(name="number")
+    request_attr = snow_request.get_attribute(name="number")
+
+    # All should have the same pool ID now
+    assert task_attr.parameters.number_pool_id is not None
+    assert incident_attr.parameters.number_pool_id is not None
+    assert request_attr.parameters.number_pool_id is not None
+    assert task_attr.parameters.number_pool_id == incident_attr.parameters.number_pool_id
+    assert task_attr.parameters.number_pool_id == request_attr.parameters.number_pool_id
+
+    # Verify the CoreNumberPool was created with correct node and node_attribute
+    pool_id = task_attr.parameters.number_pool_id
+    pools = await NodeManager.query(
+        db=db,
+        schema=CoreNumberPoolProtocol,
+        filters={"id": pool_id},
+    )
+    assert len(pools) == 1
+    pool = pools[0]
+    # Pool should reference the generic (where the attribute is defined), not the inheriting nodes
+    assert pool.node.value == "SnowTask"
+    assert pool.node_attribute.value == "number"
+    assert pool.pool_type.value.value == NumberPoolType.SCHEMA.value
+
+
+async def test_synchronizer_assigns_separate_pools_for_non_inherited_attributes(
+    db: InfrahubDatabase, register_core_models_schema: SchemaBranch
+) -> None:
+    """Test that non-inherited NumberPool attributes with the same name get separate pools.
+
+    Given:
+      - GenericSchema 'TestGeneric' (no NumberPool attribute)
+      - NodeSchema 'TestNodeA' inherits from 'TestGeneric', has NumberPool 'sequence_num'
+      - NodeSchema 'TestNodeB' inherits from 'TestGeneric', has NumberPool 'sequence_num'
+
+    When:
+      - SchemaNumberPoolSynchronizer.run() is called
+
+    Then:
+      - Two separate pools are created (one per node)
+      - Each node has its own independent pool ID
+    """
+    # Create schemas with same-named NumberPool on sibling nodes (not inherited)
+    generic_schema = GenericSchema(
+        name="TestGeneric",
+        namespace="Test",
+        include_in_menu=False,
+        label="Test Generic",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+        ],
+    )
+    node_a_schema = NodeSchema(
+        name="NodeA",
+        namespace="Test",
+        inherit_from=["TestTestGeneric"],
+        include_in_menu=True,
+        label="Node A",
+        attributes=[
+            AttributeSchema(
+                name="sequence_num",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                unique=True,
+            ),
+        ],
+    )
+    node_b_schema = NodeSchema(
+        name="NodeB",
+        namespace="Test",
+        inherit_from=["TestTestGeneric"],
+        include_in_menu=True,
+        label="Node B",
+        attributes=[
+            AttributeSchema(
+                name="sequence_num",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                unique=True,
+            ),
+        ],
+    )
+
+    schema = SchemaRoot(generics=[generic_schema], nodes=[node_a_schema, node_b_schema])
+    registry.schema.register_schema(schema=schema)
+
+    # Run the synchronizer
+    snps = build_synchronizer(db)
+    await snps.run()
+
+    # After synchronizer runs, get the updated schemas
+    updated_schema_branch = registry.schema.get_schema_branch(name=registry.default_branch)
+    node_a = updated_schema_branch.get_node(name="TestNodeA", duplicate=False)
+    node_b = updated_schema_branch.get_node(name="TestNodeB", duplicate=False)
+
+    node_a_attr = node_a.get_attribute(name="sequence_num")
+    node_b_attr = node_b.get_attribute(name="sequence_num")
+
+    # Both should have pool IDs, but they should be DIFFERENT
+    assert node_a_attr.parameters.number_pool_id is not None
+    assert node_b_attr.parameters.number_pool_id is not None
+    assert node_a_attr.parameters.number_pool_id != node_b_attr.parameters.number_pool_id
+
+    # Verify the CoreNumberPools were created with correct node and node_attribute values
+    pool_a = await NodeManager.get_one(db=db, id=node_a_attr.parameters.number_pool_id)
+    pool_b = await NodeManager.get_one(db=db, id=node_b_attr.parameters.number_pool_id)
+
+    # Each pool should reference its respective node (not inherited, so each node has its own pool)
+    assert pool_a.get_attribute("node").value == "TestNodeA"
+    assert pool_a.get_attribute("node_attribute").value == "sequence_num"
+    assert pool_a.get_attribute("pool_type").value.value == NumberPoolType.SCHEMA.value
+
+    assert pool_b.get_attribute("node").value == "TestNodeB"
+    assert pool_b.get_attribute("node_attribute").value == "sequence_num"
+    assert pool_b.get_attribute("pool_type").value.value == NumberPoolType.SCHEMA.value
 
 
 def test_validate_min_max_number_attribute() -> None:

--- a/backend/tests/component/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/component/graphql/mutations/test_resource_manager.py
@@ -14,6 +14,7 @@ from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import registry as graphql_registry
 from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
 from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.graphql import graphql
@@ -903,13 +904,14 @@ async def test_test_number_pool_update(
 
 @pytest.fixture
 async def snow_ticket_schema_with_pools(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
     upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
     snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
     await snps.run()
     registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+    graphql_registry.clear_cache()
 
 
 async def test_delete_number_pool_in_use_by_numberpool_attribute(

--- a/backend/tests/component/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/component/graphql/mutations/test_resource_manager.py
@@ -14,6 +14,8 @@ from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import SNOW_TICKET_SCHEMA, TICKET, load_schema
 
@@ -899,16 +901,25 @@ async def test_test_number_pool_update(
     assert query_after_delete.data["CoreNumberPool"]["count"] == 0
 
 
-async def test_delete_number_pool_in_use_by_numberpool_attribute(
+@pytest.fixture
+async def snow_ticket_schema_with_pools(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
 ) -> None:
     await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+    await snps.run()
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+
+async def test_delete_number_pool_in_use_by_numberpool_attribute(
+    db: InfrahubDatabase, default_branch: Branch, snow_ticket_schema_with_pools: None
+) -> None:
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     node_schema = registry.schema.get(name="SnowTask", branch=default_branch)
     number_pool_attribute = node_schema.get_attribute(name="number")
     assert isinstance(number_pool_attribute.parameters, NumberPoolParameters)
-    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
     query_before_creation = await graphql(
         schema=gql_params.schema,
         source=QUERY_NUMBER_POOL,
@@ -921,57 +932,7 @@ async def test_delete_number_pool_in_use_by_numberpool_attribute(
 
     assert not query_before_creation.errors
     assert query_before_creation.data
-    assert query_before_creation.data["CoreNumberPool"]["count"] == 0
-
-    create_snow_incident_mutation = """
-    mutation CreateSnowIncident(
-        $title: String!,
-    ) {
-    SnowIncidentCreate(
-        data: {
-        title: {value: $title},
-        }
-    ) {
-        object {
-            title {
-                value
-            }
-            number {
-                value
-                source {
-                    id
-                }
-            }
-            identifier {
-                value
-            }
-        }
-      }
-    }
-    """
-
-    create_snow_incident = await graphql(
-        schema=gql_params.schema,
-        source=create_snow_incident_mutation,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={
-            "title": "Printer is saying PC load Letter",
-        },
-    )
-
-    assert not create_snow_incident.errors
-    assert create_snow_incident.data
-    assert (
-        create_snow_incident.data["SnowIncidentCreate"]["object"]["title"]["value"]
-        == "Printer is saying PC load Letter"
-    )
-    assert create_snow_incident.data["SnowIncidentCreate"]["object"]["number"]["value"] == 1
-    assert (
-        create_snow_incident.data["SnowIncidentCreate"]["object"]["number"]["source"]["id"]
-        == number_pool_attribute.parameters.number_pool_id
-    )
-    assert create_snow_incident.data["SnowIncidentCreate"]["object"]["identifier"]["value"] == "INC1"
+    assert query_before_creation.data["CoreNumberPool"]["count"] == 1
 
     delete_fail = await graphql(
         schema=gql_params.schema,
@@ -988,15 +949,13 @@ async def test_delete_number_pool_in_use_by_numberpool_attribute(
 
 
 async def test_update_schema_number_pool_range(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+    db: InfrahubDatabase, default_branch: Branch, snow_ticket_schema_with_pools: None
 ) -> None:
-    await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     node_schema = registry.schema.get(name="SnowTask", branch=default_branch)
     number_pool_attribute = node_schema.get_attribute(name="number")
     assert isinstance(number_pool_attribute.parameters, NumberPoolParameters)
-    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
     query_before_creation = await graphql(
         schema=gql_params.schema,
         source=QUERY_NUMBER_POOL,
@@ -1009,46 +968,7 @@ async def test_update_schema_number_pool_range(
 
     assert not query_before_creation.errors
     assert query_before_creation.data
-    assert query_before_creation.data["CoreNumberPool"]["count"] == 0
-
-    create_snow_incident_mutation = """
-    mutation CreateSnowIncident(
-        $title: String!,
-    ) {
-    SnowIncidentCreate(
-        data: {
-        title: {value: $title},
-        }
-    ) {
-        object {
-            title {
-                value
-            }
-            number {
-                value
-                source {
-                    id
-                }
-            }
-            identifier {
-                value
-            }
-        }
-      }
-    }
-    """
-
-    create_snow_incident = await graphql(
-        schema=gql_params.schema,
-        source=create_snow_incident_mutation,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={
-            "title": "Printer is saying PC load Letter",
-        },
-    )
-    assert not create_snow_incident.errors
-    assert create_snow_incident.data
+    assert query_before_creation.data["CoreNumberPool"]["count"] == 1
 
     update_forbidden = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/component/pools/test_schema_number_pool_upserter.py
+++ b/backend/tests/component/pools/test_schema_number_pool_upserter.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from infrahub.core.branch.models import Branch

--- a/backend/tests/component/pools/test_schema_number_pool_upserter.py
+++ b/backend/tests/component/pools/test_schema_number_pool_upserter.py
@@ -1,3 +1,4 @@
+
 import pytest
 
 from infrahub.core.branch.models import Branch
@@ -8,6 +9,7 @@ from infrahub.core.registry import registry
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
@@ -33,7 +35,9 @@ def base_schema() -> NodeSchema:
 
 
 @pytest.fixture
-async def default_number_pool(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None) -> Node:
+async def default_number_pool(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> Node:
     number_pool = await Node.init(db=db, schema="CoreNumberPool", branch=default_branch)
     await number_pool.new(
         db=db,
@@ -89,7 +93,9 @@ async def test_get_existing_number_pool_id_returns_none_when_no_pool(
     assert pool_id is None
 
 
-async def test_upsert_number_pool_creates_new_pool(db: InfrahubDatabase, base_schema: NodeSchema) -> None:
+async def test_upsert_number_pool_creates_new_pool(
+    db: InfrahubDatabase, base_schema: NodeSchema, register_core_models_schema: SchemaBranch
+) -> None:
     """Test that upsert_number_pool creates a new pool when none exists."""
     upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
     attribute = base_schema.get_attribute("number")

--- a/backend/tests/component/pools/test_schema_number_pool_upserter.py
+++ b/backend/tests/component/pools/test_schema_number_pool_upserter.py
@@ -1,0 +1,315 @@
+import pytest
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.constants import NumberPoolType
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.registry import registry
+from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.database import InfrahubDatabase
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
+from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
+
+
+@pytest.fixture
+def base_schema() -> NodeSchema:
+    return NodeSchema(
+        name="Node",
+        namespace="Test",
+        attributes=[
+            AttributeSchema(name="name", kind="Text"),
+            AttributeSchema(
+                name="number",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                unique=True,
+                parameters=NumberPoolParameters(start_range=1, end_range=100),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+async def default_number_pool(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None) -> Node:
+    number_pool = await Node.init(db=db, schema="CoreNumberPool", branch=default_branch)
+    await number_pool.new(
+        db=db,
+        name="Pre-existing Pool",
+        node="TestNode",
+        node_attribute="number",
+        start_range=1,
+        end_range=100,
+        pool_type=NumberPoolType.SCHEMA.value,
+    )
+    await number_pool.save(db=db)
+    return number_pool
+
+
+@pytest.fixture
+def schema_with_number_pool_id(default_number_pool: Node, base_schema: NodeSchema) -> NodeSchema:
+    number_attr = base_schema.get_attribute("number")
+    number_attr.parameters.number_pool_id = default_number_pool.id
+    return base_schema
+
+
+async def test_get_existing_number_pool_id_returns_pool_id_from_attribute(
+    db: InfrahubDatabase,
+    default_number_pool: Node,
+    schema_with_number_pool_id: NodeSchema,
+) -> None:
+    """Test that get_existing_number_pool_id returns pool_id when set in parameters."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = schema_with_number_pool_id.get_attribute("number")
+
+    pool_id = await upserter.get_existing_number_pool_id(
+        schema_node=schema_with_number_pool_id,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    assert pool_id == default_number_pool.id
+
+
+async def test_get_existing_number_pool_id_returns_none_when_no_pool(
+    db: InfrahubDatabase, base_schema: NodeSchema
+) -> None:
+    """Test that get_existing_number_pool_id returns None when no pool exists."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = base_schema.get_attribute("number")
+
+    pool_id = await upserter.get_existing_number_pool_id(
+        schema_node=base_schema,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    assert pool_id is None
+
+
+async def test_upsert_number_pool_creates_new_pool(db: InfrahubDatabase, base_schema: NodeSchema) -> None:
+    """Test that upsert_number_pool creates a new pool when none exists."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = base_schema.get_attribute("number")
+
+    pool = await upserter.upsert_number_pool(
+        schema_node=base_schema,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    assert pool.node.value == "TestNode"
+    assert pool.node_attribute.value == "number"
+    assert pool.start_range.value == 1
+    assert pool.end_range.value == 100
+    assert pool.pool_type.value.value == NumberPoolType.SCHEMA.value
+
+
+async def test_upsert_number_pool_returns_existing_pool(
+    db: InfrahubDatabase,
+    base_schema: NodeSchema,
+    default_number_pool: Node,
+) -> None:
+    """Test that upsert_number_pool returns existing pool when one exists."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = base_schema.get_attribute("number")
+
+    # Create first pool
+    pool1 = await upserter.upsert_number_pool(
+        schema_node=base_schema,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    # Request again - should return the same pool
+    pool2 = await upserter.upsert_number_pool(
+        schema_node=base_schema,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    assert pool1.id == pool2.id
+
+
+async def test_upsert_number_pool_with_pool_id_set(
+    db: InfrahubDatabase, schema_with_number_pool_id: NodeSchema, default_number_pool: Node
+) -> None:
+    """Test that upsert_number_pool retrieves pool when pool_id is already set."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = schema_with_number_pool_id.get_attribute("number")
+
+    retrieved_pool = await upserter.upsert_number_pool(
+        schema_node=schema_with_number_pool_id,
+        attribute=attribute,
+        branch_name=registry.default_branch,
+    )
+
+    assert retrieved_pool.id == default_number_pool.id
+
+
+async def test_upsert_number_pool_inherited_uses_generic_kind(db: InfrahubDatabase) -> None:
+    """Test that upsert_number_pool uses the generic's kind for inherited attributes."""
+    # Register the schemas with generics
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
+    schema_branch = registry.schema.register_schema(schema=schema)
+
+    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
+    incident_attr = snow_incident.get_attribute(name="number")
+
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    registry.node["CoreNumberPool"] = CoreNumberPool
+
+    pool = await upserter.upsert_number_pool(
+        schema_node=snow_incident,
+        attribute=incident_attr,
+        branch_name=registry.default_branch,
+    )
+
+    # Pool should be created for the generic (SnowTask), not the node (SnowIncident)
+    assert pool.node.value == "SnowTask"
+    assert pool.node_attribute.value == "number"
+
+
+async def test_upsert_number_pool_inherited_shares_pool(db: InfrahubDatabase) -> None:
+    """Test that inherited attributes from different nodes share the same pool."""
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
+    schema_branch = registry.schema.register_schema(schema=schema)
+
+    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
+    snow_request = schema_branch.get_node(name="SnowRequest", duplicate=False)
+    incident_attr = snow_incident.get_attribute(name="number")
+    request_attr = snow_request.get_attribute(name="number")
+
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    registry.node["CoreNumberPool"] = CoreNumberPool
+
+    pool_incident = await upserter.upsert_number_pool(
+        schema_node=snow_incident,
+        attribute=incident_attr,
+        branch_name=registry.default_branch,
+    )
+    pool_request = await upserter.upsert_number_pool(
+        schema_node=snow_request,
+        attribute=request_attr,
+        branch_name=registry.default_branch,
+    )
+
+    # Both should get the same pool (from the generic)
+    assert pool_incident.id == pool_request.id
+    assert pool_incident.node.value == "SnowTask"
+
+
+async def test_upsert_number_pool_non_inherited_gets_own_pool(db: InfrahubDatabase) -> None:
+    """Test that non-inherited attributes get their own pools."""
+    generic_schema = GenericSchema(
+        name="BaseGeneric",
+        namespace="Test",
+        include_in_menu=False,
+        label="Base Generic",
+        attributes=[
+            AttributeSchema(name="name", kind="Text"),
+        ],
+    )
+    node_a = NodeSchema(
+        name="NodeA",
+        namespace="Test",
+        inherit_from=["TestBaseGeneric"],
+        attributes=[
+            AttributeSchema(
+                name="counter",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                unique=True,
+            ),
+        ],
+    )
+    node_b = NodeSchema(
+        name="NodeB",
+        namespace="Test",
+        inherit_from=["TestBaseGeneric"],
+        attributes=[
+            AttributeSchema(
+                name="counter",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                unique=True,
+            ),
+        ],
+    )
+
+    schema = SchemaRoot(generics=[generic_schema], nodes=[node_a, node_b])
+    schema_branch = registry.schema.register_schema(schema=schema)
+
+    node_a_schema = schema_branch.get_node(name="TestNodeA", duplicate=False)
+    node_b_schema = schema_branch.get_node(name="TestNodeB", duplicate=False)
+    attr_a = node_a_schema.get_attribute(name="counter")
+    attr_b = node_b_schema.get_attribute(name="counter")
+
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+
+    pool_a = await upserter.upsert_number_pool(
+        schema_node=node_a_schema,
+        attribute=attr_a,
+        branch_name=registry.default_branch,
+    )
+    pool_b = await upserter.upsert_number_pool(
+        schema_node=node_b_schema,
+        attribute=attr_b,
+        branch_name=registry.default_branch,
+    )
+
+    # Each node should have its own pool
+    assert pool_a.id != pool_b.id
+    assert pool_a.node.value == "TestNodeA"
+    assert pool_b.node.value == "TestNodeB"
+
+
+async def test_upsert_number_pool_invalid_type_raises(db: InfrahubDatabase) -> None:
+    """Test that upsert_number_pool raises ValueError for non-NumberPool attributes."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+    attribute = SNOW_INCIDENT.get_attribute("identifier")
+
+    with pytest.raises(ValueError, match="is not a NumberPool type"):
+        await upserter.upsert_number_pool(
+            schema_node=SNOW_INCIDENT,
+            attribute=attribute,
+            branch_name=registry.default_branch,
+        )
+
+
+async def test_get_inherited_pool_info_returns_none_for_non_node_schema(db: InfrahubDatabase) -> None:
+    """Test that get_inherited_pool_info returns None for GenericSchema."""
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+
+    result = upserter.get_inherited_pool_info(
+        node_schema=SNOW_TASK,
+        attribute_name="number",
+        branch_name=registry.default_branch,
+    )
+
+    assert result is None
+
+
+async def test_get_inherited_pool_info_returns_info_for_inherited_attribute(db: InfrahubDatabase) -> None:
+    """Test that get_inherited_pool_info returns correct info for inherited attributes."""
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT])
+    schema_branch = registry.schema.register_schema(schema=schema)
+
+    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
+
+    upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+
+    result = upserter.get_inherited_pool_info(
+        node_schema=snow_incident,
+        attribute_name="number",
+        branch_name=registry.default_branch,
+    )
+
+    assert result is not None
+    assert result.generic_kind == "SnowTask"
+    # pool_id is None because the generic hasn't been assigned a pool yet
+    assert result.pool_id is None

--- a/backend/tests/functional/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/functional/convert_object_type/test_convert_object_type.py
@@ -7,7 +7,10 @@ from infrahub_sdk.convert_object_type import ConversionFieldInput, ConversionFie
 
 from infrahub.core.constants.infrahubkind import NUMBERPOOL
 from infrahub.core.query.resource_manager import NumberPoolGetReserved
+from infrahub.core.registry import registry
 from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, SchemaRoot
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -154,6 +157,11 @@ class TestConvertObjectType(TestInfrahubApp):
 
 
 class TestConvertObjectTypeResourcePool(TestInfrahubApp):
+    async def _run_number_pool_validator(self, db: InfrahubDatabase) -> None:
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+        await snps.run()
+
     @pytest.fixture
     async def schemas_person(self, node_group_schema: None, data_schema: None) -> SchemaRoot:
         person_generic = GenericSchema(
@@ -191,6 +199,8 @@ class TestConvertObjectTypeResourcePool(TestInfrahubApp):
     ) -> None:
         response = await client.schema.load(schemas=[schemas_person.model_dump()])
         assert len(response.errors) == 0, response.errors
+
+        await self._run_number_pool_validator(db)
 
         # Create some objects
         persons: dict[str, InfrahubNode] = {}

--- a/backend/tests/functional/pools/test_numberpool_branch.py
+++ b/backend/tests/functional/pools/test_numberpool_branch.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING
 import pytest
 from infrahub_sdk.graphql import Query
 
+from infrahub.core.registry import registry
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.graphql.manager import registry as graphql_registry
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -48,6 +52,12 @@ BRANCH2 = "branch2"
 
 
 class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
+    async def _run_number_pool_validator(self, db: InfrahubDatabase) -> None:
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+        await snps.run()
+        graphql_registry.clear_cache()
+
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
         schema = SchemaRoot(
@@ -71,6 +81,8 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
             schemas=[initial_schema.model_dump()], wait_until_converged=True
         )
         assert not schema_load_response.errors
+
+        await self._run_number_pool_validator(db)
 
         # Create incidents/requests to ensure there are some data into the database
         for idx in range(1, 4):

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 import pytest
 from infrahub_sdk.graphql import Query
 
-from infrahub.auth import AccountSession, AuthType
-from infrahub.context import InfrahubContext
 from infrahub.core.constants import HashableModelState
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -15,9 +13,10 @@ from infrahub.core.registry import registry
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.exceptions import NodeNotFoundError
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.pools.registration import get_branches_with_schema_number_pool
-from infrahub.pools.tasks import validate_schema_number_pools
-from infrahub.services import InfrahubServices
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.workers.dependencies import build_cache
 from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
@@ -58,6 +57,12 @@ number_pool_allocation_query = Query(
 
 
 class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
+    async def _post_schema_load_updates(self, db: InfrahubDatabase) -> None:
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+        await snps.run()
+        graphql_registry.clear_cache()
+
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
         schema = SchemaRoot(
@@ -84,18 +89,11 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
                 schemas=[initial_schema.model_dump()], wait_until_converged=True
             )
             assert not schema_load_response.errors
+        await self._post_schema_load_updates(db)
 
     async def test_numberpool_assignment_direct_node(
         self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
     ) -> None:
-        service = await InfrahubServices.new(database=db)
-        context = InfrahubContext.init(
-            branch=default_branch,
-            account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
-        )
-
-        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
-
         test_schema = registry.schema.get_node_schema(name="TestNumberAttribute")
         test_attribute = test_schema.get_attribute(name="assigned_number")
         assert isinstance(test_attribute.parameters, NumberPoolParameters)
@@ -121,11 +119,10 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         schema = SchemaRoot(version="1.0", nodes=[node_schema_definition])
         schema_load_response = await client.schema.load(schemas=[schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
+        await self._post_schema_load_updates(db)
 
         after_purge = get_branches_with_schema_number_pool(kind="TestNumberAttribute", attribute_name="assigned_number")
         assert after_purge == []
-
-        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
 
         with pytest.raises(NodeNotFoundError):
             await NodeManager.find_object(
@@ -137,13 +134,7 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
     async def test_numberpool_assignment_from_generic(
         self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
     ) -> None:
-        service = await InfrahubServices.new(database=db)
-        context = InfrahubContext.init(
-            branch=default_branch,
-            account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
-        )
-
-        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
+        await self._post_schema_load_updates(db)
 
         test_schema = registry.schema.get_node_schema(name="SnowIncident")
         test_attribute = test_schema.get_attribute(name="number")
@@ -173,11 +164,10 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         schema = SchemaRoot(version="1.0", generics=[snow_task], nodes=[snow_request, snow_incident])
         schema_load_response = await client.schema.load(schemas=[schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
+        await self._post_schema_load_updates(db)
 
         after_purge = get_branches_with_schema_number_pool(kind="SnowTask", attribute_name="number")
         assert after_purge == []
-
-        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
 
         with pytest.raises(NodeNotFoundError):
             await NodeManager.find_object(
@@ -198,6 +188,7 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
             schemas=[initial_schema.model_dump()], wait_until_converged=True
         )
         assert not schema_load_response.errors
+        await self._post_schema_load_updates(db)
 
         # Create incidents to ensure there are some data into the database
         for idx in range(1, 6):
@@ -207,6 +198,9 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
         pools_before = await client.all(kind="CoreNumberPool", branch=default_branch.name)
         assert len(pools_before) == 1
+        expected_pool_names = {("SnowTask", "number")}
+        number_pool_details = {(pool.node.value, pool.node_attribute.value) for pool in pools_before}
+        assert number_pool_details == expected_pool_names
 
         # Add a new attribute to the existing schema with a large pool
         new_schema = initial_schema.duplicate()
@@ -223,10 +217,14 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
         schema_load_response = await client.schema.load(schemas=[new_schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
+        await self._post_schema_load_updates(db)
 
         # Validate that the new pool has been created
         pools_after = await client.all(kind="CoreNumberPool", branch=default_branch.name)
         assert len(pools_after) == 2
+        expected_pool_names.add(("SnowIncident", "new_number"))
+        number_pool_details = {(pool.node.value, pool.node_attribute.value) for pool in pools_after}
+        assert number_pool_details == expected_pool_names
 
         # Validate that the existing incidents have been updated with the new number
         incidents = await registry.manager.query(db=db, branch=default_branch, schema=incident_schema)

--- a/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
@@ -631,7 +631,8 @@ class TestAddNumberPoolToExistingGenericWithInheritingNode(TestInfrahubApp):
         generic_without_numberpool: dict[str, Any],
     ) -> None:
         """Load the generic and inheriting node WITHOUT the NumberPool attribute."""
-        await client.schema.load(schemas=[generic_without_numberpool], branch=default_branch.name)
+        response = await client.schema.load(schemas=[generic_without_numberpool], branch=default_branch.name)
+        assert not response.errors
 
     @pytest.fixture(scope="class")
     async def add_numberpool_to_generic(
@@ -642,7 +643,8 @@ class TestAddNumberPoolToExistingGenericWithInheritingNode(TestInfrahubApp):
         load_initial_schema: None,
     ) -> None:
         """Add the NumberPool attribute to the existing generic (migrations create the pool)."""
-        await client.schema.load(schemas=[generic_with_numberpool], branch=default_branch.name)
+        response = await client.schema.load(schemas=[generic_with_numberpool], branch=default_branch.name)
+        assert not response.errors
 
     @pytest.fixture(scope="class")
     async def run_synchronizer(

--- a/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
@@ -1,0 +1,757 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import NumberPoolType
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.protocols import CoreNumberPool
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.exceptions import ValidationError
+from infrahub.log import get_logger
+from infrahub.pools.schema_number_pool_synchronizer import SchemaNumberPoolSynchronizer
+from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+log = get_logger()
+SERVER_KIND = "TestingServer"
+
+
+class TestNumberPoolSingleInstanceAcrossBranches(TestInfrahubApp):
+    """Test that NumberPool attribute creates a single CoreNumberPool instance shared across branches.
+
+    This test verifies:
+    1. Loading the same schema on default and a user branch results in only one CoreNumberPool
+    2. Instances created on different branches get unique values from the shared pool
+    """
+
+    @pytest.fixture(scope="class")
+    def schema_with_numberpool(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [
+                {
+                    "name": "Server",
+                    "namespace": "Testing",
+                    "include_in_menu": True,
+                    "label": "Server",
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                        {
+                            "name": "rack_unit",
+                            "kind": "NumberPool",
+                            "optional": False,
+                            "read_only": True,
+                            "parameters": {"start_range": 1, "end_range": 42},
+                        },
+                    ],
+                }
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    async def setup_branch(
+        self,
+        db: InfrahubDatabase,
+    ) -> Branch:
+        branch = await create_branch(db=db, branch_name="numberpool-single-instance-branch")
+        return branch
+
+    @pytest.fixture(scope="class")
+    async def load_schema_on_default(
+        self,
+        default_branch: Branch,
+        client: InfrahubClient,
+        schema_with_numberpool: dict[str, Any],
+    ) -> None:
+        response = await client.schema.load(schemas=[schema_with_numberpool], branch=default_branch.name)
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def load_schema_on_branch(
+        self,
+        client: InfrahubClient,
+        setup_branch: Branch,
+        schema_with_numberpool: dict[str, Any],
+    ) -> None:
+        response = await client.schema.load(schemas=[schema_with_numberpool], branch=setup_branch.name)
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def schemas_loaded(
+        self,
+        setup_branch: Branch,
+        load_schema_on_default: None,
+        load_schema_on_branch: None,
+    ) -> None:
+        """Fixture that ensures schemas are loaded on both branches before proceeding."""
+
+    @pytest.fixture(scope="class")
+    async def create_server_on_default(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        schemas_loaded: None,
+    ) -> Node:
+        server = await Node.init(schema=SERVER_KIND, db=db, branch=default_branch)
+        await server.new(db=db, name="server-default")
+        await server.save(db=db)
+        return server
+
+    @pytest.fixture(scope="class")
+    async def create_server_on_branch(
+        self,
+        db: InfrahubDatabase,
+        setup_branch: Branch,
+        schemas_loaded: None,
+    ) -> Node:
+        server = await Node.init(schema=SERVER_KIND, db=db, branch=setup_branch)
+        await server.new(db=db, name="server-branch")
+        await server.save(db=db)
+        return server
+
+    async def test_instance_creation_fails_without_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        setup_branch: Branch,
+        schemas_loaded: None,
+    ) -> None:
+        """Validate that creating instances fails when the NumberPool doesn't exist yet."""
+        branches = [
+            (default_branch, "default"),
+            (setup_branch, "branch"),
+        ]
+
+        for branch, branch_label in branches:
+            # Get the number_pool_id from the branch schema
+            schema = registry.schema.get_node_schema(name=SERVER_KIND, branch=branch.name)
+            rack_unit_attr = schema.get_attribute(name="rack_unit")
+            assert isinstance(rack_unit_attr.parameters, NumberPoolParameters)
+            number_pool_id = rack_unit_attr.parameters.number_pool_id
+            assert number_pool_id is None, f"{branch_label} branch schema should not have a number_pool_id assigned"
+
+            # Try to create on this branch - should fail
+            with pytest.raises(ValidationError) as exc_info:
+                server = await Node.init(schema=SERVER_KIND, db=db, branch=branch)
+                await server.new(db=db, name=f"server-should-fail-{branch_label}")
+                await server.save(db=db)
+
+            error_message = str(exc_info.value)
+            assert "The pool for rack_unit has not been provisioned yet" in error_message
+
+    async def test_synchronizer_creates_single_pool(
+        self,
+        db: InfrahubDatabase,
+        schemas_loaded: None,
+    ) -> None:
+        """Validate that SchemaNumberPoolSynchronizer creates exactly one CoreNumberPool after schemas are loaded."""
+        # Run the synchronizer
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        synchronizer = SchemaNumberPoolSynchronizer(
+            db=db,
+            log=log,
+            schema_manager=registry.schema,
+            upserter=upserter,
+        )
+        await synchronizer.run()
+
+        # Query for all schema-type number pools
+        pools = await NodeManager.query(
+            db=db,
+            schema="CoreNumberPool",
+            filters={"pool_type__value": NumberPoolType.SCHEMA.value},
+            branch_agnostic=True,
+        )
+
+        # Filter to find pools for the TestingServer.rack_unit attribute
+        server_pools = [
+            pool
+            for pool in pools
+            if pool.get_attribute("node").value == SERVER_KIND
+            and pool.get_attribute("node_attribute").value == "rack_unit"
+        ]
+
+        assert len(server_pools) == 1, (
+            f"Expected exactly 1 CoreNumberPool for {SERVER_KIND}.rack_unit after running synchronizer, "
+            f"found {len(server_pools)}"
+        )
+
+        # Verify the pool has the correct range
+        pool = server_pools[0]
+        assert pool.get_attribute("start_range").value == 1
+        assert pool.get_attribute("end_range").value == 42
+
+    async def test_single_numberpool_instance_exists(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        setup_branch: Branch,
+        schemas_loaded: None,
+        create_server_on_default: Node,
+        create_server_on_branch: Node,
+    ) -> None:
+        """Validate that only one CoreNumberPool instance exists after creating objects on multiple branches."""
+        pools = await NodeManager.query(db=db, schema="CoreNumberPool", branch_agnostic=True)
+
+        # Filter to find pools for the TestingServer.rack_unit attribute
+        server_pools = [
+            pool
+            for pool in pools
+            if pool.get_attribute("node").value == SERVER_KIND
+            and pool.get_attribute("node_attribute").value == "rack_unit"
+        ]
+
+        assert len(server_pools) == 1, (
+            f"Expected exactly 1 CoreNumberPool for {SERVER_KIND}.rack_unit, found {len(server_pools)}"
+        )
+
+    async def test_instances_have_unique_values(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        setup_branch: Branch,
+        create_server_on_default: Node,
+        create_server_on_branch: Node,
+    ) -> None:
+        """Validate that instances created on different branches got unique attribute values."""
+        # Re-query to get fresh values
+        default_servers = await registry.manager.query(db=db, schema=SERVER_KIND, branch=default_branch)
+        branch_servers = await registry.manager.query(db=db, schema=SERVER_KIND, branch=setup_branch)
+
+        assert len(default_servers) == 1
+        assert len(branch_servers) == 1
+
+        default_value = default_servers[0].rack_unit.value
+        branch_value = branch_servers[0].rack_unit.value
+
+        # Both should have received values
+        assert default_value is not None, "Server on default branch should have a rack_unit value"
+        assert branch_value is not None, "Server on user branch should have a rack_unit value"
+
+        # Values should be unique (different)
+        assert default_value != branch_value, (
+            f"Servers on different branches should have unique rack_unit values, but both got {default_value}"
+        )
+
+        # Values should be within the pool range (1-42)
+        assert 1 <= default_value <= 42, f"rack_unit value {default_value} is outside pool range 1-42"
+        assert 1 <= branch_value <= 42, f"rack_unit value {branch_value} is outside pool range 1-42"
+
+    async def test_schema_number_pool_id_matches_pool_in_registry(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        setup_branch: Branch,
+        create_server_on_default: Node,
+        create_server_on_branch: Node,
+    ) -> None:
+        """Validate that the schema's number_pool_id in the registry matches the actual CoreNumberPool ID."""
+        # Get the actual pool
+        pools = await NodeManager.query(db=db, schema="CoreNumberPool", branch_agnostic=True)
+        server_pools = [
+            pool
+            for pool in pools
+            if pool.get_attribute("node").value == SERVER_KIND
+            and pool.get_attribute("node_attribute").value == "rack_unit"
+        ]
+        assert len(server_pools) == 1
+        actual_pool_id = server_pools[0].id
+
+        # Check the schema on default branch in registry
+        default_schema = registry.schema.get_node_schema(name=SERVER_KIND, branch=default_branch.name)
+        default_attr = default_schema.get_attribute(name="rack_unit")
+        assert isinstance(default_attr.parameters, NumberPoolParameters)
+        assert default_attr.parameters.number_pool_id == actual_pool_id, (
+            f"Default branch registry schema number_pool_id ({default_attr.parameters.number_pool_id}) "
+            f"doesn't match actual pool ID ({actual_pool_id})"
+        )
+
+        # Check the schema on user branch in registry
+        branch_schema = registry.schema.get_node_schema(name=SERVER_KIND, branch=setup_branch.name)
+        branch_attr = branch_schema.get_attribute(name="rack_unit")
+        assert isinstance(branch_attr.parameters, NumberPoolParameters)
+        assert branch_attr.parameters.number_pool_id == actual_pool_id, (
+            f"User branch registry schema number_pool_id ({branch_attr.parameters.number_pool_id}) "
+            f"doesn't match actual pool ID ({actual_pool_id})"
+        )
+
+    async def test_schema_number_pool_id_matches_pool_in_database(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        setup_branch: Branch,
+        create_server_on_default: Node,
+        create_server_on_branch: Node,
+    ) -> None:
+        """Validate that the schema's number_pool_id in the database matches the actual CoreNumberPool ID."""
+        # Get the actual pool
+        pools = await NodeManager.query(db=db, schema="CoreNumberPool", branch_agnostic=True)
+        server_pools = [
+            pool
+            for pool in pools
+            if pool.get_attribute("node").value == SERVER_KIND
+            and pool.get_attribute("node_attribute").value == "rack_unit"
+        ]
+        assert len(server_pools) == 1
+        actual_pool_id = server_pools[0].id
+
+        # Load schema fresh from database for default branch
+        default_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        default_schema_from_db = default_schema_branch.get_node(name=SERVER_KIND)
+        default_attr_from_db = default_schema_from_db.get_attribute(name="rack_unit")
+        assert isinstance(default_attr_from_db.parameters, NumberPoolParameters)
+        assert default_attr_from_db.parameters.number_pool_id == actual_pool_id, (
+            f"Default branch database schema number_pool_id ({default_attr_from_db.parameters.number_pool_id}) "
+            f"doesn't match actual pool ID ({actual_pool_id})"
+        )
+
+        # Load schema fresh from database for user branch
+        branch_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=setup_branch)
+        branch_schema_from_db = branch_schema_branch.get_node(name=SERVER_KIND)
+        branch_attr_from_db = branch_schema_from_db.get_attribute(name="rack_unit")
+        assert isinstance(branch_attr_from_db.parameters, NumberPoolParameters)
+        assert branch_attr_from_db.parameters.number_pool_id == actual_pool_id, (
+            f"User branch database schema number_pool_id ({branch_attr_from_db.parameters.number_pool_id}) "
+            f"doesn't match actual pool ID ({actual_pool_id})"
+        )
+
+
+class TestInheritedNumberPoolReusesExistingPool(TestInfrahubApp):
+    """Test that a new node inheriting from an existing generic with a NumberPool reuses the existing pool.
+
+    This test verifies:
+    1. Load a generic with a NumberPool attribute
+    2. Run synchronizer to create the CoreNumberPool
+    3. Load a new node that inherits from the generic
+    4. Verify the node's inherited attribute uses the SAME pool (no new pool created)
+    """
+
+    @pytest.fixture(scope="class")
+    def generic_schema_with_numberpool(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [
+                {
+                    "name": "BaseTask",
+                    "namespace": "Testing",
+                    "include_in_menu": False,
+                    "label": "Base Task",
+                    "attributes": [
+                        {"name": "title", "kind": "Text"},
+                        {
+                            "name": "ticket_number",
+                            "kind": "NumberPool",
+                            "optional": False,
+                            "read_only": True,
+                            "unique": True,
+                            "parameters": {"start_range": 1000, "end_range": 9999},
+                        },
+                    ],
+                }
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def node_inheriting_from_generic(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [
+                {
+                    "name": "Incident",
+                    "namespace": "Testing",
+                    "inherit_from": ["TestingBaseTask"],
+                    "include_in_menu": True,
+                    "label": "Incident",
+                    "attributes": [
+                        {"name": "severity", "kind": "Text"},
+                    ],
+                }
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    async def load_generic_schema(
+        self,
+        default_branch: Branch,
+        client: InfrahubClient,
+        generic_schema_with_numberpool: dict[str, Any],
+    ) -> None:
+        """Load the generic schema first."""
+        response = await client.schema.load(schemas=[generic_schema_with_numberpool], branch=default_branch.name)
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def run_synchronizer_for_generic(
+        self,
+        db: InfrahubDatabase,
+        load_generic_schema: None,
+    ) -> str:
+        """Run the synchronizer to create the CoreNumberPool for the generic."""
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        synchronizer = SchemaNumberPoolSynchronizer(
+            db=db,
+            log=log,
+            schema_manager=registry.schema,
+            upserter=upserter,
+        )
+        await synchronizer.run()
+
+        # Get the pool ID that was created
+        pools = await NodeManager.query(
+            db=db,
+            schema=CoreNumberPool,
+            filters={
+                "node__value": "TestingBaseTask",
+                "node_attribute__value": "ticket_number",
+                "pool_type__value": NumberPoolType.SCHEMA.value,
+            },
+            branch_agnostic=True,
+        )
+        assert len(pools) == 1, "Expected exactly one pool for TestingBaseTask.ticket_number"
+        return pools[0].id
+
+    @pytest.fixture(scope="class")
+    async def load_inheriting_node_schema(
+        self,
+        default_branch: Branch,
+        client: InfrahubClient,
+        node_inheriting_from_generic: dict[str, Any],
+        run_synchronizer_for_generic: str,
+    ) -> None:
+        """Load the node schema that inherits from the generic."""
+        response = await client.schema.load(schemas=[node_inheriting_from_generic], branch=default_branch.name)
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def run_synchronizer_after_node_added(
+        self,
+        db: InfrahubDatabase,
+        load_inheriting_node_schema: None,
+    ) -> None:
+        """Run the synchronizer again after adding the inheriting node."""
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        synchronizer = SchemaNumberPoolSynchronizer(
+            db=db,
+            log=log,
+            schema_manager=registry.schema,
+            upserter=upserter,
+        )
+        await synchronizer.run()
+
+    async def test_no_new_pool_created_for_inherited_attribute(
+        self,
+        db: InfrahubDatabase,
+        run_synchronizer_for_generic: str,
+        run_synchronizer_after_node_added: None,
+    ) -> None:
+        """Verify that no new pool was created when the inheriting node was added."""
+        original_pool_id = run_synchronizer_for_generic
+
+        # Query for all pools related to ticket_number attribute
+        all_pools = await NodeManager.query(
+            db=db,
+            schema=CoreNumberPool,
+            filters={
+                "pool_type__value": NumberPoolType.SCHEMA.value,
+            },
+            branch_agnostic=True,
+        )
+
+        # Should still be exactly one pool
+        assert len(all_pools) == 1, (
+            f"Expected exactly 1 pool for ticket_number attribute, found {len(all_pools)}. "
+            "A new pool should NOT be created for the inherited attribute."
+        )
+        the_pool = all_pools[0]
+        assert the_pool.node.value == "TestingBaseTask", "Pool should reference the generic 'TestingBaseTask'"
+        assert the_pool.node_attribute.value == "ticket_number", "Pool should reference attribute 'ticket_number'"
+
+        # And it should be the same pool as before
+        assert the_pool.id == original_pool_id, (
+            f"Pool ID changed from {original_pool_id} to {the_pool.id}. "
+            "The inherited attribute should use the existing pool."
+        )
+
+    async def test_inherited_attribute_uses_generic_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        run_synchronizer_for_generic: str,
+        run_synchronizer_after_node_added: None,
+    ) -> None:
+        """Verify that the inherited attribute on the node has the same pool ID as the generic."""
+        original_pool_id = run_synchronizer_for_generic
+
+        # Get the generic's attribute pool ID from registry
+        generic_schema = registry.schema.get_generic_schema(name="TestingBaseTask", branch=default_branch.name)
+        generic_attr = generic_schema.get_attribute(name="ticket_number")
+        assert isinstance(generic_attr.parameters, NumberPoolParameters)
+        assert generic_attr.parameters.number_pool_id == original_pool_id
+
+        # Get the node's inherited attribute pool ID from registry
+        node_schema = registry.schema.get_node_schema(name="TestingIncident", branch=default_branch.name)
+        node_attr = node_schema.get_attribute(name="ticket_number")
+        assert isinstance(node_attr.parameters, NumberPoolParameters)
+
+        # The inherited attribute should have the SAME pool ID as the generic
+        assert node_attr.parameters.number_pool_id == original_pool_id, (
+            f"Inherited attribute pool ID ({node_attr.parameters.number_pool_id}) "
+            f"doesn't match generic's pool ID ({original_pool_id})"
+        )
+
+    async def test_pool_references_generic_not_node(
+        self,
+        db: InfrahubDatabase,
+        run_synchronizer_for_generic: str,
+        run_synchronizer_after_node_added: None,
+    ) -> None:
+        """Verify that only one CoreNumberPool exists and it references the generic (not the inheriting node)."""
+        original_pool_id = run_synchronizer_for_generic
+
+        # Query ALL schema-type number pools
+        all_schema_pools = await NodeManager.query(
+            db=db,
+            schema=CoreNumberPool,
+            filters={"pool_type__value": NumberPoolType.SCHEMA.value},
+            branch_agnostic=True,
+        )
+
+        # Should be exactly one pool total
+        assert len(all_schema_pools) == 1, (
+            f"Expected exactly 1 schema-type CoreNumberPool, found {len(all_schema_pools)}. "
+            f"Pool IDs: {[p.id for p in all_schema_pools]}"
+        )
+
+        pool = all_schema_pools[0]
+
+        # Verify it's the original pool
+        assert pool.id == original_pool_id, f"Pool ID ({pool.id}) doesn't match original ({original_pool_id})"
+
+        # The pool should reference the generic (where the attribute is defined)
+        assert pool.node.value == "TestingBaseTask", (
+            f"Pool should reference the generic 'TestingBaseTask', not '{pool.node.value}'"
+        )
+        assert pool.node_attribute.value == "ticket_number", (
+            f"Pool should reference attribute 'ticket_number', not '{pool.node_attribute.value}'"
+        )
+
+    async def test_create_instances_share_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        run_synchronizer_for_generic: str,
+        run_synchronizer_after_node_added: None,
+    ) -> None:
+        """Verify that instances of the inheriting node get values from the shared pool."""
+        # Create an instance of the inheriting node
+        incident = await Node.init(schema="TestingIncident", db=db, branch=default_branch)
+        await incident.new(db=db, title="Test Incident", severity="High")
+        await incident.save(db=db)
+
+        # The ticket_number should have been allocated from the pool
+        assert incident.ticket_number.value is not None
+        assert 1000 <= incident.ticket_number.value <= 9999, (
+            f"ticket_number value {incident.ticket_number.value} is outside pool range 1000-9999"
+        )
+        assert incident.ticket_number.source_id == run_synchronizer_for_generic
+
+
+class TestAddNumberPoolToExistingGenericWithInheritingNode(TestInfrahubApp):
+    """Test that adding a NumberPool attribute to an existing generic with inheriting nodes works correctly.
+
+    This test verifies:
+    1. A generic and inheriting node exist WITHOUT a NumberPool attribute
+    2. Add a NumberPool attribute to the generic (schema migrations create the CoreNumberPool)
+    3. Verify the generic and inheriting node both have the SAME number_pool_id
+    4. Verify no separate CoreNumberPool is created for the inheriting node
+    """
+
+    @pytest.fixture(scope="class")
+    def generic_without_numberpool(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [
+                {
+                    "name": "BaseEquipment",
+                    "namespace": "Testing",
+                    "include_in_menu": False,
+                    "label": "Base Equipment",
+                    "attributes": [
+                        {"name": "description", "kind": "Text"},
+                    ],
+                }
+            ],
+            "nodes": [
+                {
+                    "name": "NetworkDevice",
+                    "namespace": "Testing",
+                    "inherit_from": ["TestingBaseEquipment"],
+                    "include_in_menu": True,
+                    "label": "Network Device",
+                    "attributes": [
+                        {"name": "hostname", "kind": "Text", "unique": True},
+                    ],
+                }
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def generic_with_numberpool(self, generic_without_numberpool: dict[str, Any]) -> dict[str, Any]:
+        generic_with_numberpool = deepcopy(generic_without_numberpool)
+        generic_with_numberpool["generics"][0]["attributes"].append(
+            {
+                "name": "asset_tag",
+                "kind": "NumberPool",
+                "optional": False,
+                "read_only": True,
+                "unique": True,
+                "parameters": {"start_range": 100000, "end_range": 999999},
+            },
+        )
+        return generic_with_numberpool
+
+    @pytest.fixture(scope="class")
+    async def load_initial_schema(
+        self,
+        default_branch: Branch,
+        client: InfrahubClient,
+        generic_without_numberpool: dict[str, Any],
+    ) -> None:
+        """Load the generic and inheriting node WITHOUT the NumberPool attribute."""
+        await client.schema.load(schemas=[generic_without_numberpool], branch=default_branch.name)
+
+    @pytest.fixture(scope="class")
+    async def add_numberpool_to_generic(
+        self,
+        default_branch: Branch,
+        client: InfrahubClient,
+        generic_with_numberpool: dict[str, Any],
+        load_initial_schema: None,
+    ) -> None:
+        """Add the NumberPool attribute to the existing generic (migrations create the pool)."""
+        await client.schema.load(schemas=[generic_with_numberpool], branch=default_branch.name)
+
+    @pytest.fixture(scope="class")
+    async def run_synchronizer(
+        self,
+        db: InfrahubDatabase,
+        add_numberpool_to_generic: None,
+    ) -> None:
+        """Run SchemaNumberPoolSynchronizer to update schema with pool IDs.
+
+        In integration tests, the synchronizer doesn't run automatically (it relies on events).
+        We run it manually to update the number_pool_id in the schema's attribute parameters.
+        """
+        upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
+        synchronizer = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
+        await synchronizer.run()
+
+    async def test_only_one_pool_exists(
+        self,
+        db: InfrahubDatabase,
+        add_numberpool_to_generic: None,
+    ) -> None:
+        """Verify that only one CoreNumberPool was created (not one for each schema)."""
+        # Query for all pools related to asset_tag attribute
+        all_pools = await NodeManager.query(
+            db=db,
+            schema=CoreNumberPool,
+            filters={
+                "node_attribute__value": "asset_tag",
+                "pool_type__value": NumberPoolType.SCHEMA.value,
+            },
+            branch_agnostic=True,
+        )
+
+        # Should be exactly one pool
+        assert len(all_pools) == 1, (
+            f"Expected exactly 1 pool for asset_tag attribute, found {len(all_pools)}. "
+            "A separate pool should NOT be created for the inheriting node."
+        )
+
+        # And it should reference the generic
+        the_pool = all_pools[0]
+        assert the_pool.node.value == "TestingBaseEquipment", (
+            f"Pool should reference the generic 'TestingBaseEquipment', not '{the_pool.node.value}'"
+        )
+
+    async def test_generic_and_node_have_same_pool_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        run_synchronizer: None,
+    ) -> None:
+        """Verify that both the generic and inheriting node have the same number_pool_id after synchronizer runs."""
+        # Get the generic's attribute pool ID from registry
+        generic_schema = registry.schema.get_generic_schema(name="TestingBaseEquipment", branch=default_branch.name)
+        generic_attr = generic_schema.get_attribute(name="asset_tag")
+        assert isinstance(generic_attr.parameters, NumberPoolParameters)
+        generic_pool_id = generic_attr.parameters.number_pool_id
+        assert generic_pool_id is not None, "Generic attribute should have a number_pool_id assigned"
+
+        # Get the node's inherited attribute pool ID from registry
+        node_schema = registry.schema.get_node_schema(name="TestingNetworkDevice", branch=default_branch.name)
+        node_attr = node_schema.get_attribute(name="asset_tag")
+        assert isinstance(node_attr.parameters, NumberPoolParameters)
+        assert node_attr.parameters.number_pool_id == generic_pool_id, (
+            f"Inherited attribute pool ID ({node_attr.parameters.number_pool_id}) "
+            f"doesn't match generic's pool ID ({generic_pool_id})"
+        )
+
+    async def test_no_pool_for_node(
+        self,
+        db: InfrahubDatabase,
+        add_numberpool_to_generic: None,
+    ) -> None:
+        """Verify that no CoreNumberPool was created for the inheriting node."""
+        # Query for pools that reference the inheriting node
+        node_pools = await NodeManager.query(
+            db=db,
+            schema=CoreNumberPool,
+            filters={
+                "node__value": "TestingNetworkDevice",
+                "pool_type__value": NumberPoolType.SCHEMA.value,
+            },
+            branch_agnostic=True,
+        )
+
+        assert len(node_pools) == 0, (
+            f"No pool should exist for 'TestingNetworkDevice', but found {len(node_pools)}. "
+            "Inherited attributes should use the generic's pool."
+        )
+
+    async def test_create_instance_uses_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        run_synchronizer: None,
+    ) -> None:
+        """Verify that creating an instance of the inheriting node allocates from the shared pool."""
+        # Create an instance of the inheriting node
+        device = await Node.init(schema="TestingNetworkDevice", db=db, branch=default_branch)
+        await device.new(db=db, hostname="router-01", description="Core router")
+        await device.save(db=db)
+
+        node_schema = registry.schema.get_node_schema(name="TestingNetworkDevice", branch=default_branch.name)
+        node_attr = node_schema.get_attribute(name="asset_tag")
+        expected_pool_id = node_attr.parameters.number_pool_id
+
+        # The asset_tag should have been allocated from the pool
+        assert device.asset_tag.value is not None
+        assert 100000 <= device.asset_tag.value <= 999999, (
+            f"asset_tag value {device.asset_tag.value} is outside pool range 100000-999999"
+        )
+        assert device.asset_tag.source_id == expected_pool_id

--- a/changelog/8222.fixed.md
+++ b/changelog/8222.fixed.md
@@ -1,0 +1,1 @@
+Prevent creating multiple number pools for the same schema if it is separately loaded on multiple branches. It is now possible to encounter an error if a user tries to create an instance of a schema immediately after an update to include a NumberPool attribute because the associated CoreNumberPool must be created by an asynchronous task.

--- a/frontend/app/src/shared/api/rest/types.generated.ts
+++ b/frontend/app/src/shared/api/rest/types.generated.ts
@@ -1964,7 +1964,7 @@ export interface components {
             start_range: number;
             /**
              * Number Pool Id
-             * @description The ID of the numberpool associated with this attribute
+             * @description The ID of the numberpool associated with this attribute. Only set after the number pool has been provisioned.
              */
             number_pool_id?: string | null;
         };

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -5587,7 +5587,7 @@
                             }
                         ],
                         "title": "Number Pool Id",
-                        "description": "The ID of the numberpool associated with this attribute",
+                        "description": "The ID of the numberpool associated with this attribute. Only set after the number pool has been provisioned.",
                         "update": "not_supported"
                     }
                 },


### PR DESCRIPTION
feature branch includes #8384  and #8253, both of which have been reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic synchronization and provisioning of schema-defined number pools across branches.

* **Bug Fixes**
  * Prevent duplicate number pools for the same schema across branches; consolidation/migration added to merge existing duplicates.
  * Reduced unnecessary waiting by making convergence waits conditional after pool validation.

* **Documentation**
  * Clarified that number pool IDs are set only after provisioning completes.

* **Tests**
  * Extensive new and updated tests covering synchronization, upsertion, migrations, and branch/inheritance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->