### PR TITLE
fix(docs): add queryString to tabs

### DIFF
--- a/docs/docs/development/git-best-practices.mdx
+++ b/docs/docs/development/git-best-practices.mdx
@@ -26,7 +26,7 @@ Infrahub includes the Python SDK as a Git submodule. This section covers essenti
 
 When cloning Infrahub for the first time, always include the `--recursive` flag to initialize submodules:
 
-<Tabs>
+<Tabs groupId="git-strategy" queryString>
   <TabItem value="ssh" label="SSH (recommended)">
 
 ```bash

--- a/docs/docs/guides/accounts-permissions.mdx
+++ b/docs/docs/guides/accounts-permissions.mdx
@@ -14,7 +14,7 @@ For more information on roles and permissions, see the [Roles and Permissions](.
 
 ## Creating a new account
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ### Via the Web Interface
 
@@ -56,7 +56,7 @@ For more information on roles and permissions, see the [Roles and Permissions](.
 
 ## Creating a new account group
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ### Via the Web Interface
 
@@ -97,7 +97,7 @@ For more information on roles and permissions, see the [Roles and Permissions](.
 
 ## Creating and assigning roles
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ### Via the Web Interface
 
@@ -145,7 +145,7 @@ For a complete list of available global and object permissions, see the [Roles a
 
 ### Creating and global permissions
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ### Via the Web Interface
 
@@ -189,7 +189,7 @@ For a complete list of available global and object permissions, see the [Roles a
 
 ### Creating and objects permissions
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ### Via the Web Interface
 

--- a/docs/docs/guides/check.mdx
+++ b/docs/docs/guides/check.mdx
@@ -85,12 +85,12 @@ Create three tags with different naming patterns:
 
 You can create these tags using the Infrahub UI or in batch using object file:
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 
 For targeted checks, you will also need to create a group that includes the tags you want to validate.
 
-<Tabs>
+<Tabs groupId="setup-method" queryString>
 <TabItem value="Using Object File" >
 
   1. Create a file named `groups.yml` in the `objects` directory of your repository:
@@ -153,7 +153,7 @@ For targeted checks, you will also need to create a group that includes the tags
 </Tabs>
 </TabItem>
 <TabItem value="Global Check">
-<Tabs>
+<Tabs groupId="setup-method" queryString>
 <TabItem value="Using Object File" >
   1. Create a file named `tags.yml` in the `objects` directory of your repository:
 
@@ -206,7 +206,7 @@ Next, create a GraphQL query that fetches the data your check needs to process.
 
 Create a `tags_query.gql` file in the `queries` directory of your repository:
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 ```graphql title="queries/tags_query.gql"
 query TagsQuery($name: String!) {
@@ -255,7 +255,7 @@ Access the sandbox by clicking your user icon in the bottom left corner and sele
 
 :::
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 
 1. Copy the above GraphQL query in the main section
@@ -385,7 +385,7 @@ Now that you have your GraphQL query and Python check, edit your [.infrahub.yml]
 
 1. Add the following configuration to the file `.infrahub.yml`:
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 
 ```yaml title=".infrahub.yml"
@@ -435,7 +435,7 @@ infrahubctl check --list
 
 If successful, you'll see output like:
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 ```shell
 Python checks defined in repository: 1
@@ -472,7 +472,7 @@ infrahubctl check check_color_tags_name --branch=create-tag-check
 
 If successful, you'll see output like:
 
-<Tabs groupId="check-type">
+<Tabs groupId="check-type" queryString>
 <TabItem value="Targeted Check">
 ```shell
 INFO     HTTP Request: GET http://localhost:8000/api/schema?branch=create-tag-check2 "HTTP/1.1 200 OK"

--- a/docs/docs/guides/configuration-changes.mdx
+++ b/docs/docs/guides/configuration-changes.mdx
@@ -42,7 +42,7 @@ For this guide, we'll use `INFRAHUB_HTTP_TIMEOUT` as an example. It affects how 
 
 Configure the variable before starting or restarting your Infrahub containers.
 
-<Tabs groupId="installation-method">
+<Tabs groupId="installation-method" queryString>
 <TabItem value="docker-compose" label="Docker Compose" default>
 
 :::note
@@ -129,7 +129,7 @@ helm upgrade infrahub opsmill/infrahub \
 
 Restart your Infrahub containers to apply the new configuration.
 
-<Tabs groupId="installation-method">
+<Tabs groupId="installation-method" queryString>
 <TabItem value="docker-compose" label="Docker Compose" default>
 
 :::note
@@ -187,7 +187,7 @@ Rolling out changes will trigger a pod restart. Depending on your deployment con
 
 Confirm that your configuration change has been applied successfully.
 
-<Tabs>
+<Tabs groupId="installation-method" queryString>
 <TabItem value="docker-compose" label="Docker Compose" default>
 
 :::note

--- a/docs/docs/guides/create-schema.mdx
+++ b/docs/docs/guides/create-schema.mdx
@@ -103,7 +103,7 @@ View your schema in the [Web UI](http://localhost:8000/schema?branch=network-dev
 
 Test your schema by creating a device and interface:
 
-<Tabs>
+<Tabs groupId="method" queryString>
 <TabItem value="graphql" label="GraphQL" default>
 
 Open the GraphQL sandbox (bottom left of the web interface) and execute:

--- a/docs/docs/guides/customize-field-ordering.mdx
+++ b/docs/docs/guides/customize-field-ordering.mdx
@@ -49,7 +49,7 @@ Before editing your schema, decide on your desired field order and weight strate
 
 ### Common strategies
 
-<Tabs>
+<Tabs groupId="method" queryString>
 <TabItem value="conservative" label="Conservative (Recommended)">
 
 Use weights that leave plenty of room for future insertions:
@@ -190,7 +190,7 @@ nodes:
 
 Update your schema using `infrahubctl`:
 
-<Tabs>
+<Tabs groupId="method" queryString>
 <TabItem value="file" label="Single File">
 
 ```shell

--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -20,7 +20,7 @@ This guide shows you how to create comprehensive backups of your Infrahub deploy
 
 ### Step 1: Install the backup tool
 
-<Tabs groupId="backup-method">
+<Tabs groupId="backup-method" queryString>
 <TabItem value="infrahubops" label="infrahub-backup CLI (Recommended)" default>
 
 Install the infrahub-backup CLI tool:
@@ -52,7 +52,7 @@ Alternatively, you can use the [legacy tool](#using-the-python-based-backup-util
 
 ### Step 2: Backup the databases
 
-<Tabs groupId="backup-method">
+<Tabs groupId="backup-method" queryString>
 <TabItem value="infrahubops" label="infrahub-backup CLI" default>
 
 Create a backup of your running Infrahub instance:
@@ -129,7 +129,7 @@ python -m utilities.db_backup neo4j backup \
 
 ### Step 3: Backup the artifact store
 
-<Tabs groupId="storage-type">
+<Tabs groupId="storage-type" queryString>
 <TabItem value="s3" label="S3 Storage" default>
 
 If using S3 for artifact storage, use AWS CLI or your preferred S3 backup tool:
@@ -158,7 +158,7 @@ docker compose cp -r infrahub-server:/opt/infrahub/storage /backup/artifacts/
 
 Ensure Infrahub services are running before starting the restore process. You can start from a scratch/blank deployment.
 
-<Tabs groupId="restore-method">
+<Tabs groupId="restore-method" queryString>
 <TabItem value="infrahubops" label="infrahub-backup CLI" default>
 
 Restore from a backup archive:
@@ -193,7 +193,7 @@ If restoring manually, follow the steps below for each component.
 
 ### Step 2: Restore the databases
 
-<Tabs groupId="restore-method">
+<Tabs groupId="restore-method" queryString>
 <TabItem value="infrahubops" label="infrahub-backup CLI" default>
 
 This is automatically handled by infrahub-backup.
@@ -264,7 +264,7 @@ python -m utilities.db_backup neo4j restore \
 
 ### Step 3: Restore the artifact store
 
-<Tabs groupId="storage-type">
+<Tabs groupId="storage-type" queryString>
 <TabItem value="s3" label="S3 Storage" default>
 
 ```bash
@@ -285,7 +285,7 @@ cp -r /backup/artifacts/ /path/to/infrahub/artifacts/
 
 ### Step 4: Restart Infrahub services
 
-<Tabs groupId="restore-method">
+<Tabs groupId="restore-method" queryString>
 <TabItem value="infrahubops" label="infrahub-backup CLI" default>
 
 This is automatically handled by infrahub-backup.

--- a/docs/docs/guides/generator.mdx
+++ b/docs/docs/guides/generator.mdx
@@ -65,7 +65,7 @@ If you prefer a "as code" approach, use the object file method. Otherwise, you c
 
 :::
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="Using Object File" default>
   1. Create a file named `groups.yml` in the `objects` directory of your repository:
 
@@ -158,7 +158,7 @@ Choose the method you already use to manage schema changes in your Infrahub depl
 
 :::
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="Using Git Integration" default>
   2. Update the `.infrahub.yml` file to include the new schema file:
 

--- a/docs/docs/guides/groups.mdx
+++ b/docs/docs/guides/groups.mdx
@@ -23,7 +23,7 @@ Before starting this guide, ensure you have:
 
 Choose your preferred method to create a group:
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 Navigate to **Object Management** → **Groups** in the left menu.
@@ -81,7 +81,7 @@ group.save()
 
 Add objects as members of your newly created group:
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 1. Select your group from the Groups list
@@ -154,7 +154,7 @@ group.save()
 
 Confirm that your objects have been successfully added to the group:
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 1. Navigate to **Object Management** → **Groups**
@@ -218,7 +218,7 @@ Confirm your group is working correctly:
 
 ### Remove members from a group
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 1. Navigate to your group's Members tab
@@ -251,7 +251,7 @@ mutation RemoveGroupMembers {
 
 ### Delete a group
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 1. Select the group from the Groups list

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -43,7 +43,7 @@ Allocating more CPU cores to the Neo4j database will only improve performance on
 
 Infrahub Community is deployed as a container-based architecture and can be installed using several methods.
 
-<Tabs>
+<Tabs groupId="install-method" queryString>
 <TabItem value="Docker compose via curl" default>
 
 ### Using curl and Docker Compose
@@ -62,7 +62,7 @@ You can also specify a specific version or the `develop` branch in the URL:
 
 #### Start an Infrahub environment
 
-<Tabs groupId="os">
+<Tabs groupId="os" queryString>
 <TabItem value="macOS" default>
 
 ```bash
@@ -95,7 +95,7 @@ docker ps | grep infrahub
 
 #### Stop and remove an Infrahub environment
 
-<Tabs groupId="os">
+<Tabs groupId="os" queryString>
 <TabItem value="macOS" default>
 
 ```bash
@@ -352,7 +352,7 @@ Infrahub Enterprise is based on the Community version, with several enhancements
 
 Infrahub Enterprise can be deployed using the same methods as Infrahub Community.
 
-<Tabs>
+<Tabs groupId="install-method" queryString>
 <TabItem value="Docker compose via curl" default>
 
 ### Using curl and Docker Compose
@@ -384,7 +384,7 @@ You can also specify a sizing preset in the URL. This will automatically configu
 
 #### Start an Infrahub Enterprise environment
 
-<Tabs groupId="os">
+<Tabs groupId="os" queryString>
 <TabItem value="macOS" default>
 
 ```bash
@@ -405,7 +405,7 @@ sudo docker compose -p infrahub up -d
 
 #### Stop and remove an Infrahub Enterprise environment
 
-<Tabs groupId="os">
+<Tabs groupId="os" queryString>
 <TabItem value="macOS" default>
 
 ```bash

--- a/docs/docs/guides/managing-api-tokens.mdx
+++ b/docs/docs/guides/managing-api-tokens.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 API tokens can be used as an authentication mechanism for Infrahub's REST- and GraphQL API, the Python SDK and infrahubctl.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
 1. Login to Infrahub's web interface as an administrator.

--- a/docs/docs/guides/object-conversion.mdx
+++ b/docs/docs/guides/object-conversion.mdx
@@ -37,7 +37,7 @@ Fields that match these criteria will be automatically mapped during conversion.
 
 ## Step 2: Convert the object type
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web Interface" default>
 
 Navigate to the object you want to convert and select **Convert object type** from the actions dropdown menu.

--- a/docs/docs/guides/object-template.mdx
+++ b/docs/docs/guides/object-template.mdx
@@ -119,7 +119,7 @@ Heading back to Infrahub you will notice new entries in the left-hand menu. Befo
 
 ### Create a device type
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
   1. Navigate to the left-hand menu and select `Device Type`
@@ -157,7 +157,7 @@ In Infrahub's implementation of object template, **the template doesn't hold any
 
 All template-related records can be found in the menu under the dedicated section `Object Management` > `Templates`.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
   1. Go to `Object Management` > `Templates`
@@ -199,7 +199,7 @@ Ensure you **reference the device template created in the previous step**. For d
 
 :::
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
   1. Click the `+ Add Object Templates` button
@@ -248,7 +248,7 @@ With the device template and interface templates in place, you're all set to cre
 
 Heading back to the main menu we will create a device object.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
   1. Click `Device` item in the left hand side menu

--- a/docs/docs/guides/profiles.mdx
+++ b/docs/docs/guides/profiles.mdx
@@ -175,7 +175,7 @@ From Infrahub 1.7 relationships can also be defined in Profiles. If you are usin
 
 :::
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Open the **Infrahub UI** in your browser
@@ -248,7 +248,7 @@ mutation {
 
 Query Infrahub to confirm the Profile exists:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Object Management** → **Profiles**
@@ -301,7 +301,7 @@ You should see the Profile with all attributes set to your specified values.
 
 Now that we have a Profile, let's create multiple interfaces that inherit configuration from it. When using Profiles, you only need to specify the unique attributes (like name) and reference the Profile for all standardized values.
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -398,7 +398,7 @@ The query should return the IDs of the created interfaces:
 
 Now let's verify that the interfaces have properly inherited values from the Profile. Infrahub's metadata shows which values came from Profiles, giving you complete transparency about data origin.
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -485,7 +485,7 @@ While Profiles ensure consistency, you sometimes need exceptions for specific de
 
 Create an interface with a custom MTU value that overrides the Profile default:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -523,7 +523,7 @@ mutation {
 
 Confirm that the MTU was overridden while other values still come from the Profile:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -590,7 +590,7 @@ One of the key benefits of Profiles is that when you update a Profile, all nodes
 
 We will change the `end-user-interface` Profile to set a new default **MTU** of `9000` instead of `1500`.
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Open the **Infrahub UI** in your browser
@@ -621,7 +621,7 @@ mutation {
 
 ### Verify the update in interfaces
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -675,7 +675,7 @@ Learn more about Profile priorities in the [Profile priority system](../topics/p
 
 #### Step 1: Creating another Profile
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Object Management** → **Profiles**
@@ -710,7 +710,7 @@ mutation {
 
 #### Step 2: Assigning multiple Profiles to an interface
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**
@@ -753,7 +753,7 @@ mutation {
 
 Let's check which Profile values are being applied when multiple Profiles define the same attribute:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
 <TabItem value="web" label="Web interface">
 
 1. Navigate to **Interface**

--- a/docs/docs/guides/python-transform.mdx
+++ b/docs/docs/guides/python-transform.mdx
@@ -76,7 +76,7 @@ This allows you to manage the returned data with helper methods on the SDK objec
 Read more on the [Infrahub Python SDK]($(base_url)python-sdk/introduction).
 :::
 
-<Tabs groupId="convertResponse">
+<Tabs groupId="convertResponse" queryString>
   <TabItem value="Non-converted query response">
 ```graphql
 query DeviceQuery {
@@ -235,7 +235,7 @@ The query will require an input parameter called `$name` what will refer to the 
 
 The next step is to create the actual Python Transformation. The Transformation is a Python class that inherits from InfrahubTransform from the [Python SDK]($(base_url)python-sdk/introduction). Create a file called `device_config_render/device_config.py`:
 
-<Tabs groupId="convertResponse">
+<Tabs groupId="convertResponse" queryString>
   <TabItem value="Non-converted query response">
   <!-- vale Infrahub.spelling = NO -->
 ```python
@@ -297,7 +297,7 @@ With this configuration, the endpoint of our Transformation will be [http://loca
 
 4. The Transformation method
 
-<Tabs groupId="convertResponse">
+<Tabs groupId="convertResponse" queryString>
   <TabItem value="Non-converted query response">
     <!-- vale Infrahub.spelling = NO -->
 ```python
@@ -359,7 +359,7 @@ Read more on the [Infrahub Python SDK]($(base_url)python-sdk/introduction).
 
 See [this topic](../topics/infrahub-yml.mdx) for a full explanation of everything that can be defined in the `.infrahub.yml` file.
 
-<Tabs groupId="convertResponse">
+<Tabs groupId="convertResponse" queryString>
   <TabItem value="Non-converted query response">
     <!-- markdownlint-disable MD046 -->
     <!-- vale Infrahub.swap = NO -->
@@ -394,7 +394,7 @@ queries:
   </TabItem>
 </Tabs>
 
-<Tabs>
+<Tabs groupId="transform-type" queryString>
   <TabItem value="Python Transformation" default>
     Two parts here are required, first the `name` of the Transformation which should be unique across Infrahub and also the `file_path` that should point to the Python file within the repository. In this example we have also defined `class_name`, the reason for this is that we gave our class the name `DeviceConfigTransform` instead of the default `Transform`.
   </TabItem>

--- a/docs/docs/guides/repository.mdx
+++ b/docs/docs/guides/repository.mdx
@@ -71,7 +71,7 @@ If you are using a **personal access token for authentication**, you should put 
 
 :::
 
-<Tabs>
+<Tabs groupId="method" queryString>
 <TabItem value="Via the Web Interface" default>
   1. Log in to the Infrahub UI
   2. Go to **Integrations > Git Repositories**
@@ -88,7 +88,7 @@ If you are using a **personal access token for authentication**, you should put 
 <TabItem value="Via infrahubctl">
   Using the [infrahubctl]($(base_url)infrahubctl/infrahubctl) command-line tool, you can add a repository by running the following command:
 
-  <Tabs groupId="repository-type">
+  <Tabs groupId="repository-type" queryString>
     <TabItem value="Repository" default>
     ```shell
     infrahubctl repository add "My Git Repository" "https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git" --username MY_USERNAME --password MY_TOKEN_OR_PASSWORD
@@ -134,7 +134,7 @@ If you are using a **personal access token for authentication**, you should put 
 
   3. Use one of the mutations below based on your repository type:
 
-  <Tabs groupId="repository-type">
+  <Tabs groupId="repository-type" queryString>
     <TabItem value="Repository" default>
     ```graphql
     mutation {
@@ -192,7 +192,7 @@ If you are using a **personal access token for authentication**, you should put 
 
   2. Create the repository object:
 
-  <Tabs groupId="repository-type">
+  <Tabs groupId="repository-type" queryString>
     <TabItem value="Repository" default>
     ```python
     # Create repository object
@@ -236,7 +236,7 @@ Unlike fully integrated repositories which sync automatically, read-only reposit
 
 For more details on how each repository type tracks changes, refer to the [Repository Topic](../topics/repository.mdx#read-only-vs-core).
 
-<Tabs>
+<Tabs groupId="method" queryString>
 <TabItem value="Via the Web Interface" default>
 
 1. Log in to the Infrahub UI
@@ -391,7 +391,7 @@ RUN update-ca-certificates
 INFRAHUB_VERSION=latest && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION} .
 ```
 
-<Tabs>
+<Tabs groupId="deployment" queryString>
 <TabItem value="Using Docker Compose" default>
 
 If you are using Docker Compose, you can override part of your existing `docker-compose.yml` file to use your custom image. See the official [Docker Compose documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/#how-to-merge-multiple-compose-files) for more details.
@@ -447,7 +447,7 @@ RUN git config --global http.sslVerify "false"
 INFRAHUB_VERSION=latest && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION} .
 ```
 
-<Tabs>
+<Tabs groupId="deployment" queryString>
 <TabItem value="Using Docker Compose" default>
 
 If you are using Docker Compose, you can override part of your existing `docker-compose.yml` file to use your custom image. See the official [Docker Compose documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/#how-to-merge-multiple-compose-files) for more details.
@@ -503,7 +503,7 @@ RUN git config --global http.proxy http://user:password@internal.proxy:8080
 INFRAHUB_VERSION=latest && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION} .
 ```
 
-<Tabs>
+<Tabs groupId="deployment" queryString>
 <TabItem value="Using Docker Compose" default>
 
 If you are using Docker Compose, you can override part of your existing `docker-compose.yml` file to use your custom image. See the official [Docker Compose documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/#how-to-merge-multiple-compose-files) for more details.

--- a/docs/docs/guides/resource-manager.mdx
+++ b/docs/docs/guides/resource-manager.mdx
@@ -159,7 +159,7 @@ A `CoreIPAddressPool` allows you to dynamically allocate IP addresses from one o
 First, create an IP Prefix object that the resource manager will use as a resource.
 You can create a prefix (for example, `10.100.0.0/24`) either via the web interface or through the GraphQL interface.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ![Creating prefix 10.100.0 via the Web Interface](../media/guides/resources-manager/resource_manager_rss_prefix_10_100_0.png)
   </TabItem>
@@ -198,7 +198,7 @@ Next, create a resource manager of kind `CoreIPAddressPool` with the following p
 
 The `CoreIPAddressPool` can be created using the web interface, or by using this GraphQL mutation. Replace the id of the resource with the id of the prefix of the previous step.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
   ![Creating IP address pool via the Web Interface](../media/guides/resources-manager/resource_manager_pool_ip.png)
   </TabItem>
@@ -243,7 +243,7 @@ Please refer to the [Resource Manager Topic](../topics/resource-manager.mdx) for
 
 Execute the following mutation to allocate an IP address out of the pool. Replace the id with the id of the `CoreIPAddressPool` we created previously.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="graphql" label="Via the GraphQL Interface">
 
   ```graphql
@@ -277,7 +277,7 @@ You can allocate resources in an idempotent way by specifying an identifier in t
 
 Execute this mutation twice, note the identifier. The resulting IP address should be the same, as well as the id. Replace the id with the id of the `CoreIPAddressPool` we created previously.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="graphql" label="Via the GraphQL Interface">
 
   ```graphql
@@ -309,7 +309,7 @@ IP address pools (`CoreIPAddressPool`) dynamically allocate individual IP addres
 
 Create the IP prefix that serves as the allocation source:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **IPAM** → **IP Prefixes**  and create a new prefix with:
@@ -351,7 +351,7 @@ Save the prefix ID for the next step!
 
 Create a `CoreIPAddressPool` resource manager:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **Object Management** → **Resource Managers** and create a new IP Address Pool with:
@@ -404,7 +404,7 @@ You can allocate IP addresses in two ways: direct allocation or allocation durin
 
 Allocate an IP address directly from the pool:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
   This method is currently not available in the Web interface. Use the GraphQL method instead.
@@ -468,7 +468,7 @@ You have created an IP address record from the pool!
 
 Allocate an IP address when creating a device:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
   Navigate to **Devices** → **Add Device**. Next to the Primary IP Address field, click the pools button and select your resource pool.
@@ -520,7 +520,7 @@ IP prefix pools (`CoreIPPrefixPool`) allocate IP subnets from larger prefixes.
 
 Create the parent prefix:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **IPAM** → **IP Prefixes** and create a new prefix with:
@@ -561,7 +561,7 @@ Navigate to **IPAM** → **IP Prefixes** and create a new prefix with:
 
 Create a `CoreIPPrefixPool` resource manager:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **Object Management** → **Resource Managers** and create a new IP Prefix Pool with:
@@ -614,7 +614,7 @@ You can allocate IP prefixes in two ways: direct allocation or allocation during
 
 Allocate an IP prefix directly from the pool:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
   This method is currently not available in the Web interface. Use the GraphQL method instead.
@@ -653,7 +653,7 @@ You have created an IP prefix record from the pool!
 
 Allocate an IP prefix when creating a customer service:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
   Navigate to **Customer Service** → **Add Customer Service**.
@@ -730,7 +730,7 @@ Please refer to the [Resource Manager Topic](../topics/resource-manager.mdx) for
 
 Execute the following mutation to allocate an IP prefix out of the pool. Replace the id with the id of the `CoreIPPrefixPool` we created previously.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="graphql" label="Via the GraphQL Interface">
 
   ```graphql
@@ -762,7 +762,7 @@ Another way we can use resource managers is in situations where we create a node
 
 This feature is not yet available directly via the Web Interface.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="graphql" label="Via the GraphQL Interface" default>
   In this mutation we use the `from_pool` resolver to indicate we want to allocate a `assigned_prefix` from a resource pool. Replace the id with the id of the `CoreIPPrefixPool` we created previously.
 
@@ -806,7 +806,7 @@ You can allocate resources in an idempotent way by specifying an identifier in t
 
 Execute this mutation twice, note the identifier. The resulting IP prefix should be the same, as well as the id. Replace the id with the id of the `CoreIPPrefixPool` we created previously.
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="graphql" label="Via the GraphQL Interface">
 
   ```graphql
@@ -838,7 +838,7 @@ Number pools (`CoreNumberPool`) automatically assign sequential numbers to numer
 
 Create a pool for VLAN IDs:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **Object Management** → **Resource Managers** and create a new Number Pool with:
@@ -885,7 +885,7 @@ Save the pool ID for allocation operations!
 
 ### Step 2: Allocate VLAN ID
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
   Navigate to **VLAN** → **Add VLAN**. Next to the VLAN ID field, click the pools button and select your number pool.
@@ -1015,7 +1015,7 @@ Save the prefix IDs for the next step!
 
 4. Create a `CoreIPAddressPool` resource manager:
 
-<Tabs groupId="method">
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Navigate to **Object Management** → **Resource Managers** and create a new IP Address Pool with:

--- a/docs/docs/guides/sso.mdx
+++ b/docs/docs/guides/sso.mdx
@@ -35,7 +35,7 @@ Select a protocol based on your identity provider's support. Most modern provide
 OIDC provides standardized user information and is recommended for new implementations. See [Authentication topic](../topics/authentication.mdx) for details on the differences between OIDC and OAuth2.
 :::
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
   <TabItem value="oidc" default>
   OpenID Connect (OIDC) is recommended when available as it provides standardized user profile information.
   </TabItem>
@@ -67,7 +67,7 @@ https://<your-infrahub-hostname>/auth/<protocol>/<provider-slot>/callback
 
 For a production Infrahub instance at `infrahub.example.com`:
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
   <TabItem value="oidc" default>
   ```
   https://infrahub.example.com/auth/oidc/provider1/callback
@@ -86,7 +86,7 @@ Use the `INFRAHUB_PUBLIC_URL` environment variable to specify the externally acc
 
 For a local development instance:
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
   <TabItem value="oidc" default>
   ```
   http://localhost:8000/auth/oidc/provider1/callback
@@ -143,7 +143,7 @@ Make note of the following information for Infrahub configuration:
 On the registration overview page, click the **Endpoints** tab to find the necessary URLs.
 :::
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
 <TabItem value="oidc" default>
 | Field | Location/Value |
 |-------|-------|
@@ -170,7 +170,7 @@ On the registration overview page, click the **Endpoints** tab to find the neces
 :::success
 At the end of this step, you should have gathered all the necessary information to configure SSO in Infrahub.
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
 <TabItem value="oidc" default>
 
 | Client ID | Client Secret | Discovery URL |
@@ -201,9 +201,9 @@ For detailed configuration options, see the [configuration reference](../referen
 For multiple identity providers, refer to the [Advanced Configuration Section](#multiple-identity-providers).
 :::
 
-<Tabs groupId="selected-protocol">
+<Tabs groupId="selected-protocol" queryString>
 <TabItem value="oidc" default>
-<Tabs groupId="config-method">
+<Tabs groupId="config-method" queryString>
 <TabItem value="environment-variables" default>
 
 ```bash
@@ -244,7 +244,7 @@ oidc_providers = ["provider1"]
 
 </TabItem>
 <TabItem value="oauth2">
-<Tabs groupId="config-method">
+<Tabs groupId="config-method" queryString>
 <TabItem value="environment-variables" default>
 
 ```bash
@@ -333,7 +333,7 @@ To configure multiple identity providers:
 - Configure each provider using the same steps as above, but with the appropriate slot name (for example `provider1`, `provider2`)
 - Make sure to set the `INFRAHUB_SECURITY_OIDC_PROVIDERS` or `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` variable to include all configured providers
 
-<Tabs groupId="config-method">
+<Tabs groupId="config-method" queryString>
 <TabItem value="environment-variables" default>
 
 ```bash
@@ -421,7 +421,7 @@ If your identity provider cannot provide group information, configure a default 
 You must create this default group in Infrahub before configuring it here.
 :::
 
-<Tabs groupId="config-method">
+<Tabs groupId="config-method" queryString>
 <TabItem value="environment-variables" default>
 
 ```bash

--- a/docs/docs/guides/upgrade.mdx
+++ b/docs/docs/guides/upgrade.mdx
@@ -29,7 +29,7 @@ For earlier versions, please refer to the [release notes](../release-notes/infra
 
 ### Upgrading to Infrahub 1.2 and after
 
-<Tabs>
+<Tabs groupId="deployment" queryString>
 <TabItem value="docker" label="Docker" default>
 
 ```bash
@@ -110,7 +110,7 @@ For earlier versions, please refer to the [release notes](/release-notes/infrahu
 
 ### Upgrading to Infrahub Enterprise 1.2 and after
 
-<Tabs>
+<Tabs groupId="deployment" queryString>
 <TabItem value="docker" label="Docker" default>
 
 ```bash

--- a/docs/docs/guides/webhooks.mdx
+++ b/docs/docs/guides/webhooks.mdx
@@ -11,7 +11,7 @@ Infrahub supports two different types of webhooks:
 
 # Managing webhooks
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
 1. Login to Infrahub's web interface as an administrator.
@@ -145,7 +145,7 @@ Add your repository containing the Transformation to Infrahub. See the [reposito
 
 ## 5. Create the custom webhook
 
-<Tabs>
+<Tabs groupId="method" queryString>
   <TabItem value="web" label="Via the Web Interface" default>
 
 1. Navigate to **Integrations** > **Webhooks**.

--- a/docs/docs/snippets/attribute-kind-params.mdx
+++ b/docs/docs/snippets/attribute-kind-params.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 <!-- vale Infrahub.spelling = NO -->
 
-<Tabs>
+<Tabs groupId="attribute-kind" queryString>
 <TabItem value="Number">
 | Parameter | Default |
 | --------- | ------- |

--- a/docs/docs/topics/schema.mdx
+++ b/docs/docs/topics/schema.mdx
@@ -1178,7 +1178,7 @@ In order to update the human readable identifier, it's required to temporarily p
 All Node, Generic, Attribute or Relationship have their unique identifier that can be find easily in the schema explorer in the frontend [http://localhost:8000/schema](http://localhost:8000/schema)
 The internal identifier should be an UUID4, with 36 characters.
 
-<Tabs>
+<Tabs groupId="schema-version" queryString>
 <TabItem value="new" label="New Version">
 
 ```yaml {4-6} showLineNumbers

--- a/docs/docs/topics/webhooks.mdx
+++ b/docs/docs/topics/webhooks.mdx
@@ -106,7 +106,7 @@ When using webhooks over HTTPS, you can configure your system to validate certif
 
 Here are some example payloads of some events that may be sent.
 <!-- vale off -->
-<Tabs>
+<Tabs groupId="event-type" queryString>
   <TabItem value="infrahub.branch.created" label="infrahub.branch.created" default>
 
 ```json

--- a/docs/src/theme/Tabs/index.tsx
+++ b/docs/src/theme/Tabs/index.tsx
@@ -1,0 +1,43 @@
+import React, {useEffect} from 'react';
+import Tabs from '@theme-original/Tabs';
+import type TabsType from '@theme/Tabs';
+import type {WrapperProps} from '@docusaurus/types';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+type Props = WrapperProps<typeof TabsType>;
+
+export default function TabsWrapper(props: Props): React.JSX.Element {
+  const isBrowser = useIsBrowser();
+
+  // On the client, read the query string BEFORE the first render
+  // so that useState inside the original Tabs initializes with
+  // the correct tab value instead of the default.
+  let defaultValue = props.defaultValue;
+  if (isBrowser && props.queryString && props.groupId) {
+    const paramName =
+      typeof props.queryString === 'string'
+        ? props.queryString
+        : props.groupId;
+    const params = new URLSearchParams(window.location.search);
+    const qsValue = params.get(paramName);
+    if (qsValue) {
+      defaultValue = qsValue;
+    }
+  }
+
+  // After hydration, re-scroll to hash anchor since the correct
+  // tab content is now visible.
+  useEffect(() => {
+    if (isBrowser && window.location.hash) {
+      const id = decodeURIComponent(window.location.hash.slice(1));
+      const el = document.getElementById(id);
+      if (el) {
+        requestAnimationFrame(() => {
+          el.scrollIntoView();
+        });
+      }
+    }
+  }, [isBrowser]);
+
+  return <Tabs key={String(isBrowser)} {...props} defaultValue={defaultValue} />;
+}


### PR DESCRIPTION
This allows sharing anchored URLs pointing to non-default tabs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation tabs now support URL query-string state and explicit tab grouping, enabling sharable links that open specific tabs and preserve selection across navigation.
  * Tabs now initialize from the URL and auto-scroll to the referenced section on load, improving deep-linking and navigation in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->