### PR TITLE
Fix disappearing IP with mask outside prefix range

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1012,6 +1012,32 @@ class IPPrefixReconcileQuery(Query):
         self.namespace_id = _get_namespace_id(namespace)
         super().__init__(**kwargs)
 
+    def _build_possible_parent_prefixes(
+        self, is_address: bool, prefixlen: int, prefix_bin: str, prefix_bin_host: str
+    ) -> None:
+        """Build the list of possible parent prefix candidates for the parent-finding query."""
+        possible_prefix_map: dict[str, int] = {}
+        if is_address:
+            # For addresses, use the full host binary to find parent prefixes at any
+            # prefix length, regardless of the address's own mask (#7267).
+            # Cap at max_prefixlen - 1 so that host-route prefixes (/32 IPv4, /128 IPv6)
+            # are not considered as parents for addresses with a less specific mask.
+            parent_search_binary = prefix_bin
+            max_parent_prefixlen = self.ip_value.max_prefixlen - 1
+            start_prefixlen = max(prefixlen, max_parent_prefixlen)
+        else:
+            parent_search_binary = prefix_bin_host
+            start_prefixlen = prefixlen - 1
+        for max_prefix_len in range(start_prefixlen, -1, -1):
+            tmp_prefix = parent_search_binary[:max_prefix_len]
+            possible_prefix = tmp_prefix.ljust(self.ip_value.max_prefixlen, "0")
+            if possible_prefix not in possible_prefix_map:
+                possible_prefix_map[possible_prefix] = max_prefix_len
+        self.params["possible_prefix_and_length_list"] = [
+            [prefix, length] for prefix, length in possible_prefix_map.items()
+        ]
+        self.params["possible_prefix_list"] = list(possible_prefix_map.keys())
+
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
         self.params.update(branch_params)
@@ -1035,19 +1061,10 @@ class IPPrefixReconcileQuery(Query):
         self.params["prefix_binary_full"] = prefix_bin
         self.params["prefix_binary_host"] = prefix_bin_host
         self.params["ip_version"] = self.ip_value.version
-        # possible prefix: highest possible prefix length for a match
-        possible_prefix_map: dict[str, int] = {}
-        start_prefixlen = prefixlen if is_address else prefixlen - 1
-        for max_prefix_len in range(start_prefixlen, -1, -1):
-            tmp_prefix = prefix_bin_host[:max_prefix_len]
-            possible_prefix = tmp_prefix.ljust(self.ip_value.max_prefixlen, "0")
-            if possible_prefix not in possible_prefix_map:
-                possible_prefix_map[possible_prefix] = max_prefix_len
-        self.params["possible_prefix_and_length_list"] = []
-        self.params["possible_prefix_list"] = []
-        for possible_prefix, max_length in possible_prefix_map.items():
-            self.params["possible_prefix_and_length_list"].append([possible_prefix, max_length])
-            self.params["possible_prefix_list"].append(possible_prefix)
+        self.params["max_prefixlen"] = self.ip_value.max_prefixlen
+        self._build_possible_parent_prefixes(
+            is_address=is_address, prefixlen=prefixlen, prefix_bin=prefix_bin, prefix_bin_host=prefix_bin_host
+        )
 
         namespace_query = """
         // ------------------
@@ -1283,7 +1300,7 @@ class IPPrefixReconcileQuery(Query):
             AND (ip_node IS NULL OR maybe_new_child.uuid <> ip_node.uuid)
             AND (
                 ($ip_prefix_kind IN labels(maybe_new_child) AND av.prefixlen > $prefixlen)
-                OR ($ip_address_kind IN labels(maybe_new_child) AND av.prefixlen >= $prefixlen)
+                OR ($ip_address_kind IN labels(maybe_new_child) AND ($prefixlen < $max_prefixlen OR av.prefixlen >= $prefixlen))
             )
             AND av.version = $ip_version
             AND av.binary_address STARTS WITH $prefix_binary_host
@@ -1323,7 +1340,7 @@ class IPPrefixReconcileQuery(Query):
             WITH av, is_active, (
                 (
                     ($ip_prefix_kind IN labels(maybe_new_child) AND av.prefixlen > $prefixlen)
-                    OR ($ip_address_kind IN labels(maybe_new_child) AND av.prefixlen >= $prefixlen)
+                    OR ($ip_address_kind IN labels(maybe_new_child) AND ($prefixlen < $max_prefixlen OR av.prefixlen >= $prefixlen))
                 )
                 AND av.version = $ip_version
                 AND av.binary_address STARTS WITH $prefix_binary_host
@@ -1356,7 +1373,7 @@ class IPPrefixReconcileQuery(Query):
                     WHEN potential_parent[0] = ips[ind][0] THEN has_more_specific_parent  // skip comparison to self
                     WHEN $ip_address_kind in labels(potential_parent[0]) THEN has_more_specific_parent  // address cannot be a parent
                     WHEN $ip_prefix_attribute_kind IN labels(ips[ind][1]) AND (potential_parent[1]).prefixlen >= (ips[ind][1]).prefixlen THEN has_more_specific_parent  // prefix with same or greater prefixlen for prefix cannot be parent
-                    WHEN $ip_address_attribute_kind IN labels(ips[ind][1]) AND (potential_parent[1]).prefixlen > (ips[ind][1]).prefixlen THEN has_more_specific_parent  // prefix with greater prefixlen for address cannot be parent
+                    WHEN $ip_address_attribute_kind IN labels(ips[ind][1]) AND (potential_parent[1]).prefixlen >= $max_prefixlen AND (potential_parent[1]).prefixlen > (ips[ind][1]).prefixlen THEN has_more_specific_parent  // host-route prefix (/32 or /128) cannot parent addresses with less specific mask
                     WHEN (ips[ind][1]).binary_address STARTS WITH SUBSTRING((potential_parent[1]).binary_address, 0, (potential_parent[1]).prefixlen) THEN TRUE  // we found a parent
                     ELSE has_more_specific_parent
                 END

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -94,7 +94,7 @@ async def _resolve_available_address_nodes(
     ip_range_schema = registry.get_node_schema(name=InfrahubKind.IPRANGEAVAILABLE, branch=branch)
 
     # Make sure nodes are ordered by addresses
-    sorted_nodes = sorted(existing_nodes, key=lambda n: n.address.obj)
+    sorted_nodes = sorted(existing_nodes, key=lambda n: n.address.obj.ip)
     prefix_first_address = (
         ip_prefix.network_address if _include_first_and_last_ips(ip_prefix=prefix) else ip_prefix.network_address + 1
     )

--- a/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
@@ -530,18 +530,31 @@ async def test_address_cannot_be_parent(
     prefix_node = await Node.init(db=db, schema=prefix_schema)
     await prefix_node.new(db=db, prefix="172.20.20.0/27", ip_namespace=ip_namespace)
     await prefix_node.save(db=db)
-    address_node = await Node.init(db=db, schema=address_schema)
-    await address_node.new(db=db, address="172.20.20.0/24", ip_namespace=ip_namespace)
-    await address_node.save(db=db)
 
-    for ip_value in (ipaddress.ip_interface("172.20.20.0/24"), ipaddress.ip_network("172.20.20.0/27")):
+    address_a = await Node.init(db=db, schema=address_schema)
+    await address_a.new(db=db, address="172.20.20.0/24", ip_namespace=ip_namespace)
+    await address_a.save(db=db)
+    address_b = await Node.init(db=db, schema=address_schema)
+    await address_b.new(db=db, address="172.20.20.1/32", ip_namespace=ip_namespace)
+    await address_b.save(db=db)
+
+    query = await IPPrefixReconcileQuery.init(
+        db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("172.20.20.0/27")
+    )
+    await query.execute(db=db)
+    data = query.get_data()
+    assert data is not None
+    assert data.calculated_parent_uuid is None
+    assert set(data.calculated_children_uuids) == {address_a.id, address_b.id}
+
+    for address_value in ("172.20.20.0/24", "172.20.20.1/32"):
         query = await IPPrefixReconcileQuery.init(
-            db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ip_value
+            db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_interface(address_value)
         )
         await query.execute(db=db)
         data = query.get_data()
         assert data is not None
-        assert data.calculated_parent_uuid is None
+        assert data.calculated_parent_uuid == prefix_node.id
         assert data.calculated_children_uuids == ()
 
 

--- a/backend/tests/component/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/component/core/ipam/test_ipam_reconciler.py
@@ -434,3 +434,75 @@ async def test_ipprefix_swap_values_on_branch(db: InfrahubDatabase, default_bran
     # check parent is correct
     updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
     assert len(updated_parent_rel) == 0
+
+
+async def test_ipaddress_mask_less_specific_than_parent_prefix(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
+    """IP addresses with a mask less specific than their parent prefix should remain children of that prefix based on host address containment."""
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
+    namespace = ip_dataset_01["ns1"]
+    net143 = ip_dataset_01["net143"]
+
+    # Create an IP address 10.10.1.5/32 within net143
+    new_address = await Node.init(db=db, schema=address_schema)
+    await new_address.new(db=db, address="10.10.1.5/32", ip_namespace=namespace)
+    await new_address.save(db=db)
+
+    reconciler = IpamReconciler(db=db, branch=default_branch)
+    ip_interface = ipaddress.ip_interface(new_address.address.value)
+    await reconciler.reconcile(ip_value=ip_interface, namespace=namespace)
+
+    updated_address = await NodeManager.get_one(db=db, branch=default_branch, id=new_address.id)
+    prefix_rels = await updated_address.ip_prefix.get_relationships(db=db)
+    assert len(prefix_rels) == 1
+    assert prefix_rels[0].peer_id == net143.id
+
+    # Now change the IP mask to /24 (less specific than the parent prefix /27)
+    # Host 10.10.1.5 is still within 10.10.1.0/27
+    updated_address.address.value = "10.10.1.5/24"
+    await updated_address.save(db=db)
+
+    ip_interface_updated = ipaddress.ip_interface(updated_address.address.value)
+    await reconciler.reconcile(ip_value=ip_interface_updated, namespace=namespace, node_uuid=updated_address.get_id())
+
+    # The host address 10.10.1.5 is still within net143, so the IP should remain a child of net143 regardless of its mask
+    re_updated_address = await NodeManager.get_one(db=db, branch=default_branch, id=new_address.id)
+    prefix_rels = await re_updated_address.ip_prefix.get_relationships(db=db)
+    assert len(prefix_rels) == 1
+    assert prefix_rels[0].peer_id == net143.id
+
+
+async def test_prefix_reconcile_finds_address_with_less_specific_mask(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+) -> None:
+    """Reconciling a prefix should find child IP addresses even when their mask is less specific than the prefix."""
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
+    namespace = ip_dataset_01["ns1"]
+    net143 = ip_dataset_01["net143"]
+
+    # Create an IP address 10.10.1.5/24 (mask less specific than the /27 prefix)
+    new_address = await Node.init(db=db, schema=address_schema)
+    await new_address.new(db=db, address="10.10.1.5/24", ip_namespace=namespace)
+    await new_address.save(db=db)
+
+    # Reconcile the prefix, it should find the address as a child
+    reconciler = IpamReconciler(db=db, branch=default_branch)
+    ip_network = ipaddress.ip_network(net143.prefix.value)
+    await reconciler.reconcile(ip_value=ip_network, namespace=namespace)
+
+    # Verify the prefix should list the new address as a child
+    updated_prefix = await NodeManager.get_one(db=db, branch=default_branch, id=net143.id)
+    address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    address_peer_ids = {rel.peer_id for rel in address_rels}
+    assert new_address.id in address_peer_ids
+
+    # Verify the address should have net143 as its parent
+    updated_address = await NodeManager.get_one(db=db, branch=default_branch, id=new_address.id)
+    prefix_rels = await updated_address.ip_prefix.get_relationships(db=db)
+    assert len(prefix_rels) == 1
+    assert prefix_rels[0].peer_id == net143.id

--- a/changelog/7267.fixed.md
+++ b/changelog/7267.fixed.md
@@ -1,0 +1,1 @@
+Fixed IP addresses disappearing from their parent prefix when the address mask is less specific than the prefix length


### PR DESCRIPTION
# Why

IP addresses "disappear" from their parent prefix when their mask (prefixlen) is less specific than the prefix. For example, `10.1.0.33/28` vanishes from `10.1.0.32/29` even though host `10.1.0.33` is within the /29 range. The IPAM reconciliation query uses the address's mask to determine containment instead of checking whether the host address falls within the prefix range.

Closes #7267

<img width="647" height="385" alt="image" src="https://github.com/user-attachments/assets/509ca109-ece1-449c-9f52-963456687928" />

## What changed

- In IPAM reconciliation query (`backend/infrahub/core/query/ipam.py`): addresses are now matched to prefixes based on host containment rather than mask comparison.
- GraphQL resolver (`backend/infrahub/graphql/resolvers/ipam.py`): fixed address gap calculation that sorted by `IPInterface` (network+mask) instead of host IP, producing phantom "available" ranges when addresses had different masks.
- Extracted `_build_possible_parent_prefixes()` helper from `query_init()`.

API contract and schema unchanged.

## How to review

Focus on the query changes in `ipam.py`, 3 Cypher conditions were relaxed for addresses (guarded by `$prefixlen < $max_prefixlen` for host-route safety), and a new `$max_prefixlen` parameter was added.

## How to test

```bash
uv run pytest backend/tests/component/core/ipam/ -v
```

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented IP addresses from disappearing from their parent prefix when the address mask is less-specific than the prefix, and improved parent/child detection across host-route boundaries.
* **Tests**
  * Added and updated reconciliation tests to cover less-specific masks and parent/child discovery scenarios.
* **Changelog**
  * Added entry documenting the IP address reconciliation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->