### PR TITLE
Update merged status color

### DIFF
--- a/frontend/app/src/entities/branches/ui/branch-list-item/branch-status-badge.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-list-item/branch-status-badge.tsx
@@ -49,7 +49,7 @@ export function BranchStatusBadge({
     }
     case BRANCH_STATUS.MERGED: {
       return (
-        <Badge className={classNames(pillStyle, className)} variant="blue" {...props}>
+        <Badge className={classNames(pillStyle, className)} variant="purple" {...props}>
           Merged
         </Badge>
       );

--- a/frontend/app/src/shared/components/ui/badge.tsx
+++ b/frontend/app/src/shared/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         red: "border-transparent bg-red-100 text-red-900",
         blue: "border-transparent bg-custom-blue-700/10 text-custom-blue-700",
         yellow: "border-transparent bg-yellow-100 text-yellow-900",
-        purple: "border-transparent bg-purple-50 text-purple-900",
+        purple: "border-transparent bg-purple-100 text-purple-800",
         "gray-outline": "border-gray-400 bg-white text-gray-700",
         "lightgray-outline": "border-gray-200 bg-white text-gray-500",
         "blue-outline": "border-custom-blue-700 bg-white text-custom-blue-700",


### PR DESCRIPTION
<img width="1299" height="613" alt="image" src="https://github.com/user-attachments/assets/b9e25d83-180c-494a-9d3f-315a27020ddc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Merged branch status now displays a purple badge instead of blue.
  - Updated the purple badge color palette (slightly deeper background and lighter text) for improved contrast and readability.
  - Visual-only adjustments; no behavior or interactions changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->