### PR TITLE
set profiles relationship weight to 99,000

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -891,8 +891,12 @@ class SchemaManager(NodeManager):
                 if branch_hash:
                     branch_processed.add(branch_hash)
                 if branch := self._branches.get(active_branch):
-                    nodes = branch.get_all(include_internal=True, duplicate=False)
-                    hashes_to_keep.update([node.get_hash() for node in nodes.values()])
+                    # Use stored hash keys from the dicts rather than recalculating the hash
+                    # on cached objects, in case objects have been improperly mutated in-place
+                    hashes_to_keep.update(branch.nodes.values())
+                    hashes_to_keep.update(branch.generics.values())
+                    hashes_to_keep.update(branch.profiles.values())
+                    hashes_to_keep.update(branch.templates.values())
 
         removed_branches: list[str] = []
         for branch_name in list(self._branches.keys()):

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -891,12 +891,8 @@ class SchemaManager(NodeManager):
                 if branch_hash:
                     branch_processed.add(branch_hash)
                 if branch := self._branches.get(active_branch):
-                    # Use stored hash keys from the dicts rather than recalculating the hash
-                    # on cached objects, in case objects have been improperly mutated in-place
-                    hashes_to_keep.update(branch.nodes.values())
-                    hashes_to_keep.update(branch.generics.values())
-                    hashes_to_keep.update(branch.profiles.values())
-                    hashes_to_keep.update(branch.templates.values())
+                    nodes = branch.get_all(include_internal=True, duplicate=False)
+                    hashes_to_keep.update([node.get_hash() for node in nodes.values()])
 
         removed_branches: list[str] = []
         for branch_name in list(self._branches.keys()):

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -163,12 +163,7 @@ class SchemaBranch:
         Since the object themselves are considered immutable we just need to use the hash from each object to calculate the global hash.
         """
         md5hash = hashlib.md5(usedforsecurity=False)
-        for key, value in sorted(
-            tuple(self.nodes.items())
-            + tuple(self.generics.items())
-            + tuple(self.profiles.items())
-            + tuple(self.templates.items())
-        ):
+        for key, value in sorted(tuple(self.nodes.items()) + tuple(self.generics.items())):
             md5hash.update(str(key).encode())
             md5hash.update(str(value).encode())
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -82,7 +82,7 @@ profiles_rel_settings: dict[str, Any] = {
     "kind": RelationshipKind.PROFILE,
     "cardinality": RelationshipCardinality.MANY,
     "branch": BranchSupportType.AWARE,
-    "order_weight": 99_000,    
+    "order_weight": 99_000,
 }
 
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -82,6 +82,7 @@ profiles_rel_settings: dict[str, Any] = {
     "kind": RelationshipKind.PROFILE,
     "cardinality": RelationshipCardinality.MANY,
     "branch": BranchSupportType.AWARE,
+    "order_weight": 99_000,    
 }
 
 
@@ -162,7 +163,12 @@ class SchemaBranch:
         Since the object themselves are considered immutable we just need to use the hash from each object to calculate the global hash.
         """
         md5hash = hashlib.md5(usedforsecurity=False)
-        for key, value in sorted(tuple(self.nodes.items()) + tuple(self.generics.items())):
+        for key, value in sorted(
+            tuple(self.nodes.items())
+            + tuple(self.generics.items())
+            + tuple(self.profiles.items())
+            + tuple(self.templates.items())
+        ):
             md5hash.update(str(key).encode())
             md5hash.update(str(value).encode())
 
@@ -617,7 +623,9 @@ class SchemaBranch:
         self.process_hierarchy()
         self.process_branch_support()
         self.manage_object_template_schemas()
+        self.manage_object_template_relationships()
         self.manage_profile_schemas()
+        self.manage_profile_relationships()
         self.add_hierarchy_generic()
         self.add_hierarchy_node()
 
@@ -644,8 +652,6 @@ class SchemaBranch:
     def process_post_validation(self) -> None:
         self.cleanup_inherited_elements()
         self.add_groups()
-        self.manage_object_template_relationships()
-        self.manage_profile_relationships()
         self.generate_weight()
         self.process_labels()
         self.process_dropdowns()

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -83,6 +83,7 @@ class TestDiffRebase(TestInfrahubApp):
         continent_schema.parent = None
         main_schema_root.nodes.append(continent_schema)
         manufacturer_schema = main_schema_root.get(TestKind.MANUFACTURER)
+        manufacturer_schema.generate_profile = False
         manufacturer_schema.relationships.append(
             RelationshipSchema(
                 name="continents",


### PR DESCRIPTION
undo a couple lines from #8427 and set a static value for the weight of the profile relationships to try to prevent the `order_weight` of the `profiles` relationship from changing whenever a relationship is added to or removed from a schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted relationship weighting and validation ordering for more consistent schema processing.
  * Optimized branch cleanup to use existing in-memory keys, reducing redundant recomputation.
  * Enhanced merge diagnostics and error reporting to surface detailed schema/branch state on failures.
* **Tests**
  * Added test-time schema registration and deterministic dump helpers for better branch/state validation.
  * Limited integration test runs to a targeted subset for faster, focused troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->