### PR TITLE
prep release 1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.7.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.5) - 2026-02-23
+
+### Removed
+
+- Removed unused `enable` configuration toggle from broker, cache, and workflow settings
+
+### Fixed
+
+- Add migration to handle setting duplicated schemas on the default branch to be deleted, keeping the one with the latest update ([#8221](https://github.com/opsmill/infrahub/issues/8221))
+- Handle deleted parent relationship schemas when combining diffs without crashing ([#8388](https://github.com/opsmill/infrahub/issues/8388))
+- Prevent saving generated "profiles" and "object_template" schema relationships to the database. Includes a migration to clean up any already on the database. ([#8426](https://github.com/opsmill/infrahub/issues/8426))
+- Fixed regression (introduced in Infrahub 1.5) regarding merge performance. ([#8438](https://github.com/opsmill/infrahub/issues/8438))
+- Add full support for updating existing Template instances via schema migrations when the associated node or generic schema is updated in a manner that would add or remove attributes to or from the Template's schema.
+- Adds automatic retries to database queries during a branch merge to handle transient errors
+- Allow generating Template schemas for both a generic schema and a node inheriting from that generic. Previously, schema validation would raise a validation error and prevent this.
+- Fixed an issue where Infrahub was calculating the wrong authentication signature caused by HTTPX v0.28.0 switching to compact JSON payload encoding.
+- Fixed issue where system user showed as the last user changing a proposed change after merge
+
 ## [Infrahub - v1.7.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.4) - 2026-02-03
 
 ### Removed

--- a/changelog/+05d00859.fixed.md
+++ b/changelog/+05d00859.fixed.md
@@ -1,1 +1,0 @@
-Fixed issue where system user showed as the last user changing a proposed change after merge

--- a/changelog/+801e68b0.fixed.md
+++ b/changelog/+801e68b0.fixed.md
@@ -1,1 +1,0 @@
-Add full support for updating existing Template instances via schema migrations when the associated node or generic schema is updated in a manner that would add or remove attributes to or from the Template's schema.

--- a/changelog/+ad648740.fixed.md
+++ b/changelog/+ad648740.fixed.md
@@ -1,1 +1,0 @@
-Adds automatic retries to database queries during a branch merge to handle transient errors

--- a/changelog/+b92c6844.removed.md
+++ b/changelog/+b92c6844.removed.md
@@ -1,1 +1,0 @@
-Removed unused `enable` configuration toggle from broker, cache, and workflow settings

--- a/changelog/+fecfa688.fixed.md
+++ b/changelog/+fecfa688.fixed.md
@@ -1,1 +1,0 @@
-Allow generating Template schemas for both a generic schema and a node inheriting from that generic. Previously, schema validation would raise a validation error and prevent this.

--- a/changelog/+webhook_signature.fixed.md
+++ b/changelog/+webhook_signature.fixed.md
@@ -1,1 +1,0 @@
-Fixed an issue where Infrahub was calculating the wrong authentication signature caused by HTTPX v0.28.0 switching to compact JSON payload encoding.

--- a/changelog/8221.fixed.md
+++ b/changelog/8221.fixed.md
@@ -1,1 +1,0 @@
-Add migration to handle setting duplicated schemas on the default branch to be deleted, keeping the one with the latest update

--- a/changelog/8388.fixed.md
+++ b/changelog/8388.fixed.md
@@ -1,1 +1,0 @@
-Handle deleted parent relationship schemas when combining diffs without crashing

--- a/changelog/8426.fixed.md
+++ b/changelog/8426.fixed.md
@@ -1,1 +1,0 @@
-Prevent saving generated "profiles" and "object_template" schema relationships to the database. Includes a migration to clean up any already on the database.

--- a/changelog/8438.fixed.md
+++ b/changelog/8438.fixed.md
@@ -1,1 +1,0 @@
-Fixed regression (introduced in Infrahub 1.5) regarding merge performance.

--- a/docs/docs/release-notes/infrahub/release-1_7_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_7_5.mdx
@@ -18,6 +18,8 @@ title: Release 1.7.5
   </tbody>
 </table>
 
+<!-- vale off -->
+
 ### Removed
 
 - Removed unused `enable` configuration toggle from broker, cache, and workflow settings
@@ -33,3 +35,5 @@ title: Release 1.7.5
 - Allow generating Template schemas for both a generic schema and a node inheriting from that generic. Previously, schema validation would raise a validation error and prevent this.
 - Fixed an issue where Infrahub was calculating the wrong authentication signature caused by HTTPX v0.28.0 switching to compact JSON payload encoding.
 - Fixed issue where system user showed as the last user changing a proposed change after merge
+
+<!-- vale on -->

--- a/docs/docs/release-notes/infrahub/release-1_7_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_7_5.mdx
@@ -1,0 +1,35 @@
+---
+title: Release 1.7.5
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.7.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>February 23rd, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.7.5](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.7.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Removed
+
+- Removed unused `enable` configuration toggle from broker, cache, and workflow settings
+
+### Fixed
+
+- Add migration to handle setting duplicated schemas on the default branch to be deleted, keeping the one with the latest update ([#8221](https://github.com/opsmill/infrahub/issues/8221))
+- Handle deleted parent relationship schemas when combining diffs without crashing ([#8388](https://github.com/opsmill/infrahub/issues/8388))
+- Prevent saving generated "profiles" and "object_template" schema relationships to the database. Includes a migration to clean up any already on the database. ([#8426](https://github.com/opsmill/infrahub/issues/8426))
+- Fixed regression (introduced in Infrahub 1.5) regarding merge performance. ([#8438](https://github.com/opsmill/infrahub/issues/8438))
+- Add full support for updating existing Template instances via schema migrations when the associated node or generic schema is updated in a manner that would add or remove attributes to or from the Template's schema.
+- Adds automatic retries to database queries during a branch merge to handle transient errors
+- Allow generating Template schemas for both a generic schema and a node inheriting from that generic. Previously, schema validation would raise a validation error and prevent this.
+- Fixed an issue where Infrahub was calculating the wrong authentication signature caused by HTTPX v0.28.0 switching to compact JSON payload encoding.
+- Fixed issue where system user showed as the last user changing a proposed change after merge

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -423,6 +423,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_7_5',
             'release-notes/infrahub/release-1_7_4',
             'release-notes/infrahub/release-1_7_3',
             'release-notes/infrahub/release-1_7_2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.7.4"
+version = "1.7.5"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.14"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.7.4"
+version = "1.7.5"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.7.4"
+version = "1.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.7.4"
+version = "1.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
prep release 1.7.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Infrahub v1.7.5 (2026-02-23) summarizing removals and multiple fixes.
  * Cleaned up and finalized changelog entries, removing obsolete/redundant notes.

* **Chores**
  * Bumped project version metadata to 1.7.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->