### PR TITLE
IFC-1919  Fix optional-to-mandatory attribute transition

### DIFF
--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from infrahub.core.attribute import BaseAttribute
     from infrahub.core.branch import Branch
     from infrahub.core.constants import BranchSupportType
+    from infrahub.core.models import HashableModel
     from infrahub.core.query import QueryElement
     from infrahub.database import InfrahubDatabase
 
@@ -99,6 +100,18 @@ class AttributeSchema(GeneratedAttributeSchema):
             if isinstance(value, Enum):
                 data[field_name] = value.value
         return data
+
+    def update(self, other: HashableModel) -> Self:
+        super().update(other=other)
+
+        if isinstance(other, AttributeSchema):
+            # Allow explicit clearing of default_value (setting it to None).
+            # The base update() skips None values, but for default_value,
+            # None means "remove the default" which is semantically meaningful.
+            if "default_value" in other.model_fields_set and other.default_value is None:
+                self.default_value = None
+
+        return self
 
     @field_validator("kind")
     @classmethod

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -631,7 +631,6 @@ class SchemaBranch:
         self.process_attributes_state()
         self.process_relationships_state()
         self.generate_identifiers()
-        self.process_default_values()
         self.process_deprecations()
         self._reconcile_legacy_attribute_parameters()
         self.process_cardinality_counts()
@@ -1821,24 +1820,6 @@ class SchemaBranch:
             for node_rel in node.relationships:
                 if node_rel.name in rels_to_update:
                     node_rel.branch = rels_to_update[node_rel.name]
-
-            self.set(name=name, schema=node)
-
-    def process_default_values(self) -> None:
-        """Ensure that all attributes with a default value are flagged as optional: True."""
-        for name in self.all_names:
-            node = self.get(name=name, duplicate=False)
-
-            attr_names_to_update = [
-                attr.name for attr in node.attributes if attr.default_value is not None and not attr.optional
-            ]
-            if not attr_names_to_update:
-                continue
-
-            node = node.duplicate()
-            for attr_name in attr_names_to_update:
-                attr = node.get_attribute(name=attr_name)
-                attr.optional = True
 
             self.set(name=name, schema=node)
 

--- a/backend/tests/component/core/schema_manager/conftest.py
+++ b/backend/tests/component/core/schema_manager/conftest.py
@@ -104,7 +104,7 @@ def schema_all_in_one() -> dict[str, Any]:
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
                     {"name": "level", "kind": "Number", "branch": BranchSupportType.AWARE.value},
-                    {"name": "color", "kind": "Text", "default_value": "#444444"},
+                    {"name": "color", "kind": "Text", "default_value": "#444444", "optional": True},
                     {"name": "description", "kind": "Text", "optional": True},
                 ],
                 "relationships": [
@@ -253,7 +253,7 @@ def schema_criticality_tag() -> dict[str, Any]:
                 "attributes": [
                     {"name": "name", "kind": "Text", "label": "Name", "unique": True},
                     {"name": "level", "kind": "Number", "label": "Level"},
-                    {"name": "color", "kind": "Text", "label": "Color", "default_value": "#444444"},
+                    {"name": "color", "kind": "Text", "label": "Color", "default_value": "#444444", "optional": True},
                     {"name": "description", "kind": "Text", "label": "Description", "optional": True},
                 ],
                 "relationships": [
@@ -309,7 +309,7 @@ def schema_parent_component() -> dict:
                 "attributes": [
                     {"name": "name", "kind": "Text", "label": "Name", "unique": True},
                     {"name": "level", "kind": "Number", "label": "Level"},
-                    {"name": "color", "kind": "Text", "label": "Color", "default_value": "#444444"},
+                    {"name": "color", "kind": "Text", "label": "Color", "default_value": "#444444", "optional": True},
                     {"name": "description", "kind": "Text", "label": "Description", "optional": True},
                 ],
                 "relationships": [

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -374,16 +374,17 @@ async def test_schema_branch_process_branch_support(schema_all_in_one) -> None:
     assert criticality.get_attribute(name="description").branch == BranchSupportType.AGNOSTIC
 
 
-async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
+async def test_schema_branch_mandatory_with_default_value(schema_all_in_one) -> None:
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
+    schema.process()
 
-    schema.process_default_values()
-
+    # Attribute with default_value AND explicit optional=True stays optional
     generic = schema.get(name="InfraGenericInterface")
     assert generic.get_attribute(name="mybool").optional is True
     assert generic.get_attribute(name="my_generic_name").optional is False
 
+    # Attribute with default_value AND explicit optional=True stays optional
     criticality = schema.get(name="TestingCriticality")
     assert criticality.get_attribute(name="color").optional is True
 
@@ -392,7 +393,7 @@ async def test_schema_update_optional_with_default_to_mandatory(schema_criticali
     """Load a schema with optional+default, update to mandatory without default."""
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
-    schema.process_default_values()
+    schema.process()
 
     criticality = schema.get(name="TestingCriticality")
     color_attr = criticality.get_attribute(name="color")
@@ -412,7 +413,7 @@ async def test_schema_update_optional_with_default_to_mandatory(schema_criticali
 
     updated_branch = SchemaBranch(cache={}, name="test")
     updated_branch.load_schema(schema=SchemaRoot(**updated_data))
-    updated_branch.process_default_values()
+    updated_branch.process()
 
     # Merge the update into the original schema
     updated_criticality = updated_branch.get(name="TestingCriticality", duplicate=False)
@@ -426,11 +427,48 @@ async def test_schema_update_optional_with_default_to_mandatory(schema_criticali
     assert color_attr.default_value is None
 
 
-async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_tag) -> None:
-    """Verify default values processing respects explicit optional through schema updates."""
+async def test_schema_update_optional_with_default_to_mandatory_with_default(schema_criticality_tag) -> None:
+    """Load a schema with optional+default, update to mandatory while keeping the default."""
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
-    schema.process_default_values()
+    schema.process()
+
+    criticality = schema.get(name="TestingCriticality")
+    color_attr = criticality.get_attribute(name="color")
+    assert color_attr.optional is True
+    assert color_attr.default_value == "#444444"
+
+    # Update: make color mandatory but keep the default value
+    updated_data = copy.deepcopy(schema_criticality_tag)
+    for node in updated_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = False
+                    break
+            break
+
+    updated_branch = SchemaBranch(cache={}, name="test")
+    updated_branch.load_schema(schema=SchemaRoot(**updated_data))
+    updated_branch.process()
+
+    updated_criticality = updated_branch.get(name="TestingCriticality")
+    updated_color = updated_criticality.get_attribute(name="color")
+    assert updated_color.optional is False
+    assert updated_color.default_value == "#444444"
+
+    # Verify the diff detects the optional change
+    original_criticality = schema.get(name="TestingCriticality")
+    original_color = original_criticality.get_attribute(name="color")
+    diff = original_color.diff(updated_color)
+    assert "optional" in diff.changed
+
+
+async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_tag) -> None:
+    """Verify schema processing respects explicit optional through schema updates."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
+    schema.process()
 
     criticality = schema.get(name="TestingCriticality")
     color = criticality.get_attribute(name="color")
@@ -448,7 +486,7 @@ async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_
 
     updated_branch = SchemaBranch(cache={}, name="test")
     updated_branch.load_schema(schema=SchemaRoot(**updated_data))
-    updated_branch.process_default_values()
+    updated_branch.process()
 
     updated_criticality = updated_branch.get(name="TestingCriticality")
     updated_color = updated_criticality.get_attribute(name="color")

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -464,8 +464,8 @@ async def test_schema_update_optional_with_default_to_mandatory_with_default(sch
     assert "optional" in diff.changed
 
 
-async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_tag) -> None:
-    """Verify schema processing respects explicit optional through schema updates."""
+async def test_schema_optional_to_mandatory_without_default(schema_criticality_tag) -> None:
+    """Verify schema processing correctly transitions an attribute from optional to mandatory without default."""
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
     schema.process()
@@ -492,6 +492,76 @@ async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_
     updated_color = updated_criticality.get_attribute(name="color")
     assert updated_color.optional is False
     assert updated_color.default_value is None
+
+
+async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_tag) -> None:
+    """Verify an attribute can go through mandatory -> optional -> mandatory via schema processing."""
+    # Start with color as optional (has default_value + optional=True in fixture)
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
+    schema.process()
+
+    criticality = schema.get(name="TestingCriticality")
+    color = criticality.get_attribute(name="color")
+    assert color.optional is True
+    assert color.default_value == "#444444"
+
+    # Step 2: Make color mandatory without default
+    mandatory_data = copy.deepcopy(schema_criticality_tag)
+    for node in mandatory_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = False
+                    attr["default_value"] = None
+                    break
+            break
+
+    mandatory_branch = SchemaBranch(cache={}, name="test")
+    mandatory_branch.load_schema(schema=SchemaRoot(**mandatory_data))
+    mandatory_branch.process()
+
+    mandatory_color = mandatory_branch.get(name="TestingCriticality").get_attribute(name="color")
+    assert mandatory_color.optional is False
+    assert mandatory_color.default_value is None
+
+    # Back to optional with a new default
+    optional_again_data = copy.deepcopy(schema_criticality_tag)
+    for node in optional_again_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = True
+                    attr["default_value"] = "#ffffff"
+                    break
+            break
+
+    optional_branch = SchemaBranch(cache={}, name="test")
+    optional_branch.load_schema(schema=SchemaRoot(**optional_again_data))
+    optional_branch.process()
+
+    optional_color = optional_branch.get(name="TestingCriticality").get_attribute(name="color")
+    assert optional_color.optional is True
+    assert optional_color.default_value == "#ffffff"
+
+    # Back to mandatory again, keeping the new default
+    mandatory_again_data = copy.deepcopy(schema_criticality_tag)
+    for node in mandatory_again_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = False
+                    attr["default_value"] = "#ffffff"
+                    break
+            break
+
+    mandatory_again_branch = SchemaBranch(cache={}, name="test")
+    mandatory_again_branch.load_schema(schema=SchemaRoot(**mandatory_again_data))
+    mandatory_again_branch.process()
+
+    final_color = mandatory_again_branch.get(name="TestingCriticality").get_attribute(name="color")
+    assert final_color.optional is False
+    assert final_color.default_value == "#ffffff"
 
 
 async def test_schema_branch_reconcile_legacy_attribute_parameters() -> None:

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -388,6 +388,74 @@ async def test_schema_branch_process_default_values(schema_all_in_one) -> None:
     assert criticality.get_attribute(name="color").optional is True
 
 
+async def test_schema_update_optional_with_default_to_mandatory(schema_criticality_tag) -> None:
+    """Load a schema with optional+default, update to mandatory without default."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
+    schema.process_default_values()
+
+    criticality = schema.get(name="TestingCriticality")
+    color_attr = criticality.get_attribute(name="color")
+    assert color_attr.optional is True
+    assert color_attr.default_value == "#444444"
+
+    # Update: make color mandatory with no default
+    updated_data = copy.deepcopy(schema_criticality_tag)
+    for node in updated_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = False
+                    attr["default_value"] = None
+                    break
+            break
+
+    updated_branch = SchemaBranch(cache={}, name="test")
+    updated_branch.load_schema(schema=SchemaRoot(**updated_data))
+    updated_branch.process_default_values()
+
+    # Merge the update into the original schema
+    updated_criticality = updated_branch.get(name="TestingCriticality", duplicate=False)
+    criticality = schema.get(name="TestingCriticality")
+    for updated_attr in updated_criticality.attributes:
+        existing_attr = criticality.get_attribute(name=updated_attr.name)
+        existing_attr.update(updated_attr)
+
+    color_attr = criticality.get_attribute(name="color")
+    assert color_attr.optional is False
+    assert color_attr.default_value is None
+
+
+async def test_schema_roundtrip_mandatory_optional_mandatory(schema_criticality_tag) -> None:
+    """Verify default values processing respects explicit optional through schema updates."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_criticality_tag))
+    schema.process_default_values()
+
+    criticality = schema.get(name="TestingCriticality")
+    color = criticality.get_attribute(name="color")
+    assert color.optional is True
+
+    updated_data = copy.deepcopy(schema_criticality_tag)
+    for node in updated_data["nodes"]:
+        if node["name"] == "Criticality":
+            for attr in node["attributes"]:
+                if attr["name"] == "color":
+                    attr["optional"] = False
+                    attr["default_value"] = None
+                    break
+            break
+
+    updated_branch = SchemaBranch(cache={}, name="test")
+    updated_branch.load_schema(schema=SchemaRoot(**updated_data))
+    updated_branch.process_default_values()
+
+    updated_criticality = updated_branch.get(name="TestingCriticality")
+    updated_color = updated_criticality.get_attribute(name="color")
+    assert updated_color.optional is False
+    assert updated_color.default_value is None
+
+
 async def test_schema_branch_reconcile_legacy_attribute_parameters() -> None:
     """Test that SchemaBranch.load_schema() syncs top-level and parameters fields for attributes with legacy parameters."""
     regex = "abc"

--- a/backend/tests/component/core/test_manager_node.py
+++ b/backend/tests/component/core/test_manager_node.py
@@ -541,7 +541,7 @@ async def test_query_filter_with_multiple_values_rel(
     assert len(nodes) == 4
 
 
-async def test_qeury_with_multiple_values_invalid_type(
+async def test_query_with_multiple_values_invalid_type(
     db: InfrahubDatabase,
     person_john_main: Node,
     person_jane_main: Node,

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -45,17 +45,17 @@ CONVERSION_RESPONSE_COMMON_FIELDS = {
         "relationship_cardinality": None,
     },
     "internal_status": {
-        "is_mandatory": False,
+        "is_mandatory": True,
         "source_field_name": "internal_status",
         "relationship_cardinality": None,
     },
     "operational_status": {
-        "is_mandatory": False,
+        "is_mandatory": True,
         "source_field_name": "operational_status",
         "relationship_cardinality": None,
     },
     "sync_status": {
-        "is_mandatory": False,
+        "is_mandatory": True,
         "source_field_name": "sync_status",
         "relationship_cardinality": None,
     },
@@ -163,7 +163,7 @@ class TestConvertRepository(TestInfrahubApp):
             "FieldsMappingTypeConversion": {
                 "mapping": {
                     **CONVERSION_RESPONSE_COMMON_FIELDS,
-                    "ref": {"is_mandatory": False, "source_field_name": None, "relationship_cardinality": None},
+                    "ref": {"is_mandatory": True, "source_field_name": None, "relationship_cardinality": None},
                     "commit": {"is_mandatory": False, "source_field_name": "commit", "relationship_cardinality": None},
                 }
             }
@@ -301,7 +301,7 @@ class TestConvertRepository(TestInfrahubApp):
                 "mapping": {
                     **CONVERSION_RESPONSE_COMMON_FIELDS,
                     "default_branch": {
-                        "is_mandatory": False,
+                        "is_mandatory": True,
                         "source_field_name": None,
                         "relationship_cardinality": None,
                     },
@@ -448,7 +448,7 @@ class TestConvertRepository(TestInfrahubApp):
                 "mapping": {
                     **CONVERSION_RESPONSE_COMMON_FIELDS,
                     "default_branch": {
-                        "is_mandatory": False,
+                        "is_mandatory": True,
                         "source_field_name": None,
                         "relationship_cardinality": None,
                     },

--- a/backend/tests/helpers/schema/device.py
+++ b/backend/tests/helpers/schema/device.py
@@ -54,7 +54,7 @@ DEVICE = NodeSchema(
     attributes=[
         AttributeSchema(name="name", kind="Text", unique=True),
         AttributeSchema(name="manufacturer", kind="Text"),
-        AttributeSchema(name="height", kind="Number", default_value=1),
+        AttributeSchema(name="height", kind="Number", default_value=1, optional=True),
         AttributeSchema(name="weight", kind="Number"),
         AttributeSchema(
             name="airflow",

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
@@ -10,6 +10,7 @@ from infrahub.core.node import Node
 from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.protocols import TestingPerson
 
 from .shared import TestSchemaLifecycleBase
 
@@ -71,6 +72,14 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
         persons = await registry.manager.query(db=db, schema=TestKind.PERSON)
         assert len(persons) == 2
 
+        alice = await registry.manager.get_one(
+            db=db, id=initial_dataset["alice"], kind=TestingPerson, raise_on_error=True
+        )
+        assert alice.height.value == 170
+
+        bob = await registry.manager.get_one(db=db, id=initial_dataset["bob"], kind=TestingPerson, raise_on_error=True)
+        assert bob.height.value == 180
+
     async def test_check_mandatory_no_default_succeeds_when_all_have_values(
         self,
         client: InfrahubClient,
@@ -86,6 +95,7 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
     async def test_load_mandatory_no_default_succeeds(
         self,
         client: InfrahubClient,
+        db: InfrahubDatabase,
         initial_dataset: dict[str, str],
         schema_person_mandatory_height_no_default: SchemaRoot,
     ) -> None:
@@ -101,6 +111,17 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
         height_attr = person_schema.get_attribute(name="height")
         assert height_attr.optional is False
         assert height_attr.default_value is None
+
+        # Height values should be preserved after schema transition
+        alice = await registry.manager.get_one(
+            db=db, id=initial_dataset["alice"], kind=TestingPerson, branch=branch.name, raise_on_error=True
+        )
+        assert alice.height.value == 170
+
+        bob = await registry.manager.get_one(
+            db=db, id=initial_dataset["bob"], kind=TestingPerson, branch=branch.name, raise_on_error=True
+        )
+        assert bob.height.value == 180
 
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
@@ -157,6 +178,14 @@ class TestSchemaLifecycleOptionalToMandatoryWithDefault(TestSchemaLifecycleBase)
         persons = await registry.manager.query(db=db, schema=TestKind.PERSON)
         assert len(persons) == 2
 
+        alice = await registry.manager.get_one(
+            db=db, id=initial_dataset["alice"], kind=TestingPerson, raise_on_error=True
+        )
+        assert alice.height.value == 170
+
+        bob = await registry.manager.get_one(db=db, id=initial_dataset["bob"], kind=TestingPerson, raise_on_error=True)
+        assert bob.height.value == 180
+
     async def test_check_mandatory_with_default_succeeds(
         self,
         client: InfrahubClient,
@@ -172,6 +201,7 @@ class TestSchemaLifecycleOptionalToMandatoryWithDefault(TestSchemaLifecycleBase)
     async def test_load_mandatory_with_default_succeeds(
         self,
         client: InfrahubClient,
+        db: InfrahubDatabase,
         initial_dataset: dict[str, str],
         schema_person_mandatory_height_with_default: SchemaRoot,
     ) -> None:
@@ -187,6 +217,17 @@ class TestSchemaLifecycleOptionalToMandatoryWithDefault(TestSchemaLifecycleBase)
         height_attr = person_schema.get_attribute(name="height")
         assert height_attr.optional is False
         assert height_attr.default_value == 180
+
+        # Height values should be preserved after schema transition
+        alice = await registry.manager.get_one(
+            db=db, id=initial_dataset["alice"], kind=TestingPerson, branch=branch.name, raise_on_error=True
+        )
+        assert alice.height.value == 170
+
+        bob = await registry.manager.get_one(
+            db=db, id=initial_dataset["bob"], kind=TestingPerson, branch=branch.name, raise_on_error=True
+        )
+        assert bob.height.value == 180
 
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.node import Node
+from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+
+from .shared import TestSchemaLifecycleBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.schema import SchemaRoot
+    from infrahub.database import InfrahubDatabase
+
+
+class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_person_with_default_height(self) -> SchemaRoot:
+        schema = copy.deepcopy(CAR_SCHEMA)
+        schema.version = "1.0"
+
+        person = schema.get(name=TestKind.PERSON)
+        person.get_attribute(name="height").default_value = 180
+
+        return schema
+
+    @pytest.fixture(scope="class")
+    def schema_person_mandatory_height_no_default(self, schema_person_with_default_height: SchemaRoot) -> SchemaRoot:
+        """Height becomes mandatory (optional=False) AND default_value is cleared."""
+        schema = copy.deepcopy(schema_person_with_default_height)
+        person = schema.get(name=TestKind.PERSON)
+
+        height_attr = person.get_attribute(name="height")
+        height_attr.optional = False
+        height_attr.default_value = None
+
+        return schema
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self, db: InfrahubDatabase, initialize_registry: None, schema_person_with_default_height: SchemaRoot
+    ) -> dict[str, str]:
+        await load_schema(db=db, schema=schema_person_with_default_height, update_db=True)
+
+        alice = await Node.init(schema=TestKind.PERSON, db=db)
+        await alice.new(db=db, name="Alice", height=170)
+        await alice.save(db=db)
+
+        # Bob gets the default height (180)
+        bob = await Node.init(schema=TestKind.PERSON, db=db)
+        await bob.new(db=db, name="Bob")
+        await bob.save(db=db)
+
+        return {"alice": alice.id, "bob": bob.id}
+
+    async def test_baseline(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
+        persons = await registry.manager.query(db=db, schema=TestKind.PERSON)
+        assert len(persons) == 2
+
+    async def test_check_mandatory_no_default_succeeds_when_all_have_values(
+        self,
+        client: InfrahubClient,
+        initial_dataset: dict[str, str],
+        schema_person_mandatory_height_no_default: SchemaRoot,
+    ) -> None:
+        """Making height mandatory after clearing default_value should pass because no existing objects have null height."""
+        success, _ = await client.schema.check(
+            schemas=[schema_person_mandatory_height_no_default.model_dump(mode="json")]
+        )
+        assert success
+
+    async def test_load_mandatory_no_default_succeeds(
+        self,
+        client: InfrahubClient,
+        initial_dataset: dict[str, str],
+        schema_person_mandatory_height_no_default: SchemaRoot,
+    ) -> None:
+        """Loading the mandatory schema should succeed."""
+        branch = await client.branch.create(branch_name="mandatory-height")
+        response = await client.schema.load(
+            schemas=[schema_person_mandatory_height_no_default.model_dump(mode="json")], branch=branch.name
+        )
+        assert not response.errors
+        assert response.schema_updated
+
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
+        await verify_no_duplicate_relationships(db=db)
+        await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
@@ -60,7 +60,14 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
 
         return {"alice": alice.id, "bob": bob.id}
 
-    async def test_baseline(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
+    async def test_baseline(
+        self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset: dict[str, str]
+    ) -> None:
+        person_schema = registry.schema.get(name=TestKind.PERSON, duplicate=False)
+        height_attr = person_schema.get_attribute(name="height")
+        assert height_attr.optional is True
+        assert height_attr.default_value == 180
+
         persons = await registry.manager.query(db=db, schema=TestKind.PERSON)
         assert len(persons) == 2
 
@@ -89,6 +96,11 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
         )
         assert not response.errors
         assert response.schema_updated
+
+        person_schema = registry.schema.get(name=TestKind.PERSON, branch=branch.name, duplicate=False)
+        height_attr = person_schema.get_attribute(name="height")
+        assert height_attr.optional is False
+        assert height_attr.default_value is None
 
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py
@@ -105,3 +105,89 @@ class TestSchemaLifecycleOptionalToMandatory(TestSchemaLifecycleBase):
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)
+
+
+class TestSchemaLifecycleOptionalToMandatoryWithDefault(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_person_with_default_height(self) -> SchemaRoot:
+        schema = copy.deepcopy(CAR_SCHEMA)
+        schema.version = "1.0"
+
+        person = schema.get(name=TestKind.PERSON)
+        person.get_attribute(name="height").default_value = 180
+
+        return schema
+
+    @pytest.fixture(scope="class")
+    def schema_person_mandatory_height_with_default(self, schema_person_with_default_height: SchemaRoot) -> SchemaRoot:
+        """Height becomes mandatory (optional=False) while keeping default_value=180."""
+        schema = copy.deepcopy(schema_person_with_default_height)
+        person = schema.get(name=TestKind.PERSON)
+
+        height_attr = person.get_attribute(name="height")
+        height_attr.optional = False
+
+        return schema
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self, db: InfrahubDatabase, initialize_registry: None, schema_person_with_default_height: SchemaRoot
+    ) -> dict[str, str]:
+        await load_schema(db=db, schema=schema_person_with_default_height, update_db=True)
+
+        alice = await Node.init(schema=TestKind.PERSON, db=db)
+        await alice.new(db=db, name="Alice", height=170)
+        await alice.save(db=db)
+
+        # Bob gets the default height (180)
+        bob = await Node.init(schema=TestKind.PERSON, db=db)
+        await bob.new(db=db, name="Bob")
+        await bob.save(db=db)
+
+        return {"alice": alice.id, "bob": bob.id}
+
+    async def test_baseline(
+        self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset: dict[str, str]
+    ) -> None:
+        person_schema = registry.schema.get(name=TestKind.PERSON, duplicate=False)
+        height_attr = person_schema.get_attribute(name="height")
+        assert height_attr.optional is True
+        assert height_attr.default_value == 180
+
+        persons = await registry.manager.query(db=db, schema=TestKind.PERSON)
+        assert len(persons) == 2
+
+    async def test_check_mandatory_with_default_succeeds(
+        self,
+        client: InfrahubClient,
+        initial_dataset: dict[str, str],
+        schema_person_mandatory_height_with_default: SchemaRoot,
+    ) -> None:
+        """Making height mandatory while keeping default_value should pass."""
+        success, _ = await client.schema.check(
+            schemas=[schema_person_mandatory_height_with_default.model_dump(mode="json")]
+        )
+        assert success
+
+    async def test_load_mandatory_with_default_succeeds(
+        self,
+        client: InfrahubClient,
+        initial_dataset: dict[str, str],
+        schema_person_mandatory_height_with_default: SchemaRoot,
+    ) -> None:
+        """Loading the mandatory+default schema should succeed."""
+        branch = await client.branch.create(branch_name="mandatory-height-with-default")
+        response = await client.schema.load(
+            schemas=[schema_person_mandatory_height_with_default.model_dump(mode="json")], branch=branch.name
+        )
+        assert not response.errors
+        assert response.schema_updated
+
+        person_schema = registry.schema.get(name=TestKind.PERSON, branch=branch.name, duplicate=False)
+        height_attr = person_schema.get_attribute(name="height")
+        assert height_attr.optional is False
+        assert height_attr.default_value == 180
+
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
+        await verify_no_duplicate_relationships(db=db)
+        await verify_no_edges_added_after_node_delete(db=db)

--- a/backend/tests/protocols.py
+++ b/backend/tests/protocols.py
@@ -626,7 +626,7 @@ class TestingCar(CoreNode):
 class TestingDevice(TestingInterfaceHolder):
     name: String
     manufacturer: String
-    height: Integer
+    height: IntegerOptional
     weight: Integer
     airflow: Enum
     part_number: StringOptional

--- a/backend/tests/unit/core/schema/test_attribute_schema.py
+++ b/backend/tests/unit/core/schema/test_attribute_schema.py
@@ -35,7 +35,7 @@ def test_attribute_schema_update_default_value_type_distinction() -> None:
 
     attr2 = AttributeSchema(name="val", kind="Text", default_value="hello")
     attr2.update(AttributeSchema(name="val", kind="Text", default_value=""))
-    assert not attr2.default_value
+    assert attr2.default_value == ""  # noqa: PLC1901
 
     attr3 = AttributeSchema(name="val", kind="Number", default_value=42)
     attr3.update(AttributeSchema(name="val", kind="Number", default_value=0))

--- a/backend/tests/unit/core/schema/test_attribute_schema.py
+++ b/backend/tests/unit/core/schema/test_attribute_schema.py
@@ -78,3 +78,28 @@ def test_attribute_schema_roundtrip_mandatory_optional_mandatory() -> None:
     attr.update(AttributeSchema(name="role", kind="Text", optional=False, default_value=None))
     assert attr.optional is False
     assert attr.default_value is None
+
+
+def test_attribute_schema_mandatory_with_default_value() -> None:
+    """Verify that an AttributeSchema can be created with optional=False and a default_value."""
+    attr = AttributeSchema(name="timeout", kind="Number", optional=False, default_value=180)
+    assert attr.optional is False
+    assert attr.default_value == 180
+
+
+def test_attribute_schema_update_optional_default_to_mandatory_with_default() -> None:
+    """Verify updating from optional+default to mandatory+default detects optional change in diff."""
+    existing = AttributeSchema(name="timeout", kind="Number", optional=True, default_value=180)
+    assert existing.optional is True
+    assert existing.default_value == 180
+
+    update_source = AttributeSchema(name="timeout", kind="Number", optional=False, default_value=180)
+    existing.update(update_source)
+
+    assert existing.optional is False
+    assert existing.default_value == 180
+
+    original = AttributeSchema(name="timeout", kind="Number", optional=True, default_value=180)
+    diff = original.diff(existing)
+    assert "optional" in diff.changed
+    assert "default_value" not in diff.changed

--- a/backend/tests/unit/core/schema/test_attribute_schema.py
+++ b/backend/tests/unit/core/schema/test_attribute_schema.py
@@ -1,0 +1,80 @@
+from infrahub.core.schema import AttributeSchema
+
+
+def test_attribute_schema_update_clears_default_value() -> None:
+    """Verify that AttributeSchema.update() clears default_value when the source has explicit default_value=None."""
+    existing = AttributeSchema(name="color", kind="Text", default_value="#444444", optional=True)
+    assert existing.default_value == "#444444"
+
+    update_source = AttributeSchema(name="color", kind="Text", default_value=None, optional=False)
+    assert "default_value" in update_source.model_fields_set
+
+    existing.update(update_source)
+
+    assert existing.default_value is None
+    assert existing.optional is False
+
+
+def test_attribute_schema_update_preserves_default_value() -> None:
+    """Verify AttributeSchema.update() preserves default_value when source omits it (not in model_fields_set)."""
+    existing = AttributeSchema(name="color", kind="Text", default_value="#444444", optional=True)
+    assert existing.default_value == "#444444"
+
+    update_source = AttributeSchema(name="color", kind="Text", optional=True)
+    assert "default_value" not in update_source.model_fields_set
+
+    existing.update(update_source)
+    assert existing.default_value == "#444444"
+
+
+def test_attribute_schema_update_default_value_type_distinction() -> None:
+    """Verify AttributeSchema.update() correctly distinguishes default_value=None (clears) from falsy values (preserves)."""
+    attr1 = AttributeSchema(name="val", kind="Text", default_value="hello")
+    attr1.update(AttributeSchema(name="val", kind="Text", default_value=None))
+    assert attr1.default_value is None
+
+    attr2 = AttributeSchema(name="val", kind="Text", default_value="hello")
+    attr2.update(AttributeSchema(name="val", kind="Text", default_value=""))
+    assert not attr2.default_value
+
+    attr3 = AttributeSchema(name="val", kind="Number", default_value=42)
+    attr3.update(AttributeSchema(name="val", kind="Number", default_value=0))
+    assert attr3.default_value == 0
+
+    attr4 = AttributeSchema(name="val", kind="Boolean", default_value=True)
+    attr4.update(AttributeSchema(name="val", kind="Boolean", default_value=False))
+    assert attr4.default_value is False
+
+
+def test_attribute_schema_update_to_mandatory_triggers_migration() -> None:
+    """Verify that updating optional from True to False is detected as a diff change."""
+    existing = AttributeSchema(name="role", kind="Text", default_value="spine", optional=True)
+    assert existing.optional is True
+
+    update_source = AttributeSchema(name="role", kind="Text", optional=False, default_value=None)
+    assert "default_value" in update_source.model_fields_set
+
+    existing.update(update_source)
+
+    assert existing.optional is False
+    assert existing.default_value is None
+
+    original = AttributeSchema(name="role", kind="Text", default_value="spine", optional=True)
+    diff = original.diff(existing)
+    assert "optional" in diff.changed
+    assert "default_value" in diff.changed
+
+
+def test_attribute_schema_roundtrip_mandatory_optional_mandatory() -> None:
+    """Verify an attribute can go mandatory -> optional and default -> mandatory through sequential updates."""
+    attr = AttributeSchema(name="role", kind="Text", optional=False)
+    assert attr.optional is False
+    assert attr.default_value is None
+
+    attr.update(AttributeSchema(name="role", kind="Text", optional=True, default_value="leaf"))
+    assert attr.optional is True
+    assert attr.default_value == "leaf"
+
+    attr.update(AttributeSchema(name="role", kind="Text", optional=False, default_value=None))
+    assert attr.optional is False
+    assert attr.default_value is None

--- a/changelog/7409.fixed.md
+++ b/changelog/7409.fixed.md
@@ -1,0 +1,1 @@
+Fixed inability to change an optional attribute with a default value to mandatory

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1786,7 +1786,9 @@ type CoreCheckDefinition implements CoreNode & CoreTaskTarget {
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   tags(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedBuiltinTag!
   targets: NestedEdgedCoreGroup!
-  """Maximum execution time in seconds before the check times out"""
+  """
+  Maximum execution time in seconds before the check times out (required)
+  """
   timeout: NumberAttribute
 }
 
@@ -3410,7 +3412,7 @@ type CoreGlobalPermission implements CoreBasePermission & CoreNode {
   _updated_at: DateTime @deprecated(reason: "Query the node_metadata field instead. Will be removed in Infrahub 1.9")
   """The global action this permission grants or denies (required)"""
   action: Dropdown
-  """Decide to deny or allow the action at a global level"""
+  """Decide to deny or allow the action at a global level (required)"""
   decision: NumberAttribute
   description: TextAttribute
   display_label: String
@@ -3710,7 +3712,7 @@ type CoreGroupAction implements CoreAction & CoreNode {
   """Unique identifier"""
   id: String!
   """
-  Defines if the action should add or remove members from a group when triggered
+  Defines if the action should add or remove members from a group when triggered (required)
   """
   member_action: Dropdown
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
@@ -3836,7 +3838,9 @@ type CoreGroupTriggerRule implements CoreNode & CoreTriggerRule {
   """Unique identifier"""
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
-  """Indicate if the match should be for when members are added or removed"""
+  """
+  Indicate if the match should be for when members are added or removed (required)
+  """
   member_update: Dropdown
   """The name of the trigger rule"""
   name: TextAttribute
@@ -4396,7 +4400,7 @@ type CoreNodeTriggerAttributeMatch implements CoreNode & CoreNodeTriggerMatch {
   """The value the attribute is updated to"""
   value: TextAttribute
   """
-  The value_match defines how the update will be evaluated, if it has to match the new value, the previous value or both
+  The value_match defines how the update will be evaluated, if it has to match the new value, the previous value or both (required)
   """
   value_match: Dropdown
   """The previous value of the targeted attribute"""
@@ -4523,7 +4527,7 @@ type CoreNodeTriggerRelationshipMatch implements CoreNode & CoreNodeTriggerMatch
   id: String!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """
-  Indicates if the relationship was added or removed or just updated in any way
+  Indicates if the relationship was added or removed or just updated in any way (required)
   """
   modification_type: Dropdown
   """The node_id of the relationship peer to match against"""
@@ -4788,7 +4792,7 @@ type CoreNumberPool implements CoreNode & CoreResourcePool & LineageSource {
   node: TextAttribute
   """The attribute of the selected model (required)"""
   node_attribute: TextAttribute
-  """Defines how this number pool was created"""
+  """Defines how this number pool was created (required)"""
   pool_type: TextAttribute
   """The start range for the pool (required)"""
   start_range: NumberAttribute
@@ -4899,10 +4903,10 @@ input CoreObjectComponentTemplateUpdateInput {
 """A permission that grants rights to perform actions on objects"""
 type CoreObjectPermission implements CoreBasePermission & CoreNode {
   _updated_at: DateTime @deprecated(reason: "Query the node_metadata field instead. Will be removed in Infrahub 1.9")
-  """The action this permission grants or denies"""
+  """The action this permission grants or denies (required)"""
   action: TextAttribute
   """
-  Decide to deny or allow the action.If allowed, it can be configured for the default branch, any other branches or all branches
+  Decide to deny or allow the action.If allowed, it can be configured for the default branch, any other branches or all branches (required)
   """
   decision: NumberAttribute
   description: TextAttribute
@@ -5248,7 +5252,7 @@ type CoreProposedChange implements CoreNode & CoreTaskTarget {
   hfid: [String!]
   """Unique identifier"""
   id: String!
-  """Whether the proposed change is still a draft"""
+  """Whether the proposed change is still a draft (required)"""
   is_draft: CheckboxAttribute
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
@@ -5379,7 +5383,7 @@ type CoreReadOnlyRepository implements CoreGenericRepository & CoreNode & CoreTa
   """Connectivity status of the repository"""
   operational_status: Dropdown
   queries(depth__is_protected: Boolean, depth__owner__id: ID, depth__source__id: ID, depth__value: BigInt, depth__values: [BigInt], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], height__is_protected: Boolean, height__owner__id: ID, height__source__id: ID, height__value: BigInt, height__values: [BigInt], ids: [ID], isnull: Boolean, limit: Int, models__is_protected: Boolean, models__owner__id: ID, models__source__id: ID, models__value: GenericScalar, models__values: [GenericScalar], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, operations__is_protected: Boolean, operations__owner__id: ID, operations__source__id: ID, operations__value: GenericScalar, operations__values: [GenericScalar], order: OrderInput, query__is_protected: Boolean, query__owner__id: ID, query__source__id: ID, query__value: String, query__values: [String], variables__is_protected: Boolean, variables__owner__id: ID, variables__source__id: ID, variables__value: GenericScalar, variables__values: [GenericScalar]): NestedPaginatedCoreGraphQLQuery!
-  """Git reference (branch or tag) to track"""
+  """Git reference (branch or tag) to track (required)"""
   ref: TextAttribute
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """Current synchronization status of the repository"""
@@ -5515,7 +5519,7 @@ type CoreRepository implements CoreGenericRepository & CoreNode & CoreTaskTarget
   """Current commit hash being tracked"""
   commit: TextAttribute
   credential: NestedEdgedCoreCredential!
-  """Default branch name in the Git repository"""
+  """Default branch name in the Git repository (required)"""
   default_branch: TextAttribute
   """Description of the repository"""
   description: TextAttribute


### PR DESCRIPTION
# Why

When an attribute has `optional: true` with a `default_value`, it is impossible to later change it to `optional: false` (mandatory) while keeping the default. The `process_default_values()` method in `SchemaBranch` forces `optional=True` on **every** attribute that has a non-null `default_value`, making `optional=False` + `default_value` an impossible combination.

Closes #7409

## What changed

- Override `AttributeSchema.update()` to detect when `default_value` is explicitly set to `None` (via Pydantic's `model_fields_set`) and clear it on the existing attribute. This lets `process_default_values()` skip the attribute, preserving `optional: false`.
- Removed `process_default_values()` from `SchemaBranch.process_pre_validation()` entirely. This method was overriding explicit `optional=False` on any attribute with a `default_value`, preventing the mandatory+default combination.

## How to test

```bash
uv run pytest backend/tests/unit/core/schema/ -x -q
uv run pytest backend/tests/component/core/schema_manager/ -x -q
uv run pytest backend/tests/integration/schema_lifecycle/test_schema_validator_optional_to_mandatory.py -xvs
```

## Impact & rollout

- **Backward compatibility:** This might affect schemas that are already loaded in the database when they are being re-loaded from the API if these schemas use a combination of `optional: false` with a `default_value` set. They are stored as `optional: true` in the database and they'll get updated to `optional: false`.


## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changing an optional attribute with a default to mandatory — updates can now explicitly clear preserved defaults.

* **Behavioral Changes**
  * Refined schema processing and cardinality/default handling so optional/default transitions behave predictably.

* **Tests**
  * Added extensive unit, component, and integration tests for optional/default ↔ mandatory/no-default transitions, merging, diffs, and lifecycle flows; minor test renames and fixtures updated.

* **Documentation**
  * Marked many GraphQL input fields as "(required)" for clearer client guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->