### PR TITLE
pass rel weight into profile schemas

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2262,6 +2262,7 @@ class SchemaBranch:
                     min_count=relationship.min_count,
                     max_count=relationship.max_count,
                     label=relationship.label,
+                    order_weight=relationship.order_weight,
                     inherited=False,
                 )
             )

--- a/changelog/+cbc0cee2.fixed.md
+++ b/changelog/+cbc0cee2.fixed.md
@@ -1,0 +1,1 @@
+Pass order weights into Profile schema fields to prevent reordering causing a hash mismatch


### PR DESCRIPTION
trying to retrieve a Profile schema from the registry could result in an incorrect hash error that looked like this
```
ValueError: Schema 'ProfileInfraMlagDomain' on branch den1-maintenance-conflict has incorrect hash: 'e6b82d3f8d44ac7a06025a0f4ecb4081'
```

the root cause seems to be that different order weights could be assigned to relationships on profiles and passing the order weights from the node/generic schema into the generated profile schema seems to fix the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hash mismatches that occurred when reordering relationships in profiles. Order weights are now properly preserved when applying relationships to profile schemas, ensuring consistent hashing across reordering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->