### PR TITLE
make SchemaBranch.process() idempotent

### DIFF
--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -132,8 +132,6 @@ class NodeSchema(GeneratedNodeSchema):
                 continue
             if relationship.name in (OBJECT_TEMPLATE_RELATIONSHIP_NAME, PROFILES_RELATIONSHIP_NAME):
                 continue
-            if relationship.kind == RelationshipKind.HIERARCHY:
-                continue
 
             new_relationship = relationship.duplicate()
             new_relationship.id = None

--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -132,6 +132,8 @@ class NodeSchema(GeneratedNodeSchema):
                 continue
             if relationship.name in (OBJECT_TEMPLATE_RELATIONSHIP_NAME, PROFILES_RELATIONSHIP_NAME):
                 continue
+            if relationship.kind == RelationshipKind.HIERARCHY:
+                continue
 
             new_relationship = relationship.duplicate()
             new_relationship.id = None

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2444,6 +2444,8 @@ class SchemaBranch:
                 "cardinality": RelationshipCardinality.ONE,
                 "branch": BranchSupportType.AWARE,
                 "order_weight": 1,
+                "max_count": 1,
+                "min_count": 0,
             }
 
             # Add relationship between node and template

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2213,17 +2213,15 @@ class SchemaBranch:
                 if parent_rel.peer != parent_peer:
                     parent_rel.peer = parent_peer
 
-            if node.children:
-                if "children" not in node.relationship_names:
-                    node.relationships.append(
-                        self._get_hierarchy_child_rel(
-                            peer=node.children, hierarchical=node.hierarchy, read_only=read_only
-                        )
-                    )
-                else:
-                    children_rel = node.get_relationship(name="children")
-                    if children_rel.peer != node.children:
-                        children_rel.peer = node.children
+            children_peer = node.children or node.hierarchy
+            if "children" not in node.relationship_names:
+                node.relationships.append(
+                    self._get_hierarchy_child_rel(peer=children_peer, hierarchical=node.hierarchy, read_only=read_only)
+                )
+            else:
+                children_rel = node.get_relationship(name="children")
+                if children_rel.peer != children_peer:
+                    children_rel.peer = children_peer
 
             self.set(name=node_name, schema=node)
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2198,20 +2198,20 @@ class SchemaBranch:
             node = node.duplicate()
             read_only = InfrahubKind.IPPREFIX in node.inherit_from
 
-            if node.parent:
-                if "parent" not in node.relationship_names:
-                    node.relationships.append(
-                        self._get_hierarchy_parent_rel(
-                            peer=node.parent,
-                            hierarchical=node.hierarchy,
-                            read_only=read_only,
-                            optional=node.parent in [node_name] + self.generic_names,
-                        )
+            parent_peer = node.parent or node.hierarchy
+            if "parent" not in node.relationship_names:
+                node.relationships.append(
+                    self._get_hierarchy_parent_rel(
+                        peer=parent_peer,
+                        hierarchical=node.hierarchy,
+                        read_only=read_only,
+                        optional=parent_peer in [node_name] + self.generic_names,
                     )
-                else:
-                    parent_rel = node.get_relationship(name="parent")
-                    if parent_rel.peer != node.parent:
-                        parent_rel.peer = node.parent
+                )
+            else:
+                parent_rel = node.get_relationship(name="parent")
+                if parent_rel.peer != parent_peer:
+                    parent_rel.peer = parent_peer
 
             if node.children:
                 if "children" not in node.relationship_names:

--- a/backend/tests/component/core/schema/schema_branch/test_process_idempotency.py
+++ b/backend/tests/component/core/schema/schema_branch/test_process_idempotency.py
@@ -1,0 +1,255 @@
+import pytest
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind
+from infrahub.core.registry import registry
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+
+LOCATION_GENERIC = GenericSchema(
+    name="Location",
+    namespace="Test",
+    label="Location",
+    hierarchical=True,
+    include_in_menu=True,
+    default_filter="name__value",
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="description", kind="Text", optional=True),
+    ],
+)
+
+NETWORK_ELEMENT_GENERIC = GenericSchema(
+    name="NetworkElement",
+    namespace="Test",
+    label="Network Element",
+    include_in_menu=True,
+    attributes=[
+        AttributeSchema(name="description", kind="Text", optional=True),
+    ],
+)
+
+CONTINENT_NODE = NodeSchema(
+    name="Continent",
+    namespace="Test",
+    label="Continent",
+    include_in_menu=True,
+    default_filter="name__value",
+    inherit_from=["TestLocation"],
+    parent="",
+    children="TestCountry",
+    generate_profile=True,
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+    ],
+)
+
+COUNTRY_NODE = NodeSchema(
+    name="Country",
+    namespace="Test",
+    label="Country",
+    include_in_menu=True,
+    default_filter="name__value",
+    inherit_from=["TestLocation"],
+    parent="TestContinent",
+    children="TestSite",
+    generate_profile=True,
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="iso_code", kind="Text", optional=True),
+    ],
+)
+
+SITE_NODE = NodeSchema(
+    name="Site",
+    namespace="Test",
+    label="Site",
+    include_in_menu=True,
+    default_filter="name__value",
+    inherit_from=["TestLocation"],
+    parent="TestCountry",
+    children="",
+    generate_profile=True,
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="address", kind="Text", optional=True),
+    ],
+)
+
+DEVICE_NODE = NodeSchema(
+    name="Device",
+    namespace="Test",
+    label="Device",
+    include_in_menu=True,
+    default_filter="name__value",
+    generate_profile=True,
+    generate_template=True,
+    inherit_from=["TestNetworkElement"],
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="role", kind="Text", optional=True),
+    ],
+    relationships=[
+        RelationshipSchema(
+            name="site",
+            peer="TestSite",
+            kind=RelationshipKind.ATTRIBUTE,
+            cardinality=RelationshipCardinality.ONE,
+            optional=True,
+        ),
+        RelationshipSchema(
+            name="interfaces",
+            peer="TestInterface",
+            kind=RelationshipKind.COMPONENT,
+            cardinality=RelationshipCardinality.MANY,
+            optional=True,
+        ),
+    ],
+)
+
+INTERFACE_NODE = NodeSchema(
+    name="Interface",
+    namespace="Test",
+    label="Interface",
+    include_in_menu=True,
+    default_filter="name__value",
+    generate_profile=True,
+    generate_template=True,
+    inherit_from=["TestNetworkElement"],
+    attributes=[
+        AttributeSchema(name="name", kind="Text"),
+        AttributeSchema(name="speed", kind="Number", optional=True),
+        AttributeSchema(name="enabled", kind="Boolean", default_value=True),
+    ],
+    relationships=[
+        RelationshipSchema(
+            name="device",
+            peer="TestDevice",
+            kind=RelationshipKind.PARENT,
+            cardinality=RelationshipCardinality.ONE,
+            optional=False,
+        ),
+    ],
+)
+
+
+@pytest.fixture
+def idempotency_schema() -> SchemaRoot:
+    return SchemaRoot(
+        nodes=[CONTINENT_NODE, COUNTRY_NODE, SITE_NODE, DEVICE_NODE, INTERFACE_NODE],
+        generics=[LOCATION_GENERIC, NETWORK_ELEMENT_GENERIC],
+    )
+
+
+def _describe_hash_diff(before: SchemaBranch, after: SchemaBranch) -> str:
+    """Compare two SchemaBranch instances and return a human-readable diff description.
+
+    Useful for diagnosing hash mismatches. Compares per-schema model fields for all
+    nodes and generics, reporting only the fields that differ.
+    """
+    lines: list[str] = []
+    all_names = sorted(set(before.node_names + before.generic_names + after.node_names + after.generic_names))
+    for name in all_names:  # noqa: PLR1702
+        try:
+            obj_before = before.get(name=name, duplicate=False)
+            dump_before = obj_before.model_dump()
+        except Exception:
+            lines.append(f"{name}: only in 'after'")
+            continue
+        try:
+            obj_after = after.get(name=name, duplicate=False)
+            dump_after = obj_after.model_dump()
+        except Exception:
+            lines.append(f"{name}: only in 'before'")
+            continue
+        if obj_before.get_hash() == obj_after.get_hash():
+            continue
+        lines.append(f"{name}:")
+        for key in sorted(set(dump_before.keys()) | set(dump_after.keys())):
+            v1, v2 = dump_before.get(key), dump_after.get(key)
+            if v1 == v2:
+                continue
+            if key not in ("attributes", "relationships"):
+                lines.append(f"  {key}: {v1!r} -> {v2!r}")
+                continue
+            items1 = {i["name"]: i for i in v1} if v1 else {}
+            items2 = {i["name"]: i for i in v2} if v2 else {}
+            for iname in sorted(set(items1.keys()) | set(items2.keys())):
+                i1, i2 = items1.get(iname), items2.get(iname)
+                if i1 == i2:
+                    continue
+                if i1 is None:
+                    lines.append(f"  {key}.{iname}: ADDED")
+                elif i2 is None:
+                    lines.append(f"  {key}.{iname}: REMOVED")
+                else:
+                    for fk in sorted(set(i1.keys()) | set(i2.keys())):
+                        if i1.get(fk) != i2.get(fk):
+                            lines.append(f"  {key}.{iname}.{fk}: {i1.get(fk)!r} -> {i2.get(fk)!r}")
+    return "\n".join(lines) if lines else "(no per-schema diffs found)"
+
+
+def test_process_idempotency(register_core_models_schema: SchemaBranch, idempotency_schema: SchemaRoot) -> None:
+    """Calling process() twice on the same SchemaBranch produces an identical hash."""
+    schema_branch = register_core_models_schema
+    schema_branch.load_schema(schema=idempotency_schema)
+    schema_branch.process()
+
+    hash_after_first = schema_branch.get_hash()
+    nodes_after_first = sorted(schema_branch.node_names)
+    generics_after_first = sorted(schema_branch.generic_names)
+    profiles_after_first = sorted(schema_branch.profile_names)
+    templates_after_first = sorted(schema_branch.template_names)
+
+    snapshot = schema_branch.duplicate()
+
+    schema_branch.process()
+
+    hash_after_second = schema_branch.get_hash()
+    nodes_after_second = sorted(schema_branch.node_names)
+    generics_after_second = sorted(schema_branch.generic_names)
+    profiles_after_second = sorted(schema_branch.profile_names)
+    templates_after_second = sorted(schema_branch.template_names)
+
+    assert hash_after_first == hash_after_second, (
+        f"get_hash() changed after second process()\n{_describe_hash_diff(snapshot, schema_branch)}"
+    )
+    assert nodes_after_first == nodes_after_second, "node names changed after second process()"
+    assert generics_after_first == generics_after_second, "generic names changed after second process()"
+    assert profiles_after_first == profiles_after_second, "profile names changed after second process()"
+    assert templates_after_first == templates_after_second, "template names changed after second process()"
+
+
+async def test_process_idempotency_after_db_roundtrip(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_builtin_models_schema: SchemaBranch,
+    idempotency_schema: SchemaRoot,
+) -> None:
+    """Schema loaded, saved to DB, reloaded, and processed produces the same hash."""
+    schema_after_register = registry.schema.register_schema(schema=idempotency_schema, branch=default_branch.name)
+
+    # load_schema_to_db mutates schema_after_register in-place (assigns DB ids),
+    # so capture the hash after the save, not before.
+    await registry.schema.load_schema_to_db(schema=schema_after_register, db=db, branch=default_branch)
+    hash_after_save = schema_after_register.get_hash()
+
+    # load_schema_from_db calls process() internally
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    loaded_schema = schema_branch.duplicate()
+    await registry.schema.load_schema_from_db(db=db, branch=default_branch, schema=loaded_schema)
+
+    hash_after_reload = loaded_schema.get_hash()
+
+    assert hash_after_save == hash_after_reload, (
+        f"Hash mismatch after DB roundtrip.\n"
+        f"  After save:   {hash_after_save}\n"
+        f"  After reload: {hash_after_reload}\n"
+        f"{_describe_hash_diff(schema_after_register, loaded_schema)}"
+    )
+
+    diff = schema_after_register.diff(other=loaded_schema)
+    assert not diff.all, f"Unexpected diff after DB roundtrip: {diff.all}"

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -4036,13 +4036,16 @@ async def test_hierarchical_validate_parent_children(
 
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
-    with pytest.raises(ValueError, match=r"Unable to find the relationship"):
-        region_schema = schema_branch.get(name="LocationRegion", duplicate=False)
-        region_schema.get_relationship(name="parent")
+    # Nodes at the edges of a hierarchy (parent="" or children="") get a
+    # relationship pointing to the hierarchy generic
+    region_schema = schema_branch.get(name="LocationRegion", duplicate=False)
+    region_parent_rel = region_schema.get_relationship(name="parent")
+    assert region_parent_rel.peer == "LocationGeneric"
+    assert region_parent_rel.optional is True
 
-    with pytest.raises(ValueError, match=r"Unable to find the relationship"):
-        rack_schema = schema_branch.get(name="LocationRack", duplicate=False)
-        rack_schema.get_relationship(name="children")
+    rack_schema = schema_branch.get(name="LocationRack", duplicate=False)
+    rack_children_rel = rack_schema.get_relationship(name="children")
+    assert rack_children_rel.peer == "LocationGeneric"
 
     eu: Node = await Node.init(db=db, schema="LocationRegion", branch=default_branch)
     await eu.new(db=db, name="Europe")

--- a/changelog/+20ce829a.fixed.md
+++ b/changelog/+20ce829a.fixed.md
@@ -1,0 +1,1 @@
+Update schema validation and processing to be completely idempotent to prevent incorrect hash errors when retrieving schemas


### PR DESCRIPTION
# Problem

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->
Schema hash errors of the type `Schema 'LocationContinent' on branch None has incorrect hash: '93f166b0364aba675b37f07ffe0c000c'` following merging #8427 that made sure to keep `profiles` and `object_template` generated relationship schemas out of the database. These errors have been observed in local and E2E testing

- on profiles schemas (corrected in #8468)
- on hierarchical schemas, specifically `LocationContinent` and `LocationSite` which are at the top and bottom of the hierarchy in our testing schema https://github.com/opsmill/infrahub/actions/runs/22370786493/job/64748971197?pr=8460
- on schemas with `generate_template=True` (`InfraDevice` and `InfraPatchPanel` in our testing schema)

# Fix 

The root of the problem is that calling `SchemaBranch.process()` was not idempotent between the first and second time, so if a schema is loaded and `.process()` is called on the schema two or more times on the API worker handling the schema update, but only one time on all the other workers that just load the schema from the database, then the schema hashes could diverge and cause the `Schema "Abc" has incorrect hash` errors

Unit testing and manual testing against a local Infrahub instance revealed two issues
- the `object_template` Relationship schema was being saved to the database with `max_count=0`, but if it is run through `.process()` two or more times, that `max_count` is set to `1`. this does not happen on the first run through `process()` b/c `process_cardinality_counts()` is called before `manage_object_template_relationship()`

- the original code only created `parent`/`children` relationships when `node.parent` or `node.children` were truthy. an empty string (used for hierarchy edge nodes: `LocationContinent` / `LocationRack`) was falsy and skipped. This caused `process()` to be non-idempotent: on the first call, edge nodes got no parent/children rel. But `add_hierarchy_generic()` added these rels to the generic, and on a second `process()` call, `process_inheritance()` copied them from the generic into the nodes. the fix uses `parent_peer = node.parent or node.hierarchy` (and similar for `children`), so edge nodes always get a parent/children relationship pointing to the hierarchy generic. this matches the behavior when loading a schema due to multiple `process()` calls
# Testing

a couple of new tests that load a schema with all of our schemas that generate other schemas/attributes/relationships during processing and makes sure that `process()` is idempotent when run in memory and when retrieving a schema from the database so hopefully we can avoid this in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect hash errors by making schema validation and processing fully idempotent.

* **Improvements**
  * More consistent handling of parent/child relationships in schema hierarchies to avoid mismatches.
  * Explicit cardinality constraints added for object templates to enforce expected limits.

* **Tests**
  * Added comprehensive idempotency tests and strengthened hierarchical validation tests.

* **Changelog**
  * Added entry describing idempotency and schema-processing fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->