### PR TITLE
Correctly set default value from template having resource pool in object creation form

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -586,10 +586,6 @@ exports[`fix ts error`] = {
     "src/shared/components/form/pool-selector.tsx:952651893": [
       [72, 46, 2, "tsc: Property \'id\' does not exist on type \'PoolSource | ProfileSource | TemplateSource | { type: SourceType; } | { type: SourceType; } | { type: SourceType; }\'.\\n  Property \'id\' does not exist on type \'{ type: SourceType; }\'.", "5861160"]
     ],
-    "src/shared/components/form/utils/getFieldDefaultValue.ts:4119882594": [
-      [2, 35, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"],
-      [128, 6, 5, "tsc: Type \'null | string | undefined\' is not assignable to type \'null | string\'.\\n  Type \'undefined\' is not assignable to type \'null | string\'.", "173467459"]
-    ],
     "src/shared/components/form/utils/isFieldDisabled.test.ts:1750380810": [
       [14, 6, 4, "tsc: Type \'null\' is not assignable to type \'AuthContextType | undefined\'.", "2087565485"],
       [30, 6, 4, "tsc: Type \'null\' is not assignable to type \'AuthContextType | undefined\'.", "2087565485"],

--- a/frontend/app/src/shared/components/form/type.ts
+++ b/frontend/app/src/shared/components/form/type.ts
@@ -25,6 +25,7 @@ export type PoolSource = {
   label: string | null;
   kind: string;
   id: string;
+  fromTemplate?: boolean;
 };
 
 export type ProfileSource = {

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
@@ -569,6 +569,7 @@ describe("getFieldDefaultValue", () => {
       expect(defaultValue).to.deep.equal({
         source: {
           type: "pool",
+          fromTemplate: true,
           id: "pool-id",
           label: "My Number Pool",
           kind: "CoreNumberPool",

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
@@ -8,7 +8,7 @@ import {
 import { store } from "@/shared/stores";
 
 import type { AttributeType } from "@/entities/nodes/getObjectItemDisplayValue";
-import type { NodeObject } from "@/entities/nodes/types";
+import type { NodeObject, NodeObjectWithMetadata } from "@/entities/nodes/types";
 import {
   genericSchemasAtom,
   nodeSchemasAtom,
@@ -511,8 +511,8 @@ describe("getFieldDefaultValue", () => {
       // GIVEN
       const fieldSchema = generateAttributeSchema({ name: "field1" });
       const objectTemplate: NodeObject = {
-        id: "template-id" as any,
-        __typename: "FakeTemplate" as any,
+        id: "template-id",
+        __typename: "FakeTemplate",
         field1: {
           value: "template-value",
         },
@@ -530,6 +530,84 @@ describe("getFieldDefaultValue", () => {
           kind: "FakeTemplate",
         },
         value: "template-value",
+      });
+    });
+
+    it("returns pool value from template when field value is null and source is a pool", () => {
+      // GIVEN
+      store.set(nodeSchemasAtom, [
+        generateNodeSchema({
+          kind: "CoreNumberPool",
+          inherit_from: ["CoreResourcePool"],
+        }),
+      ]);
+
+      const fieldSchema = generateAttributeSchema({ name: "field1" });
+      const objectTemplate: NodeObjectWithMetadata = {
+        id: "template-id",
+        __typename: "FakeTemplate",
+        field1: {
+          value: null,
+          is_default: false,
+          is_from_profile: false,
+          is_protected: false,
+          is_visible: true,
+          owner: null,
+          updated_at: new Date().toISOString(),
+          source: {
+            id: "pool-id",
+            display_label: "My Number Pool",
+            __typename: "CoreNumberPool",
+          },
+        },
+      };
+
+      // WHEN
+      const defaultValue = getFieldDefaultValue({ fieldSchema, objectTemplate });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({
+        source: {
+          type: "pool",
+          id: "pool-id",
+          label: "My Number Pool",
+          kind: "CoreNumberPool",
+        },
+        value: { from_pool: { id: "pool-id" } },
+      });
+    });
+
+    it("returns null when template field value is null and source is not a pool", () => {
+      // GIVEN
+      const fieldSchema = generateAttributeSchema({ name: "field1" });
+      const objectTemplate: NodeObjectWithMetadata = {
+        id: "template-id",
+        __typename: "FakeTemplate",
+        field1: {
+          value: null,
+          is_default: false,
+          is_from_profile: false,
+          is_protected: false,
+          is_visible: true,
+          owner: null,
+          updated_at: new Date().toISOString(),
+          source: {
+            id: "pool-id",
+            display_label: "My Number Pool",
+            __typename: "CoreNumberPool",
+          },
+        },
+      };
+
+      // WHEN
+      const defaultValue = getFieldDefaultValue({ fieldSchema, objectTemplate });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({
+        source: {
+          type: "schema",
+        },
+        value: null,
       });
     });
 

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
@@ -592,9 +592,9 @@ describe("getFieldDefaultValue", () => {
           owner: null,
           updated_at: new Date().toISOString(),
           source: {
-            id: "pool-id",
-            display_label: "My Number Pool",
-            __typename: "CoreNumberPool",
+            id: "some-id",
+            display_label: "Some Source",
+            __typename: "TestNode",
           },
         },
       };

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
@@ -1,6 +1,5 @@
 import * as R from "remeda";
 
-import type { LineageSource } from "@/shared/api/graphql/generated/graphql";
 import { DEFAULT_FORM_FIELD_VALUE } from "@/shared/components/form/constants";
 import type { ProfileData } from "@/shared/components/form/object-form";
 import type {
@@ -126,7 +125,7 @@ const getDefaultValueFromProfiles = (
     source: {
       type: "profile",
       id: profileWithDefaultValueForField.id,
-      label: profileWithDefaultValueForField.display_label,
+      label: getNodeLabel(profileWithDefaultValueForField),
       kind: profileWithDefaultValueForField.__typename,
     },
     value: (
@@ -148,7 +147,7 @@ const getDefaultValueFromPool = (
     return null;
   }
 
-  const pool = currentField.source as LineageSource;
+  const pool = currentField.source;
 
   if (!pool) return null;
   if (!pool.id) return null;
@@ -167,14 +166,30 @@ const getDefaultValueFromPool = (
 export const getDefaultValueFromTemplate = (
   fieldName: string,
   objectTemplate?: NodeObject | null
-): AttributeValueFromTemplate | null => {
+): AttributeValueFromTemplate | AttributeValueFromPool | null => {
   if (!objectTemplate) return null;
 
   const currentField = objectTemplate[fieldName] as NodeAttributeWithMetadata | undefined;
 
   if (!currentField) return null;
 
-  if (currentField.value === null) return null;
+  if (currentField.value === null) {
+    if (currentField.source?.__typename) {
+      const { schema: sourceSchema } = getSchema(currentField.source.__typename);
+      if (sourceSchema && isPoolSchema(sourceSchema)) {
+        return {
+          source: {
+            type: "pool",
+            id: currentField.source.id,
+            label: getNodeLabel(currentField.source),
+            kind: currentField.source.__typename,
+          },
+          value: { from_pool: { id: currentField.source.id } },
+        };
+      }
+    }
+    return null;
+  }
 
   if (currentField.is_from_profile) return null;
 

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
@@ -180,6 +180,7 @@ export const getDefaultValueFromTemplate = (
         return {
           source: {
             type: "pool",
+            fromTemplate: true,
             id: currentField.source.id,
             label: getNodeLabel(currentField.source),
             kind: currentField.source.__typename,

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -306,6 +306,7 @@ describe("getRelationshipDefaultValue", () => {
       expect(defaultValue).to.deep.equal({
         source: {
           type: "pool",
+          fromTemplate: true,
           label: "My IP Pool",
           id: "pool-id",
           kind: "CoreIPAddressPool",

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -269,6 +269,84 @@ describe("getRelationshipDefaultValue", () => {
       });
     });
 
+    it("returns pool value from template when template relationship node is null and _from_resource_pool exists", () => {
+      // GIVEN
+      store.set(nodeSchemasAtom, [
+        generateNodeSchema({ kind: "TemplateType", display_labels: ["label"] }),
+        generateNodeSchema({
+          kind: "CoreIPAddressPool",
+          display_labels: ["name__value"],
+        }),
+      ]);
+
+      const relationshipName = "ip_address";
+      const objectTemplate: NodeObject = {
+        id: "template-id",
+        display_label: "Template Object",
+        __typename: "TemplateType",
+        ip_address: {
+          node: null,
+        },
+        ip_address_from_resource_pool: {
+          node: {
+            id: "pool-id",
+            display_label: "My IP Pool",
+            __typename: "CoreIPAddressPool",
+          },
+        },
+      };
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        objectTemplate,
+        relationshipName,
+      });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({
+        source: {
+          type: "pool",
+          label: "My IP Pool",
+          id: "pool-id",
+          kind: "CoreIPAddressPool",
+        },
+        value: {
+          id: "pool-id",
+          display_label: "My IP Pool",
+          __typename: "CoreIPAddressPool",
+        },
+      });
+    });
+
+    it("returns null from template when template relationship node is null and _from_resource_pool node is also null", () => {
+      // GIVEN
+      store.set(nodeSchemasAtom, [
+        generateNodeSchema({ kind: "TemplateType", display_labels: ["label"] }),
+      ]);
+
+      const relationshipName = "ip_address";
+      const objectTemplate: NodeObject = {
+        id: "template-id",
+        display_label: "Template Object",
+        __typename: "TemplateType",
+        ip_address: {
+          node: null,
+        },
+        ip_address_from_resource_pool: {
+          node: null,
+        },
+      };
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        objectTemplate,
+        relationshipName,
+      });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({ source: null, value: null });
+    });
+
     it("returns default form field value when template exists but relationship name is not found", () => {
       // GIVEN
       const relationshipName = "nonExistentRelationship";

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -179,7 +179,7 @@ const getRelationshipValueFromParent = (
 export const getRelationshipDefaultValueFromTemplate = (
   objectTemplate: NodeObject | null | undefined,
   relationshipName: string | undefined
-): RelationshipValueFromTemplate | null => {
+): RelationshipValueFromTemplate | RelationshipValueFromPool | null => {
   if (!objectTemplate || !relationshipName) return null;
 
   const relationshipTemplate = objectTemplate[relationshipName] as NodeRelationship | undefined;
@@ -212,7 +212,23 @@ export const getRelationshipDefaultValueFromTemplate = (
   }
 
   const { node } = relationshipTemplate;
-  if (!node) return null;
+  if (!node) {
+    const poolRelationship = objectTemplate[
+      relationshipName + FROM_RESOURCE_POOL_SUFFIX
+    ] as NodeRelationshipOneWithMetadata | undefined;
+
+    if (!poolRelationship?.node) return null;
+
+    return {
+      source: {
+        type: "pool",
+        label: getNodeLabel(poolRelationship.node),
+        id: poolRelationship.node.id,
+        kind: poolRelationship.node.__typename,
+      },
+      value: poolRelationship.node,
+    };
+  }
 
   return {
     source,

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -213,9 +213,9 @@ export const getRelationshipDefaultValueFromTemplate = (
 
   const { node } = relationshipTemplate;
   if (!node) {
-    const poolRelationship = objectTemplate[
-      relationshipName + FROM_RESOURCE_POOL_SUFFIX
-    ] as NodeRelationshipOneWithMetadata | undefined;
+    const poolRelationship = objectTemplate[relationshipName + FROM_RESOURCE_POOL_SUFFIX] as
+      | NodeRelationshipOneWithMetadata
+      | undefined;
 
     if (!poolRelationship?.node) return null;
 

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -222,6 +222,7 @@ export const getRelationshipDefaultValueFromTemplate = (
     return {
       source: {
         type: "pool",
+        fromTemplate: true,
         label: getNodeLabel(poolRelationship.node),
         id: poolRelationship.node.id,
         kind: poolRelationship.node.__typename,

--- a/frontend/app/src/shared/components/form/utils/mutations/getCreateMutationFromFormData.test.ts
+++ b/frontend/app/src/shared/components/form/utils/mutations/getCreateMutationFromFormData.test.ts
@@ -277,6 +277,80 @@ describe("getCreateMutationFromFormData", () => {
       });
     });
 
+    it("excludes pool value when it comes from template", () => {
+      // GIVEN
+      const fields: Array<DynamicFieldProps> = [
+        buildFormField({
+          name: "ip_address",
+          type: "relationship",
+          pool: {
+            kind: "CoreIPAddressPool",
+            defaultAllocatedObjectKind: "InfraIPAddress",
+            fromPoolRelationshipName: "ip_address_from_resource_pool",
+          },
+        }),
+      ];
+      const formData: Record<string, FormRelationshipValue> = {
+        ip_address: {
+          source: {
+            type: "pool",
+            fromTemplate: true,
+            label: "Loopbacks pool",
+            id: "pool-id",
+            kind: "CoreIPAddressPool",
+          },
+          value: {
+            id: "pool-id",
+            display_label: "Loopbacks pool",
+            __typename: "CoreIPAddressPool",
+          },
+        },
+      };
+
+      // WHEN
+      const mutationData = getCreateMutationFromFormData(fields, formData, "template-id");
+
+      // THEN
+      expect(mutationData).to.deep.equal({
+        object_template: { id: "template-id" },
+      });
+    });
+
+    it("includes pool value when user selects pool manually", () => {
+      // GIVEN
+      const fields: Array<DynamicFieldProps> = [
+        buildFormField({
+          name: "ip_address",
+          type: "relationship",
+          pool: {
+            kind: "CoreIPAddressPool",
+            defaultAllocatedObjectKind: "InfraIPAddress",
+            fromPoolRelationshipName: "ip_address_from_resource_pool",
+          },
+        }),
+      ];
+      const formData: Record<string, FormRelationshipValue> = {
+        ip_address: {
+          source: {
+            type: "pool",
+            label: "User selected pool",
+            id: "user-pool-id",
+            kind: "CoreIPAddressPool",
+          },
+          value: { from_pool: { id: "user-pool-id" } },
+        },
+      };
+
+      // WHEN
+      const mutationData = getCreateMutationFromFormData(fields, formData, "template-id");
+
+      // THEN
+      expect(mutationData).to.deep.equal({
+        object_template: { id: "template-id" },
+        ip_address_from_resource_pool: { id: "user-pool-id" },
+      });
+    });
+
     it("only sends null on direct field when value is null", () => {
       // GIVEN
       const fields: Array<DynamicFieldProps> = [
@@ -569,6 +643,30 @@ describe("getCreateMutationFromFormDataOnly", () => {
     // THEN
     expect(mutationData).to.deep.equal({
       field1: { from_pool: { id: "pool-id" } },
+    });
+  });
+
+  it("excludes pool values from template", () => {
+    // GIVEN
+    const formData: Record<string, FormFieldValue> = {
+      field1: {
+        source: {
+          type: "pool",
+          fromTemplate: true,
+          label: "Pool 1",
+          id: "pool-id",
+          kind: "ResourcePool",
+        },
+        value: { from_pool: { id: "pool-id" } },
+      },
+    };
+
+    // WHEN
+    const mutationData = getCreateMutationFromFormDataOnly(formData, undefined, "template-id");
+
+    // THEN
+    expect(mutationData).to.deep.equal({
+      object_template: { id: "template-id" },
     });
   });
 

--- a/frontend/app/src/shared/components/form/utils/mutations/getCreateMutationFromFormData.ts
+++ b/frontend/app/src/shared/components/form/utils/mutations/getCreateMutationFromFormData.ts
@@ -22,6 +22,9 @@ export const getCreateMutationFromFormData = (
     }
 
     if (isFormFieldValueFromPool(fieldData)) {
+      if (fieldData.source.fromTemplate) {
+        return acc;
+      }
       const fromPoolField = field.pool?.fromPoolRelationshipName;
       if (fromPoolField && "from_pool" in fieldData.value) {
         return { ...acc, [fromPoolField]: { id: fieldData.value.from_pool.id } };
@@ -97,6 +100,9 @@ export const getCreateMutationFromFormDataOnly = (
     }
 
     if (isFormFieldValueFromPool(fieldData)) {
+      if (fieldData.source.fromTemplate) {
+        return acc;
+      }
       return { ...acc, [fieldName]: fieldData.value };
     }
 

--- a/frontend/app/tests/e2e/object-template/template-with-pool.spec.ts
+++ b/frontend/app/tests/e2e/object-template/template-with-pool.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+import { ACCOUNT_STATE_PATH } from "../../constants";
+import { generateRandomBranchName } from "../../utils";
+import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
+
+test.describe("/object-template - Pool from template", () => {
+  test.describe.configure({ mode: "serial" });
+  test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
+  const BRANCH_NAME = generateRandomBranchName("template-pool");
+
+  test.beforeAll(async ({ request }) => {
+    await createBranchAPI(request, BRANCH_NAME);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteBranchAPI(request, BRANCH_NAME);
+  });
+
+  test("should create a device template with pool for primary_address", async ({ page }) => {
+    await test.step("Navigate to object templates", async () => {
+      await page.goto(`/objects/CoreObjectTemplate?branch=${BRANCH_NAME}`);
+      await expect(page.getByRole("heading")).toContainText("Object Template");
+    });
+
+    await test.step("Create device template with pool allocation for primary_address", async () => {
+      await page.getByTestId("create-object-button").click();
+      await page.getByLabel("Select an object type").click();
+      await page.getByRole("option", { name: "Device Infra" }).click();
+      await page.getByLabel("Template Name *").fill("pool_device_template");
+
+      await page.getByTestId("select-open-pool-option-button").click();
+      await page.getByRole("option", { name: "Loopbacks pool" }).click();
+      await expect(page.getByTestId("source-pool-badge")).toBeVisible();
+      await expect(page.getByLabel("Primary_Address")).toContainText("Allocated by pool");
+
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("InfraDevice created")).toBeVisible();
+    });
+  });
+
+  test("should not include template pool values in create mutation", async ({ page }) => {
+    await test.step("Navigate to Device list", async () => {
+      await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+      await expect(page.getByRole("heading")).toContainText("Device");
+    });
+
+    await test.step("Create device from template and verify mutation excludes pool data", async () => {
+      await page.getByTestId("create-object-button").click();
+      await page.getByRole("button", { name: "Start from template" }).click();
+      await page.getByRole("option", { name: "pool_device_template" }).click();
+      await expect(page.getByTestId("source-pool-badge")).toBeVisible();
+      await expect(page.getByLabel("Primary IP Address")).toContainText("Loopbacks pool");
+
+      await page.getByRole("textbox", { name: "Name *" }).fill("device-from-pool-template");
+      await page.getByRole("textbox", { name: "Type *" }).fill("test type");
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Device created")).toBeVisible();
+    });
+  });
+
+  test("should show pool-allocated primary address on device detail view", async ({ page }) => {
+    await test.step("Navigate to created device", async () => {
+      await page.goto(`/objects/InfraDevice?branch=${BRANCH_NAME}`);
+      await page.getByRole("link", { name: "device-from-pool-template" }).click();
+    });
+
+    await test.step("Verify primary address was allocated from pool", async () => {
+      await expect(page.getByText("Primary IP Address10.0.0.")).toBeVisible(); // The allocated IP should be visible as a link
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Forms now fall back to resource-pool values when template values are missing, improving initial field and relationship population.
  * When neither template nor pool values exist, forms return explicit empty defaults to avoid partial states.
  * Pool-derived values marked as originating from a template are treated as template defaults and are not emitted as user-selected pool choices during creation.

* **Tests & E2E**
  * Added unit and end-to-end tests for pool-fallbacks, template-origin behavior, and null-source scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->