### PR TITLE
Use Python 3.13 within invoke task framework

### DIFF
--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -54,7 +54,7 @@ CACHE_DOCKER_IMAGE = os.getenv(
 here = Path(__file__).parent.resolve()
 TOP_DIRECTORY_NAME = here.parent.name
 BUILD_NAME = os.getenv("INFRAHUB_BUILD_NAME", re.sub(r"[^a-zA-Z0-9_/.]", "", str(TOP_DIRECTORY_NAME)))
-PYTHON_VER = os.getenv("PYTHON_VER", "3.12")
+PYTHON_VER = os.getenv("PYTHON_VER", "3.13")
 
 PWD = Path.cwd()
 


### PR DESCRIPTION
# Why

Use Python 3.13 in Invoke tasks as the main pipelines are testing against Python 3.13 and not Python 3.12

## What changed

Change from using Python 3.12 to 3.13 in the main invoke tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Python runtime version to 3.13, upgrading from the previous version 3.12 to leverage the latest Python improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->