### PR TITLE
Add instructions for Jira reference

### DIFF
--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -306,33 +306,23 @@ if [ -z "$BRANCH_NUMBER" ]; then
     fi
 fi
 
-# Determine initials
-if [ -z "$INITIALS" ]; then
-    if [ "$HAS_GIT" = true ]; then
-        INITIALS=$(get_git_initials)
-        if [ -z "$INITIALS" ]; then
-            echo "Error: Could not determine initials." >&2
-            echo "Set OPSMILL_GIT_USER_SHORT, git config user.name, or use --initials <initials>" >&2
-            exit 1
-        fi
-    else
-        echo "Error: No git available and --initials not provided." >&2
-        echo "Use --initials <initials> to specify manually." >&2
-        exit 1
-    fi
+# If BRANCH_NUMBER is a ticket ID (e.g., infp-460, ifc-2140), use it as-is.
+# Otherwise zero-pad as a 3-digit integer (legacy numeric mode).
+if [[ "$BRANCH_NUMBER" =~ ^[a-z]+-[0-9]+$ ]]; then
+    FEATURE_NUM="$BRANCH_NUMBER"
+else
+    # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+    FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
 fi
-
-# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
-FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-BRANCH_NAME="${INITIALS}-${FEATURE_NUM}-${BRANCH_SUFFIX}"
+BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 
 # GitHub enforces a 244-byte limit on branch names
 # Validate and truncate if necessary
 MAX_BRANCH_LENGTH=244
 if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     # Calculate how much we need to trim from suffix
-    # Account for: initials (variable) + hyphen (1) + feature number (3) + hyphen (1)
-    PREFIX_LENGTH=$(( ${#INITIALS} + 1 + 3 + 1 ))
+    # Account for: feature number (variable) + hyphen (1)
+    PREFIX_LENGTH=$(( ${#FEATURE_NUM} + 1 ))
     MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - PREFIX_LENGTH))
 
     # Truncate suffix at word boundary if possible
@@ -341,7 +331,7 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
 
     ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-    BRANCH_NAME="${INITIALS}-${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
 
     >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
     >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
@@ -365,11 +355,10 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","INITIALS":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM" "$INITIALS"
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"
     echo "FEATURE_NUM: $FEATURE_NUM"
-    echo "INITIALS: $INITIALS"
     echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
 fi

--- a/dev/commands/speckit.specify.md
+++ b/dev/commands/speckit.specify.md
@@ -10,7 +10,7 @@ handoffs:
     send: true
 ---
 
-## User Input
+## User input
 
 ```text
 $ARGUMENTS
@@ -36,35 +36,26 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Determine the Jira/JPD reference and create the feature branch**:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
+   a. Determine the Jira/JPD reference for this feature:
+      - Parse `$ARGUMENTS` for a ticket ID matching:
+        - JPD format: `infp-[0-9]+` (e.g., `infp-460`)
+        - Jira epic format: `ifc-[0-9]+` (e.g., `ifc-2140`)
+      - If no ticket ID is found in the arguments, prompt the user:
 
-      ```bash
-      git fetch --all --prune
-      ```
+        > "Please provide a Jira or JPD reference for this feature (e.g., `infp-460` for a JPD item or `ifc-2140` for a Jira epic):"
 
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/([a-z]{2,4}-)?[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*([a-z]{2,4}-)?[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/([a-z]{2,4}-)?[0-9]+-<short-name>`
+      - Do not proceed until a valid ticket ID is provided.
 
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - The `--initials` flag is optional; initials are auto-detected from `git config user.name` (first letter of first name + first two letters of last name, lowercased)
-      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   b. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the ticket ID and short-name:
+      - Pass `--number <ticket-id>` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json --number infp-460 --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json -Number infp-460 -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Numbers are global across all developers -- scan ALL branches regardless of initials prefix
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - A valid ticket ID is required — never invent or skip it
+   - Ticket IDs are unique identifiers; no branch scanning is needed
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths


### PR DESCRIPTION
# Why

Update instructions to Spec Kit specify command to better align with how we want to name our folders for Spec Kit specifications.

## What changed

* Instructions to ensure that we prefix the folder names with Jira epic or JPD card along with the short name of the feature
* Update bash script to account for the fact that we don't use numbers
* Also remove the initials for the username from the shell script.

## How to review

* Consider if this better suites our needs
* Try it out

Note that in order to keep this small I've not changed any of the instructions when it comes to creating a local branch. This is to keep the change small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature creation workflow to require explicit Jira/JPD ticket IDs instead of auto-scanning for branch numbers.
  * Clarified user input requirements for ticket references (JPD: `infp-<digits>`; Jira: `ifc-<digits>`).

* **Refactor**
  * Simplified branch naming scheme to use ticket ID only, removing user initials from branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->