### PR TITLE
 #8237 (IFC-2235): Update queries on node using HFID to reference relationships 

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -766,11 +766,12 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def resolve_relationships(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> None:
         extra_filters: dict[str, set[str]] = {}
+        schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)
 
-        if not self._existing:
-            # If we are creating a new node, we need to resolve extra filters from HFID and Display Labels,
-            # if we don't do this the fields might be blank
-            schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)
+        # If we are creating a new node, we need to resolve extra filters from HFID,
+        # if we don't do this the fields might be blank.
+        # We could also need it when we need to recompute the HFID
+        if not self._existing or self._human_friendly_id:
             try:
                 hfid_identifier = schema_branch.hfids.get_node_definition(kind=self._schema.kind)
                 for rel_name, attrs in hfid_identifier.relationship_fields.items():
@@ -778,6 +779,10 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             except KeyError:
                 # No HFID defined for this kind
                 ...
+        # If we are creating a new node, we need to resolve extra filters from Display Labels,
+        # if we don't do this the fields might be blank.
+        # We could also need it when we need to recompute the Display Labels
+        if not self._existing or self._display_label:
             try:
                 display_label_identifier = schema_branch.display_labels.get_template_node(kind=self._schema.kind)
                 for rel_name, attrs in display_label_identifier.relationship_fields.items():

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -53,6 +53,9 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.creation_context import NodeCreationContext
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.schema.schema_branch_display import TemplateLabel
+    from infrahub.core.schema.schema_branch_hfid import HFIDDefinition
     from infrahub.database import InfrahubDatabase
 
 SchemaProtocol = TypeVar("SchemaProtocol")
@@ -764,32 +767,36 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         return self
 
-    async def resolve_relationships(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> None:
+    @staticmethod
+    def _merge_relationship_fields(
+        definitions: list[HFIDDefinition | TemplateLabel],
+    ) -> dict[str, set[str]]:
+        """Merge ``relationship_fields`` from the given definitions into a single mapping."""
         extra_filters: dict[str, set[str]] = {}
-        schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)
+        for definition in definitions:
+            for rel_name, attrs in definition.relationship_fields.items():
+                extra_filters.setdefault(rel_name, set()).update(attrs)
+        return extra_filters
 
-        # If we are creating a new node, we need to resolve extra filters from HFID,
-        # if we don't do this the fields might be blank.
-        # We could also need it when we need to recompute the HFID
-        if not self._existing or self._human_friendly_id:
-            try:
-                hfid_identifier = schema_branch.hfids.get_node_definition(kind=self._schema.kind)
-                for rel_name, attrs in hfid_identifier.relationship_fields.items():
-                    extra_filters.setdefault(rel_name, set()).update(attrs)
-            except KeyError:
-                # No HFID defined for this kind
-                ...
-        # If we are creating a new node, we need to resolve extra filters from Display Labels,
-        # if we don't do this the fields might be blank.
-        # We could also need it when we need to recompute the Display Labels
-        if not self._existing or self._display_label:
-            try:
-                display_label_identifier = schema_branch.display_labels.get_template_node(kind=self._schema.kind)
-                for rel_name, attrs in display_label_identifier.relationship_fields.items():
-                    extra_filters.setdefault(rel_name, set()).update(attrs)
-            except KeyError:
-                # No Display Label defined for this kind
-                ...
+    def _collect_extra_filters(self, schema_branch: SchemaBranch) -> dict[str, set[str]]:
+        """Collect peer attributes that must be loaded during relationship resolution."""
+        definitions: list[HFIDDefinition | TemplateLabel] = []
+
+        # If we are creating a new node, we need to resolve extra filters from Display Labels or HFIDs, if we don't do
+        # this the fields might be blank.
+        # We could also need it when we need to recompute the Display Labels or HFIDs
+        if (not self._existing) or self._human_friendly_id:
+            if hfid := schema_branch.hfids.get_template_nodes().get(self._schema.kind):
+                definitions.append(hfid)
+        if (not self._existing) or self._display_label:
+            if display_labels := schema_branch.display_labels.get_template_nodes().get(self._schema.kind):
+                definitions.append(display_labels)
+
+        return self._merge_relationship_fields(definitions)
+
+    async def resolve_relationships(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> None:
+        schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)
+        extra_filters = self._collect_extra_filters(schema_branch=schema_branch)
 
         for name in self._relationships:
             relm: RelationshipManager = getattr(self, name)

--- a/backend/tests/component/graphql/test_mutation_upsert.py
+++ b/backend/tests/component/graphql/test_mutation_upsert.py
@@ -827,7 +827,7 @@ async def test_upsert_preserves_relationship_display_label(
         root_value=None,
         variable_values={},
     )
-    await _basic_asserts(result_create)
+    _basic_asserts(result_create)
     assert result_create.data["TestingTShirtUpsert"]["object"]["display_label"] == "Classic Red"
     tshirt_id = result_create.data["TestingTShirtUpsert"]["object"]["id"]
 
@@ -843,13 +843,13 @@ async def test_upsert_preserves_relationship_display_label(
         root_value=None,
         variable_values={},
     )
-    await _basic_asserts(result_upsert)
+    _basic_asserts(result_upsert)
     assert result_upsert.data["TestingTShirtUpsert"]["object"]["id"] == tshirt_id
     # display_label should still be "Classic Red"
     assert result_upsert.data["TestingTShirtUpsert"]["object"]["display_label"] == "Classic Red"
 
 
-async def _basic_asserts(result_upsert: ExecutionResult):
+def _basic_asserts(result_upsert: ExecutionResult) -> None:
     assert result_upsert.errors is None
     assert result_upsert.data
     assert result_upsert.data["TestingTShirtUpsert"]["ok"] is True

--- a/backend/tests/component/graphql/test_mutation_upsert.py
+++ b/backend/tests/component/graphql/test_mutation_upsert.py
@@ -1,3 +1,5 @@
+from graphql import ExecutionResult
+
 from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
@@ -13,7 +15,7 @@ from infrahub.services import InfrahubServices
 from tests.adapters.event import MemoryInfrahubEvent
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
-from tests.helpers.schema import COLOR, TICKET, TSHIRT
+from tests.helpers.schema import COLOR, TICKET, TSHIRT, load_schema
 from tests.node_creation import create_and_save
 
 
@@ -780,3 +782,74 @@ async def test_upsert_with_required_relationship_from_template(
     assert tshirt_obj["name"]["value"] == "My Tshirt"
     assert tshirt_obj["color"]["node"]["id"] == color_node.id
     assert tshirt_obj["color"]["node"]["name"]["value"] == "Red"
+
+
+async def test_upsert_preserves_relationship_display_label(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    """Validate that display_label with relationship-based Jinja2 template stays correct after upsert.
+
+    Steps:
+    - Create mutation (through Upsert query), display_label correctly renders relationship values (e.g. "Classic Red")
+    - Update mutation (through a second Upsert query) display_label should still render correctly
+
+    Uses HFID-based relationship references (passing color by name "Red" instead of UUID) to
+    replicate how object file loading works.
+    """
+    await load_schema(db=db, schema=SchemaRoot(nodes=[COLOR, TSHIRT]), branch_name=default_branch.name)
+
+    # Create a color node
+    color_node = await Node.init(db=db, schema="TestingColor", branch=default_branch)
+    await color_node.new(db=db, name="Red", description="Bright Red")
+    await color_node.save(db=db)
+
+    upsert_mutation = """
+    mutation {
+        TestingTShirtUpsert(data: {
+            name: {value: "Classic"},
+            color: {id: "Red"}
+        }) {
+            ok
+            object {
+                id
+                display_label
+            }
+        }
+    }
+    """
+
+    # First upsert: creates the TShirt (display_label template: "{{ name__value }} {{ color__name__value }}")
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result_create = await graphql(
+        schema=gql_params.schema,
+        source=upsert_mutation,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    await _basic_asserts(result_create)
+    assert result_create.data["TestingTShirtUpsert"]["object"]["display_label"] == "Classic Red"
+    tshirt_id = result_create.data["TestingTShirtUpsert"]["object"]["id"]
+
+    # Second upsert: updates the same TShirt (matched by uniqueness_constraints on name)
+    # This is where the bug manifests: display_label becomes "Classic None"
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+
+    # Act
+    result_upsert = await graphql(
+        schema=gql_params.schema,
+        source=upsert_mutation,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    await _basic_asserts(result_upsert)
+    assert result_upsert.data["TestingTShirtUpsert"]["object"]["id"] == tshirt_id
+    # display_label should still be "Classic Red"
+    assert result_upsert.data["TestingTShirtUpsert"]["object"]["display_label"] == "Classic Red"
+
+
+async def _basic_asserts(result_upsert: ExecutionResult):
+    assert result_upsert.errors is None
+    assert result_upsert.data
+    assert result_upsert.data["TestingTShirtUpsert"]["ok"] is True

--- a/changelog/8237.fixed.md
+++ b/changelog/8237.fixed.md
@@ -1,0 +1,2 @@
+Fixed display labels showing 'None' for relationship-based fields after upsert.
+Relationship peer attributes needed by display label and HFID templates are now correctly loaded during node updates.

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -42,13 +42,32 @@ class NodeManager:
             raise ValidationError("Node name is required")
 ```
 
-Use `TYPE_CHECKING` blocks for imports only needed for type hints to avoid circular imports:
+All backend modules use `from __future__ import annotations`, which turns annotations into strings at runtime. This means imports used **only** in type hints have no runtime effect and can be placed under `TYPE_CHECKING` to prevent circular imports:
 
 ```python
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
+```
+
+If an import is only referenced in parameter types, return types, or variable annotations, move it under `TYPE_CHECKING` — especially when it causes or risks a circular import chain:
+
+```python
+# ❌ Bad - top-level import only used in annotations; causes circular import
+from infrahub.core.schema.schema_branch import SchemaBranch
+
+def collect_filters(self, schema_branch: SchemaBranch) -> dict[str, set[str]]:
+    ...
+
+# ✅ Good - deferred under TYPE_CHECKING
+if TYPE_CHECKING:
+    from infrahub.core.schema.schema_branch import SchemaBranch
+
+def collect_filters(self, schema_branch: SchemaBranch) -> dict[str, set[str]]:
+    ...
 ```
 
 ## Data Structures

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -63,6 +63,8 @@ def collect_filters(self, schema_branch: SchemaBranch) -> dict[str, set[str]]:
     ...
 
 # ✅ Good - deferred under TYPE_CHECKING
+from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from infrahub.core.schema.schema_branch import SchemaBranch
 

--- a/dev/knowledge/backend/display-labels-and-hfid.md
+++ b/dev/knowledge/backend/display-labels-and-hfid.md
@@ -1,0 +1,109 @@
+# Display Labels and Human Friendly IDs
+
+> Part of: `dev/knowledge/backend/` | Related: [mutations.md](mutations.md), [architecture.md](architecture.md)
+
+Display labels and HFIDs are computed node properties backed by Jinja2 templates (display labels) or schema path lists (HFIDs). They depend on attributes and relationship peer attributes, requiring special handling during relationship resolution.
+
+## Schema Definition
+
+On `BaseNodeSchema`:
+
+- **`display_label`**: Jinja2 template string (e.g., `"{{ name__value }} {{ color__name__value }}"`)
+- **`human_friendly_id`**: List of schema paths (e.g., `["name__value", "owner__name__value"]`)
+- **`display_labels`** (deprecated): Legacy list format, auto-converted to `display_label` during schema processing
+
+Schema paths use `__` separators: `color__name__value` means "follow the `color` relationship, read the `name` attribute's `value` property."
+
+## Key Classes
+
+### NodePropertyAttribute subclasses
+
+**Location:** `backend/infrahub/core/node/node_property_attribute.py`
+
+- **`DisplayLabel`**: Wraps a Jinja2 `display_label` template
+- **`HumanFriendlyIdentifier`**: Wraps an HFID path list
+
+Both provide:
+
+| Method | Purpose |
+|--------|---------|
+| `analyze_variables()` | Parses template to extract attribute/relationship dependencies |
+| `compute(db, node)` | Resolves variables via `node.get_path_value()`, renders template |
+| `needs_update(fields)` | Returns True if any dependent field changed |
+| `set_value(value, manually_assigned)` | Manual override; skips future `compute()` calls |
+
+### Schema Registries
+
+**Location:** `backend/infrahub/core/schema/schema_branch_display.py`, `schema_branch_hfid.py`
+
+Each registry stores per-kind definitions with:
+
+- **`attributes`**: Direct attribute dependencies (e.g., `{"name"}`)
+- **`relationships`**: Relationship names referenced (e.g., `{"color"}`)
+- **`relationship_fields`**: Map of relationship name to peer attribute names (e.g., `{"color": {"name"}}`)
+
+Registries also maintain **`RelationshipTriggers`** -- inverse mappings for recomputation when a peer's attribute changes.
+
+Registration happens during schema processing: display labels are registered inside `SchemaBranch.validate_display_label()`, and HFIDs are registered via `SchemaBranch.register_human_friendly_id()` (a separate step from `process_human_friendly_id()`, both called from `process_post_validation()`).
+
+## resolve_relationships() and extra_filters
+
+**Location:** `Node.resolve_relationships()` and `Node._collect_extra_filters()` in `backend/infrahub/core/node/__init__.py`
+
+When a node's display label or HFID template references relationship peer attributes (e.g., `color__name__value`), those attributes must be loaded during `Relationship.resolve()`. The `resolve_relationships()` method calls `_collect_extra_filters()`, which reads `relationship_fields` from the registries and builds the filter map. These are then passed as `extra_filters` to each `RelationshipManager.resolve()`.
+
+```
+resolve_relationships()
+  -> _collect_extra_filters()
+       -> read relationship_fields from schema_branch.hfids / schema_branch.display_labels
+       -> build extra_filters: {"color": {"name"}, "owner": {"family_name"}}
+  -> for each RelationshipManager:
+       relm.resolve(db, fields=extra_filters[rel_name])
+         -> Relationship.resolve() loads peer with those fields populated
+```
+
+### Guard Conditions
+
+In `_collect_extra_filters()`, extra filters are only computed when needed:
+
+```python
+if not self._existing or self._human_friendly_id:
+    # Fetch HFID-related peer attributes
+if not self._existing or self._display_label:
+    # Fetch display-label-related peer attributes
+```
+
+- **New nodes** (`not self._existing`): Always need extra filters
+- **Existing nodes with HFID/display_label set**: Need extra filters for recomputation during updates
+
+## Lifecycle
+
+### Create
+
+1. `Node.new()` -> `_process_fields()` -> `_process_fields_relationships()` (creates RelationshipManagers)
+2. `Node.save()` -> `resolve_relationships()` (loads peers with extra_filters) -> `_create()`
+3. `_create()` -> `add_human_friendly_id()` / `add_display_label()` (compute and persist)
+
+### Update
+
+1. `Node.load()` receives `human_friendly_id` and `display_label` kwargs, wraps them in property objects
+2. `Node.save()` -> `resolve_relationships()` (extra_filters gated by `self._human_friendly_id` / `self._display_label`)
+3. `_update()` checks `needs_update(fields)` for each property; recomputes and persists if needed
+
+### Manual Override
+
+`set_display_label(value)` and `set_human_friendly_id(value)` set `manually_assigned=True`, which causes `compute()` to no-op on future calls.
+
+
+## Key Files
+
+| File | What |
+|------|------|
+| `core/node/node_property_attribute.py` | `DisplayLabel`, `HumanFriendlyIdentifier` classes |
+| `core/node/__init__.py` | `resolve_relationships()`, `_collect_extra_filters()`, `add_display_label()`, `_update()` |
+| `core/schema/schema_branch_display.py` | `DisplayLabels` registry, `TemplateLabel` |
+| `core/schema/schema_branch_hfid.py` | `HFIDs` registry, `HFIDDefinition` |
+| `core/schema/schema_branch.py` | `validate_display_label()`, `process_human_friendly_id()` |
+| `core/schema/basenode_schema.py` | `SchemaAttributePath` (parsed template variables) |
+| `display_labels/models.py` | `DisplayLabelJinja2GraphQL` (GraphQL query generation) |
+| `graphql/mutations/display_label.py` | Manual display_label override mutation |

--- a/dev/knowledge/backend/display-labels-and-hfid.md
+++ b/dev/knowledge/backend/display-labels-and-hfid.md
@@ -1,9 +1,8 @@
-# Display Labels and Human Friendly IDs
+# Display Labels and Human-Friendly IDs
 
 > Part of: `dev/knowledge/backend/` | Related: [mutations.md](mutations.md), [architecture.md](architecture.md)
 
-Display labels and HFIDs are computed node properties backed by Jinja2 templates (display labels) or schema path lists (HFIDs). They depend on attributes and relationship peer attributes, requiring special handling during relationship resolution.
-
+Display labels and HFIDs are computed node properties. Display labels use Jinja2 templates; HFIDs use schema path lists.
 ## Schema Definition
 
 On `BaseNodeSchema`:

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -1,0 +1,133 @@
+# Mutations
+
+> Part of: `dev/knowledge/backend/` | Related: [display-labels-and-hfid.md](display-labels-and-hfid.md), [architecture.md](architecture.md)
+
+GraphQL mutations for creating, updating, upserting, and deleting nodes. All mutations are transaction-wrapped and use locking for constraint safety.
+
+## Mutation Dispatch
+
+**Location:** `backend/infrahub/graphql/mutations/main.py`
+
+`InfrahubMutationMixin.mutate()` dispatches based on class name:
+
+| Suffix | Method | Flow |
+|--------|--------|------|
+| `Create` | `mutate_create()` | `create_node()` -> `Node.new()` -> `Node.save()` |
+| `Update` | `mutate_update()` | `Node.load()` -> `Node.from_graphql()` -> `Node.save()` |
+| `Upsert` | `mutate_upsert()` | Find-or-create, then create or update path |
+| `Delete` | `mutate_delete()` | Load -> delete |
+
+## Create Flow
+
+```
+mutate_create()
+  -> create_node()                    # create.py
+       -> preview node (process_pools=False) for lock calculation
+       -> acquire InfrahubMultiLock
+       -> _do_create_node()
+            -> NodeCreationContext     # tracks side-effect nodes for events
+            -> Node.new()
+                 -> _process_fields()  # validates, hydrates attrs & rels
+                 -> _process_macros()  # evaluates mandatory computed attrs
+            -> NodeConstraintRunner.check()
+            -> Node.save()
+                 -> resolve_relationships()  # loads peers with extra_filters
+                 -> _create()
+                      -> add_human_friendly_id()
+                      -> add_display_label()
+                      -> NodeCreateAllQuery  # bulk Neo4j insert
+            -> handle_template_relationships()  # recursive template instantiation
+       -> apply profiles if applicable
+  -> emit NodeCreatedEvent
+```
+
+## Update Flow
+
+```
+mutate_update()
+  -> NodeManager.find_object()       # by id or hfid
+  -> _call_mutate_update()
+       -> preview object for lock calculation
+       -> acquire InfrahubMultiLock
+       -> mutate_update_object()
+            -> Node.from_graphql()    # applies new data to loaded node
+                 -> attribute.from_graphql()  # update attrs in-place
+                 -> RelationshipManager.update()  # see below
+            -> NodeConstraintRunner.check(updated fields only)
+            -> Node.save(fields=[changed fields])
+                 -> resolve_relationships()
+                 -> _update()
+                      -> attr.save() for each changed attribute
+                      -> rel.save() for each changed relationship
+                      -> recompute HFID/display_label if needs_update()
+  -> emit NodeUpdatedEvent
+```
+
+## Upsert Flow
+
+```
+mutate_upsert()
+  -> identify node by (in priority order):
+       1. "id" in data -> load by UUID
+       2. default_filter (no HFID) -> MutationNodeGetterByDefaultFilter
+       3. "hfid" in data -> load by human_friendly_id
+  -> if found: _call_mutate_update()
+  -> if not found:
+       -> mutate_create()
+       -> on HFIDViolatedError (concurrent create race):
+            -> load node by ID from exception
+            -> _call_mutate_update(skip_uniqueness_check=True)
+            -> handle file idempotency (checksum comparison)
+```
+
+## Relationship Resolution During Mutations
+
+### RelationshipManager.update()
+
+**Location:** `backend/infrahub/core/relationship/model.py`
+
+When updating relationships, the manager compares new data against existing relationships:
+
+1. Fetch current relationships from DB -> `previous_relationships` dict (keyed by `peer_id`)
+2. Clear `_relationships` list
+3. For each new item:
+   - **UUID match** (string or dict with `"id"`): Reuse existing `Relationship` object from `previous_relationships`
+   - **No match** (HFID, default_filter, new UUID): Create new `Relationship` via `.new()`
+4. Mark as changed if the set of peers differs
+
+### UUID vs HFID References
+
+This distinction matters for display_label/HFID computation:
+
+| Reference type | RelationshipManager.update() behavior | Peer data |
+|----------------|---------------------------------------|-----------|
+| UUID | Reuses old `Relationship` object | Peer already resolved with attributes |
+| HFID / default_filter | Creates new `Relationship` object | Peer needs fresh resolution |
+
+New `Relationship` objects require `resolve()` to load the peer. The `extra_filters` in `resolve_relationships()` ensure the peer's attributes needed by display_label/HFID templates are loaded during resolution.
+
+### RelationshipManager.save()
+
+After resolution, `save()` reconciles local state with the database:
+
+- Peer in both local and DB: compare properties, update if different
+- Peer only in local: create new relationship in DB
+- Peer only in DB: delete orphaned relationship
+
+## Locking Strategy
+
+1. A preview node is created with `process_pools=False` (no side effects)
+2. Lock names are computed from uniqueness constraints and resource pool fields
+3. `InfrahubMultiLock` acquired before the transaction
+4. Actual mutation runs inside the lock
+
+## Key Files
+
+| File | What |
+|------|------|
+| `graphql/mutations/main.py` | Mutation dispatcher, create/update/upsert/delete |
+| `core/node/__init__.py` | `Node.new()`, `load()`, `from_graphql()`, `_create()`, `_update()`, `save()` |
+| `core/node/create.py` | `create_node()`, `_do_create_node()`, template relationship handling |
+| `core/relationship/model.py` | `RelationshipManager.update()`, `resolve()`, `save()` |
+| `core/constraint/node/runner.py` | `NodeConstraintRunner` for uniqueness/constraint checks |
+| `core/query/node.py` | `NodeCreateAllQuery` and other DB queries |


### PR DESCRIPTION
# Why

### Problem statement

Update queries recompute and provide incorrect values for computed attributes using related node attributes.
For example, after an update query on an object with the following schema:

```
version: "1.0"

nodes:
  - name: DeviceType
    namespace: Dcim
    description: A model of device
    label: Device Type
    icon: mdi:poll
    include_in_menu: true
    human_friendly_id:
      - name__value
    display_label: "{{ name__value }} (Manufacturer: {{ manufacturer__name__value }})"
    order_by:
      - manufacturer__name__value
      - name__value
    uniqueness_constraints:
      - [manufacturer, name__value]
    attributes:
      - name: name
        kind: Text
        unique: true
        order_weight: 1000
    relationships:
      - name: manufacturer
        peer: OrganizationManufacturer
        cardinality: one
        kind: Attribute
        order_weight: 1250
        optional: false
```
`display_label` will be evaluated as "`name__value`(None)", because `{{ manufacturer__name__value }}` evaluates to `None`.

This is due to the fact that `infrahub.core.node.Node.resolve_relationships` method does not retrieve the required attributes from the relationships when the node is not being created.
This `display_label` recompute is called in the `infrahub.core.node.Node._update` method due to a legitimate call to `infrahub.core.node.node_property_attribute.NodePropertyAttribute.needs_update`.


Closes #8237 / [IFC-2235]

## What changed

Condition that queries additional attributes from the database when resolving the `relationships` in `infrahub.core.node.Node.resolve_relationships`.

**Before this PR,** this was only triggered during node creation.

**After this PR**, this will be called:
- During node creation
- During node update, if it has a display label or a hfid

## How to test

```bash
uv run pytest -xvs backend/tests/component/graphql/test_mutation_upsert.py::test_upsert_preserves_relationship_display_label                                                                                 
```

## Impact & rollout

- **Performance:** We are querying additional attributes from relationships whenever a node is update if it has a display label or a HFID.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)


[IFC-2235]: https://opsmill.atlassian.net/browse/IFC-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display labels incorrectly showing 'None' for relationship-based fields after upsert operations.

* **Refactor**
  * Streamlined relationship resolution to pre-collect related filters so related attributes are reliably loaded during updates, preserving display labels.

* **Documentation**
  * Added guides on display labels, human-friendly identifiers, and GraphQL mutations; updated Python type-hint/import guidance.

* **Tests**
  * Added test verifying display label preservation across successive upserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->