### PR TITLE
make sure input number pool is validated for template instances

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -623,7 +623,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         if "from_pool" in data:
             self.from_pool = data["from_pool"]
             if process_pools:
-                await self.node.handle_pool(db=db, attribute=self, errors=[])
+                await self.node.handle_pool(db=db, attribute=self)
             changed = True
 
         if changed and self.is_from_profile:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -350,7 +350,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         self,
         db: InfrahubDatabase,
         attribute: BaseAttribute,
-        errors: list,
+        errors: list[ValidationError],
         allocate_resources: bool = True,
     ) -> None:
         """Evaluate if a resource has been requested from a pool and apply the resource

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -346,8 +346,12 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         return cls(**attrs)
 
-    async def handle_pool(
-        self, db: InfrahubDatabase, attribute: BaseAttribute, errors: list, allocate_resources: bool = True
+    async def handle_pool(  # noqa: PLR0911
+        self,
+        db: InfrahubDatabase,
+        attribute: BaseAttribute,
+        errors: list,
+        allocate_resources: bool = True,
     ) -> None:
         """Evaluate if a resource has been requested from a pool and apply the resource
 
@@ -358,19 +362,25 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         1. Schema-defined NumberPool attributes (kind="NumberPool" with number_pool_id in parameters)
         2. User-specified from_pool (user explicitly passes {"from_pool": {"id": pool_id}} to a Number attribute)
         """
+        number_pool_id: str | None = None
         # Templates should not allocate from pools - just store the reference
         # Actual allocation happens when creating objects from the template
         if isinstance(self._schema, TemplateSchema):
             if attribute.from_pool:
-                attribute.source = attribute.from_pool["id"]
+                number_pool_id = str(attribute.from_pool["id"])
+                attribute.source = number_pool_id
                 attribute.value = None
+                allocate_resources = False
             elif attribute.from_pool is None:
                 attribute.clear_source()
-            return
+                return
 
-        number_pool_id: str | None = None
         # Case 1: Schema-defined NumberPool attribute
-        if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
+        if (
+            not number_pool_id
+            and attribute.schema.kind == "NumberPool"
+            and isinstance(attribute.schema.parameters, NumberPoolParameters)
+        ):
             number_pool_id = attribute.schema.parameters.number_pool_id
             if not number_pool_id:
                 errors.append(
@@ -382,13 +392,13 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             attribute.from_pool = {"id": number_pool_id}
             attribute.is_default = False
         # Case 2: User-specified from_pool on a regular Number attribute
-        elif attribute.from_pool:
+        elif not number_pool_id and attribute.from_pool:
             number_pool_id = attribute.from_pool.get("id")
             if not number_pool_id:
                 errors.append(ValidationError({f"{attribute.name}.from_pool": "No pool ID specified in from_pool."}))
                 return
 
-        if not allocate_resources or not number_pool_id:
+        if not number_pool_id:
             # no pool allocation necessary
             return
 
@@ -402,6 +412,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                     {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
                 )
             )
+            return
+
+        if not allocate_resources:
             return
 
         if (

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -346,11 +346,10 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         return cls(**attrs)
 
-    async def handle_pool(  # noqa: PLR0911
+    async def handle_pool(
         self,
         db: InfrahubDatabase,
         attribute: BaseAttribute,
-        errors: list[ValidationError],
         allocate_resources: bool = True,
     ) -> None:
         """Evaluate if a resource has been requested from a pool and apply the resource
@@ -367,7 +366,12 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         # Actual allocation happens when creating objects from the template
         if isinstance(self._schema, TemplateSchema):
             if attribute.from_pool:
-                number_pool_id = str(attribute.from_pool["id"])
+                try:
+                    number_pool_id = str(attribute.from_pool["id"])
+                except KeyError as exc:
+                    raise ValidationError(
+                        {f"{attribute.name}.from_pool": "Missing 'id' in from_pool reference."}
+                    ) from exc
                 attribute.source = number_pool_id
                 attribute.value = None
                 allocate_resources = False
@@ -383,20 +387,16 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         ):
             number_pool_id = attribute.schema.parameters.number_pool_id
             if not number_pool_id:
-                errors.append(
-                    ValidationError(
-                        {f"{attribute.name}": f"The pool for {attribute.name} has not been provisioned yet."}
-                    )
+                raise ValidationError(
+                    {f"{attribute.name}": f"The pool for {attribute.name} has not been provisioned yet."}
                 )
-                return
             attribute.from_pool = {"id": number_pool_id}
             attribute.is_default = False
         # Case 2: User-specified from_pool on a regular Number attribute
         elif not number_pool_id and attribute.from_pool:
             number_pool_id = attribute.from_pool.get("id")
             if not number_pool_id:
-                errors.append(ValidationError({f"{attribute.name}.from_pool": "No pool ID specified in from_pool."}))
-                return
+                raise ValidationError({f"{attribute.name}.from_pool": "No pool ID specified in from_pool."})
 
         if not number_pool_id:
             # no pool allocation necessary
@@ -406,13 +406,10 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             number_pool = await registry.manager.get_one(
                 db=db, id=number_pool_id, kind=CoreNumberPool, raise_on_error=True
             )
-        except NodeNotFoundError:
-            errors.append(
-                ValidationError(
-                    {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
-                )
-            )
-            return
+        except NodeNotFoundError as exc:
+            raise ValidationError(
+                {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
+            ) from exc
 
         if not allocate_resources:
             return
@@ -425,21 +422,18 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 next_free = await number_pool.get_resource(
                     db=db, branch=self._branch, node=self, attribute=attribute.schema
                 )
-            except PoolExhaustedError:
-                errors.append(
-                    ValidationError({f"{attribute.name}.from_pool": f"The pool {number_pool.node.value} is exhausted."})
-                )
-                return
+            except PoolExhaustedError as exc:
+                raise ValidationError(
+                    {f"{attribute.name}.from_pool": f"The pool {number_pool.node.value} is exhausted."}
+                ) from exc
 
             attribute.value = next_free
             attribute.source = number_pool.id
         else:
-            errors.append(
-                ValidationError(
-                    {
-                        f"{attribute.name}.from_pool": f"The {number_pool.name.value} pool can't be used for '{attribute.name}'."
-                    }
-                )
+            raise ValidationError(
+                {
+                    f"{attribute.name}.from_pool": f"The {number_pool.name.value} pool can't be used for '{attribute.name}'."
+                }
             )
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
@@ -622,7 +616,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 )
                 if not self._existing:
                     attribute: BaseAttribute = getattr(self, attr_schema.name)
-                    await self.handle_pool(db=db, attribute=attribute, errors=errors, allocate_resources=process_pools)
+                    await self.handle_pool(db=db, attribute=attribute, allocate_resources=process_pools)
 
                     if attr_schema.name in self._profile_provided_attrs:
                         continue

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
@@ -499,3 +500,18 @@ async def test_template_children_and_pool_recorded_as_side_effects(
 
     ip_side_effects = [n for n in side_effects if n.get_kind() == "IpamIPAddress"]
     assert len(ip_side_effects) == 1
+
+
+async def test_create_template_with_invalid_number_pool_id(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
+) -> None:
+    """Creating a template with from_pool referencing a nonexistent number pool should fail."""
+    fake_pool_id = str(uuid4())
+
+    template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    with pytest.raises(ValidationError, match=fake_pool_id):
+        await template.new(
+            db=db, template_name="device-template-bad-pool", rack_unit={"from_pool": {"id": fake_pool_id}}
+        )

--- a/backend/tests/component/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/component/graphql/mutations/test_resource_manager.py
@@ -120,6 +120,21 @@ mutation CreateTemplateTicketWithPool($pool_id: String!) {
 }
 """
 
+UPDATE_TICKET_WITH_POOL = """
+mutation UpdateTicketWithPool($ticket_id: String!, $pool_id: String!) {
+    TestingTicketUpdate(data: {
+        id: $ticket_id
+        ticket_id: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
 
 @pytest.fixture
 async def prefix_pool_01(
@@ -267,7 +282,32 @@ async def test_create_template_with_invalid_number_pool_id(
     )
 
     assert result.errors
-    assert FAKE_POOL_ID in str(result.errors[0])
+    assert f"The pool requested {{'id': '{FAKE_POOL_ID}'}} was not found." in str(result.errors[0])
+
+
+async def test_update_object_with_invalid_number_pool_id(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Updating an existing node's Number attribute with from_pool referencing a nonexistent pool should fail."""
+    await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
+    default_branch.update_schema_hash()
+
+    schema = registry.schema.get_node_schema(name="TestingTicket", branch=default_branch)
+    ticket = await Node.init(db=db, schema=schema, branch=default_branch)
+    await ticket.new(db=db, title="existing-ticket", ticket_id=42)
+    await ticket.save(db=db)
+
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_TICKET_WITH_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ticket_id": ticket.id, "pool_id": FAKE_POOL_ID},
+    )
+
+    assert result.errors
+    assert f"The pool requested {{'id': '{FAKE_POOL_ID}'}} was not found." in str(result.errors[0])
 
 
 async def test_update_object_and_assign_prefix_from_pool(

--- a/backend/tests/component/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/component/graphql/mutations/test_resource_manager.py
@@ -24,6 +24,102 @@ from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import SNOW_TICKET_SCHEMA, TICKET, load_schema
 
+FAKE_POOL_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+CREATE_PREFIX_FROM_POOL = """
+mutation CreatePrefixFromPool($name: String!, $pool_id: String!) {
+    TestMandatoryPrefixCreate(data: {
+        name: { value: $name }
+        prefix: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            name {
+                value
+            }
+            prefix {
+                node {
+                    prefix {
+                        value
+                    }
+                }
+                properties {
+                    source {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+CREATE_ADDRESS_FROM_POOL = """
+mutation CreateAddressFromPool($name: String!, $pool_id: String!) {
+    TestMandatoryAddressCreate(data: {
+        name: { value: $name }
+        address: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            name {
+                value
+            }
+            address {
+                node {
+                    address {
+                        value
+                    }
+                }
+                properties {
+                    source {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+CREATE_TICKET_WITH_POOL = """
+mutation CreateTicketWithPool($pool_id: String!) {
+    TestingTicketCreate(data: {
+        title: { value: "ticket-bad-pool" }
+        ticket_id: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
+CREATE_TEMPLATE_TICKET_WITH_POOL = """
+mutation CreateTemplateTicketWithPool($pool_id: String!) {
+    TemplateTestingTicketCreate(data: {
+        template_name: { value: "bad-pool-template" }
+        ticket_id: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
 
 @pytest.fixture
 async def prefix_pool_01(
@@ -60,41 +156,6 @@ async def test_create_object_and_assign_prefix_from_pool(
 ) -> None:
     pool = prefix_pool_01["pool"]
 
-    query = (
-        """
-    mutation {
-        TestMandatoryPrefixCreate(data: {
-            name: { value: "site1" }
-            prefix: {
-                from_pool: {
-                    id: "%s"
-                }
-            }
-        }) {
-            ok
-            object {
-                name {
-                    value
-                }
-                prefix {
-                    node {
-                        prefix {
-                            value
-                        }
-                    }
-                    properties {
-                        source {
-                            id
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
@@ -103,10 +164,10 @@ async def test_create_object_and_assign_prefix_from_pool(
     )
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=CREATE_PREFIX_FROM_POOL,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"name": "site1", "pool_id": pool.id},
     )
 
     assert not result.errors
@@ -134,6 +195,79 @@ async def test_create_object_and_assign_prefix_from_pool(
     assert parent_events[0].meta.account_id == session_first_account.account_id
     assert prefix_events[0].meta.account_id == session_first_account.account_id
     assert prefix_events[0].meta.parent == parent_events[0].meta.id
+
+
+@pytest.mark.parametrize(
+    "query,field,name",
+    [
+        pytest.param(CREATE_PREFIX_FROM_POOL, "prefix", "site-bad-pool", id="prefix"),
+        pytest.param(CREATE_ADDRESS_FROM_POOL, "address", "server-bad-pool", id="address"),
+    ],
+)
+async def test_create_object_with_invalid_ip_pool_id(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_ipnamespace: Node,
+    register_ipam_extended_schema: SchemaBranch,
+    init_nodes_registry: None,
+    query: str,
+    field: str,
+    name: str,
+) -> None:
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": name, "pool_id": FAKE_POOL_ID},
+    )
+
+    assert result.errors
+    assert f"Unable to find the pool to generate a node for the relationship '{field}'" in str(result.errors[0])
+
+
+async def test_create_object_with_invalid_number_pool_id(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
+    default_branch.update_schema_hash()
+
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_TICKET_WITH_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"pool_id": FAKE_POOL_ID},
+    )
+
+    assert result.errors
+    assert f"The pool requested {{'id': '{FAKE_POOL_ID}'}} was not found." in str(result.errors[0])
+
+
+async def test_create_template_with_invalid_number_pool_id(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Creating a template with from_pool referencing a nonexistent number pool should fail."""
+    ticket_with_template = TICKET.model_copy(deep=True)
+    ticket_with_template.generate_template = True
+    ticket_with_template.get_attribute(name="ticket_id").unique = False
+    await load_schema(db=db, schema=SchemaRoot(nodes=[ticket_with_template]))
+    default_branch.update_schema_hash()
+
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_TEMPLATE_TICKET_WITH_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"pool_id": FAKE_POOL_ID},
+    )
+
+    assert result.errors
+    assert FAKE_POOL_ID in str(result.errors[0])
 
 
 async def test_update_object_and_assign_prefix_from_pool(
@@ -228,41 +362,6 @@ async def test_create_object_and_assign_address_from_pool(
     )
     await pool.save(db=db)
 
-    query = (
-        """
-    mutation {
-        TestMandatoryAddressCreate(data: {
-            name: { value: "server1" }
-            address: {
-                from_pool: {
-                    id: "%s"
-                }
-            }
-        }) {
-            ok
-            object {
-                name {
-                    value
-                }
-                address {
-                    node {
-                        address {
-                            value
-                        }
-                    }
-                    properties {
-                        source {
-                            id
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
@@ -271,10 +370,10 @@ async def test_create_object_and_assign_address_from_pool(
     )
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=CREATE_ADDRESS_FROM_POOL,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"name": "server1", "pool_id": pool.id},
     )
 
     assert not result.errors


### PR DESCRIPTION
<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->
We were not validating the input `from_pool` ID when it was used on an attribute of a Template instance. End result was that we would link a Number attribute to a non-existent pool in an illegal manner in the database

<!-- Goal: what outcome does this PR achieve? -->
Now we will validate the input pool ID regardless of whether it is on a Template instance or not

Also found that we were silently swallowing number pool failures when trying to update a Number attribute to use a NumberPool. Fixed by updating `handle_pool` to actually raise errors instead of mutating an `errors` list in place and added a test to cover it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for number-pool allocations; operations now report clear errors for invalid or missing pool IDs and better handle exhausted pools.
  * Tightened allocation gating to avoid incorrect allocations when pool info is absent or incompatible.

* **Refactor**
  * Internal API updated to clarify pool-allocation control flow.

* **Tests**
  * Added and expanded tests covering invalid pool-ID scenarios for templates and resource creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->