### PR TITLE
INFP-403 set order weight on system controlled attributes of the CoreFileObject generic

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/file_object.py
+++ b/backend/infrahub/core/schema/definitions/core/file_object.py
@@ -16,6 +16,7 @@ core_file_object = GenericSchema(
             description="The name of the file as uploaded by the user",
             read_only=True,
             optional=False,
+            order_weight=99990,
             allow_override=AllowOverrideType.NONE,
         ),
         Attr(
@@ -24,6 +25,7 @@ core_file_object = GenericSchema(
             description="SHA-1 checksum calculated on the uploaded file",
             read_only=True,
             optional=False,
+            order_weight=99991,
             allow_override=AllowOverrideType.NONE,
         ),
         Attr(
@@ -32,6 +34,7 @@ core_file_object = GenericSchema(
             description="The size of the file in bytes",
             read_only=True,
             optional=False,
+            order_weight=99992,
             allow_override=AllowOverrideType.NONE,
         ),
         Attr(
@@ -40,6 +43,7 @@ core_file_object = GenericSchema(
             description="The MIME type of the file",
             read_only=True,
             optional=False,
+            order_weight=99993,
             allow_override=AllowOverrideType.NONE,
         ),
         Attr(
@@ -48,6 +52,7 @@ core_file_object = GenericSchema(
             description="The ID of the uploaded file in Infrahub's storage",
             read_only=True,
             optional=False,
+            order_weight=99994,
             allow_override=AllowOverrideType.NONE,
         ),
     ],


### PR DESCRIPTION
# Why

Initially we decided to not show system controlled attributes, for objects inheriting from the CoreFileObject generic, in the UI.

After reviewing and receiving feedback we decided to revert that change.

However we want to make sure that these attributes are de-prioritized in the UI (detailed + list view).

## What changed

set order_weight on system controlled attributes of the CoreFileObject generic.

We will need to revisit the displaying of these attributes after we implement a way to not show attributes like this by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file object attribute ordering configuration for improved consistency in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->