### PR TITLE
return latest diff for merged branch

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -97,6 +97,10 @@ class Branch(StandardNode):
         return self.created_at
 
     @property
+    def is_terminal(self) -> bool:
+        return self.status in (BranchStatus.MERGED, BranchStatus.DELETING)
+
+    @property
     def active_schema_hash(self) -> SchemaBranchHash:
         if self.schema_hash:
             return self.schema_hash

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -11,7 +11,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import ResourceNotFoundError, ValidationError
 from infrahub.log import get_logger
 from infrahub.proposed_change.constants import ProposedChangeState
 
@@ -173,6 +173,16 @@ class DiffCoordinator:
     ) -> EnrichedDiffRootMetadata:
         tracking_id = BranchTrackingId(name=diff_branch.name)
         self.logger.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
+        if diff_branch.is_terminal:
+            self.logger.info(
+                f"Branch {diff_branch.name} is in terminal state {diff_branch.status.value}, returning latest diff"
+            )
+            diff_roots = await self.diff_repo.get_roots_metadata(
+                diff_branch_names=[diff_branch.name], tracking_id=tracking_id, exclude_merged=False
+            )
+            if not diff_roots:
+                raise ResourceNotFoundError(f"No stored diff found for terminal branch {diff_branch.name}")
+            return diff_roots[0]
         existing_incremental_lock = self.diff_locker.get_existing_lock(
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
         )

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -507,7 +507,7 @@ class DiffTreeResolver:
         proposed_change_id: str | None = None,
     ) -> DiffQueryParams:
         # For terminal branches with no explicit time filters,
-        # return the latest stored diff instead of trying to compute a new one
+        # return the latest stored diff for the branch regardless of time
         if branch_info.is_terminal and not from_time and not to_time:
             return DiffQueryParams(
                 from_time=None,

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -490,12 +490,12 @@ class DiffTreeResolver:
                 is_terminal=diff_branch.is_terminal,
             )
         except BranchNotFoundError:
-            # case for a request with a deleted branch and a proposed change ID
-            if not proposed_change_id:
-                raise
-            if not branch:
+            if not branch and not proposed_change_id:
                 raise ValidationError("Must include the branch or proposed_change_id argument") from None
-            return DiffBranchInfo(name=branch, branch_start_timestamp=None, is_terminal=False)
+            # case for deleted branch with an input proposed_change_id
+            if branch:
+                return DiffBranchInfo(name=branch, branch_start_timestamp=None, is_terminal=False)
+            raise
 
     def _get_diff_query_params(
         self,

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -12,7 +12,7 @@ from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.diff_locker import DiffLocker
-from infrahub.core.diff.model.path import NameTrackingId
+from infrahub.core.diff.model.path import BranchTrackingId, NameTrackingId, TrackingId
 from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.query.diff import DiffCountChanges
@@ -42,6 +42,21 @@ if TYPE_CHECKING:
 
 GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
 GrapheneCardinalityEnum = GrapheneEnum.from_enum(RelationshipCardinality)
+
+
+@dataclass
+class DiffBranchInfo:
+    name: str
+    branch_start_timestamp: Timestamp | None
+    is_terminal: bool
+
+
+@dataclass
+class DiffQueryParams:
+    from_time: Timestamp | None
+    to_time: Timestamp | None
+    tracking_id: TrackingId | None
+    exclude_merged: bool
 
 
 @dataclass
@@ -461,27 +476,59 @@ class DiffTreeResolver:
             to_timestamp = at
         return from_timestamp, to_timestamp
 
-    async def _get_branch_and_from_time(
+    async def _get_branch_info(
         self,
         db: InfrahubDatabase,
         branch: str | None,
         proposed_change_id: str | None,
-    ) -> tuple[str, Timestamp | None]:
+    ) -> DiffBranchInfo:
         try:
             diff_branch = await registry.get_branch(db=db, branch=branch)
-            diff_branch_name: str | None = diff_branch.name
-            branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
+            return DiffBranchInfo(
+                name=diff_branch.name,
+                branch_start_timestamp=Timestamp(diff_branch.get_branched_from()),
+                is_terminal=diff_branch.is_terminal,
+            )
         except BranchNotFoundError:
             # case for a request with a deleted branch and a proposed change ID
             if not proposed_change_id:
                 raise
-            diff_branch_name = branch  # Use the requested branch name for the query
-            branch_start_timestamp = None
+            if not branch:
+                raise ValidationError("Must include the branch or proposed_change_id argument") from None
+            return DiffBranchInfo(name=branch, branch_start_timestamp=None, is_terminal=False)
 
-        if not diff_branch_name:
-            raise ValidationError("Must include the branch or proposed_change_id argument")
+    def _get_diff_query_params(
+        self,
+        branch_info: DiffBranchInfo,
+        at: Timestamp,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+        name: str | None = None,
+        proposed_change_id: str | None = None,
+    ) -> DiffQueryParams:
+        # For terminal branches with no explicit time filters,
+        # return the latest stored diff instead of trying to compute a new one
+        if branch_info.is_terminal and not from_time and not to_time:
+            return DiffQueryParams(
+                from_time=None,
+                to_time=None,
+                tracking_id=BranchTrackingId(branch_info.name),
+                exclude_merged=False,
+            )
 
-        return diff_branch_name, branch_start_timestamp
+        from_timestamp, to_timestamp = self._get_timestamp(
+            from_time=from_time,
+            to_time=to_time,
+            branch_start_timestamp=branch_info.branch_start_timestamp,
+            at=at,
+            proposed_change_id=proposed_change_id,
+        )
+        return DiffQueryParams(
+            from_time=from_timestamp,
+            to_time=to_timestamp,
+            tracking_id=NameTrackingId(name) if name else None,
+            exclude_merged=branch_info.is_terminal or not proposed_change_id,
+        )
 
     async def resolve(
         self,
@@ -502,18 +549,19 @@ class DiffTreeResolver:
         graphql_context: GraphqlContext = info.context
         base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
 
-        diff_branch_name, branch_start_timestamp = await self._get_branch_and_from_time(
+        branch_info = await self._get_branch_info(
             db=graphql_context.db, branch=branch, proposed_change_id=proposed_change_id
+        )
+        query_params = self._get_diff_query_params(
+            branch_info=branch_info,
+            at=graphql_context.at or Timestamp(),
+            from_time=from_time,
+            to_time=to_time,
+            name=name,
+            proposed_change_id=proposed_change_id,
         )
 
         diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=base_branch)
-        from_timestamp, to_timestamp = self._get_timestamp(
-            from_time=from_time,
-            to_time=to_time,
-            branch_start_timestamp=branch_start_timestamp,
-            at=graphql_context.at or Timestamp(),
-            proposed_change_id=proposed_change_id,
-        )
 
         # Convert filters to dict and merge root_node_uuids for compatibility
         filters_dict = dict(filters or {})
@@ -527,10 +575,10 @@ class DiffTreeResolver:
         diff_locker = DiffLocker()
         async with (
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=True
+                target_branch_name=base_branch.name, source_branch_name=branch_info.name, is_incremental=True
             ),
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=False
+                target_branch_name=base_branch.name, source_branch_name=branch_info.name, is_incremental=False
             ),
         ):
             lock_acquired_time = Timestamp()
@@ -538,25 +586,26 @@ class DiffTreeResolver:
                 get_start_time = Timestamp()
                 enriched_diffs = await diff_repo.get(
                     base_branch_name=base_branch.name,
-                    diff_branch_names=[diff_branch_name],
-                    from_time=from_timestamp,
-                    to_time=to_timestamp,
+                    diff_branch_names=[branch_info.name],
+                    from_time=query_params.from_time,
+                    to_time=query_params.to_time,
                     filters=EnrichedDiffQueryFilters(**filters_dict),
                     include_parents=include_parents,
                     limit=limit,
                     offset=offset,
-                    tracking_id=NameTrackingId(name) if name else None,
+                    tracking_id=query_params.tracking_id,
                     include_empty=True,
                     proposed_change_id=proposed_change_id,
-                    # include merged diffs if filtering on proposed change
-                    exclude_merged=not proposed_change_id,
+                    exclude_merged=query_params.exclude_merged,
                 )
                 get_end_time = Timestamp()
 
                 span.set_attribute("base_branch_name", base_branch.name)
-                span.set_attribute("diff_branch_name", diff_branch_name)
-                span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
-                span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
+                span.set_attribute("diff_branch_name", branch_info.name)
+                span.set_attribute(
+                    "from_time", query_params.from_time.to_string() if query_params.from_time else "null"
+                )
+                span.set_attribute("to_time", query_params.to_time.to_string() if query_params.to_time else "null")
                 span.set_attribute("proposed_change_id", proposed_change_id or "null")
                 span.set_attribute("lock_request_time", lock_request_time.to_string())
                 span.set_attribute("lock_acquired_time", lock_acquired_time.to_string())
@@ -589,7 +638,7 @@ class DiffTreeResolver:
                 diff_response=diff_tree,
                 from_time=enriched_diff.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,
-                diff_branch_name=diff_branch_name if need_branch_changes else None,
+                diff_branch_name=branch_info.name if need_branch_changes else None,
             )
         return await self.to_graphql(fields=full_fields, diff_object=diff_tree)
 
@@ -607,18 +656,18 @@ class DiffTreeResolver:
         graphql_context: GraphqlContext = info.context
         base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
 
-        diff_branch_name, branch_start_timestamp = await self._get_branch_and_from_time(
+        branch_info = await self._get_branch_info(
             db=graphql_context.db, branch=branch, proposed_change_id=proposed_change_id
+        )
+        query_params = self._get_diff_query_params(
+            branch_info=branch_info,
+            at=graphql_context.at or Timestamp(),
+            from_time=from_time,
+            to_time=to_time,
+            proposed_change_id=proposed_change_id,
         )
 
         diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=base_branch)
-        from_timestamp, to_timestamp = self._get_timestamp(
-            from_time=from_time,
-            to_time=to_time,
-            branch_start_timestamp=branch_start_timestamp,
-            at=graphql_context.at or Timestamp(),
-            proposed_change_id=proposed_change_id,
-        )
 
         filters_dict = dict(filters or {})
 
@@ -627,10 +676,10 @@ class DiffTreeResolver:
         diff_locker = DiffLocker()
         async with (
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=True
+                target_branch_name=base_branch.name, source_branch_name=branch_info.name, is_incremental=True
             ),
             diff_locker.acquire_lock(
-                target_branch_name=base_branch.name, source_branch_name=diff_branch_name, is_incremental=False
+                target_branch_name=base_branch.name, source_branch_name=branch_info.name, is_incremental=False
             ),
         ):
             lock_acquired_time = Timestamp()
@@ -638,20 +687,22 @@ class DiffTreeResolver:
                 get_start_time = Timestamp()
                 summary = await diff_repo.summary(
                     base_branch_name=base_branch.name,
-                    diff_branch_names=[diff_branch_name],
-                    from_time=from_timestamp,
-                    to_time=to_timestamp,
+                    diff_branch_names=[branch_info.name],
+                    from_time=query_params.from_time,
+                    to_time=query_params.to_time,
+                    tracking_id=query_params.tracking_id,
                     filters=filters_dict,
                     proposed_change_id=proposed_change_id,
-                    # include merged diffs if filtering on proposed change
-                    exclude_merged=not proposed_change_id,
+                    exclude_merged=query_params.exclude_merged,
                 )
                 get_end_time = Timestamp()
 
                 span.set_attribute("base_branch_name", base_branch.name)
-                span.set_attribute("diff_branch_name", diff_branch_name)
-                span.set_attribute("from_time", from_timestamp.to_string() if from_timestamp else "null")
-                span.set_attribute("to_time", to_timestamp.to_string() if to_timestamp else "null")
+                span.set_attribute("diff_branch_name", branch_info.name)
+                span.set_attribute(
+                    "from_time", query_params.from_time.to_string() if query_params.from_time else "null"
+                )
+                span.set_attribute("to_time", query_params.to_time.to_string() if query_params.to_time else "null")
                 span.set_attribute("proposed_change_id", proposed_change_id or "null")
                 span.set_attribute("lock_request_time", lock_request_time.to_string())
                 span.set_attribute("lock_acquired_time", lock_acquired_time.to_string())
@@ -664,7 +715,7 @@ class DiffTreeResolver:
 
         diff_tree_summary = DiffTreeSummary(
             base_branch=base_branch.name,
-            diff_branch=diff_branch_name,
+            diff_branch=branch_info.name,
             from_time=summary.from_time.to_datetime(),
             to_time=summary.to_time.to_datetime(),
             **summary.model_dump(exclude={"from_time", "to_time"}),
@@ -678,7 +729,7 @@ class DiffTreeResolver:
                 diff_response=diff_tree_summary,
                 from_time=summary.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,
-                diff_branch_name=diff_branch_name if need_branch_changes else None,
+                diff_branch_name=branch_info.name if need_branch_changes else None,
             )
         return diff_tree_summary
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -493,7 +493,7 @@ class DiffTreeResolver:
             if not branch and not proposed_change_id:
                 raise ValidationError("Must include the branch or proposed_change_id argument") from None
             # case for deleted branch with an input proposed_change_id
-            if branch:
+            if branch and proposed_change_id:
                 return DiffBranchInfo(name=branch, branch_start_timestamp=None, is_terminal=False)
             raise
 

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -7,6 +7,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
@@ -256,6 +257,21 @@ class TestDiffCoordinator:
         )
         assert no_changes_diff.from_time == no_changes_diff_metadata.from_time == diff_with_data.from_time
         assert no_changes_diff.to_time == no_changes_diff_metadata.to_time
+
+        # mark branch as merged and verify update_branch_diff returns stored diff without recalculating
+        await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=branch.name)])
+        branch.status = BranchStatus.MERGED
+        await branch.save(db=db)
+        registry.branch[branch.name] = branch
+        self.reset_mocks(wrapped_diff_coordinator)
+
+        terminal_diff_metadata = await wrapped_diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch
+        )
+        assert type(terminal_diff_metadata) is EnrichedDiffRootMetadata
+        assert terminal_diff_metadata.uuid == no_changes_diff_metadata.uuid
+        wrapped_diff_coordinator.diff_calculator.calculate_diff.assert_not_awaited()
+        wrapped_diff_coordinator.diff_repo.save.assert_not_awaited()
 
     async def test_unrelated_changes_skip_some_expensive_operations(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node

--- a/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
@@ -81,6 +81,17 @@ query GetDiffTreeSummary($branch: String){
 }
 """
 
+DIFF_UPDATE_MUTATION = """
+mutation($branch: String!) {
+    DiffUpdate(
+        data: { branch: $branch },
+        wait_until_completion: true
+    ) {
+        ok
+    }
+}
+"""
+
 
 @pytest.fixture
 async def diff_branch(db: InfrahubDatabase, default_branch: Branch) -> Branch:
@@ -224,3 +235,53 @@ async def test_diff_tree_summary_merged_branch(
     assert summary["base_branch"] == default_branch.name
     assert summary["diff_branch"] == diff_branch.name
     assert summary["num_updated"] == 1
+
+
+async def test_diff_update_mutation_on_merged_branch(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_low: Node,
+    diff_branch: Branch,
+    diff_coordinator: DiffCoordinator,
+    diff_repository: DiffRepository,
+) -> None:
+    """DiffUpdate mutation on a merged branch should succeed without recalculating."""
+    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
+    branch_crit.color.value = "#abcdef"
+    await branch_crit.save(db=db)
+
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+
+    # capture diff metadata before the mutation
+    pre_metadata = await diff_repository.get_roots_metadata(
+        diff_branch_names=[diff_branch.name],
+        tracking_id=BranchTrackingId(name=diff_branch.name),
+        exclude_merged=False,
+    )
+    assert len(pre_metadata) == 1
+
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=params.schema,
+        source=DIFF_UPDATE_MUTATION,
+        context_value=params.context,
+        root_value=None,
+        variable_values={"branch": diff_branch.name},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["DiffUpdate"]["ok"] is True
+
+    # verify diff timestamps are unchanged after update
+    post_metadata = await diff_repository.get_roots_metadata(
+        diff_branch_names=[diff_branch.name],
+        tracking_id=BranchTrackingId(name=diff_branch.name),
+        exclude_merged=False,
+    )
+    assert len(post_metadata) == 1
+    assert post_metadata[0].uuid == pre_metadata[0].uuid
+    assert post_metadata[0].from_time == pre_metadata[0].from_time
+    assert post_metadata[0].to_time == pre_metadata[0].to_time

--- a/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
@@ -67,9 +68,36 @@ query GetDiffTree($branch: String, $from_time: DateTime, $to_time: DateTime){
 }
 """
 
+DIFF_TREE_QUERY_BY_PROPOSED_CHANGE = """
+query ($branch: String, $proposed_change_id: String){
+    DiffTree (branch: $branch, proposed_change_id: $proposed_change_id) {
+        nodes {
+            uuid
+            kind
+            label
+            status
+        }
+    }
+}
+"""
+
 DIFF_TREE_SUMMARY_QUERY = """
 query GetDiffTreeSummary($branch: String){
     DiffTreeSummary (branch: $branch) {
+        base_branch
+        diff_branch
+        num_added
+        num_removed
+        num_updated
+        num_conflicts
+        num_unchanged
+    }
+}
+"""
+
+DIFF_TREE_SUMMARY_QUERY_BY_PROPOSED_CHANGE = """
+query ($branch: String, $proposed_change_id: String){
+    DiffTreeSummary (branch: $branch, proposed_change_id: $proposed_change_id) {
         base_branch
         diff_branch
         num_added
@@ -93,195 +121,330 @@ mutation($branch: String!) {
 """
 
 
-@pytest.fixture
-async def diff_branch(db: InfrahubDatabase, default_branch: Branch) -> Branch:
-    return await create_branch(db=db, branch_name="branch")
+class TestDiffTreeTerminalBranch:
+    """Tests for DiffTree queries on merged and deleted branches.
 
+    Uses class-scoped fixtures to set up the database, schema, and diff data once,
+    then runs tests sequentially. Tests are ordered so that earlier tests verify
+    behavior on a merged (but still registered) branch, and later tests simulate
+    branch deletion from the registry.
+    """
 
-@pytest.fixture
-async def diff_repository(db: InfrahubDatabase, diff_branch: Branch) -> DiffRepository:
-    component_registry = get_component_registry()
-    return await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+    @pytest.fixture(scope="class")
+    async def diff_branch(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> Branch:
+        return await create_branch(db=db, branch_name="branch")
 
+    @pytest.fixture(scope="class")
+    async def diff_repository(self, db: InfrahubDatabase, diff_branch: Branch) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
 
-@pytest.fixture
-async def diff_coordinator(db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
-    component_registry = get_component_registry()
-    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
-    coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
-    coordinator.data_check_synchronizer.synchronize.return_value = []
-    return coordinator
+    @pytest.fixture(scope="class")
+    async def diff_coordinator(self, db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+        coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        coordinator.data_check_synchronizer.synchronize.return_value = []
+        return coordinator
 
+    @pytest.fixture(scope="class")
+    async def criticality_low(self, db: InfrahubDatabase, criticality_schema_scope_class: NodeSchema) -> Node:
+        obj = await Node.init(db=db, schema=criticality_schema_scope_class)
+        await obj.new(db=db, name="low", level=4)
+        await obj.save(db=db)
+        return obj
 
-async def _merge_branch(db: InfrahubDatabase, diff_branch: Branch, diff_repository: DiffRepository) -> None:
-    """Simulate the merge process: mark tracking IDs as merged and set branch status."""
-    await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=diff_branch.name)])
-    diff_branch.status = BranchStatus.MERGED
-    await diff_branch.save(db=db)
-    registry.branch[diff_branch.name] = diff_branch
+    @pytest.fixture(scope="class")
+    async def proposed_change_id(self, db: InfrahubDatabase) -> str:
+        """Make a mock Proposed Change"""
+        pc_id = str(uuid4())
+        await db.execute_query(query="CREATE (pc:Node {uuid: $uuid})", params={"uuid": pc_id})
+        return pc_id
 
+    @pytest.fixture(scope="class")
+    async def diff_ready(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        criticality_low: Node,
+        diff_branch: Branch,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+        proposed_change_id: str,
+    ) -> dict:
+        """Set up the diff: make a change on the branch, create and link the diff."""
+        branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
+        branch_crit.color.value = "#abcdef"
+        await branch_crit.save(db=db)
 
-async def test_diff_tree_merged_branch_returns_stored_diff(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    criticality_schema: NodeSchema,
-    criticality_low: Node,
-    diff_branch: Branch,
-    diff_coordinator: DiffCoordinator,
-    diff_repository: DiffRepository,
-) -> None:
-    """DiffTree query on a merged branch should return the stored BranchTrackingId diff."""
-    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
-    branch_crit.color.value = "#abcdef"
-    await branch_crit.save(db=db)
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch_scope_class, diff_branch=diff_branch
+        )
 
-    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+        await diff_repository.link_to_proposed_change(
+            diff_uuids=[enriched_diff_metadata.uuid],
+            proposed_change_id=proposed_change_id,
+        )
 
-    default_branch.update_schema_hash()
-    params = await prepare_graphql_params(db=db, branch=default_branch)
-    result = await graphql(
-        schema=params.schema,
-        source=DIFF_TREE_QUERY,
-        context_value=params.context,
-        root_value=None,
-        variable_values={"branch": diff_branch.name},
-    )
+        return {"diff_uuid": enriched_diff_metadata.uuid}
 
-    assert result.errors is None
-    assert result.data
-    diff_tree = result.data["DiffTree"]
-    assert diff_tree is not None
-    assert diff_tree["base_branch"] == default_branch.name
-    assert diff_tree["diff_branch"] == diff_branch.name
-    assert diff_tree["num_updated"] == 1
-    assert len(diff_tree["nodes"]) == 1
-    node = diff_tree["nodes"][0]
-    assert node["uuid"] == criticality_low.id
-    assert node["status"] == "UPDATED"
+    @pytest.fixture(scope="class")
+    async def merged_branch(
+        self,
+        db: InfrahubDatabase,
+        diff_branch: Branch,
+        diff_repository: DiffRepository,
+        diff_ready: dict,
+    ) -> Branch:
+        """Simulate the merge process: mark tracking IDs as merged and set branch status."""
+        await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=diff_branch.name)])
+        diff_branch.status = BranchStatus.MERGED
+        await diff_branch.save(db=db)
+        registry.branch[diff_branch.name] = diff_branch
+        return diff_branch
 
+    # -------------------------------------------------------------------------
+    # Tests on a merged branch (still in the registry)
+    # -------------------------------------------------------------------------
 
-async def test_diff_tree_merged_branch_honors_explicit_time_filters(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    criticality_schema: NodeSchema,
-    criticality_low: Node,
-    diff_branch: Branch,
-    diff_coordinator: DiffCoordinator,
-    diff_repository: DiffRepository,
-) -> None:
-    """Explicit time filters should be honored even for merged branches."""
-    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
-    branch_crit.color.value = "#abcdef"
-    await branch_crit.save(db=db)
+    async def test_diff_tree_merged_branch_returns_stored_diff(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        criticality_low: Node,
+        merged_branch: Branch,
+    ) -> None:
+        """DiffTree query on a merged branch should return the stored BranchTrackingId diff."""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_QUERY,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": merged_branch.name},
+        )
 
-    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+        assert result.errors is None
+        assert result.data
+        diff_tree = result.data["DiffTree"]
+        assert diff_tree is not None
+        assert diff_tree["base_branch"] == default_branch_scope_class.name
+        assert diff_tree["diff_branch"] == merged_branch.name
+        assert diff_tree["num_updated"] == 1
+        assert len(diff_tree["nodes"]) == 1
+        node = diff_tree["nodes"][0]
+        assert node["uuid"] == criticality_low.id
+        assert node["status"] == "UPDATED"
 
-    # Use a time range far in the future - no diff covers this range
-    far_future = "2099-01-01T00:00:00Z"
-    farther_future = "2099-12-31T23:59:59Z"
+    async def test_diff_tree_merged_branch_honors_explicit_time_filters(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        merged_branch: Branch,
+    ) -> None:
+        """Explicit time filters should be honored even for merged branches."""
+        far_future = "2099-01-01T00:00:00Z"
+        farther_future = "2099-12-31T23:59:59Z"
 
-    default_branch.update_schema_hash()
-    params = await prepare_graphql_params(db=db, branch=default_branch)
-    result = await graphql(
-        schema=params.schema,
-        source=DIFF_TREE_QUERY_WITH_TIME_FILTERS,
-        context_value=params.context,
-        root_value=None,
-        variable_values={
-            "branch": diff_branch.name,
-            "from_time": far_future,
-            "to_time": farther_future,
-        },
-    )
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_QUERY_WITH_TIME_FILTERS,
+            context_value=params.context,
+            root_value=None,
+            variable_values={
+                "branch": merged_branch.name,
+                "from_time": far_future,
+                "to_time": farther_future,
+            },
+        )
 
-    assert result.errors is None
-    assert result.data
-    assert result.data["DiffTree"] is None
+        assert result.errors is None
+        assert result.data
+        assert result.data["DiffTree"] is None
 
+    async def test_diff_tree_summary_merged_branch(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        merged_branch: Branch,
+    ) -> None:
+        """DiffTreeSummary query on a merged branch should return the stored summary."""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_SUMMARY_QUERY,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": merged_branch.name},
+        )
 
-async def test_diff_tree_summary_merged_branch(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    criticality_schema: NodeSchema,
-    criticality_low: Node,
-    diff_branch: Branch,
-    diff_coordinator: DiffCoordinator,
-    diff_repository: DiffRepository,
-) -> None:
-    """DiffTreeSummary query on a merged branch should return the stored summary."""
-    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
-    branch_crit.color.value = "#abcdef"
-    await branch_crit.save(db=db)
+        assert result.errors is None
+        assert result.data
+        summary = result.data["DiffTreeSummary"]
+        assert summary is not None
+        assert summary["base_branch"] == default_branch_scope_class.name
+        assert summary["diff_branch"] == merged_branch.name
+        assert summary["num_updated"] == 1
 
-    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+    async def test_diff_update_mutation_on_merged_branch(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        merged_branch: Branch,
+        diff_repository: DiffRepository,
+    ) -> None:
+        """DiffUpdate mutation on a merged branch should succeed without recalculating."""
+        pre_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[merged_branch.name],
+            tracking_id=BranchTrackingId(name=merged_branch.name),
+            exclude_merged=False,
+        )
+        assert len(pre_metadata) == 1
 
-    default_branch.update_schema_hash()
-    params = await prepare_graphql_params(db=db, branch=default_branch)
-    result = await graphql(
-        schema=params.schema,
-        source=DIFF_TREE_SUMMARY_QUERY,
-        context_value=params.context,
-        root_value=None,
-        variable_values={"branch": diff_branch.name},
-    )
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_UPDATE_MUTATION,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": merged_branch.name},
+        )
 
-    assert result.errors is None
-    assert result.data
-    summary = result.data["DiffTreeSummary"]
-    assert summary is not None
-    assert summary["base_branch"] == default_branch.name
-    assert summary["diff_branch"] == diff_branch.name
-    assert summary["num_updated"] == 1
+        assert result.errors is None
+        assert result.data
+        assert result.data["DiffUpdate"]["ok"] is True
 
+        post_metadata = await diff_repository.get_roots_metadata(
+            diff_branch_names=[merged_branch.name],
+            tracking_id=BranchTrackingId(name=merged_branch.name),
+            exclude_merged=False,
+        )
+        assert len(post_metadata) == 1
+        assert post_metadata[0].uuid == pre_metadata[0].uuid
+        assert post_metadata[0].from_time == pre_metadata[0].from_time
+        assert post_metadata[0].to_time == pre_metadata[0].to_time
 
-async def test_diff_update_mutation_on_merged_branch(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    criticality_low: Node,
-    diff_branch: Branch,
-    diff_coordinator: DiffCoordinator,
-    diff_repository: DiffRepository,
-) -> None:
-    """DiffUpdate mutation on a merged branch should succeed without recalculating."""
-    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
-    branch_crit.color.value = "#abcdef"
-    await branch_crit.save(db=db)
+    async def test_diff_tree_merged_branch_with_proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        criticality_low: Node,
+        merged_branch: Branch,
+        proposed_change_id: str,
+    ) -> None:
+        """DiffTree with branch + proposed_change_id should return the linked diff on a merged branch."""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_QUERY_BY_PROPOSED_CHANGE,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": merged_branch.name, "proposed_change_id": proposed_change_id},
+        )
 
-    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+        assert result.errors is None
+        assert result.data
+        diff_tree = result.data["DiffTree"]
+        assert diff_tree is not None
+        assert len(diff_tree["nodes"]) == 1
+        assert diff_tree["nodes"][0]["uuid"] == criticality_low.id
 
-    # capture diff metadata before the mutation
-    pre_metadata = await diff_repository.get_roots_metadata(
-        diff_branch_names=[diff_branch.name],
-        tracking_id=BranchTrackingId(name=diff_branch.name),
-        exclude_merged=False,
-    )
-    assert len(pre_metadata) == 1
+    async def test_diff_tree_summary_merged_branch_with_proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        merged_branch: Branch,
+        proposed_change_id: str,
+    ) -> None:
+        """DiffTreeSummary with branch + proposed_change_id should return the linked summary on a merged branch."""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_SUMMARY_QUERY_BY_PROPOSED_CHANGE,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": merged_branch.name, "proposed_change_id": proposed_change_id},
+        )
 
-    default_branch.update_schema_hash()
-    params = await prepare_graphql_params(db=db, branch=default_branch)
-    result = await graphql(
-        schema=params.schema,
-        source=DIFF_UPDATE_MUTATION,
-        context_value=params.context,
-        root_value=None,
-        variable_values={"branch": diff_branch.name},
-    )
+        assert result.errors is None
+        assert result.data
+        summary = result.data["DiffTreeSummary"]
+        assert summary is not None
+        assert summary["num_updated"] == 1
 
-    assert result.errors is None
-    assert result.data
-    assert result.data["DiffUpdate"]["ok"] is True
+    # -------------------------------------------------------------------------
+    # Tests on a deleted branch (removed from registry and DB)
+    # -------------------------------------------------------------------------
 
-    # verify diff timestamps are unchanged after update
-    post_metadata = await diff_repository.get_roots_metadata(
-        diff_branch_names=[diff_branch.name],
-        tracking_id=BranchTrackingId(name=diff_branch.name),
-        exclude_merged=False,
-    )
-    assert len(post_metadata) == 1
-    assert post_metadata[0].uuid == pre_metadata[0].uuid
-    assert post_metadata[0].from_time == pre_metadata[0].from_time
-    assert post_metadata[0].to_time == pre_metadata[0].to_time
+    @pytest.fixture(scope="class")
+    async def deleted_branch(
+        self,
+        db: InfrahubDatabase,
+        merged_branch: Branch,
+    ) -> Branch:
+        """Delete the branch and remove it from registry"""
+        await merged_branch.delete(db=db)
+        registry.branch.pop(merged_branch.name, None)
+        return merged_branch
+
+    async def test_diff_tree_deleted_branch_with_proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        criticality_low: Node,
+        deleted_branch: Branch,
+        proposed_change_id: str,
+    ) -> None:
+        """DiffTree with branch + proposed_change_id should work after the branch is deleted"""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_QUERY_BY_PROPOSED_CHANGE,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": deleted_branch.name, "proposed_change_id": proposed_change_id},
+        )
+
+        assert result.errors is None, (
+            f"Expected no errors querying diff for deleted branch with proposed_change_id, got: {result.errors}"
+        )
+        diff_tree = result.data["DiffTree"]
+        assert diff_tree is not None
+        assert len(diff_tree["nodes"]) == 1
+        assert diff_tree["nodes"][0]["uuid"] == criticality_low.id
+        assert diff_tree["nodes"][0]["status"] == "UPDATED"
+
+    async def test_diff_tree_summary_deleted_branch_with_proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        deleted_branch: Branch,
+        proposed_change_id: str,
+    ) -> None:
+        """DiffTreeSummary with branch + proposed_change_id should work after the branch is deleted"""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_SUMMARY_QUERY_BY_PROPOSED_CHANGE,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": deleted_branch.name, "proposed_change_id": proposed_change_id},
+        )
+
+        assert result.errors is None, (
+            f"Expected no errors querying diff summary for deleted branch with proposed_change_id, got: {result.errors}"
+        )
+        summary = result.data["DiffTreeSummary"]
+        assert summary is not None
+        assert summary["num_updated"] == 1
+        assert summary["num_added"] == 0
+        assert summary["num_removed"] == 0

--- a/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
@@ -448,3 +448,23 @@ class TestDiffTreeTerminalBranch:
         assert summary["num_updated"] == 1
         assert summary["num_added"] == 0
         assert summary["num_removed"] == 0
+
+    async def test_diff_tree_deleted_branch_with_invalid_proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        deleted_branch: Branch,
+    ) -> None:
+        """DiffTree with deleted branch and unlinked proposed_change_id should return None."""
+        default_branch_scope_class.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=params.schema,
+            source=DIFF_TREE_QUERY_BY_PROPOSED_CHANGE,
+            context_value=params.context,
+            root_value=None,
+            variable_values={"branch": deleted_branch.name, "proposed_change_id": str(uuid4())},
+        )
+
+        assert result.errors is None
+        assert result.data["DiffTree"] is None

--- a/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_terminal_branch.py
@@ -1,0 +1,226 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema import NodeSchema
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+
+DIFF_TREE_QUERY = """
+query GetDiffTree($branch: String){
+    DiffTree (branch: $branch) {
+        base_branch
+        diff_branch
+        from_time
+        to_time
+        num_added
+        num_removed
+        num_updated
+        num_conflicts
+        nodes {
+            uuid
+            kind
+            label
+            status
+            attributes {
+                name
+                status
+                properties {
+                    property_type
+                    previous_value
+                    new_value
+                    status
+                }
+            }
+        }
+    }
+}
+"""
+
+DIFF_TREE_QUERY_WITH_TIME_FILTERS = """
+query GetDiffTree($branch: String, $from_time: DateTime, $to_time: DateTime){
+    DiffTree (branch: $branch, from_time: $from_time, to_time: $to_time) {
+        base_branch
+        diff_branch
+        num_added
+        num_removed
+        num_updated
+        nodes {
+            uuid
+            kind
+            label
+            status
+        }
+    }
+}
+"""
+
+DIFF_TREE_SUMMARY_QUERY = """
+query GetDiffTreeSummary($branch: String){
+    DiffTreeSummary (branch: $branch) {
+        base_branch
+        diff_branch
+        num_added
+        num_removed
+        num_updated
+        num_conflicts
+        num_unchanged
+    }
+}
+"""
+
+
+@pytest.fixture
+async def diff_branch(db: InfrahubDatabase, default_branch: Branch) -> Branch:
+    return await create_branch(db=db, branch_name="branch")
+
+
+@pytest.fixture
+async def diff_repository(db: InfrahubDatabase, diff_branch: Branch) -> DiffRepository:
+    component_registry = get_component_registry()
+    return await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+
+
+@pytest.fixture
+async def diff_coordinator(db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+    coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+    coordinator.data_check_synchronizer.synchronize.return_value = []
+    return coordinator
+
+
+async def _merge_branch(db: InfrahubDatabase, diff_branch: Branch, diff_repository: DiffRepository) -> None:
+    """Simulate the merge process: mark tracking IDs as merged and set branch status."""
+    await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=diff_branch.name)])
+    diff_branch.status = BranchStatus.MERGED
+    await diff_branch.save(db=db)
+    registry.branch[diff_branch.name] = diff_branch
+
+
+async def test_diff_tree_merged_branch_returns_stored_diff(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_schema: NodeSchema,
+    criticality_low: Node,
+    diff_branch: Branch,
+    diff_coordinator: DiffCoordinator,
+    diff_repository: DiffRepository,
+) -> None:
+    """DiffTree query on a merged branch should return the stored BranchTrackingId diff."""
+    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
+    branch_crit.color.value = "#abcdef"
+    await branch_crit.save(db=db)
+
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=params.schema,
+        source=DIFF_TREE_QUERY,
+        context_value=params.context,
+        root_value=None,
+        variable_values={"branch": diff_branch.name},
+    )
+
+    assert result.errors is None
+    assert result.data
+    diff_tree = result.data["DiffTree"]
+    assert diff_tree is not None
+    assert diff_tree["base_branch"] == default_branch.name
+    assert diff_tree["diff_branch"] == diff_branch.name
+    assert diff_tree["num_updated"] == 1
+    assert len(diff_tree["nodes"]) == 1
+    node = diff_tree["nodes"][0]
+    assert node["uuid"] == criticality_low.id
+    assert node["status"] == "UPDATED"
+
+
+async def test_diff_tree_merged_branch_honors_explicit_time_filters(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_schema: NodeSchema,
+    criticality_low: Node,
+    diff_branch: Branch,
+    diff_coordinator: DiffCoordinator,
+    diff_repository: DiffRepository,
+) -> None:
+    """Explicit time filters should be honored even for merged branches."""
+    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
+    branch_crit.color.value = "#abcdef"
+    await branch_crit.save(db=db)
+
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+
+    # Use a time range far in the future - no diff covers this range
+    far_future = "2099-01-01T00:00:00Z"
+    farther_future = "2099-12-31T23:59:59Z"
+
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=params.schema,
+        source=DIFF_TREE_QUERY_WITH_TIME_FILTERS,
+        context_value=params.context,
+        root_value=None,
+        variable_values={
+            "branch": diff_branch.name,
+            "from_time": far_future,
+            "to_time": farther_future,
+        },
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["DiffTree"] is None
+
+
+async def test_diff_tree_summary_merged_branch(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_schema: NodeSchema,
+    criticality_low: Node,
+    diff_branch: Branch,
+    diff_coordinator: DiffCoordinator,
+    diff_repository: DiffRepository,
+) -> None:
+    """DiffTreeSummary query on a merged branch should return the stored summary."""
+    branch_crit = await NodeManager.get_one(db=db, id=criticality_low.id, branch=diff_branch)
+    branch_crit.color.value = "#abcdef"
+    await branch_crit.save(db=db)
+
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
+    await _merge_branch(db=db, diff_branch=diff_branch, diff_repository=diff_repository)
+
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=params.schema,
+        source=DIFF_TREE_SUMMARY_QUERY,
+        context_value=params.context,
+        root_value=None,
+        variable_values={"branch": diff_branch.name},
+    )
+
+    assert result.errors is None
+    assert result.data
+    summary = result.data["DiffTreeSummary"]
+    assert summary is not None
+    assert summary["base_branch"] == default_branch.name
+    assert summary["diff_branch"] == diff_branch.name
+    assert summary["num_updated"] == 1


### PR DESCRIPTION
TODO:
- [x] manual test

## Problem

when a user requests a diff via graphql using the `DiffTree` or `DiffTree<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * For branches in a terminal state (merged or deleting), diff endpoints now return the most recent stored result instead of recalculating, improving consistency and performance.
  * Branch objects expose a read-only terminal-state check to power this behavior.
  * Diff query handling and time/filters were refined to better support terminal branches and proposed-change lookups.

* **Tests**
  * Added comprehensive tests covering diff queries, summaries, updates, time-filtering, and terminal-branch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->` queries, if the branch in question has been merged, the `DiffTree` queries will try to retrieve the latest diff for the branch using the branch's `branched_from` time. `branched_from` is updated to the time of the merge when a branch is merged and this causes the diff to appear empty for a merged branch.

## Fixes

- check if a branch is in a terminal state and, if so, just get the latest diff for that branch b/c it should be the diff used during the branch merge.
- prevent updating a diff for a merged branch, just return the existing latest diff
- a little refactoring to make the logic that retrieves the diff easier to understand and more DRY in the `DiffTree` resolvers
