### PR TITLE
IFC-2302 Fix double pool allocation with object templates

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -36,6 +36,7 @@ from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError, NodeNotFoundError, PoolExhaustedError, ValidationError
 from infrahub.pools.default_allocator import DefaultPoolAllocator
+from infrahub.pools.noop_allocator import NoOpPoolAllocator
 from infrahub.profiles.mandatory_fields_checker import ProfilesMandatoryFieldGetter
 from infrahub.templates.node_applier import NodeTemplateApplier
 from infrahub.types import ATTRIBUTE_TYPES
@@ -429,7 +430,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 )
             )
 
-    async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
+    async def handle_object_template(
+        self, fields: dict, db: InfrahubDatabase, errors: list, process_pools: bool = True
+    ) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""
         object_template_field = fields.get(OBJECT_TEMPLATE_RELATIONSHIP_NAME)
         if not object_template_field:
@@ -456,7 +459,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             )
             return
 
-        pool_allocator = DefaultPoolAllocator(db=db, branch=self._branch)
+        pool_allocator = DefaultPoolAllocator(db=db, branch=self._branch) if process_pools else NoOpPoolAllocator()
         applier = NodeTemplateApplier(db=db, branch=self._branch, pool_allocator=pool_allocator)
         applied_fields = await applier.apply(
             template=template, target_schema=self._schema, target_id=self.id, user_fields=fields
@@ -506,7 +509,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 log.error(f"{field_name} is not a valid input for {self.get_kind()}")
 
         # Backfill fields with the ones from the template if there's one
-        await self.handle_object_template(fields=fields, db=db, errors=errors)
+        await self.handle_object_template(fields=fields, db=db, errors=errors, process_pools=process_pools)
 
         if not self._existing:
             (

--- a/backend/infrahub/pools/noop_allocator.py
+++ b/backend/infrahub/pools/noop_allocator.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from infrahub.core.attribute import BaseAttribute
+    from infrahub.core.node import Node
+    from infrahub.core.relationship.model import RelationshipManager
+
+from infrahub.pools.allocator import PoolAllocator
+
+
+class NoOpPoolAllocator(PoolAllocator):
+    """Pool allocator that skips all allocations."""
+
+    async def allocate_for_attribute(self, attribute: BaseAttribute, identifier: str) -> Any | None:  # noqa: ARG002
+        return None
+
+    async def allocate_for_relationship(self, pool_relationship: RelationshipManager, identifier: str) -> Node | None:  # noqa: ARG002
+        return None

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -229,7 +229,7 @@ async def test_object_from_template_raises_validation_error_when_pool_exhausted(
     """Creating object from template should raise ValidationError when pool is exhausted."""
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     small_prefix = await Node.init(db=db, schema=prefix_schema)
-    await small_prefix.new(db=db, prefix="10.10.3.8/30", ip_namespace=ip_namespace, parent=ip_prefix, is_pool=True)
+    await small_prefix.new(db=db, prefix="10.10.3.8/30", ip_namespace=ip_namespace, parent=ip_prefix, is_pool=False)
     await small_prefix.save(db=db)
 
     pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPADDRESSPOOL, branch=default_branch)

--- a/backend/tests/component/templates/test_template_applier.py
+++ b/backend/tests/component/templates/test_template_applier.py
@@ -13,8 +13,8 @@ from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.schema import AttributeSchema, RelationshipSchema, SchemaRoot
-from infrahub.pools.allocator import PoolAllocator
 from infrahub.pools.default_allocator import DefaultPoolAllocator
+from infrahub.pools.noop_allocator import NoOpPoolAllocator
 from infrahub.templates.node_applier import NodeTemplateApplier
 from tests.constants import TestKind
 from tests.helpers.schema import TAG, load_schema
@@ -24,16 +24,6 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-
-
-class NoOpPoolAllocator(PoolAllocator):
-    """Test pool allocator that skips all allocations (because we don't care here)."""
-
-    async def allocate_for_attribute(self, *args: Any, **kwargs: Any) -> Any | None:
-        return None
-
-    async def allocate_for_relationship(self, *args: Any, **kwargs: Any) -> Node | None:
-        return None
 
 
 @dataclass

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -415,6 +415,59 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
         assert updated["primary_address"]["node"] is None
         assert updated["primary_address_from_resource_pool"]["node"]["id"] == ip_address_pool.id
 
+    @pytest.fixture(scope="class")
+    async def small_prefix(self, db: InfrahubDatabase, ip_namespace: Node, ip_prefix: Node) -> Node:
+        prefix = await Node.init(db=db, schema="IpamIPPrefix")
+        await prefix.new(db=db, prefix="10.20.30.0/30", ip_namespace=ip_namespace, parent=ip_prefix, is_pool=False)
+        await prefix.save(db=db)
+        return prefix
+
+    @pytest.fixture(scope="class")
+    async def small_pool(self, db: InfrahubDatabase, ip_namespace: Node, small_prefix: Node) -> Node:
+        pool = await Node.init(db=db, schema=InfrahubKind.IPADDRESSPOOL)
+        await pool.new(
+            db=db,
+            name="small-address-pool",
+            resources=[small_prefix],
+            ip_namespace=ip_namespace,
+            default_address_type="IpamIPAddress",
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def template_with_small_pool(self, db: InfrahubDatabase, small_pool: Node, device_schema: None) -> Node:
+        template = await Node.init(db=db, schema="TemplateInfraDevice")
+        await template.new(db=db, template_name="device-small-pool", primary_address_from_resource_pool=small_pool)
+        await template.save(db=db)
+        return template
+
+    async def test_pool_template_performs_correct_allocations(
+        self, db: InfrahubDatabase, template_with_small_pool: Node, small_prefix: Node, client: InfrahubClient
+    ) -> None:
+        """With an IPv4 /30 creating 2 devices must both succeed."""
+        addresses = list(small_prefix.prefix.obj.hosts())
+        for i in range(2):
+            result = await client.execute_graphql(
+                query=CREATE_DEVICE_FROM_TEMPLATE,
+                variables={"name": f"device-small-pool-{i}", "template_id": template_with_small_pool.id},
+            )
+            device_id = result["InfraDeviceCreate"]["object"]["id"]
+            device = await NodeManager.get_one(id=device_id, db=db)
+            addr_peer = await device.primary_address.get_peer(db=db)
+            assert addr_peer is not None
+            assert addr_peer.address.obj.ip == addresses[i]
+
+    async def test_small_pool_exhausts_after_exact_capacity(
+        self, template_with_small_pool: Node, client: InfrahubClient
+    ) -> None:
+        """After 2 allocations from an IPv4 /30, the pool should be exhausted."""
+        with pytest.raises(GraphQLError, match=r"no more addresses available"):
+            await client.execute_graphql(
+                query=CREATE_DEVICE_FROM_TEMPLATE,
+                variables={"name": "device-small-pool-overflow", "template_id": template_with_small_pool.id},
+            )
+
 
 class TestTemplateNumberPoolAttributes(TestInfrahubApp):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
# Why

When creating an object via `create_node()` with an `object_template` that has a `_from_resource_pool` relationship (IP address or prefix pool), the pool resource is allocated **twice**: once during the preview phase (wasted) and once during actual creation (used). This wastes pool resources and causes premature pool exhaustion.

`create_node()` has a preview phase used only for lock name detection, but `handle_object_template()` ignored that flag and always used a `DefaultPoolAllocator`, which turned out saving real IP address nodes to the database.

## What changed

- Introduced `NoOpPoolAllocator` a no-op implementation of `PoolAllocator` that skips all allocations
- Passed `process_pools` to `handle_object_template()`, when `False`, it uses `NoOpPoolAllocator` instead of `DefaultPoolAllocator`

Number pool attributes were already unaffected.

No schema changes. No API contract changes. No migration needed.

### Suggested review order
1. `backend/infrahub/pools/noop_allocator.py` trivial
2. `backend/infrahub/core/node/__init__.py` the fix itself (small changes)
3. `backend/tests/functional/templates/test_template_resource_pool.py` functional regression test

## How to test

```bash
uv run pytest backend/tests/functional/templates/test_template_resource_pool.py::TestTemplateResourcePoolCreation -v
```

## Checklist

- [x] Tests added/updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template processing can now opt out of pool allocations via a new flag, letting templates be applied without consuming pool resources.

* **Chores**
  * Added a no-op pool allocator implementation to support non-allocating template runs.

* **Tests**
  * Expanded pool-related tests (allocation and exhaustion) and updated tests to use the shared no-op allocator; adjusted a test case to reflect pool semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->