### PR TITLE
allow updating pools by name

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -415,9 +415,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if not allocate_resources:
             return
 
-        if not allocate_resources:
-            return
-
         if (
             number_pool.node.value in [self._schema.kind] + self._schema.inherit_from
             and number_pool.node_attribute.value == attribute.name

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -415,6 +415,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if not allocate_resources:
             return
 
+        if not allocate_resources:
+            return
+
         if (
             number_pool.node.value in [self._schema.kind] + self._schema.inherit_from
             and number_pool.node_attribute.value == attribute.name

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -404,9 +404,17 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             return
 
         try:
-            number_pool = await registry.manager.get_one(
-                db=db, id=number_pool_id, kind=CoreNumberPool, raise_on_error=True
-            )
+            if is_valid_uuid(number_pool_id):
+                number_pool = await registry.manager.get_one(
+                    db=db, id=number_pool_id, kind=CoreNumberPool, raise_on_error=True
+                )
+            else:
+                results = await registry.manager.query(
+                    db=db, schema=InfrahubKind.NUMBERPOOL, filters={"name__value": number_pool_id}
+                )
+                if not results:
+                    raise NodeNotFoundError(node_type=InfrahubKind.NUMBERPOOL, identifier=number_pool_id)
+                number_pool = results[0]
         except NodeNotFoundError as exc:
             raise ValidationError(
                 {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -13,6 +13,7 @@ from typing import (
     Mapping,
     Sequence,
     TypeVar,
+    cast,
     overload,
 )
 
@@ -561,8 +562,16 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
             self.set_peer(value=peer)
 
         if not self.peer_id and self.from_pool and "id" in self.from_pool:
+            pool: Node | None = None
             pool_id = str(self.from_pool.get("id"))
-            pool = await registry.manager.get_one(db=db, id=pool_id, branch=self.branch)
+            if is_valid_uuid(pool_id):
+                pool = await registry.manager.get_one(db=db, id=pool_id, branch=self.branch)
+            else:
+                results = await registry.manager.query(
+                    db=db, schema=InfrahubKind.RESOURCEPOOL, filters={"name__value": pool_id}, branch=self.branch
+                )
+                results = cast("list[Node]", results)
+                pool = results[0] if results else None
 
             if not pool:
                 raise NodeNotFoundError(

--- a/backend/tests/component/graphql/resource_manager/test_ip_pool_lookup_by_name.py
+++ b/backend/tests/component/graphql/resource_manager/test_ip_pool_lookup_by_name.py
@@ -1,0 +1,523 @@
+from typing import Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_ipam_namespace
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.node.ipam import BuiltinIPPrefix
+from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
+from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+
+FAKE_POOL_NAME = "nonexistent-pool"
+PREFIX_POOL_NAME = "prefix-pool-by-name"
+PREFIX_POOL_2_NAME = "prefix-pool-2-by-name"
+ADDRESS_POOL_NAME = "address-pool-by-name"
+ADDRESS_POOL_2_NAME = "address-pool-2-by-name"
+
+CREATE_PREFIX_FROM_POOL = """
+mutation CreatePrefixFromPool($name: String!, $pool_id: String!) {
+    TestMandatoryPrefixCreate(data: {
+        name: { value: $name }
+        prefix: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            id
+            prefix {
+                properties {
+                    source {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+CREATE_ADDRESS_FROM_POOL = """
+mutation CreateAddressFromPool($name: String!, $pool_id: String!) {
+    TestMandatoryAddressCreate(data: {
+        name: { value: $name }
+        address: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            id
+            address {
+                properties {
+                    source {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+UPDATE_PREFIX_FROM_POOL = """
+mutation UpdatePrefixFromPool($id: String!, $pool_id: String!) {
+    TestMandatoryPrefixUpdate(data: {
+        id: $id
+        prefix: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
+UPDATE_ADDRESS_FROM_POOL = """
+mutation UpdateAddressFromPool($id: String!, $pool_id: String!) {
+    TestMandatoryAddressUpdate(data: {
+        id: $id
+        address: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
+
+class TestIPPoolLookupByName:
+    """Tests for referencing IP resource pools by name instead of UUID in from_pool."""
+
+    @pytest.fixture(scope="class")
+    async def register_ipam_schema(self, default_branch_scope_class: Branch, ipam_schema: SchemaRoot) -> SchemaBranch:
+        schema_branch = registry.schema.register_schema(schema=ipam_schema, branch=default_branch_scope_class.name)
+        default_branch_scope_class.update_schema_hash()
+        return schema_branch
+
+    @pytest.fixture(scope="class")
+    async def register_ipam_extended_schema(
+        self, default_branch_scope_class: Branch, register_ipam_schema: SchemaBranch
+    ) -> SchemaBranch:
+        SCHEMA: dict[str, Any] = {
+            "nodes": [
+                {
+                    "name": "MandatoryPrefix",
+                    "namespace": "Test",
+                    "attributes": [{"name": "name", "kind": "Text"}],
+                    "relationships": [
+                        {
+                            "name": "prefix",
+                            "peer": "IpamIPPrefix",
+                            "kind": "Attribute",
+                            "optional": False,
+                            "cardinality": "one",
+                        },
+                    ],
+                },
+                {
+                    "name": "MandatoryAddress",
+                    "namespace": "Test",
+                    "attributes": [{"name": "name", "kind": "Text"}],
+                    "relationships": [
+                        {
+                            "name": "address",
+                            "peer": "IpamIPAddress",
+                            "kind": "Attribute",
+                            "optional": False,
+                            "cardinality": "one",
+                        },
+                    ],
+                },
+            ],
+        }
+        schema_branch = registry.schema.register_schema(
+            schema=SchemaRoot(**SCHEMA), branch=default_branch_scope_class.name
+        )
+        default_branch_scope_class.update_schema_hash()
+        return schema_branch
+
+    @pytest.fixture(scope="class")
+    def init_nodes_registry(self) -> None:
+        registry.node["Node"] = Node
+        registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+        registry.node[InfrahubKind.IPPREFIXPOOL] = CoreIPPrefixPool
+        registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
+
+    @pytest.fixture(scope="class")
+    async def default_ipnamespace(
+        self, db: InfrahubDatabase, register_core_models_schema_scope_class: SchemaBranch
+    ) -> None:
+        if not registry._default_ipnamespace:
+            ip_namespace = await create_ipam_namespace(db=db)
+            registry.default_ipnamespace = ip_namespace.id
+
+    @pytest.fixture(scope="class")
+    async def ip_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        default_ipnamespace: None,
+        register_ipam_extended_schema: SchemaBranch,
+        init_nodes_registry: None,
+    ) -> dict[str, Any]:
+        prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch_scope_class)
+
+        ns1 = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+        await ns1.new(db=db, name="ns1-by-name")
+        await ns1.save(db=db)
+
+        net_parent = await Node.init(db=db, schema=prefix_schema)
+        await net_parent.new(db=db, prefix="10.20.0.0/16", ip_namespace=ns1)
+        await net_parent.save(db=db)
+
+        net_for_address = await Node.init(db=db, schema=prefix_schema)
+        await net_for_address.new(db=db, prefix="10.20.3.0/27", parent=net_parent, ip_namespace=ns1)
+        await net_for_address.save(db=db)
+
+        net_existing = await Node.init(db=db, schema=prefix_schema)
+        await net_existing.new(db=db, prefix="10.20.1.0/24", parent=net_parent, ip_namespace=ns1)
+        await net_existing.save(db=db)
+
+        return {"ns1": ns1, "net_parent": net_parent, "net_for_address": net_for_address, "net_existing": net_existing}
+
+    @pytest.fixture(scope="class")
+    async def prefix_pool(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> CoreIPPrefixPool:
+        prefix_pool_schema = registry.schema.get_node_schema(
+            name=InfrahubKind.IPPREFIXPOOL, branch=default_branch_scope_class
+        )
+        pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db, branch=default_branch_scope_class)
+        await pool.new(
+            db=db,
+            name=PREFIX_POOL_NAME,
+            default_prefix_length=24,
+            default_prefix_type="IpamIPPrefix",
+            resources=[ip_dataset["net_parent"]],
+            ip_namespace=ip_dataset["ns1"],
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def prefix_pool_2(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> CoreIPPrefixPool:
+        prefix_pool_schema = registry.schema.get_node_schema(
+            name=InfrahubKind.IPPREFIXPOOL, branch=default_branch_scope_class
+        )
+        pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db, branch=default_branch_scope_class)
+        await pool.new(
+            db=db,
+            name=PREFIX_POOL_2_NAME,
+            default_prefix_length=24,
+            default_prefix_type="IpamIPPrefix",
+            resources=[ip_dataset["net_parent"]],
+            ip_namespace=ip_dataset["ns1"],
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def address_pool(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> CoreIPAddressPool:
+        address_pool_schema = registry.schema.get_node_schema(
+            name=InfrahubKind.IPADDRESSPOOL, branch=default_branch_scope_class
+        )
+        pool = await CoreIPAddressPool.init(schema=address_pool_schema, db=db, branch=default_branch_scope_class)
+        await pool.new(
+            db=db,
+            name=ADDRESS_POOL_NAME,
+            default_address_type="IpamIPAddress",
+            resources=[ip_dataset["net_for_address"]],
+            ip_namespace=ip_dataset["ns1"],
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture(scope="class")
+    async def address_pool_2(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> CoreIPAddressPool:
+        address_pool_schema = registry.schema.get_node_schema(
+            name=InfrahubKind.IPADDRESSPOOL, branch=default_branch_scope_class
+        )
+        pool = await CoreIPAddressPool.init(schema=address_pool_schema, db=db, branch=default_branch_scope_class)
+        await pool.new(
+            db=db,
+            name=ADDRESS_POOL_2_NAME,
+            default_address_type="IpamIPAddress",
+            resources=[ip_dataset["net_for_address"]],
+            ip_namespace=ip_dataset["ns1"],
+        )
+        await pool.save(db=db)
+        return pool
+
+    # --- Prefix: create ---
+
+    async def test_create_prefix_from_pool_by_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, prefix_pool: CoreIPPrefixPool
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_PREFIX_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "site-prefix-by-name", "pool_id": PREFIX_POOL_NAME},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["TestMandatoryPrefixCreate"]["ok"]
+        assert (
+            result.data["TestMandatoryPrefixCreate"]["object"]["prefix"]["properties"]["source"]["id"] == prefix_pool.id
+        )
+
+        obj_id = result.data["TestMandatoryPrefixCreate"]["object"]["id"]
+        loaded = await NodeManager.get_one(id=obj_id, db=db, branch=default_branch_scope_class)
+        assert loaded is not None
+        prefix_rels = await loaded.prefix.get_relationships(db=db)
+        assert len(prefix_rels) == 1
+        assert prefix_rels[0].source_id == prefix_pool.id
+
+    # --- Prefix: update (to different pool) ---
+
+    async def test_update_prefix_from_pool_by_name(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        prefix_pool: CoreIPPrefixPool,
+        prefix_pool_2: CoreIPPrefixPool,
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+
+        # Create object using pool 1 by name
+        create_result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_PREFIX_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "site-update-prefix-pool", "pool_id": PREFIX_POOL_NAME},
+        )
+        assert not create_result.errors
+        assert create_result.data
+        obj_id = create_result.data["TestMandatoryPrefixCreate"]["object"]["id"]
+        assert (
+            create_result.data["TestMandatoryPrefixCreate"]["object"]["prefix"]["properties"]["source"]["id"]
+            == prefix_pool.id
+        )
+
+        # Update to use pool 2 by name
+        update_result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_PREFIX_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"id": obj_id, "pool_id": PREFIX_POOL_2_NAME},
+        )
+        assert not update_result.errors
+        assert update_result.data
+        assert update_result.data["TestMandatoryPrefixUpdate"]["ok"]
+
+        # Retrieve the updated object to confirm the pool changed
+        loaded = await NodeManager.get_one(id=obj_id, db=db, branch=default_branch_scope_class)
+        assert loaded is not None
+        prefix_rels = await loaded.get_relationship("prefix").get_relationships(db=db)
+        assert len(prefix_rels) == 1
+        assert prefix_rels[0].source_id == prefix_pool_2.id
+
+    # --- Prefix: create with invalid name ---
+
+    async def test_create_prefix_with_invalid_pool_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_PREFIX_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "site-bad-name", "pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert "Unable to find the pool to generate a node for the relationship 'prefix'" in str(result.errors[0])
+
+    # --- Prefix: update with invalid name ---
+
+    async def test_update_prefix_with_invalid_pool_name(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        ip_dataset: dict[str, Any],
+    ) -> None:
+        schema = registry.schema.get_node_schema(name="TestMandatoryPrefix", branch=default_branch_scope_class)
+        obj = await Node.init(db=db, schema=schema, branch=default_branch_scope_class)
+        await obj.new(db=db, name="site-bad-update-prefix", prefix=ip_dataset["net_existing"])
+        await obj.save(db=db)
+
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_PREFIX_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"id": obj.id, "pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert "Unable to find the pool to generate a node for the relationship 'prefix'" in str(result.errors[0])
+
+    # --- Address: create ---
+
+    async def test_create_address_from_pool_by_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, address_pool: CoreIPAddressPool
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "server-address-by-name", "pool_id": ADDRESS_POOL_NAME},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["TestMandatoryAddressCreate"]["ok"]
+        assert (
+            result.data["TestMandatoryAddressCreate"]["object"]["address"]["properties"]["source"]["id"]
+            == address_pool.id
+        )
+
+        obj_id = result.data["TestMandatoryAddressCreate"]["object"]["id"]
+        loaded = await NodeManager.get_one(id=obj_id, db=db, branch=default_branch_scope_class)
+        assert loaded is not None
+        address_rels = await loaded.address.get_relationships(db=db)
+        assert len(address_rels) == 1
+        assert address_rels[0].source_id == address_pool.id
+
+    # --- Address: update (to different pool) ---
+
+    async def test_update_address_from_pool_by_name(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        address_pool: CoreIPAddressPool,
+        address_pool_2: CoreIPAddressPool,
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+
+        # Create object using pool 1 by name
+        create_result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "server-update-addr-pool", "pool_id": ADDRESS_POOL_NAME},
+        )
+        assert not create_result.errors
+        assert create_result.data
+        obj_id = create_result.data["TestMandatoryAddressCreate"]["object"]["id"]
+        assert (
+            create_result.data["TestMandatoryAddressCreate"]["object"]["address"]["properties"]["source"]["id"]
+            == address_pool.id
+        )
+
+        # Update to use pool 2 by name
+        update_result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"id": obj_id, "pool_id": ADDRESS_POOL_2_NAME},
+        )
+        assert not update_result.errors
+        assert update_result.data
+        assert update_result.data["TestMandatoryAddressUpdate"]["ok"]
+
+        # Retrieve the updated object to confirm the pool changed
+        loaded = await NodeManager.get_one(id=obj_id, db=db, branch=default_branch_scope_class)
+        assert loaded is not None
+        address_rels = await loaded.address.get_relationships(db=db)
+        assert len(address_rels) == 1
+        assert address_rels[0].source_id == address_pool_2.id
+
+    # --- Address: create with invalid name ---
+
+    async def test_create_address_with_invalid_pool_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, ip_dataset: dict[str, Any]
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "server-bad-name", "pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert "Unable to find the pool to generate a node for the relationship 'address'" in str(result.errors[0])
+
+    # --- Address: update with invalid name ---
+
+    async def test_update_address_with_invalid_pool_name(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        address_pool: CoreIPAddressPool,
+    ) -> None:
+        default_branch_scope_class.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+
+        # Create a valid address object first
+        create_result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"name": "server-bad-update-addr", "pool_id": address_pool.id},
+        )
+        assert not create_result.errors
+        assert create_result.data
+        obj_id = create_result.data["TestMandatoryAddressCreate"]["object"]["id"]
+
+        result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_ADDRESS_FROM_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"id": obj_id, "pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert "Unable to find the pool to generate a node for the relationship 'address'" in str(result.errors[0])

--- a/backend/tests/component/graphql/resource_manager/test_number_pool_lookup_by_name.py
+++ b/backend/tests/component/graphql/resource_manager/test_number_pool_lookup_by_name.py
@@ -1,0 +1,162 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind, MetadataOptions
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+from tests.helpers.schema import TICKET, load_schema
+
+FAKE_POOL_NAME = "nonexistent-pool"
+TICKET_POOL_NAME = "ticket-pool-by-name"
+
+CREATE_TICKET_WITH_POOL = """
+mutation CreateTicketWithPool($pool_id: String!) {
+    TestingTicketCreate(data: {
+        title: { value: "ticket-from-pool" }
+        ticket_id: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+UPDATE_TICKET_WITH_POOL = """
+mutation UpdateTicketWithPool($ticket_id: String!, $pool_id: String!) {
+    TestingTicketUpdate(data: {
+        id: $ticket_id
+        ticket_id: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+    }
+}
+"""
+
+
+class TestNumberPoolLookupByName:
+    """Tests for referencing number pools by name instead of UUID in from_pool."""
+
+    @pytest.fixture(scope="class")
+    async def number_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+    ) -> CoreNumberPool:
+        await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
+        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+        pool = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
+        await pool.new(
+            db=db,
+            name=TICKET_POOL_NAME,
+            node="TestingTicket",
+            node_attribute="ticket_id",
+            start_range=1,
+            end_range=100,
+        )
+        await pool.save(db=db)
+        default_branch_scope_class.update_schema_hash()
+        return pool
+
+    async def test_create_ticket_from_pool_by_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
+    ) -> None:
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_TICKET_WITH_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"pool_id": TICKET_POOL_NAME},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["TestingTicketCreate"]["ok"]
+
+        obj_id = result.data["TestingTicketCreate"]["object"]["id"]
+        loaded = await NodeManager.get_one(
+            id=obj_id, db=db, branch=default_branch_scope_class, include_metadata=MetadataOptions.LINKED_NODES
+        )
+        assert loaded is not None
+        assert loaded.ticket_id.source_id == number_pool.id
+
+    async def test_update_ticket_from_pool_by_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
+    ) -> None:
+        schema = registry.schema.get_node_schema(name="TestingTicket", branch=default_branch_scope_class)
+        ticket = await Node.init(db=db, schema=schema, branch=default_branch_scope_class)
+        await ticket.new(db=db, title="ticket-for-update-by-name", ticket_id=42)
+        await ticket.save(db=db)
+
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_TICKET_WITH_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"ticket_id": ticket.id, "pool_id": TICKET_POOL_NAME},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["TestingTicketUpdate"]["ok"]
+
+        loaded = await NodeManager.get_one(
+            id=ticket.id, db=db, branch=default_branch_scope_class, include_metadata=MetadataOptions.LINKED_NODES
+        )
+        assert loaded is not None
+        assert loaded.ticket_id.source_id == number_pool.id
+
+    async def test_create_ticket_with_invalid_pool_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
+    ) -> None:
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_TICKET_WITH_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert f"The pool requested {{'id': '{FAKE_POOL_NAME}'}} was not found." in str(result.errors[0])
+
+    async def test_update_ticket_with_invalid_pool_name(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
+    ) -> None:
+        schema = registry.schema.get_node_schema(name="TestingTicket", branch=default_branch_scope_class)
+        ticket = await Node.init(db=db, schema=schema, branch=default_branch_scope_class)
+        await ticket.new(db=db, title="ticket-for-bad-update", ticket_id=99)
+        await ticket.save(db=db)
+
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch_scope_class)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=UPDATE_TICKET_WITH_POOL,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"ticket_id": ticket.id, "pool_id": FAKE_POOL_NAME},
+        )
+
+        assert result.errors
+        assert f"The pool requested {{'id': '{FAKE_POOL_NAME}'}} was not found." in str(result.errors[0])

--- a/backend/tests/component/graphql/resource_manager/test_resource_manager.py
+++ b/backend/tests/component/graphql/resource_manager/test_resource_manager.py
@@ -25,6 +25,7 @@ from tests.helpers.graphql import graphql
 from tests.helpers.schema import SNOW_TICKET_SCHEMA, TICKET, load_schema
 
 FAKE_POOL_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+FAKE_POOL_NAME = "nonexistent-pool"
 
 CREATE_PREFIX_FROM_POOL = """
 mutation CreatePrefixFromPool($name: String!, $pool_id: String!) {
@@ -132,6 +133,210 @@ mutation UpdateTicketWithPool($ticket_id: String!, $pool_id: String!) {
     }) {
         ok
     }
+}
+"""
+
+UPDATE_PREFIX_FROM_POOL = """
+mutation UpdatePrefixFromPool($id: String!, $pool_id: String!) {
+    TestMandatoryPrefixUpdate(data: {
+        id: $id
+        prefix: {
+            from_pool: {
+                id: $pool_id
+            }
+        }
+    }) {
+        ok
+        object {
+            name {
+                value
+            }
+            prefix {
+                node {
+                    prefix {
+                        value
+                    }
+                }
+                properties {
+                    source {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+PREFIX_POOL_GET_RESOURCE = """
+mutation PrefixPoolGetResource($pool_id: String!) {
+    InfrahubIPPrefixPoolGetResource(data: {
+        id: $pool_id
+    }) {
+        ok
+        node {
+            kind
+            display_label
+        }
+    }
+}
+"""
+
+PREFIX_POOL_GET_RESOURCE_WITH_IDENTIFIER = """
+mutation PrefixPoolGetResourceWithIdentifier($pool_id: String!, $identifier: String!) {
+    InfrahubIPPrefixPoolGetResource(data: {
+        id: $pool_id
+        identifier: $identifier
+    }) {
+        ok
+        node {
+            id
+            kind
+            display_label
+            identifier
+        }
+    }
+}
+"""
+
+PREFIX_POOL_GET_RESOURCE_WITH_PREFIX_LENGTH = """
+mutation PrefixPoolGetResourceWithPrefixLength($pool_id: String!, $prefix_length: Int!) {
+    InfrahubIPPrefixPoolGetResource(data: {
+        id: $pool_id
+        prefix_length: $prefix_length
+    }) {
+        ok
+        node {
+            kind
+            display_label
+        }
+    }
+}
+"""
+
+ADDRESS_POOL_GET_RESOURCE = """
+mutation AddressPoolGetResource($pool_id: String!) {
+    InfrahubIPAddressPoolGetResource(data: {
+        id: $pool_id
+    }) {
+        ok
+        node {
+            kind
+            display_label
+        }
+    }
+}
+"""
+
+ADDRESS_POOL_GET_RESOURCE_WITH_IDENTIFIER = """
+mutation AddressPoolGetResourceWithIdentifier($pool_id: String!, $identifier: String!) {
+    InfrahubIPAddressPoolGetResource(data: {
+        id: $pool_id
+        identifier: $identifier
+    }) {
+        ok
+        node {
+            id
+            kind
+            display_label
+            identifier
+        }
+    }
+}
+"""
+
+ADDRESS_POOL_GET_RESOURCE_WITH_PREFIX_LENGTH = """
+mutation AddressPoolGetResourceWithPrefixLength($pool_id: String!, $prefix_length: Int!) {
+    InfrahubIPAddressPoolGetResource(data: {
+        id: $pool_id
+        prefix_length: $prefix_length
+    }) {
+        ok
+        node {
+            kind
+            display_label
+        }
+    }
+}
+"""
+
+CREATE_NUMBER_POOL = """
+mutation CreateNumberPool(
+    $name: String!,
+    $node: String!,
+    $node_attribute: String!,
+    $start_range: BigInt!,
+    $end_range: BigInt!
+  ) {
+  CoreNumberPoolCreate(
+    data: {
+      name: {value: $name},
+      node:{value: $node},
+      node_attribute: {value: $node_attribute},
+      start_range: {value: $start_range},
+      end_range: {value: $end_range}
+    }
+  ) {
+    object {
+      display_label
+      id
+    }
+  }
+}
+"""
+
+UPDATE_NUMBER_POOL = """
+mutation UpdateNumberPool(
+    $id: String!,
+    $name: String,
+    $node: String,
+    $node_attribute: String,
+    $start_range: BigInt,
+    $end_range: BigInt
+  ) {
+  CoreNumberPoolUpdate(
+    data: {
+      id: $id,
+      name: {value: $name},
+      node:{value: $node},
+      node_attribute: {value: $node_attribute},
+      start_range: {value: $start_range},
+      end_range: {value: $end_range}
+    }
+  ) {
+    object {
+      display_label
+      id
+    }
+  }
+}
+"""
+
+
+DELETE_NUMBER_POOL = """
+mutation DeleteNumberPool(
+    $id: String!,
+  ) {
+  CoreNumberPoolDelete(
+    data: {
+      id: $id,
+    }
+  ) {
+    ok
+  }
+}
+"""
+
+
+QUERY_NUMBER_POOL = """
+query NumberPool(
+    $id: ID!,
+  ) {
+  CoreNumberPool(
+    ids: [$id]
+  ) {
+    count
+  }
 }
 """
 
@@ -322,46 +527,14 @@ async def test_update_object_and_assign_prefix_from_pool(
     await obj.new(db=db, name="site1", prefix=net142)
     await obj.save(db=db)
 
-    query = """
-    mutation {
-        TestMandatoryPrefixUpdate(data: {
-            id: "%s"
-            prefix: {
-                from_pool: {
-                    id: "%s"
-                }
-            }
-        }) {
-            ok
-            object {
-                name {
-                    value
-                }
-                prefix {
-                    node {
-                        prefix {
-                            value
-                        }
-                    }
-                    properties {
-                        source {
-                            id
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """ % (obj.id, pool.id)
-
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=UPDATE_PREFIX_FROM_POOL,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"id": obj.id, "pool_id": pool.id},
     )
 
     assert not result.errors
@@ -468,23 +641,6 @@ async def test_prefix_pool_get_resource(
     )
     await pool.save(db=db)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPPrefixPoolGetResource(data: {
-            id: "%s"
-        }) {
-            ok
-            node {
-                kind
-                display_label
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
@@ -493,10 +649,10 @@ async def test_prefix_pool_get_resource(
     )
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=PREFIX_POOL_GET_RESOURCE,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id},
     )
 
     assert not result.errors
@@ -544,36 +700,16 @@ async def test_prefix_pool_get_resource_with_identifier(
 
     resource = await pool.get_resource(db=db, identifier="myidentifier", branch=default_branch)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPPrefixPoolGetResource(data: {
-            id: "%s"
-            identifier: "myidentifier"
-        }) {
-            ok
-            node {
-                id
-                kind
-                display_label
-                identifier
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=PREFIX_POOL_GET_RESOURCE_WITH_IDENTIFIER,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id, "identifier": "myidentifier"},
     )
 
     assert not result.errors
@@ -617,32 +753,14 @@ async def test_prefix_pool_get_resource_with_prefix_length(
     )
     await pool.save(db=db)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPPrefixPoolGetResource(data: {
-            id: "%s"
-            prefix_length: 31
-        }) {
-            ok
-            node {
-                kind
-                display_label
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=PREFIX_POOL_GET_RESOURCE_WITH_PREFIX_LENGTH,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id, "prefix_length": 31},
     )
 
     assert not result.errors
@@ -678,23 +796,6 @@ async def test_address_pool_get_resource(
     )
     await pool.save(db=db)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPAddressPoolGetResource(data: {
-            id: "%s"
-        }) {
-            ok
-            node {
-                kind
-                display_label
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
@@ -703,10 +804,10 @@ async def test_address_pool_get_resource(
     )
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=ADDRESS_POOL_GET_RESOURCE,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id},
     )
 
     assert not result.errors
@@ -753,34 +854,14 @@ async def test_address_pool_get_resource_with_identifier(
 
     resource = await pool.get_resource(db=db, identifier="myidentifier", branch=default_branch)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPAddressPoolGetResource(data: {
-            id: "%s"
-            identifier: "myidentifier"
-        }) {
-            ok
-            node {
-                id
-                kind
-                display_label
-                identifier
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=ADDRESS_POOL_GET_RESOURCE_WITH_IDENTIFIER,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id, "identifier": "myidentifier"},
     )
 
     assert not result.errors
@@ -817,32 +898,14 @@ async def test_address_pool_get_resource_with_prefix_length(
     )
     await pool.save(db=db)
 
-    query = (
-        """
-    mutation {
-        InfrahubIPAddressPoolGetResource(data: {
-            id: "%s"
-            prefix_length: 32
-        }) {
-            ok
-            node {
-                kind
-                display_label
-            }
-        }
-    }
-    """
-        % pool.id
-    )
-
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
-        source=query,
+        source=ADDRESS_POOL_GET_RESOURCE_WITH_PREFIX_LENGTH,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={},
+        variable_values={"pool_id": pool.id, "prefix_length": 32},
     )
 
     assert not result.errors
@@ -852,87 +915,6 @@ async def test_address_pool_get_resource_with_prefix_length(
         "display_label": "10.10.3.2/32",
         "kind": "IpamIPAddress",
     }
-
-
-CREATE_NUMBER_POOL = """
-mutation CreateNumberPool(
-    $name: String!,
-    $node: String!,
-    $node_attribute: String!,
-    $start_range: BigInt!,
-    $end_range: BigInt!
-  ) {
-  CoreNumberPoolCreate(
-    data: {
-      name: {value: $name},
-      node:{value: $node},
-      node_attribute: {value: $node_attribute},
-      start_range: {value: $start_range},
-      end_range: {value: $end_range}
-    }
-  ) {
-    object {
-      display_label
-      id
-    }
-  }
-}
-"""
-
-UPDATE_NUMBER_POOL = """
-mutation UpdateNumberPool(
-    $id: String!,
-    $name: String,
-    $node: String,
-    $node_attribute: String,
-    $start_range: BigInt,
-    $end_range: BigInt
-  ) {
-  CoreNumberPoolUpdate(
-    data: {
-      id: $id,
-      name: {value: $name},
-      node:{value: $node},
-      node_attribute: {value: $node_attribute},
-      start_range: {value: $start_range},
-      end_range: {value: $end_range}
-    }
-  ) {
-    object {
-      display_label
-      id
-    }
-  }
-}
-"""
-
-
-DELETE_NUMBER_POOL = """
-mutation DeleteNumberPool(
-    $id: String!,
-  ) {
-  CoreNumberPoolDelete(
-    data: {
-      id: $id,
-    }
-  ) {
-    ok
-  }
-}
-"""
-
-
-QUERY_NUMBER_POOL = """
-query NumberPool(
-    $id: ID!,
-  ) {
-  CoreNumberPool(
-    ids: [$id]
-  ) {
-    count
-  }
-}
-"""
 
 
 async def test_test_number_pool_creation_errors(

--- a/backend/tests/component/graphql/test_mutation_upsert.py
+++ b/backend/tests/component/graphql/test_mutation_upsert.py
@@ -714,6 +714,7 @@ async def test_upsert_with_required_relationship_from_template(
       - Upsert a Tshirt specifying the template (should succeed and apply the color from the template).
     """
     registry.schema.register_schema(schema=SchemaRoot(nodes=[TSHIRT, COLOR]), branch=default_branch.name)
+    default_branch.update_schema_hash()
 
     # Create a color node
     color_node = await Node.init(db=db, schema="TestingColor", branch=default_branch)


### PR DESCRIPTION
IFC-2300

should follow #8482 

allow specifying resource pools (IP Prefix/Address and NumberPool) by name in the `from_pool` input. the `name` attribute is unique on the `CoreResourcePool` generic

for example 
```
mutation {
    TestingTicketUpdate(data: {
        id: "abc"
        ticket_id: {
            from_pool: {
                id: "name of my NumberPool"
            }
        }
    }) {
        ok
    }
}
```

purposefully chose not to use `NodeManager.get_by_id_or_default_filter` b/c we are trying to not use `default_filter` any longer. instead this uses `is_valid_uuid` and tries to get by name using `NodeManager.query` if the input is not an ID.

added graphql component tests to cover the changes
- creating and updating prefix and address pools using IDs and names on IP relationships
- creating and updating number pools using IDs and names on Number attributes
- negative tests for all the above cases with invalid names

also moved some of the test files around and removed string interpolation from some of the graphql query strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pools can be referenced by name or UUID in GraphQL mutations for creating/updating IP prefixes, IP addresses, and tickets; existing UUID behavior is preserved.
  * Clear user-facing errors returned when a referenced pool name does not exist.

* **Tests**
  * Added comprehensive end-to-end tests covering pool lookup by name for IP and number pools, plus a test update ensuring schema hash refresh after schema registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->