### PR TITLE
Show related nodes and templates in the profile details view

### DIFF
--- a/changelog/+profile-relationships-tab.added.md
+++ b/changelog/+profile-relationships-tab.added.md
@@ -1,0 +1,1 @@
+Profile details view now displays the objects where the profile is being used

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.test.ts
@@ -39,15 +39,47 @@ describe("getRelationshipsVisibleInTab", () => {
     expect(result).toEqual(relationships);
   });
 
-  it("should return relationships with kind Profile and cardinality many", () => {
+  it("should return Profile relationships named related_nodes", () => {
     // GIVEN
-    const relationships = [generateRelationshipSchema({ kind: "Profile", cardinality: "many" })];
+    const relationships = [
+      generateRelationshipSchema({ kind: "Profile", cardinality: "many", name: "related_nodes" }),
+    ];
 
     // WHEN
     const result = getRelationshipsVisibleInTab(relationships);
 
     // THEN
     expect(result).toEqual(relationships);
+  });
+
+  it("should return Profile relationships named related_templates", () => {
+    // GIVEN
+    const relationships = [
+      generateRelationshipSchema({
+        kind: "Profile",
+        cardinality: "many",
+        name: "related_templates",
+      }),
+    ];
+
+    // WHEN
+    const result = getRelationshipsVisibleInTab(relationships);
+
+    // THEN
+    expect(result).toEqual(relationships);
+  });
+
+  it("should not return Profile relationships with other names", () => {
+    // GIVEN
+    const relationships = [
+      generateRelationshipSchema({ kind: "Profile", cardinality: "many", name: "profiles" }),
+    ];
+
+    // WHEN
+    const result = getRelationshipsVisibleInTab(relationships);
+
+    // THEN
+    expect(result).toEqual([]);
   });
 
   it("should return relationships with kind Template and cardinality many", () => {

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.test.ts
@@ -39,6 +39,17 @@ describe("getRelationshipsVisibleInTab", () => {
     expect(result).toEqual(relationships);
   });
 
+  it("should return relationships with kind Profile and cardinality many", () => {
+    // GIVEN
+    const relationships = [generateRelationshipSchema({ kind: "Profile", cardinality: "many" })];
+
+    // WHEN
+    const result = getRelationshipsVisibleInTab(relationships);
+
+    // THEN
+    expect(result).toEqual(relationships);
+  });
+
   it("should return relationships with kind Template and cardinality many", () => {
     // GIVEN
     const relationships = [generateRelationshipSchema({ kind: "Template", cardinality: "many" })];
@@ -76,7 +87,6 @@ describe("getRelationshipsVisibleInTab", () => {
       generateRelationshipSchema({ kind: "Attribute", cardinality: "many" }),
       generateRelationshipSchema({ kind: "Parent", cardinality: "many" }),
       generateRelationshipSchema({ kind: "Group", cardinality: "many" }),
-      generateRelationshipSchema({ kind: "Profile", cardinality: "many" }),
     ];
 
     // WHEN

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.ts
@@ -3,9 +3,10 @@ import type { RelationshipKind } from "@/entities/nodes/types";
 import type { RelationshipSchema } from "@/entities/schema/types";
 
 const RELATIONSHIP_KIND_VISIBLE_IN_TAB: Array<RelationshipKind> = [
-  "Generic",
   "Component",
+  "Generic",
   "Hierarchy",
+  "Profile",
   "Template",
 ];
 

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-tab.ts
@@ -6,9 +6,10 @@ const RELATIONSHIP_KIND_VISIBLE_IN_TAB: Array<RelationshipKind> = [
   "Component",
   "Generic",
   "Hierarchy",
-  "Profile",
   "Template",
 ];
+
+const PROFILE_RELATIONSHIP_NAMES_VISIBLE_IN_TAB = ["related_nodes", "related_templates"];
 
 export function isRelationshipVisibleInTab(relationshipSchema: RelationshipSchema): boolean {
   if (
@@ -16,6 +17,10 @@ export function isRelationshipVisibleInTab(relationshipSchema: RelationshipSchem
     isFromResourcePoolRelationship(relationshipSchema.name)
   ) {
     return false;
+  }
+
+  if (relationshipSchema.kind === "Profile") {
+    return PROFILE_RELATIONSHIP_NAMES_VISIBLE_IN_TAB.includes(relationshipSchema.name);
   }
 
   return RELATIONSHIP_KIND_VISIBLE_IN_TAB.includes(relationshipSchema.kind);


### PR DESCRIPTION

<img width="1442" height="336" alt="image" src="https://github.com/user-attachments/assets/6914d4d1-fad8-4fe4-8bd5-7542890ee459" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile details view now shows objects that reference or use the profile.

* **Tests**
  * Added tests confirming which profile relationships appear in the profile tab and that unrelated relationships remain hidden.

* **Documentation**
  * Added a changelog entry describing the profile relationships visibility update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->