### PR TITLE
explicitly set the HFID on resource pool schemas

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/resource_pool.py
+++ b/backend/infrahub/core/schema/definitions/core/resource_pool.py
@@ -62,6 +62,7 @@ core_ip_prefix_pool = NodeSchema(
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
     inherit_from=[InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
+    human_friendly_id=["name__value"],
     attributes=[
         Attr(
             name="default_prefix_length",
@@ -120,6 +121,7 @@ core_ip_address_pool = NodeSchema(
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
     inherit_from=[InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
+    human_friendly_id=["name__value"],
     attributes=[
         Attr(
             name="default_address_type",
@@ -169,6 +171,7 @@ core_number_pool = NodeSchema(
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
     inherit_from=[InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
+    human_friendly_id=["name__value"],
     attributes=[
         Attr(
             name="node",


### PR DESCRIPTION
this does not actually change the CoreNumberPool, CoreIPAddressPool, or CoreIPPrefixPool schemas. the HFID was already being set to `["name__value"]` b/c `name` is a unique attribute on the schemas. this PR just makes it explicit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced identification of resource pools (IP prefix, IP address, and number pools) to display with friendly names based on the resource name field for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->