### PR TITLE
Hide refresh and rebase actions on merged proposed changes

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -63,9 +63,9 @@ exports[`fix ts error`] = {
     "src/entities/diff/node-diff/conflict.tsx:1915762184": [
       [4, 39, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
-    "src/entities/diff/node-diff/index.tsx:331347187": [
-      [87, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
-      [108, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
+    "src/entities/diff/node-diff/index.tsx:1740748086": [
+      [90, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
+      [112, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],
     "src/entities/diff/node-diff/node-property.tsx:2777655921": [
       [27, 22, 17, "tsc: Property \'base_branch_label\' does not exist on type \'DiffConflict\'. Did you mean \'base_branch_value\'?", "1959743778"],

--- a/frontend/app/src/entities/diff/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/node-diff/index.tsx
@@ -24,6 +24,7 @@ import { DiffNoFound } from "@/entities/diff/ui/diff-no-found";
 import { DiffRebaseButton } from "@/entities/diff/ui/diff-rebase-button";
 import { DiffRefreshButton } from "@/entities/diff/ui/diff-refresh-button";
 import DiffTree from "@/entities/diff/ui/diff-tree";
+import { MERGE_STATE } from "@/entities/proposed-changes/constants";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 import { DiffFilter } from "@/entities/proposed-changes/ui/diff-filter";
 
@@ -38,6 +39,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
   // When branch prop is provided, we're in branch diff view - use only the branch prop
   // When no branch prop, we're in proposed change view - use source_branch from proposedChangesDetails
   const branchName: string = branch || proposedChangesDetails?.source_branch?.value;
+  const isMerged = proposedChangesDetails?.state?.value === MERGE_STATE;
   const branchExists = useBranchExists(branchName);
 
   // Get filters merged with status filter
@@ -77,6 +79,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
       <DiffComputing
         sourceBranch={branchName}
         destinationBranch={proposedChangesDetails.destination_branch?.value ?? DEFAULT_BRANCH_NAME}
+        hideActions={isMerged}
       />
     );
   }
@@ -87,6 +90,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
         branchName={branchName}
         lastRefreshedAt={firstPageNodes.to_time}
         branchExists={branchExists}
+        hideActions={isMerged}
       />
     );
   }
@@ -108,7 +112,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
         <span className="ml-auto inline-flex gap-1 text-xs">
           Updated <DateDisplay date={firstPageNodes?.to_time} />
         </span>
-        {branchExists && (
+        {branchExists && !isMerged && (
           <>
             <DiffRefreshButton size="sm" variant="primary" branchName={branchName} />
             <DiffRebaseButton branchName={branchName} />

--- a/frontend/app/src/entities/diff/ui/diff-computing.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-computing.tsx
@@ -8,9 +8,10 @@ import { DiffRefreshButton } from "@/entities/diff/ui/diff-refresh-button";
 export interface DiffComputingProps {
   sourceBranch: string;
   destinationBranch: string;
+  hideActions?: boolean;
 }
 
-export function DiffComputing({ sourceBranch, destinationBranch }: DiffComputingProps) {
+export function DiffComputing({ sourceBranch, destinationBranch, hideActions }: DiffComputingProps) {
   return (
     <div className="mt-10 flex flex-col items-center gap-5">
       <LoadingIndicator message="" />
@@ -33,7 +34,7 @@ export function DiffComputing({ sourceBranch, destinationBranch }: DiffComputing
         <p>Once completed, you&apos;ll be able to view the detailed changes.</p>
       </div>
 
-      <DiffRefreshButton branchName={sourceBranch} />
+      {!hideActions && <DiffRefreshButton branchName={sourceBranch} />}
     </div>
   );
 }

--- a/frontend/app/src/entities/diff/ui/diff-computing.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-computing.tsx
@@ -11,7 +11,11 @@ export interface DiffComputingProps {
   hideActions?: boolean;
 }
 
-export function DiffComputing({ sourceBranch, destinationBranch, hideActions }: DiffComputingProps) {
+export function DiffComputing({
+  sourceBranch,
+  destinationBranch,
+  hideActions,
+}: DiffComputingProps) {
   return (
     <div className="mt-10 flex flex-col items-center gap-5">
       <LoadingIndicator message="" />

--- a/frontend/app/src/entities/diff/ui/diff-empty.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-empty.tsx
@@ -9,9 +9,10 @@ export interface DiffEmptyProps {
   branchName: string;
   lastRefreshedAt: Date;
   branchExists?: boolean;
+  hideActions?: boolean;
 }
 
-export function DiffEmpty({ branchName, lastRefreshedAt, branchExists = true }: DiffEmptyProps) {
+export function DiffEmpty({ branchName, lastRefreshedAt, branchExists = true, hideActions }: DiffEmptyProps) {
   return (
     <div className="my-10 flex flex-col items-center gap-5">
       <div className="inline-flex rounded-full bg-white p-3">
@@ -27,10 +28,10 @@ export function DiffEmpty({ branchName, lastRefreshedAt, branchExists = true }: 
           </Tooltip>
           .
         </p>
-        {branchExists && <p>If you have made any changes, please refresh the diff:</p>}
+        {branchExists && !hideActions && <p>If you have made any changes, please refresh the diff:</p>}
       </div>
 
-      {branchExists && <DiffRefreshButton branchName={branchName} />}
+      {branchExists && !hideActions && <DiffRefreshButton branchName={branchName} />}
     </div>
   );
 }

--- a/frontend/app/src/entities/diff/ui/diff-empty.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-empty.tsx
@@ -12,7 +12,12 @@ export interface DiffEmptyProps {
   hideActions?: boolean;
 }
 
-export function DiffEmpty({ branchName, lastRefreshedAt, branchExists = true, hideActions }: DiffEmptyProps) {
+export function DiffEmpty({
+  branchName,
+  lastRefreshedAt,
+  branchExists = true,
+  hideActions,
+}: DiffEmptyProps) {
   return (
     <div className="my-10 flex flex-col items-center gap-5">
       <div className="inline-flex rounded-full bg-white p-3">
@@ -28,7 +33,9 @@ export function DiffEmpty({ branchName, lastRefreshedAt, branchExists = true, hi
           </Tooltip>
           .
         </p>
-        {branchExists && !hideActions && <p>If you have made any changes, please refresh the diff:</p>}
+        {branchExists && !hideActions && (
+          <p>If you have made any changes, please refresh the diff:</p>
+        )}
       </div>
 
       {branchExists && !hideActions && <DiffRefreshButton branchName={branchName} />}


### PR DESCRIPTION
<img width="1296" height="942" alt="image" src="https://github.com/user-attachments/assets/be62f518-f3da-40c4-8388-a336a32b8d9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Action buttons (refresh and rebase) are hidden when a change is merged, removing irrelevant controls.
  * Diff views suppress guidance text and action controls for merged branches to declutter the interface.
  * Header action buttons now appear only for existing, non-merged branches, making available actions clearer and context-appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->