### PR TITLE
Fix IPAM view failing to load when more than 40 IP namespaces exist

### DIFF
--- a/changelog/8481.fixed.md
+++ b/changelog/8481.fixed.md
@@ -1,0 +1,1 @@
+Fix IPAM view failing to load when more than 40 IP namespaces exist.

--- a/frontend/app/src/entities/ipam/constants.ts
+++ b/frontend/app/src/entities/ipam/constants.ts
@@ -1,6 +1,7 @@
 import type { Filter } from "@/shared/hooks/useFilters";
 
 export const IP_NAMESPACE_GENERIC = "BuiltinIPNamespace";
+export const IP_NAMESPACE_KIND = "IpamNamespace";
 export const IP_ADDRESS_GENERIC = "BuiltinIPAddress";
 export const IP_ADDRESS_AVAILABLE_KIND = "InternalIPRangeAvailable" as const;
 export const IP_PREFIX_GENERIC = "BuiltinIPPrefix";

--- a/frontend/app/src/entities/ipam/ip-namespaces/domain/get-ip-namespace.query.ts
+++ b/frontend/app/src/entities/ipam/ip-namespaces/domain/get-ip-namespace.query.ts
@@ -1,0 +1,47 @@
+import { IP_NAMESPACE_GENERIC, IP_NAMESPACE_KIND } from "@/entities/ipam/constants";
+import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
+import { useObjects } from "@/entities/nodes/object/domain/get-objects.query";
+import type { NodeObject } from "@/entities/nodes/types";
+import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
+
+const DEFAULT_NAMESPACE_FILTERS = [{ name: "default__value", value: true }];
+
+/**
+ * Fetches a single IP namespace — either by ID or the default one.
+ *
+ * Two different hooks and schemas are needed because:
+ * - By ID: queries BuiltinIPNamespace (the generic) so it works with any concrete
+ *   namespace schema, including custom ones that inherit from the generic.
+ * - Default: queries IpamNamespace (the concrete) because the `default` attribute
+ *   only exists on this type, not on the generic. IpamNamespace is always present
+ *   since Infrahub creates it automatically.
+ *
+ * Only one hook is enabled at a time based on whether an ID is provided.
+ */
+export function useGetIpNamespace({ ipNamespaceId }: { ipNamespaceId?: string | null } = {}): {
+  data: NodeObject | undefined;
+  isPending: boolean;
+  error: Error | null;
+} {
+  const { schema: genericSchema } = useSchema(IP_NAMESPACE_GENERIC, { throwIfNotFound: true });
+  const { schema: concreteSchema } = useSchema(IP_NAMESPACE_KIND, { throwIfNotFound: true });
+
+  const byIdQuery = useGetObject(
+    { objectSchema: genericSchema, objectId: ipNamespaceId ?? "" },
+    { enabled: !!ipNamespaceId }
+  );
+
+  const defaultQuery = useObjects(
+    { schema: concreteSchema, filters: DEFAULT_NAMESPACE_FILTERS },
+    { enabled: !ipNamespaceId }
+  );
+
+  if (ipNamespaceId) {
+    return byIdQuery;
+  }
+
+  return {
+    ...defaultQuery,
+    data: defaultQuery.data?.pages?.[0]?.[0],
+  };
+}

--- a/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-provider.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-provider.tsx
@@ -9,14 +9,15 @@ import ErrorScreen from "@/shared/components/errors/error-screen";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 
 import { IP_ADDRESS_GENERIC, IPAM_QSP } from "@/entities/ipam/constants";
+import { useGetIpNamespace } from "@/entities/ipam/ip-namespaces/domain/get-ip-namespace.query";
 import type { IpNamespace } from "@/entities/ipam/ip-namespaces/domain/get-ip-namespace-list";
-import { useGetIpNamespaceList } from "@/entities/ipam/ip-namespaces/domain/get-ip-namespace-list.query";
 import { constructPathForIpam } from "@/entities/ipam/utils";
+import type { NodeObject } from "@/entities/nodes/types";
 import { getSchema } from "@/entities/schema/domain/get-schema";
 import { isOfKind } from "@/entities/schema/utils/is-of-kind";
 
 type IpNamespaceContext = {
-  currentIpNamespace: IpNamespace;
+  currentIpNamespace: NodeObject;
   setCurrentIpNamespace: (newIpNamespace: IpNamespace) => void;
 };
 
@@ -26,29 +27,23 @@ export function IpNamespaceProvider({ children }: { children: React.ReactNode })
   const { objectKind } = useParams();
   const navigate = useNavigate();
   const [namespaceQSP] = useQueryState(IPAM_QSP.NAMESPACE);
-  const { data, error, isPending } = useGetIpNamespaceList();
+
+  const {
+    data: currentIpNamespace,
+    isPending,
+    error,
+  } = useGetIpNamespace({ ipNamespaceId: namespaceQSP });
 
   if (isPending) {
     return <LoadingIndicator className="h-full" message="Loading IP namespaces..." />;
   }
 
-  if (error) {
-    return <ErrorScreen message={error.message} />;
-  }
-
-  const namespaceList = data.pages.flat() ?? [];
-
-  const selectedNamespace = namespaceList.find((namespace) => {
-    if (namespaceQSP) return namespace.id === namespaceQSP;
-    return !!namespace.default?.value;
-  });
-
-  if (!selectedNamespace) {
+  if (error || !currentIpNamespace) {
     return (
       <ErrorScreen
         message={
           <Col className="items-center">
-            <span>{`IP Namespace ${namespaceQSP ?? "default"} not found.`}</span>
+            <span>{error?.message ?? `IP Namespace ${namespaceQSP ?? "default"} not found.`}</span>
             <Link
               to={constructPath("/ipam")}
               className="inline-flex items-center gap-2 text-indigo-700 hover:underline"
@@ -64,7 +59,7 @@ export function IpNamespaceProvider({ children }: { children: React.ReactNode })
   return (
     <IpNamespaceContext.Provider
       value={{
-        currentIpNamespace: selectedNamespace,
+        currentIpNamespace,
         setCurrentIpNamespace: (newIpNamespace) => {
           const newIpNamespaceId = newIpNamespace.default?.value ? null : newIpNamespace.id;
 

--- a/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
@@ -102,7 +102,7 @@ test.describe("/ipam - IP Namespace", () => {
 
   test("shows error when ip namespace does not exist", async ({ page }) => {
     await page.goto(`/ipam?namespace=non-existent&branch=${BRANCH_NAME}`);
-    await expect(page.getByText("IP Namespace non-existent not found.")).toBeVisible();
+    await expect(page.getByText("Cannot find IP Namespace with id non-existent")).toBeVisible();
 
     await page.getByRole("link", { name: "Go to default IP namespace" }).click();
     await expect(page.getByTestId("namespace-select")).toContainText("default");


### PR DESCRIPTION
issue: https://github.com/opsmill/infrahub/issues/8481

In environments with more than 40 IP namespaces, the IPAM view could show "IP Namespace default not found" and refuse to load. The default namespace is now fetched directly instead of searching through a paginated list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPAM view failing to load when more than 40 IP namespaces exist.

* **Improved Behavior**
  * Namespace loading now supports direct-by-ID and default lookups and exposes the current namespace directly for more reliable selection.

* **Tests**
  * Updated end-to-end expectation for IP Namespace not-found error message.

* **Documentation**
  * Added changelog entry documenting the IPAM view fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->