### PR TITLE
add _from_resource_pool relationships for Number attributes on Templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2482,6 +2482,39 @@ class SchemaBranch:
 
                 self.set(name=node_name, schema=node_schema)
 
+    def _create_attribute_resource_pool_relationship(self, attr: AttributeSchema) -> RelationshipSchema | None:
+        """Create a resource pool relationship for a Number attribute on a template.
+
+        When a Number attribute supports templates, this creates a corresponding relationship
+        to CoreNumberPool so the template can reference a pool for allocation.
+
+        Args:
+            attr: The attribute schema from the original node
+
+        Returns:
+            A RelationshipSchema for the resource pool relationship, or None if not applicable
+        """
+        if attr.kind != "Number":
+            return None
+
+        pool_rel_name = f"{attr.name}{RESOURCE_POOL_REL_SUFFIX}"
+        pool_identifier = f"{attr.name}{RESOURCE_POOL_REL_SUFFIX}".lower()
+        pool_label = attr.name.replace("_", " ").title() + " from Resource Pool"
+
+        return RelationshipSchema(
+            name=pool_rel_name,
+            peer=InfrahubKind.NUMBERPOOL,
+            description=f"Generated relationship for using a resource pool on the '{attr.name}' attribute",
+            kind=RelationshipKind.GENERIC,
+            optional=True,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.OUTBOUND,
+            branch=attr.branch,
+            identifier=pool_identifier,
+            label=pool_label,
+            inherited=attr.inherited,
+        )
+
     def _create_resource_pool_relationship(self, relationship: RelationshipSchema) -> RelationshipSchema | None:
         """Create a resource pool relationship for IP address or prefix relationships.
 
@@ -2515,8 +2548,8 @@ class SchemaBranch:
             return None
 
         pool_rel_name = f"{relationship.name}{RESOURCE_POOL_REL_SUFFIX}"
-        pool_identifier = f"{relationship.get_identifier()}{RESOURCE_POOL_REL_SUFFIX}"
-        pool_label = relationship.name.title() + " from Resource Pool"
+        pool_identifier = f"{relationship.get_identifier()}{RESOURCE_POOL_REL_SUFFIX}".lower()
+        pool_label = relationship.name.title().replace("_", " ") + " from Resource Pool"
 
         return RelationshipSchema(
             name=pool_rel_name,
@@ -2602,6 +2635,14 @@ class SchemaBranch:
             ):
                 template_schema.human_friendly_id = [parent_hfid] + template_schema.human_friendly_id
                 template_schema.uniqueness_constraints[0].append(relationship.name)
+
+        # Add resource pool relationships for eligible attributes (e.g., Number → CoreNumberPool)
+        for node_attr in node.attributes:
+            if not node_attr.support_templates:
+                continue
+            attr_pool_relationship = self._create_attribute_resource_pool_relationship(attr=node_attr)
+            if attr_pool_relationship:
+                template_schema.relationships.append(attr_pool_relationship)
 
         if getattr(node, "generate_profile", False):
             if PROFILES_RELATIONSHIP_NAME not in [r.name for r in template_schema.relationships]:

--- a/backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py
+++ b/backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py
@@ -1,7 +1,10 @@
+
 from infrahub.core.constants import (
     InfrahubKind,
     RelationshipCardinality,
+    RelationshipKind,
 )
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.schema import (
     AttributeSchema,
     NodeSchema,
@@ -128,3 +131,53 @@ async def test_manage_object_templates_with_resource_pool_relationships() -> Non
     assert ip_prefix_pool_rel.peer == InfrahubKind.IPPREFIXPOOL
     assert ip_prefix_pool_rel.cardinality == RelationshipCardinality.ONE
     assert ip_prefix_pool_rel.optional is True
+
+
+async def test_number_attribute_generates_pool_relationship() -> None:
+    """Test that Number attributes on templates get _from_resource_pool relationships to CoreNumberPool."""
+    schema_branch = SchemaBranch(cache={}, name="test")
+
+    test_schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Device",
+                namespace="Infra",
+                generate_template=True,
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                    AttributeSchema(name="vlan_id", kind="Number"),
+                    AttributeSchema(name="asn", kind="Number"),
+                    AttributeSchema(name="unique_number", kind="Number", unique=True),
+                    AttributeSchema(name="read_only_number", kind="Number", read_only=True),
+                    AttributeSchema(name="description", kind="Text"),
+                    AttributeSchema(name="active", kind="Boolean"),
+                ],
+            ),
+        ]
+    )
+
+    schema_branch.load_schema(schema=SchemaRoot(**core_models).merge(schema=test_schema))
+    schema_branch.generate_identifiers()
+    schema_branch.process_inheritance()
+    schema_branch.manage_object_template_schemas()
+    schema_branch.manage_object_template_relationships()
+
+    device_template = schema_branch.get_template("TemplateInfraDevice", duplicate=False)
+
+    resource_pool_rel_names = {
+        r_name for r_name in device_template.relationship_names if r_name.endswith(RESOURCE_POOL_REL_SUFFIX)
+    }
+    assert resource_pool_rel_names == {f"vlan_id{RESOURCE_POOL_REL_SUFFIX}", f"asn{RESOURCE_POOL_REL_SUFFIX}"}
+
+    # Verify pool relationships exist for both Number attributes
+    vlan_pool_rel = device_template.get_relationship("vlan_id_from_resource_pool")
+    assert vlan_pool_rel.peer == InfrahubKind.NUMBERPOOL
+    assert vlan_pool_rel.cardinality == RelationshipCardinality.ONE
+    assert vlan_pool_rel.optional is True
+    assert vlan_pool_rel.kind == RelationshipKind.GENERIC
+
+    asn_pool_rel = device_template.get_relationship("asn_from_resource_pool")
+    assert asn_pool_rel.peer == InfrahubKind.NUMBERPOOL
+    assert asn_pool_rel.cardinality == RelationshipCardinality.ONE
+    assert asn_pool_rel.optional is True
+    assert asn_pool_rel.kind == RelationshipKind.GENERIC

--- a/backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py
+++ b/backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py
@@ -1,4 +1,3 @@
-
 from infrahub.core.constants import (
     InfrahubKind,
     RelationshipCardinality,


### PR DESCRIPTION
add the generated `<attr_name>_from_resource_pool` relationships to `CoreNumberPool` for `kind=Number` attributes when generating a template schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Number attributes on templates can now automatically reference resource pools
  * Enhanced resource pool relationship naming with improved formatting consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->