### PR TITLE
provision number pools from templates using `_from_resource_pool` rels

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -107,7 +107,7 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         async def allocate_numbers(db: InfrahubDatabase) -> None:
             for node in nodes:
                 number = await number_pool.get_resource(  # type: ignore[attr-defined]
-                    db=db, branch=branch, node=node, attribute=self.new_attribute_schema, at=at
+                    db=db, branch=branch, identifier=node.get_id(), attribute=self.new_attribute_schema, at=at
                 )
                 attr = node.get_attribute(name=self.new_attribute_schema.name)
                 attr.value = number

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -432,7 +432,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         ):
             try:
                 next_free = await number_pool.get_resource(
-                    db=db, branch=self._branch, node=self, attribute=attribute.schema
+                    db=db, branch=self._branch, identifier=self.get_id(), attribute=attribute.schema
                 )
             except PoolExhaustedError as exc:
                 raise ValidationError(

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -157,6 +157,7 @@ async def allocate_from_resource_pools(
             )  # type: ignore
             attribute = obj.get_attribute(name=original_name)
             attribute.value = allocated_value
+            attribute.is_default = False
             attribute.source = pool.id  # type: ignore[assignment]
         elif original_name in obj_schema.relationship_names:
             # IP pool: allocate a node and set it as the relationship peer

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -6,7 +6,6 @@ from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.constants import (
     SYSTEM_USER_ID,
-    InfrahubKind,
     MetadataOptions,
     RelationshipCardinality,
     RelationshipKind,
@@ -62,20 +61,6 @@ async def extract_peer_data(
             continue
 
         template_attr = template_peer.get_attribute(name=attr_name)
-
-        # NumberPool from_pool handling requires two code paths:
-        # 1. Template just created in-memory: from_pool is set but not yet persisted
-        # 2. Template loaded from DB: from_pool is not persisted, must reconstruct from source
-        if template_attr.from_pool:
-            obj_peer_data[attr_name] = {"from_pool": template_attr.from_pool}
-            continue
-
-        if template_attr.value is None and template_attr.source_id:  # type: ignore
-            source = await template_attr.get_source(db=db)
-            if source and source.get_kind() == InfrahubKind.NUMBERPOOL:
-                obj_peer_data[attr_name] = {"from_pool": {"id": source.id}}
-                continue
-
         if template_attr.value is None:
             continue
         if template_attr.is_default:
@@ -143,7 +128,13 @@ async def allocate_from_resource_pools(
     at: Timestamp | None = None,
     user_id: str = SYSTEM_USER_ID,
 ) -> None:
-    """Allocate resources from template's _from_resource_pool relationships to the object."""
+    """Allocate resources from template's _from_resource_pool relationships to the object.
+
+    Handles two cases:
+    - Relationship pools (IP address/prefix): allocates a new node and sets it as the relationship peer
+    - Attribute pools (Number): allocates a value and sets it on the attribute
+    The pool is set as the source of the attribute/relationship in either case
+    """
     template_schema = template.get_schema()
     obj_schema = obj.get_schema()
 
@@ -151,23 +142,33 @@ async def allocate_from_resource_pools(
         if not rel_schema.name.endswith(RESOURCE_POOL_REL_SUFFIX):
             continue
 
-        original_rel_name = rel_schema.name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
-
-        if original_rel_name not in obj_schema.relationship_names:
-            continue
+        original_name = rel_schema.name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
 
         pool_rel_manager = template.get_relationship(name=rel_schema.name)
         pool = await pool_rel_manager.get_peer(db=db)
         if not pool:
             continue
 
-        allocated_resource = await pool.get_resource(db=db, branch=branch, identifier=obj.id, at=at, user_id=user_id)  # type: ignore
-        NodeCreationContext.record_if_active(node=allocated_resource)
+        if original_name in obj_schema.attribute_names:
+            # Number pool: allocate a value and set it on the attribute
+            attr_schema = obj_schema.get_attribute(name=original_name)
+            allocated_value = await pool.get_resource(  # type: ignore[attr-defined]
+                db=db, branch=branch, identifier=obj.get_id(), attribute=attr_schema
+            )  # type: ignore
+            attribute = obj.get_attribute(name=original_name)
+            attribute.value = allocated_value
+            attribute.source = pool.id  # type: ignore[assignment]
+        elif original_name in obj_schema.relationship_names:
+            # IP pool: allocate a node and set it as the relationship peer
+            allocated_resource = await pool.get_resource(  # type: ignore[attr-defined]
+                db=db, branch=branch, identifier=obj.get_id(), at=at, user_id=user_id
+            )  # type: ignore
+            NodeCreationContext.record_if_active(node=allocated_resource)
 
-        obj_rel_manager = obj.get_relationship(name=original_rel_name)
-        await obj_rel_manager.update(
-            data=PeerWithRelationshipMetadata(peer=allocated_resource, source_id=pool.id), db=db
-        )
+            obj_rel_manager = obj.get_relationship(name=original_name)
+            await obj_rel_manager.update(
+                data=PeerWithRelationshipMetadata(peer=allocated_resource, source_id=pool.id), db=db
+            )
 
 
 async def handle_template_relationships(

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -86,16 +86,14 @@ class CoreNumberPool(Node):
         self,
         db: InfrahubDatabase,
         branch: Branch,
-        node: Node,
         attribute: AttributeSchema,
-        identifier: str | None = None,
+        identifier: str,
         at: Timestamp | None = None,
     ) -> int:
         async with lock.registry.get(name=self.get_id(), namespace=RESOURCE_POOL_LOCK_NAMESPACE):
             # NOTE: ideally we should use the HFID as the identifier (if available)
             # one of the challenge with using the HFID is that it might change over time
             # so we need to ensure that the identifier is stable, or we need to handle the case where the identifier changes
-            identifier = identifier or node.get_id()
 
             # Check if there is already a resource allocated with this identifier
             # if not, pull all existing number and allocate the next available

--- a/backend/infrahub/pools/allocator.py
+++ b/backend/infrahub/pools/allocator.py
@@ -4,17 +4,23 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from infrahub.core.attribute import BaseAttribute
     from infrahub.core.node import Node
     from infrahub.core.relationship.model import RelationshipManager
+    from infrahub.core.schema import MainSchemaTypes
 
 
 class PoolAllocator(ABC):
     """Interface for pool allocation strategies."""
 
     @abstractmethod
-    async def allocate_for_attribute(self, attribute: BaseAttribute, identifier: str) -> Any | None:
-        """Allocate from pool for an attribute (e.g. NumberPool)."""
+    async def allocate_for_attribute(
+        self,
+        pool_relationship: RelationshipManager,
+        target_schema: MainSchemaTypes,
+        attribute_name: str,
+        identifier: str,
+    ) -> Any | None:
+        """Allocate from a _from_resource_pool relationship for an attribute (e.g., Number → CoreNumberPool)."""
 
     @abstractmethod
     async def allocate_for_relationship(self, pool_relationship: RelationshipManager, identifier: str) -> Node | None:

--- a/backend/infrahub/pools/default_allocator.py
+++ b/backend/infrahub/pools/default_allocator.py
@@ -33,7 +33,6 @@ class DefaultPoolAllocator(PoolAllocator):
             return None
 
         attr_schema = target_schema.get_attribute(name=attribute_name)
-        # NumberPool.get_resource needs a node-like object for identifier; use identifier directly
         return await pool.get_resource(db=self.db, branch=self.branch, identifier=identifier, attribute=attr_schema)  # type: ignore[attr-defined]
 
     async def allocate_for_relationship(self, pool_relationship: RelationshipManager, identifier: str) -> Node | None:

--- a/backend/infrahub/pools/default_allocator.py
+++ b/backend/infrahub/pools/default_allocator.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from infrahub.core import registry
 from infrahub.core.creation_context import NodeCreationContext
-from infrahub.core.protocols import CoreNumberPool
-from infrahub.exceptions import NodeNotFoundError, PoolExhaustedError, ValidationError
 from infrahub.pools.allocator import PoolAllocator
 
 if TYPE_CHECKING:
-    from infrahub.core.attribute import BaseAttribute
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.core.relationship.model import RelationshipManager
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.database import InfrahubDatabase
 
 
@@ -25,36 +22,19 @@ class DefaultPoolAllocator(PoolAllocator):
 
     async def allocate_for_attribute(
         self,
-        attribute: BaseAttribute,
-        identifier: str,  # noqa: ARG002
+        pool_relationship: RelationshipManager,
+        target_schema: MainSchemaTypes,
+        attribute_name: str,
+        identifier: str,
     ) -> Any | None:
-        """Allocate from pool if attribute references one."""
-        if not attribute.from_pool:
+        """Allocate from a _from_resource_pool relationship for an attribute (Number → CoreNumberPool)."""
+        pool = await pool_relationship.get_peer(db=self.db)
+        if not pool:
             return None
 
-        pool_id = attribute.from_pool.get("id")
-        if not pool_id:
-            return None
-
-        try:
-            number_pool = await registry.manager.get_one(
-                db=self.db, id=pool_id, kind=CoreNumberPool, raise_on_error=True
-            )
-        except NodeNotFoundError as exc:
-            raise ValidationError(
-                {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
-            ) from exc
-
-        try:
-            next_value = await number_pool.get_resource(  # type: ignore
-                db=self.db, branch=self.branch, node=attribute.node, attribute=attribute.schema
-            )
-        except PoolExhaustedError as exc:
-            raise ValidationError(
-                {f"{attribute.name}.from_pool": f"The pool {number_pool.name.value} is exhausted."}
-            ) from exc
-
-        return next_value
+        attr_schema = target_schema.get_attribute(name=attribute_name)
+        # NumberPool.get_resource needs a node-like object for identifier; use identifier directly
+        return await pool.get_resource(db=self.db, branch=self.branch, identifier=identifier, attribute=attr_schema)  # type: ignore[attr-defined]
 
     async def allocate_for_relationship(self, pool_relationship: RelationshipManager, identifier: str) -> Node | None:
         """Allocate from pool referenced by relationship."""

--- a/backend/infrahub/pools/noop_allocator.py
+++ b/backend/infrahub/pools/noop_allocator.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from infrahub.core.attribute import BaseAttribute
     from infrahub.core.node import Node
     from infrahub.core.relationship.model import RelationshipManager
+    from infrahub.core.schema import MainSchemaTypes
 
 from infrahub.pools.allocator import PoolAllocator
 
@@ -13,7 +13,13 @@ from infrahub.pools.allocator import PoolAllocator
 class NoOpPoolAllocator(PoolAllocator):
     """Pool allocator that skips all allocations."""
 
-    async def allocate_for_attribute(self, attribute: BaseAttribute, identifier: str) -> Any | None:  # noqa: ARG002
+    async def allocate_for_attribute(
+        self,
+        pool_relationship: RelationshipManager,  # noqa: ARG002
+        target_schema: MainSchemaTypes,  # noqa: ARG002
+        attribute_name: str,  # noqa: ARG002
+        identifier: str,  # noqa: ARG002
+    ) -> Any | None:
         return None
 
     async def allocate_for_relationship(self, pool_relationship: RelationshipManager, identifier: str) -> Node | None:  # noqa: ARG002

--- a/backend/infrahub/templates/node_applier.py
+++ b/backend/infrahub/templates/node_applier.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from infrahub.core.constants import (
     OBJECT_TEMPLATE_NAME_ATTR,
     OBJECT_TEMPLATE_RELATIONSHIP_NAME,
-    InfrahubKind,
     RelationshipCardinality,
     RelationshipKind,
 )
@@ -30,14 +29,16 @@ class NodeTemplateApplier:
     async def apply(
         self,
         template: CoreObjectTemplate,
-        target_schema: MainSchemaTypes,  # noqa: ARG002
+        target_schema: MainSchemaTypes,
         target_id: str,
         user_fields: dict[str, Any],
     ) -> dict[str, Any]:
         """Apply template and return merged fields. User fields take precedence."""
         fields = dict(user_fields)
         await self._apply_attributes(template=template, fields=fields)
-        await self._apply_relationships(template=template, target_id=target_id, fields=fields)
+        await self._apply_relationships(
+            template=template, target_schema=target_schema, target_id=target_id, fields=fields
+        )
         return fields
 
     async def _apply_attributes(self, template: CoreObjectTemplate, fields: dict[str, Any]) -> None:
@@ -46,35 +47,29 @@ class NodeTemplateApplier:
                 continue
 
             attr = template.get_attribute(name=attr_name)
-
-            # NumberPool from_pool handling requires two code paths:
-            # 1. Template just created in-memory: from_pool is set but not yet persisted
-            # 2. Template loaded from DB: from_pool is not persisted, must reconstruct from source
-            if attr.from_pool:
-                fields[attr_name] = {"from_pool": attr.from_pool}
+            if attr.value is None:
                 continue
 
-            if attr.value is None and attr.source_id:  # type: ignore[attr-defined]
-                source = await attr.get_source(db=self.db)
-                if source and source.get_kind() == InfrahubKind.NUMBERPOOL:
-                    fields[attr_name] = {"from_pool": {"id": source.id}}
-                    continue
+            # source_id is dynamically set by NodePropertyMixin._init_node_property_mixin hence the type hint ignore
+            field_data: dict[str, Any] = {"value": attr.value, "source": attr.source_id or template.id}  # type: ignore[attr-defined]
+            if attr.is_from_profile:
+                field_data["is_from_profile"] = True
+            fields[attr_name] = field_data
 
-            if attr.value is not None:
-                # source_id is dynamically set by NodePropertyMixin._init_node_property_mixin hence the type hint ignore
-                field_data: dict[str, Any] = {"value": attr.value, "source": attr.source_id or template.id}  # type: ignore[attr-defined]
-                if attr.is_from_profile:
-                    field_data["is_from_profile"] = True
-                fields[attr_name] = field_data
-
-    async def _apply_relationships(self, template: CoreObjectTemplate, target_id: str, fields: dict[str, Any]) -> None:
+    async def _apply_relationships(
+        self, template: CoreObjectTemplate, target_schema: MainSchemaTypes, target_id: str, fields: dict[str, Any]
+    ) -> None:
         template_schema = template.get_schema()
         for rel_name in template_schema.relationship_names:
             rel_schema = template_schema.get_relationship(name=rel_name)
 
             if rel_name.endswith(RESOURCE_POOL_REL_SUFFIX):
                 await self._handle_pool_relationship(
-                    template=template, pool_rel_name=rel_name, target_id=target_id, fields=fields
+                    template=template,
+                    pool_rel_name=rel_name,
+                    target_schema=target_schema,
+                    target_id=target_id,
+                    fields=fields,
                 )
                 continue
 
@@ -95,19 +90,37 @@ class NodeTemplateApplier:
                 fields[rel_name] = [{"id": peer_id} for peer_id in peers]
 
     async def _handle_pool_relationship(
-        self, template: CoreObjectTemplate, pool_rel_name: str, target_id: str, fields: dict[str, Any]
+        self,
+        template: CoreObjectTemplate,
+        pool_rel_name: str,
+        target_schema: MainSchemaTypes,
+        target_id: str,
+        fields: dict[str, Any],
     ) -> None:
-        """Allocate from pool and set the original relationship."""
-        original_rel_name = pool_rel_name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
+        """Allocate from pool and set the original relationship or attribute."""
+        original_name = pool_rel_name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
 
-        if original_rel_name in fields:
+        if original_name in fields:
             return
 
         pool_relationship = template.get_relationship(name=pool_rel_name)
+
+        if original_name in target_schema.attribute_names:
+            # Number pool: allocate a value for the attribute
+            allocated_value = await self.pool_allocator.allocate_for_attribute(
+                pool_relationship=pool_relationship,
+                target_schema=target_schema,
+                attribute_name=original_name,
+                identifier=target_id,
+            )
+            if allocated_value is not None:
+                pool_node = await pool_relationship.get_peer(db=self.db, raise_on_error=True)
+                fields[original_name] = {"value": allocated_value, "source": pool_node.id}
+            return
+        # IP pool: allocate a node for the relationship
         allocated = await self.pool_allocator.allocate_for_relationship(
             pool_relationship=pool_relationship, identifier=target_id
         )
-
         if allocated:
             pool_node = await pool_relationship.get_peer(db=self.db, raise_on_error=True)
-            fields[original_rel_name] = {"peer": allocated, "_relation__source": pool_node.id}
+            fields[original_name] = {"peer": allocated, "_relation__source": pool_node.id}

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -14,7 +14,7 @@ from infrahub.core.node.create import create_node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.schema import AttributeSchema, RelationshipSchema
-from infrahub.exceptions import PoolExhaustedError, ValidationError
+from infrahub.exceptions import NodeNotFoundError, PoolExhaustedError
 from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA
 
@@ -307,36 +307,40 @@ async def number_pool(
     return pool
 
 
-async def test_template_with_number_pool_attribute_does_not_allocate(
+async def test_template_with_number_pool_relationship_does_not_allocate(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
 ) -> None:
-    """Template with from_pool attribute should store reference but not allocate."""
+    """Template with _from_resource_pool relationship should store pool reference but not allocate."""
     template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
 
     template = await Node.init(schema=template_schema, db=db, branch=default_branch)
     await template.new(
-        db=db, template_name="device-template-with-pool-attr", rack_unit={"from_pool": {"id": number_pool.id}}
+        db=db,
+        template_name="device-template-with-pool-attr",
+        rack_unit_from_resource_pool={"id": number_pool.id},
     )
     await template.save(db=db)
 
     assert template.id is not None
     assert template.rack_unit.value is None
 
-    source = await template.rack_unit.get_source(db=db)
-    assert source is not None
-    assert source.id == number_pool.id
+    pool_rel = await template.rack_unit_from_resource_pool.get_peer(db=db)
+    assert pool_rel is not None
+    assert pool_rel.id == number_pool.id
 
 
 async def test_object_from_template_with_number_pool_allocates_value(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
 ) -> None:
-    """Object created from template should allocate from the NumberPool."""
+    """Object created from template should allocate from the NumberPool via _from_resource_pool relationship."""
     template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
     node_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
 
     template = await Node.init(schema=template_schema, db=db, branch=default_branch)
     await template.new(
-        db=db, template_name="device-template-for-number-allocation", rack_unit={"from_pool": {"id": number_pool.id}}
+        db=db,
+        template_name="device-template-for-number-allocation",
+        rack_unit_from_resource_pool={"id": number_pool.id},
     )
     await template.save(db=db)
 
@@ -372,7 +376,9 @@ async def test_object_from_template_with_explicit_value_uses_explicit(
 
     template = await Node.init(schema=template_schema, db=db, branch=default_branch)
     await template.new(
-        db=db, template_name="device-template-explicit-override", rack_unit={"from_pool": {"id": number_pool.id}}
+        db=db,
+        template_name="device-template-explicit-override",
+        rack_unit_from_resource_pool={"id": number_pool.id},
     )
     await template.save(db=db)
 
@@ -399,7 +405,7 @@ async def test_object_from_template_with_explicit_value_uses_explicit(
 async def test_object_from_template_raises_error_when_number_pool_exhausted(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
 ) -> None:
-    """Creating object from template raises ValidationError when NumberPool is exhausted."""
+    """Creating object from template raises PoolExhaustedError when NumberPool is exhausted."""
     small_pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
     await small_pool.new(
         db=db, name="small-rack-unit-pool", node=TestKind.DEVICE, node_attribute="rack_unit", start_range=1, end_range=2
@@ -411,7 +417,9 @@ async def test_object_from_template_raises_error_when_number_pool_exhausted(
 
     template = await Node.init(schema=template_schema, db=db, branch=default_branch)
     await template.new(
-        db=db, template_name="device-template-small-number-pool", rack_unit={"from_pool": {"id": small_pool.id}}
+        db=db,
+        template_name="device-template-small-number-pool",
+        rack_unit_from_resource_pool={"id": small_pool.id},
     )
     await template.save(db=db)
 
@@ -431,7 +439,7 @@ async def test_object_from_template_raises_error_when_number_pool_exhausted(
         )
         assert device.id is not None
 
-    with pytest.raises(ValidationError, match=r"The pool (.*) is exhausted"):
+    with pytest.raises(PoolExhaustedError):
         await create_node(
             data={
                 "name": "device-should-fail-number",
@@ -505,13 +513,15 @@ async def test_template_children_and_pool_recorded_as_side_effects(
 async def test_create_template_with_invalid_number_pool_id(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None
 ) -> None:
-    """Creating a template with from_pool referencing a nonexistent number pool should fail."""
+    """Saving a template with _from_resource_pool referencing a nonexistent pool should fail."""
     fake_pool_id = str(uuid4())
 
     template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
-
     template = await Node.init(schema=template_schema, db=db, branch=default_branch)
-    with pytest.raises(ValidationError, match=fake_pool_id):
-        await template.new(
-            db=db, template_name="device-template-bad-pool", rack_unit={"from_pool": {"id": fake_pool_id}}
-        )
+    await template.new(
+        db=db,
+        template_name="device-template-bad-pool",
+        rack_unit_from_resource_pool=fake_pool_id,
+    )
+    with pytest.raises(NodeNotFoundError):
+        await template.save(db=db)

--- a/backend/tests/component/graphql/resource_manager/test_number_pool_lookup_by_name.py
+++ b/backend/tests/component/graphql/resource_manager/test_number_pool_lookup_by_name.py
@@ -169,11 +169,7 @@ CREATE_TEMPLATE_TICKET_WITH_POOL = """
 mutation CreateTemplateTicketWithPool($template_name: String!, $pool_id: String!) {
     TemplateTestingTicketCreate(data: {
         template_name: { value: $template_name }
-        ticket_id: {
-            from_pool: {
-                id: $pool_id
-            }
-        }
+        ticket_id_from_resource_pool: { id: $pool_id }
     }) {
         ok
         object {
@@ -200,11 +196,7 @@ UPDATE_TEMPLATE_TICKET_WITH_POOL = """
 mutation UpdateTemplateTicketWithPool($template_id: String!, $pool_id: String!) {
     TemplateTestingTicketUpdate(data: {
         id: $template_id
-        ticket_id: {
-            from_pool: {
-                id: $pool_id
-            }
-        }
+        ticket_id_from_resource_pool: { id: $pool_id }
     }) {
         ok
     }
@@ -263,7 +255,9 @@ class TestNumberPoolTemplate:
         )
         assert loaded is not None
         assert loaded.ticket_id.value is None
-        assert loaded.ticket_id.source_id == number_pool.id
+        pool_peer = await loaded.ticket_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == number_pool.id
 
     async def test_create_template_from_number_pool_by_id(
         self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
@@ -287,7 +281,9 @@ class TestNumberPoolTemplate:
         )
         assert loaded is not None
         assert loaded.ticket_id.value is None
-        assert loaded.ticket_id.source_id == number_pool.id
+        pool_peer = await loaded.ticket_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == number_pool.id
 
     async def test_update_template_from_number_pool_by_name(
         self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
@@ -324,7 +320,9 @@ class TestNumberPoolTemplate:
         )
         assert loaded is not None
         assert loaded.ticket_id.value is None
-        assert loaded.ticket_id.source_id == number_pool.id
+        pool_peer = await loaded.ticket_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == number_pool.id
 
     async def test_update_template_from_number_pool_by_id(
         self, db: InfrahubDatabase, default_branch_scope_class: Branch, number_pool: CoreNumberPool
@@ -361,4 +359,6 @@ class TestNumberPoolTemplate:
         )
         assert loaded is not None
         assert loaded.ticket_id.value is None
-        assert loaded.ticket_id.source_id == number_pool.id
+        pool_peer = await loaded.ticket_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == number_pool.id

--- a/backend/tests/component/graphql/resource_manager/test_resource_manager.py
+++ b/backend/tests/component/graphql/resource_manager/test_resource_manager.py
@@ -110,11 +110,7 @@ CREATE_TEMPLATE_TICKET_WITH_POOL = """
 mutation CreateTemplateTicketWithPool($pool_id: String!) {
     TemplateTestingTicketCreate(data: {
         template_name: { value: "bad-pool-template" }
-        ticket_id: {
-            from_pool: {
-                id: $pool_id
-            }
-        }
+        ticket_id_from_resource_pool: { id: $pool_id }
     }) {
         ok
     }
@@ -487,7 +483,7 @@ async def test_create_template_with_invalid_number_pool_id(
     )
 
     assert result.errors
-    assert f"The pool requested {{'id': '{FAKE_POOL_ID}'}} was not found." in str(result.errors[0])
+    assert f"Unable to find the node {FAKE_POOL_ID} / CoreNumberPool in the database." in str(result.errors[0])
 
 
 async def test_update_object_with_invalid_number_pool_id(

--- a/backend/tests/component/templates/test_template_applier.py
+++ b/backend/tests/component/templates/test_template_applier.py
@@ -494,19 +494,19 @@ class TestNodeTemplateApplierNumberPoolAttributes:
         device_with_rack_unit_schema: None,
         number_pool: CoreNumberPool,
     ) -> Node:
-        """A device template with from_pool reference for rack_unit."""
+        """A device template with _from_resource_pool relationship for rack_unit."""
         template_schema = registry.schema.get_template_schema(name="TemplateTestingDevice", branch=default_branch)
         template = await Node.init(schema=template_schema, db=db, branch=default_branch)
         await template.new(
             db=db,
             template_name="device-with-rack-unit-template",
             manufacturer="Acme",
-            rack_unit={"from_pool": {"id": number_pool.id}},
+            rack_unit_from_resource_pool={"id": number_pool.id},
         )
         await template.save(db=db)
         return template
 
-    async def test_applier_passes_from_pool_to_target(
+    async def test_applier_allocates_number_from_pool(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
@@ -514,7 +514,32 @@ class TestNodeTemplateApplierNumberPoolAttributes:
         number_pool: CoreNumberPool,
         device_template_with_pool: Node,
     ) -> None:
-        """Applier should pass from_pool reference to target fields for later allocation."""
+        """Applier should allocate a number from the pool and set it on the attribute."""
+        applier = NodeTemplateApplier(
+            db=db, branch=default_branch, pool_allocator=DefaultPoolAllocator(db=db, branch=default_branch)
+        )
+        target_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+        user_fields: dict[str, Any] = {"name": "my-device", "weight": 100, "airflow": "Front to rear"}
+
+        fields = await applier.apply(
+            template=device_template_with_pool,
+            target_schema=target_schema,
+            target_id="new-device-id",
+            user_fields=user_fields,
+        )
+
+        _validate_template_fields(fields=fields, user_fields=user_fields)
+        assert fields["rack_unit"] == {"value": 1, "source": number_pool.id}
+
+    async def test_applier_skips_pool_attribute_with_noop_allocator(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        device_with_rack_unit_schema: None,
+        number_pool: CoreNumberPool,
+        device_template_with_pool: Node,
+    ) -> None:
+        """With NoOpPoolAllocator, pool-backed attributes should not appear in fields."""
         applier = NodeTemplateApplier(db=db, branch=default_branch, pool_allocator=NoOpPoolAllocator())
         target_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
         user_fields: dict[str, Any] = {"name": "my-device", "weight": 100, "airflow": "Front to rear"}
@@ -527,7 +552,7 @@ class TestNodeTemplateApplierNumberPoolAttributes:
         )
 
         _validate_template_fields(fields=fields, user_fields=user_fields)
-        assert fields["rack_unit"] == {"from_pool": {"id": number_pool.id}}
+        assert "rack_unit" not in fields
 
     async def test_applier_preserves_user_value_over_pool_reference(
         self,

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -514,23 +514,26 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
     async def template_with_pool_slot(
         self, client: InfrahubClient, slot_pool: Node, device_schema: None
     ) -> InfrahubNode:
-        sdk_pool = await client.get(kind=InfrahubKind.NUMBERPOOL, id=slot_pool.id)
         template = await client.create(
             kind="TemplateInfraRack",
             template_name="rack-pool-slot",
             location="datacenter-1",
-            slot_id=sdk_pool,
+            slot_id_from_resource_pool=slot_pool.id,
         )
         await template.save()
         return template
 
     async def test_template_with_pool_stores_reference_not_value(
-        self, db: InfrahubDatabase, template_with_pool_slot: InfrahubNode
+        self, db: InfrahubDatabase, template_with_pool_slot: InfrahubNode, slot_pool: Node
     ) -> None:
-        """Template with from_pool should store reference without allocating a value."""
+        """Template with _from_resource_pool should store pool reference without allocating a value."""
         template = await NodeManager.get_one(id=template_with_pool_slot.id, db=db)
         assert template.template_name.value == "rack-pool-slot"
         assert template.slot_id.value is None
+
+        pool_peer = await template.slot_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == slot_pool.id
 
     async def test_rack_from_template_with_static_slot(
         self, db: InfrahubDatabase, template_with_static_slot: Node, client: InfrahubClient
@@ -618,16 +621,20 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
     async def test_template_can_swap_pool_to_static_value(
         self, db: InfrahubDatabase, slot_pool: Node, client: InfrahubClient, device_schema: None
     ) -> None:
-        """Swapping from pool to static value should set the value and clear the pool source."""
-        sdk_pool = await client.get(kind=InfrahubKind.NUMBERPOOL, id=slot_pool.id)
+        """Swapping from pool to static value should set the value and clear the pool relationship."""
         template = await client.create(
-            kind="TemplateInfraRack", template_name="rack-pool-to-static", location="datacenter-1", slot_id=sdk_pool
+            kind="TemplateInfraRack",
+            template_name="rack-pool-to-static",
+            location="datacenter-1",
+            slot_id_from_resource_pool=slot_pool.id,
         )
         await template.save()
 
-        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        tmpl = await NodeManager.get_one(id=template.id, db=db)
         assert tmpl.slot_id.value is None
-        assert tmpl.slot_id.source_id == slot_pool.id
+        pool_peer = await tmpl.slot_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == slot_pool.id
 
         await client.execute_graphql(
             query="""
@@ -635,7 +642,8 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
                 TemplateInfraRackUpdate(
                     data: {
                         id: $id
-                        slot_id: { value: $slot_id, from_pool: null }
+                        slot_id: { value: $slot_id }
+                        slot_id_from_resource_pool: null
                     }
                 ) {
                     ok
@@ -645,21 +653,24 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
             variables={"id": template.id, "slot_id": 42},
         )
 
-        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        tmpl = await NodeManager.get_one(id=template.id, db=db)
         assert tmpl.slot_id.value == 42
-        assert tmpl.slot_id.source_id is None
+        pool_peer = await tmpl.slot_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is None
 
     async def test_template_can_swap_static_value_to_pool(
         self, db: InfrahubDatabase, slot_pool: Node, client: InfrahubClient, device_schema: None
     ) -> None:
-        """Swapping from static value to pool should clear the value and set pool as source."""
-        template = await Node.init(db=db, schema="TemplateInfraRack")
-        await template.new(db=db, template_name="rack-static-to-pool", location="datacenter-1", slot_id=75)
-        await template.save(db=db)
+        """Swapping from static value to pool should clear the value and set pool relationship."""
+        template = await client.create(
+            kind="TemplateInfraRack", template_name="rack-static-to-pool", location="datacenter-1", slot_id=75
+        )
+        await template.save()
 
-        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        tmpl = await NodeManager.get_one(id=template.id, db=db)
         assert tmpl.slot_id.value == 75
-        assert tmpl.slot_id.source_id is None
+        pool_peer = await tmpl.slot_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is None
 
         await client.execute_graphql(
             query="""
@@ -667,7 +678,7 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
                 TemplateInfraRackUpdate(
                     data: {
                         id: $id
-                        slot_id: { from_pool: { id: $pool_id } }
+                        slot_id_from_resource_pool: { id: $pool_id }
                     }
                 ) {
                     ok
@@ -677,9 +688,11 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
             variables={"id": template.id, "pool_id": slot_pool.id},
         )
 
-        tmpl = await NodeManager.get_one(id=template.id, db=db, include_metadata=MetadataOptions.SOURCE)
+        tmpl = await NodeManager.get_one(id=template.id, db=db)
         assert tmpl.slot_id.value is None
-        assert tmpl.slot_id.source_id == slot_pool.id
+        pool_peer = await tmpl.slot_id_from_resource_pool.get_peer(db=db)
+        assert pool_peer is not None
+        assert pool_peer.id == slot_pool.id
 
 
 class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
@@ -841,14 +854,11 @@ class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
         rack_unit_pool: Node,
     ) -> InfrahubNode:
         """Device template with 8 interface templates, all using pool allocations."""
-        sdk_rack_pool = await client.get(kind=InfrahubKind.NUMBERPOOL, id=rack_unit_pool.id)
-        sdk_vlan_pool = await client.get(kind=InfrahubKind.NUMBERPOOL, id=vlan_pool.id)
-
         device_template = await client.create(
             kind="TemplateInfraDevice",
             template_name="device-with-8-interfaces",
             mgmt_address_from_resource_pool=mgmt_address_pool.id,
-            rack_unit=sdk_rack_pool,
+            rack_unit_from_resource_pool=rack_unit_pool.id,
         )
         await device_template.save()
 
@@ -857,7 +867,7 @@ class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
                 kind="TemplateInfraInterface",
                 template_name=f"interface-eth{i}",
                 name=f"eth{i}",
-                vlan_id=sdk_vlan_pool,
+                vlan_id_from_resource_pool=vlan_pool.id,
                 device=device_template,
                 prefix_from_resource_pool=interface_prefix_pool.id,
             )

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -678,6 +678,7 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
                 TemplateInfraRackUpdate(
                     data: {
                         id: $id
+                        slot_id: { value: null }
                         slot_id_from_resource_pool: { id: $pool_id }
                     }
                 ) {


### PR DESCRIPTION
update template provisioning logic to look for `<attribute.name>_from_resource_pool` relationships instead of the `source` of the attribute on the template

example
1. I have a `InfraDevice` schema that includes a `device_number` attribute with `kind=Number`
2. I create an instance of `TemplateInfraDevice` with the `device_number_from_resource_pool` relationship linked to a CoreNumberPool
3. I provision an instance of `InfraDevice` using the template in step 2 and the new `InfraDevice.device_number` is provisioned from the CoreNumberPool linked in step 2

previous method for linking an attribute on a template to a CoreNumberPool was to set the `source` of the attribute to the CoreNumberPool