### PR TITLE
Cleanup in logic to assign number pool relationships for templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2494,7 +2494,7 @@ class SchemaBranch:
         Returns:
             A RelationshipSchema for the resource pool relationship, or None if not applicable
         """
-        if attr.kind != "Number":
+        if attr.kind != "Number" or not attr.support_templates:
             return None
 
         pool_rel_name = f"{attr.name}{RESOURCE_POOL_REL_SUFFIX}"
@@ -2638,8 +2638,6 @@ class SchemaBranch:
 
         # Add resource pool relationships for eligible attributes (e.g., Number → CoreNumberPool)
         for node_attr in node.attributes:
-            if not node_attr.support_templates:
-                continue
             attr_pool_relationship = self._create_attribute_resource_pool_relationship(attr=node_attr)
             if attr_pool_relationship:
                 template_schema.relationships.append(attr_pool_relationship)


### PR DESCRIPTION
# Why

Moves some of the logic away from `add_relationships_to_template()` for easier readability

## What changed

Move logic from `add_relationships_to_template()` to `_create_attribute_resource_pool_relationship()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined the logic for creating resource pool relationships with template-supporting attributes. Number-type attributes now correctly require template support to establish these relationships, improving the reliability of resource management in template configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->