### PR TITLE
Forbid loading schemas with restricted resource pool suffix

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -349,6 +349,7 @@ async def load_schema(
     warnings: list[SchemaWarning] = []
     for schema in schemas.schemas:
         errors += schema.validate_namespaces()
+        errors += schema.validate_reserved_suffixes()
         warnings += schema.gather_warnings()
 
     if errors:
@@ -433,6 +434,7 @@ async def check_schema(
     warnings: list[SchemaWarning] = []
     for schema in schemas.schemas:
         errors += schema.validate_namespaces()
+        errors += schema.validate_reserved_suffixes()
         warnings += schema.gather_warnings()
 
     if errors:

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -8,6 +8,7 @@ from infrahub_sdk.utils import deep_merge_dict
 from pydantic import BaseModel, ConfigDict, Field
 
 from infrahub.core.constants import RESTRICTED_NAMESPACES
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.models import HashableModel
 from infrahub.exceptions import SchemaNotFoundError
 
@@ -94,6 +95,22 @@ class SchemaRoot(BaseModel):
             if model.namespace in RESTRICTED_NAMESPACES:
                 errors.append(f"Restricted namespace '{model.namespace}' used on '{model.name}'")
 
+        return errors
+
+    def validate_reserved_suffixes(self) -> list[str]:
+        models = self.nodes + self.generics + self.extensions.nodes
+        errors: list[str] = []
+        for model in models:
+            for attr in model.attributes:
+                if attr.name.endswith(RESOURCE_POOL_REL_SUFFIX):
+                    errors.append(
+                        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on attribute '{attr.name}' in '{model.kind}'"
+                    )
+            for rel in model.relationships:
+                if rel.name.endswith(RESOURCE_POOL_REL_SUFFIX):
+                    errors.append(
+                        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on relationship '{rel.name}' in '{model.kind}'"
+                    )
         return errors
 
     def gather_warnings(self) -> list[SchemaWarning]:

--- a/backend/tests/component/api/test_40_schema.py
+++ b/backend/tests/component/api/test_40_schema.py
@@ -551,3 +551,99 @@ async def test_schema_load_restricted_names(
         response.json()["errors"][0]["message"]
         == f"TestingParent: {reserved_name} isn't allowed as an attribute name on hierarchical nodes."
     )
+
+
+async def test_schema_load_reserved_suffix_attribute(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    prefect_test_fixture: None,
+    workflow_local: WorkflowLocalExecution,
+    authentication_base: Node,
+    helper: TestHelper,
+) -> None:
+    with client:
+        response = client.post(
+            "/api/schema/load",
+            headers=admin_headers,
+            json={"schemas": [helper.schema_file("reserved_suffix_attribute_01.json")]},
+        )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["errors"][0]["message"]
+        == "Reserved suffix '_from_resource_pool' used on attribute 'foo_from_resource_pool' in 'TestTestNode'"
+    )
+
+
+async def test_schema_load_reserved_suffix_relationship(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    prefect_test_fixture: None,
+    workflow_local: WorkflowLocalExecution,
+    authentication_base: Node,
+    helper: TestHelper,
+) -> None:
+    with client:
+        response = client.post(
+            "/api/schema/load",
+            headers=admin_headers,
+            json={"schemas": [helper.schema_file("reserved_suffix_relationship_01.json")]},
+        )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["errors"][0]["message"]
+        == "Reserved suffix '_from_resource_pool' used on relationship 'bar_from_resource_pool' in 'TestTestNode'"
+    )
+
+
+async def test_schema_check_reserved_suffix_attribute(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    prefect_test_fixture: None,
+    workflow_local: WorkflowLocalExecution,
+    authentication_base: Node,
+    helper: TestHelper,
+) -> None:
+    with client:
+        response = client.post(
+            "/api/schema/check",
+            headers=admin_headers,
+            json={"schemas": [helper.schema_file("reserved_suffix_attribute_01.json")]},
+        )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["errors"][0]["message"]
+        == "Reserved suffix '_from_resource_pool' used on attribute 'foo_from_resource_pool' in 'TestTestNode'"
+    )
+
+
+async def test_schema_check_reserved_suffix_relationship(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    prefect_test_fixture: None,
+    workflow_local: WorkflowLocalExecution,
+    authentication_base: Node,
+    helper: TestHelper,
+) -> None:
+    with client:
+        response = client.post(
+            "/api/schema/check",
+            headers=admin_headers,
+            json={"schemas": [helper.schema_file("reserved_suffix_relationship_01.json")]},
+        )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["errors"][0]["message"]
+        == "Reserved suffix '_from_resource_pool' used on relationship 'bar_from_resource_pool' in 'TestTestNode'"
+    )

--- a/backend/tests/component/core/test_schema.py
+++ b/backend/tests/component/core/test_schema.py
@@ -7,11 +7,14 @@ from pydantic import ValidationError
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.schema import (
     AttributeSchema,
     DropdownChoice,
+    NodeExtensionSchema,
     NodeSchema,
     RelationshipSchema,
+    SchemaExtension,
     SchemaRoot,
     SchemaWarning,
     SchemaWarningKind,
@@ -680,3 +683,96 @@ def test_validate_namespaces_and_keyword_separation() -> None:
         schema_branch.process_validate()
 
     assert "Python keyword 'from' cannot be used as an attribute name" in str(exc.value)
+
+
+def test_validate_reserved_suffixes_attribute() -> None:
+    attr_name = f"foo{RESOURCE_POOL_REL_SUFFIX}"
+    schema_root = SchemaRoot(
+        nodes=[
+            {
+                "name": "TestNode",
+                "namespace": "Test",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [{"name": attr_name, "kind": "Text"}],
+            }
+        ]
+    )
+    errors = schema_root.validate_reserved_suffixes()
+    assert len(errors) == 1
+    assert (
+        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on attribute '{attr_name}' in 'TestTestNode'" in errors[0]
+    )
+
+
+def test_validate_reserved_suffixes_relationship() -> None:
+    rel_name = f"bar{RESOURCE_POOL_REL_SUFFIX}"
+    schema_root = SchemaRoot(
+        nodes=[
+            {
+                "name": "TestNode",
+                "namespace": "Test",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [{"name": "name", "kind": "Text"}],
+                "relationships": [
+                    {
+                        "name": rel_name,
+                        "peer": "TestOther",
+                        "cardinality": "one",
+                    }
+                ],
+            }
+        ]
+    )
+    errors = schema_root.validate_reserved_suffixes()
+    assert len(errors) == 1
+    assert (
+        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on relationship '{rel_name}' in 'TestTestNode'" in errors[0]
+    )
+
+
+def test_validate_reserved_suffixes_valid_schema() -> None:
+    schema_root = SchemaRoot(
+        nodes=[
+            {
+                "name": "TestNode",
+                "namespace": "Test",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [{"name": "name", "kind": "Text"}],
+            }
+        ]
+    )
+    errors = schema_root.validate_reserved_suffixes()
+    assert errors == []
+
+
+def test_validate_reserved_suffixes_extension_attribute() -> None:
+    attr_name = f"foo{RESOURCE_POOL_REL_SUFFIX}"
+    schema_root = SchemaRoot(
+        extensions=SchemaExtension(
+            nodes=[NodeExtensionSchema(kind="TestTestNode", attributes=[{"name": attr_name, "kind": "Text"}])]
+        )
+    )
+    errors = schema_root.validate_reserved_suffixes()
+    assert len(errors) == 1
+    assert (
+        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on attribute '{attr_name}' in 'TestTestNode'" in errors[0]
+    )
+
+
+def test_validate_reserved_suffixes_extension_relationship() -> None:
+    rel_name = f"bar{RESOURCE_POOL_REL_SUFFIX}"
+    schema_root = SchemaRoot(
+        extensions=SchemaExtension(
+            nodes=[
+                NodeExtensionSchema(
+                    kind="TestTestNode",
+                    relationships=[{"name": rel_name, "peer": "TestOther", "cardinality": "one"}],
+                )
+            ]
+        )
+    )
+    errors = schema_root.validate_reserved_suffixes()
+    assert len(errors) == 1
+    assert (
+        f"Reserved suffix '{RESOURCE_POOL_REL_SUFFIX}' used on relationship '{rel_name}' in 'TestTestNode'" in errors[0]
+    )

--- a/backend/tests/fixtures/schemas/reserved_suffix_attribute_01.json
+++ b/backend/tests/fixtures/schemas/reserved_suffix_attribute_01.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "TestNode",
+            "namespace": "Test",
+            "attributes": [
+                {
+                    "name": "foo_from_resource_pool",
+                    "kind": "Text",
+                    "optional": true
+                }
+            ]
+        }
+    ]
+}

--- a/backend/tests/fixtures/schemas/reserved_suffix_relationship_01.json
+++ b/backend/tests/fixtures/schemas/reserved_suffix_relationship_01.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "TestNode",
+            "namespace": "Test",
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text",
+                    "optional": false
+                }
+            ],
+            "relationships": [
+                {
+                    "name": "bar_from_resource_pool",
+                    "peer": "TestOther",
+                    "cardinality": "one",
+                    "optional": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Why

Forbid loading schemas with restricted resource pool suffix in attribute and relationship names.

PR3 in Aarons refactor list

## What changed

* Adds a new control to be validated within the API layer when loading a schema
* Adds unit tests for the added function
* Adds schema loading tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema validation now enforces reserved suffix naming restrictions for attributes and relationships; schemas containing reserved suffixes are rejected at load time.
* **Tests**
  * Added coverage verifying reserved-suffix validation for attributes, relationships and extensions, and that valid schemas pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->