### PR TITLE
Add conditional to prevent setting `from_pool` on a template attribute

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -19,7 +19,7 @@ from infrahub.core.constants import (
     RelationshipCardinality,
     RelationshipKind,
 )
-from infrahub.core.constants.schema import SchemaElementPathType
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX, SchemaElementPathType
 from infrahub.core.metadata.interface import MetadataInterface
 from infrahub.core.metadata.model import MetadataInfo
 from infrahub.core.protocols import CoreNumberPool, CoreObjectTemplate
@@ -366,21 +366,17 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         2. User-specified from_pool (user explicitly passes {"from_pool": {"id": pool_id}} to a Number attribute)
         """
         number_pool_id: str | None = None
-        # Templates should not allocate from pools - just store the reference
-        # Actual allocation happens when creating objects from the template
+        # Templates must use _from_resource_pool relationships, not from_pool
         if isinstance(self._schema, TemplateSchema):
             if attribute.from_pool:
-                try:
-                    number_pool_id = str(attribute.from_pool["id"])
-                except KeyError as exc:
-                    raise ValidationError(
-                        {f"{attribute.name}.from_pool": "Missing 'id' in from_pool reference."}
-                    ) from exc
-                attribute.value = None
-                allocate_resources = False
-            elif attribute.from_pool is None:
-                attribute.clear_source()
-                return
+                pool_rel_name = f"{attribute.name}{RESOURCE_POOL_REL_SUFFIX}"
+                raise ValidationError(
+                    {
+                        f"{attribute.name}.from_pool": (
+                            f"'from_pool' is not supported on template attributes. Set the '{pool_rel_name}' relationship on this template instead."
+                        )
+                    }
+                )
 
         # Case 1: Schema-defined NumberPool attribute
         if (

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -14,7 +14,7 @@ from infrahub.core.node.create import create_node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.schema import AttributeSchema, RelationshipSchema
-from infrahub.exceptions import NodeNotFoundError, PoolExhaustedError
+from infrahub.exceptions import NodeNotFoundError, PoolExhaustedError, ValidationError
 from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA
 
@@ -327,6 +327,22 @@ async def test_template_with_number_pool_relationship_does_not_allocate(
     pool_rel = await template.rack_unit_from_resource_pool.get_peer(db=db)
     assert pool_rel is not None
     assert pool_rel.id == number_pool.id
+
+
+async def test_template_from_pool_on_attribute_raises_validation_error(
+    db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
+) -> None:
+    """Using from_pool on a template attribute should raise ValidationError."""
+    template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+
+    with pytest.raises(
+        ValidationError,
+        match=r"'from_pool' is not supported on template attributes\. Set the 'rack_unit_from_resource_pool' relationship on this template instead\.",
+    ):
+        await template.new(
+            db=db, template_name="device-template-from-pool-attr", rack_unit={"from_pool": {"id": number_pool.id}}
+        )
 
 
 async def test_object_from_template_with_number_pool_allocates_value(

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -695,6 +695,26 @@ class TestTemplateNumberPoolAttributes(TestInfrahubApp):
         assert pool_peer is not None
         assert pool_peer.id == slot_pool.id
 
+    async def test_template_from_pool_on_attribute_blocked(self, slot_pool: Node, client: InfrahubClient) -> None:
+        """Using from_pool on a template attribute should raise an error."""
+        with pytest.raises(GraphQLError, match="'from_pool' is not supported on template attributes"):
+            await client.execute_graphql(
+                query="""
+                mutation CreateTemplateWithFromPool($pool_id: String!) {
+                    TemplateInfraRackCreate(
+                        data: {
+                            template_name: { value: "rack-from-pool-blocked" }
+                            slot_id: { from_pool: { id: $pool_id } }
+                        }
+                    ) {
+                        ok
+                        object { id }
+                    }
+                }
+                """,
+                variables={"pool_id": slot_pool.id},
+            )
+
 
 class TestTemplateNestedComponentPoolAllocations(TestInfrahubApp):
     """End-to-end test for pool allocations in templates with nested component relationships.


### PR DESCRIPTION
# Why

Templates currently accept `from_pool` on both attributes and relationships, which stores a pool reference directly. Now that `_from_resource_pool` relationships exist for both IP relationships and number attributes, the `from_pool` mechanism on templates is useless. This PR blocks `from_pool` on templates and directs users to the `_from_resource_pool` relationships instead.

## What changed

- `from_pool` on template attributes now raises `ValidationError`: when a template attribute has `from_pool` set, instead of storing the pool reference via the attribute source mechanism, a `ValidationError` is raised with a message directing the user to set the corresponding `_from_resource_pool` relationship.
- No change to non-template behaviour, `from_pool` continues to work normally on regular nodes. The `_from_resource_pool` relationship flow for templates is unaffected.

## How to test

```bash
uv run pytest -x backend/tests/component/core/node/test_template_pool_allocation.py -v
uv run pytest -x backend/tests/functional/templates/test_template_resource_pool.py -v
```

## Checklist

- [x] Tests added/updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Templates that specify an incorrect pool attribute are now explicitly rejected with a clear validation error directing the correct pool relationship.

* **Tests**
  * Added tests to confirm invalid pool usage on template attributes is blocked and returns the expected validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->