### PR TITLE
Add conditional to prevent setting `from_pool` on a template relationship

### DIFF
--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from infrahub.core import registry
 from infrahub.core.changelog.models import ChangelogRelationshipMapper
 from infrahub.core.constants import SYSTEM_USER_ID, BranchSupportType, InfrahubKind, MetadataOptions, RelationshipKind
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.creation_context import NodeCreationContext
 from infrahub.core.metadata.interface import MetadataInterface
 from infrahub.core.metadata.model import MetadataInfo, MetadataQueryOptions
@@ -906,6 +907,17 @@ class RelationshipManager:
         await rm._validate_hierarchy()
 
         for item in data:
+            if isinstance(item, dict) and item.get("from_pool") is not None and rm.node._schema.is_template_schema:
+                pool_rel_name = f"{rm.name}{RESOURCE_POOL_REL_SUFFIX}"
+                raise ValidationError(
+                    {
+                        rm.name: (
+                            f"'from_pool' is not supported on template relationships. "
+                            f"Set the '{pool_rel_name}' relationship on this template instead."
+                        )
+                    }
+                )
+
             if not isinstance(item, rm.rel_class | str | dict) and not hasattr(item, "_schema"):
                 raise ValidationError({rm.name: f"Invalid data provided to form a relationship {item}"})
 

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -345,6 +345,26 @@ async def test_template_from_pool_on_attribute_raises_validation_error(
         )
 
 
+async def test_template_from_pool_on_relationship_raises_validation_error(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    device_schema: None,
+    ip_address_pool: CoreIPAddressPool,
+) -> None:
+    """Using from_pool on a template relationship should raise ValidationError."""
+    template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+
+    with pytest.raises(
+        ValidationError,
+        match=r"'from_pool' is not supported on template relationships\. "
+        r"Set the 'primary_ip_from_resource_pool' relationship on this template instead\.",
+    ):
+        await template.new(
+            db=db, template_name="device-template-from-pool-rel", primary_ip={"from_pool": {"id": ip_address_pool.id}}
+        )
+
+
 async def test_object_from_template_with_number_pool_allocates_value(
     db: InfrahubDatabase, default_branch: Branch, device_with_rack_unit_schema: None, number_pool: CoreNumberPool
 ) -> None:

--- a/backend/tests/functional/templates/test_template_resource_pool.py
+++ b/backend/tests/functional/templates/test_template_resource_pool.py
@@ -468,6 +468,28 @@ class TestTemplateResourcePoolCreation(TestInfrahubApp):
                 variables={"name": "device-small-pool-overflow", "template_id": template_with_small_pool.id},
             )
 
+    async def test_template_from_pool_on_relationship_blocked(
+        self, ip_address_pool: Node, client: InfrahubClient
+    ) -> None:
+        """Using from_pool on a template relationship should raise an error."""
+        with pytest.raises(GraphQLError, match="'from_pool' is not supported on template relationships"):
+            await client.execute_graphql(
+                query="""
+                mutation CreateTemplateWithFromPool($pool_id: String!) {
+                    TemplateInfraDeviceCreate(
+                        data: {
+                            template_name: { value: "device-from-pool-blocked" }
+                            primary_address: { from_pool: { id: $pool_id } }
+                        }
+                    ) {
+                        ok
+                        object { id }
+                    }
+                }
+                """,
+                variables={"pool_id": ip_address_pool.id},
+            )
+
 
 class TestTemplateNumberPoolAttributes(TestInfrahubApp):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
# Why

Since we have `_from_resource_pool` relationships on templates, the `from_pool` mechanism on template relationships is useless and misguiding. Users should be directed to the `_from_resource_pool` relationships instead.

Similar to https://github.com/opsmill/infrahub/pull/8552

## What changed

- `from_pool` on template relationships now raises `ValidationError` in `RelationshipManager.init()`, the reason to place the guard here is for it to be able to run both in a GraphQL and a non-GraphQL context.

- No change to non-template behaviour, `from_pool` on relationships for regular nodes continues to work. The `_from_resource_pool` relationship flow on templates is unaffected.

## How to test

```bash
uv run pytest -x backend/tests/component/core/node/test_template_pool_allocation.py -v
uv run pytest -x backend/tests/functional/templates/test_template_resource_pool.py -v
```

## Checklist

- [x] Tests added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents using `from_pool` on template relationships; users now get a clear validation error directing them to the pool-specific relationship instead.
* **Tests**
  * Added unit and functional tests to verify that `from_pool` usage on template relationships is blocked and returns the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->