### PR TITLE
Add a new label for specs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,3 +14,7 @@
 "type/documentation":
   - changed-files:
       - any-glob-to-any-file: ["docs/**"]
+
+"type/spec":
+  - changed-files:
+      - any-glob-to-any-file: ["dev/specs/**"]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -82,6 +82,10 @@
   description: "Topic for brainstorming, discussions"
   color: "e19e0f"
 
+- name: "type/spec"
+  description: "A specification for an upcoming change to the project"
+  color: "8b5cf6"
+
 - name: "type/user-centric"
   description: "Issue that would improve the overall experience of our users"
   color: "ff8c00"


### PR DESCRIPTION
# Why

To make it easier to see which open PRs we have that include specifications that needs to be reviewed

## What changed

* Update to labels file to sync labels within project
* Update rules to automatically apply the new label to PRs that update spec files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new specification label to the project management system for organizing specification-related files and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->