### PR TITLE
PR2: Guard Against Setting Both Attribute Value and Pool Relationship

### DIFF
--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from infrahub.core.branch import Branch
-from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
 from infrahub.core.relationship.constraints.interface import RelationshipManagerConstraintInterface
@@ -9,7 +8,6 @@ from infrahub.database import InfrahubDatabase
 
 if TYPE_CHECKING:
     from infrahub.core.relationship.model import RelationshipManager
-    from infrahub.core.schema import MainSchemaTypes
 
 
 class NodeConstraintRunner:
@@ -35,9 +33,10 @@ class NodeConstraintRunner:
                 await self.uniqueness_constraint.check(node, filters=field_filters)
 
             node_schema = node.get_schema()
-            effective_filters = self._expand_filters_for_pool_relationships(
-                field_filters=field_filters, node_schema=node_schema
-            )
+            effective_filters = field_filters
+            if effective_filters:
+                for constraint in self.relationship_manager_constraints:
+                    effective_filters = constraint.expand_filters(effective_filters, node_schema)
 
             for relationship_name in node_schema.relationship_names:
                 if effective_filters and relationship_name not in effective_filters:
@@ -46,19 +45,3 @@ class NodeConstraintRunner:
                 await relationship_manager.fetch_relationship_ids(db=db, force_refresh=True)
                 for relationship_constraint in self.relationship_manager_constraints:
                     await relationship_constraint.check(relm=relationship_manager, node_schema=node_schema, node=node)
-
-    @staticmethod
-    def _expand_filters_for_pool_relationships(
-        field_filters: list[str] | None, node_schema: "MainSchemaTypes"
-    ) -> list[str] | None:
-        """When an attribute is in field_filters and has a corresponding _from_resource_pool relationship,
-        include that relationship in the filters so the exclusive constraint can run."""
-        if not field_filters or not node_schema.is_template_schema:
-            return field_filters
-
-        expanded = list(field_filters)
-        for name in field_filters:
-            pool_rel_name = f"{name}{RESOURCE_POOL_REL_SUFFIX}"
-            if pool_rel_name in node_schema.relationship_names and pool_rel_name not in expanded:
-                expanded.append(pool_rel_name)
-        return expanded

--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
 from infrahub.core.relationship.constraints.interface import RelationshipManagerConstraintInterface
@@ -8,6 +9,7 @@ from infrahub.database import InfrahubDatabase
 
 if TYPE_CHECKING:
     from infrahub.core.relationship.model import RelationshipManager
+    from infrahub.core.schema import MainSchemaTypes
 
 
 class NodeConstraintRunner:
@@ -32,12 +34,31 @@ class NodeConstraintRunner:
             if not skip_uniqueness_check:
                 await self.uniqueness_constraint.check(node, filters=field_filters)
 
-            for relationship_name in node.get_schema().relationship_names:
-                if field_filters and relationship_name not in field_filters:
+            node_schema = node.get_schema()
+            effective_filters = self._expand_filters_for_pool_relationships(
+                field_filters=field_filters, node_schema=node_schema
+            )
+
+            for relationship_name in node_schema.relationship_names:
+                if effective_filters and relationship_name not in effective_filters:
                     continue
                 relationship_manager: RelationshipManager = getattr(node, relationship_name)
                 await relationship_manager.fetch_relationship_ids(db=db, force_refresh=True)
                 for relationship_constraint in self.relationship_manager_constraints:
-                    await relationship_constraint.check(
-                        relm=relationship_manager, node_schema=node.get_schema(), node=node
-                    )
+                    await relationship_constraint.check(relm=relationship_manager, node_schema=node_schema, node=node)
+
+    @staticmethod
+    def _expand_filters_for_pool_relationships(
+        field_filters: list[str] | None, node_schema: "MainSchemaTypes"
+    ) -> list[str] | None:
+        """When an attribute is in field_filters and has a corresponding _from_resource_pool relationship,
+        include that relationship in the filters so the exclusive constraint can run."""
+        if not field_filters or not node_schema.is_template_schema:
+            return field_filters
+
+        expanded = list(field_filters)
+        for name in field_filters:
+            pool_rel_name = f"{name}{RESOURCE_POOL_REL_SUFFIX}"
+            if pool_rel_name in node_schema.relationship_names and pool_rel_name not in expanded:
+                expanded.append(pool_rel_name)
+        return expanded

--- a/backend/infrahub/core/relationship/constraints/interface.py
+++ b/backend/infrahub/core/relationship/constraints/interface.py
@@ -9,3 +9,8 @@ from ..model import RelationshipManager
 class RelationshipManagerConstraintInterface(ABC):
     @abstractmethod
     async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None: ...
+
+    def expand_filters(self, field_filters: list[str], node_schema: MainSchemaTypes) -> list[str]:  # noqa: ARG002
+        """Expand field_filters to include additional relationships this constraint needs checked. Override in
+        subclasses that need cross-field validation."""
+        return field_filters

--- a/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
+++ b/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
@@ -29,6 +29,17 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
         self.db = db
         self.branch = branch
 
+    def expand_filters(self, field_filters: list[str], node_schema: MainSchemaTypes) -> list[str]:
+        if not node_schema.is_template_schema:
+            return field_filters
+
+        expanded = list(field_filters)
+        for name in field_filters:
+            pool_rel_name = f"{name}{RESOURCE_POOL_REL_SUFFIX}"
+            if pool_rel_name in node_schema.relationship_names and pool_rel_name not in expanded:
+                expanded.append(pool_rel_name)
+        return expanded
+
     async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:
         if not node_schema.is_template_schema:
             return

--- a/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
+++ b/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
@@ -87,8 +87,7 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
                 }
             )
 
-    @staticmethod
-    def _check_attribute_counterpart_not_set(node: Node, attribute_name: str, current_name: str) -> None:
+    def _check_attribute_counterpart_not_set(self, node: Node, attribute_name: str, current_name: str) -> None:
         """Check that the counterpart attribute does not have a user-set value."""
         try:
             attr = node.get_attribute(name=attribute_name)

--- a/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
+++ b/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
@@ -54,7 +54,7 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
             if original_name in node_schema.relationship_names:
                 await self._check_counterpart_not_set(node=node, counterpart_name=original_name, current_name=rel_name)
             elif original_name in node_schema.attribute_names:
-                await self._check_attribute_counterpart_not_set(
+                self._check_attribute_counterpart_not_set(
                     node=node, attribute_name=original_name, current_name=rel_name
                 )
         else:
@@ -88,7 +88,7 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
             )
 
     @staticmethod
-    async def _check_attribute_counterpart_not_set(node: Node, attribute_name: str, current_name: str) -> None:
+    def _check_attribute_counterpart_not_set(node: Node, attribute_name: str, current_name: str) -> None:
         """Check that the counterpart attribute does not have a user-set value."""
         try:
             attr = node.get_attribute(name=attribute_name)

--- a/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
+++ b/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInterface):
-    """Constraint that prevents setting both a relationship and its _from_resource_pool counterpart on templates.
+    """Constraint that prevents setting both a relationship/attribute and its _from_resource_pool counterpart on templates.
 
     On template instances, users can either:
-    - Set a fixed relationship value (e.g., ip_address pointing to a specific IP)
-    - Set a pool to allocate from (e.g., ip_address_from_resource_pool pointing to a pool)
+    - Set a fixed value (relationship peer or attribute value)
+    - Set a pool to allocate from (e.g., ip_address_from_resource_pool or weight_from_resource_pool)
 
     But not both at the same time.
     """
@@ -39,8 +39,13 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
         rel_name = relm.schema.name
 
         if rel_name.endswith(RESOURCE_POOL_REL_SUFFIX):
-            original_rel_name = rel_name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
-            await self._check_counterpart_not_set(node=node, counterpart_name=original_rel_name, current_name=rel_name)
+            original_name = rel_name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
+            if original_name in node_schema.relationship_names:
+                await self._check_counterpart_not_set(node=node, counterpart_name=original_name, current_name=rel_name)
+            elif original_name in node_schema.attribute_names:
+                await self._check_attribute_counterpart_not_set(
+                    node=node, attribute_name=original_name, current_name=rel_name
+                )
         else:
             # Check if this relationship has a pool counterpart and if it's set
             pool_rel_name = f"{rel_name}{RESOURCE_POOL_REL_SUFFIX}"
@@ -67,6 +72,24 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
                     current_name: (
                         f"Cannot set '{current_name}' when '{counterpart_name}' is already set. "
                         "Templates can only use one of: direct relationship or resource pool allocation."
+                    )
+                }
+            )
+
+    @staticmethod
+    async def _check_attribute_counterpart_not_set(node: Node, attribute_name: str, current_name: str) -> None:
+        """Check that the counterpart attribute does not have a user-set value."""
+        try:
+            attr = node.get_attribute(name=attribute_name)
+        except ValueError:
+            return
+
+        if not attr.is_default and attr.value is not None:
+            raise ValidationError(
+                {
+                    current_name: (
+                        f"Cannot set '{current_name}' when '{attribute_name}' has a value set. "
+                        "Templates can only use one of: direct attribute value or resource pool allocation."
                     )
                 }
             )

--- a/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
+++ b/backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py
@@ -35,6 +35,8 @@ class TemplateResourcePoolExclusiveConstraint(RelationshipManagerConstraintInter
 
         expanded = list(field_filters)
         for name in field_filters:
+            if name not in node_schema.attribute_names:
+                continue
             pool_rel_name = f"{name}{RESOURCE_POOL_REL_SUFFIX}"
             if pool_rel_name in node_schema.relationship_names and pool_rel_name not in expanded:
                 expanded.append(pool_rel_name)

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
 from infrahub.core import registry
-from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality
+from infrahub.core.constants import InfrahubKind, RelationshipCardinality
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -26,35 +26,6 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-
-
-IPAM_SCHEMA: dict[str, Any] = {
-    "nodes": [
-        {
-            "name": "IPPrefix",
-            "namespace": "Ipam",
-            "default_filter": "prefix__value",
-            "order_by": ["prefix__value"],
-            "display_labels": ["prefix__value"],
-            "branch": BranchSupportType.AWARE.value,
-            "inherit_from": [InfrahubKind.IPPREFIX],
-        },
-        {
-            "name": "IPAddress",
-            "namespace": "Ipam",
-            "default_filter": "address__value",
-            "order_by": ["address__value"],
-            "display_labels": ["address__value"],
-            "branch": BranchSupportType.AWARE.value,
-            "inherit_from": [InfrahubKind.IPADDRESS],
-        },
-    ],
-}
-
-
-@pytest.fixture(scope="class")
-def ipam_schema() -> SchemaRoot:
-    return SchemaRoot(**IPAM_SCHEMA)
 
 
 @pytest.fixture(scope="class")

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -7,7 +7,10 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality
+from infrahub.core.constraint.node.runner import NodeConstraintRunner
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
 from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
@@ -241,7 +244,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
         )
         await template.save(db=db)
 
-        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
         await loaded_template.primary_ip.update(db=db, data={"id": ip_address.id})
 
         with pytest.raises(ValidationError) as exc:
@@ -294,7 +297,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
         )
         await template.save(db=db)
 
-        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
         await loaded_template.primary_ip_from_resource_pool.update(db=db, data=None)
         await loaded_template.primary_ip.update(db=db, data={"id": ip_address.id})
 
@@ -343,7 +346,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
             relm=template.weight_from_resource_pool, node_schema=template.get_schema(), node=template
         )
 
-        # No error raised
+        # No error raised, pool is allowed when attribute has no user-set value
         assert result is None
 
     async def test_constraint_rejects_attribute_pool_when_attribute_has_value(
@@ -392,7 +395,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
         await template.new(db=db, template_name="device-template-attr-then-pool", weight=42)
         await template.save(db=db)
 
-        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
         await loaded_template.weight_from_resource_pool.update(db=db, data={"id": number_pool.id})
 
         with pytest.raises(ValidationError) as exc:
@@ -422,7 +425,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
         await template.new(db=db, template_name="device-template-reset-attr", weight=42)
         await template.save(db=db)
 
-        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
         weight_attr = loaded_template.get_attribute(name="weight")
         weight_attr.value = None
         weight_attr.is_default = True
@@ -435,5 +438,154 @@ class TestTemplateResourcePoolExclusiveConstraint:
             node=loaded_template,
         )
 
-        # No error raised
+        # No error raised, pool is allowed after resetting attribute
+        assert result is None
+
+
+class TestNodeConstraintRunnerPoolFilterExpansion:
+    """Tests that NodeConstraintRunner expands field_filters to include _from_resource_pool
+    relationships when an attribute is being updated on a template."""
+
+    @pytest.fixture(scope="class")
+    def ipam_schema(self) -> SchemaRoot:
+        SCHEMA: dict[str, Any] = {
+            "nodes": [
+                {
+                    "name": "IPPrefix",
+                    "namespace": "Ipam",
+                    "default_filter": "prefix__value",
+                    "order_by": ["prefix__value"],
+                    "display_labels": ["prefix__value"],
+                    "branch": BranchSupportType.AWARE.value,
+                    "inherit_from": [InfrahubKind.IPPREFIX],
+                },
+                {
+                    "name": "IPAddress",
+                    "namespace": "Ipam",
+                    "default_filter": "address__value",
+                    "order_by": ["address__value"],
+                    "display_labels": ["address__value"],
+                    "branch": BranchSupportType.AWARE.value,
+                    "inherit_from": [InfrahubKind.IPADDRESS],
+                },
+            ],
+        }
+        return SchemaRoot(**SCHEMA)
+
+    @pytest.fixture(scope="class")
+    async def register_ipam_schema(self, default_branch_scope_class: Branch, ipam_schema: SchemaRoot) -> None:
+        registry.schema.register_schema(schema=ipam_schema, branch=default_branch_scope_class.name)
+        default_branch_scope_class.update_schema_hash()
+
+    @pytest.fixture(scope="class")
+    def init_nodes_registry(self) -> None:
+        registry.node["Node"] = Node
+        registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+        registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
+        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    @pytest.fixture(scope="class")
+    async def device_schema_with_pool_rel(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        register_ipam_schema: None,
+        init_nodes_registry: None,
+    ) -> None:
+        device = copy.deepcopy(DEVICE)
+        device.relationships = [
+            RelationshipSchema(
+                name="primary_ip", peer="IpamIPAddress", cardinality=RelationshipCardinality.ONE, optional=True
+            )
+        ]
+        schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
+        registry.schema.register_schema(schema=schema, branch=default_branch_scope_class.name)
+
+    @pytest.fixture(scope="class")
+    async def number_pool(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, device_schema_with_pool_rel: None
+    ) -> CoreNumberPool:
+        pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+        await pool.new(
+            db=db,
+            name="runner-weight-pool",
+            node=TestKind.DEVICE,
+            node_attribute="weight",
+            start_range=1,
+            end_range=100,
+        )
+        await pool.save(db=db)
+        return pool
+
+    async def test_runner_rejects_attribute_update_when_pool_is_set(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Runner rejects setting attribute value when pool relationship exists."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(db=db, template_name="device-template-pool-then-attr", weight_from_resource_pool=number_pool)
+        await template.save(db=db)
+
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        weight_attr = loaded_template.get_attribute(name="weight")
+        weight_attr.value = 42
+        weight_attr.is_default = False
+
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+        runner = NodeConstraintRunner(
+            db=db,
+            branch=default_branch_scope_class,
+            uniqueness_constraint=NodeGroupedUniquenessConstraint(db=db, branch=default_branch_scope_class),
+            relationship_manager_constraints=[constraint],
+        )
+
+        with pytest.raises(ValidationError) as exc:
+            await runner.check(node=loaded_template, field_filters=["weight"], skip_uniqueness_check=True)
+
+        assert "Cannot set 'weight_from_resource_pool' when 'weight' has a value set." in exc.value.message
+
+    async def test_runner_allows_attribute_update_after_clearing_pool(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Runner allows setting attribute value after clearing pool relationship."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(
+            db=db, template_name="device-template-clear-pool-then-attr", weight_from_resource_pool=number_pool
+        )
+        await template.save(db=db)
+
+        loaded_template = await NodeManager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        await loaded_template.weight_from_resource_pool.update(db=db, data=None)
+        weight_attr = loaded_template.get_attribute(name="weight")
+        weight_attr.value = 42
+        weight_attr.is_default = False
+
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+        runner = NodeConstraintRunner(
+            db=db,
+            branch=default_branch_scope_class,
+            uniqueness_constraint=NodeGroupedUniquenessConstraint(db=db, branch=default_branch_scope_class),
+            relationship_manager_constraints=[constraint],
+        )
+
+        # Act
+        result = await runner.check(node=loaded_template, field_filters=["weight"], skip_uniqueness_check=True)
+
+        # No error occurred
         assert result is None

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -347,13 +347,10 @@ class TestTemplateResourcePoolExclusiveConstraint:
         weight_attr = template.get_attribute(name="weight")
         assert weight_attr.is_default is True
 
-        # Act
-        result = await constraint.check(
+        # Act & Assert -> No error should occur, pool is allowed when attribute has no user-set value
+        await constraint.check(
             relm=template.weight_from_resource_pool, node_schema=template.get_schema(), node=template
         )
-
-        # No error raised, pool is allowed when attribute has no user-set value
-        assert result is None
 
     async def test_constraint_rejects_attribute_pool_when_attribute_has_value(
         self,
@@ -437,15 +434,12 @@ class TestTemplateResourcePoolExclusiveConstraint:
         weight_attr.is_default = True
         await loaded_template.weight_from_resource_pool.update(db=db, data={"id": number_pool.id})
 
-        # Act
-        result = await constraint.check(
+        # Act & Assert -> No error should occur, pool is allowed after resetting attribute
+        await constraint.check(
             relm=loaded_template.weight_from_resource_pool,
             node_schema=loaded_template.get_schema(),
             node=loaded_template,
         )
-
-        # No error raised, pool is allowed after resetting attribute
-        assert result is None
 
 
 class TestNodeConstraintRunnerPoolFilterExpansion:
@@ -518,8 +512,5 @@ class TestNodeConstraintRunnerPoolFilterExpansion:
             relationship_manager_constraints=[constraint],
         )
 
-        # Act
-        result = await runner.check(node=loaded_template, field_filters=["weight"], skip_uniqueness_check=True)
-
-        # No error occurred
-        assert result is None
+        # Act & Assert -> No error should occur
+        await runner.check(node=loaded_template, field_filters=["weight"], skip_uniqueness_check=True)

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -10,11 +10,13 @@ from infrahub.core.constants import BranchSupportType, InfrahubKind, Relationshi
 from infrahub.core.node import Node
 from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.relationship.constraints.template_resource_pool_exclusive import (
     TemplateResourcePoolExclusiveConstraint,
 )
 from infrahub.core.schema import RelationshipSchema, SchemaRoot
 from infrahub.exceptions import ValidationError
+from tests.constants import TestKind
 from tests.helpers.schema.device import DEVICE, INTERFACE, INTERFACE_HOLDER
 
 if TYPE_CHECKING:
@@ -60,6 +62,7 @@ class TestTemplateResourcePoolExclusiveConstraint:
         registry.node["Node"] = Node
         registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
         registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
+        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
 
     @pytest.fixture(scope="class")
     async def device_schema_with_pool_rel(
@@ -298,3 +301,139 @@ class TestTemplateResourcePoolExclusiveConstraint:
         await constraint.check(
             relm=loaded_template.primary_ip, node_schema=loaded_template.get_schema(), node=loaded_template
         )
+
+    @pytest.fixture(scope="class")
+    async def number_pool(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, device_schema_with_pool_rel: None
+    ) -> CoreNumberPool:
+        pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+        await pool.new(
+            db=db,
+            name="weight-pool",
+            node=TestKind.DEVICE,
+            node_attribute="weight",
+            start_range=1,
+            end_range=100,
+        )
+        await pool.save(db=db)
+        return pool
+
+    async def test_constraint_allows_attribute_pool_when_attribute_is_default(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Pool relationship is allowed when the attribute has no user-set value."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(db=db, template_name="device-template-attr-pool-only", weight_from_resource_pool=number_pool)
+
+        # Attribute is defaulted
+        weight_attr = template.get_attribute(name="weight")
+        assert weight_attr.is_default is True
+
+        # Act
+        result = await constraint.check(
+            relm=template.weight_from_resource_pool, node_schema=template.get_schema(), node=template
+        )
+
+        # No error raised
+        assert result is None
+
+    async def test_constraint_rejects_attribute_pool_when_attribute_has_value(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Pool relationship is rejected when the attribute has a user-set value."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(
+            db=db,
+            template_name="device-template-attr-and-pool",
+            weight=42,
+            weight_from_resource_pool=number_pool,
+        )
+
+        with pytest.raises(ValidationError) as exc:
+            # Act
+            await constraint.check(
+                relm=template.weight_from_resource_pool, node_schema=template.get_schema(), node=template
+            )
+
+        assert "Cannot set 'weight_from_resource_pool' when 'weight' has a value set." in exc.value.message
+
+    async def test_constraint_rejects_attribute_pool_when_attribute_set_on_saved_template(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Pool relationship is rejected when the attribute was set on a previously saved template."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(db=db, template_name="device-template-attr-then-pool", weight=42)
+        await template.save(db=db)
+
+        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        await loaded_template.weight_from_resource_pool.update(db=db, data={"id": number_pool.id})
+
+        with pytest.raises(ValidationError) as exc:
+            # Act
+            await constraint.check(
+                relm=loaded_template.weight_from_resource_pool,
+                node_schema=loaded_template.get_schema(),
+                node=loaded_template,
+            )
+
+        assert "Cannot set 'weight_from_resource_pool' when 'weight' has a value set." in exc.value.message
+
+    async def test_constraint_allows_attribute_pool_after_resetting_attribute(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        device_schema_with_pool_rel: None,
+        number_pool: CoreNumberPool,
+    ) -> None:
+        """Pool relationship is allowed after the attribute value is reset to default."""
+        template_schema = registry.schema.get_template_schema(
+            name="TemplateTestingDevice", branch=default_branch_scope_class
+        )
+        constraint = TemplateResourcePoolExclusiveConstraint(db=db, branch=default_branch_scope_class)
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch_scope_class)
+        await template.new(db=db, template_name="device-template-reset-attr", weight=42)
+        await template.save(db=db)
+
+        loaded_template = await registry.manager.get_one(db=db, id=template.id, branch=default_branch_scope_class)
+        weight_attr = loaded_template.get_attribute(name="weight")
+        weight_attr.value = None
+        weight_attr.is_default = True
+        await loaded_template.weight_from_resource_pool.update(db=db, data={"id": number_pool.id})
+
+        # Act
+        result = await constraint.check(
+            relm=loaded_template.weight_from_resource_pool,
+            node_schema=loaded_template.get_schema(),
+            node=loaded_template,
+        )
+
+        # No error raised
+        assert result is None

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -28,63 +28,85 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
+IPAM_SCHEMA: dict[str, Any] = {
+    "nodes": [
+        {
+            "name": "IPPrefix",
+            "namespace": "Ipam",
+            "default_filter": "prefix__value",
+            "order_by": ["prefix__value"],
+            "display_labels": ["prefix__value"],
+            "branch": BranchSupportType.AWARE.value,
+            "inherit_from": [InfrahubKind.IPPREFIX],
+        },
+        {
+            "name": "IPAddress",
+            "namespace": "Ipam",
+            "default_filter": "address__value",
+            "order_by": ["address__value"],
+            "display_labels": ["address__value"],
+            "branch": BranchSupportType.AWARE.value,
+            "inherit_from": [InfrahubKind.IPADDRESS],
+        },
+    ],
+}
+
+
+@pytest.fixture(scope="class")
+def ipam_schema() -> SchemaRoot:
+    return SchemaRoot(**IPAM_SCHEMA)
+
+
+@pytest.fixture(scope="class")
+async def register_ipam_schema(default_branch_scope_class: Branch, ipam_schema: SchemaRoot) -> None:
+    registry.schema.register_schema(schema=ipam_schema, branch=default_branch_scope_class.name)
+    default_branch_scope_class.update_schema_hash()
+
+
+@pytest.fixture(scope="class")
+def init_nodes_registry() -> None:
+    registry.node["Node"] = Node
+    registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+    registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+
+@pytest.fixture(scope="class")
+async def device_schema_with_pool_rel(
+    db: InfrahubDatabase,
+    default_branch_scope_class: Branch,
+    register_core_models_schema_scope_class: SchemaBranch,
+    register_ipam_schema: None,
+    init_nodes_registry: None,
+) -> None:
+    device = copy.deepcopy(DEVICE)
+    device.relationships = [
+        RelationshipSchema(
+            name="primary_ip", peer="IpamIPAddress", cardinality=RelationshipCardinality.ONE, optional=True
+        )
+    ]
+    schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
+    registry.schema.register_schema(schema=schema, branch=default_branch_scope_class.name)
+
+
+@pytest.fixture(scope="class")
+async def number_pool(
+    db: InfrahubDatabase, default_branch_scope_class: Branch, device_schema_with_pool_rel: None
+) -> CoreNumberPool:
+    pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+    await pool.new(
+        db=db,
+        name="weight-pool",
+        node=TestKind.DEVICE,
+        node_attribute="weight",
+        start_range=1,
+        end_range=100,
+    )
+    await pool.save(db=db)
+    return pool
+
+
 class TestTemplateResourcePoolExclusiveConstraint:
-    @pytest.fixture(scope="class")
-    def ipam_schema(self) -> SchemaRoot:
-        SCHEMA: dict[str, Any] = {
-            "nodes": [
-                {
-                    "name": "IPPrefix",
-                    "namespace": "Ipam",
-                    "default_filter": "prefix__value",
-                    "order_by": ["prefix__value"],
-                    "display_labels": ["prefix__value"],
-                    "branch": BranchSupportType.AWARE.value,
-                    "inherit_from": [InfrahubKind.IPPREFIX],
-                },
-                {
-                    "name": "IPAddress",
-                    "namespace": "Ipam",
-                    "default_filter": "address__value",
-                    "order_by": ["address__value"],
-                    "display_labels": ["address__value"],
-                    "branch": BranchSupportType.AWARE.value,
-                    "inherit_from": [InfrahubKind.IPADDRESS],
-                },
-            ],
-        }
-        return SchemaRoot(**SCHEMA)
-
-    @pytest.fixture(scope="class")
-    async def register_ipam_schema(self, default_branch_scope_class: Branch, ipam_schema: SchemaRoot) -> None:
-        registry.schema.register_schema(schema=ipam_schema, branch=default_branch_scope_class.name)
-        default_branch_scope_class.update_schema_hash()
-
-    @pytest.fixture(scope="class")
-    def init_nodes_registry(self) -> None:
-        registry.node["Node"] = Node
-        registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
-        registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
-        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
-
-    @pytest.fixture(scope="class")
-    async def device_schema_with_pool_rel(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        register_core_models_schema_scope_class: SchemaBranch,
-        register_ipam_schema: None,
-        init_nodes_registry: None,
-    ) -> None:
-        device = copy.deepcopy(DEVICE)
-        device.relationships = [
-            RelationshipSchema(
-                name="primary_ip", peer="IpamIPAddress", cardinality=RelationshipCardinality.ONE, optional=True
-            )
-        ]
-        schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
-        registry.schema.register_schema(schema=schema, branch=default_branch_scope_class.name)
-
     @pytest.fixture(scope="class")
     async def ip_namespace(self, db: InfrahubDatabase, register_ipam_schema: SchemaBranch) -> Node:
         ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
@@ -305,22 +327,6 @@ class TestTemplateResourcePoolExclusiveConstraint:
             relm=loaded_template.primary_ip, node_schema=loaded_template.get_schema(), node=loaded_template
         )
 
-    @pytest.fixture(scope="class")
-    async def number_pool(
-        self, db: InfrahubDatabase, default_branch_scope_class: Branch, device_schema_with_pool_rel: None
-    ) -> CoreNumberPool:
-        pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
-        await pool.new(
-            db=db,
-            name="weight-pool",
-            node=TestKind.DEVICE,
-            node_attribute="weight",
-            start_range=1,
-            end_range=100,
-        )
-        await pool.save(db=db)
-        return pool
-
     async def test_constraint_allows_attribute_pool_when_attribute_is_default(
         self,
         db: InfrahubDatabase,
@@ -445,78 +451,6 @@ class TestTemplateResourcePoolExclusiveConstraint:
 class TestNodeConstraintRunnerPoolFilterExpansion:
     """Tests that NodeConstraintRunner expands field_filters to include _from_resource_pool
     relationships when an attribute is being updated on a template."""
-
-    @pytest.fixture(scope="class")
-    def ipam_schema(self) -> SchemaRoot:
-        SCHEMA: dict[str, Any] = {
-            "nodes": [
-                {
-                    "name": "IPPrefix",
-                    "namespace": "Ipam",
-                    "default_filter": "prefix__value",
-                    "order_by": ["prefix__value"],
-                    "display_labels": ["prefix__value"],
-                    "branch": BranchSupportType.AWARE.value,
-                    "inherit_from": [InfrahubKind.IPPREFIX],
-                },
-                {
-                    "name": "IPAddress",
-                    "namespace": "Ipam",
-                    "default_filter": "address__value",
-                    "order_by": ["address__value"],
-                    "display_labels": ["address__value"],
-                    "branch": BranchSupportType.AWARE.value,
-                    "inherit_from": [InfrahubKind.IPADDRESS],
-                },
-            ],
-        }
-        return SchemaRoot(**SCHEMA)
-
-    @pytest.fixture(scope="class")
-    async def register_ipam_schema(self, default_branch_scope_class: Branch, ipam_schema: SchemaRoot) -> None:
-        registry.schema.register_schema(schema=ipam_schema, branch=default_branch_scope_class.name)
-        default_branch_scope_class.update_schema_hash()
-
-    @pytest.fixture(scope="class")
-    def init_nodes_registry(self) -> None:
-        registry.node["Node"] = Node
-        registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
-        registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
-        registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
-
-    @pytest.fixture(scope="class")
-    async def device_schema_with_pool_rel(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        register_core_models_schema_scope_class: SchemaBranch,
-        register_ipam_schema: None,
-        init_nodes_registry: None,
-    ) -> None:
-        device = copy.deepcopy(DEVICE)
-        device.relationships = [
-            RelationshipSchema(
-                name="primary_ip", peer="IpamIPAddress", cardinality=RelationshipCardinality.ONE, optional=True
-            )
-        ]
-        schema = SchemaRoot(generics=[INTERFACE_HOLDER, INTERFACE], nodes=[device])
-        registry.schema.register_schema(schema=schema, branch=default_branch_scope_class.name)
-
-    @pytest.fixture(scope="class")
-    async def number_pool(
-        self, db: InfrahubDatabase, default_branch_scope_class: Branch, device_schema_with_pool_rel: None
-    ) -> CoreNumberPool:
-        pool = await CoreNumberPool.init(db=db, schema=InfrahubKind.NUMBERPOOL)
-        await pool.new(
-            db=db,
-            name="runner-weight-pool",
-            node=TestKind.DEVICE,
-            node_attribute="weight",
-            start_range=1,
-            end_range=100,
-        )
-        await pool.save(db=db)
-        return pool
 
     async def test_runner_rejects_attribute_update_when_pool_is_set(
         self,


### PR DESCRIPTION
# Why

Currently, a user can define a direct value for an attribute related to a template object and, at the same time, define a `_from_resource_pool` relationship, which aims to provide a value for this attribute when an object is created from the template.

## Goal

Add additional safeguards to prevent the direct attribute value and resource pool provisioning from being used concurrently when a node object is created from the template.

## What changed

- An additional check has been added to the current existing template & ressource pool exclusive constraint `TemplateResourcePoolExclusiveConstraint`. This check is also triggered during the node creation through the `NodeConstraintRunner`.

### Design 

- Tried to keep the `infrahub.core.constraint.node.runner.NodeConstraintRunner` as generic as possible. But I still had to add a new logic step into his algorithm.

## How to test

```bash
uv run pytest -xvs backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
```

## Impact & rollout

- **Backward compatibility:** Issue can occur if there is already existing concurrent relationships and attribute value defined on an existing template
- **Deployment notes:** requires coordinated release

## Checklist

- [x] Tests added/updated
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default filter-expansion hook for relationship constraints so constraints can extend field filters.

* **Bug Fixes**
  * Constraint checks now respect expanded filters and consistently use the node schema when evaluating relationships.
  * Template pool constraint enforces mutual exclusion against both relationship and attribute counterparts, rejecting invalid pool+attribute combinations.

* **Tests**
  * Expanded tests and fixtures for pool-related constraints, attribute interactions, and runner filter expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->