### PR TITLE
Fix flaky test_create_python_check_definition

### DIFF
--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -40,11 +40,7 @@ from tests.conftest import TestHelper
 from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
-
-@pytest.fixture(autouse=True)
-def non_mocked_hosts() -> list:
-    """Workaround to tell HTTPX Mock to not mock the requests to prefect targeting 127.0.0.1."""
-    return ["127.0.0.1"]
+pytestmark = pytest.mark.httpx_mock(should_mock=lambda request: request.url.host != "127.0.0.1")
 
 
 async def test_directories_props(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dev = [
     "pandas==2.3.3",
     "semver>=3.0.2,<4",
     "ruamel-yaml==0.18.6",
-    "pytest-httpx>=0.30",
+    "pytest-httpx>=0.33",
     "docker==7.1.0",
     "psutil==6.1.0",
     "jwcrypto==1.5.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1520,7 +1520,7 @@ dev = [
     { name = "pytest-codspeed", specifier = ">=4.2.0,<5" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = ">=1.1.3,<2" },
-    { name = "pytest-httpx", specifier = ">=0.30" },
+    { name = "pytest-httpx", specifier = ">=0.33" },
     { name = "pytest-timeout", specifier = "==2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.4,<3.5" },
     { name = "ruamel-yaml", specifier = "==0.18.6" },


### PR DESCRIPTION
# Why

`test_create_python_check_definition` is flaky. Prefect's `APILogHandler` seems to send POST requests to `http://127.0.0.1:8202/api/logs/`, and `pytest_httpx` 0.36 catches them as unexpected requests.
-> see https://github.com/opsmill/infrahub/actions/runs/22906518420/job/66466841005?pr=8559

The `non_mocked_hosts` fixture at the top of the file is dead code, it was a `pytest_httpx` feature removed in [v0.31.0](https://github.com/Colin-b/pytest_httpx/releases/tag/v0.31.0). The `non_mocked_hosts` marker option was itself removed in [v0.33.0](https://github.com/Colin-b/pytest_httpx/releases/tag/v0.33.0), replaced by `should_mock`.

## What changed

- Replaced dead `non_mocked_hosts` fixture with `pytestmark = pytest.mark.httpx_mock(should_mock=...)` to properly exclude Prefect's `127.0.0.1` requests from httpx mocking
- Bumped `pytest-httpx` pin from `>=0.30` to `>=0.33` since `should_mock` was introduced in v0.33.0

## How to test

```bash
uv run pytest -xvs backend/tests/component/git/test_git_repository.py::test_create_python_check_definition
uv run ruff check backend/tests/component/git/test_git_repository.py
```

## Checklist

- [x] Tests added/updated

🤖 Created with [Claude Code](https://claude.com/claude-code)