### PR TITLE
Fix flaky test_event_query_prefect

### DIFF
--- a/backend/tests/component/graphql/queries/test_event.py
+++ b/backend/tests/component/graphql/queries/test_event.py
@@ -142,6 +142,11 @@ query MutatedNodes($id: [String!]) {
 }
 """
 
+_TEST_ID = uuid.uuid4().hex[:8]
+BRANCH1_NAME = f"branch1-{_TEST_ID}"
+BRANCH2_NAME = f"branch2-{_TEST_ID}"
+BRANCH3_NAME = f"branch3-{_TEST_ID}"
+
 ACCOUNT1_ID = "33b15615-649e-4e9e-89b0-85e187251f1f"
 ACCOUNT2_ID = "518b434f-40bf-4b65-b700-04696535ca8e"
 
@@ -223,35 +228,35 @@ async def events_data(
     await group_eu.new(db=db, name="Europe", children=[group_fr])
     await group_eu.save(db=db)
 
-    branch1 = Branch(uuid=branch1_id, name="branch1")
-    branch2 = Branch(uuid=branch2_id, name="branch2")
-    branch3 = Branch(uuid=branch3_id, name="branch3")
+    branch1 = Branch(uuid=branch1_id, name=BRANCH1_NAME)
+    branch2 = Branch(uuid=branch2_id, name=BRANCH2_NAME)
+    branch3 = Branch(uuid=branch3_id, name=BRANCH3_NAME)
 
     items: dict[str, InfrahubEvent] = {
         "branch1_created": BranchCreatedEvent(
-            branch_name="branch1",
+            branch_name=BRANCH1_NAME,
             branch_id=str(branch1_id),
             sync_with_git=True,
             meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch1_rebased": BranchRebasedEvent(
-            branch_name="branch1",
+            branch_name=BRANCH1_NAME,
             branch_id=str(branch1_id),
             meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch2_created": BranchCreatedEvent(
-            branch_name="branch2",
+            branch_name=BRANCH2_NAME,
             branch_id=str(branch2_id),
             sync_with_git=False,
             meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch2_rebased": BranchRebasedEvent(
-            branch_name="branch2",
+            branch_name=BRANCH2_NAME,
             branch_id=str(branch2_id),
             meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch3_created": BranchCreatedEvent(
-            branch_name="branch3",
+            branch_name=BRANCH3_NAME,
             branch_id=str(branch3_id),
             sync_with_git=True,
             meta=EventMeta.with_dummy_context(branch=branch3),
@@ -457,7 +462,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": "branch1"},
+        variables={"branch": BRANCH1_NAME},
     )
     assert result_branch1.errors is None
     assert result_branch1.data
@@ -469,7 +474,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_SIMPLE_COUNT_EVENT,
-        variables={"branch": "branch1"},
+        variables={"branch": BRANCH1_NAME},
     )
     assert result_count_branch1.errors is None
     assert result_count_branch1.data
@@ -523,7 +528,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": "branch1", "account": ACCOUNT1_ID},
+        variables={"branch": BRANCH1_NAME, "account": ACCOUNT1_ID},
     )
     assert branch1_account1.errors is None
     assert branch1_account1.data
@@ -533,7 +538,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": "branch1", "account": ACCOUNT2_ID},
+        variables={"branch": BRANCH1_NAME, "account": ACCOUNT2_ID},
     )
     assert branch1_account2.errors is None
     assert branch1_account2.data
@@ -543,7 +548,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": "branch2", "account": ACCOUNT1_ID},
+        variables={"branch": BRANCH2_NAME, "account": ACCOUNT1_ID},
     )
     assert branch2_account1.errors is None
     assert branch2_account1.data
@@ -553,7 +558,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": "branch2", "account": ACCOUNT2_ID},
+        variables={"branch": BRANCH2_NAME, "account": ACCOUNT2_ID},
     )
     assert branch2_account2.errors is None
     assert branch2_account2.data
@@ -585,7 +590,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"account": ACCOUNT1_ID, "branch": ["branch1", "branch3"]},
+        variables={"account": ACCOUNT1_ID, "branch": [BRANCH1_NAME, BRANCH3_NAME]},
     )
     assert account1_branch1_branch3.errors is None
     assert account1_branch1_branch3.data
@@ -596,7 +601,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"level": 1, "branch": ["branch3"]},
+        variables={"level": 1, "branch": [BRANCH3_NAME]},
     )
     assert branch3_level_1.errors is None
     assert branch3_level_1.data
@@ -608,7 +613,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"has_children": True, "branch": ["branch3"]},
+        variables={"has_children": True, "branch": [BRANCH3_NAME]},
     )
     assert branch3_has_children_true.errors is None
     assert branch3_has_children_true.data
@@ -632,20 +637,19 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"event_type": ["infrahub.node.created"]},
+        variables={"event_type": ["infrahub.node.created"], "limit": 50},
     )
     assert created_branch1.errors is None
     assert created_branch1.data
-    assert created_branch1.data["InfrahubEvent"]["count"] == 11
-    assert [node["node"]["event"] for node in created_branch1.data["InfrahubEvent"]["edges"]] == [
-        "infrahub.node.created"
-    ] * 10
+    clean_result = filter_outofscope_events(created_branch1.data, event_ids_inscope)
+    assert clean_result["InfrahubEvent"]["count"] == 11
+    assert [node["node"]["event"] for node in clean_result["InfrahubEvent"]["edges"]] == ["infrahub.node.created"] * 11
 
     all_branch1 = await run_query(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": ["branch1"]},
+        variables={"branch": [BRANCH1_NAME]},
     )
     assert all_branch1.errors is None
     assert all_branch1.data
@@ -656,7 +660,7 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"branch": ["branch1"], "since": occurred_at},
+        variables={"branch": [BRANCH1_NAME], "since": occurred_at},
     )
     assert since_timestamp.errors is None
     assert since_timestamp.data


### PR DESCRIPTION
# Why

`test_event_query_prefect` fails from time to time in CI with:

```
FAILED backend/tests/component/graphql/queries/test_event.py::test_event_query_prefect - assert == failed.

LHS vs RHS shown below

<Insert a number greater than 11>
11
```
-> see https://github.com/opsmill/infrahub/actions/runs/22899989741/job/66460736640?pr=8543

The root cause: the query at line 639 filters by `event_type=["infrahub.node.created"]` without using `filter_outofscope_events`, so the count includes events from the entire Prefect instance and not just the 11 created by this test. The default `limit=10` also meant only 10 edges were returned, masking a second mismatch.

The generic branch names (`"branch1"`, `"branch2"`, `"branch3"`) could also cause collisions with other tests sharing the same Prefect instance, I have observed it while creating a test using new branches.

## What changed

- Applied `filter_outofscope_events` to the `event_type`-only query that was missing it, with `limit: 50` to fetch all matching events
- Fixed edges assertion from `* 10` to `* 11` as the default `limit=10` was silently dropping the 11th event
- Made branch names unique per test run by appending a random suffix (`uuid4().hex[:8]`), stored in module-level constants `BRANCH1_NAME`, `BRANCH2_NAME`, `BRANCH3_NAME` in order to preventive measure against cross-test collisions

## How to test

```bash
uv run pytest -xvs backend/tests/component/graphql/queries/test_event.py::test_event_query_prefect
uv run ruff check backend/tests/component/graphql/queries/test_event.py
```

## Checklist

- [x] Tests added/updated

🤖 Created with [Claude Code](https://claude.com/claude-code)