### PR TITLE
set attr _from_resource_pool relationships in db migration

### DIFF
--- a/backend/infrahub/core/migrations/graph/m063_template_ip_pool_relationship_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m063_template_ip_pool_relationship_cleanup.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind, MetadataOptions
+from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
 from infrahub.core.initialization import get_root_node
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.shared import (
@@ -26,9 +27,14 @@ IP_POOL_KINDS = {InfrahubKind.IPADDRESSPOOL, InfrahubKind.IPPREFIXPOOL}
 
 
 class Migration063(MigrationRequiringRebase):
-    """Migrate IP pool-sourced relationships on templates to _from_resource_pool relationships."""
+    """Migrate pool-sourced relationships and attributes on templates to _from_resource_pool relationships.
 
-    name: str = "063_template_ip_pool_relationship_cleanup"
+    Handles two cases:
+    1. IP relationships sourced from IP pools → creates _from_resource_pool relationship, deletes original
+    2. Number attributes sourced from Number pools → creates _from_resource_pool relationship, clears attribute source
+    """
+
+    name: str = "063_template_pool_relationship_cleanup"
     minimum_version: int = 62
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
@@ -58,15 +64,21 @@ class Migration063(MigrationRequiringRebase):
             for template_kind in schema_branch.template_names:
                 template_schema = schema_branch.get(name=template_kind, duplicate=False)
 
-                # Build map: original_rel_name -> pool_rel_name
-                pool_rel_map: dict[str, str] = {}
-                for rel in template_schema.relationships:
-                    if rel.name.endswith("_from_resource_pool"):
-                        original_name = rel.name.removesuffix("_from_resource_pool")
-                        if original_name in template_schema.relationship_names:
-                            pool_rel_map[original_name] = rel.name
+                # Build map: original_rel_name -> pool_rel_name (for IP relationships)
+                rel_pool_map: dict[str, str] = {}
+                # Build map: attr_name -> pool_rel_name (for Number attributes)
+                attr_pool_map: dict[str, str] = {}
 
-                if not pool_rel_map:
+                for rel in template_schema.relationships:
+                    if not rel.name.endswith(RESOURCE_POOL_REL_SUFFIX):
+                        continue
+                    original_name = rel.name.removesuffix(RESOURCE_POOL_REL_SUFFIX)
+                    if original_name in template_schema.relationship_names:
+                        rel_pool_map[original_name] = rel.name
+                    elif original_name in template_schema.attribute_names:
+                        attr_pool_map[original_name] = rel.name
+
+                if not rel_pool_map and not attr_pool_map:
                     continue
 
                 templates = await NodeManager.query(
@@ -78,7 +90,11 @@ class Migration063(MigrationRequiringRebase):
 
                 for template in templates:
                     await self._process_one_template(
-                        db=db, template=template, pool_rel_map=pool_rel_map, migration_input=migration_input
+                        db=db,
+                        template=template,
+                        rel_pool_map=rel_pool_map,
+                        attr_pool_map=attr_pool_map,
+                        migration_input=migration_input,
                     )
 
         except Exception as exc:
@@ -88,12 +104,18 @@ class Migration063(MigrationRequiringRebase):
         return MigrationResult()
 
     async def _process_one_template(
-        self, db: InfrahubDatabase, template: Node, pool_rel_map: dict[str, str], migration_input: MigrationInput
+        self,
+        db: InfrahubDatabase,
+        template: Node,
+        rel_pool_map: dict[str, str],
+        attr_pool_map: dict[str, str],
+        migration_input: MigrationInput,
     ) -> None:
         at = migration_input.at
         user_id = migration_input.user_id
 
-        for original_rel_name, pool_rel_name in pool_rel_map.items():
+        # Handle IP relationship pool sources
+        for original_rel_name, pool_rel_name in rel_pool_map.items():
             rel_mgr = template.get_relationship(original_rel_name)
 
             # Find the first relationship sourced from an IP pool (at most one per manager)
@@ -113,3 +135,27 @@ class Migration063(MigrationRequiringRebase):
                 # Soft-delete the original pool-sourced relationship
                 await rel.delete(db=db, at=at, user_id=user_id)
                 break
+
+        # Handle Number attribute pool sources
+        for attr_name, pool_rel_name in attr_pool_map.items():
+            attribute = template.get_attribute(attr_name)
+            if not attribute or not getattr(attribute, "source_id", None):
+                continue
+
+            source = await attribute.get_source(db=db)
+            if not source or source.get_kind() != InfrahubKind.NUMBERPOOL:
+                continue
+
+            # Check if _from_resource_pool relationship already exists (idempotency)
+            pool_rel_mgr = template.get_relationship(pool_rel_name)
+            existing_pool_rels = await pool_rel_mgr.get_relationships(db=db)
+            if existing_pool_rels:
+                continue
+
+            # Create _from_resource_pool relationship pointing to the pool
+            await pool_rel_mgr.update(db=db, data=source)
+            await pool_rel_mgr.save(db=db, at=at, user_id=user_id)
+
+            # Clear the attribute source
+            attribute.clear_source()
+            await attribute.save(db=db, at=at, user_id=user_id)

--- a/backend/infrahub/core/migrations/graph/m063_template_ip_pool_relationship_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m063_template_ip_pool_relationship_cleanup.py
@@ -149,12 +149,11 @@ class Migration063(MigrationRequiringRebase):
             # Check if _from_resource_pool relationship already exists (idempotency)
             pool_rel_mgr = template.get_relationship(pool_rel_name)
             existing_pool_rels = await pool_rel_mgr.get_relationships(db=db)
-            if existing_pool_rels:
-                continue
 
-            # Create _from_resource_pool relationship pointing to the pool
-            await pool_rel_mgr.update(db=db, data=source)
-            await pool_rel_mgr.save(db=db, at=at, user_id=user_id)
+            if not existing_pool_rels or existing_pool_rels[0].peer_id != source.id:
+                # Create or repair the _from_resource_pool relationship
+                await pool_rel_mgr.update(db=db, data=source)
+                await pool_rel_mgr.save(db=db, at=at, user_id=user_id)
 
             # Clear the attribute source
             attribute.clear_source()

--- a/backend/tests/component/core/migrations/graph/test_063_template_ip_pool_relationship_cleanup.py
+++ b/backend/tests/component/core/migrations/graph/test_063_template_ip_pool_relationship_cleanup.py
@@ -48,7 +48,10 @@ class TestMigration063(TestInfrahubApp):
                     "namespace": "Test",
                     "generate_template": True,
                     "display_labels": ["name__value"],
-                    "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                        {"name": "vlan_id", "kind": "Number", "optional": True},
+                    ],
                     "relationships": [
                         {
                             "name": "primary_address",
@@ -119,6 +122,20 @@ class TestMigration063(TestInfrahubApp):
         return pool
 
     @pytest.fixture(scope="class")
+    async def number_pool(self, db: InfrahubDatabase, device_schema: NodeSchema) -> Node:
+        pool = await Node.init(db=db, schema=InfrahubKind.NUMBERPOOL)
+        await pool.new(
+            db=db,
+            name="test-vlan-pool",
+            node="TestDevice",
+            node_attribute="vlan_id",
+            start_range=100,
+            end_range=200,
+        )
+        await pool.save(db=db)
+        return pool
+
+    @pytest.fixture(scope="class")
     async def ip_address(self, db: InfrahubDatabase, ip_namespace: Node) -> Node:
         addr = await Node.init(db=db, schema="IpamIPAddress")
         await addr.new(db=db, address="10.0.0.1/32", ip_namespace=ip_namespace)
@@ -140,6 +157,7 @@ class TestMigration063(TestInfrahubApp):
         ip_address_pool: Node,
         child_prefix: Node,
         ip_prefix_pool: Node,
+        number_pool: Node,
     ) -> Node:
         template = await Node.init(db=db, schema="TemplateTestDevice")
         await template.new(
@@ -147,12 +165,13 @@ class TestMigration063(TestInfrahubApp):
             template_name="pooled-device-template",
             primary_address=ip_address,
             management_prefix=child_prefix,
+            vlan_id=150,
         )
         await template.save(db=db)
 
-        # Set pool sources on both relationships
         loaded = await NodeManager.get_one(db=db, id=template.id, include_metadata=MetadataOptions.LINKED_NODES)
 
+        # Set pool sources on both IP relationships
         address_rel_mgr = loaded.get_relationship("primary_address")
         address_rels = await address_rel_mgr.get_relationships(db=db)
         address_rels[0].source = ip_address_pool.id
@@ -162,6 +181,10 @@ class TestMigration063(TestInfrahubApp):
         prefix_rels = await prefix_rel_mgr.get_relationships(db=db)
         prefix_rels[0].source = ip_prefix_pool.id
         await prefix_rel_mgr.save(db=db)
+
+        # Set number pool as source on vlan_id attribute
+        loaded.vlan_id.source = number_pool.id
+        await loaded.save(db=db, fields=["vlan_id"])
 
         return loaded
 
@@ -189,6 +212,7 @@ class TestMigration063(TestInfrahubApp):
             template_name="plain-device-template",
             primary_address=plain_ip_address,
             management_prefix=plain_child_prefix,
+            vlan_id=42,
         )
         await template.save(db=db)
         return template
@@ -206,6 +230,7 @@ class TestMigration063(TestInfrahubApp):
         ip_address_pool: Node,
         child_prefix: Node,
         ip_prefix_pool: Node,
+        number_pool: Node,
     ) -> Node:
         template = await Node.init(db=db, schema="TemplateTestDevice", branch=test_branch)
         await template.new(
@@ -213,6 +238,7 @@ class TestMigration063(TestInfrahubApp):
             template_name="branch-device-template",
             primary_address=ip_address,
             management_prefix=child_prefix,
+            vlan_id=175,
         )
         await template.save(db=db)
 
@@ -229,6 +255,9 @@ class TestMigration063(TestInfrahubApp):
         prefix_rels = await prefix_mgr.get_relationships(db=db)
         prefix_rels[0].source = ip_prefix_pool.id
         await prefix_mgr.save(db=db)
+
+        loaded.vlan_id.source = number_pool.id
+        await loaded.save(db=db, fields=["vlan_id"])
 
         return loaded
 
@@ -270,12 +299,49 @@ class TestMigration063(TestInfrahubApp):
         pool_rels = await loaded.get_relationship(f"{rel_name}_from_resource_pool").get_relationships(db=db)
         assert len(pool_rels) == 0
 
-    async def test_creates_from_resource_pool_and_deletes_original(
+    async def _assert_attr_pool_migrated(
+        self,
+        db: InfrahubDatabase,
+        template_id: str,
+        attr_name: str,
+        pool_id: str,
+        branch: Branch | None = None,
+    ) -> None:
+        loaded = await NodeManager.get_one(
+            db=db, id=template_id, branch=branch, include_metadata=MetadataOptions.LINKED_NODES
+        )
+
+        pool_rels = await loaded.get_relationship(f"{attr_name}_from_resource_pool").get_relationships(db=db)
+        assert len(pool_rels) == 1
+        assert pool_rels[0].peer_id == pool_id
+
+        attribute = loaded.get_attribute(attr_name)
+        assert attribute.source_id is None
+
+    async def _assert_attr_pool_unchanged(
+        self,
+        db: InfrahubDatabase,
+        template_id: str,
+        attr_name: str,
+        branch: Branch | None = None,
+    ) -> None:
+        loaded = await NodeManager.get_one(
+            db=db, id=template_id, branch=branch, include_metadata=MetadataOptions.LINKED_NODES
+        )
+
+        pool_rels = await loaded.get_relationship(f"{attr_name}_from_resource_pool").get_relationships(db=db)
+        assert len(pool_rels) == 0
+
+        attribute = loaded.get_attribute(attr_name)
+        assert attribute.source_id is None
+
+    async def test_migrates_pool_sources(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
         ip_address_pool: Node,
         ip_prefix_pool: Node,
+        number_pool: Node,
         ip_address: Node,
         child_prefix: Node,
         plain_ip_address: Node,
@@ -304,12 +370,17 @@ class TestMigration063(TestInfrahubApp):
         )
         assert len(prefix_pool_rels) == 0
 
+        assert loaded.vlan_id.source_id == number_pool.id
+        vlan_pool_rels = await loaded.get_relationship("vlan_id_from_resource_pool").get_relationships(db=db)
+        assert len(vlan_pool_rels) == 0
+
         # Run migration
         async with db.start_session() as dbs:
             migration = Migration063()
             result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not result.errors
 
+        # Verify IP relationships migrated
         await self._assert_rel_migrated(
             db=db, template_id=template_with_pool_source.id, rel_name="primary_address", pool_id=ip_address_pool.id
         )
@@ -325,6 +396,12 @@ class TestMigration063(TestInfrahubApp):
             rel_name="management_prefix",
             peer_id=plain_child_prefix.id,
         )
+
+        # Verify Number attribute migrated
+        await self._assert_attr_pool_migrated(
+            db=db, template_id=template_with_pool_source.id, attr_name="vlan_id", pool_id=number_pool.id
+        )
+        await self._assert_attr_pool_unchanged(db=db, template_id=template_without_pool_source.id, attr_name="vlan_id")
 
         # Verify idempotency: running again produces no errors and same results
         async with db.start_session() as dbs:
@@ -347,6 +424,10 @@ class TestMigration063(TestInfrahubApp):
             rel_name="management_prefix",
             peer_id=plain_child_prefix.id,
         )
+        await self._assert_attr_pool_migrated(
+            db=db, template_id=template_with_pool_source.id, attr_name="vlan_id", pool_id=number_pool.id
+        )
+        await self._assert_attr_pool_unchanged(db=db, template_id=template_without_pool_source.id, attr_name="vlan_id")
 
     async def test_execute_against_branch(
         self,
@@ -354,6 +435,7 @@ class TestMigration063(TestInfrahubApp):
         test_branch: Branch,
         ip_address_pool: Node,
         ip_prefix_pool: Node,
+        number_pool: Node,
         plain_ip_address: Node,
         plain_child_prefix: Node,
         template_without_pool_source: Node,
@@ -382,6 +464,13 @@ class TestMigration063(TestInfrahubApp):
             pool_id=ip_prefix_pool.id,
             branch=test_branch,
         )
+        await self._assert_attr_pool_migrated(
+            db=db,
+            template_id=branch_template_with_pool_source.id,
+            attr_name="vlan_id",
+            pool_id=number_pool.id,
+            branch=test_branch,
+        )
         await self._assert_rel_unchanged(
             db=db, template_id=template_without_pool_source.id, rel_name="primary_address", peer_id=plain_ip_address.id
         )
@@ -391,3 +480,4 @@ class TestMigration063(TestInfrahubApp):
             rel_name="management_prefix",
             peer_id=plain_child_prefix.id,
         )
+        await self._assert_attr_pool_unchanged(db=db, template_id=template_without_pool_source.id, attr_name="vlan_id")


### PR DESCRIPTION
update the existing database migration for setting `_from_resource_pool` relationships to also include attributes on Templates that have a `source` of a `CoreNumberPool`

the previous migration (062) already handles NULLing the value of any attributes on Templates with a source of a CoreNumberPool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migration expanded to handle both IP pool relationships and number/VLAN attribute pool sources.
  * Migration flow reorganized to build and process separate maps for relationship and attribute pool sources.
  * Per-template processing enhanced for idempotent creation of resource-pool linkages and cleanup of original pool sources.

* **Tests**
  * Test coverage extended to validate number/VLAN attribute migrations, branch-scoped behavior, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->