### PR TITLE
Update CODEOWNERS: require backend review for python_sdk/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /docker-compose.yml @opsmill/cloud
 uv.lock @opsmill/backend
 pyproject.toml @opsmill/backend
+/python_sdk/ @opsmill/backend


### PR DESCRIPTION
# Why

Changes to `/python_sdk/` commit reference in `infrahub` project don't trigger a review request from the backend team.

## What changed

- Added `/python_sdk/ @opsmill/backend` to `.github/CODEOWNERS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->