### PR TITLE
Documentation file storage and object file

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -34,3 +34,5 @@ config:
 # Files to ignore within docs/docs/
 ignores:
   - "docs/docs/reference/**"
+  - "docs/docs/release-notes/**"
+  - "**/AGENTS.md"

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -25,6 +25,7 @@ bool
 boolean
 booleans
 Buildkite
+Ceph
 changelog
 check_color_tags_name
 check_definitions
@@ -133,6 +134,7 @@ namespaces
 nats
 Nautobot
 Neo4j
+NGINX
 Netbox
 Netutils
 Newsfragment
@@ -211,6 +213,7 @@ Toml
 TOML
 toolchain
 Towncrier
+Traefik
 TypeScript
 uniqueness_constraints
 unoptimized

--- a/docs/docs/development/git-best-practices.mdx
+++ b/docs/docs/development/git-best-practices.mdx
@@ -288,7 +288,7 @@ Follow these practices to ensure smooth code review and integration.
 
 ## Documentation branching workflow
 
-Use the branch that matches when the change must appear on https://docs.infrahub.app:
+Use the branch that matches when the change must appear on [docs.infrahub.app](https://docs.infrahub.app):
 
 ### Minor fixes to published docs
 

--- a/docs/docs/development/style-guide.mdx
+++ b/docs/docs/development/style-guide.mdx
@@ -146,6 +146,7 @@ When listing items and descriptions, prefer the use of a colon (:) instead of a 
 When a word appears at the start of a bullet point in a list where other items begin with capitalized words, capitalize it for consistency.
 
 **Correct:**
+
 ```markdown
 - **Caching**: Generated artifacts are stored...
 - **Traceability**: Past values remain available...
@@ -154,6 +155,7 @@ When a word appears at the start of a bullet point in a list where other items b
 ```
 
 **Incorrect:**
+
 ```markdown
 - **Caching**: Generated artifacts are stored...
 - **Traceability**: Past values remain available...
@@ -166,6 +168,7 @@ When a word appears at the start of a bullet point in a list where other items b
 When a word appears as link text at the start of a bullet point in a list where other items begin with capitalized words, capitalize it.
 
 **Correct:**
+
 ```markdown
 - [Version control](version-control): Understand how branches work...
 - [Schema](schema): Learn about data models...
@@ -174,6 +177,7 @@ When a word appears as link text at the start of a bullet point in a list where 
 ```
 
 **Incorrect:**
+
 ```markdown
 - [Version control](version-control): Understand how branches work...
 - [Schema](schema): Learn about data models...

--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -148,7 +148,7 @@ For local filesystem storage, copy the object storage directory:
 
 ```bash
 # Copy object storage directory to backup location
-docker compose cp -r infrahub-server:/opt/infrahub/storage /backup/object_store/
+docker compose cp infrahub-server:/opt/infrahub/storage/. /backup/object_store/
 ```
 
 </TabItem>
@@ -278,8 +278,8 @@ aws s3 sync /backup/object_store/ s3://your-infrahub-bucket
 <TabItem value="local" label="Local Filesystem">
 
 ```bash
-# Restore object storage directory
-cp -r /backup/object_store/ /path/to/infrahub/storage/
+# Restore object storage directory into the container
+docker compose cp /backup/object_store/. infrahub-server:/opt/infrahub/storage/
 ```
 
 </TabItem>

--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -6,13 +6,13 @@ import EnterpriseBadge from '@site/src/components/EnterpriseBadge';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide shows you how to create comprehensive backups of your Infrahub deployment and restore them when needed. You'll learn to backup the Neo4j graph database, artifact storage, and task management data to ensure complete data recovery capabilities.
+This guide shows you how to create comprehensive backups of your Infrahub deployment and restore them when needed. You'll learn to backup the Neo4j graph database, object storage, and task management data to ensure complete data recovery capabilities.
 
 ## Prerequisites
 
 - Running Infrahub deployment (Docker Compose or Kubernetes)
 - Administrative access to the Neo4j database
-- Access to the artifact storage location (S3 or local filesystem)
+- Access to the object storage location (S3 or local filesystem)
 - Sufficient storage space for backup files
 - For cluster deployments: Understanding of your cluster topology
 
@@ -70,7 +70,7 @@ The tool automatically:
 - Calculates SHA256 checksums for integrity verification
 
 :::note
-We plan to add artifact storage backup in a future release. Handle artifact storage backups separately for now.
+We plan to add object storage backup in a future release. Handle object storage backups separately for now.
 :::
 
 </TabItem>
@@ -127,26 +127,28 @@ python -m utilities.db_backup neo4j backup \
 </TabItem>
 </Tabs>
 
-### Step 3: Backup the artifact store
+### Step 3: Backup the object storage
+
+The [object storage](../topics/object-storage.mdx) layer holds all file content (file objects and artifacts) outside of the graph database. The graph database references this content through `storage_id` values, so both must be backed up together to maintain consistency.
 
 <Tabs groupId="storage-type" queryString>
 <TabItem value="s3" label="S3 Storage" default>
 
-If using S3 for artifact storage, use AWS CLI or your preferred S3 backup tool:
+If using S3 for object storage, use AWS CLI or your preferred S3 backup tool:
 
 ```bash
 # Sync S3 bucket to local backup directory
-aws s3 sync s3://your-infrahub-bucket /backup/artifacts/
+aws s3 sync s3://your-infrahub-bucket /backup/object_store/
 ```
 
 </TabItem>
 <TabItem value="local" label="Local Filesystem">
 
-For local filesystem storage, copy the artifact directory:
+For local filesystem storage, copy the object storage directory:
 
 ```bash
-# Copy artifacts directory to backup location
-docker compose cp -r infrahub-server:/opt/infrahub/storage /backup/artifacts/
+# Copy object storage directory to backup location
+docker compose cp -r infrahub-server:/opt/infrahub/storage /backup/object_store/
 ```
 
 </TabItem>
@@ -262,22 +264,22 @@ python -m utilities.db_backup neo4j restore \
 </TabItem>
 </Tabs>
 
-### Step 3: Restore the artifact store
+### Step 3: Restore the object storage
 
 <Tabs groupId="storage-type" queryString>
 <TabItem value="s3" label="S3 Storage" default>
 
 ```bash
 # Restore S3 bucket from backup
-aws s3 sync /backup/artifacts/ s3://your-infrahub-bucket
+aws s3 sync /backup/object_store/ s3://your-infrahub-bucket
 ```
 
 </TabItem>
 <TabItem value="local" label="Local Filesystem">
 
 ```bash
-# Restore artifacts directory
-cp -r /backup/artifacts/ /path/to/infrahub/artifacts/
+# Restore object storage directory
+cp -r /backup/object_store/ /path/to/infrahub/storage/
 ```
 
 </TabItem>

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -566,7 +566,7 @@ infrahub:
           host: "infrahub-cache-master"
 ```
 
-The `host` value should match your Redis service name. If you deployed Redis using the bundled dependency, this defaults to `infrahub-cache-master`. This configuration is only required when using sizing presets — the base chart (e.g. `4.0.0`) does not require it.
+The `host` value should match your Redis service name. If you deployed Redis using the bundled dependency, this defaults to `infrahub-cache-master`. This configuration is only required when using sizing presets — the base chart (for example, `4.0.0`) does not require it.
 
 :::
 
@@ -574,7 +574,7 @@ The `host` value should match your Redis service name. If you deployed Redis usi
 
 If you are upgrading from a Helm chart version earlier than 4.0.0, update your `values.yml` file:
 
-1. **Remove old configuration preset values:** Delete any environment variables and settings that were previously copied from sizing presets (i.e., `INFRAHUB_CACHE_ADDRESS`, `PREFECT_REDIS_MESSAGING_HOST`, replica counts, resource limits). The flavored charts now handle these automatically.
+1. **Remove old configuration preset values:** Delete any environment variables and settings that were previously copied from sizing presets (for example, `INFRAHUB_CACHE_ADDRESS`, `PREFECT_REDIS_MESSAGING_HOST`, replica counts, resource limits). The flavored charts now handle these automatically.
 
 2. **Add the Redis host configuration:** Add the following to your `values.yml` file:
 

--- a/docs/docs/topics/file-object.mdx
+++ b/docs/docs/topics/file-object.mdx
@@ -140,7 +140,7 @@ For production deployments behind a reverse proxy, the proxy must also allow lar
 
 ### Backups
 
-File objects are stored in the [object storage](./object-storage.mdx) layer, which is separate from the graph database.
+The file content for file objects is stored in the [object storage](./object-storage.mdx) layer, which is separate from the graph database.
 
 :::warning Data loss risk
 Unlike artifacts, which can be regenerated from their definitions, user-uploaded files may only exist in object storage. Losing object storage without a backup means those files are unrecoverable. Both the graph database and object storage must be backed up together to maintain consistency.

--- a/docs/docs/topics/file-object.mdx
+++ b/docs/docs/topics/file-object.mdx
@@ -2,17 +2,19 @@
 title: File objects
 ---
 
+import ReferenceLink from "../../src/components/Card";
+
 # File objects
 
-Infrastructure management often involves more than just structured data. Contracts, compliance reports, network diagrams, configuration backups, and firmware images are all essential assets that relate directly to the devices, circuits, and services they describe. Infrahub's file object feature lets you attach files to any node in the graph, making these documents first-class citizens of your infrastructure data model with full version control, branch isolation, and permission enforcement.
+Infrastructure management often involves more than just structured data. Contracts, documents, and pictures are all essential assets that relate directly to the devices, circuits, and services they describe. Infrahub's file object feature lets you attach files to any node in the graph, making these files first-class citizens of your infrastructure data model with full version control, branch isolation, and permission enforcement.
 
 ![Detail view of a circuit contract file object showing metadata, file preview, and activity log](../media/topics/object_file_topic.png)
 
 ## Why file objects matter
 
-In many organizations, infrastructure documentation lives in separate systems: contracts in a shared drive, diagrams in a wiki, firmware in an FTP server. This separation creates a gap between the data that describes the infrastructure and the files that support it. When a circuit contract expires, the team managing the circuit may not know where to find the document. When a firmware image needs to be traced back to a specific device deployment, the link between the two is maintained manually, if at all.
+In many organizations, infrastructure documentation lives in separate systems: contracts in a shared drive, documents in a wiki, pictures on a file server. This separation creates a gap between the data that describes the infrastructure and the files that support it. When a circuit contract expires, the team managing the circuit may not know where to find the document. When a site photo needs to be traced back to a specific installation, the link between the two is maintained manually, if at all.
 
-File objects bridge this gap by storing files alongside the infrastructure data they relate to. A circuit contract becomes a node in the graph, linked to the circuit it covers. A firmware image becomes a node linked to the device models it supports. This means that when you query a circuit, you can also retrieve its contracts, and when you view a device, you can access its associated firmware, all from the same system and the same API.
+File objects bridge this gap by storing files alongside the infrastructure data they relate to. A circuit contract becomes a node in the graph, linked to the circuit it covers. A site photo becomes a node linked to the location it documents. This means that when you query a circuit, you can also retrieve its contracts, and when you view a site, you can access its associated pictures, all from the same system and the same API.
 
 ## Concepts and definitions
 
@@ -73,23 +75,11 @@ You can also define relationships from the other direction. A `NetworkCircuit` n
 
 ### Storage architecture
 
-Infrahub's file storage follows two key principles: immutability and separation of concerns.
-
-Files are stored in a content-addressable store that is completely separate from the graph database. The storage layer is a key-value system where each file is identified by a UUID. Once a file is stored, it is never modified or deleted. This immutability is what enables version control and time travel for files.
+File content is persisted in Infrahub's [object storage](./object-storage.mdx) layer, which is completely separate from the graph database. The storage layer is an immutable key-value system where each file is identified by a UUID. Once a file is stored, it is never modified or deleted. This immutability is what enables version control and time travel for files.
 
 The graph database handles all the branch-aware, time-aware logic. A file object node contains a `storage_id` attribute that points to the stored file. When you update a file, Infrahub stores the new version under a new UUID and updates the node's `storage_id` on the current branch. The original file remains untouched in storage, and any branch or point in time that referenced the old `storage_id` continues to resolve to the original file.
 
-```text
-Storage layer (branch-agnostic):
-  "abc-123" → file bytes (original version)
-  "def-456" → file bytes (updated version)
-
-Graph database (branch-aware):
-  Branch "main":    NetworkCircuitContract { storage_id: "abc-123" }
-  Branch "feature": NetworkCircuitContract { storage_id: "def-456" }
-```
-
-This design means that the storage layer does not need to understand branches or time. It stores files and retrieves them by UUID. All the complexity of version control lives in the graph database, where Infrahub already has mature support for branching, merging, and time travel.
+<ReferenceLink title="Object storage" url="./object-storage" />
 
 ### Version control integration
 
@@ -115,13 +105,13 @@ A network team managing hundreds of circuits can define a `NetworkCircuitContrac
 
 When a contract is renewed, the team uploads the new document on a branch, updates the contract dates, and submits a proposed change for review. The main branch continues to show the original contract until the change is approved and merged.
 
-### Firmware management
+### Documents
 
-An operations team can create a `FirmwareImage` file object type linked to device models. Firmware binaries are uploaded and associated with the device platforms they support. When planning an upgrade, the team can query which firmware version is currently linked to each device model and download the image directly from Infrahub.
+Teams can attach operational documents — handover reports, maintenance logs, or compliance certificates — to the infrastructure nodes they relate to. Because file objects support time travel, the team can retrieve the document that was active at any point in time, which is valuable during audits.
 
-### Compliance documentation
+### Pictures
 
-A security team can attach audit reports, compliance certificates, or policy documents to the infrastructure nodes they relate to. Because file objects support time travel, the team can retrieve the compliance document that was active at any point in time, which is valuable during audits.
+Site photos, rack elevation pictures, or equipment labels can be stored as file objects linked to locations or devices. When a site is surveyed, the team uploads pictures and associates them with the relevant nodes. Anyone querying the site can view the photos alongside the structured data.
 
 ## Connection to other concepts
 
@@ -134,7 +124,7 @@ File objects build on several existing Infrahub features:
 - **[Permissions and roles](./permissions-roles.mdx)**: File access is controlled by the same role-based permissions as other data.
 - **[Artifact](./artifact.mdx)**: While artifacts are system-generated outputs from transformations, file objects are user-uploaded documents. Both use the object storage layer, but they serve different purposes.
 
-## Configuration
+## Operational considerations
 
 ### File size limits
 
@@ -144,7 +134,19 @@ The maximum upload size defaults to 50 MB and can be adjusted through Infrahub's
 INFRAHUB_STORAGE_MAX_FILE_SIZE=200   # in MB, default is 50
 ```
 
-For production deployments behind a reverse proxy, the proxy must also allow large request bodies. See the [configuration reference](../reference/configuration.mdx) for details.
+For production deployments behind a reverse proxy, the proxy must also allow large request bodies.
+
+<ReferenceLink title="How to configure Infrahub" url="../guides/configuration-changes" />
+
+### Backups
+
+File objects are stored in the [object storage](./object-storage.mdx) layer, which is separate from the graph database.
+
+:::warning Data loss risk
+Unlike artifacts, which can be regenerated from their definitions, user-uploaded files may only exist in object storage. Losing object storage without a backup means those files are unrecoverable. Both the graph database and object storage must be backed up together to maintain consistency.
+:::
+
+<ReferenceLink title="How to backup object storage" url="../guides/database-backup#step-3-backup-the-object-storage" />
 
 ## Further reading
 

--- a/docs/docs/topics/object-storage.mdx
+++ b/docs/docs/topics/object-storage.mdx
@@ -2,76 +2,139 @@
 title: Object storage
 ---
 
+import ReferenceLink from "../../src/components/Card";
+
 # Object storage
 
-Infrahub provides an interface to store and retrieve files or objects in object storage. Object storage is used internally within Infrahub to store rendered artifacts, but you can also use it to store any text-based file or content.
+Infrahub uses an object storage layer to persist binary and text content outside of the graph database. This layer stores the raw bytes of [file objects](./file-object.mdx) and rendered [artifacts](./artifact.mdx). Separating file content from graph data allows Infrahub to keep the graph database focused on relationships, metadata, and version control while delegating bulk storage to a system optimized for that purpose.
 
-You can interact with object storage through the REST API and Python SDK. For practical steps, see the [object storage guide](../guides/object-storage.mdx) and the [object storage Python SDK guide]($(base_url)python-sdk/guides/object-storage).
+## What uses object storage
 
-## Supported storage backends
+Object storage serves two use cases in Infrahub:
 
-Infrahub supports two storage backends:
+- **File objects**: User-uploaded files attached to nodes in the graph. These are managed through the file object system and access is controlled by Infrahub's [permission system](./permissions-roles.mdx). See [file objects](./file-object.mdx) for details.
+- **Artifacts**: System-generated outputs from Transformations. These are created automatically by artifact definitions and stored in the same storage layer. See [artifacts](./artifact.mdx) for details.
 
-- Local storage (configured by default)
-- AWS S3 (or S3-compatible) storage
+Both file objects and artifacts store a `storage_id` in the graph database that references the content in object storage. The difference is in how the content is created — user uploads for file objects, automated Transformations for artifacts — and how access is governed.
 
-You configure the backend by setting the appropriate environment variables. These variables are typically set in your Docker Compose YAML file or in the deployment environment for your containers. See the [Infrahub configuration reference](../reference/configuration.mdx) for a full list of options.
+## Storage backends
 
----
-
-### Local storage
-
-By default, Infrahub uses local storage for artifacts and files. No additional configuration is required unless you want to change the storage location.
-
-To explicitly configure local storage, set the following environment variables in your Docker Compose YAML file or deployment environment:
-
-```yaml
-    # ... other configuration ...
-      INFRAHUB_STORAGE_DRIVER: "local"
-      INFRAHUB_STORAGE_LOCAL_PATH: "/opt/infrahub/storage"
-    # ... other configuration ...
-```
-
-All Infrahub API servers and task workers must have access to the specified directory.
-
----
-
-### AWS S3 storage
-
-To use AWS S3 or any S3-compatible storage, set the following environment variables in your Docker Compose YAML file or deployment environment:
-
-```yaml
-    # ... other configuration ...
-    INFRAHUB_STORAGE_DRIVER: "s3"
-    AWS_ACCESS_KEY_ID: "my_access_key"
-    AWS_SECRET_ACCESS_KEY: "secret_access_key"
-    INFRAHUB_STORAGE_BUCKET_NAME: "my-infrahub-bucket"
-    INFRAHUB_STORAGE_ENDPOINT_URL: "s3.eu-central-1.amazonaws.com"
-    # ... other configuration ...
-```
-
-For all available configuration options and environment variables, refer to the [Infrahub configuration reference](../reference/configuration.mdx#infrahub_storage_s3).
-
----
+Infrahub supports two storage backends. The choice of backend is transparent to the rest of the system — all API endpoints, SDK methods, and internal operations work identically regardless of which backend is configured.
 
 :::info
-You can switch between storage backends by changing the value of `INFRAHUB_STORAGE_DRIVER` and updating the relevant environment variables in your deployment configuration.
+Use **local filesystem** storage for development and testing. For production and multi-node deployments, use **S3-compatible storage** to avoid shared filesystem requirements.
 :::
 
-:::warning
-If you change the storage driver (for example, from `local` to `s3` or vice versa), **existing artifacts will not be automatically migrated**.  
-To regenerate artifacts:
+### Local filesystem
 
-- You must either delete the old artifacts, or
-- Manually update their checksum values and regenerate them.
+The default backend stores files on the local filesystem. This is suitable for development, testing, and single-node deployments.
 
-Failing to do so may result in missing or stale artifact files.
+```yaml
+INFRAHUB_STORAGE_DRIVER: "local"
+INFRAHUB_STORAGE_LOCAL_PATH: "/opt/infrahub/storage"
+```
+
+All Infrahub API servers and task workers must have access to the configured directory. In multi-node deployments with local storage, this typically means a shared network filesystem.
+
+### S3-compatible storage
+
+For production and multi-node deployments, Infrahub supports Amazon S3 and any S3-compatible service (MinIO, Ceph, and others).
+
+```yaml
+INFRAHUB_STORAGE_DRIVER: "s3"
+AWS_ACCESS_KEY_ID: "my_access_key"
+AWS_SECRET_ACCESS_KEY: "secret_access_key"
+INFRAHUB_STORAGE_BUCKET_NAME: "my-infrahub-bucket"
+INFRAHUB_STORAGE_ENDPOINT_URL: "s3.eu-central-1.amazonaws.com"
+```
+
+Additional S3 options include SSL configuration, ACL defaults, query string authentication, and custom domains. See the [configuration reference](../reference/configuration.mdx) for the full list.
+
+## How it works
+
+### Concepts and definitions
+
+**Object storage** is a key-value store where each entry is identified by a UUID. When content is uploaded, Infrahub generates a UUID using a time-sortable format (UUIDT), stores the content under that key, and returns the identifier to the caller. All subsequent operations — retrieval, deletion — reference this identifier.
+
+A **storage driver** is the backend that handles the actual persistence of content. Infrahub abstracts the driver behind a unified interface, so the rest of the system interacts with object storage the same way regardless of whether files land on a local filesystem or in an S3 bucket.
+
+A **storage identifier** (or `storage_id`) is the UUID that links a graph node to its stored content. File object nodes and artifact nodes both carry a `storage_id` attribute that points to the corresponding entry in object storage.
+
+### Architecture
+
+The object storage layer sits between the Infrahub API and the configured storage backend. It exposes four operations:
+
+- **Store**: Write content under a given identifier
+- **Retrieve**: Read content as a decoded string by identifier
+- **Retrieve binary**: Read content as raw bytes by identifier
+- **Delete**: Remove content by identifier
+
+These operations are driver-agnostic. The `InfrahubObjectStorage` class loads the configured driver at startup and delegates all calls to it. This design means that adding a new storage backend only requires implementing the driver interface — no changes to the API or core logic.
+
+### Immutability
+
+Content in object storage is immutable. Once a file is stored, it is never modified in place. When a file is updated, Infrahub stores the new version under a new UUID. The previous version remains in storage, which is what enables time travel and branch isolation for file objects and artifacts.
+
+This approach avoids the complexity of in-place updates and means the storage layer does not need to understand branches, merge conflicts, or version history. All of that logic lives in the graph database, where Infrahub already has mature support for it.
+
+### Relationship to the graph database
+
+The graph database and object storage serve complementary roles:
+
+```text
+Graph database (branch-aware, time-aware):
+  Stores metadata, relationships, and storage_id references
+  Handles branching, merging, time travel, permissions
+
+Object storage (branch-agnostic):
+  Stores raw file content by UUID
+  Simple key-value store, no version control logic
+```
+
+When you query a file object on a specific branch or at a specific point in time, the graph database resolves which `storage_id` was active in that context. The storage layer then retrieves the corresponding content. This separation keeps both systems focused on their core responsibility.
+
+## Operational considerations
+
+### File size limits
+
+The maximum upload size defaults to 50 MB and can be adjusted through the `INFRAHUB_STORAGE_MAX_FILE_SIZE` environment variable (value in MB). For deployments behind a reverse proxy, the proxy must also be configured to allow matching request body sizes (for example, `client_max_body_size` in NGINX or request size middleware in Traefik).
+
+<ReferenceLink title="How to configure Infrahub" url="../guides/configuration-changes" />
+
+### Storage growth
+
+Because object storage is immutable, content accumulates over time. Every file update creates a new entry while the previous version remains in storage to support time travel and branch history. There is currently no automatic garbage collection for orphaned content. In environments with frequent file updates, storage usage should be monitored.
+
+### Shared access in multi-node deployments
+
+When using local filesystem storage across multiple API servers or task workers, all nodes must have access to the same storage directory. This typically requires a shared network filesystem (NFS or similar). S3-compatible storage avoids this constraint entirely since all nodes access the same bucket over the network.
+
+<ReferenceLink title="Production deployment guide" url="../guides/production-deployment" />
+
+### Backups
+
+Object storage should be included in your backup strategy alongside the graph database. The two are tightly coupled: the graph database holds `storage_id` references that point to content in object storage. Restoring one without the other results in broken references (dangling `storage_id` values pointing to missing files) or orphaned files (content in storage with no corresponding graph node).
+
+:::warning Data loss risk
+Unlike artifacts, which can be regenerated from their definitions, user-uploaded file objects may only exist in object storage. If storage is lost without a backup, those files are unrecoverable.
 :::
 
----
+<ReferenceLink title="How to backup object storage" url="../guides/database-backup#step-3-backup-the-object-storage" />
 
-## Object model
+### Backend migration
 
-Objects or files stored within object storage are identified by a unique identifier (UUID). This identifier is assigned when the object is created. All interactions with the object use this identifier.
+:::warning Backend migration
+Switching storage backends (for example, from `local` to `s3`) does not migrate existing content. Files stored under the previous backend become inaccessible. Artifacts can be regenerated, but user-uploaded file objects must be re-uploaded.
+:::
 
-For more details on configuration options, see the [Infrahub configuration reference](../reference/configuration.mdx).
+## Connection to other concepts
+
+- **[File objects](./file-object.mdx)**: The primary way users interact with stored files. File objects are graph nodes that combine metadata with a reference to content in object storage.
+- **[Artifacts](./artifact.mdx)**: System-generated content stored in the same storage layer, produced by Transformation pipelines.
+- **[Permissions and roles](./permissions-roles.mdx)**: Access to file content is enforced at the API level based on permissions on the corresponding graph node.
+
+## Further reading
+
+- [Object storage guide](../guides/object-storage.mdx): Practical steps for uploading and retrieving content
+- [File objects](./file-object.mdx): Attaching files to nodes with full version control
+- [Configuration reference](../reference/configuration.mdx): All storage-related environment variables and settings


### PR DESCRIPTION
https://bgi-doc-file-storage.infrahub.pages.dev/topics/object-storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded object storage docs with detailed architecture, operations, deployment guidance, and migration warnings.
  * Updated backup and file-object guides to use consistent object storage terminology.
  * Minor wording, formatting, and link refinements across installation, style guide, and examples.

* **Chores**
  * Adjusted docs tooling to ignore release notes and agent reference files.
  * Added spelling exceptions for Ceph, NGINX, and Traefik.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->