### PR TITLE
Use query analyzer fields for artifact definition regeneration

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -132,6 +132,10 @@ class ObjectAccess:
     attributes: set[str] = field(default_factory=set)
     relationships: set[str] = field(default_factory=set)
 
+    @property
+    def fields(self) -> set[str]:
+        return self.attributes.union(self.relationships)
+
 
 @dataclass
 class GraphQLVariable:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -726,7 +726,6 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         artifacts_by_member[artifact.object.peer.id] = artifact.id
 
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
-    impacted_artifacts = model.branch_diff.get_subscribers_ids(kind=InfrahubKind.ARTIFACT)
 
     source_schema_branch = registry.schema.get_schema_branch(name=model.source_branch)
     source_branch = registry.get_branch_from_registry(branch=model.source_branch)
@@ -740,10 +739,52 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         document=cached_parse(model.artifact_definition.query_payload),
     )
 
+    # only_has_unique_targets is True when the query is guaranteed to return results
+    # for a specific set of nodes — e.g. it uses an `ids` argument or a uniqueness
+    # constraint. When False, the query may return any number of nodes and we cannot
+    # map a changed node back to a specific artifact without re-running every target.
     only_has_unique_targets = query_analyzer.query_report.only_has_unique_targets
-    if not only_has_unique_targets:
+
+    # Collect the IDs of nodes whose changes are actually relevant to this query.
+    # A change is relevant only when at least one field that was modified is also
+    # read by the query. This lets us skip regeneration when, for example, only a
+    # `description` field changed but the query only reads `name` and `color`.
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
+    relevant_node_changes = []
+    for node_diff in diff_summary:
+        if (
+            node_diff["branch"] == model.source_branch
+            and node_diff["kind"] in query_analyzer.query_report.requested_read
+        ):
+            updated_fields = {element["name"] for element in node_diff["elements"]}
+            relevant_fields = set(query_analyzer.query_report.fields_by_kind(node_diff["kind"]))
+            if updated_fields & relevant_fields:
+                relevant_node_changes.append(node_diff["id"])
+
+    if only_has_unique_targets:
+        # The query targets specific nodes by ID or unique constraint, so we can
+        # look up exactly which artifacts are linked to the changed nodes and limit
+        # regeneration to only those artifacts.
+        subscribers = await _get_subscribers_for_nodes(
+            node_ids=relevant_node_changes, branch=model.source_branch, client=client
+        )
+        impacted_artifacts = [
+            subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == InfrahubKind.ARTIFACT
+        ]
+    elif relevant_node_changes:
+        # The query does not guarantee unique targets, so we cannot determine which
+        # specific artifacts are affected. At least one relevant field changed, so we
+        # must fall back to regenerating all artifacts for this definition to be safe.
+        impacted_artifacts = list(artifacts_by_member.values())
         log.warning(
             f"Artifact definition {artifact_definition.name.value} query does not guarantee unique targets. All targets will be processed."
+        )
+    else:
+        # No node of a queried kind had any of its queried fields modified, so no
+        # artifact can be stale regardless of query targeting capability.
+        impacted_artifacts = []
+        log.info(
+            f"Artifact definition {artifact_definition.name.value} has no applicable node changes. Existing artifacts will not be re-rendered."
         )
 
     managed_branch = model.source_branch_sync_with_git and model.branch_diff.has_file_modifications
@@ -759,7 +800,6 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
             artifact_id=artifact_id,
             managed_branch=managed_branch,
             impacted_artifacts=impacted_artifacts,
-            only_has_unique_targets=only_has_unique_targets,
         ):
             log.info(f"Trigger Artifact processing for {member.display_label}")
 
@@ -809,19 +849,17 @@ def _should_render_artifact(
     artifact_id: str | None,
     managed_branch: bool,
     impacted_artifacts: list[str],
-    only_has_unique_targets: bool,
 ) -> bool:
     """Returns a boolean to indicate if an artifact should be generated or not.
     Will return true if:
         * The artifact_id wasn't set which could be that it's a new object that doesn't have a previous artifact
-        * The source branch is not data only which would indicate that it could contain updates in git to the transform
+        * The source branch is synced with git and has file modifications (managed_branch)
         * The artifact_id exists in the impacted_artifacts list
-        * The query failes the only_has_unique_targets check
     Will return false if:
-        * The source branch is a data only branch and the artifact_id exists and is not in the impacted list
+        * The artifact_id exists and is not in the impacted list
     """
 
-    if not only_has_unique_targets or not artifact_id or managed_branch:
+    if not artifact_id or managed_branch:
         return True
 
     return artifact_id in impacted_artifacts
@@ -1158,8 +1196,8 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
     diff_summary = await client.get_diff_summary(branch=model.source_branch)
     await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
     branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
-    await _populate_subscribers(
-        branch_diff=branch_diff, diff_summary=diff_summary, branch=model.source_branch, client=client
+    branch_diff.subscribers.extend(
+        await _get_subscribers_from_diff(diff_summary=diff_summary, branch=model.source_branch, client=client)
     )
 
     if model.check_type is CheckType.ARTIFACT:
@@ -1663,17 +1701,28 @@ async def _gather_repository_repository_diffs(
             repo.files_changed = files_changed
 
 
-async def _populate_subscribers(
-    branch_diff: ProposedChangeBranchDiff, diff_summary: list[NodeDiff], branch: str, client: InfrahubClient
-) -> None:
+async def _get_subscribers_for_nodes(
+    node_ids: list[str], branch: str, client: InfrahubClient
+) -> list[ProposedChangeSubscriber]:
     result = await client.execute_graphql(
         query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS,
         branch_name=branch,
-        variables={"members": get_modified_node_ids(diff_summary=diff_summary, branch=branch)},
+        variables={"members": node_ids},
     )
-
+    subscribers = []
     for group in result[InfrahubKind.GRAPHQLQUERYGROUP]["edges"]:
         for subscriber in group["node"]["subscribers"]["edges"]:
-            branch_diff.subscribers.append(
+            subscribers.append(
                 ProposedChangeSubscriber(subscriber_id=subscriber["node"]["id"], kind=subscriber["node"]["__typename"])
             )
+    return subscribers
+
+
+async def _get_subscribers_from_diff(
+    diff_summary: list[NodeDiff], branch: str, client: InfrahubClient
+) -> list[ProposedChangeSubscriber]:
+    return await _get_subscribers_for_nodes(
+        node_ids=get_modified_node_ids(diff_summary=diff_summary, branch=branch),
+        branch=branch,
+        client=client,
+    )

--- a/backend/tests/adapters/workflow.py
+++ b/backend/tests/adapters/workflow.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.constants import ValidatorConclusion
+from infrahub.services.adapters.workflow import InfrahubWorkflow
+from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
+
+if TYPE_CHECKING:
+    from infrahub.context import InfrahubContext
+
+
+class WorkflowRecorder(InfrahubWorkflow):
+    """Records workflow calls without executing them. Use for testing code that submits workflows."""
+
+    def __init__(self) -> None:
+        self.execute_calls: list[dict[str, Any]] = []
+        self.submit_calls: list[dict[str, Any]] = []
+
+    async def execute_workflow(
+        self,
+        workflow: WorkflowDefinition,
+        expected_return: type | None = None,
+        context: InfrahubContext | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+    ) -> Any:
+        self.execute_calls.append({"workflow": workflow, "parameters": parameters or {}})
+        if expected_return is ValidatorConclusion:
+            return ValidatorConclusion.SUCCESS
+        return None
+
+    async def submit_workflow(
+        self,
+        workflow: WorkflowDefinition,
+        context: InfrahubContext | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+    ) -> WorkflowInfo:
+        self.submit_calls.append({"workflow": workflow, "parameters": parameters or {}})
+        return WorkflowInfo(id=uuid.uuid4())
+
+    def get_execute_calls_for(self, workflow: WorkflowDefinition) -> list[dict[str, Any]]:
+        return [c for c in self.execute_calls if c["workflow"] == workflow]
+
+    def get_submit_calls_for(self, workflow: WorkflowDefinition) -> list[dict[str, Any]]:
+        return [c for c in self.submit_calls if c["workflow"] == workflow]

--- a/backend/tests/component/proposed_change/conftest.py
+++ b/backend/tests/component/proposed_change/conftest.py
@@ -1,0 +1,55 @@
+from infrahub_sdk.diff import NodeDiff, NodeDiffElement, NodeDiffSummary
+
+from infrahub.core.diff.model.diff import DiffElementType
+
+QUERY_UNIQUE_TARGETS = """
+query GetNetworkDevice($ids: [ID!]!) {
+    TestNetworkDevice(ids: $ids) {
+        edges {
+            node {
+                name { value }
+                color { value }
+            }
+        }
+    }
+}
+"""
+
+QUERY_NON_UNIQUE_TARGETS = """
+query GetAllNetworkDevices {
+    TestNetworkDevice {
+        edges {
+            node {
+                name { value }
+                color { value }
+            }
+        }
+    }
+}
+"""
+
+
+def make_node_diff(
+    node_id: str,
+    kind: str,
+    branch: str,
+    field_names: list[str],
+    action: str = "updated",
+) -> NodeDiff:
+    """Build a NodeDiff for use in diff summary cache."""
+    return NodeDiff(
+        branch=branch,
+        action=action,
+        kind=kind,
+        id=node_id,
+        display_label="",
+        elements=[
+            NodeDiffElement(
+                name=field_name,
+                element_type=DiffElementType.ATTRIBUTE.value,
+                action="updated",
+                summary=NodeDiffSummary(added=0, updated=1, removed=0),
+            )
+            for field_name in field_names
+        ],
+    )

--- a/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
+++ b/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
@@ -1,0 +1,788 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub import config
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
+from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.message_bus.types import (
+    ProposedChangeArtifactDefinition,
+    ProposedChangeBranchDiff,
+    ProposedChangeRepository,
+)
+from infrahub.proposed_change.branch_diff import set_diff_summary_cache
+from infrahub.proposed_change.models import RequestArtifactDefinitionCheck
+from infrahub.proposed_change.tasks import _get_subscribers_from_diff, validate_artifacts_generation
+from infrahub.server import app
+from infrahub.workers.dependencies import build_client, build_workflow
+from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.schema import load_schema
+from tests.helpers.test_app import TestInfrahubAppBase
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from fast_depends import Provider
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+    from tests.adapters.cache import MemoryCache
+    from tests.adapters.message_bus import BusSimulator
+    from tests.helpers.test_client import InfrahubTestClient
+
+from .conftest import QUERY_NON_UNIQUE_TARGETS, QUERY_UNIQUE_TARGETS, make_node_diff
+
+SOURCE_BRANCH = "feature/artifact-test"
+
+ARTIFACT_SCHEMA = SchemaRoot(
+    nodes=[
+        NodeSchema(
+            name="NetworkDevice",
+            namespace="Test",
+            default_filter="name__value",
+            display_labels=["name__value"],
+            inherit_from=["CoreArtifactTarget"],
+            uniqueness_constraints=[["name__value"]],
+            attributes=[
+                AttributeSchema(name="name", kind="Text", unique=True),
+                AttributeSchema(name="description", kind="Text", optional=True),
+                AttributeSchema(name="color", kind="Text", optional=True),
+            ],
+        )
+    ]
+)
+
+
+class TestValidateArtifactsGeneration(TestInfrahubAppBase):
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_recorder(
+        self,
+        prefect: Generator[str, None, None],
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[WorkflowRecorder, None]:
+        original = config.OVERRIDE.workflow
+        recorder = WorkflowRecorder()
+        config.OVERRIDE.workflow = recorder
+        with dependency_provider.scope(build_workflow, lambda: recorder):
+            yield recorder
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+    @pytest.fixture(scope="class")
+    async def client(
+        self,
+        test_client: InfrahubTestClient,
+        api_admin_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[InfrahubClient, None]:
+        sdk_config = Config(
+            api_token=api_admin_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
+        )
+        sdk_client = InfrahubClient(config=sdk_config)
+        original_client = service._client
+        service._client = sdk_client
+        with dependency_provider.scope(build_client, lambda: sdk_client):
+            yield sdk_client
+        service._client = original_client
+
+    @pytest.fixture(autouse=True)
+    def clear_recorder(self, workflow_recorder: WorkflowRecorder) -> None:
+        workflow_recorder.execute_calls.clear()
+        workflow_recorder.submit_calls.clear()
+
+    @pytest.fixture(scope="class")
+    async def artifact_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+        memory_cache: MemoryCache,
+        admin_account: CoreAccount,
+    ) -> dict[str, Any]:
+        # Load schema for default branch, saved to DB
+        await load_schema(db=db, schema=ARTIFACT_SCHEMA, update_db=True)
+
+        # Create all AWARE/AGNOSTIC nodes on the default branch BEFORE creating
+        # the source branch, so they are inherited by the branch when it forks.
+
+        # --- Create 4 network devices on default branch ---
+        dev1 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev1.new(db=db, name="dev1", color="red", description="Device 1")
+        await dev1.save(db=db)
+
+        dev2 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev2.new(db=db, name="dev2", color="blue", description="Device 2")
+        await dev2.save(db=db)
+
+        dev3 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev3.new(db=db, name="dev3", color="green", description="Device 3")
+        await dev3.save(db=db)
+
+        dev4 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev4.new(db=db, name="dev4", color="yellow", description="Device 4")
+        await dev4.save(db=db)
+
+        # --- Repository node (AGNOSTIC) ---
+        repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await repo.new(
+            db=db,
+            name="test-artifact-repo",
+            location="https://github.com/test/artifact-repo.git",
+        )
+        await repo.save(db=db)
+
+        # --- GraphQL query nodes (AWARE) ---
+        query_unique = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_unique.new(db=db, name="GetNetworkDevice", query=QUERY_UNIQUE_TARGETS)
+        await query_unique.save(db=db)
+
+        query_non_unique = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_non_unique.new(db=db, name="GetAllNetworkDevices", query=QUERY_NON_UNIQUE_TARGETS)
+        await query_non_unique.save(db=db)
+
+        # --- Transform (AWARE) ---
+        transform = await Node.init(db=db, schema="CoreTransformJinja2")
+        await transform.new(
+            db=db,
+            name="device-render",
+            query=str(query_unique.id),
+            repository=str(repo.id),
+            template_path="device.j2",
+        )
+        await transform.save(db=db)
+
+        # --- Target group (AWARE) with all 4 devices ---
+        targets_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await targets_group.new(db=db, name="device-targets", members=[dev1, dev2, dev3, dev4])
+        await targets_group.save(db=db)
+
+        # --- Artifact definition for artdef_full (AWARE) ---
+        artdef_full_node = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+        await artdef_full_node.new(
+            db=db,
+            name="artifact-full",
+            targets=targets_group,
+            transformation=transform,
+            content_type="application/json",
+            artifact_name="device-config",
+            parameters={"value": {"name": "name__value"}},
+        )
+        await artdef_full_node.save(db=db)
+
+        # --- Artifact definition for artdef_partial (AWARE, same group; only dev1/dev2 will have existing artifacts) ---
+        artdef_partial_node = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+        await artdef_partial_node.new(
+            db=db,
+            name="artifact-partial",
+            targets=targets_group,
+            transformation=transform,
+            content_type="application/json",
+            artifact_name="device-partial-config",
+            parameters={"value": {"name": "name__value"}},
+        )
+        await artdef_partial_node.save(db=db)
+
+        # --- Create source branch AFTER all AWARE nodes are on main ---
+        # This ensures the branch inherits them all via the graph branching model.
+        source_branch_obj = await create_branch(branch_name=SOURCE_BRANCH, db=db)
+
+        # Propagate schema to source branch registry entry (in-process only, no DB write)
+        await load_schema(db=db, schema=ARTIFACT_SCHEMA, branch_name=SOURCE_BRANCH, update_db=False)
+
+        # --- Artifacts for artdef_full on source_branch (CoreArtifact is LOCAL) ---
+        art1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art1.new(
+            db=db,
+            name="device-config",
+            definition=artdef_full_node,
+            status="Ready",
+            object=dev1,
+            storage_id=str(uuid.uuid4()),
+            checksum="aaaa",
+            content_type="application/json",
+        )
+        await art1.save(db=db)
+
+        art2 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art2.new(
+            db=db,
+            name="device-config",
+            definition=artdef_full_node,
+            status="Ready",
+            object=dev2,
+            storage_id=str(uuid.uuid4()),
+            checksum="bbbb",
+            content_type="application/json",
+        )
+        await art2.save(db=db)
+
+        art3 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art3.new(
+            db=db,
+            name="device-config",
+            definition=artdef_full_node,
+            status="Ready",
+            object=dev3,
+            storage_id=str(uuid.uuid4()),
+            checksum="cccc",
+            content_type="application/json",
+        )
+        await art3.save(db=db)
+
+        art4 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art4.new(
+            db=db,
+            name="device-config",
+            definition=artdef_full_node,
+            status="Ready",
+            object=dev4,
+            storage_id=str(uuid.uuid4()),
+            checksum="dddd",
+            content_type="application/json",
+        )
+        await art4.save(db=db)
+
+        # --- Artifacts for artdef_partial on source_branch (only dev1 and dev2) ---
+        art1_p = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art1_p.new(
+            db=db,
+            name="device-partial-config",
+            definition=artdef_partial_node,
+            status="Ready",
+            object=dev1,
+            storage_id=str(uuid.uuid4()),
+            checksum="eeee",
+            content_type="application/json",
+        )
+        await art1_p.save(db=db)
+
+        art2_p = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art2_p.new(
+            db=db,
+            name="device-partial-config",
+            definition=artdef_partial_node,
+            status="Ready",
+            object=dev2,
+            storage_id=str(uuid.uuid4()),
+            checksum="ffff",
+            content_type="application/json",
+        )
+        await art2_p.save(db=db)
+
+        # --- CoreGraphQLQueryGroups on source_branch for artdef_full ---
+        # Each group links one device (member) to its artifact (subscriber)
+        qg1 = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg1.new(
+            db=db,
+            name="qg-dev1-full",
+            query=str(query_unique.id),
+            members=[dev1],
+            subscribers=[art1],
+        )
+        await qg1.save(db=db)
+
+        qg2 = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg2.new(
+            db=db,
+            name="qg-dev2-full",
+            query=str(query_unique.id),
+            members=[dev2],
+            subscribers=[art2],
+        )
+        await qg2.save(db=db)
+
+        qg3 = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg3.new(
+            db=db,
+            name="qg-dev3-full",
+            query=str(query_unique.id),
+            members=[dev3],
+            subscribers=[art3],
+        )
+        await qg3.save(db=db)
+
+        qg4 = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg4.new(
+            db=db,
+            name="qg-dev4-full",
+            query=str(query_unique.id),
+            members=[dev4],
+            subscribers=[art4],
+        )
+        await qg4.save(db=db)
+
+        # --- CoreGraphQLQueryGroups on source_branch for artdef_partial (dev1 and dev2 only) ---
+        qg1_p = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg1_p.new(
+            db=db,
+            name="qg-dev1-partial",
+            query=str(query_unique.id),
+            members=[dev1],
+            subscribers=[art1_p],
+        )
+        await qg1_p.save(db=db)
+
+        qg2_p = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+        await qg2_p.new(
+            db=db,
+            name="qg-dev2-partial",
+            query=str(query_unique.id),
+            members=[dev2],
+            subscribers=[art2_p],
+        )
+        await qg2_p.save(db=db)
+
+        # --- Proposed change node ---
+        pc = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+        await pc.new(
+            db=db,
+            name="test-artifact-pc",
+            source_branch=SOURCE_BRANCH,
+            destination_branch=default_branch.name,
+        )
+        await pc.save(db=db)
+
+        # --- ProposedChangeRepository (Pydantic model, no DB node needed) ---
+        repository = ProposedChangeRepository(
+            repository_id=repo.id,
+            repository_name="test-artifact-repo",
+            read_only=False,
+            source_branch=SOURCE_BRANCH,
+            destination_branch=default_branch.name,
+            internal_status=RepositoryInternalStatus.ACTIVE.value,
+            source_commit="source-commit-sha",
+            destination_commit="dest-commit-sha",
+        )
+
+        # --- ProposedChangeArtifactDefinition models (Pydantic, carry query payload) ---
+        artdef_full = ProposedChangeArtifactDefinition(
+            definition_id=artdef_full_node.id,
+            definition_name="artifact-full",
+            artifact_name="device-config",
+            query_name="GetNetworkDevice",
+            query_id=query_unique.id,
+            query_models=["TestNetworkDevice"],
+            query_payload=QUERY_UNIQUE_TARGETS,
+            repository_id=repo.id,
+            transform_kind=InfrahubKind.TRANSFORMJINJA2,
+            template_path="device.j2",
+            content_type="application/json",
+            timeout=60,
+        )
+
+        artdef_full_non_unique = ProposedChangeArtifactDefinition(
+            definition_id=artdef_full_node.id,
+            definition_name="artifact-full",
+            artifact_name="device-config",
+            query_name="GetAllNetworkDevices",
+            query_id=query_non_unique.id,
+            query_models=["TestNetworkDevice"],
+            query_payload=QUERY_NON_UNIQUE_TARGETS,
+            repository_id=repo.id,
+            transform_kind=InfrahubKind.TRANSFORMJINJA2,
+            template_path="device.j2",
+            content_type="application/json",
+            timeout=60,
+        )
+
+        artdef_partial = ProposedChangeArtifactDefinition(
+            definition_id=artdef_partial_node.id,
+            definition_name="artifact-partial",
+            artifact_name="device-partial-config",
+            query_name="GetNetworkDevice",
+            query_id=query_unique.id,
+            query_models=["TestNetworkDevice"],
+            query_payload=QUERY_UNIQUE_TARGETS,
+            repository_id=repo.id,
+            transform_kind=InfrahubKind.TRANSFORMJINJA2,
+            template_path="device.j2",
+            content_type="application/json",
+            timeout=60,
+        )
+
+        return {
+            "source_branch": SOURCE_BRANCH,
+            "proposed_change_id": pc.id,
+            "dev1_id": dev1.id,
+            "dev2_id": dev2.id,
+            "dev3_id": dev3.id,
+            "dev4_id": dev4.id,
+            "art1_id": art1.id,
+            "art2_id": art2.id,
+            "art3_id": art3.id,
+            "art4_id": art4.id,
+            "art1_p_id": art1_p.id,
+            "art2_p_id": art2_p.id,
+            "repository": repository,
+            "artdef_full": artdef_full,
+            "artdef_full_non_unique": artdef_full_non_unique,
+            "artdef_partial": artdef_partial,
+        }
+
+    def _make_context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext(
+            branch=BranchContext(name=default_branch.name),
+            account=AccountSession(account_id=account.id, auth_type=AuthType.API),
+        )
+
+    async def _make_branch_diff(
+        self,
+        dataset: dict[str, Any],
+        pipeline_id: uuid.UUID,
+        diff_summary: list[dict],
+        client: InfrahubClient,
+        files_changed: list[str] | None = None,
+    ) -> ProposedChangeBranchDiff:
+        repository = dataset["repository"]
+        if files_changed:
+            repository = ProposedChangeRepository(
+                repository_id=repository.repository_id,
+                repository_name=repository.repository_name,
+                read_only=repository.read_only,
+                source_branch=repository.source_branch,
+                destination_branch=repository.destination_branch,
+                internal_status=repository.internal_status,
+                source_commit=repository.source_commit,
+                destination_commit=repository.destination_commit,
+                files_changed=files_changed,
+            )
+        subscribers = await _get_subscribers_from_diff(diff_summary=diff_summary, branch=SOURCE_BRANCH, client=client)
+        return ProposedChangeBranchDiff(
+            pipeline_id=pipeline_id,
+            repositories=[repository],
+            subscribers=subscribers,
+        )
+
+    async def _run(
+        self,
+        model: RequestArtifactDefinitionCheck,
+        context: InfrahubContext,
+        diff_summary: list[dict],
+        memory_cache: MemoryCache,
+    ) -> None:
+        await set_diff_summary_cache(
+            pipeline_id=model.branch_diff.pipeline_id,
+            diff_summary=diff_summary,
+            cache=memory_cache,
+        )
+        await validate_artifacts_generation(model=model, context=context)
+
+    async def test_unique_query_selective_field_change(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Unique query: dev1 and dev3 change 'name' (queried), dev2 changes 'description' (not queried).
+        Only art1 and art3 should be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+            make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+            make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {artifact_dataset["dev1_id"], artifact_dataset["dev3_id"]}
+
+    async def test_unique_query_only_non_queried_field_changes(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Unique query: all devices change 'description' (not queried).
+        No artifacts should be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+            make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+            make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+            make_node_diff(artifact_dataset["dev4_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        assert workflow_recorder.execute_calls == []
+
+    async def test_unique_query_all_queried_field_changes(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Unique query: all 4 devices change 'name' (queried).
+        All 4 artifacts should be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+            make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+            make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+            make_node_diff(artifact_dataset["dev4_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {
+            artifact_dataset["dev1_id"],
+            artifact_dataset["dev2_id"],
+            artifact_dataset["dev3_id"],
+            artifact_dataset["dev4_id"],
+        }
+
+    async def test_unique_query_new_targets_always_regenerate(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Unique query with artdef_partial: dev3 changes 'description' (not queried).
+        dev1 and dev2 have existing artifacts that are not impacted.
+        dev3 and dev4 have no existing artifacts (artifact_id=None) → always regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_partial"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {artifact_dataset["dev3_id"], artifact_dataset["dev4_id"]}
+
+    async def test_non_unique_query_non_queried_field_change_skips_regeneration(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Non-unique query: only 'description' (not queried) changes.
+        Even though the query can't target specific nodes, the queried fields
+        haven't changed so no regeneration is needed."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+            make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full_non_unique"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        assert workflow_recorder.execute_calls == []
+
+    async def test_non_unique_query_queried_field_change_regenerates_all(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """Non-unique query: dev2 changes 'name' (queried).
+        Because the query cannot identify specific targets, all 4 artifacts must be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full_non_unique"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {
+            artifact_dataset["dev1_id"],
+            artifact_dataset["dev2_id"],
+            artifact_dataset["dev3_id"],
+            artifact_dataset["dev4_id"],
+        }
+
+    async def test_managed_branch_with_file_changes_regenerates_all(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """When source branch is synced with git and the repository has file changes,
+        all artifacts must be regenerated regardless of which fields changed."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        # Only description changed (not queried) — but managed_branch=True overrides this
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset,
+            pipeline_id,
+            diff_summary=diff_summary,
+            client=client,
+            files_changed=["templates/device.j2"],
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=True,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {
+            artifact_dataset["dev1_id"],
+            artifact_dataset["dev2_id"],
+            artifact_dataset["dev3_id"],
+            artifact_dataset["dev4_id"],
+        }
+
+    async def test_managed_branch_without_file_changes_uses_field_targeting(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """When source branch is synced with git but no file changes, field-level targeting
+        still applies. Only the artifact for dev1 (name changed) should be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        # No files_changed → has_file_modifications=False → managed_branch=False
+        diff_summary = [
+            make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
+        ]
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_full"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=True,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {artifact_dataset["dev1_id"]}

--- a/changelog/+15041d55.changed.md
+++ b/changelog/+15041d55.changed.md
@@ -1,0 +1,1 @@
+This change prevents redundant artifact regenerations by only triggering on node changes that affect fields actually read by the associated GraphQL query, reducing the number of artifacts that need to be regenerated and speeding up the pipeline.


### PR DESCRIPTION
# Why

Improve artifact definition regeneration within pipeline to avoid regenerating artifacts that doesn't need to be touched.

## Current state

Some background for clarity: Currently when you have setup an artifact definition to create or update artifacts within a pipeline we have three scenarios when an artifact is regenerated (if an artifact for whatever reason doesn't exist it should always be created)

* The source branch is synced with git and there are file changes in the repo compared to what's in the default branch. Currently we can't guarantee that a change to a file might have been used by a transport as there are so many ways you can import other files from Python. (in the future this will be more selective to only trigger if the transform code or query has been updated.)
* The GraphQL query is written so that it fullfills the `only_has_unique_targets` requirements: In this case we will only regenerate artifacts that has modifications to one of the members of its GraphQL query group
The `only_has_unique_targets` is true if the query and the query parameter is enough to always target a single known node.

As an example using this query:

```graphql
query TagQueryUnique($tag_name: String!) {
  BuiltinTag(name__value: $tag_name) {
    edges {
      node {
        name {
          value
        }
      }
    }
  }
}
```

Since the name of a tag has a uniqueness constraint required along with the fact that the `$tag_name` parameter is required in the query we can be sure that this query would always capture the required initial node along with its relationships if any. The way to break `only_has_unique_targets` would be to have the variable be optional `TagQuery($tag_name: String)` without "!". 

* The GraphQL query is written so that it doesn't fullfil `only_has_unique_targets`. If this is the case all artifacts would be regenerated.

If we look at this query instead:

```graphql
query TagQuery($tag_name: String!) {
  BuiltinTag(name__value: $tag_name) {
    edges {
      node {
        name {
          value
        }
      }
    }
  }
  IpamNamespace {
    edges {
      node {
        name {
          value
        }
      }
    }
  }
}
```
Here the tag part is still fine, however when we want to use all of the IpamNamespace in the query we don't have a current way in the pipeline to determine if a new namespace has been created or deleted and as such we default to the safer option of over re-generation instead of risking an invalid artifact. (Down the road additional improvements could be done here to specifically trigger regeneration if in this case a new IpamNamespace has been created)

## What currently gets regenerated

Even with `only_has_unique_targets`, the way this works is that whenever we create an artifact from an artifact definition the query that goes with the artifact will have a matching `CoreGraphQLQueryGroup` that contains the members of all of the nodes included in the query. For larger environments or queries there could be over 1000 members in such a group and the criteria to regenerate an artifact would be if anything on at least one of those nodes got modified within a branch. As an example looking at `TagQueryUnique` from above we can see that the query uses the "name" attribute from the BuiltinTag (which is assumed to be used to render the artifact), however the current implementation would regenerated an artifact for a given BuiltinTag even if it was just the "description" attribute that was modified.

If we consider a network environment with any type of mesh setup there's a big chance that there is a big overlap between multiple artifacts and even unrelated changes to nodes multiple relationships away from the initial node of the artifact could trigger the regeneration of an artifact.

## The goal of this PR

Within this PR we further utilize the InfrahubGraphQLQueryAnalyzer class and instead of only consulting `only_has_unique_targets` within the `GraphQLQueryReport` we also look at the `requested_read` property. This allows us to specifically look at what fields (i.e attributes and or relationships) that are being read by the GraphQL query and only trigger a regeneration if any of those has been changed on the node.

We still need to combine this with `only_has_unique_targets`, but we get a few new states:

* The source branch is synced with git and there are file changes in the repo compared to what's in the default branch: This works exactly like before as described above
* With `only_has_unique_targets`: We only regenerate artifacts if any of the members of its GraphQL query group has any updated fields that matches the `requested_read` property of the GraphQL query group.
* Without `only_has_unique_targets`: We can look at the `requested_read` property and combine this with the diff. If the modifications within the branch doesn't touch any of the fields we are targeting no artifacts get regenerated.
* Without `only_has_unique_targets`: We can look at the `requested_read` property and combine this with the diff. If the modifications within the branch matches any of the fields we are targeting all artifacts get regenerated.

# What changed

* Added a fields property to `ObjectAccess` within the GraphQL query analyzer for easier access to all relationships and attributes that are being read by a query.
* Refactor and remove `_populate_subscribers()`, replaced by `_get_subscribers_for_nodes()` and `__get_subscribers_from_diff()`. There were two reasons first we had different input types then `__populate_subscribers()` mutated the branch_diff param in a weird way that wasn't obvious to the caller. This has been cleaned up so that we instead return a list of subscribers that are added to the branch_diff where it's called
* Updates to logic to determine which artifacts should be regenerated based on the fields that are actually read as defined by the GraphQL query report.
* Added tests to check for different scenarios. These aren't end to end tests, we just want to validate what would happen with regards to which artifacts would be requested to be regenerated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Artifact regeneration is more selective: only artifacts whose queries reference changed fields (including attributes and relationships) are triggered, reducing redundant runs.
* **Tests**
  * Added tests, helpers, and a workflow recorder to simulate diffs and capture workflow invocations, validating selective regeneration across unique/non-unique queries, managed-branch overrides, and file-change scenarios.
* **Changelog**
  * Added entry describing the updated artifact regeneration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->