### PR TITLE
Spec-Kitty adaptation to infrahub and Spec-kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ python_testcontainers/dist/*
 python_testcontainers/infrahub_testcontainers.egg-info/*
 
 schema/node_modules/*
+
+# Spec-kitty
+dev/spec-kitty/.worktrees/

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -37,7 +37,7 @@ get_current_branch() {
         for dir in "$specs_dir"/*; do
             if [[ -d "$dir" ]]; then
                 local dirname=$(basename "$dir")
-                if [[ "$dirname" =~ ^([a-z]{2,4}-)?([0-9]{3})- ]]; then
+                if [[ "$dirname" =~ ^([a-z]{2,4}-)?([0-9]{3,})- ]]; then
                     local number=${BASH_REMATCH[2]}
                     number=$((10#$number))
                     if [[ "$number" -gt "$highest" ]]; then
@@ -72,9 +72,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^([a-z]{2,4}-)?[0-9]{3}- ]]; then
+    if [[ ! "$branch" =~ ^([a-z]{2,4}-)?[0-9]{3,}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: fac-001-feature-name (initials-number-name)" >&2
+        echo "Feature branches should be named like: infp-445-feature-name (prefix-number-name)" >&2
         return 1
     fi
 
@@ -90,8 +90,8 @@ find_feature_dir_by_prefix() {
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
 
-    # Extract numeric prefix from branch (e.g., "004" from "fac-004-whatever" or "004-whatever")
-    if [[ ! "$branch_name" =~ ^(([a-z]{2,4})-)?([0-9]{3})- ]]; then
+    # Extract numeric prefix from branch (e.g., "445" from "infp-445-whatever" or "004-whatever")
+    if [[ ! "$branch_name" =~ ^(([a-z]{2,4})-)?([0-9]{3,})- ]]; then
         # If branch doesn't have numeric prefix, fall back to exact match
         echo "$specs_dir/$branch_name"
         return

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -65,6 +65,12 @@ has_git() {
 check_feature_branch() {
     local branch="$1"
     local has_git_repo="$2"
+    local skip_check="${SPECIFY_SKIP_BRANCH_CHECK:-false}"
+
+    # Allow skipping branch check via environment variable
+    if [[ "$skip_check" == "true" ]]; then
+        return 0
+    fi
 
     # For non-git repos, we can't enforce branch naming but still provide output
     if [[ "$has_git_repo" != "true" ]]; then
@@ -73,8 +79,19 @@ check_feature_branch() {
     fi
 
     if [[ ! "$branch" =~ ^([a-z]{2,4}-)?[0-9]{3,}- ]]; then
+        # Before failing, check if find_feature_dir_by_prefix can resolve a spec directory
+        local repo_root
+        repo_root=$(get_repo_root)
+        local resolved_dir
+        resolved_dir=$(find_feature_dir_by_prefix "$repo_root" "$branch")
+        if [[ -d "$resolved_dir" ]]; then
+            # A spec directory exists for this branch via prefix lookup — allow it
+            return 0
+        fi
+
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
         echo "Feature branches should be named like: infp-445-feature-name (prefix-number-name)" >&2
+        echo "Or set SPECIFY_SKIP_BRANCH_CHECK=true to bypass this check." >&2
         return 1
     fi
 
@@ -92,7 +109,22 @@ find_feature_dir_by_prefix() {
 
     # Extract numeric prefix from branch (e.g., "445" from "infp-445-whatever" or "004-whatever")
     if [[ ! "$branch_name" =~ ^(([a-z]{2,4})-)?([0-9]{3,})- ]]; then
-        # If branch doesn't have numeric prefix, fall back to exact match
+        # If branch doesn't have numeric prefix, try to find a spec dir containing the branch name
+        # or any numeric prefix from the branch name
+        if [[ -d "$specs_dir" ]]; then
+            for dir in "$specs_dir"/*; do
+                if [[ -d "$dir" ]]; then
+                    local dirname=$(basename "$dir")
+                    for num in $(echo "$branch_name" | grep -oE '[0-9]{3,}'); do
+                        if [[ "$dirname" =~ ^([a-z]{2,4}-)?${num}- ]]; then
+                            echo "$dir"
+                            return
+                        fi
+                    done
+                fi
+            done
+        fi
+        # Fall back to exact match
         echo "$specs_dir/$branch_name"
         return
     fi

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -166,15 +166,15 @@ get_highest_from_branches() {
             # Clean branch name: remove leading markers and remote prefixes
             clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
             
-            # Extract feature number if branch matches new format: initials-###-* or old format: ###-*
-            if echo "$clean_branch" | grep -q '^[a-z]\{2,4\}-[0-9]\{3\}-'; then
-                number=$(echo "$clean_branch" | sed 's/^[a-z]*-//' | grep -o '^[0-9]\{3\}' || echo "0")
+            # Extract feature number if branch matches new format: initials-###+-* or old format: ###+-*
+            if echo "$clean_branch" | grep -q '^[a-z]\{2,4\}-[0-9]\{3,\}-'; then
+                number=$(echo "$clean_branch" | sed 's/^[a-z]*-//' | grep -o '^[0-9]\+' || echo "0")
                 number=$((10#$number))
                 if [ "$number" -gt "$highest" ]; then
                     highest=$number
                 fi
-            elif echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
-                number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
+            elif echo "$clean_branch" | grep -q '^[0-9]\{3,\}-'; then
+                number=$(echo "$clean_branch" | grep -o '^[0-9]\+' || echo "0")
                 number=$((10#$number))
                 if [ "$number" -gt "$highest" ]; then
                     highest=$number

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Regenerate with: `uv run invoke backend.generate` or `cd frontend/app && npm run
 
 ### Always Do
 
+- Before modifying code in any domain, read the relevant docs in `dev/knowledge/` for that domain
 - Run formatters before committing (`uv run invoke format`, `npm run biome:fix`)
 - Write tests for new functionality
 - Use type hints for Python (backend) and TypeScript types (frontend)

--- a/dev/commands/kitty-spec.constitution.md
+++ b/dev/commands/kitty-spec.constitution.md
@@ -1,0 +1,84 @@
+---
+description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+handoffs:
+  - label: Build Specification
+    agent: kitty-spec.specify
+    prompt: Implement the feature specification based on the updated constitution. I want to build...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non-negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old -> new
+   - List of modified principles (old title -> new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (done / pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" -> replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.

--- a/dev/commands/kitty-spec.constitution.md
+++ b/dev/commands/kitty-spec.constitution.md
@@ -46,7 +46,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each command file in `dev/commands/kitty-spec.*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/dev/commands/kitty-spec.dashboard.md
+++ b/dev/commands/kitty-spec.dashboard.md
@@ -14,6 +14,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 This command displays the current status of all work packages for the feature, both as a terminal summary and optionally as a browser-based kanban board.
 
+0. **Check for stop/kill request**:
+   - If `$ARGUMENTS` contains `stop`, `kill`, or `--kill`, stop the running dashboard:
+     ```bash
+     python dev/spec-kitty/kittify/scripts/dashboard.py --kill
+     ```
+   - Report that the dashboard has been stopped and exit — do NOT continue to the remaining steps.
+
 1. **Determine feature**:
    - Parse `$ARGUMENTS` for an optional feature/branch name
    - If not provided, use the current git branch name
@@ -59,7 +66,7 @@ This command displays the current status of all work packages for the feature, b
 
    Report:
    - Dashboard URL: `http://localhost:5050`
-   - How to stop: `python dev/spec-kitty/kittify/scripts/dashboard.py --kill` or Ctrl+C
+   - How to stop: `/kitty-spec.dashboard stop`
    - Auto-refreshes every 5 seconds
 
 5. **Suggest next actions** based on current state:

--- a/dev/commands/kitty-spec.dashboard.md
+++ b/dev/commands/kitty-spec.dashboard.md
@@ -1,0 +1,69 @@
+---
+description: Display kanban dashboard for work package status, with optional browser-based view.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command displays the current status of all work packages for the feature, both as a terminal summary and optionally as a browser-based kanban board.
+
+1. **Determine feature**:
+   - Parse `$ARGUMENTS` for an optional feature/branch name
+   - If not provided, use the current git branch name
+   - Verify `dev/spec-kitty/work-packages/<branch-name>/` exists
+
+2. **Read all WP files** from `dev/spec-kitty/work-packages/<branch-name>/`:
+   - Parse YAML frontmatter from each WP (id, lane, assigned_to, agent)
+   - Extract title from heading
+   - Count acceptance criteria per WP
+
+3. **Display terminal summary**:
+
+   First, run the status script:
+   ```bash
+   dev/spec-kitty/kittify/scripts/manage-workpackages.sh status <branch-name>
+   ```
+
+   Then display a detailed kanban view:
+
+   ```
+   ┌─────────────┬─────────────┬─────────────┬─────────────┐
+   │   PLANNED   │    DOING    │ FOR REVIEW  │    DONE     │
+   ├─────────────┼─────────────┼─────────────┼─────────────┤
+   │ WP03        │ WP01 (agent)│ WP02        │             │
+   │ WP04        │             │             │             │
+   │ WP05        │             │             │             │
+   └─────────────┴─────────────┴─────────────┴─────────────┘
+   Progress: 0/5 done (0%)
+   ```
+
+   Also list each WP with its title:
+   ```bash
+   dev/spec-kitty/kittify/scripts/manage-workpackages.sh list <branch-name>
+   ```
+
+4. **Launch browser dashboard** (optional):
+
+   If the user requests it or the environment supports it:
+
+   ```bash
+   python dev/spec-kitty/kittify/scripts/dashboard.py --feature <branch-name> &
+   ```
+
+   Report:
+   - Dashboard URL: `http://localhost:5050`
+   - How to stop: `python dev/spec-kitty/kittify/scripts/dashboard.py --kill` or Ctrl+C
+   - Auto-refreshes every 5 seconds
+
+5. **Suggest next actions** based on current state:
+   - WPs in `planned` with met dependencies -> "Ready to start: `/kitty-spec.implement <WP_ID>`"
+   - WPs in `for_review` -> "Ready for review: `/kitty-spec.review <WP_ID>`"
+   - WPs in `done` -> "Ready to merge: `/kitty-spec.merge <WP_ID>`"
+   - All WPs `done` -> "All work packages complete! Run `/kitty-spec.merge --all` to merge everything"

--- a/dev/commands/kitty-spec.implement.md
+++ b/dev/commands/kitty-spec.implement.md
@@ -1,0 +1,89 @@
+---
+description: Implement a work package in an isolated git worktree.
+handoffs:
+  - label: Review Work Package
+    agent: kitty-spec.review
+    prompt: Review the completed work package
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command implements a single work package in an isolated git worktree, enabling parallel development across multiple WPs.
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+
+2. **Select work package**:
+   - Parse `$ARGUMENTS` for an optional WP ID (e.g., `WP01`). If not provided:
+   - Determine the current branch name from git
+   - Scan `dev/spec-kitty/work-packages/<branch-name>/` for WP files
+   - Auto-select the first WP with `lane: planned` (in numerical order)
+   - If no planned WPs exist, report that all WPs are in progress or complete
+
+3. **Validate dependencies**:
+   - Read the selected WP file
+   - Verify its `lane` is `planned`
+   - Check the `Dependencies` section: all referenced WP IDs must have `lane: done`
+   - If dependencies are not met, report which WPs are blocking and suggest waiting or working on a different WP
+
+4. **Create worktree** (if not already created):
+   ```bash
+   dev/spec-kitty/kittify/scripts/manage-workpackages.sh create-worktree <branch> <WP_ID>
+   ```
+
+5. **Transition WP to doing**:
+   ```bash
+   dev/spec-kitty/kittify/scripts/manage-workpackages.sh transition <branch> <WP_ID> doing
+   ```
+
+6. **Load implementation context**:
+   - Read the WP file: goal, tasks, implementation prompt, files to modify
+   - Read `FEATURE_DIR/plan.md` for architecture context
+   - Read `FEATURE_DIR/data-model.md` if referenced in the WP
+   - Read `FEATURE_DIR/contracts/` if referenced in the WP
+   - Read `.specify/memory/constitution.md` for project principles
+
+7. **Display the implementation prompt** from the WP file to establish clear scope.
+
+8. **Execute implementation** in the worktree:
+   - Follow the WP's task list sequentially
+   - For each task:
+     - Implement the change in the worktree directory
+     - Mark the task as `[X]` in `FEATURE_DIR/tasks.md`
+     - Commit changes in the worktree branch with descriptive messages
+   - Stay within the scope defined by "Files To Modify" in the WP
+   - If you need to modify files not listed in the WP, note this for the review phase
+
+9. **Post-implementation checks**:
+   - Run linting on changed files (`uv run invoke lint` for Python, `cd frontend/app && npm run biome:fix` for frontend)
+   - Run relevant unit tests if identifiable
+   - Verify no unintended changes outside the WP scope
+
+10. **Transition WP to for_review**:
+    ```bash
+    dev/spec-kitty/kittify/scripts/manage-workpackages.sh transition <branch> <WP_ID> for_review
+    ```
+
+11. **Report**:
+    - WP ID and title
+    - Worktree branch name (for review/merge)
+    - Files changed (list)
+    - Tasks completed vs total
+    - Any out-of-scope changes made (flagged for review)
+    - Suggest running `/kitty-spec.review <WP_ID>` next
+
+## Implementation Rules
+
+- **Scope discipline**: Only modify files listed in the WP's "Files To Modify" section unless absolutely necessary
+- **Commit granularity**: One commit per logical change, not one giant commit
+- **Test awareness**: If the WP includes test tasks, write tests before or alongside implementation
+- **Constitution compliance**: Follow all project principles from the constitution
+- **Error handling**: If a task cannot be completed, mark it with a note in tasks.md and continue with remaining tasks

--- a/dev/commands/kitty-spec.implement.md
+++ b/dev/commands/kitty-spec.implement.md
@@ -36,8 +36,10 @@ This command implements a single work package in an isolated git worktree, enabl
 
 4. **Create worktree** (if not already created):
    ```bash
-   dev/spec-kitty/kittify/scripts/manage-workpackages.sh create-worktree <branch> <WP_ID>
+   WORKTREE_PATH=$(dev/spec-kitty/kittify/scripts/manage-workpackages.sh create-worktree <branch> <WP_ID> | grep 'Created worktree at:' | sed 's/Created worktree at: //')
+   cd "$WORKTREE_PATH"
    ```
+   All subsequent file modifications and git operations must run inside this worktree directory.
 
 5. **Transition WP to doing**:
    ```bash
@@ -50,6 +52,7 @@ This command implements a single work package in an isolated git worktree, enabl
    - Read `FEATURE_DIR/data-model.md` if referenced in the WP
    - Read `FEATURE_DIR/contracts/` if referenced in the WP
    - Read `.specify/memory/constitution.md` for project principles
+   - **Required**: Read `dev/knowledge/` docs relevant to the files being modified. If the implementation instructions contradict these docs, STOP and ask the user which is correct before proceeding.
 
 7. **Display the implementation prompt** from the WP file to establish clear scope.
 

--- a/dev/commands/kitty-spec.merge.md
+++ b/dev/commands/kitty-spec.merge.md
@@ -1,0 +1,97 @@
+---
+description: Merge completed work packages and clean up worktrees.
+handoffs:
+  - label: View Dashboard
+    agent: kitty-spec.dashboard
+    prompt: Show the current work package status
+  - label: Create PR
+    agent: git-commit
+    prompt: Commit and push changes for PR creation
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command merges approved work packages back into the feature branch and cleans up worktrees.
+
+1. **Parse arguments**:
+   - `$ARGUMENTS` may contain:
+     - A specific WP ID (e.g., `WP01`) -- merge just that WP
+     - `--all` flag -- merge all done WPs
+     - Empty -- prompt user to choose
+
+2. **Determine feature context**:
+   - Get current branch name from git
+   - List all WPs from `dev/spec-kitty/work-packages/<branch-name>/`
+   - Parse each WP's frontmatter for lane status
+
+3. **Pre-merge validation**:
+   - All targeted WPs must have `lane: done`
+   - If `--all`: verify ALL WPs are done. If not, list remaining WPs and their lanes
+   - For each WP to merge, check for potential merge conflicts:
+     - Compare "Files To Modify" across WPs being merged
+     - If overlapping files, warn about potential conflicts and suggest merge order
+
+4. **Merge WPs** (in dependency order):
+
+   For each WP to merge:
+
+   a. Ensure we're on the feature branch:
+      ```bash
+      git checkout <feature-branch>
+      ```
+
+   b. Merge the worktree branch:
+      ```bash
+      git merge kitty/<branch>-<WP_ID> --no-ff -m "feat: merge WP## - <WP title>"
+      ```
+
+   c. Handle conflicts:
+      - If merge conflicts occur, report the conflicting files to the user
+      - Do NOT auto-resolve conflicts -- present them for manual resolution
+      - After user resolves: `git add <resolved-files> && git commit`
+
+   d. Clean up worktree:
+      ```bash
+      dev/spec-kitty/kittify/scripts/manage-workpackages.sh cleanup-worktree <branch> <WP_ID>
+      ```
+
+5. **Post-merge validation**:
+   - Run formatting: `uv run invoke format` (Python), `cd frontend/app && npm run biome:fix` (frontend)
+   - Run linting: `uv run invoke lint` (Python)
+   - Run relevant tests if identifiable
+   - Report any issues found
+
+6. **Report merge summary**:
+   ```markdown
+   ## Merge Summary
+
+   | WP | Title | Status | Conflicts |
+   |----|-------|--------|-----------|
+   | WP01 | ... | Merged | None |
+   | WP02 | ... | Merged | 2 files resolved |
+
+   **Post-merge checks**: Lint PASS, Format PASS
+   **Worktrees cleaned**: WP01, WP02
+   **Remaining WPs**: WP03 (planned), WP04 (doing)
+   ```
+
+7. **Suggest next steps**:
+   - If all WPs merged: suggest `/git-commit` to commit and push for PR
+   - If WPs remain: suggest `/kitty-spec.implement` for next planned WP
+   - If review needed: suggest `/kitty-spec.review` for for_review WPs
+
+## Merge Rules
+
+- Always use `--no-ff` to preserve WP merge history
+- Merge in dependency order (WPs with no deps first)
+- Never force-merge or auto-resolve conflicts
+- Clean up worktrees only after successful merge
+- Run formatters/linters after all merges complete (not after each individual merge)

--- a/dev/commands/kitty-spec.plan.md
+++ b/dev/commands/kitty-spec.plan.md
@@ -22,7 +22,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied). Read all `dev/knowledge/` docs relevant to the domains the feature touches. These contain deprecation notices, required patterns, and architectural constraints that MUST inform the plan.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
@@ -30,7 +30,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
+   - Phase 2: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts. Suggest running `/kitty-spec.tasks` next to generate tasks and work packages for parallel implementation.
@@ -76,8 +76,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 3. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh claude`
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
+   - Update the Claude agent context file
    - Add only new technology from current plan
    - Preserve manual additions between markers
 

--- a/dev/commands/kitty-spec.plan.md
+++ b/dev/commands/kitty-spec.plan.md
@@ -1,0 +1,89 @@
+---
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+handoffs:
+  - label: Create Tasks & Work Packages
+    agent: kitty-spec.tasks
+    prompt: Break the plan into tasks and work packages
+    send: true
+  - label: Create Checklist
+    agent: speckit.checklist
+    prompt: Create a checklist for the following domain...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts. Suggest running `/kitty-spec.tasks` next to generate tasks and work packages for parallel implementation.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION -> research task
+   - For each dependency -> best practices task
+   - For each integration -> patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** -> `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action -> endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Agent context update**:
+   - Run `.specify/scripts/bash/update-agent-context.sh claude`
+   - These scripts detect which AI agent is in use
+   - Update the appropriate agent-specific context file
+   - Add only new technology from current plan
+   - Preserve manual additions between markers
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+## Key rules
+
+- Use absolute paths
+- ERROR on gate failures or unresolved clarifications

--- a/dev/commands/kitty-spec.research.md
+++ b/dev/commands/kitty-spec.research.md
@@ -1,0 +1,89 @@
+---
+description: Run Phase 0 research scaffolding before planning to resolve unknowns and make informed technology decisions.
+handoffs:
+  - label: Build Technical Plan
+    agent: kitty-spec.plan
+    prompt: Create a plan based on the research findings
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command extracts and formalizes the research phase into a standalone step, producing a structured `research.md` before planning begins.
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. All paths must be absolute.
+
+2. **Load context**:
+   - Read `FEATURE_DIR/spec.md` for feature requirements and scope
+   - Read `.specify/memory/constitution.md` for project principles and constraints
+   - If `FEATURE_DIR/plan.md` exists, scan for NEEDS CLARIFICATION markers
+
+3. **Identify research areas**: For each area needing investigation:
+   - Technology choices referenced in spec or plan
+   - Integration patterns with existing systems
+   - Security or compliance requirements
+   - Performance or scalability concerns
+   - Third-party dependencies or APIs
+   - Domain-specific best practices
+
+4. **Conduct research**: For each identified area:
+   - Research best practices, patterns, and alternatives
+   - Use web search if available for up-to-date information
+   - Evaluate trade-offs (complexity, maintenance, performance, team familiarity)
+   - Consider project constitution principles when making recommendations
+
+5. **Consolidate findings** into `FEATURE_DIR/research.md`:
+
+   ```markdown
+   # Research: [Feature Name]
+
+   ## Summary
+
+   <high-level overview of research conducted and key decisions>
+
+   ## Decisions
+
+   ### [Topic 1]
+
+   - **Decision**: [what was chosen]
+   - **Rationale**: [why this option was selected]
+   - **Alternatives considered**:
+     - [Alternative A]: [why rejected]
+     - [Alternative B]: [why rejected]
+   - **Risks**: [known risks or trade-offs]
+
+   ### [Topic 2]
+   ...
+
+   ## Open Questions
+
+   <any remaining questions that need stakeholder input>
+
+   ## References
+
+   <links to documentation, articles, or resources consulted>
+   ```
+
+6. **Optionally populate** `FEATURE_DIR/data-model.md` with initial entity sketches if the research reveals clear data structures.
+
+7. **Report**:
+   - Path to `research.md`
+   - Decisions made (count and summary)
+   - Areas still needing clarification (if any)
+   - Suggest running `/kitty-spec.plan` next to build the technical plan
+
+## Guidelines
+
+- Focus on decisions that affect architecture, not implementation details
+- Prefer options that align with project constitution principles
+- Document trade-offs explicitly -- don't just pick the "best" option without explaining why alternatives were rejected
+- Keep research actionable: every section should inform a planning or implementation decision
+- If web search is unavailable, rely on codebase context, existing patterns, and general best practices

--- a/dev/commands/kitty-spec.review.md
+++ b/dev/commands/kitty-spec.review.md
@@ -1,0 +1,100 @@
+---
+description: Structured code review for a completed work package with quality gates.
+handoffs:
+  - label: Merge Work Package
+    agent: kitty-spec.merge
+    prompt: Merge the approved work package
+    send: true
+  - label: Fix Issues
+    agent: kitty-spec.implement
+    prompt: Fix the review issues found in the work package
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command performs a structured code review on a completed work package, checking acceptance criteria and quality gates before approving for merge.
+
+1. **Select work package**:
+   - Parse `$ARGUMENTS` for a WP ID (e.g., `WP01`). If not provided:
+   - Determine the current branch name from git
+   - Scan `dev/spec-kitty/work-packages/<branch-name>/` for WP files
+   - Auto-select the first WP with `lane: for_review` (in numerical order)
+   - If no WPs are in `for_review`, report current status
+
+2. **Validate state**:
+   - Read the selected WP file
+   - Verify its `lane` is `for_review`
+   - If not, report the current lane and suggest the appropriate action
+
+3. **Load review context**:
+   - Read the WP file: acceptance criteria, tasks, files to modify
+   - Read `FEATURE_DIR/plan.md` for architecture expectations
+   - Read `.specify/memory/constitution.md` for quality principles
+   - Get the worktree branch name: `kitty/<branch>-<WP_ID>`
+
+4. **Gather changes**:
+   - Run `git diff main...<worktree-branch>` to see all changes (or diff against the feature branch)
+   - List all files modified in the worktree branch
+   - Count lines added/removed
+
+5. **Quality Gates** - check each and report pass/fail:
+
+   | Gate | Check | Pass Criteria |
+   |------|-------|--------------|
+   | Acceptance Criteria | Compare WP acceptance_criteria against implementation | All criteria demonstrably met |
+   | Scope Compliance | Compare changed files against WP "Files To Modify" | No unintended file changes outside WP scope |
+   | Constitution | Review against project principles | Code follows all applicable principles |
+   | Tests | Check for new/updated tests | Tests exist for new functionality |
+   | Security | Scan for secrets/credentials | No sensitive data committed |
+   | Linting | Run linters on changed files | `uv run invoke lint` (Python) or `npm run biome:fix` (frontend) passes |
+   | Task Completion | Check tasks marked [X] in tasks.md | All WP tasks completed |
+
+6. **Decision**:
+
+   - **APPROVE** (all gates pass):
+     1. Transition WP to `done`:
+        ```bash
+        dev/spec-kitty/kittify/scripts/manage-workpackages.sh transition <branch> <WP_ID> done
+        ```
+     2. Report: WP approved, ready for `/kitty-spec.merge <WP_ID>`
+
+   - **REQUEST CHANGES** (any gate fails):
+     1. Transition WP back to `planned`:
+        ```bash
+        dev/spec-kitty/kittify/scripts/manage-workpackages.sh transition <branch> <WP_ID> planned
+        ```
+     2. Append failure details to the WP activity log
+     3. Report: which gates failed, specific issues to fix, suggest `/kitty-spec.implement <WP_ID>` to address
+
+7. **Present results** with a clear pass/fail table:
+
+   ```markdown
+   ## Review Results: WP##
+
+   | Gate | Status | Notes |
+   |------|--------|-------|
+   | Acceptance Criteria | PASS/FAIL | details |
+   | Scope Compliance | PASS/FAIL | details |
+   | Constitution | PASS/FAIL | details |
+   | Tests | PASS/FAIL | details |
+   | Security | PASS/FAIL | details |
+   | Linting | PASS/FAIL | details |
+   | Task Completion | PASS/FAIL | details |
+
+   **Decision**: APPROVED / CHANGES REQUESTED
+   ```
+
+## Review Principles
+
+- Be thorough but pragmatic -- minor style issues don't warrant rejection if linting passes
+- Focus on correctness, security, and adherence to the plan
+- Flag architectural concerns even if not strictly a gate failure
+- Out-of-scope changes are a warning, not automatic rejection (sometimes necessary)

--- a/dev/commands/kitty-spec.specify.md
+++ b/dev/commands/kitty-spec.specify.md
@@ -1,0 +1,225 @@
+---
+description: Create or update the feature specification from a natural language feature description.
+handoffs:
+  - label: Build Technical Plan
+    agent: kitty-spec.plan
+    prompt: Create a plan for the spec. I am building with...
+  - label: Clarify Spec Requirements
+    agent: speckit.clarify
+    prompt: Clarify specification requirements
+    send: true
+---
+
+## User input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+The text the user typed after `/kitty-spec.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the branch:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" -> "user-auth"
+     - "Implement OAuth2 integration for the API" -> "oauth2-api-integration"
+     - "Create a dashboard for analytics" -> "analytics-dashboard"
+     - "Fix payment processing timeout bug" -> "fix-payment-timeout"
+
+2. **Determine the Jira/JPD reference and create the feature branch**:
+
+   a. Determine the Jira/JPD reference for this feature:
+      - Parse `$ARGUMENTS` for a ticket ID matching:
+        - JPD format: `infp-[0-9]+` (e.g., `infp-460`)
+        - Jira epic format: `ifc-[0-9]+` (e.g., `ifc-2140`)
+      - If no ticket ID is found in the arguments, prompt the user:
+
+        > "Please provide a Jira or JPD reference for this feature (e.g., `infp-460` for a JPD item or `ifc-2140` for a Jira epic):"
+
+      - Do not proceed until a valid ticket ID is provided.
+
+   b. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the ticket ID and short-name:
+      - Pass `--number <ticket-id>` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json --number infp-460 --short-name "user-auth" "Add user authentication"`
+
+   **IMPORTANT**:
+   - A valid ticket ID is required -- never invent or skip it
+   - Ticket IDs are unique identifiers; no branch scanning is needed
+   - You must only ever run this script once per feature
+   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
+   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+
+3. Load `.specify/templates/spec-template.md` to understand required sections.
+
+4. Follow this execution flow:
+
+    1. Parse user description from Input
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+
+      ## Content Quality
+
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+
+      ## Requirement Completeness
+
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+
+      ## Feature Readiness
+
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+
+      ## Notes
+
+      - Items marked incomplete require spec updates before `/kitty-spec.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 7
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user
+        4. Wait for user to respond with their choices
+        5. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        6. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/kitty-spec.plan`).
+
+   **Note**: After `/kitty-spec.tasks`, work packages will be generated for parallel implementation.
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+
+## General Guidelines
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: RESTful APIs unless specified otherwise
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/dev/commands/kitty-spec.tasks.md
+++ b/dev/commands/kitty-spec.tasks.md
@@ -1,0 +1,164 @@
+---
+description: Generate tasks and decompose into work packages for parallel implementation.
+handoffs:
+  - label: Analyze For Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency
+    send: true
+  - label: Implement Work Package
+    agent: kitty-spec.implement
+    prompt: Start implementing the first work package
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map endpoints to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Work Package Decomposition** (NEW - SpecKitty-specific):
+
+   a. Determine the current branch name (from git or FEATURE_DIR path).
+
+   b. Create the work packages directory: `dev/spec-kitty/work-packages/<branch-name>/`
+
+   c. Group tasks from tasks.md into work packages (max 10):
+      - Each WP should be independently implementable and testable
+      - Group by functional area / user story
+      - Respect dependencies: WPs with blocking deps listed explicitly
+      - Mark which files each WP touches (for parallel conflict detection)
+      - WPs that touch different files can run in parallel
+      - WPs that touch the same files must be sequential
+
+   d. For each WP, create `dev/spec-kitty/work-packages/<branch-name>/WP##.md`:
+      - Use `dev/spec-kitty/kittify/templates/workpackage-template.md` as base
+      - Fill in: id, feature, acceptance_criteria, goal, tasks, implementation prompt, files, dependencies
+      - Set lane to `planned`
+      - Number WPs sequentially: WP01, WP02, WP03...
+
+   e. Report WP summary:
+      - Total WPs created
+      - Dependency graph (which WPs can run in parallel)
+      - Estimated parallelism gain (e.g., "WP01+WP02 can run in parallel, saving ~30% time")
+
+6. **Report**: Output path to generated tasks.md and WP summary:
+   - Total task count
+   - Task count per user story
+   - Work packages created (count and paths)
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+   - Suggest running `/kitty-spec.implement` next
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- WRONG: `- [ ] Create User model` (missing ID and Story label)
+- WRONG: `T001 [US1] Create model` (missing checkbox)
+- WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Endpoints/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each contract/endpoint -> to the user story it serves
+   - If tests requested: Each contract -> contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships -> service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure -> Setup phase (Phase 1)
+   - Foundational/blocking tasks -> Foundational phase (Phase 2)
+   - Story-specific setup -> within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) -> Models -> Services -> Endpoints -> Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/dev/commands/kitty-spec.tasks.md
+++ b/dev/commands/kitty-spec.tasks.md
@@ -25,6 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Required**: Read `dev/knowledge/` docs for all domains the feature touches. These contain deprecation notices and required patterns that must be reflected in generated tasks.
    - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 

--- a/dev/commands/speckit.implement.md
+++ b/dev/commands/speckit.implement.md
@@ -48,6 +48,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 3. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan
    - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **REQUIRED**: Read `dev/knowledge/` docs relevant to the files being modified. If the implementation instructions contradict these docs, STOP and ask the user which is correct before proceeding.
    - **IF EXISTS**: Read data-model.md for entities and relationships
    - **IF EXISTS**: Read contracts/ for API specifications and test requirements
    - **IF EXISTS**: Read research.md for technical decisions and constraints

--- a/dev/commands/speckit.plan.md
+++ b/dev/commands/speckit.plan.md
@@ -22,7 +22,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied). Read all `dev/knowledge/` docs relevant to the domains the feature touches. These contain deprecation notices, required patterns, and architectural constraints that MUST inform the plan.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
@@ -76,8 +76,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 3. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh claude`
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
+   - Update the Claude agent context file
    - Add only new technology from current plan
    - Preserve manual additions between markers
 

--- a/dev/commands/speckit.tasks.md
+++ b/dev/commands/speckit.tasks.md
@@ -25,6 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Required**: Read `dev/knowledge/` docs for all domains the feature touches. These contain deprecation notices and required patterns that must be reflected in generated tasks.
    - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 

--- a/dev/spec-kitty/README.md
+++ b/dev/spec-kitty/README.md
@@ -1,0 +1,93 @@
+# SpecKitty (kitty-spec.*)
+
+SpecKitty extends the existing SpecKit workflow with **work-package-based parallelism**, **git worktree isolation**, **structured review**, and **merge phases**.
+
+## How It Differs from SpecKit
+
+| Aspect | SpecKit (`speckit.*`) | SpecKitty (`kitty-spec.*`) |
+|--------|----------------------|---------------------------|
+| Task execution | Sequential (tasks.md top-to-bottom) | Parallel via work packages |
+| Isolation | Single branch | Git worktrees per WP |
+| Review | Manual | Structured quality gates |
+| Merge | N/A | Explicit merge phase with conflict detection |
+| Dashboard | N/A | Terminal + browser kanban |
+
+## Shared Artifacts
+
+Both tools share two directories at the repository root:
+
+- `.specify/` -- Infrastructure (scripts, templates, constitution)
+  - `.specify/scripts/` -- Bash helpers used by both SpecKit and SpecKitty
+  - `.specify/templates/` -- Spec, plan, and task templates
+  - `.specify/memory/constitution.md` -- Project constitution
+- `specs/` -- Feature artifacts (created per feature branch)
+  - `specs/<branch>/spec.md` -- Feature specification
+  - `specs/<branch>/plan.md` -- Implementation plan
+  - `specs/<branch>/tasks.md` -- Task list
+  - `specs/<branch>/research.md` -- Research decisions
+
+## SpecKitty-Only Files
+
+All SpecKitty-specific files live under `dev/spec-kitty/`:
+
+```
+dev/spec-kitty/
+├── work-packages/<branch>/   # WP files (WP01.md, WP02.md, ...)
+├── .worktrees/                # Git worktrees (gitignored)
+└── kittify/
+    ├── scripts/               # Management scripts
+    ├── templates/             # WP template
+    └── missions.yaml          # Mission config (placeholder)
+```
+
+## Workflow
+
+```
+/kitty-spec.constitution   (optional) Set project principles
+        │
+/kitty-spec.specify        Create feature specification
+        │
+/kitty-spec.research       (optional) Research unknowns
+        │
+/kitty-spec.plan           Design technical architecture
+        │
+/kitty-spec.tasks          Generate tasks + work packages
+        │
+/kitty-spec.implement      Implement WP in isolated worktree
+        │                  (repeat for each WP, can run in parallel)
+/kitty-spec.review         Review completed WP against quality gates
+        │
+/kitty-spec.merge          Merge WPs back, clean up worktrees
+        │
+/kitty-spec.dashboard      View status at any time
+```
+
+## Quick Start
+
+```
+/kitty-spec.specify Add OAuth2 integration for the API (ifc-2140)
+```
+
+This creates the spec, then follow the handoff suggestions through the workflow.
+
+## Work Package Lanes
+
+Each WP moves through these lanes:
+
+- **planned** -- Ready to be implemented
+- **doing** -- Currently being worked on (in a worktree)
+- **for_review** -- Implementation complete, needs review
+- **done** -- Reviewed and approved, ready to merge
+
+## Scripts
+
+```bash
+# List WPs and their status
+dev/spec-kitty/kittify/scripts/manage-workpackages.sh list <branch>
+
+# View kanban summary
+dev/spec-kitty/kittify/scripts/manage-workpackages.sh status <branch>
+
+# Launch browser dashboard
+python dev/spec-kitty/kittify/scripts/dashboard.py --feature <branch>
+```

--- a/dev/spec-kitty/kittify/memory/constitution.md
+++ b/dev/spec-kitty/kittify/memory/constitution.md
@@ -1,0 +1,1 @@
+../../../constitution.md

--- a/dev/spec-kitty/kittify/missions.yaml
+++ b/dev/spec-kitty/kittify/missions.yaml
@@ -1,3 +1,4 @@
+---
 # SpecKitty Missions Configuration
 # Placeholder for future mission definitions
 missions: []

--- a/dev/spec-kitty/kittify/missions.yaml
+++ b/dev/spec-kitty/kittify/missions.yaml
@@ -1,0 +1,3 @@
+# SpecKitty Missions Configuration
+# Placeholder for future mission definitions
+missions: []

--- a/dev/spec-kitty/kittify/scripts/dashboard.py
+++ b/dev/spec-kitty/kittify/scripts/dashboard.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Minimal Flask-based kanban dashboard for SpecKitty work packages."""
+
+import argparse
+import os
+import re
+import signal
+import sys
+from pathlib import Path
+
+try:
+    from flask import Flask, Response
+except ImportError:
+    print("Flask is required: pip install flask")
+    sys.exit(1)
+
+app = Flask(__name__)
+FEATURE = ""
+WP_DIR = Path()
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="5">
+<title>SpecKitty Dashboard - {feature}</title>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #1a1a2e; color: #eee; padding: 20px; }}
+  h1 {{ text-align: center; margin-bottom: 20px; color: #e94560; }}
+  .board {{ display: flex; gap: 16px; justify-content: center; }}
+  .lane {{ flex: 1; max-width: 280px; background: #16213e; border-radius: 8px; padding: 12px; min-height: 300px; }}
+  .lane h2 {{ text-align: center; padding: 8px; border-radius: 4px; margin-bottom: 12px; font-size: 14px; text-transform: uppercase; }}
+  .lane.planned h2 {{ background: #555; }}
+  .lane.doing h2 {{ background: #1a56db; }}
+  .lane.for_review h2 {{ background: #c27803; }}
+  .lane.done h2 {{ background: #057a55; }}
+  .card {{ background: #0f3460; border-radius: 6px; padding: 10px; margin-bottom: 8px; }}
+  .card .id {{ font-weight: bold; color: #e94560; }}
+  .card .title {{ font-size: 13px; margin-top: 4px; }}
+  .card .agent {{ font-size: 11px; color: #888; margin-top: 4px; }}
+  .progress {{ text-align: center; margin-top: 20px; font-size: 18px; }}
+  .bar {{ width: 60%; margin: 10px auto; background: #16213e; border-radius: 8px; height: 24px; overflow: hidden; }}
+  .bar .fill {{ height: 100%; background: #057a55; transition: width 0.3s; }}
+</style>
+</head>
+<body>
+<h1>SpecKitty: {feature}</h1>
+<div class="board">{lanes}</div>
+<div class="progress">
+  Progress: {done}/{total} done ({pct}%)
+  <div class="bar"><div class="fill" style="width:{pct}%"></div></div>
+</div>
+</body>
+</html>"""
+
+
+def parse_wp_frontmatter(filepath: Path) -> dict:
+    """Parse YAML frontmatter from a WP file."""
+    text = filepath.read_text()
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return {}
+    data = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, val = line.partition(":")
+            data[key.strip()] = val.strip().strip('"')
+    # Extract title from heading
+    title_match = re.search(r"^# Work Package WP\d+: (.+)$", text, re.MULTILINE)
+    data["title"] = title_match.group(1) if title_match else ""
+    return data
+
+
+def build_board() -> str:
+    """Build the HTML kanban board."""
+    lanes = {"planned": [], "doing": [], "for_review": [], "done": []}
+    wp_path = WP_DIR / FEATURE
+
+    if wp_path.is_dir():
+        for f in sorted(wp_path.glob("WP*.md")):
+            wp = parse_wp_frontmatter(f)
+            lane = wp.get("lane", "planned")
+            if lane in lanes:
+                lanes[lane].append(wp)
+
+    total = sum(len(v) for v in lanes.values())
+    done = len(lanes["done"])
+    pct = (done * 100 // total) if total > 0 else 0
+
+    lanes_html = ""
+    for lane_name, label in [
+        ("planned", "Planned"),
+        ("doing", "Doing"),
+        ("for_review", "For Review"),
+        ("done", "Done"),
+    ]:
+        cards = ""
+        for wp in lanes[lane_name]:
+            agent_line = f'<div class="agent">{wp.get("agent", "")}</div>' if wp.get("agent") else ""
+            cards += f'<div class="card"><span class="id">{wp.get("id", "?")}</span><div class="title">{wp.get("title", "")}</div>{agent_line}</div>'
+        lanes_html += f'<div class="lane {lane_name}"><h2>{label}</h2>{cards}</div>'
+
+    return HTML_TEMPLATE.format(feature=FEATURE, lanes=lanes_html, done=done, total=total, pct=pct)
+
+
+@app.route("/")
+def index():
+    return Response(build_board(), content_type="text/html")
+
+
+def main():
+    global FEATURE, WP_DIR
+
+    parser = argparse.ArgumentParser(description="SpecKitty Dashboard")
+    parser.add_argument("--feature", required=True, help="Feature branch name")
+    parser.add_argument("--port", type=int, default=5050, help="Port (default: 5050)")
+    parser.add_argument("--kill", action="store_true", help="Kill running dashboard")
+    args = parser.parse_args()
+
+    if args.kill:
+        os.system("pkill -f 'dashboard.py.*--feature'")
+        print("Dashboard stopped.")
+        return
+
+    FEATURE = args.feature
+    WP_DIR = Path(__file__).resolve().parent.parent.parent / "work-packages"
+
+    print(f"SpecKitty Dashboard: http://localhost:{args.port}")
+    print(f"Feature: {FEATURE}")
+    print("Press Ctrl+C to stop.")
+
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+    app.run(host="127.0.0.1", port=args.port, debug=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/spec-kitty/kittify/scripts/dashboard.py
+++ b/dev/spec-kitty/kittify/scripts/dashboard.py
@@ -1,137 +1,32 @@
 #!/usr/bin/env python3
-"""Minimal Flask-based kanban dashboard for SpecKitty work packages."""
+"""SpecKitty Dashboard launcher.
 
-import argparse
+Delegates to the full dashboard server in dashboard/server.py.
+Kept for backwards compatibility with existing scripts.
+"""
+
+from __future__ import annotations
+
 import os
-import re
-import signal
+import subprocess  # noqa: S404
 import sys
 from pathlib import Path
 
-try:
-    from flask import Flask, Response
-except ImportError:
-    print("Flask is required: pip install flask")
-    sys.exit(1)
 
-app = Flask(__name__)
-FEATURE = ""
-WP_DIR = Path()
+def main() -> None:
+    server_script = Path(__file__).resolve().parent / "dashboard" / "server.py"
+    if not server_script.exists():
+        print(f"Error: dashboard server not found at {server_script}", file=sys.stderr)
+        sys.exit(1)
 
-HTML_TEMPLATE = """<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<meta http-equiv="refresh" content="5">
-<title>SpecKitty Dashboard - {feature}</title>
-<style>
-  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-  body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #1a1a2e; color: #eee; padding: 20px; }}
-  h1 {{ text-align: center; margin-bottom: 20px; color: #e94560; }}
-  .board {{ display: flex; gap: 16px; justify-content: center; }}
-  .lane {{ flex: 1; max-width: 280px; background: #16213e; border-radius: 8px; padding: 12px; min-height: 300px; }}
-  .lane h2 {{ text-align: center; padding: 8px; border-radius: 4px; margin-bottom: 12px; font-size: 14px; text-transform: uppercase; }}
-  .lane.planned h2 {{ background: #555; }}
-  .lane.doing h2 {{ background: #1a56db; }}
-  .lane.for_review h2 {{ background: #c27803; }}
-  .lane.done h2 {{ background: #057a55; }}
-  .card {{ background: #0f3460; border-radius: 6px; padding: 10px; margin-bottom: 8px; }}
-  .card .id {{ font-weight: bold; color: #e94560; }}
-  .card .title {{ font-size: 13px; margin-top: 4px; }}
-  .card .agent {{ font-size: 11px; color: #888; margin-top: 4px; }}
-  .progress {{ text-align: center; margin-top: 20px; font-size: 18px; }}
-  .bar {{ width: 60%; margin: 10px auto; background: #16213e; border-radius: 8px; height: 24px; overflow: hidden; }}
-  .bar .fill {{ height: 100%; background: #057a55; transition: width 0.3s; }}
-</style>
-</head>
-<body>
-<h1>SpecKitty: {feature}</h1>
-<div class="board">{lanes}</div>
-<div class="progress">
-  Progress: {done}/{total} done ({pct}%)
-  <div class="bar"><div class="fill" style="width:{pct}%"></div></div>
-</div>
-</body>
-</html>"""
-
-
-def parse_wp_frontmatter(filepath: Path) -> dict:
-    """Parse YAML frontmatter from a WP file."""
-    text = filepath.read_text()
-    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
-    if not match:
-        return {}
-    data = {}
-    for line in match.group(1).splitlines():
-        if ":" in line and not line.startswith(" "):
-            key, _, val = line.partition(":")
-            data[key.strip()] = val.strip().strip('"')
-    # Extract title from heading
-    title_match = re.search(r"^# Work Package WP\d+: (.+)$", text, re.MULTILINE)
-    data["title"] = title_match.group(1) if title_match else ""
-    return data
-
-
-def build_board() -> str:
-    """Build the HTML kanban board."""
-    lanes = {"planned": [], "doing": [], "for_review": [], "done": []}
-    wp_path = WP_DIR / FEATURE
-
-    if wp_path.is_dir():
-        for f in sorted(wp_path.glob("WP*.md")):
-            wp = parse_wp_frontmatter(f)
-            lane = wp.get("lane", "planned")
-            if lane in lanes:
-                lanes[lane].append(wp)
-
-    total = sum(len(v) for v in lanes.values())
-    done = len(lanes["done"])
-    pct = (done * 100 // total) if total > 0 else 0
-
-    lanes_html = ""
-    for lane_name, label in [
-        ("planned", "Planned"),
-        ("doing", "Doing"),
-        ("for_review", "For Review"),
-        ("done", "Done"),
-    ]:
-        cards = ""
-        for wp in lanes[lane_name]:
-            agent_line = f'<div class="agent">{wp.get("agent", "")}</div>' if wp.get("agent") else ""
-            cards += f'<div class="card"><span class="id">{wp.get("id", "?")}</span><div class="title">{wp.get("title", "")}</div>{agent_line}</div>'
-        lanes_html += f'<div class="lane {lane_name}"><h2>{label}</h2>{cards}</div>'
-
-    return HTML_TEMPLATE.format(feature=FEATURE, lanes=lanes_html, done=done, total=total, pct=pct)
-
-
-@app.route("/")
-def index():
-    return Response(build_board(), content_type="text/html")
-
-
-def main():
-    global FEATURE, WP_DIR
-
-    parser = argparse.ArgumentParser(description="SpecKitty Dashboard")
-    parser.add_argument("--feature", required=True, help="Feature branch name")
-    parser.add_argument("--port", type=int, default=5050, help="Port (default: 5050)")
-    parser.add_argument("--kill", action="store_true", help="Kill running dashboard")
-    args = parser.parse_args()
-
-    if args.kill:
-        os.system("pkill -f 'dashboard.py.*--feature'")
-        print("Dashboard stopped.")
-        return
-
-    FEATURE = args.feature
-    WP_DIR = Path(__file__).resolve().parent.parent.parent / "work-packages"
-
-    print(f"SpecKitty Dashboard: http://localhost:{args.port}")
-    print(f"Feature: {FEATURE}")
-    print("Press Ctrl+C to stop.")
-
-    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
-    app.run(host="127.0.0.1", port=args.port, debug=False)
+    # Forward all arguments
+    cmd = [sys.executable, str(server_script), *sys.argv[1:]]
+    try:
+        os.execvp(sys.executable, cmd)  # noqa: S606
+    except OSError:
+        # Fallback for platforms where execvp fails
+        result = subprocess.run(cmd, check=False)  # noqa: S603
+        sys.exit(result.returncode)
 
 
 if __name__ == "__main__":

--- a/dev/spec-kitty/kittify/scripts/dashboard/server.py
+++ b/dev/spec-kitty/kittify/scripts/dashboard/server.py
@@ -1,0 +1,717 @@
+# ruff: noqa: INP001
+"""Standalone SpecKitty dashboard server.
+
+No external dependencies — uses only Python stdlib (http.server).
+Scans specs/ for features and dev/spec-kitty/work-packages/ for kanban data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import mimetypes
+import os
+import re
+import signal
+import socket
+import subprocess  # noqa: S404
+import sys
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+DASHBOARD_DIR = Path(__file__).resolve().parent
+STATIC_DIR = DASHBOARD_DIR / "static"
+TEMPLATE_DIR = DASHBOARD_DIR / "templates"
+
+# Minimum number of URL path parts for API endpoints
+_MIN_PARTS_SIMPLE = 4  # e.g. /api/kanban/<feature>
+_MIN_PARTS_WITH_FILE = 5  # e.g. /api/artifact/<feature>/<name>
+
+
+def parse_yaml_frontmatter(filepath: Path) -> dict:
+    """Parse YAML frontmatter from a markdown file (simple key: value pairs)."""
+    try:
+        text = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return {}
+    data: dict[str, Any] = {}
+    current_key: str | None = None
+    current_list: list[str] | None = None
+
+    for line in match.group(1).splitlines():
+        # List continuation
+        if line.startswith("  - ") and current_key and current_list is not None:
+            current_list.append(line.strip("- ").strip())  # type: ignore[union-attr]
+            continue
+
+        if ":" in line and not line.startswith(" "):
+            # Save previous list
+            if current_key and current_list is not None:
+                data[current_key] = current_list
+
+            key, _, val = line.partition(":")
+            key = key.strip()
+            val = val.strip()
+            # Handle explicitly empty strings: '""' or "''"
+            if val in {'""', "''"}:
+                data[key] = ""
+                current_key = None
+                current_list = None
+                continue
+            val = val.strip('"').strip("'")
+            if not val or val == "[]":
+                current_key = key
+                current_list = []
+            else:
+                data[key] = val
+                current_key = None
+                current_list = None
+
+    if current_key and current_list is not None:
+        data[current_key] = current_list
+
+    # Extract title from heading
+    title_match = re.search(r"^# (?:Work Package )?WP\d+:\s*(.+)$", text, re.MULTILINE)
+    if title_match:
+        data["title"] = title_match.group(1).strip()
+
+    return data
+
+
+def scan_features(project_path: Path) -> list[dict[str, Any]]:
+    """Scan specs/ directory for feature directories."""
+    specs_dir = project_path / "specs"
+    features: list[dict[str, Any]] = []
+
+    if not specs_dir.is_dir():
+        return features
+
+    for entry in sorted(specs_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+
+        # Check for at least spec.md
+        spec_file = entry / "spec.md"
+        if not spec_file.exists():
+            continue
+
+        feature_id = entry.name
+        feature_name = feature_id.replace("-", " ").title()
+
+        # Detect available artifacts
+        artifacts = {}
+        for artifact_key, filename in [
+            ("spec", "spec.md"),
+            ("plan", "plan.md"),
+            ("tasks", "tasks.md"),
+            ("research", "research.md"),
+            ("quickstart", "quickstart.md"),
+            ("data_model", "data-model.md"),
+        ]:
+            artifacts[artifact_key] = {"exists": (entry / filename).exists()}
+
+        artifacts["kanban"] = {"exists": False}
+        artifacts["contracts"] = {"exists": (entry / "contracts").is_dir()}
+        artifacts["checklists"] = {"exists": (entry / "checklists").is_dir()}
+        artifacts["constitution"] = {"exists": _find_constitution(project_path) is not None}
+
+        # Find matching WP directory
+        wp_base = project_path / "dev" / "spec-kitty" / "work-packages"
+        wp_dir = _find_wp_dir(wp_base, feature_id)
+        kanban_stats = {"planned": 0, "doing": 0, "for_review": 0, "done": 0, "total": 0}
+
+        if wp_dir and wp_dir.is_dir():
+            artifacts["kanban"] = {"exists": True}
+            for wp_file in wp_dir.glob("WP*.md"):
+                fm = parse_yaml_frontmatter(wp_file)
+                lane = fm.get("lane", "planned")
+                if lane in kanban_stats:
+                    kanban_stats[lane] += 1
+                kanban_stats["total"] += 1
+
+        # Parse meta from spec frontmatter
+        meta = parse_yaml_frontmatter(spec_file)
+
+        features.append(
+            {
+                "id": feature_id,
+                "name": feature_name,
+                "path": str(entry.relative_to(project_path)),
+                "artifacts": artifacts,
+                "kanban_stats": kanban_stats,
+                "meta": meta,
+            }
+        )
+
+    return features
+
+
+def _find_wp_dir(wp_base: Path, feature_id: str) -> Path | None:
+    """Find the work-packages subdirectory matching a feature id."""
+    if not wp_base.is_dir():
+        return None
+
+    # Try exact match first
+    exact = wp_base / feature_id
+    if exact.is_dir():
+        return exact
+
+    # Extract numeric prefix from feature_id (e.g., "infp-445-webhook-headers" -> "445")
+    num_match = re.search(r"(\d+)", feature_id)
+    if num_match:
+        num = num_match.group(1)
+        for entry in wp_base.iterdir():
+            if entry.is_dir() and num in entry.name:
+                return entry
+
+    return None
+
+
+def scan_kanban(project_path: Path, feature_id: str) -> dict[str, list[dict]]:
+    """Scan work packages for a feature and return kanban lanes."""
+    lanes: dict[str, list[dict]] = {"planned": [], "doing": [], "for_review": [], "done": []}
+
+    wp_base = project_path / "dev" / "spec-kitty" / "work-packages"
+    wp_dir = _find_wp_dir(wp_base, feature_id)
+    if not wp_dir or not wp_dir.is_dir():
+        return lanes
+
+    for wp_file in sorted(wp_dir.glob("WP*.md")):
+        fm = parse_yaml_frontmatter(wp_file)
+        lane = fm.get("lane", "planned")
+        if lane not in lanes:
+            lane = "planned"
+
+        # Read full content for modal
+        try:
+            content = wp_file.read_text(encoding="utf-8")
+            # Strip frontmatter for display
+            content_match = re.match(r"^---\n.*?\n---\n?(.*)", content, re.DOTALL)
+            body = content_match.group(1) if content_match else content
+        except (OSError, UnicodeDecodeError):
+            body = ""
+
+        card = {
+            "id": fm.get("id", wp_file.stem),
+            "title": fm.get("title", wp_file.stem),
+            "lane": lane,
+            "agent": fm.get("agent", ""),
+            "assigned_to": fm.get("assigned_to", ""),
+            "acceptance_criteria": fm.get("acceptance_criteria", []),
+            "prompt": body,
+            "subtasks": [],
+        }
+
+        # Extract subtasks from the Tasks section
+        task_matches = re.findall(r"^- \[[ x]\] (.+)$", body, re.MULTILINE)
+        card["subtasks"] = task_matches
+
+        lanes[lane].append(card)
+
+    return lanes
+
+
+def _find_constitution(project_path: Path) -> Path | None:
+    """Find the project constitution file."""
+    candidates = [
+        project_path / ".specify" / "memory" / "constitution.md",
+        project_path / "dev" / "constitution.md",
+        project_path / ".kittify" / "memory" / "constitution.md",
+    ]
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+            if resolved.exists():
+                return resolved
+        except (OSError, RuntimeError):
+            continue
+    return None
+
+
+def _resolve_git_branch(project_path: Path) -> str:
+    """Return the current git branch name, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+            cwd=str(project_path),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def _is_git_worktree(project_path: Path) -> bool:
+    """Return True if project_path is inside a git worktree (not the main repo)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],  # noqa: S607
+            cwd=str(project_path),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            # .git is a file (not a directory) inside worktrees
+            return (project_path / ".git").is_file()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return False
+
+
+def _resolve_active_mission(constitution_path: Path | None) -> str:
+    """Extract the mission name from the constitution file, or return default."""
+    default = "software-dev"
+    if not constitution_path:
+        return default
+    try:
+        content = constitution_path.read_text(encoding="utf-8")
+        for line in content.splitlines():
+            if line.strip().startswith("mission:"):
+                return line.split(":", 1)[1].strip() or default
+    except (OSError, UnicodeDecodeError):
+        pass
+    return default
+
+
+def _check_file_integrity(specs_dir: Path) -> dict[str, Any]:
+    """Check presence of expected spec files across all feature directories."""
+    expected_files = ["spec.md", "plan.md", "tasks.md"]
+    integrity: dict[str, Any] = {"total_expected": 0, "total_present": 0, "total_missing": 0, "missing_files": []}
+    if not specs_dir.is_dir():
+        return integrity
+    features = [d for d in specs_dir.iterdir() if d.is_dir()]
+    integrity["total_expected"] = len(features) * len(expected_files)
+    missing: list[str] = []
+    present = 0
+    for feat_dir in features:
+        for fname in expected_files:
+            if (feat_dir / fname).is_file():
+                present += 1
+            else:
+                missing.append(f"{feat_dir.name}/{fname}")
+    integrity["total_present"] = present
+    integrity["total_missing"] = len(missing)
+    integrity["missing_files"] = missing
+    return integrity
+
+
+def _build_worktree_overview(wp_base: Path) -> dict[str, Any]:
+    """Summarise work-package statuses from the wp_base directory."""
+    overview: dict[str, Any] = {
+        "total_features": 0,
+        "active_worktrees": 0,
+        "merged_features": 0,
+        "in_development": 0,
+        "not_started": 0,
+    }
+    if not wp_base.is_dir():
+        return overview
+    wp_dirs = [d for d in wp_base.iterdir() if d.is_dir()]
+    overview["total_features"] = len(wp_dirs)
+    for wp_dir in wp_dirs:
+        status_file = wp_dir / "status.md"
+        status = ""
+        if status_file.is_file():
+            with contextlib.suppress(OSError, UnicodeDecodeError):
+                status = status_file.read_text(encoding="utf-8").lower()
+        if "merged" in status:
+            overview["merged_features"] += 1
+        elif "in_development" in status or "in-development" in status or "active" in status:
+            overview["in_development"] += 1
+            overview["active_worktrees"] += 1
+        else:
+            overview["not_started"] += 1
+    return overview
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    """HTTP handler for the SpecKitty dashboard."""
+
+    project_dir: str = ""
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass  # Suppress default logging
+
+    def _send_json(self, status: int, data: dict | list) -> None:
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_text(self, status: int, text: str, content_type: str = "text/plain") -> None:
+        body = text.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", f"{content_type}; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_404(self) -> None:
+        self.send_response(404)
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+
+        if path == "/":
+            self._handle_root()
+        elif path == "/api/features":
+            self._handle_features()
+        elif path.startswith("/api/kanban/"):
+            self._handle_kanban(path)
+        elif path.startswith("/api/artifact/"):
+            self._handle_artifact(path)
+        elif path.startswith("/api/research/"):
+            self._handle_research(path)
+        elif path.startswith("/api/contracts/"):
+            self._handle_directory_listing(path, "contracts")
+        elif path.startswith("/api/checklists/"):
+            self._handle_directory_listing(path, "checklists")
+        elif path == "/api/constitution":
+            self._handle_constitution()
+        elif path == "/api/diagnostics":
+            self._handle_diagnostics()
+        elif path == "/api/health":
+            self._send_json(200, {"status": "ok", "project_path": self.project_dir})
+        elif path.startswith("/static/"):
+            self._handle_static(path)
+        else:
+            self._send_404()
+
+    def do_POST(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/api/shutdown":
+            self._send_json(200, {"status": "stopping"})
+
+            def _stop() -> None:
+                time.sleep(0.05)
+                self.server.shutdown()
+
+            threading.Thread(target=_stop, daemon=True).start()
+        else:
+            self._send_404()
+
+    def _handle_root(self) -> None:
+        template_path = TEMPLATE_DIR / "index.html"
+        try:
+            html = template_path.read_text(encoding="utf-8")
+            self._send_text(200, html, "text/html")
+        except FileNotFoundError:
+            self._send_text(500, "Template not found")
+
+    def _handle_features(self) -> None:
+        project_path = Path(self.project_dir).resolve()
+        features = scan_features(project_path)
+
+        active_feature_id = features[0]["id"] if features else None
+
+        response = {
+            "features": features,
+            "active_feature_id": active_feature_id,
+            "project_path": str(project_path),
+            "active_worktree": "",
+            "active_mission": {
+                "name": "Infrahub",
+                "domain": "infrastructure",
+                "version": "",
+                "slug": "",
+                "description": "",
+                "path": "",
+            },
+        }
+        self._send_json(200, response)
+
+    def _handle_kanban(self, path: str) -> None:
+        parts = path.split("/")
+        if len(parts) < _MIN_PARTS_SIMPLE:
+            self._send_404()
+            return
+
+        feature_id = urllib.parse.unquote(parts[3])
+        project_path = Path(self.project_dir).resolve()
+        lanes = scan_kanban(project_path, feature_id)
+        self._send_json(200, {"lanes": lanes})
+
+    def _handle_artifact(self, path: str) -> None:
+        parts = path.split("/")
+        if len(parts) < _MIN_PARTS_WITH_FILE:
+            self._send_404()
+            return
+
+        feature_id = urllib.parse.unquote(parts[3])
+        artifact_name = urllib.parse.unquote(parts[4])
+
+        artifact_map = {
+            "spec": "spec.md",
+            "plan": "plan.md",
+            "tasks": "tasks.md",
+            "research": "research.md",
+            "quickstart": "quickstart.md",
+            "data-model": "data-model.md",
+        }
+
+        filename = artifact_map.get(artifact_name)
+        if not filename:
+            self._send_404()
+            return
+
+        project_path = Path(self.project_dir).resolve()
+        artifact_path = project_path / "specs" / feature_id / filename
+
+        if not artifact_path.exists():
+            self._send_404()
+            return
+
+        try:
+            content = artifact_path.read_text(encoding="utf-8")
+            self._send_text(200, content)
+        except (OSError, UnicodeDecodeError) as exc:
+            self._send_text(500, f"Error reading {filename}: {exc}")
+
+    def _handle_research(self, path: str) -> None:
+        parts = path.split("/")
+        if len(parts) < _MIN_PARTS_SIMPLE:
+            self._send_404()
+            return
+
+        feature_id = urllib.parse.unquote(parts[3])
+        project_path = Path(self.project_dir).resolve()
+        feature_dir = project_path / "specs" / feature_id
+
+        if len(parts) == _MIN_PARTS_SIMPLE:
+            # Return research.md content + artifacts list
+            response: dict[str, Any] = {"main_file": None, "artifacts": []}
+            research_md = feature_dir / "research.md"
+            if research_md.exists():
+                try:
+                    response["main_file"] = research_md.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    response["main_file"] = research_md.read_text(encoding="utf-8", errors="replace")
+
+            research_dir = feature_dir / "research"
+            if research_dir.is_dir():
+                for fp in sorted(research_dir.rglob("*")):
+                    if fp.is_file():
+                        icon = {".csv": "📊", ".md": "📝", ".json": "📋"}.get(fp.suffix, "📄")
+                        response["artifacts"].append(
+                            {
+                                "name": fp.name,
+                                "path": str(fp.relative_to(feature_dir)),
+                                "icon": icon,
+                            }
+                        )
+
+            self._send_json(200, response)
+            return
+
+        if len(parts) >= _MIN_PARTS_WITH_FILE:
+            file_path_str = urllib.parse.unquote(parts[4])
+            artifact_file = (feature_dir / file_path_str).resolve()
+            try:
+                artifact_file.relative_to(feature_dir.resolve())
+            except ValueError:
+                self._send_404()
+                return
+
+            if artifact_file.exists() and artifact_file.is_file():
+                try:
+                    content = artifact_file.read_text(encoding="utf-8")
+                    self._send_text(200, content)
+                except (UnicodeDecodeError, OSError) as exc:
+                    self._send_text(500, f"Error: {exc}")
+                return
+
+        self._send_404()
+
+    def _handle_directory_listing(self, path: str, directory_name: str) -> None:
+        parts = path.split("/")
+        if len(parts) < _MIN_PARTS_SIMPLE:
+            self._send_404()
+            return
+
+        feature_id = urllib.parse.unquote(parts[3])
+        project_path = Path(self.project_dir).resolve()
+        feature_dir = project_path / "specs" / feature_id
+
+        if len(parts) == _MIN_PARTS_SIMPLE:
+            response: dict[str, Any] = {"files": []}
+            artifact_dir = feature_dir / directory_name
+            if artifact_dir.is_dir():
+                for fp in sorted(artifact_dir.rglob("*")):
+                    if fp.is_file():
+                        icon = {".md": "📝", ".json": "📋"}.get(fp.suffix, "📄")
+                        response["files"].append(
+                            {
+                                "name": fp.name,
+                                "path": str(fp.relative_to(feature_dir)),
+                                "icon": icon,
+                            }
+                        )
+            self._send_json(200, response)
+            return
+
+        if len(parts) >= _MIN_PARTS_WITH_FILE:
+            file_path_str = urllib.parse.unquote(parts[4])
+            artifact_file = (feature_dir / file_path_str).resolve()
+            try:
+                artifact_file.relative_to(feature_dir.resolve())
+            except ValueError:
+                self._send_404()
+                return
+
+            if artifact_file.exists() and artifact_file.is_file():
+                try:
+                    content = artifact_file.read_text(encoding="utf-8")
+                    self._send_text(200, content)
+                except (UnicodeDecodeError, OSError) as exc:
+                    self._send_text(500, f"Error: {exc}")
+                return
+
+        self._send_404()
+
+    def _handle_constitution(self) -> None:
+        project_path = Path(self.project_dir).resolve()
+        constitution_path = _find_constitution(project_path)
+        if not constitution_path:
+            self._send_404()
+            return
+        try:
+            content = constitution_path.read_text(encoding="utf-8")
+            self._send_text(200, content)
+        except (OSError, UnicodeDecodeError) as exc:
+            self._send_text(500, f"Error: {exc}")
+
+    def _handle_diagnostics(self) -> None:
+        project_path = Path(self.project_dir).resolve()
+        specs_dir = project_path / "specs"
+        wp_base = project_path / "dev" / "spec-kitty" / "work-packages"
+        constitution_path = _find_constitution(project_path)
+
+        diagnostics: dict[str, Any] = {
+            "project_path": str(project_path),
+            "current_working_directory": str(Path.cwd()),
+            "git_branch": _resolve_git_branch(project_path),
+            "in_worktree": _is_git_worktree(project_path),
+            "active_mission": _resolve_active_mission(constitution_path),
+            "specs_dir_exists": specs_dir.is_dir(),
+            "feature_count": len(list(specs_dir.iterdir())) if specs_dir.is_dir() else 0,
+            "wp_dir_exists": wp_base.is_dir(),
+            "wp_branches": [d.name for d in wp_base.iterdir() if d.is_dir()] if wp_base.is_dir() else [],
+            "constitution_found": constitution_path is not None,
+            "file_integrity": _check_file_integrity(specs_dir),
+            "worktree_overview": _build_worktree_overview(wp_base),
+        }
+        self._send_json(200, diagnostics)
+
+    def _handle_static(self, path: str) -> None:
+        relative_path = path[len("/static/") :]
+        if not relative_path:
+            self._send_404()
+            return
+
+        safe_path = (STATIC_DIR / relative_path).resolve()
+        try:
+            safe_path.relative_to(STATIC_DIR.resolve())
+        except ValueError:
+            self._send_404()
+            return
+
+        if not safe_path.is_file():
+            self._send_404()
+            return
+
+        mime_type, _ = mimetypes.guess_type(safe_path.name)
+        try:
+            data = safe_path.read_bytes()
+        except OSError:
+            self._send_404()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", mime_type or "application/octet-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def find_free_port(start: int = 5050, end: int = 5100) -> int:
+    """Find a free port in the given range."""
+    for port in range(start, end):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", port))
+                return port
+        except OSError:
+            continue
+    return start
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SpecKitty Dashboard")
+    parser.add_argument("--feature", help="Feature to select by default (unused, kept for compat)")
+    parser.add_argument("--port", type=int, default=0, help="Port (default: auto-detect from 5050)")
+    parser.add_argument("--kill", action="store_true", help="Kill running dashboard")
+    parser.add_argument("--project-dir", default=None, help="Project root directory")
+    args = parser.parse_args()
+
+    if args.kill:
+        os.system("pkill -f 'dashboard/server.py'")  # noqa: S605, S607
+        print("Dashboard stopped.")
+        return
+
+    # Resolve project dir: walk up from script location to find specs/
+    if args.project_dir:
+        project_dir = Path(args.project_dir).resolve()
+    else:
+        # Walk up from the dashboard script to find the repo root (.git marker)
+        current = DASHBOARD_DIR
+        for _ in range(10):
+            if (current / ".git").exists():
+                break
+            current = current.parent
+        project_dir = current
+
+    DashboardHandler.project_dir = str(project_dir)
+
+    port = args.port or find_free_port()
+    server = HTTPServer(("127.0.0.1", port), DashboardHandler)
+
+    print(f"SpecKitty Dashboard: http://localhost:{port}")
+    print(f"Project: {project_dir}")
+    print("Press Ctrl+C to stop.")
+
+    def _shutdown_handler(*_: object) -> None:
+        server.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _shutdown_handler)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/spec-kitty/kittify/scripts/dashboard/static/dashboard/dashboard.css
+++ b/dev/spec-kitty/kittify/scripts/dashboard/static/dashboard/dashboard.css
@@ -1,0 +1,749 @@
+:root {
+    --baby-blue: #A7C7E7;
+    --grassy-green: #7BB661;
+    --lavender: #C9A0DC;
+    --sunny-yellow: #FFF275;
+    --soft-peach: #FFD8B1;
+    --light-gray: #E8E8E8;
+    --creamy-white: #FFFDF7;
+    --dark-text: #2c3e50;
+    --medium-text: #546e7a;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    background: var(--baby-blue);
+    color: var(--dark-text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.header {
+    background: var(--creamy-white);
+    padding: 20px 30px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 3px solid var(--sunny-yellow);
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.header-right {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.mission-display {
+    font-size: 0.9em;
+    color: var(--medium-text);
+}
+
+.mission-label {
+    color: #6b7280;
+    margin-right: 6px;
+}
+
+.mission-name {
+    font-weight: 600;
+    color: var(--dark-text);
+}
+
+.docs-site-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(123, 182, 97, 0.35);
+    background: rgba(123, 182, 97, 0.12);
+    color: var(--grassy-green);
+    font-size: 0.85em;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.docs-site-link:hover {
+    background: rgba(123, 182, 97, 0.2);
+    border-color: rgba(123, 182, 97, 0.55);
+    color: #5a9447;
+}
+
+.docs-site-link:focus-visible {
+    outline: 2px solid var(--grassy-green);
+    outline-offset: 2px;
+}
+
+.header-logo-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 60px;
+    height: 60px;
+    background: white;
+    border-radius: 14px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+    border: 2px solid rgba(123, 182, 97, 0.25);
+    overflow: hidden;
+}
+
+.header-logo {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.header h1 {
+    font-size: 1.8em;
+    color: var(--grassy-green);
+    margin: 0;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.1);
+}
+
+.header-info {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.tree-view {
+    font-size: 0.75em;
+    color: var(--medium-text);
+    font-family: 'Monaco', 'Menlo', monospace;
+    background: rgba(0,0,0,0.05);
+    padding: 6px 10px;
+    border-radius: 6px;
+    white-space: pre;
+    line-height: 1.4;
+}
+
+.feature-selector {
+    min-width: 300px;
+}
+
+.feature-selector label {
+    display: block;
+    font-size: 0.85em;
+    color: #6b7280;
+    margin-bottom: 5px;
+    font-weight: 500;
+}
+
+.feature-selector select {
+    width: 100%;
+    padding: 10px 15px;
+    border: 2px solid var(--lavender);
+    border-radius: 8px;
+    font-size: 1em;
+    background: var(--creamy-white);
+    color: var(--dark-text);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.feature-selector select:hover {
+    border-color: var(--grassy-green);
+    background: white;
+}
+
+.feature-selector select:focus {
+    outline: none;
+    border-color: var(--grassy-green);
+    box-shadow: 0 0 0 3px rgba(123, 182, 97, 0.2);
+}
+
+.last-update {
+    font-size: 0.85em;
+    color: var(--medium-text);
+}
+
+.sidebar-last-update {
+    margin: 6px 30px 20px;
+    display: block;
+}
+
+.container {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.sidebar {
+    width: 250px;
+    background: var(--creamy-white);
+    padding: 20px 0;
+    box-shadow: 2px 0 10px rgba(0,0,0,0.1);
+    overflow-y: auto;
+    border-right: 2px solid var(--light-gray);
+}
+
+.sidebar-item {
+    padding: 12px 30px;
+    cursor: pointer;
+    transition: all 0.2s;
+    border-left: 4px solid transparent;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--dark-text);
+}
+
+.sidebar-item:hover {
+    background: rgba(201, 160, 220, 0.15);
+    color: var(--grassy-green);
+}
+
+.sidebar-item.active {
+    background: rgba(123, 182, 97, 0.1);
+    border-left-color: var(--grassy-green);
+    color: var(--grassy-green);
+    font-weight: 600;
+}
+
+.sidebar-item.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.sidebar-item.disabled:hover {
+    background: transparent;
+    color: #4b5563;
+}
+
+.main-content {
+    flex: 1;
+    padding: 30px;
+    overflow-y: auto;
+}
+
+.page {
+    display: none;
+}
+
+.page.active {
+    display: block;
+}
+
+.content-card {
+    background: var(--creamy-white);
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    margin-bottom: 20px;
+    border-top: 3px solid var(--sunny-yellow);
+}
+
+.content-card h2 {
+    color: var(--grassy-green);
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--soft-peach);
+}
+
+.markdown-content {
+    line-height: 1.6;
+    color: #374151;
+}
+
+.markdown-content h1, .markdown-content h2, .markdown-content h3 {
+    margin-top: 24px;
+    margin-bottom: 12px;
+    color: #1f2937;
+}
+
+.markdown-content p {
+    margin-bottom: 12px;
+}
+
+.markdown-content code {
+    background: #f3f4f6;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Monaco', 'Menlo', monospace;
+    font-size: 0.9em;
+}
+
+.markdown-content pre {
+    background: #ffffff;
+    color: #111827;
+    padding: 16px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 16px 0;
+}
+
+.markdown-content pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+}
+
+.markdown-content ul, .markdown-content ol {
+    margin-left: 24px;
+    margin-bottom: 12px;
+}
+
+/* Status summary styles */
+.status-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+    margin-bottom: 25px;
+}
+
+.status-card {
+    background: linear-gradient(135deg, var(--creamy-white) 0%, #fafaf8 100%);
+    padding: 20px;
+    border-radius: 8px;
+    border-left: 4px solid;
+}
+
+.status-card.total { border-left-color: var(--baby-blue); }
+.status-card.progress { border-left-color: var(--sunny-yellow); }
+.status-card.review { border-left-color: var(--lavender); }
+.status-card.completed { border-left-color: var(--grassy-green); }
+.status-card.agents { border-left-color: var(--soft-peach); }
+
+.merge-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.85em;
+    font-weight: 600;
+    color: #065f46;
+    background: #d1fae5;
+    border: 1px solid #34d399;
+    margin-left: 12px;
+    white-space: nowrap;
+}
+
+.merge-badge .icon {
+    font-size: 1em;
+}
+
+.status-label {
+    font-size: 0.85em;
+    color: #6b7280;
+    font-weight: 500;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.status-value {
+    font-size: 2.5em;
+    font-weight: 700;
+    color: #1f2937;
+    line-height: 1;
+}
+
+.status-detail {
+    font-size: 0.85em;
+    color: #9ca3af;
+    margin-top: 6px;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 6px;
+    background: #e5e7eb;
+    border-radius: 3px;
+    margin-top: 10px;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--grassy-green) 0%, #5a9647 100%);
+    transition: width 0.3s ease;
+}
+
+/* Kanban board styles */
+.kanban-board {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+}
+
+.lane {
+    background: var(--creamy-white);
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    min-height: 400px;
+    border-top: 3px solid;
+}
+
+.lane-header {
+    font-size: 1.2em;
+    font-weight: 600;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.lane-header .count {
+    font-size: 0.8em;
+    background: rgba(0,0,0,0.08);
+    padding: 4px 10px;
+    border-radius: 12px;
+}
+
+.lane.planned { border-top-color: var(--baby-blue); }
+.lane.planned .lane-header { border-color: var(--baby-blue); color: var(--baby-blue); }
+
+.lane.doing { border-top-color: var(--sunny-yellow); }
+.lane.doing .lane-header { border-color: var(--sunny-yellow); color: #d4a800; }
+
+.lane.for_review { border-top-color: var(--lavender); }
+.lane.for_review .lane-header { border-color: var(--lavender); color: var(--lavender); }
+
+.lane.done { border-top-color: var(--grassy-green); }
+.lane.done .lane-header { border-color: var(--grassy-green); color: var(--grassy-green); }
+
+.card {
+    background: white;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    border-left: 4px solid;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+    background: var(--creamy-white);
+}
+
+.lane.planned .card { border-left-color: var(--baby-blue); }
+.lane.doing .card { border-left-color: var(--sunny-yellow); }
+.lane.for_review .card { border-left-color: var(--lavender); }
+.lane.done .card { border-left-color: var(--grassy-green); }
+
+.card-id {
+    font-weight: 600;
+    color: #6b7280;
+    font-size: 0.85em;
+    margin-bottom: 5px;
+}
+
+.card-title {
+    font-size: 1.05em;
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #1f2937;
+    line-height: 1.4;
+}
+
+.card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.badge {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 0.75em;
+    font-weight: 500;
+}
+
+.badge.agent {
+    background: var(--soft-peach);
+    color: #8b5a00;
+}
+
+.badge.subtasks {
+    background: var(--lavender);
+    color: #5a3a6e;
+}
+
+.empty-state {
+    text-align: center;
+    color: #9ca3af;
+    padding: 40px 20px;
+    font-style: italic;
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal.show {
+    display: flex;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.65);
+    backdrop-filter: blur(2px);
+}
+
+.modal-content {
+    position: relative;
+    background: white;
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 900px;
+    width: min(90%, 900px);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.modal-title {
+    font-size: 1.35em;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.modal-subtitle {
+    font-size: 0.9em;
+    color: #6b7280;
+    margin-top: 4px;
+}
+
+.modal-close {
+    border: none;
+    background: transparent;
+    color: #6b7280;
+    font-size: 1.2em;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.modal-close:hover,
+.modal-close:focus {
+    color: #1f2937;
+}
+
+.modal-body {
+    position: relative;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.modal-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.modal-meta span {
+    background: #f3f4f6;
+    border-radius: 12px;
+    padding: 4px 12px;
+    font-size: 0.85em;
+    color: #4b5563;
+}
+
+.modal-content .markdown-content {
+    padding: 0;
+}
+
+.modal-content .markdown-content pre {
+    background: #ffffff;
+    color: #111827;
+}
+
+.no-features {
+    text-align: center;
+    padding: 60px 40px;
+}
+
+.no-features h2 {
+    color: white;
+    margin-bottom: 15px;
+}
+
+.no-features p {
+    color: rgba(255, 255, 255, 0.8);
+    line-height: 1.6;
+}
+
+@media (max-width: 1400px) {
+    .kanban-board {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* Markdown content styling */
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+    font-weight: 600;
+    color: var(--dark-text);
+}
+
+.markdown-content h1:first-child,
+.markdown-content h2:first-child,
+.markdown-content h3:first-child {
+    margin-top: 0;
+}
+
+.markdown-content h1 { font-size: 1.8em; }
+.markdown-content h2 { font-size: 1.5em; }
+.markdown-content h3 { font-size: 1.3em; }
+.markdown-content h4 { font-size: 1.1em; }
+
+.markdown-content p {
+    margin-bottom: 1em;
+    line-height: 1.6;
+}
+
+.markdown-content ul,
+.markdown-content ol {
+    margin-bottom: 1em;
+    padding-left: 2em;
+}
+
+.markdown-content li {
+    margin-bottom: 0.3em;
+    line-height: 1.6;
+}
+
+.markdown-content blockquote {
+    border-left: 4px solid var(--lavender);
+    padding-left: 1em;
+    margin: 1em 0;
+    color: var(--medium-text);
+    background: #f9f9f9;
+    padding: 10px 15px;
+    border-radius: 4px;
+}
+
+.markdown-content code {
+    background: #f4f4f4;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+    font-size: 0.9em;
+    color: #c7254e;
+}
+
+.markdown-content pre {
+    background: #f8f9fa;
+    padding: 15px;
+    border-radius: 8px;
+    overflow-x: auto;
+    border: 1px solid #dee2e6;
+    margin-bottom: 1em;
+}
+
+.markdown-content pre code {
+    background: none;
+    padding: 0;
+    color: #212529;
+}
+
+.markdown-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+}
+
+.markdown-content table th {
+    background: var(--baby-blue);
+    padding: 10px;
+    text-align: left;
+    font-weight: 600;
+    border: 1px solid #ddd;
+}
+
+.markdown-content table td {
+    padding: 10px;
+    border: 1px solid #ddd;
+}
+
+.markdown-content table tr:nth-child(even) {
+    background: #f9f9f9;
+}
+
+.markdown-content hr {
+    border: none;
+    border-top: 2px solid var(--light-gray);
+    margin: 2em 0;
+}
+
+.markdown-content a {
+    color: var(--grassy-green);
+    text-decoration: none;
+}
+
+.markdown-content a:hover {
+    text-decoration: underline;
+}
+
+.markdown-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1em 0;
+}
+
+/* Media Queries */
+@media (max-width: 768px) {
+    .container {
+        flex-direction: column;
+    }
+    .sidebar {
+        width: 100%;
+    }
+    .kanban-board {
+        grid-template-columns: 1fr;
+    }
+}

--- a/dev/spec-kitty/kittify/scripts/dashboard/static/dashboard/dashboard.js
+++ b/dev/spec-kitty/kittify/scripts/dashboard/static/dashboard/dashboard.js
@@ -1,0 +1,1434 @@
+let currentFeature = null;
+let currentPage = 'overview';
+let allFeatures = [];
+let isConstitutionView = false;
+let lastNonConstitutionPage = 'overview';
+let projectPathDisplay = 'Loading…';
+let activeWorktreeDisplay = 'detecting…';
+let featureSelectActive = false;
+let _lastKanbanStats = '';
+let featureSelectIdleTimer = null;
+let activeMission = {
+    name: 'Loading…',
+    domain: '',
+    version: '',
+    slug: '',
+    path: '',
+    description: ''
+};
+
+if (typeof window !== 'undefined' && window.__INITIAL_MISSION__) {
+    activeMission = window.__INITIAL_MISSION__;
+}
+
+/**
+ * Intercept clicks on links within rendered markdown content.
+ * Routes artifact links (spec.md, plan.md, etc.) through the dashboard API
+ * instead of navigating to broken URLs.
+ *
+ * @param {HTMLElement} container - The container element with rendered markdown
+ * @param {string} basePath - Base path for relative links (e.g., 'research/' for research artifacts)
+ */
+function interceptMarkdownLinks(container, basePath = '') {
+    if (!container) return;
+
+    // Map of artifact names to their dashboard page keys
+    const artifactMap = {
+        'spec.md': 'spec',
+        'plan.md': 'plan',
+        'tasks.md': 'tasks',
+        'research.md': 'research',
+        'quickstart.md': 'quickstart',
+        'data-model.md': 'data_model',
+        'data_model.md': 'data_model',
+    };
+
+    container.querySelectorAll('a').forEach(link => {
+        const href = link.getAttribute('href');
+        if (!href) return;
+
+        // Skip external links and anchor links
+        if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#')) {
+            return;
+        }
+
+        // Normalize the path (remove leading ./ or /)
+        let normalizedPath = href.replace(/^\.?\//, '');
+
+        // Check if it's a known artifact (top-level .md file)
+        if (artifactMap[normalizedPath]) {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                switchPage(artifactMap[normalizedPath]);
+            });
+            link.style.cursor = 'pointer';
+            link.title = `View ${normalizedPath} in dashboard`;
+            return;
+        }
+
+        // Check if it's a research/, contracts/, or checklists/ subdirectory file
+        if (normalizedPath.startsWith('research/') || normalizedPath.startsWith('contracts/') || normalizedPath.startsWith('checklists/')) {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const fileName = normalizedPath.split('/').pop();
+                if (normalizedPath.startsWith('research/')) {
+                    loadResearchFile(normalizedPath, fileName);
+                } else if (normalizedPath.startsWith('contracts/')) {
+                    loadContractFile(normalizedPath, fileName);
+                } else if (normalizedPath.startsWith('checklists/')) {
+                    loadChecklistFile(normalizedPath, fileName);
+                }
+            });
+            link.style.cursor = 'pointer';
+            link.title = `View ${normalizedPath} in dashboard`;
+            return;
+        }
+
+        // Handle relative paths within the current context (e.g., evidence-log.csv from research.md)
+        if (basePath && !normalizedPath.includes('/')) {
+            const fullPath = basePath + normalizedPath;
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                if (basePath === 'research/') {
+                    loadResearchFile(fullPath, normalizedPath);
+                } else if (basePath === 'contracts/') {
+                    loadContractFile(fullPath, normalizedPath);
+                } else if (basePath === 'checklists/') {
+                    loadChecklistFile(fullPath, normalizedPath);
+                }
+            });
+            link.style.cursor = 'pointer';
+            link.title = `View ${fullPath} in dashboard`;
+        }
+    });
+}
+
+function updateMissionDisplay(mission) {
+    const nameEl = document.getElementById('mission-name');
+    if (!nameEl) return;
+
+    if (mission) {
+        activeMission = mission;
+    }
+
+    nameEl.textContent = activeMission.name || 'Unknown mission';
+}
+
+// Cookie-based state persistence
+function restoreState() {
+    const cookies = document.cookie.split(';').reduce((acc, cookie) => {
+        const parts = cookie.trim().split('=');
+        if (parts.length === 2) {
+            acc[parts[0]] = decodeURIComponent(parts[1]);
+        }
+        return acc;
+    }, {});
+
+    return {
+        feature: cookies.lastFeature || null,
+        page: cookies.lastPage || 'overview'
+    };
+}
+
+function saveState(feature, page) {
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1); // 1 year
+
+    if (feature) {
+        document.cookie = `lastFeature=${encodeURIComponent(feature)}; expires=${expires.toUTCString()}; path=/; SameSite=Strict`;
+    }
+    if (page) {
+        document.cookie = `lastPage=${encodeURIComponent(page)}; expires=${expires.toUTCString()}; path=/; SameSite=Strict`;
+    }
+}
+
+function setFeatureSelectActive(isActive) {
+    if (isActive) {
+        featureSelectActive = true;
+        if (featureSelectIdleTimer) {
+            clearTimeout(featureSelectIdleTimer);
+        }
+        featureSelectIdleTimer = setTimeout(() => {
+            featureSelectActive = false;
+            featureSelectIdleTimer = null;
+        }, 5000);
+    } else {
+        featureSelectActive = false;
+        if (featureSelectIdleTimer) {
+            clearTimeout(featureSelectIdleTimer);
+            featureSelectIdleTimer = null;
+        }
+    }
+}
+
+function updateTreeInfo() {
+    const treeElement = document.getElementById('tree-info');
+    if (!treeElement) {
+        return;
+    }
+    const lines = [`└─ ${projectPathDisplay}`];
+    if (activeWorktreeDisplay) {
+        lines.push(`   └─ Active worktree: ${activeWorktreeDisplay}`);
+    }
+    // Note: In 0.11.0+, worktrees are per-WP, not per-feature
+    // Feature-level worktree display removed (obsolete 0.10.x concept)
+    treeElement.textContent = lines.join('\n');
+}
+
+function computeFeatureWorktreeStatus(feature) {
+    // No-op: Feature-level worktrees are obsolete in 0.11.0+
+    // In workspace-per-WP model, worktrees are per-WP, not per-feature
+    // This function is kept for compatibility but does nothing
+}
+
+function switchFeature(featureId) {
+    const isSameFeature = featureId === currentFeature;
+    if (isConstitutionView) {
+        if (isSameFeature) {
+            return;
+        }
+        isConstitutionView = false;
+        if (lastNonConstitutionPage && lastNonConstitutionPage !== 'constitution') {
+            currentPage = lastNonConstitutionPage;
+        } else {
+            currentPage = 'overview';
+        }
+        document.querySelectorAll('.page').forEach(page => page.classList.remove('active'));
+        const currentPageEl = document.getElementById(`page-${currentPage}`);
+        if (currentPageEl) {
+            currentPageEl.classList.add('active');
+        }
+        document.querySelectorAll('.sidebar-item').forEach(item => {
+            if (item.dataset.page === currentPage) {
+                item.classList.add('active');
+            } else {
+                item.classList.remove('active');
+            }
+        });
+    }
+    currentFeature = featureId;
+    saveState(currentFeature, currentPage);
+    loadCurrentPage();
+    updateSidebarState();
+    const feature = allFeatures.find(f => f.id === currentFeature);
+    computeFeatureWorktreeStatus(feature);
+    updateTreeInfo();
+}
+
+function switchPage(pageName) {
+    if (pageName === 'constitution') {
+        showConstitution();
+        return;
+    }
+    if (pageName === 'diagnostics') {
+        showDiagnostics();
+        return;
+    }
+    isConstitutionView = false;
+    currentPage = pageName;
+    lastNonConstitutionPage = pageName;
+    saveState(currentFeature, currentPage);
+
+    // Update sidebar
+    document.querySelectorAll('.sidebar-item').forEach(item => {
+        if (item.dataset.page === pageName) {
+            item.classList.add('active');
+        } else {
+            item.classList.remove('active');
+        }
+    });
+
+    // Update pages
+    document.querySelectorAll('.page').forEach(page => {
+        page.classList.remove('active');
+    });
+    const activePageEl = document.getElementById(`page-${pageName}`);
+    if (activePageEl) {
+        activePageEl.classList.add('active');
+    }
+
+    loadCurrentPage();
+}
+
+function updateSidebarState() {
+    const feature = allFeatures.find(f => f.id === currentFeature);
+    if (!feature) return;
+
+    const artifacts = feature.artifacts;
+
+    document.querySelectorAll('.sidebar-item').forEach(item => {
+        const page = item.dataset.page;
+        // System pages (constitution, diagnostics) should never be disabled
+        if (!page || page === 'constitution' || page === 'diagnostics') {
+            item.classList.remove('disabled');
+            return;
+        }
+
+        const hasArtifact = page === 'overview' || artifacts[page.replace('-', '_')]?.exists;
+
+        if (hasArtifact) {
+            item.classList.remove('disabled');
+        } else {
+            item.classList.add('disabled');
+        }
+    });
+}
+
+function loadCurrentPage() {
+    if (isConstitutionView || currentPage === 'constitution') {
+        return;
+    }
+    if (!currentFeature) return;
+
+    if (currentPage === 'overview') {
+        loadOverview();
+    } else if (currentPage === 'kanban') {
+        loadKanban();
+    } else if (currentPage === 'contracts') {
+        loadContracts();
+    } else if (currentPage === 'checklists') {
+        loadChecklists();
+    } else if (currentPage === 'research') {
+        loadResearch();
+    } else {
+        loadArtifact(currentPage);
+    }
+}
+
+function loadOverview() {
+    const feature = allFeatures.find(f => f.id === currentFeature);
+    if (!feature) return;
+
+    const mergeBadge = (() => {
+const meta = feature.meta || {};
+const mergedAt = meta.merged_at || meta.merge_at;
+const mergedInto = meta.merged_into || meta.merge_into || meta.merged_target;
+if (!mergedAt || !mergedInto) {
+    return '';
+}
+const date = new Date(mergedAt);
+const dateStr = isNaN(date.valueOf()) ? mergedAt : date.toLocaleDateString();
+return `
+    <span class="merge-badge" title="Merged into ${escapeHtml(mergedInto)} on ${escapeHtml(dateStr)}">
+        <span class="icon">✅</span>
+        <span>merged → ${escapeHtml(mergedInto)}</span>
+    </span>
+`;
+    })();
+
+    const stats = feature.kanban_stats;
+    const total = stats.total;
+    const completed = stats.done;
+    const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+    const artifacts = feature.artifacts;
+    const artifactList = [
+        {name: 'Project Constitution', key: 'constitution', icon: '⚖️'},
+        {name: 'Specification', key: 'spec', icon: '📄'},
+        {name: 'Plan', key: 'plan', icon: '🏗️'},
+        {name: 'Tasks', key: 'tasks', icon: '📋'},
+        {name: 'Kanban Board', key: 'kanban', icon: '🎯'},
+        {name: 'Research', key: 'research', icon: '🔬'},
+        {name: 'Quickstart', key: 'quickstart', icon: '🚀'},
+        {name: 'Data Model', key: 'data_model', icon: '💾'},
+        {name: 'Contracts', key: 'contracts', icon: '📜'},
+        {name: 'Checklists', key: 'checklists', icon: '✅'},
+    ].map(a => `
+        <div style="padding: 10px; background: ${artifacts[a.key]?.exists ? '#ecfdf5' : '#fef2f2'};
+             border-radius: 6px; border-left: 3px solid ${artifacts[a.key]?.exists ? '#10b981' : '#ef4444'};">
+            ${a.icon} ${a.name}: ${artifacts[a.key]?.exists ? '✅ Available' : '❌ Not created'}
+        </div>
+    `).join('');
+
+    document.getElementById('overview-content').innerHTML = `
+<div style="margin-bottom: 30px;">
+    <h3>Feature: ${feature.name} ${mergeBadge}</h3>
+    <p style="color: #6b7280;">View and track all artifacts for this feature</p>
+</div>
+
+<div class="status-summary">
+    <div class="status-card total">
+                <div class="status-label">Total Tasks</div>
+                <div class="status-value">${total}</div>
+                <div class="status-detail">${stats.planned} planned</div>
+            </div>
+            <div class="status-card progress">
+                <div class="status-label">In Progress</div>
+                <div class="status-value">${stats.doing}</div>
+            </div>
+            <div class="status-card review">
+                <div class="status-label">Review</div>
+                <div class="status-value">${stats.for_review}</div>
+            </div>
+            <div class="status-card completed">
+                <div class="status-label">Completed</div>
+                <div class="status-value">${completed}</div>
+                <div class="status-detail">${completionRate}% done</div>
+                <div class="progress-bar">
+                    <div class="progress-fill" style="width: ${completionRate}%"></div>
+                </div>
+            </div>
+        </div>
+
+        <h3 style="margin-top: 30px; margin-bottom: 15px; color: #1f2937;">Available Artifacts</h3>
+        <div style="display: grid; gap: 10px;">
+            ${artifactList}
+        </div>
+    `;
+}
+
+function loadKanban() {
+    fetch(`/api/kanban/${currentFeature}`)
+        .then(response => response.json())
+        .then(data => {
+            renderKanban(data && data.lanes ? data.lanes : data);
+        })
+        .catch(error => {
+            document.getElementById('kanban-board').innerHTML =
+                '<div class="empty-state">Error loading kanban board</div>';
+        });
+}
+
+function renderKanban(lanes) {
+    const total = lanes.planned.length + lanes.doing.length + lanes.for_review.length + lanes.done.length;
+    const completed = lanes.done.length;
+    const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+    const agents = new Set();
+    Object.values(lanes).forEach(tasks => {
+        tasks.forEach(task => {
+            if (task.agent && task.agent !== 'system') agents.add(task.agent);
+        });
+    });
+
+    document.getElementById('kanban-status').innerHTML = `
+        <div class="status-card total">
+            <div class="status-label">Total Work Packages</div>
+            <div class="status-value">${total}</div>
+            <div class="status-detail">${lanes.planned.length} planned</div>
+        </div>
+        <div class="status-card progress">
+            <div class="status-label">In Progress</div>
+            <div class="status-value">${lanes.doing.length}</div>
+        </div>
+        <div class="status-card review">
+            <div class="status-label">Review</div>
+            <div class="status-value">${lanes.for_review.length}</div>
+        </div>
+        <div class="status-card completed">
+            <div class="status-label">Completed</div>
+            <div class="status-value">${completed}</div>
+            <div class="status-detail">${completionRate}% done</div>
+            <div class="progress-bar">
+                <div class="progress-fill" style="width: ${completionRate}%"></div>
+            </div>
+        </div>
+        <div class="status-card agents">
+            <div class="status-label">Active Agents</div>
+            <div class="status-value">${agents.size}</div>
+            <div class="status-detail">${agents.size > 0 ? Array.from(agents).join(', ') : 'none'}</div>
+        </div>
+    `;
+
+    const createCard = (task) => `
+        <div class="card" role="button">
+            <div class="card-id">${task.id}</div>
+            <div class="card-title">${task.title}</div>
+            <div class="card-meta">
+                ${task.agent ? `<span class="badge agent">${task.agent}</span>` : ''}
+                ${task.subtasks && task.subtasks.length > 0 ?
+                  `<span class="badge subtasks">${task.subtasks.length} subtask${task.subtasks.length !== 1 ? 's' : ''}</span>` : ''}
+            </div>
+        </div>
+    `;
+
+    document.getElementById('kanban-board').innerHTML = `
+        <div class="lane planned">
+            <div class="lane-header">
+                <span>📋 Planned</span>
+                <span class="count">${lanes.planned.length}</span>
+            </div>
+            <div>${lanes.planned.length === 0 ? '<div class="empty-state">No tasks</div>' : lanes.planned.map(createCard).join('')}</div>
+        </div>
+        <div class="lane doing">
+            <div class="lane-header">
+                <span>🚀 Doing</span>
+                <span class="count">${lanes.doing.length}</span>
+            </div>
+            <div>${lanes.doing.length === 0 ? '<div class="empty-state">No tasks</div>' : lanes.doing.map(createCard).join('')}</div>
+        </div>
+        <div class="lane for_review">
+            <div class="lane-header">
+                <span>👀 For Review</span>
+                <span class="count">${lanes.for_review.length}</span>
+            </div>
+            <div>${lanes.for_review.length === 0 ? '<div class="empty-state">No tasks</div>' : lanes.for_review.map(createCard).join('')}</div>
+        </div>
+        <div class="lane done">
+            <div class="lane-header">
+                <span>✅ Done</span>
+                <span class="count">${lanes.done.length}</span>
+            </div>
+            <div>${lanes.done.length === 0 ? '<div class="empty-state">No tasks</div>' : lanes.done.map(createCard).join('')}</div>
+        </div>
+    `;
+
+    ['planned', 'doing', 'for_review', 'done'].forEach(laneName => {
+        const laneCards = document.querySelectorAll(`.lane.${laneName} .card`);
+        laneCards.forEach((card, index) => {
+            const task = lanes[laneName][index];
+            if (!task) return;
+            if (!card.hasAttribute('tabindex')) {
+                card.setAttribute('tabindex', '0');
+            }
+            card.addEventListener('click', () => showPromptModal(task));
+            card.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    showPromptModal(task);
+                }
+            });
+        });
+    });
+}
+
+function formatLaneName(lane) {
+    if (!lane) return '';
+    return lane.split('_').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+}
+
+function showPromptModal(task) {
+    const modal = document.getElementById('prompt-modal');
+    if (!modal) return;
+
+    const titleEl = document.getElementById('modal-title');
+    const subtitleEl = document.getElementById('modal-subtitle');
+    const metaEl = document.getElementById('modal-prompt-meta');
+    const contentEl = document.getElementById('modal-prompt-content');
+    const modalBody = document.getElementById('modal-body');
+
+    if (titleEl) {
+        titleEl.textContent = task.title || 'Work Package Prompt';
+    }
+    if (subtitleEl) {
+        if (task.id) {
+            subtitleEl.textContent = task.id;
+            subtitleEl.style.display = 'block';
+        } else {
+            subtitleEl.textContent = '';
+            subtitleEl.style.display = 'none';
+        }
+    }
+
+    if (metaEl) {
+        const metaItems = [];
+        if (task.lane) metaItems.push(`<span>Lane: ${escapeHtml(formatLaneName(task.lane))}</span>`);
+        if (task.agent) metaItems.push(`<span>Agent: ${escapeHtml(task.agent)}</span>`);
+        if (task.subtasks && task.subtasks.length) {
+            metaItems.push(`<span>${task.subtasks.length} subtask${task.subtasks.length !== 1 ? 's' : ''}</span>`);
+        }
+        if (task.phase) metaItems.push(`<span>Phase: ${escapeHtml(task.phase)}</span>`);
+        if (task.prompt_path) metaItems.push(`<span>Source: ${escapeHtml(task.prompt_path)}</span>`);
+
+        if (metaItems.length > 0) {
+            metaEl.innerHTML = metaItems.join('');
+            metaEl.style.display = 'flex';
+        } else {
+            metaEl.innerHTML = '';
+            metaEl.style.display = 'none';
+        }
+    }
+
+    if (contentEl) {
+        if (task.prompt_markdown) {
+            contentEl.innerHTML = marked.parse(task.prompt_markdown);
+        } else {
+            contentEl.innerHTML = '<div class="empty-state">Prompt content unavailable.</div>';
+        }
+    }
+
+    if (modalBody) {
+        modalBody.scrollTop = 0;
+    }
+
+    modal.classList.remove('hidden');
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+}
+
+function hidePromptModal() {
+    const modal = document.getElementById('prompt-modal');
+    if (!modal) return;
+
+    modal.classList.remove('show');
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('modal-open');
+}
+
+const modalOverlay = document.querySelector('#prompt-modal .modal-overlay');
+if (modalOverlay) {
+    modalOverlay.addEventListener('click', hidePromptModal);
+}
+const modalCloseButton = document.getElementById('modal-close-btn');
+if (modalCloseButton) {
+    modalCloseButton.addEventListener('click', hidePromptModal);
+}
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+        const modal = document.getElementById('prompt-modal');
+        if (modal && modal.classList.contains('show')) {
+            hidePromptModal();
+        }
+    }
+});
+
+function loadArtifact(artifactName) {
+    const artifactKey = artifactName.replace('-', '_');
+    fetch(`/api/artifact/${currentFeature}/${artifactName}`)
+        .then(response => response.ok ? response.text() : Promise.reject('Not found'))
+        .then(content => {
+            // Render markdown to HTML
+            const htmlContent = marked.parse(content);
+            const container = document.getElementById(`${artifactName}-content`);
+            container.innerHTML = htmlContent;
+            // Intercept markdown links to route through dashboard
+            interceptMarkdownLinks(container);
+        })
+        .catch(error => {
+            document.getElementById(`${artifactName}-content`).innerHTML =
+                '<div class="empty-state">Artifact not available</div>';
+        });
+}
+
+function loadContracts() {
+    fetch(`/api/contracts/${currentFeature}`)
+        .then(response => response.ok ? response.json() : Promise.reject('Not found'))
+        .then(data => {
+            if (data.files && data.files.length > 0) {
+                renderContractsList(data.files);
+            } else {
+                document.getElementById('contracts-content').innerHTML =
+                    '<div class="empty-state">No contracts available. Run /spec-kitty.plan to generate contracts.</div>';
+            }
+        })
+        .catch(error => {
+            document.getElementById('contracts-content').innerHTML =
+                '<div class="empty-state">Contracts directory not found</div>';
+        });
+}
+
+function renderContractsList(files) {
+    const contractsHtml = files.map((file, idx) => {
+        const fileNameEscaped = escapeHtml(file.name);
+        const filePathEscaped = escapeHtml(file.path);
+        return `
+            <div style="margin-bottom: 20px; padding: 15px; background: white; border-radius: 8px; border-left: 4px solid var(--lavender); cursor: pointer;"
+                 data-filepath="${filePathEscaped}" data-filename="${fileNameEscaped}" class="contract-item">
+                <div style="font-weight: 600; color: var(--dark-text); margin-bottom: 5px;">
+                    ${file.icon} ${fileNameEscaped}
+                </div>
+                <div style="font-size: 0.85em; color: var(--medium-text);">
+                    Click to view contract
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    document.getElementById('contracts-content').innerHTML = `
+        <p style="margin-bottom: 20px; color: var(--medium-text);">
+            API specifications and interface definitions for this feature.
+        </p>
+        ${contractsHtml}
+    `;
+
+    // Add click handlers
+    document.querySelectorAll('.contract-item').forEach(item => {
+        item.addEventListener('click', () => {
+            loadContractFile(item.dataset.filepath, item.dataset.filename);
+        });
+    });
+}
+
+function loadContractFile(filePath, fileName) {
+    fetch(`/api/contracts/${currentFeature}/${encodeURIComponent(filePath)}`)
+        .then(response => response.ok ? response.text() : Promise.reject('Not found'))
+        .then(content => {
+            let htmlContent;
+
+            // Format JSON files nicely
+            if (fileName.endsWith('.json')) {
+                try {
+                    const jsonData = JSON.parse(content);
+                    const prettyJson = JSON.stringify(jsonData, null, 2);
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto; border: 1px solid #dee2e6;"><code style="font-family: 'Monaco', 'Menlo', monospace; font-size: 0.9em; line-height: 1.5; color: #212529;">${escapeHtml(prettyJson)}</code></pre>`;
+                } catch (e) {
+                    // If JSON parsing fails, show as plain text
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto;"><code>${escapeHtml(content)}</code></pre>`;
+                }
+            } else if (fileName.endsWith('.md')) {
+                // Render markdown files with proper styling
+                const renderedMarkdown = marked.parse(content);
+                htmlContent = `<div class="markdown-content" style="line-height: 1.6; font-size: 0.95em;">${renderedMarkdown}</div>`;
+            } else if (fileName.endsWith('.csv')) {
+                // Render CSV as a table
+                htmlContent = renderCSV(content);
+            } else if (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) {
+                // Show YAML files as code blocks
+                htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto; border: 1px solid #dee2e6;"><code style="font-family: 'Monaco', 'Menlo', monospace; font-size: 0.9em; line-height: 1.5;">${escapeHtml(content)}</code></pre>`;
+            } else {
+                // Default: show as code block
+                htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto;"><code>${escapeHtml(content)}</code></pre>`;
+            }
+
+            const container = document.getElementById('contracts-content');
+            container.innerHTML = `
+                <div style="margin-bottom: 20px;">
+                    <button onclick="loadContracts()"
+                            style="padding: 8px 16px; background: var(--baby-blue); border: none; border-radius: 6px; cursor: pointer; color: var(--dark-text); font-weight: 500;">
+                        ← Back to Contracts List
+                    </button>
+                </div>
+                <h3 style="color: var(--grassy-green); margin-bottom: 15px;">${escapeHtml(fileName)}</h3>
+                ${htmlContent}
+            `;
+            // Intercept markdown links to route through dashboard
+            interceptMarkdownLinks(container, 'contracts/');
+        })
+        .catch(error => {
+            document.getElementById('contracts-content').innerHTML =
+                '<div class="empty-state">Error loading contract file</div>';
+        });
+}
+
+function loadChecklists() {
+    fetch(`/api/checklists/${currentFeature}`)
+        .then(response => response.ok ? response.json() : Promise.reject('Not found'))
+        .then(data => {
+            if (data.files && data.files.length > 0) {
+                renderChecklistsList(data.files);
+            } else {
+                document.getElementById('checklists-content').innerHTML =
+                    '<div class="empty-state">No checklists available.</div>';
+            }
+        })
+        .catch(error => {
+            document.getElementById('checklists-content').innerHTML =
+                '<div class="empty-state">Checklists directory not found</div>';
+        });
+}
+
+function renderChecklistsList(files) {
+    const checklistsHtml = files.map((file, idx) => {
+        const fileNameEscaped = escapeHtml(file.name);
+        const filePathEscaped = escapeHtml(file.path);
+        return `
+            <div style="margin-bottom: 20px; padding: 15px; background: white; border-radius: 8px; border-left: 4px solid var(--lavender); cursor: pointer;"
+                 data-filepath="${filePathEscaped}" data-filename="${fileNameEscaped}" class="checklist-item">
+                <div style="font-weight: 600; color: var(--dark-text); margin-bottom: 5px;">
+                    ${file.icon} ${fileNameEscaped}
+                </div>
+                <div style="font-size: 0.85em; color: var(--medium-text);">
+                    Click to view checklist
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    document.getElementById('checklists-content').innerHTML = `
+        <p style="margin-bottom: 20px; color: var(--medium-text);">
+            Quality control and validation checklists for this feature.
+        </p>
+        ${checklistsHtml}
+    `;
+
+    // Add click handlers
+    document.querySelectorAll('.checklist-item').forEach(item => {
+        item.addEventListener('click', () => {
+            loadChecklistFile(item.dataset.filepath, item.dataset.filename);
+        });
+    });
+}
+
+function loadChecklistFile(filePath, fileName) {
+    fetch(`/api/checklists/${currentFeature}/${encodeURIComponent(filePath)}`)
+        .then(response => response.ok ? response.text() : Promise.reject('Not found'))
+        .then(content => {
+            let htmlContent;
+
+            // Format JSON files nicely
+            if (fileName.endsWith('.json')) {
+                try {
+                    const jsonData = JSON.parse(content);
+                    const prettyJson = JSON.stringify(jsonData, null, 2);
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto; border: 1px solid #dee2e6;"><code style="font-family: 'Monaco', 'Menlo', monospace; font-size: 0.9em; line-height: 1.5; color: #212529;">${escapeHtml(prettyJson)}</code></pre>`;
+                } catch (e) {
+                    // If JSON parsing fails, show as plain text
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto;"><code>${escapeHtml(content)}</code></pre>`;
+                }
+            } else if (fileName.endsWith('.md')) {
+                // Render markdown files with proper styling
+                const renderedMarkdown = marked.parse(content);
+                htmlContent = `<div class="markdown-content" style="line-height: 1.6; font-size: 0.95em;">${renderedMarkdown}</div>`;
+            } else if (fileName.endsWith('.csv')) {
+                // Render CSV as a table
+                htmlContent = renderCSV(content);
+            } else if (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) {
+                // Show YAML files as code blocks
+                htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto; border: 1px solid #dee2e6;"><code style="font-family: 'Monaco', 'Menlo', monospace; font-size: 0.9em; line-height: 1.5;">${escapeHtml(content)}</code></pre>`;
+            } else {
+                // Default: show as code block
+                htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto;"><code>${escapeHtml(content)}</code></pre>`;
+            }
+
+            const container = document.getElementById('checklists-content');
+            container.innerHTML = `
+                <div style="margin-bottom: 20px;">
+                    <button onclick="loadChecklists()"
+                            style="padding: 8px 16px; background: var(--baby-blue); border: none; border-radius: 6px; cursor: pointer; color: var(--dark-text); font-weight: 500;">
+                        ← Back to Checklists List
+                    </button>
+                </div>
+                <h3 style="color: var(--grassy-green); margin-bottom: 15px;">${escapeHtml(fileName)}</h3>
+                ${htmlContent}
+            `;
+            // Intercept markdown links to route through dashboard
+            interceptMarkdownLinks(container, 'checklists/');
+        })
+        .catch(error => {
+            document.getElementById('checklists-content').innerHTML =
+                '<div class="empty-state">Error loading checklist file</div>';
+        });
+}
+
+function loadResearch() {
+    fetch(`/api/research/${currentFeature}`)
+        .then(response => response.ok ? response.json() : Promise.reject('Not found'))
+        .then(data => {
+            if (data.main_file || (data.artifacts && data.artifacts.length > 0)) {
+                renderResearchContent(data);
+            } else {
+                document.getElementById('research-content').innerHTML =
+                    '<div class="empty-state">No research artifacts available. Run /spec-kitty.research to create them.</div>';
+            }
+        })
+        .catch(error => {
+            document.getElementById('research-content').innerHTML =
+                '<div class="empty-state">Research artifacts not found</div>';
+        });
+}
+
+function renderResearchContent(data) {
+    let mainContent = '';
+    if (data.main_file) {
+        mainContent = `
+            <h3 style="color: var(--grassy-green); margin-bottom: 15px;">research.md</h3>
+            ${marked.parse(data.main_file)}
+        `;
+    }
+
+    let artifactsHtml = '';
+    if (data.artifacts && data.artifacts.length > 0) {
+        const artifactItems = data.artifacts.map(file => {
+            const nameEscaped = escapeHtml(file.name);
+            const pathEscaped = escapeHtml(file.path);
+            return `
+                <div style="padding: 12px; background: white; border-radius: 8px; border-left: 4px solid var(--soft-peach); cursor: pointer;"
+                     data-filepath="${pathEscaped}" data-filename="${nameEscaped}" class="research-artifact-item">
+                    <div style="font-weight: 600; color: var(--dark-text); margin-bottom: 3px;">
+                        ${file.icon} ${nameEscaped}
+                    </div>
+                    <div style="font-size: 0.75em; color: var(--medium-text); font-family: monospace;">
+                        ${pathEscaped}
+                    </div>
+                </div>
+            `;
+        }).join('');
+
+        artifactsHtml = `
+            <h3 style="color: var(--grassy-green); margin-top: 30px; margin-bottom: 15px;">
+                Research Artifacts
+            </h3>
+            <div style="display: grid; gap: 10px;">
+                ${artifactItems}
+            </div>
+        `;
+    }
+
+    document.getElementById('research-content').innerHTML = mainContent + artifactsHtml;
+
+    // Intercept markdown links to route through dashboard
+    interceptMarkdownLinks(document.getElementById('research-content'));
+
+    // Add click handlers
+    document.querySelectorAll('.research-artifact-item').forEach(item => {
+        item.addEventListener('click', () => {
+            loadResearchFile(item.dataset.filepath, item.dataset.filename);
+        });
+    });
+}
+
+function loadResearchFile(filePath, fileName) {
+    fetch(`/api/research/${currentFeature}/${encodeURIComponent(filePath)}`)
+        .then(response => response.ok ? response.text() : Promise.reject('Not found'))
+        .then(content => {
+            let htmlContent;
+
+            if (filePath.endsWith('.md')) {
+                // Render markdown files with proper styling
+                const renderedMarkdown = marked.parse(content);
+                htmlContent = `<div class="markdown-content" style="line-height: 1.6; font-size: 0.95em;">${renderedMarkdown}</div>`;
+            } else if (filePath.endsWith('.csv')) {
+                // Render CSV as a table
+                htmlContent = renderCSV(content);
+            } else if (filePath.endsWith('.json')) {
+                // Format JSON files nicely
+                try {
+                    const jsonData = JSON.parse(content);
+                    const prettyJson = JSON.stringify(jsonData, null, 2);
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto; border: 1px solid #dee2e6;"><code style="font-family: 'Monaco', 'Menlo', monospace; font-size: 0.9em; line-height: 1.5; color: #212529;">${escapeHtml(prettyJson)}</code></pre>`;
+                } catch (e) {
+                    // If JSON parsing fails, show as plain text
+                    htmlContent = `<pre style="background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-x: auto;"><code>${escapeHtml(content)}</code></pre>`;
+                }
+            } else {
+                // Default: show as code block
+                htmlContent = `<pre style="background: white; padding: 20px; border-radius: 8px; overflow-x: auto;">${escapeHtml(content)}</pre>`;
+            }
+
+            const container = document.getElementById('research-content');
+            container.innerHTML = `
+                <div style="margin-bottom: 20px;">
+                    <button onclick="loadResearch()"
+                            style="padding: 8px 16px; background: var(--baby-blue); border: none; border-radius: 6px; cursor: pointer; color: var(--dark-text); font-weight: 500;">
+                        ← Back to Research
+                    </button>
+                </div>
+                <h3 style="color: var(--grassy-green); margin-bottom: 15px;">${escapeHtml(fileName)}</h3>
+                ${htmlContent}
+            `;
+            // Intercept markdown links to route through dashboard
+            interceptMarkdownLinks(container, 'research/');
+        })
+        .catch(error => {
+            document.getElementById('research-content').innerHTML =
+                '<div class="empty-state">Error loading research file</div>';
+        });
+}
+
+function renderCSV(csvContent) {
+    const lines = csvContent.trim().split('\n');
+    if (lines.length === 0) return '<div class="empty-state">Empty CSV file</div>';
+
+    const rows = lines.map(line => {
+        // Improved CSV parsing that handles quoted fields
+        const cells = [];
+        let current = '';
+        let inQuotes = false;
+
+        for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            const nextChar = line[i + 1];
+
+            if (char === '"') {
+                if (inQuotes && nextChar === '"') {
+                    // Escaped quote
+                    current += '"';
+                    i++; // Skip next quote
+                } else {
+                    // Toggle quote mode
+                    inQuotes = !inQuotes;
+                }
+            } else if (char === ',' && !inQuotes) {
+                // End of field
+                cells.push(current.trim());
+                current = '';
+            } else {
+                current += char;
+            }
+        }
+        // Don't forget the last field
+        cells.push(current.trim());
+
+        return cells;
+    });
+
+    const headerRow = rows[0];
+    const dataRows = rows.slice(1);
+
+    return `
+        <div style="overflow-x: auto; margin: 20px 0;">
+            <table style="width: 100%; border-collapse: collapse; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.05);">
+                <thead>
+                    <tr style="background: var(--baby-blue);">
+                        ${headerRow.map(header => `<th style="padding: 12px; text-align: left; font-weight: 600; color: var(--dark-text); border-bottom: 2px solid var(--lavender);">${escapeHtml(header)}</th>`).join('')}
+                    </tr>
+                </thead>
+                <tbody>
+                    ${dataRows.map((row, idx) => `
+                        <tr style="border-top: 1px solid #e5e7eb; ${idx % 2 === 0 ? 'background: #fafbfc;' : 'background: white;'} transition: background 0.2s;"
+                            onmouseover="this.style.background='#f0f4f8'"
+                            onmouseout="this.style.background='${idx % 2 === 0 ? '#fafbfc' : 'white'}'">
+                            ${row.map(cell => `<td style="padding: 10px; color: var(--medium-text);">${escapeHtml(cell)}</td>`).join('')}
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+            ${dataRows.length === 0 ? '<div style="text-align: center; padding: 20px; color: var(--medium-text);">No data rows in CSV</div>' : ''}
+        </div>
+    `;
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function showConstitution() {
+    if (!isConstitutionView && currentPage !== 'constitution') {
+        lastNonConstitutionPage = currentPage;
+    }
+    // Switch to constitution page
+    currentPage = 'constitution';
+    isConstitutionView = true;
+    saveState(currentFeature, 'constitution');
+    document.querySelectorAll('.sidebar-item').forEach(item => item.classList.remove('active'));
+    const constitutionItem = document.querySelector('.sidebar-item[data-page="constitution"]');
+    if (constitutionItem) {
+        constitutionItem.classList.remove('disabled');
+        constitutionItem.classList.add('active');
+    }
+    document.querySelectorAll('.page').forEach(page => page.classList.remove('active'));
+    document.getElementById('page-constitution').classList.add('active');
+
+    // Load constitution
+    fetch('/api/constitution')
+        .then(response => response.ok ? response.text() : Promise.reject('Not found'))
+        .then(content => {
+            const htmlContent = marked.parse(content);
+            const container = document.getElementById('constitution-content');
+            container.innerHTML = htmlContent;
+            // Intercept markdown links to route through dashboard
+            interceptMarkdownLinks(container);
+        })
+        .catch(error => {
+            document.getElementById('constitution-content').innerHTML =
+                '<div class="empty-state">Constitution not found. Run /spec-kitty.constitution to create it.</div>';
+        });
+}
+
+function updateWorkflowIcons(workflow) {
+    const iconMap = {
+        'complete': '✅',
+        'in_progress': '🔄',
+        'pending': '⏳'
+    };
+
+    document.getElementById('icon-specify').textContent = iconMap[workflow.specify] || '⏳';
+    document.getElementById('icon-plan').textContent = iconMap[workflow.plan] || '⏳';
+    document.getElementById('icon-tasks').textContent = iconMap[workflow.tasks] || '⏳';
+    document.getElementById('icon-implement').textContent = iconMap[workflow.implement] || '⏳';
+}
+
+function updateFeatureList(features, activeFeatureId = null) {
+    allFeatures = features;
+    const selectContainer = document.getElementById('feature-selector-container');
+    const select = document.getElementById('feature-select');
+    const singleFeatureName = document.getElementById('single-feature-name');
+    const sidebar = document.querySelector('.sidebar');
+    const mainContent = document.querySelector('.main-content');
+
+    // Restore saved state from cookies on initial load
+    const savedState = restoreState();
+
+    if (select && !select.dataset.pauseHandlersAttached) {
+        const activate = () => setFeatureSelectActive(true);
+        const deactivate = () => setFeatureSelectActive(false);
+        ['focus', 'mousedown', 'keydown', 'click', 'input'].forEach(evt => {
+            select.addEventListener(evt, activate);
+        });
+        ['change', 'blur'].forEach(evt => {
+            select.addEventListener(evt, deactivate);
+        });
+        select.dataset.pauseHandlersAttached = 'true';
+    }
+
+    // Handle 0 features - show welcome page
+    if (features.length === 0) {
+        selectContainer.style.display = 'none';
+        singleFeatureName.style.display = 'none';
+        sidebar.style.display = 'block';
+        mainContent.style.display = 'block';
+        isConstitutionView = false;
+        currentFeature = null;
+        computeFeatureWorktreeStatus(null);
+        setFeatureSelectActive(false);
+
+        // Show welcome page
+        document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+        document.getElementById('page-welcome').classList.add('active');
+        currentPage = 'welcome';
+
+        // Disable all sidebar items except constitution link
+        document.querySelectorAll('.sidebar-item').forEach(item => {
+            if (item.dataset.page === 'constitution') {
+                item.classList.remove('disabled');
+            } else {
+                item.classList.add('disabled');
+            }
+        });
+        return;
+    }
+
+    // Handle 1 feature - show name directly (no dropdown)
+    if (features.length === 1) {
+        selectContainer.style.display = 'none';
+        singleFeatureName.style.display = 'block';
+        singleFeatureName.textContent = `Feature: ${features[0].name}`;
+        currentFeature = activeFeatureId || features[0].id;
+        setFeatureSelectActive(false);
+    } else {
+        // Handle multiple features - show dropdown
+        selectContainer.style.display = 'block';
+        singleFeatureName.style.display = 'none';
+
+        const activeFeatureExists = activeFeatureId && features.find(f => f.id === activeFeatureId);
+        // Try to restore saved feature, fall back to first feature
+        const savedFeatureExists = savedState.feature && features.find(f => f.id === savedState.feature);
+        if (activeFeatureExists) {
+            currentFeature = activeFeatureId;
+        } else if (!currentFeature || !features.find(f => f.id === currentFeature)) {
+            currentFeature = savedFeatureExists ? savedState.feature : features[0].id;
+        }
+
+        select.innerHTML = features.map(f =>
+            `<option value="${f.id}" ${f.id === currentFeature ? 'selected' : ''}>${f.name}</option>`
+        ).join('');
+        select.value = currentFeature;
+    }
+
+    // Restore saved page if it's valid for the current feature
+    const feature = features.find(f => f.id === currentFeature);
+    if (savedState.page && savedState.page !== 'overview') {
+        if (savedState.page === 'constitution') {
+            // Will be handled by showConstitution() call below
+            currentPage = savedState.page;
+        } else if (savedState.page === 'kanban' && feature && feature.artifacts && feature.artifacts.kanban?.exists) {
+            currentPage = savedState.page;
+        } else if (feature && feature.artifacts) {
+            const artifactKey = savedState.page.replace('-', '_');
+            if (feature.artifacts[artifactKey]?.exists || savedState.page === 'overview') {
+                currentPage = savedState.page;
+            }
+        }
+    }
+
+    sidebar.style.display = 'block';
+    mainContent.style.display = 'block';
+
+    // Update workflow icons based on current feature
+    if (feature && feature.workflow) {
+        updateWorkflowIcons(feature.workflow);
+        computeFeatureWorktreeStatus(feature);
+    } else {
+        computeFeatureWorktreeStatus(null);
+    }
+
+    updateSidebarState();
+
+    // Restore the page view
+    if (currentPage === 'constitution') {
+        showConstitution();
+    } else {
+        isConstitutionView = false;
+        // Update sidebar highlighting
+        document.querySelectorAll('.sidebar-item').forEach(item => {
+            if (item.dataset.page === currentPage) {
+                item.classList.add('active');
+            } else {
+                item.classList.remove('active');
+            }
+        });
+        // Update page visibility
+        document.querySelectorAll('.page').forEach(page => page.classList.remove('active'));
+        const activePageEl = document.getElementById(`page-${currentPage}`);
+        if (activePageEl) {
+            activePageEl.classList.add('active');
+        }
+        loadCurrentPage();
+    }
+}
+
+function updateFeatureListSilent(features) {
+    // Same as updateFeatureList but doesn't reload the current page
+    // Used during polling to avoid resetting user's view
+    const oldFeature = allFeatures.find(f => f.id === currentFeature);
+    allFeatures = features;
+    const feature = features.find(f => f.id === currentFeature);
+
+    if (feature && feature.workflow) {
+        updateWorkflowIcons(feature.workflow);
+        computeFeatureWorktreeStatus(feature);
+    } else {
+        computeFeatureWorktreeStatus(null);
+    }
+    updateSidebarState();
+
+    // Detect artifact changes and reload overview if artifacts changed
+    if (currentPage === 'overview' && oldFeature && feature) {
+        const oldArtifacts = JSON.stringify(oldFeature.artifacts);
+        const newArtifacts = JSON.stringify(feature.artifacts);
+        if (oldArtifacts !== newArtifacts) {
+            loadOverview();
+        }
+    }
+}
+
+function fetchData(isInitialLoad = false) {
+    if (featureSelectActive && !isInitialLoad) {
+        return;
+    }
+    fetch('/api/features')
+        .then(response => response.json())
+        .then(data => {
+            // Use full update on initial load, silent update on polls
+            if (isInitialLoad) {
+                updateFeatureList(data.features, data.active_feature_id || null);
+            } else {
+                updateFeatureListSilent(data.features);
+
+                // Refresh kanban board if currently viewing it and data changed
+                if (currentPage === 'kanban' && !isConstitutionView && currentFeature) {
+                    const feature = data.features.find(f => f.id === currentFeature);
+                    const newStats = feature ? JSON.stringify(feature.kanban_stats) : '';
+                    if (newStats !== _lastKanbanStats) {
+                        _lastKanbanStats = newStats;
+                        loadKanban();
+                    }
+                }
+            }
+
+            document.getElementById('last-update').textContent = new Date().toLocaleTimeString();
+
+            if (data.project_path) {
+                projectPathDisplay = data.project_path;
+            }
+
+            if (data.active_worktree) {
+                activeWorktreeDisplay = data.active_worktree;
+            } else {
+                activeWorktreeDisplay = '';
+            }
+
+            if (data.active_mission) {
+                updateMissionDisplay(data.active_mission);
+            }
+
+            const currentFeatureObj = allFeatures.find(f => f.id === currentFeature);
+            computeFeatureWorktreeStatus(currentFeatureObj || null);
+            updateTreeInfo();
+        })
+        .catch(error => console.error('Error fetching data:', error));
+}
+
+// Initial fetch
+// Diagnostics functions
+function showDiagnostics() {
+    if (!isConstitutionView && currentPage !== 'diagnostics') {
+        lastNonConstitutionPage = currentPage;
+    }
+    // Switch to diagnostics page
+    currentPage = 'diagnostics';
+    isConstitutionView = false;
+    saveState(currentFeature, 'diagnostics');
+
+    // Update sidebar - consistent with other pages
+    document.querySelectorAll('.sidebar-item').forEach(item => {
+        if (item.dataset.page === 'diagnostics') {
+            item.classList.add('active');
+        } else {
+            item.classList.remove('active');
+        }
+    });
+
+    // Update pages
+    document.querySelectorAll('.page').forEach(page => page.classList.remove('active'));
+    const diagnosticsPage = document.getElementById('page-diagnostics');
+    if (diagnosticsPage) {
+        diagnosticsPage.classList.add('active');
+    }
+
+    loadDiagnostics();
+}
+
+function loadDiagnostics() {
+    // Show loading state
+    document.getElementById('diagnostics-loading').style.display = 'block';
+    document.getElementById('diagnostics-content').style.display = 'none';
+    document.getElementById('diagnostics-error').style.display = 'none';
+
+    fetch('/api/diagnostics')
+        .then(response => response.json())
+        .then(data => {
+            displayDiagnostics(data);
+        })
+        .catch(error => {
+            document.getElementById('diagnostics-loading').style.display = 'none';
+            document.getElementById('diagnostics-error').style.display = 'block';
+            document.getElementById('diagnostics-error-message').textContent = error.toString();
+        });
+}
+
+function displayDiagnostics(data) {
+    document.getElementById('diagnostics-loading').style.display = 'none';
+    document.getElementById('diagnostics-content').style.display = 'block';
+
+    // Display environment status
+    const statusHtml = `
+        <h3>Environment</h3>
+        <div><strong>Working Directory:</strong> ${data.current_working_directory || '(not available)'}</div>
+        <div><strong>Repository Root:</strong> ${data.project_path || '(not available)'}</div>
+        <div><strong>Git Branch:</strong> ${data.git_branch || 'Not detected'}</div>
+        <div><strong>In Worktree:</strong> ${data.in_worktree ? '✅ Yes' : '❌ No'}</div>
+        <div><strong>Active Mission:</strong> ${data.active_mission || 'software-dev'}</div>
+    `;
+    document.getElementById('diagnostics-status').innerHTML = statusHtml;
+
+    // Display file integrity
+    if (data.file_integrity) {
+        const integrityHtml = `
+            <h3>Mission File Integrity</h3>
+            <div><strong>Expected Files:</strong> ${data.file_integrity.total_expected}</div>
+            <div><strong>Present Files:</strong> ${data.file_integrity.total_present}</div>
+            <div><strong>Missing Files:</strong> ${data.file_integrity.total_missing}</div>
+            ${data.file_integrity.missing_files && data.file_integrity.missing_files.length > 0 ?
+                `<div style="margin-top: 10px;"><strong>Missing:</strong><br>${data.file_integrity.missing_files.slice(0, 5).map(f => `• ${f}`).join('<br>')}</div>` : ''}
+        `;
+        const integrityDiv = document.createElement('div');
+        integrityDiv.innerHTML = integrityHtml;
+        integrityDiv.style.marginTop = '20px';
+        document.getElementById('diagnostics-status').appendChild(integrityDiv);
+    }
+
+    // Display worktree overview
+    if (data.worktree_overview) {
+        const overviewHtml = `
+            <h3>Worktree Overview</h3>
+            <div><strong>Total Features:</strong> ${data.worktree_overview.total_features}</div>
+            <div><strong>Active Worktrees:</strong> ${data.worktree_overview.active_worktrees}</div>
+            <div><strong>Merged Features:</strong> ${data.worktree_overview.merged_features}</div>
+            <div><strong>In Development:</strong> ${data.worktree_overview.in_development}</div>
+            <div><strong>Not Started:</strong> ${data.worktree_overview.not_started}</div>
+        `;
+        const overviewDiv = document.createElement('div');
+        overviewDiv.innerHTML = overviewHtml;
+        overviewDiv.style.marginTop = '20px';
+        document.getElementById('diagnostics-status').appendChild(overviewDiv);
+    }
+
+    // Display current feature
+    if (data.current_feature && data.current_feature.detected) {
+        const stateMap = {
+            'merged': '✅ MERGED',
+            'in_development': '🔄 IN DEVELOPMENT',
+            'ready_to_merge': '🔵 READY TO MERGE',
+            'not_started': '⏳ NOT STARTED',
+            'unknown': '❓ UNKNOWN'
+        };
+        const currentHtml = `
+            <h3>Current Feature</h3>
+            <div><strong>Feature:</strong> ${data.current_feature.name}</div>
+            <div><strong>State:</strong> ${stateMap[data.current_feature.state] || data.current_feature.state}</div>
+            <div><strong>Branch Exists:</strong> ${data.current_feature.branch_exists ? '✅' : '❌'}</div>
+            <div><strong>Worktree Exists:</strong> ${data.current_feature.worktree_exists ? '✅' : '❌'}</div>
+            ${data.current_feature.worktree_path ? `<div><strong>Worktree Path:</strong> ${data.current_feature.worktree_path}</div>` : ''}
+            ${data.current_feature.artifacts_in_main && data.current_feature.artifacts_in_main.length > 0 ?
+                `<div><strong>Artifacts in Main:</strong> ${data.current_feature.artifacts_in_main.join(', ')}</div>` : ''}
+            ${data.current_feature.artifacts_in_worktree && data.current_feature.artifacts_in_worktree.length > 0 ?
+                `<div><strong>Artifacts in Worktree:</strong> ${data.current_feature.artifacts_in_worktree.join(', ')}</div>` : ''}
+        `;
+        const currentDiv = document.createElement('div');
+        currentDiv.innerHTML = currentHtml;
+        currentDiv.style.marginTop = '20px';
+        document.getElementById('diagnostics-status').appendChild(currentDiv);
+    }
+
+    // Display all features table
+    if (data.all_features && data.all_features.length > 0) {
+        const tableHtml = `
+            <h3>All Features Status</h3>
+            <table style="width: 100%; border-collapse: collapse; margin-top: 10px;">
+                <thead>
+                    <tr style="background: #f0f0f0;">
+                        <th style="padding: 8px; text-align: left; border: 1px solid #ddd;">Feature</th>
+                        <th style="padding: 8px; text-align: left; border: 1px solid #ddd;">State</th>
+                        <th style="padding: 8px; text-align: center; border: 1px solid #ddd;">Branch</th>
+                        <th style="padding: 8px; text-align: center; border: 1px solid #ddd;">Worktree</th>
+                        <th style="padding: 8px; text-align: center; border: 1px solid #ddd;">Artifacts</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${data.all_features.slice(0, 10).map(feature => {
+                        const stateDisplay = {
+                            'merged': '<span style="color: green;">MERGED</span>',
+                            'in_development': '<span style="color: orange;">ACTIVE</span>',
+                            'ready_to_merge': '<span style="color: blue;">READY</span>',
+                            'not_started': '<span style="color: gray;">NOT STARTED</span>',
+                            'unknown': '<span style="color: gray;">?</span>'
+                        }[feature.state] || feature.state;
+
+                        const branchDisplay = feature.branch_merged ? 'merged' : (feature.branch_exists ? '✓' : '-');
+                        const worktreeDisplay = feature.worktree_exists ? '✓' : '-';
+                        const artifactCount = (feature.artifacts_in_main || []).length + (feature.artifacts_in_worktree || []).length;
+                        const artifactsDisplay = artifactCount > 0 ? artifactCount : '-';
+
+                        return `
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd;">${feature.name}</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">${stateDisplay}</td>
+                                <td style="padding: 8px; text-align: center; border: 1px solid #ddd;">${branchDisplay}</td>
+                                <td style="padding: 8px; text-align: center; border: 1px solid #ddd;">${worktreeDisplay}</td>
+                                <td style="padding: 8px; text-align: center; border: 1px solid #ddd;">${artifactsDisplay}</td>
+                            </tr>
+                        `;
+                    }).join('')}
+                </tbody>
+            </table>
+            ${data.all_features.length > 10 ? `<div style="margin-top: 10px; color: #666;">... and ${data.all_features.length - 10} more features</div>` : ''}
+        `;
+        const tableDiv = document.createElement('div');
+        tableDiv.innerHTML = tableHtml;
+        tableDiv.style.marginTop = '20px';
+        document.getElementById('diagnostics-status').appendChild(tableDiv);
+    }
+
+    // Display observations (not prescriptive recommendations)
+    if (data.observations && data.observations.length > 0) {
+        document.getElementById('diagnostics-issues').style.display = 'block';
+        document.querySelector('#diagnostics-issues h3').textContent = 'Observations';
+        const obsHtml = data.observations.map(obs => `<div>• ${obs}</div>`).join('');
+        document.getElementById('diagnostics-issues-content').innerHTML = obsHtml;
+    } else {
+        document.getElementById('diagnostics-issues').style.display = 'none';
+    }
+
+    // Hide recommendations section since we're being observational
+    const recsSection = document.getElementById('diagnostics-recommendations');
+    if (recsSection) {
+        recsSection.style.display = 'none';
+    }
+}
+
+function refreshDiagnostics() {
+    loadDiagnostics();
+}
+
+updateMissionDisplay();
+updateTreeInfo();
+fetchData(true);  // Pass true for initial load
+
+// Poll every second
+// Polling handled by index.html's autoRefresh (5s interval) — no duplicate loop needed
+// setInterval(fetchData, 1000);

--- a/dev/spec-kitty/kittify/scripts/dashboard/templates/index.html
+++ b/dev/spec-kitty/kittify/scripts/dashboard/templates/index.html
@@ -130,7 +130,11 @@
             <div id="page-diagnostics" class="page">
                 <div class="content-card">
                     <h2>Diagnostics</h2>
-                    <div id="diagnostics-content" class="markdown-content">Loading...</div>
+                    <div id="diagnostics-loading" class="markdown-content">Loading...</div>
+                    <div id="diagnostics-error" style="display:none" class="markdown-content">
+                        <p id="diagnostics-error-message"></p>
+                    </div>
+                    <div id="diagnostics-content" style="display:none" class="markdown-content"></div>
                 </div>
             </div>
         </div>
@@ -183,14 +187,20 @@
                     const select = document.getElementById('feature-select');
                     const prevValue = select.value;
 
-                    select.innerHTML = allFeatures.map(f =>
-                        `<option value="${f.id}">${f.name}</option>`
-                    ).join('');
-
+                    select.textContent = '';
                     if (allFeatures.length === 0) {
-                        select.innerHTML = '<option value="">No features found</option>';
+                        const opt = document.createElement('option');
+                        opt.value = '';
+                        opt.textContent = 'No features found';
+                        select.appendChild(opt);
                         return;
                     }
+                    allFeatures.forEach(f => {
+                        const opt = document.createElement('option');
+                        opt.value = f.id;
+                        opt.textContent = f.name;
+                        select.appendChild(opt);
+                    });
 
                     // Restore state or pick active/first
                     const saved = restoreState();
@@ -203,7 +213,6 @@
                         currentFeature = targetFeature;
                         if (saved.page) currentPage = saved.page;
                         switchPage(currentPage);
-                        loadCurrentPage();
                     } else {
                         select.value = currentFeature;
                         loadCurrentPage();

--- a/dev/spec-kitty/kittify/scripts/dashboard/templates/index.html
+++ b/dev/spec-kitty/kittify/scripts/dashboard/templates/index.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>SpecKitty Dashboard</title>
+    <link rel="stylesheet" href="/static/dashboard/dashboard.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <div class="header">
+        <div class="header-left">
+            <div>
+                <h1>SpecKitty</h1>
+                <div class="mission-display">
+                    <span class="mission-label">Mission:</span>
+                    <span class="mission-name" id="mission-name">Infrahub</span>
+                </div>
+            </div>
+        </div>
+        <div class="header-right">
+            <div class="header-info">
+                <div class="feature-selector">
+                    <label for="feature-select">Active Feature</label>
+                    <select id="feature-select" onchange="switchFeature(this.value)" onfocus="setFeatureSelectActive(true)" onblur="setFeatureSelectActive(false)">
+                        <option value="">Loading features...</option>
+                    </select>
+                </div>
+                <div class="tree-view" id="tree-info">Loading...</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="sidebar">
+            <span class="last-update sidebar-last-update" id="last-update"></span>
+            <div class="sidebar-item active" data-page="overview" onclick="switchPage('overview')">📊 Overview</div>
+            <div class="sidebar-item" data-page="spec" onclick="switchPage('spec')">📄 Specification</div>
+            <div class="sidebar-item" data-page="plan" onclick="switchPage('plan')">🏗️ Plan</div>
+            <div class="sidebar-item" data-page="tasks" onclick="switchPage('tasks')">📋 Tasks</div>
+            <div class="sidebar-item" data-page="kanban" onclick="switchPage('kanban')">🎯 Kanban Board</div>
+            <div class="sidebar-item" data-page="research" onclick="switchPage('research')">🔬 Research</div>
+            <div class="sidebar-item" data-page="contracts" onclick="switchPage('contracts')">📜 Contracts</div>
+            <div class="sidebar-item" data-page="checklists" onclick="switchPage('checklists')">✅ Checklists</div>
+            <div class="sidebar-item" data-page="quickstart" onclick="switchPage('quickstart')">🚀 Quickstart</div>
+            <div class="sidebar-item" data-page="data-model" onclick="switchPage('data-model')">💾 Data Model</div>
+            <hr style="margin: 10px 30px; border: none; border-top: 1px solid #e5e7eb;">
+            <div class="sidebar-item" data-page="constitution" onclick="switchPage('constitution')">⚖️ Constitution</div>
+            <div class="sidebar-item" data-page="diagnostics" onclick="switchPage('diagnostics')">🔍 Diagnostics</div>
+        </div>
+
+        <div class="main-content">
+            <div id="page-overview" class="page active">
+                <div class="content-card">
+                    <h2>Feature Overview</h2>
+                    <div id="overview-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-spec" class="page">
+                <div class="content-card">
+                    <h2>Specification</h2>
+                    <div id="spec-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-plan" class="page">
+                <div class="content-card">
+                    <h2>Implementation Plan</h2>
+                    <div id="plan-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-tasks" class="page">
+                <div class="content-card">
+                    <h2>Tasks</h2>
+                    <div id="tasks-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-kanban" class="page">
+                <div class="content-card">
+                    <h2>Kanban Board</h2>
+                    <div id="kanban-status" class="status-summary"></div>
+                    <div id="kanban-board" class="kanban-board">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-research" class="page">
+                <div class="content-card">
+                    <h2>Research</h2>
+                    <div id="research-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-contracts" class="page">
+                <div class="content-card">
+                    <h2>Contracts</h2>
+                    <div id="contracts-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-checklists" class="page">
+                <div class="content-card">
+                    <h2>Checklists</h2>
+                    <div id="checklists-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-quickstart" class="page">
+                <div class="content-card">
+                    <h2>Quickstart</h2>
+                    <div id="quickstart-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-data-model" class="page">
+                <div class="content-card">
+                    <h2>Data Model</h2>
+                    <div id="data-model-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-constitution" class="page">
+                <div class="content-card">
+                    <h2>Project Constitution</h2>
+                    <div id="constitution-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+
+            <div id="page-diagnostics" class="page">
+                <div class="content-card">
+                    <h2>Diagnostics</h2>
+                    <div id="diagnostics-content" class="markdown-content">Loading...</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- WP Detail Modal -->
+    <div class="modal hidden" id="prompt-modal">
+        <div class="modal-overlay" onclick="hidePromptModal()"></div>
+        <div class="modal-content">
+            <div class="modal-header">
+                <div>
+                    <div class="modal-title" id="modal-title"></div>
+                    <div class="modal-subtitle" id="modal-subtitle"></div>
+                </div>
+                <button class="modal-close" onclick="hidePromptModal()">&times;</button>
+            </div>
+            <div class="modal-meta" id="modal-prompt-meta"></div>
+            <div class="modal-body" id="modal-body">
+                <div id="modal-prompt-content" class="markdown-content"></div>
+            </div>
+        </div>
+    </div>
+
+    <script src="/static/dashboard/dashboard.js"></script>
+    <script>
+        // Initialize
+        document.addEventListener('DOMContentLoaded', () => {
+            loadFeatures();
+            setInterval(autoRefresh, 5000);
+        });
+
+        function autoRefresh() {
+            if (!featureSelectActive) {
+                loadFeatures();
+            }
+        }
+
+        function loadFeatures() {
+            fetch('/api/features')
+                .then(r => r.json())
+                .then(data => {
+                    allFeatures = data.features || [];
+                    projectPathDisplay = data.project_path || '';
+                    activeWorktreeDisplay = data.active_worktree || '';
+
+                    if (data.active_mission) {
+                        updateMissionDisplay(data.active_mission);
+                    }
+
+                    const select = document.getElementById('feature-select');
+                    const prevValue = select.value;
+
+                    select.innerHTML = allFeatures.map(f =>
+                        `<option value="${f.id}">${f.name}</option>`
+                    ).join('');
+
+                    if (allFeatures.length === 0) {
+                        select.innerHTML = '<option value="">No features found</option>';
+                        return;
+                    }
+
+                    // Restore state or pick active/first
+                    const saved = restoreState();
+                    const targetFeature = saved.feature && allFeatures.find(f => f.id === saved.feature)
+                        ? saved.feature
+                        : (data.active_feature_id || allFeatures[0].id);
+
+                    if (!currentFeature || !allFeatures.find(f => f.id === currentFeature)) {
+                        select.value = targetFeature;
+                        currentFeature = targetFeature;
+                        if (saved.page) currentPage = saved.page;
+                        switchPage(currentPage);
+                        loadCurrentPage();
+                    } else {
+                        select.value = currentFeature;
+                        loadCurrentPage();
+                    }
+
+                    updateSidebarState();
+                    updateTreeInfo();
+                    updateLastUpdate();
+                })
+                .catch(err => console.error('Failed to load features:', err));
+        }
+
+        function updateLastUpdate() {
+            const el = document.getElementById('last-update');
+            if (el) {
+                el.textContent = 'Updated: ' + new Date().toLocaleTimeString();
+            }
+        }
+    </script>
+</body>
+</html>

--- a/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
+++ b/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+WP_DIR="$REPO_ROOT/dev/spec-kitty/work-packages"
+WT_DIR="$REPO_ROOT/dev/spec-kitty/.worktrees"
+
+# Source common functions if available
+COMMON_SH="$REPO_ROOT/.specify/scripts/bash/common.sh"
+if [[ -f "$COMMON_SH" ]]; then
+    source "$COMMON_SH"
+fi
+
+usage() {
+    cat <<'USAGE'
+Usage: manage-workpackages.sh <command> [args...]
+
+Commands:
+  list <feature>                        List all WPs with their current lane
+  transition <feature> <WP_ID> <lane>   Update WP lane (planned|doing|for_review|done)
+  create-worktree <feature> <WP_ID>     Create git worktree for a WP
+  cleanup-worktree <feature> <WP_ID>    Remove worktree and optionally delete branch
+  status <feature>                      Kanban summary (count per lane)
+USAGE
+    exit 1
+}
+
+get_wp_dir() {
+    local feature="$1"
+    echo "$WP_DIR/$feature"
+}
+
+get_wp_file() {
+    local feature="$1"
+    local wp_id="$2"
+    echo "$(get_wp_dir "$feature")/$wp_id.md"
+}
+
+get_lane() {
+    local wp_file="$1"
+    grep -m1 '^lane:' "$wp_file" | sed 's/^lane: *//'
+}
+
+cmd_list() {
+    local feature="${1:?Feature name required}"
+    local wp_dir
+    wp_dir="$(get_wp_dir "$feature")"
+
+    if [[ ! -d "$wp_dir" ]]; then
+        echo "No work packages found for feature: $feature"
+        exit 1
+    fi
+
+    printf "%-8s %-12s %s\n" "ID" "LANE" "TITLE"
+    printf "%-8s %-12s %s\n" "------" "----------" "-----"
+
+    for wp_file in "$wp_dir"/WP*.md; do
+        [[ -f "$wp_file" ]] || continue
+        local wp_id lane title
+        wp_id="$(basename "$wp_file" .md)"
+        lane="$(get_lane "$wp_file")"
+        title="$(grep -m1 '^# Work Package' "$wp_file" | sed 's/^# Work Package WP[0-9]*: //')"
+        printf "%-8s %-12s %s\n" "$wp_id" "$lane" "$title"
+    done
+}
+
+cmd_transition() {
+    local feature="${1:?Feature name required}"
+    local wp_id="${2:?WP ID required}"
+    local new_lane="${3:?New lane required}"
+    local wp_file
+    wp_file="$(get_wp_file "$feature" "$wp_id")"
+
+    if [[ ! -f "$wp_file" ]]; then
+        echo "ERROR: WP file not found: $wp_file"
+        exit 1
+    fi
+
+    # Validate lane
+    case "$new_lane" in
+        planned|doing|for_review|done) ;;
+        *) echo "ERROR: Invalid lane '$new_lane'. Must be: planned, doing, for_review, done"; exit 1 ;;
+    esac
+
+    local old_lane
+    old_lane="$(get_lane "$wp_file")"
+
+    # Update lane in frontmatter (portable: works on both macOS and Linux)
+    local tmp_file
+    tmp_file="$(mktemp)"
+    sed "s/^lane: .*/lane: $new_lane/" "$wp_file" > "$tmp_file" && mv "$tmp_file" "$wp_file"
+
+    # Append to activity log (portable: use awk instead of sed -i /a\)
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    tmp_file="$(mktemp)"
+    awk -v entry="  - \"$timestamp: $old_lane -> $new_lane\"" '
+        /^activity_log:/ { print; print entry; next }
+        { print }
+    ' "$wp_file" > "$tmp_file" && mv "$tmp_file" "$wp_file"
+
+    echo "Transitioned $wp_id: $old_lane -> $new_lane"
+}
+
+cmd_create_worktree() {
+    local feature="${1:?Feature name required}"
+    local wp_id="${2:?WP ID required}"
+    local worktree_path="$WT_DIR/${feature}-${wp_id}"
+    local branch_name="kitty/${feature}-${wp_id}"
+
+    if [[ -d "$worktree_path" ]]; then
+        echo "Worktree already exists at: $worktree_path"
+        exit 1
+    fi
+
+    mkdir -p "$WT_DIR"
+    git worktree add "$worktree_path" -b "$branch_name"
+    echo "Created worktree at: $worktree_path"
+    echo "Branch: $branch_name"
+}
+
+cmd_cleanup_worktree() {
+    local feature="${1:?Feature name required}"
+    local wp_id="${2:?WP ID required}"
+    local worktree_path="$WT_DIR/${feature}-${wp_id}"
+    local branch_name="kitty/${feature}-${wp_id}"
+
+    if [[ -d "$worktree_path" ]]; then
+        git worktree remove "$worktree_path" --force
+        echo "Removed worktree: $worktree_path"
+    else
+        echo "No worktree found at: $worktree_path"
+    fi
+
+    # Optionally delete branch
+    if git rev-parse --verify "$branch_name" &>/dev/null; then
+        git branch -d "$branch_name" 2>/dev/null || {
+            echo "Branch $branch_name has unmerged changes. Use -D to force delete."
+        }
+    fi
+}
+
+cmd_status() {
+    local feature="${1:?Feature name required}"
+    local wp_dir
+    wp_dir="$(get_wp_dir "$feature")"
+
+    if [[ ! -d "$wp_dir" ]]; then
+        echo "No work packages found for feature: $feature"
+        exit 1
+    fi
+
+    local planned=0 doing=0 for_review=0 done=0 total=0
+
+    for wp_file in "$wp_dir"/WP*.md; do
+        [[ -f "$wp_file" ]] || continue
+        local lane
+        lane="$(get_lane "$wp_file")"
+        case "$lane" in
+            planned) ((planned++)) ;;
+            doing) ((doing++)) ;;
+            for_review) ((for_review++)) ;;
+            done) ((done++)) ;;
+        esac
+        ((total++))
+    done
+
+    echo "Feature: $feature"
+    echo ""
+    printf "  PLANNED:    %d\n" "$planned"
+    printf "  DOING:      %d\n" "$doing"
+    printf "  FOR REVIEW: %d\n" "$for_review"
+    printf "  DONE:       %d\n" "$done"
+    echo ""
+    printf "  TOTAL:      %d\n" "$total"
+    if [[ $total -gt 0 ]]; then
+        local pct=$(( (done * 100) / total ))
+        printf "  PROGRESS:   %d%%\n" "$pct"
+    fi
+}
+
+# Main dispatch
+command="${1:-}"
+shift || true
+
+case "$command" in
+    list) cmd_list "$@" ;;
+    transition) cmd_transition "$@" ;;
+    create-worktree) cmd_create_worktree "$@" ;;
+    cleanup-worktree) cmd_cleanup_worktree "$@" ;;
+    status) cmd_status "$@" ;;
+    *) usage ;;
+esac

--- a/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
+++ b/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
@@ -127,6 +127,15 @@ cmd_cleanup_worktree() {
     local branch_name="kitty/${feature}-${wp_id}"
 
     if [[ -d "$worktree_path" ]]; then
+        if [[ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]]; then
+            echo "WARNING: Worktree has uncommitted changes: $worktree_path"
+            echo -n "Force remove and discard changes? [y/N] "
+            read -r confirm
+            if [[ "$confirm" != [yY] ]]; then
+                echo "Skipping worktree removal."
+                return 0
+            fi
+        fi
         git worktree remove "$worktree_path" --force
         echo "Removed worktree: $worktree_path"
     else

--- a/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
+++ b/dev/spec-kitty/kittify/scripts/manage-workpackages.sh
@@ -22,6 +22,7 @@ Commands:
   create-worktree <feature> <WP_ID>     Create git worktree for a WP
   cleanup-worktree <feature> <WP_ID>    Remove worktree and optionally delete branch
   status <feature>                      Kanban summary (count per lane)
+  mark-task <feature> <TASK_ID>         Mark a task as done in WP files and tasks.md
 USAGE
     exit 1
 }
@@ -115,9 +116,36 @@ cmd_create_worktree() {
     fi
 
     mkdir -p "$WT_DIR"
-    git worktree add "$worktree_path" -b "$branch_name"
+
+    # Resolve a start-point for the new branch: prefer the feature as a ref,
+    # fall back to HEAD so the command still works when no matching ref exists.
+    local start_point="HEAD"
+    if git rev-parse --verify "$feature" &>/dev/null; then
+        start_point="$feature"
+    fi
+
+    if git rev-parse --verify "refs/heads/$branch_name" &>/dev/null; then
+        echo "Reusing existing branch: $branch_name"
+        git worktree add "$worktree_path" "$branch_name"
+    else
+        git worktree add "$worktree_path" -b "$branch_name" "$start_point"
+    fi
     echo "Created worktree at: $worktree_path"
     echo "Branch: $branch_name"
+
+    # Initialize submodules in worktree
+    if [[ -f "$worktree_path/.gitmodules" ]]; then
+        echo "Initializing git submodules..."
+        git -C "$worktree_path" submodule update --init
+    fi
+
+    # Install Python dependencies if uv is available and pyproject.toml exists
+    if command -v uv &>/dev/null && [[ -f "$worktree_path/pyproject.toml" ]]; then
+        echo "Installing Python dependencies..."
+        (cd "$worktree_path" && uv sync --all-groups 2>&1) || {
+            echo "WARNING: uv sync failed. You may need to install dependencies manually."
+        }
+    fi
 }
 
 cmd_cleanup_worktree() {
@@ -127,13 +155,28 @@ cmd_cleanup_worktree() {
     local branch_name="kitty/${feature}-${wp_id}"
 
     if [[ -d "$worktree_path" ]]; then
+        # Clean up generated artifacts that cause false "uncommitted changes" warnings
+        if [[ -d "$worktree_path/.venv" ]]; then
+            echo "Cleaning up .venv directory..."
+            rm -rf "$worktree_path/.venv"
+        fi
+        if [[ -f "$worktree_path/.gitmodules" ]]; then
+            echo "De-initializing submodules..."
+            git -C "$worktree_path" submodule deinit --all --force 2>/dev/null || true
+        fi
+
+        # Check for real uncommitted changes after cleanup
         if [[ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]]; then
             echo "WARNING: Worktree has uncommitted changes: $worktree_path"
-            echo -n "Force remove and discard changes? [y/N] "
-            read -r confirm
-            if [[ "$confirm" != [yY] ]]; then
-                echo "Skipping worktree removal."
-                return 0
+            if [[ -t 0 ]]; then
+                echo -n "Force remove and discard changes? [y/N] "
+                read -r confirm || confirm="N"
+                if [[ "$confirm" != [yY] ]]; then
+                    echo "Skipping worktree removal."
+                    return 0
+                fi
+            else
+                echo "Non-interactive mode: force removing worktree."
             fi
         fi
         git worktree remove "$worktree_path" --force
@@ -167,12 +210,13 @@ cmd_status() {
         local lane
         lane="$(get_lane "$wp_file")"
         case "$lane" in
-            planned) ((planned++)) ;;
-            doing) ((doing++)) ;;
-            for_review) ((for_review++)) ;;
-            done) ((done++)) ;;
+            planned) planned=$((planned + 1)) ;;
+            doing) doing=$((doing + 1)) ;;
+            for_review) for_review=$((for_review + 1)) ;;
+            done) done=$((done + 1)) ;;
+            *) planned=$((planned + 1)) ;;
         esac
-        ((total++))
+        total=$((total + 1))
     done
 
     echo "Feature: $feature"
@@ -189,6 +233,52 @@ cmd_status() {
     fi
 }
 
+cmd_mark_task() {
+    local feature="${1:?Feature name required}"
+    local task_id="${2:?Task ID required (e.g., T001)}"
+    local wp_dir
+    wp_dir="$(get_wp_dir "$feature")"
+
+    # Find the spec/tasks.md via common.sh if available
+    local repo_root="$REPO_ROOT"
+    local tasks_file=""
+
+    if type find_feature_dir_by_prefix &>/dev/null; then
+        local feature_dir
+        feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$feature")
+        if [[ -f "$feature_dir/tasks.md" ]]; then
+            tasks_file="$feature_dir/tasks.md"
+        fi
+    fi
+
+    local count=0
+
+    # Mark in all WP files that contain this task
+    for wp_file in "$wp_dir"/WP*.md; do
+        [[ -f "$wp_file" ]] || continue
+        if grep -q "\- \[ \] $task_id " "$wp_file"; then
+            local tmp_file
+            tmp_file="$(mktemp)"
+            sed "s/- \[ \] $task_id /- [x] $task_id /" "$wp_file" > "$tmp_file" && mv "$tmp_file" "$wp_file"
+            echo "Marked $task_id as done in $(basename "$wp_file")"
+            count=$((count + 1))
+        fi
+    done
+
+    # Mark in tasks.md if found
+    if [[ -n "$tasks_file" ]] && grep -q "\- \[ \] $task_id " "$tasks_file"; then
+        local tmp_file
+        tmp_file="$(mktemp)"
+        sed "s/- \[ \] $task_id /- [x] $task_id /" "$tasks_file" > "$tmp_file" && mv "$tmp_file" "$tasks_file"
+        echo "Marked $task_id as done in tasks.md"
+        count=$((count + 1))
+    fi
+
+    if [[ $count -eq 0 ]]; then
+        echo "WARNING: Task $task_id not found in any WP file or tasks.md"
+    fi
+}
+
 # Main dispatch
 command="${1:-}"
 shift || true
@@ -199,5 +289,6 @@ case "$command" in
     create-worktree) cmd_create_worktree "$@" ;;
     cleanup-worktree) cmd_cleanup_worktree "$@" ;;
     status) cmd_status "$@" ;;
+    mark-task) cmd_mark_task "$@" ;;
     *) usage ;;
 esac

--- a/dev/spec-kitty/kittify/templates/workpackage-template.md
+++ b/dev/spec-kitty/kittify/templates/workpackage-template.md
@@ -4,8 +4,8 @@ lane: planned
 feature: <branch-name>
 assigned_to: ""
 agent: ""
-acceptance_criteria: []
-activity_log: []
+acceptance_criteria:
+activity_log:
 ---
 
 # Work Package WP##: <title>

--- a/dev/spec-kitty/kittify/templates/workpackage-template.md
+++ b/dev/spec-kitty/kittify/templates/workpackage-template.md
@@ -1,0 +1,31 @@
+---
+id: WP##
+lane: planned
+feature: <branch-name>
+assigned_to: ""
+agent: ""
+acceptance_criteria: []
+activity_log: []
+---
+
+# Work Package WP##: <title>
+
+## Goal
+
+<one-line summary of what this WP delivers>
+
+## Tasks
+
+<tasks from tasks.md that belong to this WP, copied with their IDs>
+
+## Implementation Prompt
+
+<detailed prompt the agent uses to implement this WP>
+
+## Files To Modify
+
+<list of files this WP touches - used to detect conflicts between parallel WPs>
+
+## Dependencies
+
+<list of WP IDs that must be "done" before this WP can start>


### PR DESCRIPTION
# Why

The existing `spec-kit` tool handles specification and planning but lacks parallel work package execution with isolated environments. [spec-kitty](https://github.com/Priivacy-ai/spec-kitty) fills that gap.

**Goal:** Add `spec-kitty` as a complementary implementation layer that reads spec-kit artifacts and uses git worktrees for isolated, parallel WP execution.

**Non-goal:** This does not replace spec-kit. It reads `spec.md`, `plan.md`, `tasks.md` but never writes to them.

## What changed

- **New dev tooling** (`dev/spec-kitty/`): work package management via git worktrees, browser-based kanban dashboard, WP template
- **New Claude commands** (`dev/commands/kitty-spec.*.md`): implement, review, merge, dashboard — named `kitty-spec` to avoid collision with existing `speckit` commands
- **Updated spec-kit commands** (`.plan`, `.tasks`): now require reading `dev/knowledge/` docs before proceeding
- **Updated `AGENTS.md`**: added `dev/knowledge/` check to "Always Do"
- **Updated `.specify/` scripts**: relaxed branch naming regex to support longer numeric prefixes (e.g. `pmi-445-*`), added `SPECIFY_SKIP_BRANCH_CHECK` env var and fallback for non-standard branch names

**What stayed the same:** No backend, frontend, or SDK changes. spec-kit core workflow untouched.

### Suggested review order
1. `dev/spec-kitty/README.md` for overall design
2. `manage-workpackages.sh` for worktree lifecycle
3. `dashboard/` (server + static assets)
4. `dev/commands/kitty-spec.*.md` and updated `speckit.*.md`

## How to test

```bash
uv run ruff check dev/spec-kitty/                         # clean
```

- Launch dashboard via `kitty-spec.dashboard` and verify Diagnostics page renders all sections

## Impact & rollout

- **Backward compatibility:** No breaking changes — spec-kit workflows unaffected
- **Config/env changes:** New optional `SPECIFY_SKIP_BRANCH_CHECK` env var in `.specify/scripts/bash/common.sh`

## Checklist

- [x] Tests added/updated (N/A — dev tooling, no test infra)
- [ ] Changelog entry added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)