### PR TITLE
display number pool value from template in object creationform

### DIFF
--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.test.ts
@@ -578,6 +578,40 @@ describe("getFieldDefaultValue", () => {
       });
     });
 
+    it("returns pool value from template when field value is null and companion relationship has pool", () => {
+      // GIVEN
+      const fieldSchema = generateAttributeSchema({ name: "weight", kind: "Number" });
+      const objectTemplate: NodeObject = {
+        id: "template-id",
+        __typename: "FakeTemplate",
+        weight: {
+          value: null,
+        },
+        weight_from_resource_pool: {
+          node: {
+            id: "pool-id",
+            display_label: "My Number Pool",
+            __typename: "CoreNumberPool",
+          },
+        },
+      };
+
+      // WHEN
+      const defaultValue = getFieldDefaultValue({ fieldSchema, objectTemplate });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({
+        source: {
+          type: "pool",
+          fromTemplate: true,
+          id: "pool-id",
+          label: "pool-id",
+          kind: "CoreNumberPool",
+        },
+        value: { from_pool: { id: "pool-id" } },
+      });
+    });
+
     it("returns null when template field value is null and source is not a pool", () => {
       // GIVEN
       const fieldSchema = generateAttributeSchema({ name: "field1" });

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
@@ -224,6 +224,18 @@ export const getDefaultValueFromTemplate = (
         };
       }
     }
+
+    const poolFromRelationship = getDefaultValueFromPoolRelationship(
+      fieldName,
+      objectTemplate as Record<string, AttributeType>
+    );
+    if (poolFromRelationship) {
+      return {
+        ...poolFromRelationship,
+        source: { ...poolFromRelationship.source, fromTemplate: true },
+      };
+    }
+
     return null;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to validate default value resolution from form templates when companion relationship pools are available.

* **Bug Fixes**
  * Improved default value resolution with additional fallback logic for properly handling template-derived values sourced from pool relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->