### PR TITLE
Prepare for 1.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.7.7](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.7) - 2026-03-12
+
+### Fixed
+
+- Fixed display labels showing 'None' for relationship-based fields after upsert.
+  Relationship peer attributes needed by display label and HFID templates are now correctly loaded during node updates.
+  Includes a migration to correct objects that had their display labels and or human-friendly IDs improperly updated to include a null value. ([#8237](https://github.com/opsmill/infrahub/issues/8237))
+
 ## [Infrahub - v1.7.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.7.6) - 2026-02-24
 
 ### Fixed

--- a/changelog/8237.fixed.md
+++ b/changelog/8237.fixed.md
@@ -1,3 +1,0 @@
-Fixed display labels showing 'None' for relationship-based fields after upsert.
-Relationship peer attributes needed by display label and HFID templates are now correctly loaded during node updates.
-Includes a migration to correct objects that had their display labels and or human-friendly IDs improperly updated to include a null value.

--- a/docs/docs/release-notes/infrahub/release-1_7_7.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_7_7.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.7.7
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.7.7</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>March 12th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.7.7](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.7.7)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fixed display labels showing 'None' for relationship-based fields after upsert.
+  Relationship peer attributes needed by display label and HFID templates are now correctly loaded during node updates.
+  Includes a migration to correct objects that had their display labels and or human-friendly IDs improperly updated to include a null value.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -427,6 +427,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_7_7',
             'release-notes/infrahub/release-1_7_6',
             'release-notes/infrahub/release-1_7_5',
             'release-notes/infrahub/release-1_7_4',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.7.6"
+version = "1.7.7"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.14"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.7.6"
+version = "1.7.7"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.7.6"
+version = "1.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.7.6"
+version = "1.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

Preparation for Infrahub 1.7.7

## What changed

* Raise version number
* Update changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 1.7.7

* **Bug Fixes**
  * Fixed display labels incorrectly showing as 'None' for relationship-based fields after upsert
  * Fixed loading of relationship peer attributes during node updates
  * Corrected objects with improper null values in display labels or human-friendly IDs

* **Documentation**
  * Added release notes for v1.7.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->