### PR TITLE
Fix z-index issue when bottom of data table in at same height as toolbar

### DIFF
--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -81,14 +81,6 @@ export function DataTable<T extends NodeCore>({
 
   return (
     <div className="grid content-start" style={style} {...props}>
-      {selectedRows.length > 0 && (
-        <ObjectTableToolbar
-          selectedRows={selectedRows}
-          onClose={table.resetRowSelection}
-          renderMore={toolbarActions}
-        />
-      )}
-
       {allHeaders.map((header) => {
         return flexRender(header.column.columnDef.header, {
           ...header.getContext(),
@@ -126,6 +118,14 @@ export function DataTable<T extends NodeCore>({
             )}
           </div>
         ))}
+
+      {selectedRows.length > 0 && (
+        <ObjectTableToolbar
+          selectedRows={selectedRows}
+          onClose={table.resetRowSelection}
+          renderMore={toolbarActions}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
fix regression on toolbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the selection toolbar in data tables to appear below the table, after the count/footer row.
  * Enhances visual hierarchy and keeps actions adjacent to the selection summary for clearer context.
  * Improves usability on long tables by reducing scrolling between selection info and actions.
  * No functional changes: the toolbar still appears only when rows are selected, and existing actions and close behavior remain unchanged.
  * Layout order updated for a more consistent table experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->