### PR TITLE
IHS-114: Add diff data api endpoint

### DIFF
--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Request
+from fastapi.encoders import jsonable_encoder
 
 from infrahub.api.dependencies import get_branch_dep, get_current_user, get_db
 from infrahub.core import registry
@@ -14,6 +15,10 @@ from infrahub.core.diff.model.diff import (
     BranchDiffFile,
     BranchDiffRepository,
 )
+from infrahub.core.diff.model.path import EnrichedDiffRoot, TrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
@@ -65,6 +70,38 @@ async def get_diff_files(
             response[branch_name][repository_id].files.append(BranchDiffFile(**item.to_graphql()))
 
     return response
+
+
+@router.get("/data", response_model=None)
+async def get_diff_data(
+    db: InfrahubDatabase = Depends(get_db),
+    branch: Branch = Depends(get_branch_dep),
+    time_from: str | None = None,
+    time_to: str | None = None,
+    _: AccountSession = Depends(get_current_user),
+) -> list[EnrichedDiffRoot]:
+    base_branch = await registry.get_branch(db=db, branch=registry.default_branch)
+    diff_branch = await registry.get_branch(db=db, branch=branch)
+    component_registry = get_component_registry()
+    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+
+    from_time = Timestamp(time_from) if time_from else None
+    to_time = Timestamp(time_to) if time_to else None
+
+    enriched_diffs = await diff_repo.get(
+        base_branch_name=base_branch.name,
+        diff_branch_names=[branch.name],
+        from_time=from_time,
+        to_time=to_time,
+    )
+
+    return jsonable_encoder(  # type: ignore[return-value]
+        enriched_diffs,
+        custom_encoder={
+            Timestamp: lambda t: t.to_string(),
+            TrackingId: lambda t: t.serialize(),
+        },
+    )
 
 
 @router.get("/artifacts")

--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -81,9 +81,8 @@ async def get_diff_data(
     _: AccountSession = Depends(get_current_user),
 ) -> list[EnrichedDiffRoot]:
     base_branch = await registry.get_branch(db=db, branch=registry.default_branch)
-    diff_branch = await registry.get_branch(db=db, branch=branch)
     component_registry = get_component_registry()
-    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch)
 
     from_time = Timestamp(time_from) if time_from else None
     to_time = Timestamp(time_to) if time_to else None

--- a/backend/tests/integration_docker/api/test_diff.py
+++ b/backend/tests/integration_docker/api/test_diff.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClientSync
+
+
+class TestDiffAPI(TestInfrahubDockerClient):
+    def test_diff_data_api_endpoint(self, client_sync: InfrahubClientSync) -> None:
+        branch_name = "test-branch"
+        client_sync.branch.create(branch_name=branch_name)
+
+        result = client_sync.branch.diff_data(branch_name=branch_name)
+
+        assert isinstance(result, list)

--- a/changelog/+663ba42b.added.md
+++ b/changelog/+663ba42b.added.md
@@ -1,0 +1,1 @@
+Added diff data api endpoint

--- a/frontend/app/src/shared/api/rest/types.generated.ts
+++ b/frontend/app/src/shared/api/rest/types.generated.ts
@@ -106,6 +106,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/diff/data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Diff Data */
+        get: operations["get_diff_data_api_diff_data_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/diff/artifacts": {
         parameters: {
             query?: never;
@@ -2579,6 +2596,40 @@ export interface operations {
                             [key: string]: components["schemas"]["BranchDiffRepository"];
                         };
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_diff_data_api_diff_data_get: {
+        parameters: {
+            query?: {
+                time_from?: string | null;
+                time_to?: string | null;
+                /** @description Name of the branch to use for the query */
+                branch?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -367,6 +367,92 @@
                 }
             }
         },
+        "/api/diff/data": {
+            "get": {
+                "summary": "Get Diff Data",
+                "operationId": "get_diff_data_api_diff_data_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    },
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "time_from",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Time From"
+                        }
+                    },
+                    {
+                        "name": "time_to",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Time To"
+                        }
+                    },
+                    {
+                        "name": "branch",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Name of the branch to use for the query",
+                            "title": "Branch"
+                        },
+                        "description": "Name of the branch to use for the query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/diff/artifacts": {
             "get": {
                 "summary": "Get Diff Artifacts",


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

The Python SDK's `client.branch.diff_data()` called `GET /api/diff/data` but that endpoint did not exist, returning a 404. Additionally, the SDK's URL builder was missing a `?` separator before query parameters, producing malformed URLs like `/api/diff/databranch=test-branch&branch_only=true`.

Goal: make `client.branch.diff_data()` work end-to-end by implementing the missing REST endpoint and fixing the URL generation bug.

SDK PR https://github.com/opsmill/infrahub-sdk-python/pull/865

Closes https://github.com/opsmill/infrahub-sdk-python/issues/325

## What changed

- **New endpoint `GET /api/diff/data`** — returns the enriched data-level diff for a branch as a JSON array. Uses `DiffRepository` (the same backend used by the GraphQL diff tree query) and `jsonable_encoder` with custom encoders for `Timestamp` and `TrackingId` to produce a fully serializable response.
- **Integration test** — added `TestDiffAPI.test_diff_data_api_endpoint` in `tests/integration_docker/api/test_diff.py` to confirm the endpoint responds and returns a list.

No schema changes. No existing endpoint behavior changed. The `/api/diff/files` and `/api/diff/artifacts` endpoints are untouched.

## How to review

1. `backend/infrahub/api/diff/diff.py` — the new `get_diff_data` endpoint and its `jsonable_encoder` usage with `response_model=None`
2. `backend/tests/integration_docker/api/test_diff.py` — the integration test

The `response_model=None` on the endpoint decorator is intentional: `EnrichedDiffRoot` is a dataclass with non-Pydantic types (`Timestamp`, `TrackingId`), so FastAPI's automatic Pydantic serialization is bypassed in favour of explicit `jsonable_encoder` pre-processing.

## How to test

```bash
# Run the integration test
uv run pytest backend/tests/integration_docker/api/test_diff.py -v
```

Expected: `test_diff_data_api_endpoint` returns a list (empty `[]` for a branch with no changes).

## Impact & rollout

- **Backward compatibility:** additive only — new endpoint, no existing behaviour changed
- **Performance:** no impact on existing endpoints
- **Config/env changes:** none
- **Deployment notes:** safe to deploy

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve enriched diff data with optional branch and time-range query parameters.

* **Tests**
  * Added integration test coverage for the diff data API endpoint.

* **Documentation**
  * OpenAPI/schema and generated client types updated to include the new endpoint.
  * Changelog entry added documenting the new diff data API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->