### PR TITLE
IFC-2304: Runtime resolution of webhook custom headers

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -4,6 +4,8 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
+import os
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 
@@ -18,6 +20,8 @@ from infrahub.git.repository import InfrahubReadOnlyRepository, InfrahubReposito
 from infrahub.trigger.constants import NAME_SEPARATOR
 from infrahub.trigger.models import EventTrigger, ExecuteWorkflow, TriggerDefinition, TriggerType
 from infrahub.workflows.catalogue import WEBHOOK_PROCESS
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from httpx import Response
@@ -118,6 +122,20 @@ class WebhookHeader(BaseModel):
     value: str
     kind: Literal["static", "environment"]
 
+    def resolve(self) -> str | None:
+        """Resolve the header value based on its kind.
+
+        Returns None if the value cannot be resolved (e.g. missing environment variable).
+        """
+        if self.kind == "static":
+            return self.value
+
+        resolved = os.environ.get(self.value)
+        if resolved is None:
+            logger.warning("Environment variable '%s' not found, skipping header '%s'", self.value, self.key)
+            return None
+        return resolved
+
 
 class Webhook(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -140,8 +158,9 @@ class Webhook(BaseModel):
         }
 
         for header in self.custom_headers:
-            if header.kind == "static":
-                self._headers[header.key] = header.value
+            resolved = header.resolve()
+            if resolved is not None:
+                self._headers[header.key] = resolved
 
         if self.shared_key:
             message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -4,7 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
@@ -113,12 +113,19 @@ class EventContext(BaseModel):
         )
 
 
+class WebhookHeader(BaseModel):
+    key: str
+    value: str
+    kind: Literal["static", "environment"]
+
+
 class Webhook(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str = Field(...)
     url: str = Field(...)
     event_type: str = Field(...)
     validate_certificates: bool | None = Field(...)
+    custom_headers: list[WebhookHeader] = Field(default_factory=list)
     _payload: Any = None
     _headers: dict[str, Any] | None = None
     shared_key: str | None = Field(default=None, description="Shared key for signing the webhook requests")
@@ -131,6 +138,10 @@ class Webhook(BaseModel):
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
+
+        for header in self.custom_headers:
+            if header.kind == "static":
+                self._headers[header.key] = header.value
 
         if self.shared_key:
             message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"
@@ -184,25 +195,27 @@ class CustomWebhook(Webhook):
     """Custom webhook"""
 
     @classmethod
-    def from_object(cls, obj: CoreCustomWebhook) -> Self:
+    def from_object(cls, obj: CoreCustomWebhook, custom_headers: list[WebhookHeader] | None = None) -> Self:
         return cls(
             name=obj.name.value,
             url=obj.url.value,
             event_type=obj.event_type.value,
             validate_certificates=obj.validate_certificates.value or False,
             shared_key=obj.shared_key.value,
+            custom_headers=custom_headers or [],
         )
 
 
 class StandardWebhook(Webhook):
     @classmethod
-    def from_object(cls, obj: CoreStandardWebhook) -> Self:
+    def from_object(cls, obj: CoreStandardWebhook, custom_headers: list[WebhookHeader] | None = None) -> Self:
         return cls(
             name=obj.name.value,
             url=obj.url.value,
             event_type=obj.event_type.value,
             validate_certificates=obj.validate_certificates.value or False,
             shared_key=obj.shared_key.value,
+            custom_headers=custom_headers or [],
         )
 
 
@@ -238,7 +251,9 @@ class TransformWebhook(Webhook):
         )  # type: ignore[call-overload]
 
     @classmethod
-    def from_object(cls, obj: CoreCustomWebhook, transform: CoreTransformPython) -> Self:
+    def from_object(
+        cls, obj: CoreCustomWebhook, transform: CoreTransformPython, custom_headers: list[WebhookHeader] | None = None
+    ) -> Self:
         return cls(
             name=obj.name.value,
             url=obj.url.value,
@@ -253,4 +268,5 @@ class TransformWebhook(Webhook):
             transform_timeout=transform.timeout.value,
             convert_query_response=transform.convert_query_response.value or False,
             shared_key=obj.shared_key.value,
+            custom_headers=custom_headers or [],
         )

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -117,23 +117,26 @@ class EventContext(BaseModel):
         )
 
 
+class WebhookHeaderResolutionError(Exception):
+    pass
+
+
 class WebhookHeader(BaseModel):
     key: str
     value: str
     kind: Literal["static", "environment"]
 
-    def resolve(self) -> str | None:
+    def resolve(self) -> str:
         """Resolve the header value based on its kind.
 
-        Returns None if the value cannot be resolved (e.g. missing environment variable).
+        Raises WebhookHeaderResolutionError if the value cannot be resolved.
         """
         if self.kind == "static":
             return self.value
 
         resolved = os.environ.get(self.value)
         if resolved is None:
-            logger.warning("Environment variable '%s' not found, skipping header '%s'", self.value, self.key)
-            return None
+            raise WebhookHeaderResolutionError(f"Environment variable '{self.value}' not found")
         return resolved
 
 
@@ -158,9 +161,10 @@ class Webhook(BaseModel):
         }
 
         for header in self.custom_headers:
-            resolved = header.resolve()
-            if resolved is not None:
-                self._headers[header.key] = resolved
+            try:
+                self._headers[header.key] = header.resolve()
+            except WebhookHeaderResolutionError as exc:
+                logger.warning("Webhook '%s': %s, skipping header '%s'", self.name, exc, header.key)
 
         if self.shared_key:
             message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import ujson
 from infrahub_sdk import InfrahubClient  # noqa: TC002  needed for prefect flow
@@ -13,7 +13,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.workers.dependencies import get_cache, get_client, get_http
 from infrahub.workflows.utils import add_tags
 
-from ..models import CustomWebhook, EventContext, StandardWebhook, TransformWebhook, Webhook
+from ..models import CustomWebhook, EventContext, StandardWebhook, TransformWebhook, Webhook, WebhookHeader
 
 if TYPE_CHECKING:
     from httpx import Response
@@ -36,6 +36,25 @@ async def webhook_send(webhook: Webhook, context: EventContext, event_data: dict
     return response
 
 
+KIND_MAP: dict[str, Literal["static", "environment"]] = {
+    "CoreStaticKeyValue": "static",
+    "CoreEnvironmentVariableKeyValue": "environment",
+}
+
+
+def _extract_custom_headers(webhook_node: CoreWebhook) -> list[WebhookHeader]:
+    """Extract WebhookHeader list from a webhook node's headers relationship."""
+    if not hasattr(webhook_node, "headers"):
+        return []
+    headers: list[WebhookHeader] = []
+    for peer in webhook_node.headers.peers:
+        kind = KIND_MAP.get(peer.get_kind())
+        if kind is None:
+            continue
+        headers.append(WebhookHeader(key=peer.key.value, value=peer.value.value, kind=kind))
+    return headers
+
+
 @task(name="webhook-convert-node", task_run_name="Convert node to webhook", cache_policy=NONE)
 async def convert_node_to_webhook(webhook_node: CoreWebhook, client: InfrahubClient) -> Webhook:
     webhook_kind = webhook_node.get_kind()
@@ -43,8 +62,10 @@ async def convert_node_to_webhook(webhook_node: CoreWebhook, client: InfrahubCli
     if webhook_kind not in ["CoreStandardWebhook", "CoreCustomWebhook"]:
         raise ValueError(f"Unsupported webhook kind: {webhook_kind}")
 
+    custom_headers = _extract_custom_headers(webhook_node)
+
     if webhook_kind == "CoreStandardWebhook":
-        return StandardWebhook.from_object(obj=webhook_node)
+        return StandardWebhook.from_object(obj=webhook_node, custom_headers=custom_headers)
 
     # Processing Custom Webhook
     if webhook_node.transformation.id:
@@ -54,9 +75,9 @@ async def convert_node_to_webhook(webhook_node: CoreWebhook, client: InfrahubCli
             prefetch_relationships=True,
             include=["name", "class_name", "file_path", "repository"],
         )
-        return TransformWebhook.from_object(obj=webhook_node, transform=transform)
+        return TransformWebhook.from_object(obj=webhook_node, transform=transform, custom_headers=custom_headers)
 
-    return CustomWebhook.from_object(obj=webhook_node)
+    return CustomWebhook.from_object(obj=webhook_node, custom_headers=custom_headers)
 
 
 @flow(name="webhook-process", flow_run_name="Send webhook for {webhook_name}")
@@ -81,7 +102,7 @@ async def webhook_process(
     webhook_data_str = await cache.get(key=f"webhook:{webhook_id}")
     if not webhook_data_str:
         log.info(f"Webhook {webhook_id} not found in cache")
-        webhook_node = await client.get(kind=webhook_kind, id=webhook_id)
+        webhook_node = await client.get(kind=webhook_kind, id=webhook_id, prefetch_relationships=True)
         webhook = await convert_node_to_webhook(webhook_node=webhook_node, client=client)
         webhook_data = webhook.to_cache()
         await cache.set(key=f"webhook:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS)

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -38,7 +38,7 @@ async def webhook_send(webhook: Webhook, context: EventContext, event_data: dict
 
 KIND_MAP: dict[str, Literal["static", "environment"]] = {
     "CoreStaticKeyValue": "static",
-    "CoreEnvironmentVariableKeyValue": "environment",
+    "CoreEnvKeyValue": "environment",
 }
 
 

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -47,7 +47,8 @@ def _extract_custom_headers(webhook_node: CoreWebhook) -> list[WebhookHeader]:
     if not hasattr(webhook_node, "headers"):
         return []
     headers: list[WebhookHeader] = []
-    for peer in webhook_node.headers.peers:
+    for related in webhook_node.headers.peers:
+        peer = related.peer
         kind = KIND_MAP.get(peer.get_kind())
         if kind is None:
             continue

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -169,7 +169,7 @@ async def webhook_with_headers(db: InfrahubDatabase, initial_dataset: None, clie
     await static_header.new(db=db, name="x-custom-token", key="X-Custom-Token", value="secret123")
     await static_header.save(db=db)
 
-    env_header = await Node.init(schema=InfrahubKind.ENVIRONMENTVARIABLEKEYVALUE, db=db)
+    env_header = await Node.init(schema=InfrahubKind.ENVKEYVALUE, db=db)
     await env_header.new(db=db, name="x-env-key", key="X-Env-Key", value="MY_ENV_VAR")
     await env_header.save(db=db)
 

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -164,6 +164,31 @@ async def webhook4(db: InfrahubDatabase, initial_dataset: None, client: Infrahub
 
 
 @pytest.fixture(scope="class")
+async def webhook_with_headers(db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> Node:
+    static_header = await Node.init(schema=InfrahubKind.STATICKEYVALUE, db=db)
+    await static_header.new(db=db, name="x-custom-token", key="X-Custom-Token", value="secret123")
+    await static_header.save(db=db)
+
+    env_header = await Node.init(schema=InfrahubKind.ENVIRONMENTVARIABLEKEYVALUE, db=db)
+    await env_header.new(db=db, name="x-env-key", key="X-Env-Key", value="MY_ENV_VAR")
+    await env_header.save(db=db)
+
+    webhook = await Node.init(schema=InfrahubKind.STANDARDWEBHOOK, db=db)
+    await webhook.new(
+        db=db,
+        name="WebhookWithHeaders",
+        url="https://url.mock",
+        shared_key="1234567890",
+        validate_certificates=False,
+        event_type="infrahub.branch.created",
+        branch_scope="all_branches",
+        headers=[static_header, env_header],
+    )
+    await webhook.save(db=db)
+    return webhook
+
+
+@pytest.fixture(scope="class")
 async def inactive_webhook(db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> Node:
     webhook = await Node.init(schema=InfrahubKind.STANDARDWEBHOOK, db=db)
     await webhook.new(

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -38,6 +38,7 @@ class TestWebhookProcess(TestInfrahubApp):
             "event_type": "infrahub.branch.created",
             "validate_certificates": False,
             "shared_key": "1234567890",
+            "custom_headers": [],
             "webhook_type": "StandardWebhook",
         }
 
@@ -63,6 +64,7 @@ class TestWebhookProcess(TestInfrahubApp):
             "transform_timeout": 5,
             "url": "https://url.mock",
             "validate_certificates": False,
+            "custom_headers": [],
             "webhook_type": "TransformWebhook",
         }
 

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -42,6 +42,30 @@ class TestWebhookProcess(TestInfrahubApp):
             "webhook_type": "StandardWebhook",
         }
 
+    async def test_convert_node_to_webhook_with_headers(
+        self,
+        db: InfrahubDatabase,
+        webhook_with_headers: Node,
+        client: InfrahubClient,
+    ) -> None:
+        webhook = await client.get(
+            kind=InfrahubKind.STANDARDWEBHOOK, id=webhook_with_headers.id, prefetch_relationships=True
+        )
+        converted_webhook = await convert_node_to_webhook(webhook_node=webhook, client=client)
+
+        assert converted_webhook.model_dump() == {
+            "name": "WebhookWithHeaders",
+            "url": "https://url.mock",
+            "event_type": "infrahub.branch.created",
+            "validate_certificates": False,
+            "shared_key": "1234567890",
+            "custom_headers": [
+                {"key": "X-Custom-Token", "value": "secret123", "kind": "static"},
+                {"key": "X-Env-Key", "value": "MY_ENV_VAR", "kind": "environment"},
+            ],
+            "webhook_type": "StandardWebhook",
+        }
+
     async def test_convert_node_to_webhook_transform(
         self,
         db: InfrahubDatabase,

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -140,6 +140,7 @@ def test_assign_headers_skips_missing_environment_variable(caplog: pytest.LogCap
     assert webhook._headers["X-Source"] == "infrahub"
     assert "MISSING_VAR" in caplog.text
     assert "X-API-Key" in caplog.text
+    assert "test" in caplog.text  # webhook name included in warning
 
 
 def test_webhook_signature_with_payload() -> None:

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -1,4 +1,8 @@
+import logging
+from unittest.mock import patch
 from uuid import UUID
+
+import pytest
 
 from infrahub.core.timestamp import Timestamp
 from infrahub.webhook.models import CustomWebhook, StandardWebhook, WebhookHeader
@@ -39,18 +43,6 @@ def test_standard_webhook_header() -> None:
         "webhook-signature": "v1,BQN9AgPA4evuGDChi9VKxNKRwediIXsAQz8hVHMfKNg=",
         "webhook-timestamp": "1740656629",
     }
-
-
-def test_webhook_header_model() -> None:
-    """WebhookHeader creation and serialization."""
-    header = WebhookHeader(key="Authorization", value="Bearer token123", kind="static")
-    assert header.key == "Authorization"
-    assert header.value == "Bearer token123"
-    assert header.kind == "static"
-
-    dumped = header.model_dump()
-    assert dumped == {"key": "Authorization", "value": "Bearer token123", "kind": "static"}
-    assert WebhookHeader(**dumped) == header
 
 
 def test_assign_headers_with_static_custom_header() -> None:
@@ -107,6 +99,47 @@ def test_cache_roundtrip_preserves_custom_headers() -> None:
     assert len(restored.custom_headers) == 2
     assert restored.custom_headers[0].key == "X-Source"
     assert restored.custom_headers[0].kind == "static"
+
+
+def test_assign_headers_resolves_environment_variable() -> None:
+    """Environment variable header resolves from os.environ at send time."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[WebhookHeader(key="X-API-Key", value="MY_API_KEY", kind="environment")],
+    )
+
+    with patch.dict("os.environ", {"MY_API_KEY": "secret123"}):
+        webhook._assign_headers()
+
+    assert webhook._headers is not None
+    assert webhook._headers["X-API-Key"] == "secret123"
+    assert webhook._headers["Accept"] == "application/json"
+
+
+def test_assign_headers_skips_missing_environment_variable(caplog: pytest.LogCaptureFixture) -> None:
+    """Missing environment variable is skipped with a warning, no exception raised."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[
+            WebhookHeader(key="X-API-Key", value="MISSING_VAR", kind="environment"),
+            WebhookHeader(key="X-Source", value="infrahub", kind="static"),
+        ],
+    )
+
+    with patch.dict("os.environ", {}, clear=True), caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
+        webhook._assign_headers()
+
+    assert webhook._headers is not None
+    assert "X-API-Key" not in webhook._headers
+    assert webhook._headers["X-Source"] == "infrahub"
+    assert "MISSING_VAR" in caplog.text
+    assert "X-API-Key" in caplog.text
 
 
 def test_webhook_signature_with_payload() -> None:

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from infrahub.core.timestamp import Timestamp
-from infrahub.webhook.models import StandardWebhook
+from infrahub.webhook.models import CustomWebhook, StandardWebhook, WebhookHeader
 
 
 def test_standard_webhook() -> None:
@@ -15,6 +15,7 @@ def test_standard_webhook() -> None:
         "url": "http://test.com",
         "event_type": "test",
         "validate_certificates": True,
+        "custom_headers": [],
         "shared_key": "test",
         "webhook_type": "StandardWebhook",
     }
@@ -38,6 +39,74 @@ def test_standard_webhook_header() -> None:
         "webhook-signature": "v1,BQN9AgPA4evuGDChi9VKxNKRwediIXsAQz8hVHMfKNg=",
         "webhook-timestamp": "1740656629",
     }
+
+
+def test_webhook_header_model() -> None:
+    """WebhookHeader creation and serialization."""
+    header = WebhookHeader(key="Authorization", value="Bearer token123", kind="static")
+    assert header.key == "Authorization"
+    assert header.value == "Bearer token123"
+    assert header.kind == "static"
+
+    dumped = header.model_dump()
+    assert dumped == {"key": "Authorization", "value": "Bearer token123", "kind": "static"}
+    assert WebhookHeader(**dumped) == header
+
+
+def test_assign_headers_with_static_custom_header() -> None:
+    """_assign_headers() with static custom header."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[WebhookHeader(key="Authorization", value="Bearer token", kind="static")],
+    )
+    webhook._assign_headers()
+
+    assert webhook._headers is not None
+    assert webhook._headers["Authorization"] == "Bearer token"
+    assert webhook._headers["Accept"] == "application/json"
+    assert webhook._headers["Content-Type"] == "application/json"
+
+
+def test_custom_header_overrides_default() -> None:
+    """Custom header overrides default header."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[WebhookHeader(key="Content-Type", value="text/plain", kind="static")],
+    )
+    webhook._assign_headers()
+
+    assert webhook._headers is not None
+    assert webhook._headers["Content-Type"] == "text/plain"
+
+
+def test_cache_roundtrip_preserves_custom_headers() -> None:
+    """to_cache()/from_cache() roundtrip preserves custom_headers."""
+    headers = [
+        WebhookHeader(key="X-Source", value="infrahub", kind="static"),
+        WebhookHeader(key="Y-Source", value="opsmill", kind="static"),
+    ]
+    webhook = StandardWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        shared_key="key123",
+        custom_headers=headers,
+    )
+
+    cache_data = webhook.to_cache()
+    restored = StandardWebhook.from_cache(cache_data)
+
+    assert restored.custom_headers == headers
+    assert len(restored.custom_headers) == 2
+    assert restored.custom_headers[0].key == "X-Source"
+    assert restored.custom_headers[0].kind == "static"
 
 
 def test_webhook_signature_with_payload() -> None:

--- a/backend/tests/unit/webhook/test_webhook_header.py
+++ b/backend/tests/unit/webhook/test_webhook_header.py
@@ -1,9 +1,8 @@
-import logging
 from unittest.mock import patch
 
 import pytest
 
-from infrahub.webhook.models import WebhookHeader
+from infrahub.webhook.models import WebhookHeader, WebhookHeaderResolutionError
 
 
 def test_webhook_header_model() -> None:
@@ -29,11 +28,7 @@ def test_webhook_header_resolve_environment() -> None:
         assert header.resolve() == "secret123"
 
 
-def test_webhook_header_resolve_missing_environment(caplog: pytest.LogCaptureFixture) -> None:
+def test_webhook_header_resolve_missing_environment() -> None:
     header = WebhookHeader(key="X-API-Key", value="MISSING_VAR", kind="environment")
-    with patch.dict("os.environ", {}, clear=True), caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
-        result = header.resolve()
-
-    assert result is None
-    assert "MISSING_VAR" in caplog.text
-    assert "X-API-Key" in caplog.text
+    with patch.dict("os.environ", {}, clear=True), pytest.raises(WebhookHeaderResolutionError, match="MISSING_VAR"):
+        header.resolve()

--- a/backend/tests/unit/webhook/test_webhook_header.py
+++ b/backend/tests/unit/webhook/test_webhook_header.py
@@ -1,0 +1,39 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from infrahub.webhook.models import WebhookHeader
+
+
+def test_webhook_header_model() -> None:
+    """WebhookHeader creation and serialization."""
+    header = WebhookHeader(key="Authorization", value="Bearer token123", kind="static")
+    assert header.key == "Authorization"
+    assert header.value == "Bearer token123"
+    assert header.kind == "static"
+
+    dumped = header.model_dump()
+    assert dumped == {"key": "Authorization", "value": "Bearer token123", "kind": "static"}
+    assert WebhookHeader(**dumped) == header
+
+
+def test_webhook_header_resolve_static() -> None:
+    header = WebhookHeader(key="Authorization", value="Bearer token", kind="static")
+    assert header.resolve() == "Bearer token"
+
+
+def test_webhook_header_resolve_environment() -> None:
+    header = WebhookHeader(key="X-API-Key", value="MY_API_KEY", kind="environment")
+    with patch.dict("os.environ", {"MY_API_KEY": "secret123"}):
+        assert header.resolve() == "secret123"
+
+
+def test_webhook_header_resolve_missing_environment(caplog: pytest.LogCaptureFixture) -> None:
+    header = WebhookHeader(key="X-API-Key", value="MISSING_VAR", kind="environment")
+    with patch.dict("os.environ", {}, clear=True), caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
+        result = header.resolve()
+
+    assert result is None
+    assert "MISSING_VAR" in caplog.text
+    assert "X-API-Key" in caplog.text


### PR DESCRIPTION
# Why

Webhook custom headers defined via `CoreKeyValue` schema entities (from [IFC-2303](#8590)) need to be resolved at send time. Static headers pass their value through directly, while environment variable headers must read from `os.environ` on the worker at dispatch time. Without this, the schema-level header definitions have no runtime effect.

Closes [IFC-2304]

## What changed

- **Header resolution at send time**: Static headers are passed through as-is; environment variable headers are resolved from `os.environ` on the worker when the webhook fires. Missing env vars are logged as warnings and skipped (no crash).
- **Custom headers override defaults**: Headers defined on a webhook can override built-in defaults like `Content-Type`, giving full control over the HTTP request.
- **Headers extracted from schema relationships**: When a webhook is loaded (from DB or cache), its `CoreKeyValue` peers are mapped to a lightweight runtime model that carries through the send pipeline.
- **Cache-aware**: Custom headers survive the `to_cache()`/`from_cache()` roundtrip so cached webhooks retain their header configuration.

## How to review

1. Start with `backend/infrahub/webhook/models.py` — the `WebhookHeader` model and changes to `_assign_headers()`
2. Then `backend/infrahub/webhook/tasks/process.py` — the extraction logic and plumbing into `convert_node_to_webhook`
3. Finally the tests in `backend/tests/unit/webhook/`

## How to test

```bash
uv run pytest backend/tests/unit/webhook/
```

## Impact & rollout

- **Deployment notes:** Requires the schema PR ([#8590]) to be merged first. Environment variables referenced by `CoreEnvironmentVariableKeyValue` headers must be set on the worker environment.

## Checklist

- [x] Tests added/updated
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)

[IFC-2304]: https://opsmill.atlassian.net/browse/IFC-2304
[#8590]: https://github.com/opsmill/infrahub/pull/8590

[IFC-2303]: https://opsmill.atlassian.net/browse/IFC-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ