### PR TITLE
allow removing properties from attributes in merge logic

### DIFF
--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -225,8 +225,13 @@ class DiffMergeSerializer:
                 property_diff=property_diff, python_value_type=python_type
             )
             for action, value in actions_and_values:
-                # we only delete attributes when the whole attribute is deleted
-                if action is DiffAction.REMOVED and attribute_diff.action is not DiffAction.REMOVED:
+                # we only delete attribute values when the whole attribute is deleted,
+                # but other properties can be removed independently
+                if (
+                    action is DiffAction.REMOVED
+                    and attribute_diff.action is not DiffAction.REMOVED
+                    and property_diff.property_type is DatabaseEdgeType.HAS_VALUE
+                ):
                     continue
                 prop_dicts.append(
                     PropertyMergeDict(

--- a/backend/tests/component/core/diff/test_diff_and_merge.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge.py
@@ -666,6 +666,160 @@ class TestDiffAndMerge:
 
         await verify_no_duplicate_paths(db=db)
 
+    @pytest.mark.parametrize("new_property,expected_action", [(True, DiffAction.UPDATED), (False, DiffAction.REMOVED)])
+    async def test_single_property_update(
+        self,
+        db: InfrahubDatabase,
+        diff_repository: DiffRepository,
+        default_branch: Branch,
+        person_john_main: Node,
+        person_jane_main: Node,
+        person_alfred_main: Node,
+        car_camry_main: Node,
+        new_property: bool,
+        expected_action: DiffAction,
+    ) -> None:
+        # Capture initial metadata before any changes
+        person_before = await NodeManager.get_one(
+            db=db, id=person_jane_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        person_before.get_attribute("height").source = person_john_main
+        await person_before.save(db=db)
+        person_created_at = person_before._get_created_at()
+        person_created_by = person_before._get_created_by()
+
+        car_before = await NodeManager.get_one(
+            db=db, id=car_camry_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS
+        )
+        owner_rel_manager = car_before.get_relationship("owner")
+        owner_rel = (await owner_rel_manager.get_relationships(db=db))[0]
+        owner_rel.source = person_john_main
+        before_car_source_update = Timestamp()
+        await car_before.save(db=db)
+        after_car_source_update = Timestamp()
+        car_created_at = car_before._get_created_at()
+        car_created_by = car_before._get_created_by()
+
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        person_branch = await NodeManager.get_one(db=db, branch=branch2, id=person_jane_main.id)
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
+        owner_rel_manager = car_branch.get_relationship("owner")
+        owner_rel = (await owner_rel_manager.get_relationships(db=db))[0]
+
+        if new_property:
+            person_branch.get_attribute("height").source = person_alfred_main
+            owner_rel.source = person_alfred_main
+        else:
+            person_branch.get_attribute("height").clear_source()
+            owner_rel.clear_source()
+        await person_branch.save(db=db, user_id="branch-user")
+        await car_branch.save(db=db, user_id="branch-user-2")
+
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch2
+        )
+        enriched_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
+        )
+
+        person_node = get_one_diff_node(diff_root=enriched_diff, node_uuid=person_jane_main.id)
+        assert person_node.action is DiffAction.UPDATED
+        car_node = get_one_diff_node(diff_root=enriched_diff, node_uuid=car_camry_main.id)
+        assert car_node.action is DiffAction.UPDATED
+
+        diff_merger = await self._get_diff_merger(db=db, branch=branch2)
+        at = Timestamp()
+        await diff_merger.merge_graph(at=at)
+
+        updated_person = await NodeManager.get_one(
+            db=db,
+            id=person_jane_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS | MetadataOptions.LINKED_NODES,
+        )
+        assert updated_person.get_attribute("height").value == person_jane_main.get_attribute("height").value
+        if new_property:
+            assert updated_person.get_attribute("height").source_id == person_alfred_main.id
+        else:
+            assert updated_person.get_attribute("height").source_id is None
+
+        updated_car = await NodeManager.get_one(
+            db=db,
+            id=car_camry_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS | MetadataOptions.LINKED_NODES,
+        )
+        # Fetch relationship via lazy get_relationships to include source/owner metadata
+        # (prefetch_relationships does not populate LINKED_NODES on relationships)
+        owner_rel_manager = updated_car.get_relationship("owner")
+        owner_rel = (await owner_rel_manager.get_relationships(db=db))[0]
+        assert owner_rel.peer_id == person_jane_main.id
+        if new_property:
+            assert owner_rel.source_id == person_alfred_main.id
+        else:
+            assert owner_rel.source_id is None
+
+        # Validate person node metadata
+        assert updated_person._get_created_at() == person_created_at
+        assert updated_person._get_created_by() == person_created_by
+        assert updated_person._get_updated_at() == at
+
+        # Validate the height attribute metadata
+        height_attr = updated_person.get_attribute("height")
+        assert height_attr._get_created_at() == person_created_at
+        assert height_attr._get_created_by() == person_created_by
+        assert height_attr._get_updated_at() == at
+        assert height_attr._get_updated_by() == "branch-user"
+
+        # Validate other attributes were NOT updated (name attribute)
+        name_attr = updated_person.get_attribute("name")
+        assert name_attr._get_created_at() == person_created_at
+        assert name_attr._get_created_by() == person_created_by
+        assert name_attr._get_updated_at() == person_created_at
+        assert name_attr._get_updated_by() == person_created_by
+
+        # Validate car node metadata
+        assert updated_car._get_created_at() == car_created_at
+        assert updated_car._get_created_by() == car_created_by
+        assert updated_car._get_updated_at() == at
+        assert updated_car._get_updated_by() == "branch-user-2"
+
+        # Validate relationship metadata (requires prefetch_relationships for timestamps)
+        updated_car_with_rels = await NodeManager.get_one(
+            db=db, id=car_camry_main.id, include_metadata=MetadataOptions.USER_TIMESTAMPS, prefetch_relationships=True
+        )
+        owner_rel_with_meta = await updated_car_with_rels.get_relationship("owner").get(db=db)
+        assert owner_rel_with_meta._get_updated_at() == at
+        assert owner_rel_with_meta._get_updated_by() == "branch-user-2"
+
+        await verify_no_duplicate_paths(db=db)
+
+        # Rollback verification
+        await diff_merger.rollback(at=at)
+
+        rolled_back_person = await NodeManager.get_one(
+            db=db,
+            id=person_jane_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS | MetadataOptions.LINKED_NODES,
+        )
+        assert rolled_back_person.get_attribute("height").source_id == person_john_main.id
+        # Node metadata should be restored to pre-merge state
+        assert rolled_back_person._get_created_at() == person_created_at
+        assert rolled_back_person._get_created_by() == person_created_by
+
+        rolled_back_car = await NodeManager.get_one(
+            db=db,
+            id=car_camry_main.id,
+            include_metadata=MetadataOptions.USER_TIMESTAMPS | MetadataOptions.LINKED_NODES,
+        )
+        rolled_back_owner_rel_manager = rolled_back_car.get_relationship("owner")
+        rolled_back_owner_rel = (await rolled_back_owner_rel_manager.get_relationships(db=db))[0]
+        assert rolled_back_owner_rel.source_id == person_john_main.id
+        # Car metadata should be restored to when the source was updated on main
+        assert before_car_source_update < rolled_back_car._get_updated_at() < after_car_source_update
+        assert rolled_back_car._get_updated_by() == car_created_by
+
+        await verify_no_duplicate_paths(db=db)
+
     async def test_one_many_relationship_added(
         self,
         db: InfrahubDatabase,

--- a/backend/tests/component/core/diff/test_diff_calculator.py
+++ b/backend/tests/component/core/diff/test_diff_calculator.py
@@ -4528,3 +4528,71 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
         rel_diff = person_diff.relationships[0]
         assert rel_diff.name == "cars"
         assert rel_diff.action is DiffAction.UPDATED
+
+
+@pytest.mark.parametrize("new_source,expected_action", [(True, DiffAction.UPDATED), (False, DiffAction.REMOVED)])
+async def test_diff_attribute_single_source_property_change(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_john_main,
+    person_alfred_main,
+    person_jane_main,
+    new_source: bool,
+    expected_action: DiffAction,
+) -> None:
+    """Test that updating or removing a HAS_SOURCE property from an attribute on a branch is captured in the diff."""
+    # Set a source on john's name attribute on main
+    john_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
+    john_main.name.source = person_alfred_main
+    await john_main.save(db=db)
+
+    # Create a branch after the source is set
+    branch = await create_branch(db=db, branch_name="branch")
+    from_time = Timestamp(branch.created_at)
+
+    # On the branch, update or clear the source from the name attribute
+    john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+    if new_source:
+        john_branch.name.source = person_jane_main
+    else:
+        john_branch.name.clear_source()
+    await john_branch.save(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+        include_unchanged=False,
+    )
+
+    # No changes on main
+    base_root_path = calculated_diffs.base_branch_diff
+    assert base_root_path.nodes == []
+
+    # Branch should show the source change
+    branch_root_path = calculated_diffs.diff_branch_diff
+    assert branch_root_path.branch == branch.name
+    assert len(branch_root_path.nodes) == 1
+    node_diff = branch_root_path.nodes[0]
+    assert node_diff.uuid == person_john_main.id
+    assert node_diff.kind == "TestPerson"
+    assert node_diff.action is DiffAction.UPDATED
+
+    # Find the name attribute diff
+    attrs_by_name = {a.name: a for a in node_diff.attributes}
+    assert "name" in attrs_by_name
+    name_attr_diff = attrs_by_name["name"]
+    assert name_attr_diff.action is DiffAction.UPDATED
+
+    # Verify that the HAS_SOURCE property change is included
+    props_by_type = {p.property_type: p for p in name_attr_diff.properties}
+    assert DatabaseEdgeType.HAS_SOURCE in props_by_type
+    source_prop = props_by_type[DatabaseEdgeType.HAS_SOURCE]
+    assert source_prop.action is expected_action
+    assert source_prop.previous_value == person_alfred_main.get_id()
+    if new_source:
+        assert source_prop.new_value == person_jane_main.get_id()
+    else:
+        assert source_prop.new_value is None

--- a/changelog/8583.fixed
+++ b/changelog/8583.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect merge behavior where removing the source property from an attribute was silently ignored during branch merge.


### PR DESCRIPTION
fixes #8583 

the logic that serializes a diff and passes it to a cypher query during a merge was excluding removed properties of attributes if the attribute was not completely removed. for example, if the source of an attribute is deleted on a branch (like if the attribute stops using a profile), then this change would not make it back to the default branch during a merge

fix is a small change to make sure we send the property removals on to the merge query

adds two component tests covering this situation
- one ensures that the diff is correctly including the removed properties when calculated, which it already was
- one ensures that the removed source is merged into the default branch during a merge, which it was not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of property removals during branch diffs/merges so value-type property removals are suppressed unless the whole attribute is removed.

* **Tests**
  * Added coverage for single-property updates (with and without source propagation) in diff/merge flows.
  * Added tests for source-property changes in diff calculations to validate updated/removed actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->