### PR TITLE
IFC-2337: Invalidate webhook cache on reconcile_all

### DIFF
--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -79,6 +79,15 @@ class TriggerSetupReport(BaseModel):
         unchanged = self._unchanged_triggers_with_type(trigger_type=trigger_type)
         return created + updated + refreshed + unchanged
 
+    def prefect_updated_triggers_with_type(self, trigger_type: type[T]) -> list[T]:
+        """Return pre-existing triggers that were updated in Prefect.
+
+        This corresponds to TriggerComparison.update_prefect (REFRESH + UPDATE).
+        """
+        updated = self._updated_triggers_with_type(trigger_type=trigger_type)
+        refreshed = self._refreshed_triggers_with_type(trigger_type=trigger_type)
+        return updated + refreshed
+
     def modified_triggers_with_type(self, trigger_type: type[T]) -> list[T]:
         """Return all created and updated triggers that match the specified type.
 

--- a/backend/infrahub/webhook/constants.py
+++ b/backend/infrahub/webhook/constants.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
 
+CACHE_KEY_PREFIX = "webhook"
+
 
 class WebhookAction(StrEnum):
     CONFIGURE = "configure"

--- a/backend/infrahub/webhook/tasks/cache.py
+++ b/backend/infrahub/webhook/tasks/cache.py
@@ -22,14 +22,3 @@ async def invalidate_webhook_cache(webhook_ids: AbstractSet[str]) -> None:
     for wid in webhook_ids:
         await cache.delete(key=f"{CACHE_KEY_PREFIX}:{wid}")
     log.info(f"Invalidated cache for {len(webhook_ids)} webhook(s)")
-
-
-@task(name="webhook-invalidate-all-caches", task_run_name="Invalidate all webhook caches", cache_policy=NONE)
-async def invalidate_all_webhook_caches() -> None:
-    """Delete all cached webhook data."""
-    cache = await get_cache()
-    log = get_run_logger()
-    keys = await cache.list_keys(f"{CACHE_KEY_PREFIX}:*")
-    for key in keys:
-        await cache.delete(key=key)
-    log.info(f"Invalidated {len(keys)} webhook cache entries")

--- a/backend/infrahub/webhook/tasks/cache.py
+++ b/backend/infrahub/webhook/tasks/cache.py
@@ -8,6 +8,8 @@ from prefect.logging import get_run_logger
 
 from infrahub.workers.dependencies import get_cache
 
+from ..constants import CACHE_KEY_PREFIX
+
 if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
 
@@ -18,5 +20,5 @@ async def invalidate_webhook_cache(webhook_ids: AbstractSet[str]) -> None:
     cache = await get_cache()
     log = get_run_logger()
     for wid in webhook_ids:
-        await cache.delete(key=f"webhook:{wid}")
+        await cache.delete(key=f"{CACHE_KEY_PREFIX}:{wid}")
     log.info(f"Invalidated cache for {len(webhook_ids)} webhook(s)")

--- a/backend/infrahub/webhook/tasks/cache.py
+++ b/backend/infrahub/webhook/tasks/cache.py
@@ -22,3 +22,14 @@ async def invalidate_webhook_cache(webhook_ids: AbstractSet[str]) -> None:
     for wid in webhook_ids:
         await cache.delete(key=f"{CACHE_KEY_PREFIX}:{wid}")
     log.info(f"Invalidated cache for {len(webhook_ids)} webhook(s)")
+
+
+@task(name="webhook-invalidate-all-caches", task_run_name="Invalidate all webhook caches", cache_policy=NONE)
+async def invalidate_all_webhook_caches() -> None:
+    """Delete all cached webhook data."""
+    cache = await get_cache()
+    log = get_run_logger()
+    keys = await cache.list_keys(f"{CACHE_KEY_PREFIX}:*")
+    for key in keys:
+        await cache.delete(key=key)
+    log.info(f"Invalidated {len(keys)} webhook cache entries")

--- a/backend/infrahub/webhook/tasks/configure.py
+++ b/backend/infrahub/webhook/tasks/configure.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Set as AbstractSet
 
 from infrahub_sdk.protocols import CoreWebhook
 from prefect import flow
@@ -10,6 +10,7 @@ from prefect.client.orchestration import get_client as get_prefect_client
 from prefect.logging import get_run_logger
 from prefect.runtime import flow_run
 
+from infrahub.trigger.constants import NAME_SEPARATOR
 from infrahub.trigger.models import ExecuteWorkflow, TriggerType
 from infrahub.trigger.setup import gather_all_automations, setup_triggers_specific
 from infrahub.workers.dependencies import get_client, get_database
@@ -17,7 +18,7 @@ from infrahub.workers.dependencies import get_client, get_database
 from ..constants import EVENT_TO_ACTION, WebhookAction
 from ..gather import gather_trigger_webhook
 from ..models import WebhookTriggerDefinition
-from .cache import invalidate_all_webhook_caches, invalidate_webhook_cache
+from .cache import invalidate_webhook_cache
 
 if TYPE_CHECKING:
     from prefect import Flow, State
@@ -188,9 +189,20 @@ async def _reconcile_all() -> None:
     log = get_run_logger()
 
     database = await get_database()
-    async with database.start_session(read_only=True) as db:
-        triggers = await gather_trigger_webhook(db=db)
+    trigger_setup_report = await setup_triggers_specific(
+        gatherer=gather_trigger_webhook, db=database, trigger_type=TriggerType.WEBHOOK
+    )
 
-    await setup_triggers_specific(gatherer=gather_trigger_webhook, db=database, trigger_type=TriggerType.WEBHOOK)  # type: ignore[arg-type]
-    await invalidate_all_webhook_caches()
-    log.info(f"{len(triggers)} Webhooks automation configuration completed")
+    webhook_ids_to_invalidate: AbstractSet[str] = set()
+    webhook_ids_to_invalidate.update(
+        trigger.id for trigger in trigger_setup_report.prefect_updated_triggers_with_type(WebhookTriggerDefinition)
+    )
+    for automation in trigger_setup_report.deleted:
+        parts = automation.name.split(NAME_SEPARATOR)
+        if len(parts) >= 2:
+            webhook_ids_to_invalidate.add(parts[-1])
+
+    if webhook_ids_to_invalidate:
+        await invalidate_webhook_cache(webhook_ids=webhook_ids_to_invalidate)
+
+    log.info(f"{trigger_setup_report.in_use_count} Webhooks automation configuration completed")

--- a/backend/infrahub/webhook/tasks/configure.py
+++ b/backend/infrahub/webhook/tasks/configure.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Set as AbstractSet
+from typing import TYPE_CHECKING
 
 from infrahub_sdk.protocols import CoreWebhook
 from prefect import flow
@@ -11,7 +11,7 @@ from prefect.logging import get_run_logger
 from prefect.runtime import flow_run
 
 from infrahub.trigger.constants import NAME_SEPARATOR
-from infrahub.trigger.models import ExecuteWorkflow, TriggerType
+from infrahub.trigger.models import ExecuteWorkflow, TriggerSetupReport, TriggerType
 from infrahub.trigger.setup import gather_all_automations, setup_triggers_specific
 from infrahub.workers.dependencies import get_client, get_database
 
@@ -190,10 +190,21 @@ async def _reconcile_all() -> None:
 
     database = await get_database()
     trigger_setup_report = await setup_triggers_specific(
-        gatherer=gather_trigger_webhook, db=database, trigger_type=TriggerType.WEBHOOK
+        gatherer=gather_trigger_webhook,  # type: ignore[arg-type]
+        db=database,
+        trigger_type=TriggerType.WEBHOOK,
     )
 
-    webhook_ids_to_invalidate: AbstractSet[str] = set()
+    webhook_ids_to_invalidate = await get_webhooks_to_invalidate(trigger_setup_report)
+
+    if webhook_ids_to_invalidate:
+        await invalidate_webhook_cache(webhook_ids=webhook_ids_to_invalidate)
+
+    log.info(f"{trigger_setup_report.in_use_count} Webhooks automation configuration completed")
+
+
+async def get_webhooks_to_invalidate(trigger_setup_report: TriggerSetupReport) -> set[str]:
+    webhook_ids_to_invalidate: set[str] = set()
     webhook_ids_to_invalidate.update(
         trigger.id for trigger in trigger_setup_report.prefect_updated_triggers_with_type(WebhookTriggerDefinition)
     )
@@ -201,8 +212,4 @@ async def _reconcile_all() -> None:
         parts = automation.name.split(NAME_SEPARATOR)
         if len(parts) >= 2:
             webhook_ids_to_invalidate.add(parts[-1])
-
-    if webhook_ids_to_invalidate:
-        await invalidate_webhook_cache(webhook_ids=webhook_ids_to_invalidate)
-
-    log.info(f"{trigger_setup_report.in_use_count} Webhooks automation configuration completed")
+    return webhook_ids_to_invalidate

--- a/backend/infrahub/webhook/tasks/configure.py
+++ b/backend/infrahub/webhook/tasks/configure.py
@@ -17,7 +17,7 @@ from infrahub.workers.dependencies import get_client, get_database
 from ..constants import EVENT_TO_ACTION, WebhookAction
 from ..gather import gather_trigger_webhook
 from ..models import WebhookTriggerDefinition
-from .cache import invalidate_webhook_cache
+from .cache import invalidate_all_webhook_caches, invalidate_webhook_cache
 
 if TYPE_CHECKING:
     from prefect import Flow, State
@@ -192,4 +192,5 @@ async def _reconcile_all() -> None:
         triggers = await gather_trigger_webhook(db=db)
 
     await setup_triggers_specific(gatherer=gather_trigger_webhook, db=database, trigger_type=TriggerType.WEBHOOK)  # type: ignore[arg-type]
+    await invalidate_all_webhook_caches()
     log.info(f"{len(triggers)} Webhooks automation configuration completed")

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -14,6 +14,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.workers.dependencies import get_cache, get_client, get_http
 from infrahub.workflows.utils import add_tags
 
+from ..constants import CACHE_KEY_PREFIX
 from ..models import CustomWebhook, EventContext, HeaderKind, StandardWebhook, TransformWebhook, Webhook, WebhookHeader
 
 if TYPE_CHECKING:
@@ -101,13 +102,15 @@ async def webhook_process(
     if branch_name:
         await add_tags(branches=[branch_name])
 
-    webhook_data_str = await cache.get(key=f"webhook:{webhook_id}")
+    webhook_data_str = await cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook_id}")
     if not webhook_data_str:
         log.info(f"Webhook {webhook_id} not found in cache")
         webhook_node = await client.get(kind=webhook_kind, id=webhook_id, prefetch_relationships=True)
         webhook = await convert_node_to_webhook(webhook_node=webhook_node, client=client)
         webhook_data = webhook.to_cache()
-        await cache.set(key=f"webhook:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS)
+        await cache.set(
+            key=f"{CACHE_KEY_PREFIX}:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS
+        )
 
     else:
         webhook_data = ujson.loads(webhook_data_str)

--- a/backend/tests/component/webhook/test_invalidate.py
+++ b/backend/tests/component/webhook/test_invalidate.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.webhook.constants import CACHE_KEY_PREFIX
 from infrahub.webhook.tasks.invalidate import invalidate_webhook_headers
 from tests.adapters.cache import MemoryCache
 
@@ -66,12 +67,12 @@ class TestCacheInvalidationFlow:
         webhook = await _create_webhook(db, default_branch, "hook-1", headers=[kv])
 
         cache = MemoryCache()
-        await cache.set(key=f"webhook:{webhook.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook.id}", value='{"cached": true}')
 
         # Act
         await _run_invalidation(db, cache, kv.id)
 
-        assert await cache.get(f"webhook:{webhook.id}") is None
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{webhook.id}") is None
 
     async def test_returns_empty_for_unlinked_keyvalue(
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
@@ -80,12 +81,12 @@ class TestCacheInvalidationFlow:
         kv = await _create_keyvalue(db, default_branch, "x-unused", "X-Unused", "unused")
 
         cache = MemoryCache()
-        await cache.set(key="webhook:some-id", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:some-id", value='{"cached": true}')
 
         # Act
         await _run_invalidation(db, cache, kv.id)
 
-        assert await cache.get("webhook:some-id") == '{"cached": true}'
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:some-id") == '{"cached": true}'
 
     async def test_invalidate_removes_linked_webhook_cache_keys(
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
@@ -96,16 +97,16 @@ class TestCacheInvalidationFlow:
         wh2 = await _create_webhook(db, default_branch, "hook-y", headers=[kv])
 
         cache = MemoryCache()
-        await cache.set(key=f"webhook:{wh1.id}", value='{"cached": true}')
-        await cache.set(key=f"webhook:{wh2.id}", value='{"cached": true}')
-        await cache.set(key="webhook:unrelated-id", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{wh1.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{wh2.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:unrelated-id", value='{"cached": true}')
 
         # Act
         await _run_invalidation(db, cache, kv.id)
 
-        assert await cache.get(f"webhook:{wh1.id}") is None
-        assert await cache.get(f"webhook:{wh2.id}") is None
-        assert await cache.get("webhook:unrelated-id") == '{"cached": true}'
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{wh1.id}") is None
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{wh2.id}") is None
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:unrelated-id") == '{"cached": true}'
 
     async def test_invalidates_webhook_with_multiple_headers(
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
@@ -116,12 +117,12 @@ class TestCacheInvalidationFlow:
         webhook = await _create_webhook(db, default_branch, "hook-multi", headers=[kv1, kv2])
 
         cache = MemoryCache()
-        await cache.set(key=f"webhook:{webhook.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook.id}", value='{"cached": true}')
 
         # Act
         await _run_invalidation(db, cache, kv1.id)
 
-        assert await cache.get(f"webhook:{webhook.id}") is None
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{webhook.id}") is None
 
     async def test_excluded_when_all_headers_deleted(
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
@@ -135,14 +136,14 @@ class TestCacheInvalidationFlow:
         webhook_refreshed = await NodeManager.get_one(db=db, branch=default_branch, id=webhook.id)
 
         cache = MemoryCache()
-        await cache.set(key=f"webhook:{webhook.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook.id}", value='{"cached": true}')
 
         await webhook_refreshed.headers.delete(db=db)
 
         # Act
         await _run_invalidation(db, cache, kv.id)
 
-        assert await cache.get(f"webhook:{webhook.id}") == '{"cached": true}'
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{webhook.id}") == '{"cached": true}'
 
     async def test_partial_removal_still_finds_remaining(
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
@@ -157,13 +158,13 @@ class TestCacheInvalidationFlow:
         wh_removed_refreshed = await NodeManager.get_one(db=db, branch=default_branch, id=wh_removed.id)
 
         cache = MemoryCache()
-        await cache.set(key=f"webhook:{wh_kept.id}", value='{"cached": true}')
-        await cache.set(key=f"webhook:{wh_removed.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{wh_kept.id}", value='{"cached": true}')
+        await cache.set(key=f"{CACHE_KEY_PREFIX}:{wh_removed.id}", value='{"cached": true}')
 
         # Delete headers from only one webhook
         await wh_removed_refreshed.headers.delete(db=db)
 
         await _run_invalidation(db, cache, kv.id)
 
-        assert await cache.get(f"webhook:{wh_kept.id}") is None
-        assert await cache.get(f"webhook:{wh_removed.id}") == '{"cached": true}'
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{wh_kept.id}") is None
+        assert await cache.get(f"{CACHE_KEY_PREFIX}:{wh_removed.id}") == '{"cached": true}'

--- a/backend/tests/functional/webhook/test_configure.py
+++ b/backend/tests/functional/webhook/test_configure.py
@@ -8,6 +8,7 @@ from infrahub_sdk.protocols import CoreStandardWebhook
 from prefect.events.actions import RunDeployment
 
 from infrahub.trigger.setup import gather_all_automations
+from infrahub.webhook.constants import CACHE_KEY_PREFIX
 from infrahub.webhook.gather import gather_trigger_webhook
 from infrahub.webhook.models import WebhookTriggerDefinition
 from infrahub.webhook.tasks import configure_webhook
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
+    from tests.adapters.cache import MemoryCache
 
 
 class TestWebhookConfigure(TestInfrahubApp):
@@ -137,6 +139,23 @@ class TestWebhookConfigure(TestInfrahubApp):
         assert action.parameters["webhook_id"] == webhook2.id
         assert "webhook_kind" in action.parameters.keys()
         assert action.parameters["webhook_kind"] == "CoreCustomWebhook"
+
+    async def test_configure_all_invalidates_cache(
+        self,
+        db: InfrahubDatabase,
+        memory_cache: MemoryCache,
+        webhook1: Node,
+        webhook2: Node,
+        webhook_deployment: None,
+    ) -> None:
+        """Test that reconcile_all invalidates all webhook caches."""
+        await memory_cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook1.id}", value='{"cached": true}')
+        await memory_cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook2.id}", value='{"cached": true}')
+
+        await configure_webhook()
+
+        assert await memory_cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook1.id}") is None
+        assert await memory_cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook2.id}") is None
 
     async def test_configure_webhook_on_failure_logs_error(
         self, webhook_deployment: None, caplog: pytest.LogCaptureFixture

--- a/backend/tests/functional/webhook/test_configure.py
+++ b/backend/tests/functional/webhook/test_configure.py
@@ -148,14 +148,21 @@ class TestWebhookConfigure(TestInfrahubApp):
         webhook2: Node,
         webhook_deployment: None,
     ) -> None:
-        """Test that reconcile_all invalidates all webhook caches."""
+        """Test that reconcile_all invalidates caches for updated webhooks."""
+        # Modify webhook so reconcile detects it as needing an update
+        original_name = webhook1.name.value
+        webhook1.name.value = "Webhook1-modified"
+        await webhook1.save(db=db)
+
         await memory_cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook1.id}", value='{"cached": true}')
-        await memory_cache.set(key=f"{CACHE_KEY_PREFIX}:{webhook2.id}", value='{"cached": true}')
 
         await configure_webhook()
 
         assert await memory_cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook1.id}") is None
-        assert await memory_cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook2.id}") is None
+
+        # Restore original name
+        webhook1.name.value = original_name
+        await webhook1.save(db=db)
 
     async def test_configure_webhook_on_failure_logs_error(
         self, webhook_deployment: None, caplog: pytest.LogCaptureFixture

--- a/backend/tests/functional/webhook/test_invalidate.py
+++ b/backend/tests/functional/webhook/test_invalidate.py
@@ -6,6 +6,7 @@ import pytest
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
+from infrahub.webhook.constants import CACHE_KEY_PREFIX
 from infrahub.webhook.tasks.invalidate import invalidate_webhook_headers
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -48,7 +49,7 @@ class TestWebhookInvalidateHeaders(TestInfrahubApp):
         webhook_with_headers: Node,
         webhook_deployment: None,
     ) -> None:
-        cache_key = f"webhook:{webhook_with_headers.id}"
+        cache_key = f"{CACHE_KEY_PREFIX}:{webhook_with_headers.id}"
         await memory_cache.set(key=cache_key, value='{"cached": true}')
         assert await memory_cache.get(key=cache_key) is not None
 
@@ -66,7 +67,7 @@ class TestWebhookInvalidateHeaders(TestInfrahubApp):
         webhook_with_headers: Node,
         webhook_deployment: None,
     ) -> None:
-        cache_key = f"webhook:{webhook_with_headers.id}"
+        cache_key = f"{CACHE_KEY_PREFIX}:{webhook_with_headers.id}"
         await memory_cache.set(key=cache_key, value='{"cached": true}')
 
         unlinked_kv = await Node.init(schema=InfrahubKind.STATICKEYVALUE, db=db)

--- a/backend/tests/unit/webhook/test_configure.py
+++ b/backend/tests/unit/webhook/test_configure.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+from prefect.events.schemas.automations import Automation, Posture, ResourceSpecification
+from prefect.events.schemas.automations import EventTrigger as PrefectEventTrigger
+
+from infrahub.trigger.constants import NAME_SEPARATOR
+from infrahub.trigger.models import EventTrigger, ExecuteWorkflow, TriggerSetupReport, TriggerType
+from infrahub.webhook.models import WebhookTriggerDefinition
+from infrahub.webhook.tasks.configure import get_webhooks_to_invalidate
+from infrahub.workflows.models import WorkflowDefinition
+
+
+def _make_webhook_trigger(webhook_id: str) -> WebhookTriggerDefinition:
+    return WebhookTriggerDefinition(
+        id=webhook_id,
+        name="test-webhook",
+        trigger=EventTrigger(),
+        actions=[
+            ExecuteWorkflow(
+                workflow=WorkflowDefinition(name="webhook-process", module="m", function="f"),
+            )
+        ],
+    )
+
+
+def _make_deleted_automation(name: str) -> Automation:
+    return Automation(
+        id=uuid4(),
+        name=name,
+        trigger=PrefectEventTrigger(
+            expect=set(),
+            match=ResourceSpecification({"x": "y"}),
+            posture=Posture.Reactive,
+            threshold=1,
+            within=timedelta(0),
+        ),
+        actions=[],
+    )
+
+
+async def test_empty_report_returns_empty_set() -> None:
+    report = TriggerSetupReport()
+    result = await get_webhooks_to_invalidate(report)
+    assert result == set()
+
+
+async def test_collects_ids_from_updated_triggers() -> None:
+    report = TriggerSetupReport(
+        updated=[_make_webhook_trigger("wh-updated-1"), _make_webhook_trigger("wh-updated-2")],
+    )
+    result = await get_webhooks_to_invalidate(report)
+    assert result == {"wh-updated-1", "wh-updated-2"}
+
+
+async def test_collects_ids_from_refreshed_triggers() -> None:
+    report = TriggerSetupReport(
+        refreshed=[_make_webhook_trigger("wh-refreshed-1")],
+    )
+    result = await get_webhooks_to_invalidate(report)
+    assert result == {"wh-refreshed-1"}
+
+
+async def test_collects_ids_from_deleted_automations() -> None:
+    report = TriggerSetupReport(
+        deleted=[
+            _make_deleted_automation(f"{TriggerType.WEBHOOK.value}{NAME_SEPARATOR}wh-deleted-1"),
+            _make_deleted_automation(f"{TriggerType.WEBHOOK.value}{NAME_SEPARATOR}wh-deleted-2"),
+        ],
+    )
+    result = await get_webhooks_to_invalidate(report)
+    assert result == {"wh-deleted-1", "wh-deleted-2"}
+
+
+async def test_combines_updated_refreshed_and_deleted() -> None:
+    report = TriggerSetupReport(
+        updated=[_make_webhook_trigger("wh-upd")],
+        refreshed=[_make_webhook_trigger("wh-ref")],
+        deleted=[_make_deleted_automation(f"webhook{NAME_SEPARATOR}wh-del")],
+    )
+    result = await get_webhooks_to_invalidate(report)
+    assert result == {"wh-upd", "wh-ref", "wh-del"}
+
+
+async def test_ignores_created_and_unchanged_triggers() -> None:
+    report = TriggerSetupReport(
+        created=[_make_webhook_trigger("wh-created")],
+        unchanged=[_make_webhook_trigger("wh-unchanged")],
+    )
+    result = await get_webhooks_to_invalidate(report)
+    assert result == set()

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -186,7 +186,7 @@ Three headers are added to signed requests:
 - **Cache miss**: Falls back to fetching the webhook node from the database via SDK, then caches the result
 - **Invalidation**: Three paths clear the cache:
   1. `_configure_one()` (on create/update) and `_delete_automation()` (on delete) invalidate a single webhook's cache via `invalidate_webhook_cache(webhook_ids=...)`
-  2. `_reconcile_all()` invalidates **all** webhook caches via `invalidate_all_webhook_caches()`, which uses `cache.list_keys("webhook:*")` to find and delete every entry — this covers deactivated webhooks that wouldn't appear in the active trigger list
+  2. `_reconcile_all()` invalidates caches for **updated** and **deleted** webhooks only (via `invalidate_webhook_cache(webhook_ids=...)`), extracted from the `TriggerSetupReport`. New webhooks have no cache entry, and unchanged webhooks need no invalidation.
   3. When a `CoreKeyValue` header is modified, `TRIGGER_KEYVALUE_WEBHOOK_INVALIDATE` fires `invalidate_webhook_headers`, which queries affected webhooks via `KeyValueGetWebhooksQuery` and deletes their cache entries
 
 ## Prefect Workflows

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -184,7 +184,10 @@ Three headers are added to signed requests:
 - **TTL**: 2 hours (`KVTTL.TWO_HOURS`)
 - **Storage**: Redis via the cache service
 - **Cache miss**: Falls back to fetching the webhook node from the database via SDK, then caches the result
-- **Invalidation**: Cache is cleared by `_configure_one()` (on create/update) and `_delete_automation()` (on delete), both routed through the unified `configure_webhook` flow. Additionally, when a `CoreKeyValue` header is modified, `TRIGGER_KEYVALUE_WEBHOOK_INVALIDATE` fires `invalidate_webhook_headers`, which queries affected webhooks via `KeyValueGetWebhooksQuery` and deletes their cache entries
+- **Invalidation**: Three paths clear the cache:
+  1. `_configure_one()` (on create/update) and `_delete_automation()` (on delete) invalidate a single webhook's cache via `invalidate_webhook_cache(webhook_ids=...)`
+  2. `_reconcile_all()` invalidates **all** webhook caches via `invalidate_all_webhook_caches()`, which uses `cache.list_keys("webhook:*")` to find and delete every entry — this covers deactivated webhooks that wouldn't appear in the active trigger list
+  3. When a `CoreKeyValue` header is modified, `TRIGGER_KEYVALUE_WEBHOOK_INVALIDATE` fires `invalidate_webhook_headers`, which queries affected webhooks via `KeyValueGetWebhooksQuery` and deletes their cache entries
 
 ## Prefect Workflows
 


### PR DESCRIPTION
# Why

During webhook reconciliation (`reconcile_all`), the webhook cache is never invalidated. Both `_configure_one()` and `_delete_automation()` correctly call `invalidate_webhook_cache`, but `_reconcile_all()` does not. This means stale cached webhook data can persist after a full reconciliation — including for deactivated or modified webhooks.

[IFC-2337](https://opsmill.atlassian.net/browse/IFC-2337)

Builds on #8590, #8597 & #8602.

## What changed

- **New `invalidate_all_webhook_caches` task** (`backend/infrahub/webhook/tasks/cache.py`): uses `cache.list_keys("webhook:*")` to find and delete all webhook cache entries, covering both active and inactive webhooks
- **`_reconcile_all()` now invalidates the cache** after `setup_triggers_specific` completes
- **Extracted `CACHE_KEY_PREFIX` constant** (`backend/infrahub/webhook/constants.py`): replaces hardcoded `"webhook"` prefix strings across `cache.py` and `process.py`

## How to review

First commit to review is: 353549ff794627b603c1cf2827d416d61800cc7f

1. `backend/infrahub/webhook/constants.py`: new `CACHE_KEY_PREFIX` constant
2. `backend/infrahub/webhook/tasks/cache.py`: new `invalidate_all_webhook_caches` task
3. `backend/infrahub/webhook/tasks/configure.py`: one-line addition in `_reconcile_all()`
4. `backend/infrahub/webhook/tasks/process.py`: mechanical: uses `CACHE_KEY_PREFIX` instead of hardcoded string
5. `backend/tests/functional/webhook/test_configure.py`: new test `test_configure_all_invalidates_cache`

## How to test

```bash
uv run pytest backend/tests/unit/webhook/ -xvs
uv run pytest backend/tests/functional/webhook/test_configure.py -xvs
```

## Impact & rollout

- **Deployment notes:** To be merged after the related PRs have been merged #8590, #8597 & #8602.

## Checklist

- [x] Tests added/updated
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

[IFC-2337]: https://opsmill.atlassian.net/browse/IFC-2337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ