### PR TITLE
IFC-2257: add unit test for webhook signature validation

### DIFF
--- a/backend/tests/unit/external/__init__.py
+++ b/backend/tests/unit/external/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for external and third-party library behavior that Infrahub depends on."""

--- a/backend/tests/unit/external/test_httpx_serialization.py
+++ b/backend/tests/unit/external/test_httpx_serialization.py
@@ -1,0 +1,30 @@
+import json
+
+import httpx
+
+
+def test_httpx_json_serialization_matches_signature_format() -> None:
+    """Guard against httpx changing its JSON serialization.
+
+    The webhook signature is computed over compact JSON (no spaces).
+    If httpx ever changes its serializer this test will break before.
+    """
+    payload = {
+        "data": {"id": "abc123", "kind": "BuiltinTag", "display_label": "my tag"},
+        "event_type": "infrahub.node.created",
+        "branch": "main",
+    }
+
+    # What our signature code signs (compact JSON, deterministic key order)
+    signed_body = json.dumps(payload, separators=(",", ":")).encode()
+
+    # What httpx will actually put on the wire
+    request = httpx.Request("POST", "http://test.com", json=payload)
+    httpx_body = request.content
+
+    assert httpx_body == signed_body, (
+        f"httpx JSON serialization diverged from compact json.dumps.\n"
+        f"  signed : {signed_body!r}\n"
+        f"  httpx  : {httpx_body!r}\n"
+        "Webhook receivers will reject signatures if these differ."
+    )

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -38,3 +38,33 @@ def test_standard_webhook_header() -> None:
         "webhook-signature": "v1,BQN9AgPA4evuGDChi9VKxNKRwediIXsAQz8hVHMfKNg=",
         "webhook-timestamp": "1740656629",
     }
+
+
+def test_webhook_signature_with_payload() -> None:
+    """Signature is computed on compact JSON of the payload, not str(dict) or spaced JSON.
+
+    Hardcoded expected value catches regressions if the serialization format changes.
+    """
+    webhook = StandardWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        shared_key="my-webhook-secret",
+    )
+    webhook._payload = {
+        "data": {"id": "abc123", "kind": "BuiltinTag", "display_label": "my tag"},
+        "event_type": "infrahub.node.created",
+        "branch": "main",
+    }
+    test_id = UUID("217b4ebc-b84f-4736-b1ee-222182aed371")
+    time1 = Timestamp("2025-02-27T11:43:49.064807Z")
+    webhook._assign_headers(uuid=test_id, at=time1)
+
+    assert webhook._headers == {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "webhook-id": "msg_217b4ebcb84f4736b1ee222182aed371",
+        "webhook-timestamp": "1740656629",
+        "webhook-signature": "v1,5JQxZW3lMNdaSnofcSV0Y3krxQ7aZI7EyThUqHVDGc4=",
+    }


### PR DESCRIPTION
# Why

Webhook HMAC signature calculation has had two regressions in the past:
1. Signature was computed on `str(dict)` instead of `json.dumps(dict)`
2. `json.dumps` used default separators (`, ` and `: `) instead of compact (`,`, `:`) after HTTPX 0.28.x switch

The existing `test_standard_webhook_header` test only validates signing with an empty payload, which serializes identically regardless of format — so it catches neither regression.

Closes https://opsmill.atlassian.net/browse/IFC-2257

## What changed

- Added `test_webhook_signature_with_payload` to `backend/tests/unit/webhook/test_models.py`
- Tests HMAC signature against a hardcoded expected value using a non-trivial nested payload
- Any change to JSON serialization format (spaced vs compact) or signing input (str vs JSON) breaks the test

## How to review

Single test addition in `backend/tests/unit/webhook/test_models.py`. The hardcoded signature was verified by mutating the source to reintroduce both historical bugs and confirming the test fails in each case.

## How to test

```bash
uv run invoke backend.test-unit -- -k test_webhook_signature_with_payload
```

## Checklist

- [x] Tests added/updated