### PR TITLE
Add Claude Code slash commands: pre-ci, feedback, audit-docs

### DIFF
--- a/dev/commands/audit-docs.md
+++ b/dev/commands/audit-docs.md
@@ -27,7 +27,7 @@ For each changed area identified in the commits, check all 5 documentation layer
 
 | Layer | Location | Question |
 |-------|----------|----------|
-| Technical reference | `dev/knowledge/backend/` or `frontend/` | Does the knowledge doc explain how this works? |
+| Technical reference | `dev/knowledge/backend/` or `dev/knowledge/frontend/` | Does the knowledge doc explain how this works? |
 | User-facing docs | `docs/docs/topics/` or `docs/docs/guides/` | Can users understand and use this feature? |
 | Feature spec | `dev/specs/` | Is there a spec, and does it match what was built? |
 | Changelog | `changelog/` | Is there a changelog fragment for user-visible changes? |
@@ -93,4 +93,4 @@ For approved fixes:
 
 - Prefer editing existing files over creating new ones.
 - Check cross-references in both directions (A links to B and B links to A).
-- Run `uv run invoke docs.lint` on any modified `.mdx` files.
+- Run `uv run invoke docs.lint` to perform global Markdown/MDX linting across the repo.

--- a/dev/commands/audit-docs.md
+++ b/dev/commands/audit-docs.md
@@ -1,0 +1,90 @@
+---
+description: Audit documentation completeness for a feature branch by scanning commits and cross-referencing existing docs
+argument-hint: <commit-range or branch name>
+---
+
+# Documentation Audit
+
+Audit documentation completeness after a feature branch. Scan commits, cross-reference against all documentation layers, and report gaps.
+
+## Step 1: Gather Scope
+
+If the user provided a commit range or branch name as an argument, use it. Otherwise ask:
+
+1. **Commit range**: What commits should be audited? (default: current branch vs `stable`)
+
+Then run `git log <range> --oneline --stat` to understand all changes.
+
+## Step 2: Map Changes to Documentation Layers
+
+For each changed area identified in the commits, check all 5 documentation layers:
+
+| Layer | Location | Question |
+|-------|----------|----------|
+| Technical reference | `dev/knowledge/backend/` or `frontend/` | Does the knowledge doc explain how this works? |
+| User-facing docs | `docs/docs/topics/` or `docs/docs/guides/` | Can users understand and use this feature? |
+| Feature spec | `dev/specs/` | Is there a spec, and does it match what was built? |
+| Changelog | `changelog/` | Is there a changelog fragment for user-visible changes? |
+| Cross-references | All docs | Do related docs link back in both directions? |
+
+Also check these secondary locations when relevant:
+
+- `dev/knowledge/backend/architecture.md` — Component map if new directories were created.
+- `dev/knowledge/backend/testing.md` — If new test patterns were introduced.
+- `dev/knowledge/backend/schema-definitions.md` — If new schema types were added.
+- `backend/AGENTS.md` or `frontend/app/AGENTS.md` — If new top-level modules were created.
+
+## Step 3: Generate Audit Report
+
+Present findings in this format:
+
+```markdown
+## Documentation Audit Report
+
+### Branch / Commit Range
+<!-- What was scanned -->
+
+### Changes Summary
+<!-- Grouped by area: schema, logic, tests, etc. -->
+
+### Documentation Status
+
+For each document checked:
+
+- **File**: path
+- **Status**: Current / Outdated / Missing / N/A
+- **Details**: What is good, what is missing
+
+### Gaps Found
+
+For each gap:
+
+- **What is missing**: Description
+- **Where**: Which file to update or create
+- **Severity**: High / Medium / Low
+- **Suggested fix**: Concrete content or edit
+
+### Not Gaps (By Design)
+
+Things that look like gaps but are intentionally absent. This section prevents over-documentation.
+
+Common reasons something is not a gap:
+
+- Feature uses standard mechanisms (GraphQL mutations, UI forms) that do not need a dedicated guide.
+- Entity is fully documented within a parent feature's knowledge doc.
+- An ADR is unnecessary when the spec already captures design decisions.
+```
+
+## Step 4: Apply Fixes
+
+Ask the user which fixes to apply:
+
+1. **Apply all** — Edit or create all proposed documentation.
+2. **Cherry-pick** — Let the user select which changes to apply.
+3. **None** — Keep the report as reference only.
+
+For approved fixes:
+
+- Prefer editing existing files over creating new ones.
+- Check cross-references in both directions (A links to B and B links to A).
+- Run `uv run invoke docs.lint` on any modified `.mdx` files.

--- a/dev/commands/audit-docs.md
+++ b/dev/commands/audit-docs.md
@@ -1,6 +1,6 @@
 ---
-description: Audit documentation completeness for a feature branch by scanning commits and cross-referencing existing docs
-argument-hint: <commit-range, branch name, or subject to audit>
+description: Audit documentation completeness for a feature branch, subject, or set of existing docs
+argument-hint: <commit-range, branch name, subject, or doc paths to audit>
 ---
 
 # Documentation Audit
@@ -13,13 +13,15 @@ The user may provide one of the following as an argument:
 
 - A **commit range or branch name** — audit all changes in that range.
 - A **subject** (e.g., "webhooks", "computed attributes", "IPAM") — audit documentation for that topic across the codebase, regardless of branch. Search `dev/knowledge/`, `docs/docs/`, `dev/specs/`, `backend/AGENTS.md`, `frontend/app/AGENTS.md`, and the code itself to assess coverage.
+- A **set of doc paths** (e.g., `docs/docs/guides/installation.mdx dev/knowledge/backend/templates.md`) — audit only those specific documents. Read each file, identify what feature/topic it covers, then assess completeness, accuracy, and cross-references. Also check whether the code it documents has drifted from what the doc describes.
 
 If no argument is provided, ask:
 
-1. **What to audit**: A commit range, branch name, or subject? (default: current branch vs `stable`)
+1. **What to audit**: A commit range, branch name, subject, or list of doc paths? (default: current branch vs `stable`)
 
 For commit-based audits, run `git log <range> --oneline --stat` to understand all changes.
 For subject-based audits, use Grep/Glob to find all code and docs related to the subject.
+For doc-path audits, read each provided file, extract its topic/feature scope, then search the codebase for the corresponding implementation to verify the docs are current and complete.
 
 ## Step 2: Map Changes to Documentation Layers
 
@@ -47,8 +49,8 @@ Present findings in this format:
 ```markdown
 ## Documentation Audit Report
 
-### Branch / Commit Range
-<!-- What was scanned -->
+### Scope
+<!-- What was scanned: branch/range, subject, or list of doc files -->
 
 ### Changes Summary
 <!-- Grouped by area: schema, logic, tests, etc. -->

--- a/dev/commands/audit-docs.md
+++ b/dev/commands/audit-docs.md
@@ -1,6 +1,6 @@
 ---
 description: Audit documentation completeness for a feature branch by scanning commits and cross-referencing existing docs
-argument-hint: <commit-range or branch name>
+argument-hint: <commit-range, branch name, or subject to audit>
 ---
 
 # Documentation Audit
@@ -9,11 +9,17 @@ Audit documentation completeness after a feature branch. Scan commits, cross-ref
 
 ## Step 1: Gather Scope
 
-If the user provided a commit range or branch name as an argument, use it. Otherwise ask:
+The user may provide one of the following as an argument:
 
-1. **Commit range**: What commits should be audited? (default: current branch vs `stable`)
+- A **commit range or branch name** — audit all changes in that range.
+- A **subject** (e.g., "webhooks", "computed attributes", "IPAM") — audit documentation for that topic across the codebase, regardless of branch. Search `dev/knowledge/`, `docs/docs/`, `dev/specs/`, `backend/AGENTS.md`, `frontend/app/AGENTS.md`, and the code itself to assess coverage.
 
-Then run `git log <range> --oneline --stat` to understand all changes.
+If no argument is provided, ask:
+
+1. **What to audit**: A commit range, branch name, or subject? (default: current branch vs `stable`)
+
+For commit-based audits, run `git log <range> --oneline --stat` to understand all changes.
+For subject-based audits, use Grep/Glob to find all code and docs related to the subject.
 
 ## Step 2: Map Changes to Documentation Layers
 

--- a/dev/commands/feedback.md
+++ b/dev/commands/feedback.md
@@ -1,0 +1,101 @@
+---
+description: Analyze this conversation and identify missing or incorrect documentation to improve future sessions
+---
+
+# Session Feedback
+
+Analyze this conversation and identify what documentation or context was missing, incomplete, or incorrect. The goal is to continuously improve the project's knowledge base so future conversations are more efficient.
+
+## Step 1: Session Analysis
+
+Reflect on the work done in this conversation. For each area, identify friction points:
+
+1. **Exploration overhead**: What parts of the codebase did you have to discover by searching that should have been documented? (e.g., patterns, conventions, module responsibilities)
+2. **Wrong assumptions**: Did you make incorrect assumptions due to missing or misleading documentation?
+3. **Repeated patterns**: Did you discover recurring patterns or conventions that aren't documented anywhere?
+4. **Missing context**: What background knowledge would have helped you start faster? (e.g., architecture decisions, data flow, naming conventions)
+5. **Tooling gaps**: Were there commands, scripts, or workflows that you had to figure out?
+
+## Step 2: Documentation Audit
+
+For each friction point identified, determine the appropriate fix. Check the existing documentation to avoid duplicating what's already there:
+
+- `AGENTS.md` — Top-level project instructions and component map
+- `CLAUDE.md` — Entry point referencing AGENTS.md
+- `backend/AGENTS.md` — Backend component map and conventions
+- `frontend/app/AGENTS.md` — Frontend component map and conventions
+- `docs/AGENTS.md` — Documentation site guide
+- `dev/knowledge/backend/` — Backend architecture knowledge base
+- `dev/knowledge/frontend/` — Frontend architecture knowledge base
+- `dev/guidelines/` — Coding standards and workflow guidelines
+- `dev/adr/` — Architecture Decision Records
+- `dev/commands/` — Claude Code slash commands
+- `dev/guides/` — How-to guides
+- `dev/specs/` — Feature specifications
+
+Read the relevant existing files to understand what's already documented before proposing changes.
+
+## Step 3: Generate Report
+
+Present the feedback as a structured report with the following sections. Only include sections that have content — skip empty sections.
+
+### Format
+
+```markdown
+## Session Feedback Report
+
+### What I Was Working On
+<!-- Brief summary of the task(s) performed in this conversation -->
+
+### Documentation Gaps
+<!-- Things that should be documented but aren't -->
+
+For each gap:
+
+- **Topic**: What's missing
+- **Where**: Which file should contain this (existing file to update, or new file to create)
+- **Why**: How this would have helped during this conversation
+- **Suggested content**: A draft of what should be added (be specific and actionable)
+
+### Documentation Corrections
+<!-- Things that are documented but wrong or misleading -->
+
+For each correction:
+
+- **File**: Path to the file
+- **Issue**: What's wrong or misleading
+- **Fix**: What it should say instead
+
+### Discovered Patterns
+<!-- Conventions or patterns found in the code that aren't documented -->
+
+For each pattern:
+
+- **Pattern**: Description of the convention
+- **Evidence**: Where in the code this pattern is used (file paths)
+- **Where to document**: Which AGENTS.md, knowledge doc, or guideline file should capture this
+
+### Memory Updates
+<!-- Propose additions/changes to MEMORY.md for cross-session persistence -->
+
+For each update:
+
+- **Action**: Add / Update / Remove
+- **Content**: What to write
+- **Reason**: Why this is worth remembering across sessions
+```
+
+## Step 4: Apply Changes
+
+After presenting the report, ask the user which changes they want to apply. Present the options:
+
+1. **Apply all** — Create/update all proposed documentation files and memory
+2. **Cherry-pick** — Let the user select which changes to apply
+3. **None** — Just keep the report as reference, don't modify any files
+
+For approved changes:
+
+- Edit existing files when updating documentation
+- Create new files only when no appropriate existing file exists
+- Update `MEMORY.md` with approved memory changes
+- Keep all changes minimal and focused — don't over-document

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -1,24 +1,28 @@
 ---
 description: Run all locally-executable CI checks (format, lint, unit tests)
-argument-hint:
+argument-hint: "[--fast]"
 allowed-tools:
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
   - Bash(cd frontend*:*)
+  - Bash(npm run codegen*:*)
   - Bash(npx biome*:*)
   - Bash(npx betterer*:*)
   - Bash(npx markdownlint*:*)
-  - Bash(npm run codegen*:*)
 ---
 
 # Pre-CI
 
 Run all locally-executable CI checks to catch issues before pushing.
 
-## Steps to Follow
+**Options:**
 
-Run these checks **sequentially** in the order below. Stop and report on first failure unless the failure is in formatting (which auto-fixes).
+- `--fast` — Run only formatting and fast lint checks (~20s). Skips backend lint (ty/mypy), Betterer, docs lint, generated file validation, schema validation, and unit tests.
+
+## Phase 1 — Auto-fix formatting (sequential)
+
+Run these **sequentially** — they modify files and must complete before lint checks.
 
 ### 1. Format all Python code
 
@@ -34,7 +38,7 @@ This auto-fixes formatting issues via ruff. Always run this first.
 uv run invoke docs.format
 ```
 
-Auto-fixes Markdown formatting issues.
+Auto-fixes markdown formatting issues.
 
 ### 3. Format and lint frontend code (Biome)
 
@@ -44,79 +48,34 @@ cd frontend/app && npx biome check --write .
 
 Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports errors that cannot be auto-fixed, report them to the user.
 
-### 3b. Check TypeScript regressions (Betterer)
+## Phase 2 — Fast checks (parallel)
 
-```bash
-cd frontend/app && npx betterer
-```
+**IMPORTANT: Send ALL 3 commands below in a SINGLE message with 3 parallel Bash tool calls.** Do NOT run them one at a time.
 
-Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
+1. `uv run invoke main.lint` — If ruff reports issues, they were not auto-fixable — report them to the user.
+2. `uv lock --check` — Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
+3. `cd frontend/app && npm run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
 
-### 4. Lint Python code (ruff + ty)
+---
 
-```bash
-uv run invoke main.lint
-uv run invoke backend.lint
-```
+> **If `--fast` was specified, stop here** and report results. Show the summary table with slow checks marked as "skipped".
 
-Run these separately to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. If ruff reports issues, they were not auto-fixable — report them to the user.
+---
 
-**Important:** `backend.lint` runs both ruff and ty together. The ty checker may panic with long tracebacks that bury ruff warnings. If `backend.lint` fails or has noisy output, **re-run ruff in isolation** on changed files to ensure no warnings were missed:
+## Phase 3 — Slow checks (parallel)
 
-```bash
-uv run ruff check <changed-files>
-```
+**IMPORTANT: Send ALL 6 commands below in a SINGLE message with 6 parallel Bash tool calls.** Do NOT run them one at a time.
 
-### 4b. Type-check with mypy
+1. `uv run invoke backend.lint` — Run separately from main.lint to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. If ruff reports issues, they were not auto-fixable — report them to the user.
+2. `cd frontend/app && npx betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
+3. `uv run invoke docs.lint` — Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
+4. `uv run invoke backend.validate-generated` — Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
+5. `uv run invoke schema.validate-graphqlschema` — Ensures `schema/schema.graphql` is up to date. Regenerates the file then checks for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
+6. `uv run invoke schema.validate-jsonschema` — Ensures `schema/openapi.json` is up to date. Same approach as GraphQL schema validation.
 
-```bash
-uv run invoke backend.mypy
-```
+## Phase 4 — Unit tests
 
-Runs mypy on the backend. Report any errors — these are not auto-fixable.
-
-### 5. Lint documentation (markdownlint + vale)
-
-```bash
-uv run invoke docs.lint
-```
-
-Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
-
-### 6. Check lockfile is in sync
-
-```bash
-uv lock --check
-```
-
-Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
-
-### 7. Validate generated files
-
-```bash
-uv run invoke backend.validate-generated
-```
-
-Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
-
-### 8. Validate GraphQL and JSON schemas
-
-```bash
-uv run invoke schema.validate-graphqlschema
-uv run invoke schema.validate-jsonschema
-```
-
-Ensures `schema/schema.graphql` and `schema/openapi.json` are up to date. These regenerate the files then check for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
-
-### 8b. Regenerate frontend GraphQL types (gql.tada)
-
-```bash
-cd frontend/app && npm run codegen:graphql
-```
-
-Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
-
-### 9. Run backend unit tests
+Run after all lint/validation checks pass.
 
 ```bash
 uv run invoke backend.test-unit
@@ -133,15 +92,17 @@ Summarize results in a table:
 | Python format | ... |
 | Docs format | ... |
 | Frontend format/lint | ... |
-| TS regressions (Betterer) | ... |
-| Python lint | ... |
-| mypy | ... |
-| Docs lint | ... |
+| Main Python lint | ... |
 | Lockfile sync | ... |
-| Generated files | ... |
-| Schema validation | ... |
 | Frontend GraphQL types | ... |
+| Backend lint (ty/mypy) | ... |
+| TS regressions (Betterer) | ... |
+| Docs lint | ... |
+| Generated files | ... |
+| GraphQL schema validation | ... |
+| JSON schema validation | ... |
 | Unit tests | ... |
 
-If everything passed, tell the user they're ready to push.
+If `--fast` was used, show skipped checks as "skipped".
+If everything passed (or was skipped), tell the user they're ready to push.
 If anything failed, list the specific failures and suggest fixes.

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -31,7 +31,7 @@ This auto-fixes formatting issues via ruff. Always run this first.
 uv run invoke docs.format
 ```
 
-Auto-fixes markdown formatting issues.
+Auto-fixes Markdown formatting issues.
 
 ### 3. Lint Python code (ruff + ty)
 

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -6,6 +6,8 @@ allowed-tools:
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
   - Bash(cd frontend*:*)
+  - Bash(npx biome*:*)
+  - Bash(npx betterer*:*)
   - Bash(npx markdownlint*:*)
 ---
 
@@ -33,7 +35,23 @@ uv run invoke docs.format
 
 Auto-fixes Markdown formatting issues.
 
-### 3. Lint Python code (ruff + ty)
+### 3. Format and lint frontend code (Biome)
+
+```bash
+cd frontend/app && npx biome check --write .
+```
+
+Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports errors that cannot be auto-fixed, report them to the user.
+
+### 3b. Check TypeScript regressions (Betterer)
+
+```bash
+cd frontend/app && npx betterer
+```
+
+Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
+
+### 4. Lint Python code (ruff + ty)
 
 ```bash
 uv run invoke main.lint
@@ -48,7 +66,7 @@ Run these separately to avoid `uv run invoke lint` which includes a `yamllint -s
 uv run ruff check <changed-files>
 ```
 
-### 3b. Type-check with mypy
+### 4b. Type-check with mypy
 
 ```bash
 uv run invoke backend.mypy
@@ -56,7 +74,7 @@ uv run invoke backend.mypy
 
 Runs mypy on the backend. Report any errors — these are not auto-fixable.
 
-### 4. Lint documentation (markdownlint + vale)
+### 5. Lint documentation (markdownlint + vale)
 
 ```bash
 uv run invoke docs.lint
@@ -64,7 +82,7 @@ uv run invoke docs.lint
 
 Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
 
-### 5. Check lockfile is in sync
+### 6. Check lockfile is in sync
 
 ```bash
 uv lock --check
@@ -72,7 +90,7 @@ uv lock --check
 
 Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
 
-### 6. Validate generated files
+### 7. Validate generated files
 
 ```bash
 uv run invoke backend.validate-generated
@@ -80,7 +98,7 @@ uv run invoke backend.validate-generated
 
 Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
 
-### 7. Validate GraphQL and JSON schemas
+### 8. Validate GraphQL and JSON schemas
 
 ```bash
 uv run invoke schema.validate-graphqlschema
@@ -89,7 +107,7 @@ uv run invoke schema.validate-jsonschema
 
 Ensures `schema/schema.graphql` and `schema/openapi.json` are up to date. These regenerate the files then check for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
 
-### 8. Run backend unit tests
+### 9. Run backend unit tests
 
 ```bash
 uv run invoke backend.test-unit
@@ -105,6 +123,8 @@ Summarize results in a table:
 |-------|--------|
 | Python format | ... |
 | Docs format | ... |
+| Frontend format/lint | ... |
+| TS regressions (Betterer) | ... |
 | Python lint | ... |
 | mypy | ... |
 | Docs lint | ... |

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(npx biome*:*)
   - Bash(npx betterer*:*)
   - Bash(npx markdownlint*:*)
+  - Bash(npm run codegen*:*)
 ---
 
 # Pre-CI
@@ -107,6 +108,14 @@ uv run invoke schema.validate-jsonschema
 
 Ensures `schema/schema.graphql` and `schema/openapi.json` are up to date. These regenerate the files then check for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
 
+### 8b. Regenerate frontend GraphQL types (gql.tada)
+
+```bash
+cd frontend/app && npm run codegen:graphql
+```
+
+Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
+
 ### 9. Run backend unit tests
 
 ```bash
@@ -131,6 +140,7 @@ Summarize results in a table:
 | Lockfile sync | ... |
 | Generated files | ... |
 | Schema validation | ... |
+| Frontend GraphQL types | ... |
 | Unit tests | ... |
 
 If everything passed, tell the user they're ready to push.

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -1,0 +1,117 @@
+---
+description: Run all locally-executable CI checks (format, lint, unit tests)
+argument-hint:
+allowed-tools:
+  - Bash(uv run invoke:*)
+  - Bash(uv run ruff check:*)
+  - Bash(uv lock --check:*)
+  - Bash(cd frontend*:*)
+  - Bash(npx markdownlint*:*)
+---
+
+# Pre-CI
+
+Run all locally-executable CI checks to catch issues before pushing.
+
+## Steps to Follow
+
+Run these checks **sequentially** in the order below. Stop and report on first failure unless the failure is in formatting (which auto-fixes).
+
+### 1. Format all Python code
+
+```bash
+uv run invoke format
+```
+
+This auto-fixes formatting issues via ruff. Always run this first.
+
+### 2. Format documentation
+
+```bash
+uv run invoke docs.format
+```
+
+Auto-fixes markdown formatting issues.
+
+### 3. Lint Python code (ruff + ty)
+
+```bash
+uv run invoke main.lint
+uv run invoke backend.lint
+```
+
+Run these separately to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. If ruff reports issues, they were not auto-fixable — report them to the user.
+
+**Important:** `backend.lint` runs both ruff and ty together. The ty checker may panic with long tracebacks that bury ruff warnings. If `backend.lint` fails or has noisy output, **re-run ruff in isolation** on changed files to ensure no warnings were missed:
+
+```bash
+uv run ruff check <changed-files>
+```
+
+### 3b. Type-check with mypy
+
+```bash
+uv run invoke backend.mypy
+```
+
+Runs mypy on the backend. Report any errors — these are not auto-fixable.
+
+### 4. Lint documentation (markdownlint + vale)
+
+```bash
+uv run invoke docs.lint
+```
+
+Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
+
+### 5. Check lockfile is in sync
+
+```bash
+uv lock --check
+```
+
+Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
+
+### 6. Validate generated files
+
+```bash
+uv run invoke backend.validate-generated
+```
+
+Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
+
+### 7. Validate GraphQL and JSON schemas
+
+```bash
+uv run invoke schema.validate-graphqlschema
+uv run invoke schema.validate-jsonschema
+```
+
+Ensures `schema/schema.graphql` and `schema/openapi.json` are up to date. These regenerate the files then check for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
+
+### 8. Run backend unit tests
+
+```bash
+uv run invoke backend.test-unit
+```
+
+Report pass/fail summary.
+
+## After All Checks
+
+Summarize results in a table:
+
+| Check | Status |
+|-------|--------|
+| Python format | ... |
+| Docs format | ... |
+| Python lint | ... |
+| mypy | ... |
+| Docs lint | ... |
+| Lockfile sync | ... |
+| Generated files | ... |
+| Schema validation | ... |
+| Unit tests | ... |
+
+If everything passed, tell the user they're ready to push.
+If anything failed, list the specific failures and suggest fixes.

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
+  - Bash(uv lock:*)
   - Bash(cd frontend*:*)
   - Bash(npm run codegen*:*)
   - Bash(npx biome*:*)


### PR DESCRIPTION
# Why

We have useful Claude Code workflows (running CI checks locally, session feedback, doc auditing) that developers repeat manually. Codifying them as slash commands makes them discoverable and consistent.

## What changed

### `/pre-ci` — Local CI checks

Runs all locally-executable CI checks with a summary table. Catches issues before pushing. Adapted from `infrahub-sdk-python`.

**4 phases:**

1. **Auto-fix formatting** (sequential): Python (`ruff`), docs (markdown), frontend (`biome --write`)
2. **Fast checks** (parallel): Python lint, lockfile sync, frontend GraphQL types regeneration (`codegen:graphql`)
3. **Slow checks** (parallel): Backend lint (ty/mypy), Betterer (TS regression gate), docs lint, generated file validation, GraphQL + JSON schema validation
4. **Unit tests**: `backend.test-unit`

**`--fast` flag:** Runs only phases 1–2. Skips backend lint, Betterer, docs lint, generated file validation, schema validation, and unit tests. <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added internal developer workflow guides for documentation audits, session feedback analysis, and pre-CI validation checklists to standardize processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> table shows skipped checks.

### `/feedback` — Session feedback

Analyzes a conversation to identify documentation gaps, wrong assumptions, and undocumented patterns, then proposes fixes to the knowledge base. Adapted from `infrahub-sdk-python`.

### `/audit-docs` — Documentation audit

Scans changes and cross-references all 5 documentation layers (knowledge docs, user docs, specs, changelog, cross-refs), reporting gaps with severity. Three input modes:

- **Branch/range**: audit all changes in a commit range or branch
- **Subject**: audit docs for a freeform topic (e.g., "webhooks", "IPAM")
- **Doc paths**: audit specific existing documentation files for completeness and accuracy against the current codebase

All three files live in `dev/commands/` following the existing command format.

## How to review

Three standalone markdown files in `dev/commands/`.

## How to test

Verify the commands match expectations, each can be invoked via `/pre-ci`, `/feedback`, `/audit-docs`.