### PR TITLE
Add small condition to prevent unhandled error for search anywhere

### DIFF
--- a/frontend/app/src/entities/navigation/ui/search-anywhere/search-docs.tsx
+++ b/frontend/app/src/entities/navigation/ui/search-anywhere/search-docs.tsx
@@ -26,7 +26,7 @@ export const SearchDocs = () => {
     );
   }
 
-  if (error || results.length === 0) return null;
+  if (error || !Array.isArray(results) || results.length === 0) return null;
 
   return (
     <SearchAnywhereGroup heading="Documentation">

--- a/frontend/app/src/entities/navigation/ui/search-anywhere/search-docs.tsx
+++ b/frontend/app/src/entities/navigation/ui/search-anywhere/search-docs.tsx
@@ -26,7 +26,7 @@ export const SearchDocs = () => {
     );
   }
 
-  if (error || !Array.isArray(results) || results.length === 0) return null;
+  if (error || results.length === 0) return null;
 
   return (
     <SearchAnywhereGroup heading="Documentation">

--- a/frontend/app/src/shared/api/rest/fetch.ts
+++ b/frontend/app/src/shared/api/rest/fetch.ts
@@ -22,7 +22,11 @@ export const fetchUrl = async (url: string, payload?: RequestInit) => {
 
   const rawResponse = await fetch(url, newPayload);
 
-  return rawResponse?.json();
+  if (!rawResponse.ok) {
+    throw new Error(`Request failed with status ${rawResponse.status}`);
+  }
+
+  return rawResponse.json();
 };
 
 const QSP_TO_INCLUDE = [QSP.BRANCH, QSP.DATETIME];


### PR DESCRIPTION
When trying to use the search anywhere feature, if the docs is not available, the frontend code would fail and display an unexpected error page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API requests now check HTTP response status and report errors with status information instead of treating failed responses as successful.
  * Results in clearer, more reliable error messages for network/API failures, improving troubleshooting and overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->