### PR TITLE
lock when merging

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Sequence
 from uuid import uuid4
 
 import pydantic
@@ -14,7 +14,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
-from infrahub.core.constants import MutationAction
+from infrahub.core.constants import DiffAction, MutationAction
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.diff_locker import DiffLocker
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
@@ -24,6 +24,7 @@ from infrahub.core.diff.models import RequestDiffUpdate
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.merge import BranchMerger
+from infrahub.core.merge.merge_locker import MergeLocker
 from infrahub.core.migrations.exceptions import MigrationFailureError
 from infrahub.core.migrations.runner import MigrationRunner
 from infrahub.core.schema.update_coordinator import MigrationExecutor, SchemaUpdateCoordinator
@@ -56,6 +57,12 @@ from infrahub.workflows.catalogue import (
     TRIGGER_GENERATOR_DEFINITION_RUN,
 )
 from infrahub.workflows.utils import add_tags
+
+if TYPE_CHECKING:
+    from logging import Logger, LoggerAdapter
+
+    from infrahub.core.changelog.models import NodeChangelog
+    from infrahub.database import InfrahubDatabase
 
 
 @flow(name="branch-migrate", flow_run_name="Apply migrations to branch {branch}")
@@ -273,7 +280,6 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
 
         obj = await Branch.get_by_name(db=db, name=branch)
         default_branch = await registry.get_branch(db=db, branch=registry.default_branch)
-        component_registry = get_component_registry()
         merge_event = BranchMergedEvent(
             branch_name=obj.name,
             branch_id=str(obj.get_uuid()),
@@ -281,107 +287,19 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
             meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
         )
 
-        merger: BranchMerger | None = None
-        workflow = get_workflow()
-        merge_at = Timestamp()
-        pre_merge_schema = registry.schema.get_schema_branch(name=registry.default_branch).duplicate()
-        async with lock.registry.global_graph_lock():
-            diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
-            diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=obj)
-            diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=obj)
-            merger = BranchMerger(
-                db=db,
-                diff_coordinator=diff_coordinator,
-                diff_merger=diff_merger,
-                diff_repository=diff_repository,
-                source_branch=obj,
-                diff_locker=DiffLocker(),
-                workflow=workflow,
-            )
-            branch_diff = await merger.merge(at=merge_at)
+        merge_locker = MergeLocker()
+        async with merge_locker.acquire_global_lock():
+            obj = await Branch.get_by_name(db=db, name=branch)
+            if obj.status != BranchStatus.OPEN:
+                log.info(f"Branch '{branch}' is not open (status={obj.status}), skipping merge")
+                return
 
-        changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=obj, db=db)
-        node_events = changelog_collector.collect_changelogs()
-
-        # Handle schema updates and migrations after merge
-        if merger and await merger.has_schema_changes():
-            # Load the updated schema from DB after merge
-            log.info("Loading updated schema")
-            updated_schema = await registry.schema.load_schema_from_db(
+            node_events = await _do_merge_branch(
                 db=db,
-                branch=merger.destination_branch,
-            )
-            log.info("Calculating migrations")
-            migrations = await merger.calculate_migrations(target_schema=updated_schema)
-
-            # Use coordinator to update registry and run migrations with rollback on failure
-            log.info("Running migrations")
-            coordinator = SchemaUpdateCoordinator(
-                db=db,
-                branch=merger.destination_branch,
-                schema_manager=registry.schema,
-                origin_schema=pre_merge_schema,
-                workflow=workflow,
+                log=log,
+                obj=obj,
                 context=context,
-                migration_executor=MigrationExecutor.WORKFLOW,
-                logger=log,
             )
-            await coordinator.execute(
-                candidate_schema=updated_schema,
-                at=merge_at,
-                migrations=migrations,
-                update_db=False,  # Schema nodes already written by merge
-                update_registry=True,
-                user_id=context.account.account_id,
-            )
-            log.info("Migrations completed")
-        # -------------------------------------------------------------
-        # Trigger the reconciliation of IPAM data after the merge
-        # -------------------------------------------------------------
-        diff_parser = await component_registry.get_component(IpamDiffParser, db=db, branch=obj)
-        ipam_node_details = await diff_parser.get_changed_ipam_node_details(
-            source_branch_name=obj.name,
-            target_branch_name=registry.default_branch,
-        )
-        if ipam_node_details:
-            await get_workflow().submit_workflow(
-                workflow=IPAM_RECONCILIATION,
-                context=context,
-                parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
-            )
-        # -------------------------------------------------------------
-        # remove tracking ID from the diff because there is no diff after the merge
-        # -------------------------------------------------------------
-        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
-        await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=obj.name)])
-        await diff_repository.freeze_diffs_for_branch(branch_name=obj.name)
-
-        # -------------------------------------------------------------
-        # Set branch status to MERGED to make it read-only
-        # -------------------------------------------------------------
-        obj.status = BranchStatus.MERGED
-        await obj.save(db=db)
-        registry.branch[obj.name] = obj
-
-        # -------------------------------------------------------------
-        # Cancel any remaining open proposed changes for this merged branch
-        # -------------------------------------------------------------
-        await get_workflow().submit_workflow(
-            workflow=BRANCH_CANCEL_PROPOSED_CHANGES,
-            context=context,
-            parameters={"branch_name": obj.name},
-        )
-
-        # -------------------------------------------------------------
-        # Generate an event to indicate that a branch has been merged
-        # NOTE: we still need to convert this event and potentially pull
-        #   some tasks currently executed based on the event into this workflow
-        # -------------------------------------------------------------
-        await get_workflow().submit_workflow(
-            workflow=BRANCH_MERGE_POST_PROCESS,
-            context=context,
-            parameters={"source_branch": obj.name, "target_branch": registry.default_branch},
-        )
 
         events: list[InfrahubEvent] = [merge_event]
 
@@ -400,6 +318,116 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
         event_service = await get_event_service()
         for event in events:
             await event_service.send(event=event)
+
+
+async def _do_merge_branch(
+    db: InfrahubDatabase, log: Logger | LoggerAdapter, obj: Branch, context: InfrahubContext
+) -> Sequence[tuple[DiffAction, NodeChangelog]]:
+    component_registry = get_component_registry()
+
+    merger: BranchMerger | None = None
+    workflow = get_workflow()
+    merge_at = Timestamp()
+    pre_merge_schema = registry.schema.get_schema_branch(name=registry.default_branch).duplicate()
+    async with lock.registry.global_graph_lock():
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=obj)
+        diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=obj)
+        merger = BranchMerger(
+            db=db,
+            diff_coordinator=diff_coordinator,
+            diff_merger=diff_merger,
+            diff_repository=diff_repository,
+            source_branch=obj,
+            diff_locker=DiffLocker(),
+            workflow=get_workflow(),
+        )
+        branch_diff = await merger.merge(at=merge_at)
+
+    changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=obj, db=db)
+    node_events = changelog_collector.collect_changelogs()
+
+    # Handle schema updates and migrations after merge
+    if merger and await merger.has_schema_changes():
+        # Load the updated schema from DB after merge
+        log.info("Loading updated schema")
+        updated_schema = await registry.schema.load_schema_from_db(
+            db=db,
+            branch=merger.destination_branch,
+        )
+        log.info("Calculating migrations")
+        migrations = await merger.calculate_migrations(target_schema=updated_schema)
+
+        # Use coordinator to update registry and run migrations with rollback on failure
+        log.info("Running migrations")
+        coordinator = SchemaUpdateCoordinator(
+            db=db,
+            branch=merger.destination_branch,
+            schema_manager=registry.schema,
+            origin_schema=pre_merge_schema,
+            workflow=workflow,
+            context=context,
+            migration_executor=MigrationExecutor.WORKFLOW,
+            logger=log,
+        )
+        await coordinator.execute(
+            candidate_schema=updated_schema,
+            at=merge_at,
+            migrations=migrations,
+            update_db=False,  # Schema nodes already written by merge
+            update_registry=True,
+            user_id=context.account.account_id,
+        )
+        log.info("Migrations completed")
+    # -------------------------------------------------------------
+    # Trigger the reconciliation of IPAM data after the merge
+    # -------------------------------------------------------------
+    diff_parser = await component_registry.get_component(IpamDiffParser, db=db, branch=obj)
+    ipam_node_details = await diff_parser.get_changed_ipam_node_details(
+        source_branch_name=obj.name,
+        target_branch_name=registry.default_branch,
+    )
+    if ipam_node_details:
+        await get_workflow().submit_workflow(
+            workflow=IPAM_RECONCILIATION,
+            context=context,
+            parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
+        )
+    # -------------------------------------------------------------
+    # remove tracking ID from the diff because there is no diff after the merge
+    # -------------------------------------------------------------
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
+    await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=obj.name)])
+    await diff_repository.freeze_diffs_for_branch(branch_name=obj.name)
+
+    # -------------------------------------------------------------
+    # Set branch status to MERGED to make it read-only
+    # -------------------------------------------------------------
+    obj.status = BranchStatus.MERGED
+    await obj.save(db=db)
+    registry.branch[obj.name] = obj
+
+    # -------------------------------------------------------------
+    # Cancel any remaining open proposed changes for this merged branch
+    # -------------------------------------------------------------
+    await workflow.submit_workflow(
+        workflow=BRANCH_CANCEL_PROPOSED_CHANGES,
+        context=context,
+        parameters={"branch_name": obj.name},
+    )
+
+    # -------------------------------------------------------------
+    # Generate an event to indicate that a branch has been merged
+    # NOTE: we still need to convert this event and potentially pull
+    #   some tasks currently executed based on the event into this workflow
+    # -------------------------------------------------------------
+    await workflow.submit_workflow(
+        workflow=BRANCH_MERGE_POST_PROCESS,
+        context=context,
+        parameters={"source_branch": obj.name, "target_branch": registry.default_branch},
+    )
+
+    return node_events
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -340,7 +340,7 @@ async def _do_merge_branch(
             diff_repository=diff_repository,
             source_branch=obj,
             diff_locker=DiffLocker(),
-            workflow=get_workflow(),
+            workflow=workflow,
         )
         branch_diff = await merger.merge(at=merge_at)
 
@@ -388,7 +388,7 @@ async def _do_merge_branch(
         target_branch_name=registry.default_branch,
     )
     if ipam_node_details:
-        await get_workflow().submit_workflow(
+        await workflow.submit_workflow(
             workflow=IPAM_RECONCILIATION,
             context=context,
             parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
@@ -396,7 +396,6 @@ async def _do_merge_branch(
     # -------------------------------------------------------------
     # remove tracking ID from the diff because there is no diff after the merge
     # -------------------------------------------------------------
-    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
     await diff_repository.mark_tracking_ids_merged(tracking_ids=[BranchTrackingId(name=obj.name)])
     await diff_repository.freeze_diffs_for_branch(branch_name=obj.name)
 

--- a/backend/infrahub/core/merge/__init__.py
+++ b/backend/infrahub/core/merge/__init__.py
@@ -1,0 +1,3 @@
+from infrahub.core.merge.branch_merger import BranchMerger
+
+__all__ = ["BranchMerger"]

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -10,10 +10,9 @@ from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import MergeFailedError, ValidationError
+from infrahub.git.models import GitRepositoryMerge
 from infrahub.log import get_logger
-
-from ..git.models import GitRepositoryMerge
-from ..workflows.catalogue import GIT_REPOSITORIES_MERGE
+from infrahub.workflows.catalogue import GIT_REPOSITORIES_MERGE
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -152,27 +151,27 @@ class BranchMerger:
         self,
         at: str | Timestamp | None = None,
     ) -> EnrichedDiffRoot:
-        """Merge the current branch into main."""
+        """Perform the merge. Caller must hold the global merge lock."""
         if self.source_branch.name == registry.default_branch:
             raise ValidationError(f"Unable to merge the branch '{self.source_branch.name}' into itself")
-
         log.info("Updating diff for merge")
         await self.diff_coordinator.update_branch_diff(
             base_branch=self.destination_branch, diff_branch=self.source_branch
         )
         log.info("Diff updated for merge")
 
-        log.info("Acquiring lock for merge")
+        log.info("Acquiring diff lock for merge")
         async with self.diff_locker.acquire_lock(
             target_branch_name=self.destination_branch.name,
             source_branch_name=self.source_branch.name,
             is_incremental=False,
         ):
-            log.info("Lock acquired for merge")
+            log.info("Diff lock acquired for merge")
             try:
                 errors: list[str] = []
                 async for conflict_path, conflict in self.diff_repository.get_all_conflicts_for_diff(
-                    diff_branch_name=self.source_branch.name, tracking_id=BranchTrackingId(name=self.source_branch.name)
+                    diff_branch_name=self.source_branch.name,
+                    tracking_id=BranchTrackingId(name=self.source_branch.name),
                 ):
                     if conflict.selected_branch is None or conflict.resolvable is False:
                         errors.append(conflict_path)

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -151,7 +151,7 @@ class BranchMerger:
         self,
         at: str | Timestamp | None = None,
     ) -> EnrichedDiffRoot:
-        """Perform the merge. Caller must hold the global merge lock."""
+        """Merge the current branch into main."""
         if self.source_branch.name == registry.default_branch:
             raise ValidationError(f"Unable to merge the branch '{self.source_branch.name}' into itself")
         log.info("Updating diff for merge")

--- a/backend/infrahub/core/merge/merge_locker.py
+++ b/backend/infrahub/core/merge/merge_locker.py
@@ -1,0 +1,11 @@
+from infrahub import lock
+
+
+class MergeLocker:
+    lock_namespace = "merge"
+
+    def __init__(self) -> None:
+        self.lock_registry = lock.registry
+
+    def acquire_global_lock(self) -> lock.InfrahubLock:
+        return self.lock_registry.get(name="all_branches", namespace=self.lock_namespace)

--- a/backend/tests/component/core/diff/test_merge_task_lock.py
+++ b/backend/tests/component/core/diff/test_merge_task_lock.py
@@ -1,0 +1,131 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fast_depends import Provider
+
+from infrahub import lock
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.branch.tasks import merge_branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_database
+
+
+class TestMergeTaskLock:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
+        return
+
+    @pytest.fixture
+    async def source_branch(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
+    ) -> Branch:
+        lock.initialize_lock(local_only=True)
+        return await create_branch(branch_name="branch_1", db=db)
+
+    @pytest.fixture
+    async def second_source_branch(self, db: InfrahubDatabase, source_branch: Branch) -> Branch:
+        return await create_branch(branch_name="branch_2", db=db)
+
+    @pytest.fixture
+    def context(self, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext.init(
+            branch=default_branch,
+            account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+        )
+
+    @staticmethod
+    async def _mock_do_merge(db: InfrahubDatabase, log: Any, obj: Branch, context: Any) -> list:  # noqa: ARG004
+        obj.status = BranchStatus.MERGED
+        await obj.save(db=db)
+        registry.branch[obj.name] = obj
+        return []
+
+    @staticmethod
+    def _mock_event_service() -> AsyncMock:
+        mock_svc = AsyncMock()
+        mock_svc.send = AsyncMock()
+        return mock_svc
+
+    async def test_concurrent_merges_same_branch_only_execute_once(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        source_branch: Branch,
+        workflow_local: WorkflowLocalExecution,
+        dependency_provider: Provider,
+        context: InfrahubContext,
+    ) -> None:
+        """When two merges of the same branch run concurrently, _do_merge_branch is called only once."""
+        mock_do_merge_fn = AsyncMock(side_effect=self._mock_do_merge)
+        mock_get_event_svc = AsyncMock(return_value=self._mock_event_service())
+
+        with (
+            dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+            patch("infrahub.core.branch.tasks._do_merge_branch", mock_do_merge_fn),
+            patch("infrahub.core.branch.tasks.get_event_service", mock_get_event_svc),
+        ):
+            await asyncio.gather(
+                merge_branch(branch=source_branch.name, context=context),
+                merge_branch(branch=source_branch.name, context=context),
+            )
+
+        mock_do_merge_fn.assert_awaited_once()
+
+        merged_branch = await Branch.get_by_name(db=db, name=source_branch.name)
+        assert merged_branch.status is BranchStatus.MERGED
+
+    async def test_concurrent_merges_different_branches_both_execute_sequentially(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        source_branch: Branch,
+        second_source_branch: Branch,
+        workflow_local: WorkflowLocalExecution,
+        dependency_provider: Provider,
+        context: InfrahubContext,
+    ) -> None:
+        """When two merges of different branches run concurrently, both execute but not at the same time."""
+        concurrent_count = 0
+        max_concurrent = 0
+
+        async def tracking_mock_do_merge(db: InfrahubDatabase, log: Any, obj: Branch, context: Any):
+            nonlocal concurrent_count, max_concurrent
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
+            await asyncio.sleep(0.1)
+            concurrent_count -= 1
+            obj.status = BranchStatus.MERGED
+            await obj.save(db=db)
+            registry.branch[obj.name] = obj
+            return []
+
+        mock_do_merge_fn = AsyncMock(side_effect=tracking_mock_do_merge)
+        mock_get_event_svc = AsyncMock(return_value=self._mock_event_service())
+
+        with (
+            dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+            patch("infrahub.core.branch.tasks._do_merge_branch", mock_do_merge_fn),
+            patch("infrahub.core.branch.tasks.get_event_service", mock_get_event_svc),
+        ):
+            await asyncio.gather(
+                merge_branch(branch=source_branch.name, context=context),
+                merge_branch(branch=second_source_branch.name, context=context),
+            )
+
+        assert mock_do_merge_fn.await_count == 2
+        assert max_concurrent == 1
+
+        merged_1 = await Branch.get_by_name(db=db, name=source_branch.name)
+        assert merged_1.status is BranchStatus.MERGED
+        merged_2 = await Branch.get_by_name(db=db, name=second_source_branch.name)
+        assert merged_2.status is BranchStatus.MERGED

--- a/changelog/6794.fixed.md
+++ b/changelog/6794.fixed.md
@@ -1,0 +1,1 @@
+Prevent multiple merge operations from running simultaneously, whether they are for the same branch or different branches. Only a single merge operation can run at a given time. Before executing any updates, the merge operation will check if the branch being merged is open to prevent merging a branch multiple times.


### PR DESCRIPTION
# Why

Running multiple merge operation at one time, either for the same branch or different branches, can cause unexpected results.

We should only allow one merge operation to proceed at a time. Before executing, the merge operation confirms that the branch being merged is still open. This prevents any branch from being merged multiple times.

Closes #6974 / IFC-1657

## What changed

Adds a new very simple `MergeLocker` class and uses it inside of the `merge_branch` flow. There's also some refactoring of the `merge_branch` flow to move much of the logic to a `_do_merge_branch` function to reduce indentation levels, but there is no functional difference.

# Testing

Added some component tests with more mocking than we usually do. I could make it a functional test, but it would be very expensive (diffing and merging are our two slowest operation) and kind of hard to verify.

Also did manual testing for trying to merge different branches and the same branch simultaneously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a global synchronization guard so only one merge runs at a time; merges now short-circuit when a branch is not open and reliably finalize merged state and post-merge processing.
* **Tests**
  * Added tests validating concurrent merge behavior: same-branch deduplication and correct sequential handling for different branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->