### PR TITLE
Stop using `raise_for_error` for SDK functions

### DIFF
--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.py
@@ -3,6 +3,7 @@ import logging
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.generator import InfrahubGenerator
 from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.protocols import CoreIPAddressPool, CoreIPPrefixPool
 
 
 async def find_interface(client: InfrahubClient, site_id: str) -> InfrahubNode:
@@ -97,7 +98,7 @@ class Generator(InfrahubGenerator):
 
         # Retrieve Pool for interconnection subnets
         log.info("Retrieve Pool for interconnection subnets")
-        internal_networks_pool = await self.client.get(kind="CoreIPPrefixPool", name__value="Internal networks pool")
+        internal_networks_pool = await self.client.get(kind=CoreIPPrefixPool, name__value="Internal networks pool")
 
         # Allocate the next free IP prefix for the service
         log.info("Allocate the next free IP prefix for the service")
@@ -113,7 +114,7 @@ class Generator(InfrahubGenerator):
         # Create a new Address Pool for this prefix
         log.info("Create a new Address Pool for this prefix")
         circuit_address_pool = await self.client.create(
-            kind="CoreIPAddressPool",
+            kind=CoreIPAddressPool,
             name=f"{service_name}-{service_id}",
             default_address_type="IpamIPAddress",
             default_prefix_size=31,
@@ -125,15 +126,11 @@ class Generator(InfrahubGenerator):
 
         # Use the new pool to allocate 2 IPs on the interfaces
         log.info("Use the new pool to allocate 2 IPs on the interfaces")
-        interface_a_ip = await self.client.allocate_next_ip_address(
-            resource_pool=circuit_address_pool,
-        )
+        interface_a_ip = await self.client.allocate_next_ip_address(resource_pool=circuit_address_pool)
         interface_a.ip_addresses.add(interface_a_ip)
         await interface_a.save(allow_upsert=True)
 
-        interface_b_ip = await self.client.allocate_next_ip_address(
-            resource_pool=circuit_address_pool,
-        )
+        interface_b_ip = await self.client.allocate_next_ip_address(resource_pool=circuit_address_pool)
         interface_b.ip_addresses.add(interface_b_ip)
         await interface_b.save(allow_upsert=True)
 

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/generators/backbone_service.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/generators/backbone_service.py
@@ -3,6 +3,7 @@ import logging
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.generator import InfrahubGenerator
 from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.protocols import CoreIPAddressPool, CoreIPPrefixPool
 
 
 async def find_interface(client: InfrahubClient, site_id: str) -> InfrahubNode:
@@ -97,7 +98,7 @@ class Generator(InfrahubGenerator):
 
         # Retrieve Pool for interconnection subnets
         log.info("Retrieve Pool for interconnection subnets")
-        internal_networks_pool = await self.client.get(kind="CoreIPPrefixPool", name__value="Internal networks pool")
+        internal_networks_pool = await self.client.get(kind=CoreIPPrefixPool, name__value="Internal networks pool")
 
         # Allocate the next free IP prefix for the service
         log.info("Allocate the next free IP prefix for the service")
@@ -113,7 +114,7 @@ class Generator(InfrahubGenerator):
         # Create a new Address Pool for this prefix
         log.info("Create a new Address Pool for this prefix")
         circuit_address_pool = await self.client.create(
-            kind="CoreIPAddressPool",
+            kind=CoreIPAddressPool,
             name=f"{service_name}-{service_id}",
             default_address_type="IpamIPAddress",
             default_prefix_size=31,
@@ -125,15 +126,11 @@ class Generator(InfrahubGenerator):
 
         # Use the new pool to allocate 2 IPs on the interfaces
         log.info("Use the new pool to allocate 2 IPs on the interfaces")
-        interface_a_ip = await self.client.allocate_next_ip_address(
-            resource_pool=circuit_address_pool,
-        )
+        interface_a_ip = await self.client.allocate_next_ip_address(resource_pool=circuit_address_pool)
         interface_a.ip_addresses.add(interface_a_ip)
         await interface_a.save(allow_upsert=True)
 
-        interface_b_ip = await self.client.allocate_next_ip_address(
-            resource_pool=circuit_address_pool,
-        )
+        interface_b_ip = await self.client.allocate_next_ip_address(resource_pool=circuit_address_pool)
         interface_b.ip_addresses.add(interface_b_ip)
         await interface_b.save(allow_upsert=True)
 

--- a/backend/tests/functional/proposed_change/test_check_for_approval_revoke.py
+++ b/backend/tests/functional/proposed_change/test_check_for_approval_revoke.py
@@ -18,10 +18,6 @@ class TestProposedChangeCheckForRevokeApprovals(TestInfrahubApp):
         """
 
         with pytest.raises(GraphQLError) as exc:
-            _ = await client.execute_graphql(
-                query=mutation,
-                variables={"data": {}},
-                raise_for_error=True,
-            )
+            _ = await client.execute_graphql(query=mutation, variables={"data": {}})
 
         assert "Revoking existing approvals based on branch changes is an enterprise feature." in exc.value.message

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -271,7 +271,6 @@ class TestProposedChangeReview(TestInfrahubApp):
                 query=self.review_query,
                 variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
                 branch_name=source_branch.name,
-                raise_for_error=False,
             )
 
         assert exc.value.errors[0]["message"] == "You are not allowed to review proposed changes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1854,6 +1854,7 @@ include = ["backend/tests/fixtures/**"]
 no-matching-overload = "ignore"
 possibly-missing-attribute = "ignore"
 unresolved-import = "ignore"
+invalid-argument-type = "ignore"
 
 [[tool.ty.overrides]]
 include = ["backend/tests/unit/**"]


### PR DESCRIPTION
This parameter has been deprecated for a while and will soon be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test fixtures now use protocol constants instead of string literals for pool types.

* **Tests**
  * GraphQL tests updated to rely on exception behavior for clearer error assertions.

* **Chores**
  * Extended type-checker overrides for test fixtures to suppress a specific validation.
  * Updated Python SDK reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->