### PR TITLE
Ensure very long branch names are properly displayed in the branch selector

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:399168705": [
+    "src/entities/branches/ui/branch-selector.tsx:1242595980": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:2573314349": [
+    "src/entities/branches/ui/branch-selector.tsx:2669908622": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:2068696219": [
+    "src/entities/branches/ui/branch-selector.tsx:2573314349": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:2669908622": [
+    "src/entities/branches/ui/branch-selector.tsx:399168705": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:1242595980": [
+    "src/entities/branches/ui/branch-selector.tsx:3058438850": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -48,7 +48,7 @@ export default function BranchSelector() {
           className="h-8 w-60 rounded-lg border-neutral-200 p-0 shadow-none"
           data-testid="branch-selector-trigger"
         >
-          <div className="inline-flex h-full min-w-0 grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">
+          <div className="inline-flex h-full grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">
             <div className="inline-flex min-w-0 items-center gap-1.5">
               <Icon icon="mdi:source-branch" className="shrink-0" />
               <span className="truncate">{currentBranch.name}</span>

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -45,7 +45,7 @@ export default function BranchSelector() {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className="h-8 w-72 rounded-lg border-neutral-200 p-0 shadow-none"
+          className="h-8 w-60 rounded-lg border-neutral-200 p-0 shadow-none"
           data-testid="branch-selector-trigger"
         >
           <div className="inline-flex h-full min-w-0 grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -48,7 +48,7 @@ export default function BranchSelector() {
           className="h-8 w-60 rounded-lg border-neutral-200 p-0 shadow-none"
           data-testid="branch-selector-trigger"
         >
-          <div className="inline-flex h-full grow items-center justify-between gap-1.5 border-gray-200 border-r px-3">
+          <div className="inline-flex h-full min-w-0 grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">
             <div className="inline-flex min-w-0 items-center gap-1.5">
               <Icon icon="mdi:source-branch" className="shrink-0" />
               <span className="truncate">{currentBranch.name}</span>

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -162,10 +162,10 @@ function BranchOption({ branch, onChange }: { branch: Branch; onChange: () => vo
       onSelect={onChange}
       value={branch.name}
     >
-      <div className="flex w-full min-w-0 items-center">
+      <div className="flex w-full items-center overflow-hidden">
         <span className="truncate">{branch.name}</span>
 
-        <div className="ml-auto inline-flex shrink-0 items-center gap-1">
+        <div className="ml-auto inline-flex items-center gap-1">
           {branch.is_default && (
             <span className="rounded-sm border border-gray-200 px-1.5 text-gray-400 text-xs">
               default

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -45,7 +45,7 @@ export default function BranchSelector() {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className="h-8 w-60 rounded-lg border-neutral-200 p-0 shadow-none"
+          className="h-8 w-72 rounded-lg border-neutral-200 p-0 shadow-none"
           data-testid="branch-selector-trigger"
         >
           <div className="inline-flex h-full min-w-0 grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -101,6 +101,7 @@ function BranchSelect({
       <Command
         style={{
           minWidth: "var(--radix-popover-trigger-width)",
+          maxWidth: "320px",
           maxHeight: "min(var(--radix-popover-content-available-height), 500px)",
         }}
       >
@@ -161,10 +162,10 @@ function BranchOption({ branch, onChange }: { branch: Branch; onChange: () => vo
       onSelect={onChange}
       value={branch.name}
     >
-      <div className="flex w-full items-center truncate">
+      <div className="flex w-full min-w-0 items-center">
         <span className="truncate">{branch.name}</span>
 
-        <div className="ml-auto inline-flex items-center gap-1">
+        <div className="ml-auto inline-flex shrink-0 items-center gap-1">
           {branch.is_default && (
             <span className="rounded-sm border border-gray-200 px-1.5 text-gray-400 text-xs">
               default


### PR DESCRIPTION
Add ellipsis for overflow and increase width to fit the Merged badge and add ellipsis for branches options

<img width="845" height="913" alt="82692" src="https://github.com/user-attachments/assets/d21643bd-d84b-4981-b9f9-a9b9e47882cd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Constrained dropdown popover width (max 320px) to prevent oversized menus and improve alignment.
* Prevented horizontal overflow in the branch selector trigger area to avoid layout spill.
* Adjusted option text handling to hide overflow instead of truncating, preserving visual consistency and preventing layout breakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->