### PR TITLE
Add Button component to design system with Storybook stories

### DIFF
--- a/frontend/design-system/oxlint.config.ts
+++ b/frontend/design-system/oxlint.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   ],
   rules: {
     "eslint/arrow-body-style": "off",
+    "eslint/func-style": "off",
     "eslint/max-lines-per-function": "off",
     "eslint/no-ternary": "off",
     "eslint/sort-imports": "off",
@@ -28,6 +29,7 @@ export default defineConfig({
     "oxc/no-rest-spread-properties": "off",
     "react-perf/jsx-no-new-object-as-prop": "off",
     "react-perf/jsx-props-no-spreading": "off",
+    "react/button-has-type": "off",
     "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
     "react/jsx-max-depth": "off",
     "react/jsx-props-no-spreading": "off",

--- a/frontend/design-system/package-lock.json
+++ b/frontend/design-system/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "design-system",
+  "name": "@infrahub/ui",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "design-system",
+      "name": "@infrahub/ui",
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.5.0",
@@ -3366,6 +3367,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/design-system/package.json
+++ b/frontend/design-system/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "design-system",
+  "name": "@infrahub/ui",
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles.css": "./src/index.css"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -17,6 +22,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.5.0",

--- a/frontend/design-system/src/components/button/button.stories.tsx
+++ b/frontend/design-system/src/components/button/button.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PencilIcon } from "lucide-react";
+
+import { Button, type ButtonProps, buttonVariants } from "./button";
+
+const VARIANTS = Object.keys(buttonVariants.variants.variant) as ButtonProps["variant"][];
+const SIZES = Object.keys(buttonVariants.variants.size) as ButtonProps["size"][];
+
+const ICON_SIZES = new Set(["icon", "square"]) as Set<ButtonProps["size"]>;
+
+function buttonContent(size: ButtonProps["size"]) {
+  if (ICON_SIZES.has(size)) {
+    return <PencilIcon size={14} />;
+  }
+  return size;
+}
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    disabled: false,
+  },
+  argTypes: {
+    variant: { control: "select", options: VARIANTS },
+    size: { control: "select", options: SIZES },
+    disabled: { control: "boolean" },
+    ref: { table: { disable: true } },
+    type: { table: { disable: true } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const AllVariants: Story = {
+  argTypes: {
+    variant: { table: { disable: true } },
+    size: { table: { disable: true } },
+    children: { table: { disable: true } },
+  },
+  render: ({ disabled }) => (
+    <div className="flex flex-col gap-4">
+      {VARIANTS.map((variant) => (
+        <div key={variant} className="flex items-center gap-2">
+          <span className="w-30 text-xs text-gray-500">{variant}</span>
+          {SIZES.map((size) => (
+            <Button key={`${variant}-${size}`} variant={variant} size={size} disabled={disabled}>
+              {buttonContent(size)}
+            </Button>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export const Playground: Story = {
+  args: {
+    children: "Button",
+  },
+};

--- a/frontend/design-system/src/components/button/button.tsx
+++ b/frontend/design-system/src/components/button/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const buttonVariants = tv({
+  base: "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-sm border border-transparent font-medium text-sm disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-custom-blue-700",
+  variants: {
+    variant: {
+      primary: "bg-custom-blue-700 text-white shadow-sm hover:bg-custom-blue-700/90",
+      "primary-outline":
+        "border-custom-blue-700 bg-white text-custom-blue-700 shadow-xs hover:bg-gray-100",
+      danger: "bg-red-500 text-white shadow-sm hover:bg-red-500/90",
+      warning: "bg-yellow-500 text-white shadow-sm hover:bg-yellow-500/90",
+      active: "bg-green-600 text-white shadow-sm hover:bg-green-600/90",
+      "active-outline": "border-green-600 bg-white shadow-xs hover:bg-gray-100",
+      outline: "border-gray-200 bg-white shadow-xs hover:bg-gray-100",
+      dark: "bg-gray-200 shadow-xs hover:bg-gray-300",
+      ghost: "hover:bg-gray-100",
+    },
+    size: {
+      default: "h-9 px-4 py-2",
+      xs: "h-7 px-2 text-xs",
+      sm: "h-8 px-2 text-sm",
+      icon: "h-7 w-7 rounded-full",
+      square: "h-9 w-9",
+    },
+  },
+  defaultVariants: {
+    variant: "primary",
+    size: "default",
+  },
+});
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+export function Button({
+  className,
+  variant,
+  size,
+  type = "button",
+  ref,
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={buttonVariants({ variant, size, className })}
+      type={type}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/design-system/src/index.css
+++ b/frontend/design-system/src/index.css
@@ -1,1 +1,20 @@
 @import "tailwindcss";
+
+@font-face {
+  font-family: InterVariable;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url(https://rsms.me/inter/font-files/InterVariable.woff2) format("woff2");
+}
+
+@theme {
+  --font-sans: InterVariable, sans-serif;
+  --color-custom-blue-700: #087895;
+  --color-custom-blue-green: #0b6581;
+}
+
+body {
+  color: var(--color-stone-800);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/frontend/design-system/src/index.ts
+++ b/frontend/design-system/src/index.ts
@@ -1,0 +1,1 @@
+export { Button, type ButtonProps, buttonVariants } from "./components/button/button";


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a customizable Button component with multiple variants and sizes
  * Added design system theming with CSS variables for colors and typography
  * Published design system as a new package with updated naming and module exports

* **Chores**
  * Updated linting rule suppressions for code style consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
  - Add base Button component to `@infrahub/ui` design system using `tailwind-variants`
  - Create Storybook stories with auto-generated AllVariants grid (variants × sizes) and Playground
  - Configure design system CSS with Inter font, Infrahub custom color palette, and base text color