### PR TITLE
Fix artifact detail page display when artifact generation failed

### DIFF
--- a/changelog/8394.fixed.md
+++ b/changelog/8394.fixed.md
@@ -1,0 +1,1 @@
+Fixed artifact detail page not being accessible when the artifact failed to generate

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -5,6 +5,9 @@
 //
 exports[`fix ts error`] = {
   value: `{
+    "src/entities/artifacts/types.ts:1095909013": [
+      [0, 34, 38, "tsc: Cannot find module \'@/shared/api/graphql/generated/types\' or its corresponding type declarations.", "2563440334"]
+    ],
     "src/entities/authentication/ui/login.tsx:975690659": [
       [74, 7, 10, "tsc: Property \'attribute\' is missing in type \'\\"Required\\"; }; }; autoFocus: true; } | { name: string; label: string; rules: { validate: { required: ({ value }: Pick<FormFieldValue, \\"value\\">) => true\' but required in type \'InputFieldProps\'.", "1610618705"],
       [81, 7, 18, "tsc: Property \'attribute\' is missing in type \'\\"Required\\"; }; }; } | { name: string; label: string; rules: { validate: { required: ({ value }: Pick<FormFieldValue, \\"value\\">) => true\' but required in type \'FormFieldProps\'.", "913787886"]

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -5,9 +5,6 @@
 //
 exports[`fix ts error`] = {
   value: `{
-    "src/entities/artifacts/types.ts:1344880585": [
-      [0, 34, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
-    ],
     "src/entities/authentication/ui/login.tsx:975690659": [
       [74, 7, 10, "tsc: Property \'attribute\' is missing in type \'\\"Required\\"; }; }; autoFocus: true; } | { name: string; label: string; rules: { validate: { required: ({ value }: Pick<FormFieldValue, \\"value\\">) => true\' but required in type \'InputFieldProps\'.", "1610618705"],
       [81, 7, 18, "tsc: Property \'attribute\' is missing in type \'\\"Required\\"; }; }; } | { name: string; label: string; rules: { validate: { required: ({ value }: Pick<FormFieldValue, \\"value\\">) => true\' but required in type \'FormFieldProps\'.", "913787886"]

--- a/frontend/app/src/entities/artifacts/types.ts
+++ b/frontend/app/src/entities/artifacts/types.ts
@@ -1,4 +1,4 @@
-import type { CoreArtifact } from "@/shared/api/graphql/generated/graphql";
+import type { CoreArtifact } from "@/shared/api/graphql/generated/types";
 import type { DataViewerContentType } from "@/shared/components/data-viewer/types";
 
 import type { NodeCore } from "@/entities/nodes/types";
@@ -6,9 +6,9 @@ import type { NodeCore } from "@/entities/nodes/types";
 export type ArtifactStatus = "Error" | "Pending" | "Processing" | "Ready";
 
 export interface ArtifactObject extends NodeCore {
-  checksum: NonNullable<CoreArtifact["checksum"]> & { value: string };
+  checksum: NonNullable<CoreArtifact["checksum"]> & { value: string | null };
   content_type: NonNullable<CoreArtifact["content_type"]> & { value: DataViewerContentType };
-  storage_id: NonNullable<CoreArtifact["storage_id"]> & { value: string };
+  storage_id: NonNullable<CoreArtifact["storage_id"]> & { value: string | null };
   status: NonNullable<CoreArtifact["status"]> & { value: ArtifactStatus };
   definition: NonNullable<CoreArtifact["definition"]> & { node: NodeCore };
   object: NonNullable<CoreArtifact["object"]> & { node: NodeCore };
@@ -19,9 +19,7 @@ export function assertArtifactObject(data: NodeCore | null | undefined): Artifac
 
   if (
     !artifact?.content_type?.value ||
-    !artifact.storage_id?.value ||
     !artifact.status?.value ||
-    !artifact.checksum?.value ||
     !artifact.definition?.node ||
     !artifact.object?.node
   ) {

--- a/frontend/app/src/entities/artifacts/ui/artifact-details.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-details.tsx
@@ -41,6 +41,7 @@ export function ArtifactsDetails({ artifactId, artifactSchema }: ArtifactsDetail
 
   const contentType = artifact.content_type.value;
   const extension = getExtensionFromContentType(contentType);
+  const storageId = artifact.storage_id.value;
 
   return (
     <div className="flex w-full grow flex-wrap gap-0.5 overflow-auto lg:flex-nowrap">
@@ -57,12 +58,18 @@ export function ArtifactsDetails({ artifactId, artifactSchema }: ArtifactsDetail
           </Row>
         </Col>
 
-        <ArtifactFile
-          storageId={artifact.storage_id.value}
-          fileName={`${artifactId}.${extension}`}
-          contentType={contentType}
-          className="m-1 grow overflow-hidden"
-        />
+        {storageId ? (
+          <ArtifactFile
+            storageId={storageId}
+            fileName={`${artifactId}.${extension}`}
+            contentType={contentType}
+            className="m-1 grow overflow-hidden"
+          />
+        ) : (
+          <div className="flex grow items-center justify-center p-4 text-gray-500">
+            No artifact content available
+          </div>
+        )}
       </Content.Card>
       <Card className="min-w-90 overflow-auto p-0">
         <div className="border-gray-200 border-b p-2 font-semibold">Activities</div>


### PR DESCRIPTION
# Why

  When an artifact fails to generate (e.g., transform raises an exception), the artifact detail
  page shows a full-page "Artifact data is incomplete" error, making it impossible to view the
  artifact's status, metadata, or activity history.

  Closes #8394

  ## What changed

  - **`types.ts`**: Made `storage_id` and `checksum` accept `null` values in `ArtifactObject` type,
   and removed them from the required-field assertion in `assertArtifactObject`. These fields are
  only populated on successful generation.
  - **`artifact-details.tsx`**: Conditionally renders `ArtifactFile` only when `storage_id` is
  available. Otherwise shows "No artifact content available" in the file section.
  - The rest of the artifact page (header, status badge, definition, target object, activities)
  renders normally for failed artifacts.

  ## How to test

  1. Load the schema from the issue with a `VehiclesCar` inheriting `CoreArtifactTarget`
  2. Set up a repository with a transform that raises an exception
  3. Wait for artifact generation to fail
  4. Navigate to the artifact detail page
  5. **Before**: full-page error "Artifact data is incomplete"
  6. **After**: page loads with error status badge, metadata, activities, and "No artifact content
  available" in the file section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact detail page now handles failed or incomplete artifact generation gracefully, showing a clear "No artifact content available" message when artifact content or storage identifier is missing.
  * Improved display logic for artifacts with missing identifiers or checksums so the page no longer errors and presents available metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->