### PR TITLE
Add syslog forwarding config options

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from infrahub_sdk.utils import generate_uuid
 from pydantic import (
@@ -53,6 +53,7 @@ def default_append_git_suffix_domains() -> list[str]:
 class EnterpriseFeatures(StrEnum):
     PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
     REVOKE_PROPOSED_CHANGE_APPROVALS = "revoke_proposed_change_approvals"
+    LOG_FORWARDING_SYSLOG = "log_forwarding_syslog"
 
 
 class UserInfoMethod(StrEnum):
@@ -867,6 +868,80 @@ class TraceSettings(BaseSettings):
     exporter_endpoint: str | None = Field(default=None, description="OTLP endpoint for exporting traces")
 
 
+class SyslogProtocol(StrEnum):
+    TCP = "tcp"
+    UDP = "udp"
+
+
+class SyslogFormat(StrEnum):
+    RFC5424 = "rfc5424"
+    RFC3164 = "rfc3164"
+
+
+class TcpFraming(StrEnum):
+    NEWLINE = "newline"
+    OCTET_COUNTING = "octet-counting"
+
+
+class LogForwardingDestination(BaseSettings):
+    name: str = Field(description="Unique name for the destination, used in all observability output.")
+    type: Literal["syslog"] = Field(description="Destination type.")
+    host: str = Field(description="Destination host or IP address.")
+    port: int = Field(ge=1, le=65535, description="Destination port number.")
+    protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")
+    format: SyslogFormat = Field(default=SyslogFormat.RFC5424, description="Syslog format standard.")
+    tcp_framing: TcpFraming = Field(
+        default=TcpFraming.NEWLINE, description="TCP framing method (newline or octet-counting)."
+    )
+    tls_enabled: bool = Field(default=False, description="Enable TLS encryption for TCP connections.")
+    tls_ca_bundle: str | None = Field(
+        default=None, description="Path or PEM string for CA bundle to validate syslog server certificate."
+    )
+    queue_size: int = Field(default=10000, ge=1, description="Maximum number of messages in the per-destination queue.")
+    max_reconnect_interval: int = Field(
+        default=60, ge=1, description="Maximum reconnection backoff interval in seconds."
+    )
+    shutdown_drain_timeout: int = Field(
+        default=10, ge=0, description="Seconds to wait for queue drain on graceful shutdown."
+    )
+    forward_application_logs: bool = Field(
+        default=False, description="Forward application log messages to this destination."
+    )
+    min_log_severity: ExtraLogLevel = Field(
+        default=ExtraLogLevel.WARNING,
+        description="Minimum Python log severity to forward when application log forwarding is enabled.",
+    )
+
+    @model_validator(mode="after")
+    def validate_tls_protocol(self) -> Self:
+        if self.tls_enabled and self.protocol == SyslogProtocol.UDP:
+            raise ValueError("TLS is only supported with TCP protocol, not UDP.")
+        return self
+
+
+class LogForwardingSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_LOG_FORWARDING_")
+    destinations: list[LogForwardingDestination] = Field(
+        default_factory=list,
+        description="List of log forwarding destinations. (Enterprise only: not available in the community version.)",
+    )
+
+    @field_validator("destinations")
+    @classmethod
+    def validate_unique_names(cls, v: list[LogForwardingDestination]) -> list[LogForwardingDestination]:
+        names = [d.name for d in v]
+        if len(names) != len(set(names)):
+            raise ValueError("Destination names must be unique")
+        return v
+
+    @property
+    def enterprise_features(self) -> list[EnterpriseFeatures]:
+        """Returns enterprise features enabled by log forwarding configuration."""
+        if any(d.type == "syslog" for d in self.destinations):
+            return [EnterpriseFeatures.LOG_FORWARDING_SYSLOG]
+        return []
+
+
 class PolicySettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_POLICY_")
     required_proposed_change_approvals: int = Field(
@@ -1029,11 +1104,12 @@ class Settings(BaseSettings):
     storage: StorageSettings = StorageSettings()
     trace: TraceSettings = TraceSettings()
     experimental_features: ExperimentalFeaturesSettings = ExperimentalFeaturesSettings()
+    log_forwarding: LogForwardingSettings = LogForwardingSettings()
 
     @property
     def enterprise_features(self) -> list[EnterpriseFeatures]:
         """Returns a list of enterprise features that are enabled based on the settings."""
-        return self.policy.enterprise_features
+        return self.policy.enterprise_features + self.log_forwarding.enterprise_features
 
 
 def load(config_file_name: Path | str = "infrahub.toml", config_data: dict[str, Any] | None = None) -> Settings:

--- a/backend/tests/unit/config/test_config.py
+++ b/backend/tests/unit/config/test_config.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from infrahub.config import SETTINGS, GitSettings, HTTPSettings, StorageSettings, UserInfoMethod, load
 from tests.conftest import TestHelper
 
-TEST_DATA_DIR = Path(__file__).parent / "test_data"
+TEST_DATA_DIR = Path(__file__).parent.parent / "test_data"
 
 
 def test_load_sso_config(helper: TestHelper) -> None:

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -1,0 +1,164 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from infrahub.config import (
+    EnterpriseFeatures,
+    ExtraLogLevel,
+    LogForwardingDestination,
+    LogForwardingSettings,
+    SyslogFormat,
+    SyslogProtocol,
+    load,
+)
+
+
+def test_log_forwarding_destination_valid() -> None:
+    dest = LogForwardingDestination(name="siem-primary", type="syslog", host="syslog.example.com", port=514)
+    assert dest.name == "siem-primary"
+    assert dest.type == "syslog"
+    assert dest.host == "syslog.example.com"
+    assert dest.port == 514
+    assert dest.protocol.value == "tcp"
+    assert dest.format.value == "rfc5424"
+    assert dest.tcp_framing.value == "newline"
+    assert dest.tls_enabled is False
+    assert dest.queue_size == 10000
+    assert dest.max_reconnect_interval == 60
+    assert dest.shutdown_drain_timeout == 10
+    assert dest.forward_application_logs is False
+    assert dest.min_log_severity == ExtraLogLevel.WARNING
+
+
+@pytest.mark.parametrize("invalid_port", [0, -1, 65536, 70000])
+def test_log_forwarding_destination_rejects_invalid_port(invalid_port: int) -> None:
+    with pytest.raises(ValidationError):
+        LogForwardingDestination(name="test", type="syslog", host="localhost", port=invalid_port)
+
+
+def test_log_forwarding_destination_rejects_tls_with_udp() -> None:
+    with pytest.raises(ValueError, match="TLS is only supported with TCP protocol, not UDP"):
+        LogForwardingDestination(
+            name="test", type="syslog", host="localhost", port=514, protocol=SyslogProtocol.UDP, tls_enabled=True
+        )
+
+
+def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
+    dest = LogForwardingDestination(
+        name="test", type="syslog", host="localhost", port=6514, protocol=SyslogProtocol.TCP, tls_enabled=True
+    )
+    assert dest.tls_enabled is True
+
+
+@pytest.mark.parametrize("invalid_queue_size", [0, -5])
+def test_log_forwarding_destination_rejects_invalid_queue_size(invalid_queue_size: int) -> None:
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        LogForwardingDestination(name="test", type="syslog", host="localhost", port=514, queue_size=invalid_queue_size)
+
+
+def test_log_forwarding_settings_empty_destinations() -> None:
+    settings = LogForwardingSettings()
+    assert settings.destinations == []
+    assert settings.enterprise_features == []
+
+
+def test_log_forwarding_settings_duplicate_names_rejected() -> None:
+    with pytest.raises(ValidationError, match="Destination names must be unique"):
+        LogForwardingSettings(
+            destinations=[
+                LogForwardingDestination(name="dup", type="syslog", host="host1", port=514),
+                LogForwardingDestination(name="dup", type="syslog", host="host2", port=515),
+            ]
+        )
+
+
+def test_log_forwarding_settings_unique_names_accepted() -> None:
+    settings = LogForwardingSettings(
+        destinations=[
+            LogForwardingDestination(name="primary", type="syslog", host="host1", port=514),
+            LogForwardingDestination(name="secondary", type="syslog", host="host2", port=515),
+        ]
+    )
+    assert len(settings.destinations) == 2
+
+
+def test_log_forwarding_enterprise_feature_not_detected_when_empty() -> None:
+    config = load(config_data={})
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG not in config.enterprise_features
+
+
+def test_log_forwarding_enterprise_feature_detected() -> None:
+    settings = LogForwardingSettings(
+        destinations=[
+            LogForwardingDestination(name="siem", type="syslog", host="syslog.example.com", port=514),
+        ]
+    )
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in settings.enterprise_features
+
+
+def test_log_forwarding_toml_parsing_multiple_destinations() -> None:
+    config_data = {
+        "log_forwarding": {
+            "destinations": [
+                {
+                    "name": "siem-primary",
+                    "type": "syslog",
+                    "host": "syslog.example.com",
+                    "port": 514,
+                    "protocol": "tcp",
+                    "format": "rfc5424",
+                },
+                {
+                    "name": "siem-secondary",
+                    "type": "syslog",
+                    "host": "syslog2.example.com",
+                    "port": 1514,
+                    "protocol": "udp",
+                    "format": "rfc3164",
+                },
+            ]
+        }
+    }
+    config = load(config_data=config_data)
+    assert len(config.log_forwarding.destinations) == 2
+    dest1 = config.log_forwarding.destinations[0]
+    assert dest1.name == "siem-primary"
+    assert dest1.host == "syslog.example.com"
+    assert dest1.protocol is SyslogProtocol.TCP
+    assert dest1.format is SyslogFormat.RFC5424
+    dest2 = config.log_forwarding.destinations[1]
+    assert dest2.name == "siem-secondary"
+    assert dest2.host == "syslog2.example.com"
+    assert dest2.protocol is SyslogProtocol.UDP
+    assert dest2.format is SyslogFormat.RFC3164
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in config.enterprise_features
+
+
+def test_log_forwarding_destinations_from_environment_variable() -> None:
+    destinations_json = json.dumps(
+        [
+            {"name": "siem1", "type": "syslog", "host": "host1.example.com", "port": 514},
+            {"name": "siem2", "type": "syslog", "host": "host2.example.com", "port": 1514, "protocol": "udp"},
+        ]
+    )
+    with patch.dict(os.environ, {"INFRAHUB_LOG_FORWARDING_DESTINATIONS": destinations_json}):
+        settings = LogForwardingSettings()
+    assert len(settings.destinations) == 2
+    assert settings.destinations[0].name == "siem1"
+    assert settings.destinations[0].host == "host1.example.com"
+    assert settings.destinations[1].name == "siem2"
+    assert settings.destinations[1].protocol.value == "udp"
+
+
+def test_settings_enterprise_features_aggregates_log_forwarding() -> None:
+    config_data = {
+        "log_forwarding": {"destinations": [{"name": "siem", "type": "syslog", "host": "localhost", "port": 514}]},
+        "policy": {"required_proposed_change_approvals": 2},
+    }
+    config = load(config_data=config_data)
+    features = config.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in features
+    assert EnterpriseFeatures.PROPOSED_CHANGE_REQUIRE_APPROVAL in features

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -191,9 +191,9 @@ Configuration settings for the message bus.
 | `INFRAHUB_SECURITY_ACCESS_TOKEN_LIFETIME` | Lifetime of access token in seconds | integer | 3600 |
 | `INFRAHUB_SECURITY_REFRESH_TOKEN_LIFETIME` | Lifetime of refresh token in seconds | integer | 2592000 |
 | `INFRAHUB_SECURITY_SECRET_KEY` | The secret key used to validate authentication tokens | string | None |
-| `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` | The selected OAuth2 providers | array | None |
+| `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` | The selected OAuth2 providers | array[string] | None |
 | `INFRAHUB_SECURITY_OAUTH2_PROVIDER_SETTINGS` | None | object | Check nested parameters |
-| `INFRAHUB_SECURITY_OIDC_PROVIDERS` | The selected OIDC providers | array | None |
+| `INFRAHUB_SECURITY_OIDC_PROVIDERS` | The selected OIDC providers | array[string] | None |
 | `INFRAHUB_SECURITY_OIDC_PROVIDER_SETTINGS` | None | object | Check nested parameters |
 | `INFRAHUB_SECURITY_RESTRICT_UNTRUSTED_JINJA2_FILTERS` | Indicates if untrusted Jinja2 filters should be disallowed for computed attributes | boolean | True |
 | `INFRAHUB_SECURITY_SSO_USER_DEFAULT_GROUP` | Name of the group to which users authenticated via SSO will belong if not provided by identity provider | None | None |
@@ -310,3 +310,28 @@ Configuration settings for the message bus.
 |------|-------------|------|---------|
 | `INFRAHUB_EXPERIMENTAL_GRAPHQL_ENUMS` | None | boolean | False |
 | `INFRAHUB_EXPERIMENTAL_VALUE_DB_INDEX` | None | boolean | False |
+
+## Log forwarding
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
+
+### INFRAHUB_LOG_FORWARDING_DESTINATIONS
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `NAME` | Unique name for the destination, used in all observability output. | string | None |
+| `TYPE` | Destination type. | string | None |
+| `HOST` | Destination host or IP address. | string | None |
+| `PORT` | Destination port number. | integer | None |
+| `PROTOCOL` | Transport protocol (tcp or udp). | string (tcp, udp) | tcp |
+| `FORMAT` | Syslog format standard. | string (rfc5424, rfc3164) | rfc5424 |
+| `TCP_FRAMING` | TCP framing method (newline or octet-counting). | string (newline, octet-counting) | newline |
+| `TLS_ENABLED` | Enable TLS encryption for TCP connections. | boolean | False |
+| `TLS_CA_BUNDLE` | Path or PEM string for CA bundle to validate syslog server certificate. | None | None |
+| `QUEUE_SIZE` | Maximum number of messages in the per-destination queue. | integer | 10000 |
+| `MAX_RECONNECT_INTERVAL` | Maximum reconnection backoff interval in seconds. | integer | 60 |
+| `SHUTDOWN_DRAIN_TIMEOUT` | Seconds to wait for queue drain on graceful shutdown. | integer | 10 |
+| `FORWARD_APPLICATION_LOGS` | Forward application log messages to this destination. | boolean | False |
+| `MIN_LOG_SEVERITY` | Minimum Python log severity to forward when application log forwarding is enabled. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | WARNING |

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -394,8 +394,14 @@ def _process_section_parameters(
     for param_name, param_schema in section_schema["properties"].items():
         param_type = param_schema.get("type")
         if param_type == "array":
-            array_type = param_schema.get("items", {}).get("type")
+            items = param_schema.get("items", {})
+            array_type = items.get("type")
             if array_type:
+                param_type = f"array[{array_type}]"
+            elif "$ref" in items:
+                ref_name = items["$ref"].split("/")[-1]
+                ref_schema = defs.get(ref_name, {})
+                array_type = ref_schema.get("type", "object")
                 param_type = f"array[{array_type}]"
 
         env = f"{env_prefix}{param_name}".upper() if env_prefix else None
@@ -420,6 +426,24 @@ def _process_section_parameters(
                 param_type = definition.get("type")
                 if "enum" in definition:
                     param_type += " (" + ", ".join([str(e) for e in definition["enum"]]) + ")"
+
+        # Handle arrays of objects: resolve $ref in items and extract nested parameters
+        if param_type and param_type.startswith("array[object]") and not nested_parameters:
+            items = param_schema.get("items", {})
+            items_ref = items.get("$ref")
+            if items_ref:
+                items_def = defs.get(items_ref.split("/")[-1], {})
+            else:
+                items_def = items
+            if "properties" in items_def:
+                default = "Check nested parameters"
+                nested_parameters = _process_section_parameters(
+                    section_schema=items_def,
+                    model_fields={},
+                    env_source=env_source,
+                    defs=defs,
+                    env_prefix=None,
+                )
 
         parameters.append(
             ConfigurationSectionParameter(


### PR DESCRIPTION
IFC-2349

must follow #8642 

- adds logging configuration as defined in phase 1 of the syslog forwarding plan https://github.com/opsmill/infrahub/pull/8642/changes
- updates `task/docs.py` to handle nested complex objects when generating `configuration.mdx`

need to check if defining logging destinations using JSON dumped to an env var is acceptable or if we need to support an env var for every item in the configuration, such as
```
INFRAHUB_LOG_FORWARDING_DESTINATION_1_NAME = "siem1"
INFRAHUB_LOG_FORWARDING_DESTINATION_1_host = "..."
...
INFRAHUB_LOG_FORWARDING_DESTINATION_2_NAME = "siem2"
INFRAHUB_LOG_FORWARDING_DESTINATION_2_host = "..."
```