### PR TITLE
Add tooltip in branch selector and fix disabled button

### DIFF
--- a/changelog/8629.fixed.md
+++ b/changelog/8629.fixed.md
@@ -1,0 +1,1 @@
+Fixed long branch names overflowing in the branch selector and ensured the branch creation button maintains its size when disabled

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -32,7 +32,7 @@ exports[`fix ts error`] = {
       [69, 7, 10, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; }\' but required in type \'InputFieldProps\'.", "1610618705"],
       [71, 7, 13, "tsc: Property \'attribute\' is missing in type \'{ name: string; label: string; rules: { required: true; }; }\' but required in type \'FormFieldProps\'.", "3862624788"]
     ],
-    "src/entities/branches/ui/branch-selector.tsx:3058438850": [
+    "src/entities/branches/ui/branch-selector.tsx:3141471943": [
       [5, 28, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
     "src/entities/branches/ui/branches-table/branches-toolbar.tsx:1006213371": [

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { useCommandState } from "cmdk";
 import { useQueryState } from "nuqs";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import type { Branch } from "@/shared/api/graphql/generated/graphql";
 import { constructPath } from "@/shared/api/rest/fetch";
@@ -16,6 +16,7 @@ import {
 } from "@/shared/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import { QSP } from "@/shared/config/qsp";
+import { useIsTruncated } from "@/shared/hooks/useIsTruncated";
 
 import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { useGetBranches } from "@/entities/branches/domain/get-branches.query";
@@ -33,6 +34,8 @@ export default function BranchSelector() {
   const { currentBranch } = useCurrentBranch();
   const [isOpen, setIsOpen] = useState(false);
   const [displayForm, setDisplayForm] = useState<DisplayForm>({ open: false });
+  const triggerNameRef = useRef<HTMLSpanElement>(null);
+  const isTriggerTruncated = useIsTruncated(triggerNameRef);
 
   return (
     <Popover
@@ -47,11 +50,14 @@ export default function BranchSelector() {
           variant="outline"
           className="h-8 w-60 rounded-lg border-neutral-200 p-0 shadow-none"
           data-testid="branch-selector-trigger"
+          title={isTriggerTruncated ? currentBranch.name : undefined}
         >
           <div className="inline-flex h-full grow items-center justify-between gap-1.5 overflow-hidden border-gray-200 border-r px-3">
             <div className="inline-flex min-w-0 items-center gap-1.5">
               <Icon icon="mdi:source-branch" className="shrink-0" />
-              <span className="truncate">{currentBranch.name}</span>
+              <span ref={triggerNameRef} className="truncate">
+                {currentBranch.name}
+              </span>
             </div>
             <BranchStatusBadge status={currentBranch.status} className="shrink-0" />
           </div>
@@ -154,6 +160,8 @@ function BranchSelect({
 
 function BranchOption({ branch, onChange }: { branch: Branch; onChange: () => void }) {
   const { currentBranch } = useCurrentBranch();
+  const nameRef = useRef<HTMLSpanElement>(null);
+  const isTruncated = useIsTruncated(nameRef);
 
   return (
     <ComboboxItem
@@ -161,9 +169,12 @@ function BranchOption({ branch, onChange }: { branch: Branch; onChange: () => vo
       selectedValue={currentBranch.name}
       onSelect={onChange}
       value={branch.name}
+      title={isTruncated ? branch.name : undefined}
     >
       <div className="flex w-full items-center overflow-hidden">
-        <span className="truncate">{branch.name}</span>
+        <span ref={nameRef} className="truncate">
+          {branch.name}
+        </span>
 
         <div className="ml-auto inline-flex items-center gap-1">
           {branch.is_default && (

--- a/frontend/app/src/entities/branches/ui/branches-provider.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-provider.tsx
@@ -63,7 +63,7 @@ export const BranchesProvider = ({ children }: { children?: React.ReactNode }) =
   }, [branches, branchInQueryString]);
 
   if (isPending) {
-    return <InfrahubLoading>loading branches...</InfrahubLoading>;
+    return <InfrahubLoading>Loading branches...</InfrahubLoading>;
   }
 
   if (error) {
@@ -71,7 +71,7 @@ export const BranchesProvider = ({ children }: { children?: React.ReactNode }) =
   }
 
   if (currentBranch?.name !== (branchInQueryString ?? DEFAULT_BRANCH_NAME)) {
-    return <InfrahubLoading>loading branches...</InfrahubLoading>;
+    return <InfrahubLoading>Loading branches...</InfrahubLoading>;
   }
 
   return <BranchContext value={{ currentBranch, setCurrentBranch }}>{children}</BranchContext>;

--- a/frontend/app/src/shared/components/ui/button.tsx
+++ b/frontend/app/src/shared/components/ui/button.tsx
@@ -78,8 +78,8 @@ export const ButtonWithTooltip = forwardRef<HTMLButtonElement, ButtonWithTooltip
     if (disabled && tooltipEnabled) {
       return (
         <Tooltip enabled={tooltipEnabled} content={tooltipContent} side={side}>
-          <span className={classNames("inline-flex", className)}>
-            <Button ref={ref} {...props} disabled={disabled} />
+          <span className="inline-flex">
+            <Button ref={ref} {...props} className={className} disabled={disabled} />
           </span>
         </Tooltip>
       );

--- a/frontend/app/src/shared/hooks/useIsTruncated.ts
+++ b/frontend/app/src/shared/hooks/useIsTruncated.ts
@@ -1,0 +1,17 @@
+import { type RefObject, useEffect, useState } from "react";
+
+export function useIsTruncated(ref: RefObject<HTMLElement | null>) {
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      setIsTruncated(el.scrollWidth > el.clientWidth);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return isTruncated;
+}


### PR DESCRIPTION
<img width="793" height="891" alt="23736" src="https://github.com/user-attachments/assets/b55aba82-a5db-44c5-9e34-7553f0088cfe" />
<img width="840" height="654" alt="13325" src="https://github.com/user-attachments/assets/2865bac5-002e-42ff-9523-1ea7d93db810" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips for branch names now appear only when the text is visually truncated, reducing unnecessary tooltips.
  * Long branch names no longer overflow the selector; branch creation button keeps its intended size when disabled.
  * Loading message text standardized to "Loading branches..." for consistency.
  * Disabled buttons with active tooltips preserve intended styling and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->