### PR TITLE
add syslog forwarding config options

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -902,7 +902,9 @@ class LogForwardingDestination(BaseModel):
         default=LogForwardingDestinationType.SYSLOG, description="Destination type."
     )
     host: str = Field(description="Destination host or IP address.")
-    port: int = Field(ge=1, le=65535, description="Destination port number.")
+    port: int | None = Field(
+        default=None, ge=1, le=65535, description="Destination port number. Defaults to 6514 for TLS, 514 otherwise."
+    )
     protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")
     format: SyslogFormat = Field(default=SyslogFormat.RFC5424, description="Syslog format standard.")
     tcp_framing: TcpFraming = Field(
@@ -926,6 +928,14 @@ class LogForwardingDestination(BaseModel):
         default=ExtraLogLevel.WARNING,
         description="Minimum Python log severity to forward when application log forwarding is enabled.",
     )
+
+    @property
+    def service_port(self) -> int:
+        if self.port:
+            return self.port
+        if self.tls_enabled:
+            return 6514
+        return 514
 
     @model_validator(mode="after")
     def validate_tls_protocol(self) -> Self:

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -944,10 +944,13 @@ class LogForwardingSettings(BaseSettings):
     @field_validator("destinations")
     @classmethod
     def validate_unique_names(cls, v: list[LogForwardingDestination]) -> list[LogForwardingDestination]:
-        names = [d.name for d in v]
-        if len(names) != len(set(names)):
-            raise ValueError("Destination names must be unique")
-        return v
+        unique_names = {d.name for d in v}
+        if len(unique_names) == len(v):
+            return v
+        all_names = [d.name for d in v]
+        duplicate_names = {name for name in unique_names if all_names.count(name) > 1}
+        sorted_dupes = ", ".join(sorted(duplicate_names))
+        raise ValueError(f"Destination names must be unique; duplicates found: {sorted_dupes}")
 
     @property
     def enterprise_features(self) -> list[EnterpriseFeatures]:

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -53,7 +53,7 @@ def default_append_git_suffix_domains() -> list[str]:
 class EnterpriseFeatures(StrEnum):
     PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
     REVOKE_PROPOSED_CHANGE_APPROVALS = "revoke_proposed_change_approvals"
-    LOG_FORWARDING_SYSLOG = "log_forwarding_syslog"
+    LOG_FORWARDING = "log_forwarding"
 
 
 class UserInfoMethod(StrEnum):
@@ -956,7 +956,7 @@ class LogForwardingSettings(BaseSettings):
     def enterprise_features(self) -> list[EnterpriseFeatures]:
         """Returns enterprise features enabled by log forwarding configuration."""
         if any(d.type == LogForwardingDestinationType.SYSLOG for d in self.destinations):
-            return [EnterpriseFeatures.LOG_FORWARDING_SYSLOG]
+            return [EnterpriseFeatures.LOG_FORWARDING]
         return []
 
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from infrahub_sdk.utils import generate_uuid
 from pydantic import (
@@ -53,6 +53,7 @@ def default_append_git_suffix_domains() -> list[str]:
 class EnterpriseFeatures(StrEnum):
     PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
     REVOKE_PROPOSED_CHANGE_APPROVALS = "revoke_proposed_change_approvals"
+    LOG_FORWARDING_SYSLOG = "log_forwarding_syslog"
 
 
 class UserInfoMethod(StrEnum):
@@ -876,6 +877,80 @@ class TraceSettings(BaseSettings):
     exporter_endpoint: str | None = Field(default=None, description="OTLP endpoint for exporting traces")
 
 
+class SyslogProtocol(StrEnum):
+    TCP = "tcp"
+    UDP = "udp"
+
+
+class SyslogFormat(StrEnum):
+    RFC5424 = "rfc5424"
+    RFC3164 = "rfc3164"
+
+
+class TcpFraming(StrEnum):
+    NEWLINE = "newline"
+    OCTET_COUNTING = "octet-counting"
+
+
+class LogForwardingDestination(BaseSettings):
+    name: str = Field(description="Unique name for the destination, used in all observability output.")
+    type: Literal["syslog"] = Field(description="Destination type.")
+    host: str = Field(description="Destination host or IP address.")
+    port: int = Field(ge=1, le=65535, description="Destination port number.")
+    protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")
+    format: SyslogFormat = Field(default=SyslogFormat.RFC5424, description="Syslog format standard.")
+    tcp_framing: TcpFraming = Field(
+        default=TcpFraming.NEWLINE, description="TCP framing method (newline or octet-counting)."
+    )
+    tls_enabled: bool = Field(default=False, description="Enable TLS encryption for TCP connections.")
+    tls_ca_bundle: str | None = Field(
+        default=None, description="Path or PEM string for CA bundle to validate syslog server certificate."
+    )
+    queue_size: int = Field(default=10000, ge=1, description="Maximum number of messages in the per-destination queue.")
+    max_reconnect_interval: int = Field(
+        default=60, ge=1, description="Maximum reconnection backoff interval in seconds."
+    )
+    shutdown_drain_timeout: int = Field(
+        default=10, ge=0, description="Seconds to wait for queue drain on graceful shutdown."
+    )
+    forward_application_logs: bool = Field(
+        default=False, description="Forward application log messages to this destination."
+    )
+    min_log_severity: ExtraLogLevel = Field(
+        default=ExtraLogLevel.WARNING,
+        description="Minimum Python log severity to forward when application log forwarding is enabled.",
+    )
+
+    @model_validator(mode="after")
+    def validate_tls_protocol(self) -> Self:
+        if self.tls_enabled and self.protocol == SyslogProtocol.UDP:
+            raise ValueError("TLS is only supported with TCP protocol, not UDP.")
+        return self
+
+
+class LogForwardingSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_LOG_FORWARDING_")
+    destinations: list[LogForwardingDestination] = Field(
+        default_factory=list,
+        description="List of log forwarding destinations. (Enterprise only: not available in the community version.)",
+    )
+
+    @field_validator("destinations")
+    @classmethod
+    def validate_unique_names(cls, v: list[LogForwardingDestination]) -> list[LogForwardingDestination]:
+        names = [d.name for d in v]
+        if len(names) != len(set(names)):
+            raise ValueError("Destination names must be unique")
+        return v
+
+    @property
+    def enterprise_features(self) -> list[EnterpriseFeatures]:
+        """Returns enterprise features enabled by log forwarding configuration."""
+        if any(d.type == "syslog" for d in self.destinations):
+            return [EnterpriseFeatures.LOG_FORWARDING_SYSLOG]
+        return []
+
+
 class PolicySettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_POLICY_")
     required_proposed_change_approvals: int = Field(
@@ -1038,6 +1113,7 @@ class Settings(BaseSettings):
     storage: StorageSettings = StorageSettings()
     trace: TraceSettings = TraceSettings()
     experimental_features: ExperimentalFeaturesSettings = ExperimentalFeaturesSettings()
+    log_forwarding: LogForwardingSettings = LogForwardingSettings()
 
     @model_validator(mode="after")
     def validate_git_branch_deletion_requires_branch_deletion(self) -> Self:
@@ -1048,7 +1124,7 @@ class Settings(BaseSettings):
     @property
     def enterprise_features(self) -> list[EnterpriseFeatures]:
         """Returns a list of enterprise features that are enabled based on the settings."""
-        return self.policy.enterprise_features
+        return self.policy.enterprise_features + self.log_forwarding.enterprise_features
 
 
 def load(config_file_name: Path | str = "infrahub.toml", config_data: dict[str, Any] | None = None) -> Settings:

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from infrahub_sdk.utils import generate_uuid
 from pydantic import (
@@ -892,9 +892,13 @@ class TcpFraming(StrEnum):
     OCTET_COUNTING = "octet-counting"
 
 
+class LogForwardingDestinationType(StrEnum):
+    SYSLOG = "syslog"
+
+
 class LogForwardingDestination(BaseSettings):
     name: str = Field(description="Unique name for the destination, used in all observability output.")
-    type: Literal["syslog"] = Field(description="Destination type.")
+    type: LogForwardingDestinationType = Field(description="Destination type.")
     host: str = Field(description="Destination host or IP address.")
     port: int = Field(ge=1, le=65535, description="Destination port number.")
     protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")
@@ -946,7 +950,7 @@ class LogForwardingSettings(BaseSettings):
     @property
     def enterprise_features(self) -> list[EnterpriseFeatures]:
         """Returns enterprise features enabled by log forwarding configuration."""
-        if any(d.type == "syslog" for d in self.destinations):
+        if any(d.type == LogForwardingDestinationType.SYSLOG for d in self.destinations):
             return [EnterpriseFeatures.LOG_FORWARDING_SYSLOG]
         return []
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -905,7 +905,7 @@ class LogForwardingDestination(BaseModel):
     port: int | None = Field(
         default=None, ge=1, le=65535, description="Destination port number. Defaults to 6514 for TLS, 514 otherwise."
     )
-    protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")
+    protocol: SyslogProtocol = Field(default=SyslogProtocol.UDP, description="Transport protocol (tcp or udp).")
     format: SyslogFormat = Field(default=SyslogFormat.RFC5424, description="Syslog format standard.")
     tcp_framing: TcpFraming = Field(
         default=TcpFraming.NEWLINE, description="TCP framing method (newline or octet-counting)."

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -898,7 +898,9 @@ class LogForwardingDestinationType(StrEnum):
 
 class LogForwardingDestination(BaseSettings):
     name: str = Field(description="Unique name for the destination, used in all observability output.")
-    type: LogForwardingDestinationType = Field(description="Destination type.")
+    type: LogForwardingDestinationType = Field(
+        default=LogForwardingDestinationType.SYSLOG, description="Destination type."
+    )
     host: str = Field(description="Destination host or IP address.")
     port: int = Field(ge=1, le=65535, description="Destination port number.")
     protocol: SyslogProtocol = Field(default=SyslogProtocol.TCP, description="Transport protocol (tcp or udp).")

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -896,7 +896,7 @@ class LogForwardingDestinationType(StrEnum):
     SYSLOG = "syslog"
 
 
-class LogForwardingDestination(BaseSettings):
+class LogForwardingDestination(BaseModel):
     name: str = Field(description="Unique name for the destination, used in all observability output.")
     type: LogForwardingDestinationType = Field(
         default=LogForwardingDestinationType.SYSLOG, description="Destination type."

--- a/backend/tests/unit/config/log_forwarding_multi_dest.toml
+++ b/backend/tests/unit/config/log_forwarding_multi_dest.toml
@@ -1,0 +1,22 @@
+[[log_forwarding.destinations]]
+name = "siem-primary"
+type = "syslog"
+host = "syslog.example.com"
+port = 514
+protocol = "tcp"
+format = "rfc5424"
+tls_enabled = true
+tls_ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
+queue_size = 50000
+forward_application_logs = true
+min_log_severity = "INFO"
+
+[[log_forwarding.destinations]]
+name = "backup-collector"
+type = "syslog"
+host = "syslog-backup.example.com"
+port = 1514
+protocol = "udp"
+format = "rfc3164"
+queue_size = 5000
+shutdown_drain_timeout = 5

--- a/backend/tests/unit/config/test_config.py
+++ b/backend/tests/unit/config/test_config.py
@@ -19,7 +19,7 @@ from infrahub.config import (
 )
 from tests.conftest import TestHelper
 
-TEST_DATA_DIR = Path(__file__).parent / "test_data"
+TEST_DATA_DIR = Path(__file__).parent.parent / "test_data"
 
 
 def test_load_sso_config(helper: TestHelper) -> None:

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -1,0 +1,164 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from infrahub.config import (
+    EnterpriseFeatures,
+    ExtraLogLevel,
+    LogForwardingDestination,
+    LogForwardingSettings,
+    SyslogFormat,
+    SyslogProtocol,
+    load,
+)
+
+
+def test_log_forwarding_destination_valid() -> None:
+    dest = LogForwardingDestination(name="siem-primary", type="syslog", host="syslog.example.com", port=514)
+    assert dest.name == "siem-primary"
+    assert dest.type == "syslog"
+    assert dest.host == "syslog.example.com"
+    assert dest.port == 514
+    assert dest.protocol.value == "tcp"
+    assert dest.format.value == "rfc5424"
+    assert dest.tcp_framing.value == "newline"
+    assert dest.tls_enabled is False
+    assert dest.queue_size == 10000
+    assert dest.max_reconnect_interval == 60
+    assert dest.shutdown_drain_timeout == 10
+    assert dest.forward_application_logs is False
+    assert dest.min_log_severity == ExtraLogLevel.WARNING
+
+
+@pytest.mark.parametrize("invalid_port", [0, -1, 65536, 70000])
+def test_log_forwarding_destination_rejects_invalid_port(invalid_port: int) -> None:
+    with pytest.raises(ValidationError):
+        LogForwardingDestination(name="test", type="syslog", host="localhost", port=invalid_port)
+
+
+def test_log_forwarding_destination_rejects_tls_with_udp() -> None:
+    with pytest.raises(ValueError, match="TLS is only supported with TCP protocol, not UDP"):
+        LogForwardingDestination(
+            name="test", type="syslog", host="localhost", port=514, protocol=SyslogProtocol.UDP, tls_enabled=True
+        )
+
+
+def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
+    dest = LogForwardingDestination(
+        name="test", type="syslog", host="localhost", port=6514, protocol=SyslogProtocol.TCP, tls_enabled=True
+    )
+    assert dest.tls_enabled is True
+
+
+@pytest.mark.parametrize("invalid_queue_size", [0, -5])
+def test_log_forwarding_destination_rejects_invalid_queue_size(invalid_queue_size: int) -> None:
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        LogForwardingDestination(name="test", type="syslog", host="localhost", port=514, queue_size=invalid_queue_size)
+
+
+def test_log_forwarding_settings_empty_destinations() -> None:
+    settings = LogForwardingSettings()
+    assert settings.destinations == []
+    assert settings.enterprise_features == []
+
+
+def test_log_forwarding_settings_duplicate_names_rejected() -> None:
+    with pytest.raises(ValidationError, match="Destination names must be unique"):
+        LogForwardingSettings(
+            destinations=[
+                LogForwardingDestination(name="dup", type="syslog", host="host1", port=514),
+                LogForwardingDestination(name="dup", type="syslog", host="host2", port=515),
+            ]
+        )
+
+
+def test_log_forwarding_settings_unique_names_accepted() -> None:
+    settings = LogForwardingSettings(
+        destinations=[
+            LogForwardingDestination(name="primary", type="syslog", host="host1", port=514),
+            LogForwardingDestination(name="secondary", type="syslog", host="host2", port=515),
+        ]
+    )
+    assert len(settings.destinations) == 2
+
+
+def test_log_forwarding_enterprise_feature_not_detected_when_empty() -> None:
+    config = load(config_data={})
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG not in config.enterprise_features
+
+
+def test_log_forwarding_enterprise_feature_detected() -> None:
+    settings = LogForwardingSettings(
+        destinations=[
+            LogForwardingDestination(name="siem", type="syslog", host="syslog.example.com", port=514),
+        ]
+    )
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in settings.enterprise_features
+
+
+def test_log_forwarding_toml_parsing_multiple_destinations() -> None:
+    config_data = {
+        "log_forwarding": {
+            "destinations": [
+                {
+                    "name": "siem-primary",
+                    "type": "syslog",
+                    "host": "syslog.example.com",
+                    "port": 514,
+                    "protocol": "tcp",
+                    "format": "rfc5424",
+                },
+                {
+                    "name": "siem-secondary",
+                    "type": "syslog",
+                    "host": "syslog2.example.com",
+                    "port": 1514,
+                    "protocol": "udp",
+                    "format": "rfc3164",
+                },
+            ]
+        }
+    }
+    config = load(config_data=config_data)
+    assert len(config.log_forwarding.destinations) == 2
+    dest1 = config.log_forwarding.destinations[0]
+    assert dest1.name == "siem-primary"
+    assert dest1.host == "syslog.example.com"
+    assert dest1.protocol is SyslogProtocol.TCP
+    assert dest1.format is SyslogFormat.RFC5424
+    dest2 = config.log_forwarding.destinations[1]
+    assert dest2.name == "siem-secondary"
+    assert dest2.host == "syslog2.example.com"
+    assert dest2.protocol is SyslogProtocol.UDP
+    assert dest2.format is SyslogFormat.RFC3164
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in config.enterprise_features
+
+
+def test_log_forwarding_destinations_from_environment_variable() -> None:
+    destinations_json = json.dumps(
+        [
+            {"name": "siem1", "type": "syslog", "host": "host1.example.com", "port": 514},
+            {"name": "siem2", "type": "syslog", "host": "host2.example.com", "port": 1514, "protocol": "udp"},
+        ]
+    )
+    with patch.dict(os.environ, {"INFRAHUB_LOG_FORWARDING_DESTINATIONS": destinations_json}):
+        settings = LogForwardingSettings()
+    assert len(settings.destinations) == 2
+    assert settings.destinations[0].name == "siem1"
+    assert settings.destinations[0].host == "host1.example.com"
+    assert settings.destinations[1].name == "siem2"
+    assert settings.destinations[1].protocol.value == "udp"
+
+
+def test_settings_enterprise_features_aggregates_log_forwarding() -> None:
+    config_data = {
+        "log_forwarding": {"destinations": [{"name": "siem", "type": "syslog", "host": "localhost", "port": 514}]},
+        "policy": {"required_proposed_change_approvals": 2},
+    }
+    config = load(config_data=config_data)
+    features = config.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in features
+    assert EnterpriseFeatures.PROPOSED_CHANGE_REQUIRE_APPROVAL in features

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -29,7 +29,7 @@ def test_log_forwarding_destination_valid() -> None:
     assert dest.host == "syslog.example.com"
     assert dest.port is None
     assert dest.service_port == 514
-    assert dest.protocol.value == "tcp"
+    assert dest.protocol.value == "udp"
     assert dest.format.value == "rfc5424"
     assert dest.tcp_framing.value == "newline"
     assert dest.tls_enabled is False
@@ -75,12 +75,13 @@ def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
     ("kwargs", "expected_port"),
     [
         ({}, 514),
+        ({"protocol": SyslogProtocol.TCP}, 514),
         ({"protocol": SyslogProtocol.UDP}, 514),
-        ({"tls_enabled": True}, 6514),
+        ({"protocol": SyslogProtocol.TCP, "tls_enabled": True}, 6514),
         ({"port": 1514}, 1514),
-        ({"port": 1514, "tls_enabled": True}, 1514),
+        ({"port": 1514, "protocol": SyslogProtocol.TCP, "tls_enabled": True}, 1514),
     ],
-    ids=["tcp-default", "udp-default", "tls-default", "explicit-port", "explicit-overrides-tls"],
+    ids=["udp-default", "tcp", "udp-explicit", "tls-default", "explicit-port", "explicit-overrides-tls"],
 )
 def test_service_port(kwargs: dict, expected_port: int) -> None:
     dest = LogForwardingDestination(name="test", host="localhost", **kwargs)

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,8 @@ from infrahub.config import (
     SyslogProtocol,
     load,
 )
+
+TEST_DIR = Path(__file__).parent
 
 
 def test_log_forwarding_destination_valid() -> None:
@@ -151,6 +154,38 @@ def test_log_forwarding_destinations_from_environment_variable() -> None:
     assert settings.destinations[0].host == "host1.example.com"
     assert settings.destinations[1].name == "siem2"
     assert settings.destinations[1].protocol.value == "udp"
+
+
+def test_log_forwarding_from_toml_file() -> None:
+    config_file = str(TEST_DIR / "log_forwarding_multi_dest.toml")
+    config = load(config_file_name=config_file)
+
+    assert len(config.log_forwarding.destinations) == 2
+    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in config.enterprise_features
+
+    primary = config.log_forwarding.destinations[0]
+    assert primary.name == "siem-primary"
+    assert primary.host == "syslog.example.com"
+    assert primary.port == 514
+    assert primary.protocol is SyslogProtocol.TCP
+    assert primary.format is SyslogFormat.RFC5424
+    assert primary.tls_enabled is True
+    assert primary.tls_ca_bundle == "/etc/ssl/certs/ca-certificates.crt"
+    assert primary.queue_size == 50000
+    assert primary.forward_application_logs is True
+    assert primary.min_log_severity == ExtraLogLevel.INFO
+
+    backup = config.log_forwarding.destinations[1]
+    assert backup.name == "backup-collector"
+    assert backup.host == "syslog-backup.example.com"
+    assert backup.port == 1514
+    assert backup.protocol is SyslogProtocol.UDP
+    assert backup.format is SyslogFormat.RFC3164
+    assert backup.tls_enabled is False
+    assert backup.queue_size == 5000
+    assert backup.shutdown_drain_timeout == 5
+    assert backup.forward_application_logs is False
+    assert backup.min_log_severity == ExtraLogLevel.WARNING
 
 
 def test_settings_enterprise_features_aggregates_log_forwarding() -> None:

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -125,7 +125,7 @@ def test_log_forwarding_settings_unique_names_accepted() -> None:
 
 def test_log_forwarding_enterprise_feature_not_detected_when_empty() -> None:
     config = load(config_data={})
-    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG not in config.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING not in config.enterprise_features
 
 
 def test_log_forwarding_enterprise_feature_detected() -> None:
@@ -136,7 +136,7 @@ def test_log_forwarding_enterprise_feature_detected() -> None:
             ),
         ]
     )
-    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in settings.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING in settings.enterprise_features
 
 
 def test_log_forwarding_toml_parsing_multiple_destinations() -> None:
@@ -174,7 +174,7 @@ def test_log_forwarding_toml_parsing_multiple_destinations() -> None:
     assert dest2.host == "syslog2.example.com"
     assert dest2.protocol is SyslogProtocol.UDP
     assert dest2.format is SyslogFormat.RFC3164
-    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in config.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING in config.enterprise_features
 
 
 def test_log_forwarding_destinations_from_environment_variable() -> None:
@@ -198,7 +198,7 @@ def test_log_forwarding_from_toml_file() -> None:
     config = load(config_file_name=config_file)
 
     assert len(config.log_forwarding.destinations) == 2
-    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in config.enterprise_features
+    assert EnterpriseFeatures.LOG_FORWARDING in config.enterprise_features
 
     primary = config.log_forwarding.destinations[0]
     assert primary.name == "siem-primary"
@@ -232,5 +232,5 @@ def test_settings_enterprise_features_aggregates_log_forwarding() -> None:
     }
     config = load(config_data=config_data)
     features = config.enterprise_features
-    assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in features
+    assert EnterpriseFeatures.LOG_FORWARDING in features
     assert EnterpriseFeatures.PROPOSED_CHANGE_REQUIRE_APPROVAL in features

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -22,12 +22,13 @@ TEST_DIR = Path(__file__).parent
 
 def test_log_forwarding_destination_valid() -> None:
     dest = LogForwardingDestination(
-        name="siem-primary", type=LogForwardingDestinationType.SYSLOG, host="syslog.example.com", port=514
+        name="siem-primary", type=LogForwardingDestinationType.SYSLOG, host="syslog.example.com"
     )
     assert dest.name == "siem-primary"
     assert dest.type is LogForwardingDestinationType.SYSLOG
     assert dest.host == "syslog.example.com"
-    assert dest.port == 514
+    assert dest.port is None
+    assert dest.service_port == 514
     assert dest.protocol.value == "tcp"
     assert dest.format.value == "rfc5424"
     assert dest.tcp_framing.value == "newline"
@@ -53,7 +54,6 @@ def test_log_forwarding_destination_rejects_tls_with_udp() -> None:
             name="test",
             type=LogForwardingDestinationType.SYSLOG,
             host="localhost",
-            port=514,
             protocol=SyslogProtocol.UDP,
             tls_enabled=True,
         )
@@ -69,6 +69,22 @@ def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
         tls_enabled=True,
     )
     assert dest.tls_enabled is True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_port"),
+    [
+        ({}, 514),
+        ({"protocol": SyslogProtocol.UDP}, 514),
+        ({"tls_enabled": True}, 6514),
+        ({"port": 1514}, 1514),
+        ({"port": 1514, "tls_enabled": True}, 1514),
+    ],
+    ids=["tcp-default", "udp-default", "tls-default", "explicit-port", "explicit-overrides-tls"],
+)
+def test_service_port(kwargs: dict, expected_port: int) -> None:
+    dest = LogForwardingDestination(name="test", host="localhost", **kwargs)
+    assert dest.service_port == expected_port
 
 
 @pytest.mark.parametrize("invalid_queue_size", [0, -5])

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -90,11 +90,23 @@ def test_log_forwarding_settings_empty_destinations() -> None:
 
 
 def test_log_forwarding_settings_duplicate_names_rejected() -> None:
-    with pytest.raises(ValidationError, match="Destination names must be unique"):
+    with pytest.raises(ValidationError, match="duplicates found: dup"):
         LogForwardingSettings(
             destinations=[
                 LogForwardingDestination(name="dup", type=LogForwardingDestinationType.SYSLOG, host="host1", port=514),
                 LogForwardingDestination(name="dup", type=LogForwardingDestinationType.SYSLOG, host="host2", port=515),
+            ]
+        )
+
+
+def test_log_forwarding_settings_multiple_duplicate_names_listed() -> None:
+    with pytest.raises(ValidationError, match="duplicates found: aaa, bbb"):
+        LogForwardingSettings(
+            destinations=[
+                LogForwardingDestination(name="aaa", type=LogForwardingDestinationType.SYSLOG, host="h1", port=514),
+                LogForwardingDestination(name="bbb", type=LogForwardingDestinationType.SYSLOG, host="h2", port=514),
+                LogForwardingDestination(name="aaa", type=LogForwardingDestinationType.SYSLOG, host="h3", port=514),
+                LogForwardingDestination(name="bbb", type=LogForwardingDestinationType.SYSLOG, host="h4", port=514),
             ]
         )
 

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -10,6 +10,7 @@ from infrahub.config import (
     EnterpriseFeatures,
     ExtraLogLevel,
     LogForwardingDestination,
+    LogForwardingDestinationType,
     LogForwardingSettings,
     SyslogFormat,
     SyslogProtocol,
@@ -20,9 +21,11 @@ TEST_DIR = Path(__file__).parent
 
 
 def test_log_forwarding_destination_valid() -> None:
-    dest = LogForwardingDestination(name="siem-primary", type="syslog", host="syslog.example.com", port=514)
+    dest = LogForwardingDestination(
+        name="siem-primary", type=LogForwardingDestinationType.SYSLOG, host="syslog.example.com", port=514
+    )
     assert dest.name == "siem-primary"
-    assert dest.type == "syslog"
+    assert dest.type is LogForwardingDestinationType.SYSLOG
     assert dest.host == "syslog.example.com"
     assert dest.port == 514
     assert dest.protocol.value == "tcp"
@@ -39,19 +42,31 @@ def test_log_forwarding_destination_valid() -> None:
 @pytest.mark.parametrize("invalid_port", [0, -1, 65536, 70000])
 def test_log_forwarding_destination_rejects_invalid_port(invalid_port: int) -> None:
     with pytest.raises(ValidationError):
-        LogForwardingDestination(name="test", type="syslog", host="localhost", port=invalid_port)
+        LogForwardingDestination(
+            name="test", type=LogForwardingDestinationType.SYSLOG, host="localhost", port=invalid_port
+        )
 
 
 def test_log_forwarding_destination_rejects_tls_with_udp() -> None:
     with pytest.raises(ValueError, match="TLS is only supported with TCP protocol, not UDP"):
         LogForwardingDestination(
-            name="test", type="syslog", host="localhost", port=514, protocol=SyslogProtocol.UDP, tls_enabled=True
+            name="test",
+            type=LogForwardingDestinationType.SYSLOG,
+            host="localhost",
+            port=514,
+            protocol=SyslogProtocol.UDP,
+            tls_enabled=True,
         )
 
 
 def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
     dest = LogForwardingDestination(
-        name="test", type="syslog", host="localhost", port=6514, protocol=SyslogProtocol.TCP, tls_enabled=True
+        name="test",
+        type=LogForwardingDestinationType.SYSLOG,
+        host="localhost",
+        port=6514,
+        protocol=SyslogProtocol.TCP,
+        tls_enabled=True,
     )
     assert dest.tls_enabled is True
 
@@ -59,7 +74,13 @@ def test_log_forwarding_destination_allows_tls_with_tcp() -> None:
 @pytest.mark.parametrize("invalid_queue_size", [0, -5])
 def test_log_forwarding_destination_rejects_invalid_queue_size(invalid_queue_size: int) -> None:
     with pytest.raises(ValidationError, match="greater than or equal to 1"):
-        LogForwardingDestination(name="test", type="syslog", host="localhost", port=514, queue_size=invalid_queue_size)
+        LogForwardingDestination(
+            name="test",
+            type=LogForwardingDestinationType.SYSLOG,
+            host="localhost",
+            port=514,
+            queue_size=invalid_queue_size,
+        )
 
 
 def test_log_forwarding_settings_empty_destinations() -> None:
@@ -72,8 +93,8 @@ def test_log_forwarding_settings_duplicate_names_rejected() -> None:
     with pytest.raises(ValidationError, match="Destination names must be unique"):
         LogForwardingSettings(
             destinations=[
-                LogForwardingDestination(name="dup", type="syslog", host="host1", port=514),
-                LogForwardingDestination(name="dup", type="syslog", host="host2", port=515),
+                LogForwardingDestination(name="dup", type=LogForwardingDestinationType.SYSLOG, host="host1", port=514),
+                LogForwardingDestination(name="dup", type=LogForwardingDestinationType.SYSLOG, host="host2", port=515),
             ]
         )
 
@@ -81,8 +102,10 @@ def test_log_forwarding_settings_duplicate_names_rejected() -> None:
 def test_log_forwarding_settings_unique_names_accepted() -> None:
     settings = LogForwardingSettings(
         destinations=[
-            LogForwardingDestination(name="primary", type="syslog", host="host1", port=514),
-            LogForwardingDestination(name="secondary", type="syslog", host="host2", port=515),
+            LogForwardingDestination(name="primary", type=LogForwardingDestinationType.SYSLOG, host="host1", port=514),
+            LogForwardingDestination(
+                name="secondary", type=LogForwardingDestinationType.SYSLOG, host="host2", port=515
+            ),
         ]
     )
     assert len(settings.destinations) == 2
@@ -96,7 +119,9 @@ def test_log_forwarding_enterprise_feature_not_detected_when_empty() -> None:
 def test_log_forwarding_enterprise_feature_detected() -> None:
     settings = LogForwardingSettings(
         destinations=[
-            LogForwardingDestination(name="siem", type="syslog", host="syslog.example.com", port=514),
+            LogForwardingDestination(
+                name="siem", type=LogForwardingDestinationType.SYSLOG, host="syslog.example.com", port=514
+            ),
         ]
     )
     assert EnterpriseFeatures.LOG_FORWARDING_SYSLOG in settings.enterprise_features

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -324,7 +324,7 @@ Configuration settings for the message bus.
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | `NAME` | Unique name for the destination, used in all observability output. | string | None |
-| `TYPE` | Destination type. | string | None |
+| `TYPE` | Destination type. | string (syslog) | syslog |
 | `HOST` | Destination host or IP address. | string | None |
 | `PORT` | Destination port number. | integer | None |
 | `PROTOCOL` | Transport protocol (tcp or udp). | string (tcp, udp) | tcp |

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -193,9 +193,9 @@ Configuration settings for the message bus.
 | `INFRAHUB_SECURITY_ACCESS_TOKEN_LIFETIME` | Lifetime of access token in seconds | integer | 3600 |
 | `INFRAHUB_SECURITY_REFRESH_TOKEN_LIFETIME` | Lifetime of refresh token in seconds | integer | 2592000 |
 | `INFRAHUB_SECURITY_SECRET_KEY` | The secret key used to validate authentication tokens | string | None |
-| `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` | The selected OAuth2 providers | array | None |
+| `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` | The selected OAuth2 providers | array[string] | None |
 | `INFRAHUB_SECURITY_OAUTH2_PROVIDER_SETTINGS` | None | object | Check nested parameters |
-| `INFRAHUB_SECURITY_OIDC_PROVIDERS` | The selected OIDC providers | array | None |
+| `INFRAHUB_SECURITY_OIDC_PROVIDERS` | The selected OIDC providers | array[string] | None |
 | `INFRAHUB_SECURITY_OIDC_PROVIDER_SETTINGS` | None | object | Check nested parameters |
 | `INFRAHUB_SECURITY_RESTRICT_UNTRUSTED_JINJA2_FILTERS` | Indicates if untrusted Jinja2 filters should be disallowed for computed attributes | boolean | True |
 | `INFRAHUB_SECURITY_SSO_USER_DEFAULT_GROUP` | Name of the group to which users authenticated via SSO will belong if not provided by identity provider | None | None |
@@ -312,3 +312,28 @@ Configuration settings for the message bus.
 |------|-------------|------|---------|
 | `INFRAHUB_EXPERIMENTAL_GRAPHQL_ENUMS` | None | boolean | False |
 | `INFRAHUB_EXPERIMENTAL_VALUE_DB_INDEX` | None | boolean | False |
+
+## Log forwarding
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
+
+### INFRAHUB_LOG_FORWARDING_DESTINATIONS
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `NAME` | Unique name for the destination, used in all observability output. | string | None |
+| `TYPE` | Destination type. | string | None |
+| `HOST` | Destination host or IP address. | string | None |
+| `PORT` | Destination port number. | integer | None |
+| `PROTOCOL` | Transport protocol (tcp or udp). | string (tcp, udp) | tcp |
+| `FORMAT` | Syslog format standard. | string (rfc5424, rfc3164) | rfc5424 |
+| `TCP_FRAMING` | TCP framing method (newline or octet-counting). | string (newline, octet-counting) | newline |
+| `TLS_ENABLED` | Enable TLS encryption for TCP connections. | boolean | False |
+| `TLS_CA_BUNDLE` | Path or PEM string for CA bundle to validate syslog server certificate. | None | None |
+| `QUEUE_SIZE` | Maximum number of messages in the per-destination queue. | integer | 10000 |
+| `MAX_RECONNECT_INTERVAL` | Maximum reconnection backoff interval in seconds. | integer | 60 |
+| `SHUTDOWN_DRAIN_TIMEOUT` | Seconds to wait for queue drain on graceful shutdown. | integer | 10 |
+| `FORWARD_APPLICATION_LOGS` | Forward application log messages to this destination. | boolean | False |
+| `MIN_LOG_SEVERITY` | Minimum Python log severity to forward when application log forwarding is enabled. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | WARNING |

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -326,8 +326,8 @@ Configuration settings for the message bus.
 | `NAME` | Unique name for the destination, used in all observability output. | string | None |
 | `TYPE` | Destination type. | string (syslog) | syslog |
 | `HOST` | Destination host or IP address. | string | None |
-| `PORT` | Destination port number. | integer | None |
-| `PROTOCOL` | Transport protocol (tcp or udp). | string (tcp, udp) | tcp |
+| `PORT` | Destination port number. Defaults to 6514 for TLS, 514 otherwise. | None | None |
+| `PROTOCOL` | Transport protocol (tcp or udp). | string (tcp, udp) | udp |
 | `FORMAT` | Syslog format standard. | string (rfc5424, rfc3164) | rfc5424 |
 | `TCP_FRAMING` | TCP framing method (newline or octet-counting). | string (newline, octet-counting) | newline |
 | `TLS_ENABLED` | Enable TLS encryption for TCP connections. | boolean | False |

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -394,8 +394,14 @@ def _process_section_parameters(
     for param_name, param_schema in section_schema["properties"].items():
         param_type = param_schema.get("type")
         if param_type == "array":
-            array_type = param_schema.get("items", {}).get("type")
+            items = param_schema.get("items", {})
+            array_type = items.get("type")
             if array_type:
+                param_type = f"array[{array_type}]"
+            elif "$ref" in items:
+                ref_name = items["$ref"].split("/")[-1]
+                ref_schema = defs.get(ref_name, {})
+                array_type = ref_schema.get("type", "object")
                 param_type = f"array[{array_type}]"
 
         env = f"{env_prefix}{param_name}".upper() if env_prefix else None
@@ -420,6 +426,24 @@ def _process_section_parameters(
                 param_type = definition.get("type")
                 if "enum" in definition:
                     param_type += " (" + ", ".join([str(e) for e in definition["enum"]]) + ")"
+
+        # Handle arrays of objects: resolve $ref in items and extract nested parameters
+        if param_type and param_type.startswith("array[object]") and not nested_parameters:
+            items = param_schema.get("items", {})
+            items_ref = items.get("$ref")
+            if items_ref:
+                items_def = defs.get(items_ref.split("/")[-1], {})
+            else:
+                items_def = items
+            if "properties" in items_def:
+                default = "Check nested parameters"
+                nested_parameters = _process_section_parameters(
+                    section_schema=items_def,
+                    model_fields={},
+                    env_source=env_source,
+                    defs=defs,
+                    env_prefix=None,
+                )
 
         parameters.append(
             ConfigurationSectionParameter(


### PR DESCRIPTION
IFC-2349

- adds logging configuration as defined in phase 1 of the [syslog forwarding plan](https://github.com/opsmill/infrahub-private/pull/338/changes#diff-a04b5305508a134a7602e76c42c39bc53378ab5f66873fdbe2ed250e58e20220) 
- updates `task/docs.py` to handle nested complex objects when generating `configuration.mdx`
- includes a test to confirm that multiple destinations can be easily defined in `infrahub.toml`
- to configure destinations using env vars, user needs to set the `INFRAHUB_LOG_FORWARDING_DESTINATIONS` env var to a JSON blob that looks something like this
```
'[{"name": "siem1", "type": "syslog", "host": "host1.example.com", "port": 514}, {"name": "siem2", "type": "syslog", "host": "host2.example.com", "port": 1514, "protocol": "udp"}]'
```
- if necessary, we can update env var handling to support single env vars like the below, but that would be a separate PR later
```
INFRAHUB_LOG_FORWARDING_DESTINATION_1_NAME = "siem1"
INFRAHUB_LOG_FORWARDING_DESTINATION_1_host = "..."
...
INFRAHUB_LOG_FORWARDING_DESTINATION_2_NAME = "siem2"
INFRAHUB_LOG_FORWARDING_DESTINATION_2_host = "..."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise log forwarding with syslog support: multiple destinations, TCP/UDP, formats/framing, TLS, queuing, and per-destination controls.

* **Behavior / Validation**
  * Destination names must be unique; TLS over UDP is rejected; adding destinations enables the log-forwarding enterprise feature.

* **Tests**
  * New unit tests for parsing, validation, env/TOML loading, and feature aggregation.

* **Documentation**
  * Updated configuration reference and env var types for log forwarding and array schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->