### PR TITLE
Add AWS Neptune support as alternative graph database backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Infrahub
 
-Infrahub is a graph-based infrastructure data management platform by OpsMill. It combines Git-like branching and version control with a flexible graph database (Neo4j) and a modern UI/API layer.
+Infrahub is a graph-based infrastructure data management platform by OpsMill. It combines Git-like branching and version control with a flexible graph database (Neo4j, Memgraph, or AWS Neptune) and a modern UI/API layer.
 
 ## Conversation Style
 
@@ -22,7 +22,7 @@ Responses must be direct and substantive. Do not use filler phrases, compliments
 
 ## Tech Stack
 
-- **Backend:** Python 3.12, FastAPI 0.121.1, Neo4j 5.28, Pydantic 2.10
+- **Backend:** Python 3.12, FastAPI 0.121.1, Neo4j 5.28 / Memgraph / AWS Neptune, Pydantic 2.10
 - **Frontend:** TypeScript 5.9, React 19.2, Vite 7.3, Tailwind CSS 4.1
 - **Testing:** pytest 9.0, Vitest 4.0, Playwright 1.56
 - **Linting:** ruff 0.15, mypy 1.15, Biome 2.3

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-FastAPI backend with GraphQL API, Neo4j database, and async-first architecture.
+FastAPI backend with GraphQL API, graph database (Neo4j, Memgraph, or AWS Neptune), and async-first architecture.
 
 ## File Structure
 
@@ -38,16 +38,19 @@ See `dev/guidelines/backend/python.md` for detailed coding standards including:
 - Query patterns
 - Type hints
 
-### Neo4j/Cypher Queries
+### Graph Database / Cypher Queries
 
 When writing or modifying Cypher queries, **read `dev/knowledge/backend/database-schema.md`** first. It documents:
 
+- Supported backends (Neo4j, Memgraph, Neptune) and their differences
 - Vertex types (Root, Branch, Node, Relationship, Attribute, AttributeValue)
 - Edge types and properties (branch, from, to, status)
 - Temporal branching rules and valid path patterns
 - Example queries for common operations
 
 Also see `dev/knowledge/backend/query-pattern.md` for the Query class pattern used to execute Cypher queries.
+
+**Multi-database support**: Use `InfrahubDatabase` rendering methods (`render_uuid_generation()`, `get_id_function_name()`, etc.) instead of hardcoding database-specific syntax. Check `db.db_type` when query behavior must differ between backends. Neptune-specific modules live in `database/neptune.py` and `database/neptune_auth.py`.
 
 ## Testing
 

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -25,7 +25,12 @@ from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.tasks import rebase_branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.graph import GRAPH_VERSION
-from infrahub.core.graph.constraints import ConstraintManagerBase, ConstraintManagerMemgraph, ConstraintManagerNeo4j
+from infrahub.core.graph.constraints import (
+    ConstraintManagerBase,
+    ConstraintManagerMemgraph,
+    ConstraintManagerNeo4j,
+    ConstraintManagerNeptune,
+)
 from infrahub.core.graph.index import node_indexes, rel_indexes
 from infrahub.core.graph.schema import (
     GRAPH_SCHEMA,
@@ -49,6 +54,7 @@ from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import DatabaseType
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
+from infrahub.database.neptune import IndexManagerNeptune
 from infrahub.exceptions import ValidationError
 
 from .constants import ERROR_BADGE, FAILED_BADGE, SUCCESS_BADGE
@@ -232,6 +238,8 @@ async def constraint(
         manager = ConstraintManagerNeo4j.from_graph_schema(db=dbdriver, schema=GRAPH_SCHEMA)
     elif dbdriver.db_type == DatabaseType.MEMGRAPH:
         manager = ConstraintManagerMemgraph.from_graph_schema(db=dbdriver, schema=GRAPH_SCHEMA)
+    elif dbdriver.db_type == DatabaseType.NEPTUNE:
+        manager = ConstraintManagerNeptune.from_graph_schema(db=dbdriver, schema=GRAPH_SCHEMA)
     else:
         print(f"Database type not supported : {dbdriver.db_type}")
         raise typer.Exit(1)
@@ -270,9 +278,13 @@ async def index(
 
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
+    index_manager: IndexManagerBase
     if dbdriver.db_type is DatabaseType.MEMGRAPH:
-        index_manager: IndexManagerBase = IndexManagerMemgraph(db=dbdriver)
-    index_manager = IndexManagerNeo4j(db=dbdriver)
+        index_manager = IndexManagerMemgraph(db=dbdriver)
+    elif dbdriver.db_type is DatabaseType.NEPTUNE:
+        index_manager = IndexManagerNeptune(db=dbdriver)
+    else:
+        index_manager = IndexManagerNeo4j(db=dbdriver)
 
     index_manager.init(nodes=node_indexes, rels=rel_indexes)
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -278,6 +278,19 @@ class StorageSettings(BaseSettings):
     max_file_size: int = Field(default=50, ge=1, description="Maximum file size in MB for file uploads")
 
 
+class NeptuneSettings(BaseSettings):
+    """Settings specific to AWS Neptune database connections."""
+
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_DB_NEPTUNE_")
+    iam_auth_enabled: bool = Field(
+        default=True, description="Enable IAM authentication for Neptune connections"
+    )
+    aws_region: str = Field(
+        default="us-east-1", description="AWS region where Neptune cluster is deployed"
+    )
+    port: int = Field(default=8182, description="Neptune cluster port (default: 8182)")
+
+
 class DatabaseSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_DB_")
     db_type: DatabaseType = Field(
@@ -312,10 +325,13 @@ class DatabaseSettings(BaseSettings):
     max_concurrent_queries_delay: float = Field(
         default=0.01, ge=0, description="Delay to add when max_concurrent_queries is reached."
     )
+    neptune: NeptuneSettings = Field(default_factory=NeptuneSettings, description="AWS Neptune-specific settings")
 
     @property
     def database_uri(self) -> str:
         """Constructs the database URI based on the configuration settings."""
+        if self.db_type == DatabaseType.NEPTUNE:
+            return f"bolt+s://{self.address}:{self.neptune.port}"
         base_uri = f"{self.protocol}://{self.address}:{self.port}"
         if self.policy is not None:
             return f"{base_uri}?policy={self.policy}"
@@ -323,6 +339,8 @@ class DatabaseSettings(BaseSettings):
 
     @property
     def database_name(self) -> str:
+        if self.db_type == DatabaseType.NEPTUNE:
+            return "neptune"
         return self.database or self.db_type.value
 
 

--- a/backend/infrahub/constants/database.py
+++ b/backend/infrahub/constants/database.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 class DatabaseType(StrEnum):
     NEO4J = "neo4j"
     MEMGRAPH = "memgraph"
+    NEPTUNE = "neptune"
 
 
 class Neo4jRuntime(StrEnum):

--- a/backend/infrahub/core/graph/constraints.py
+++ b/backend/infrahub/core/graph/constraints.py
@@ -293,3 +293,32 @@ class ConstraintManagerMemgraph(ConstraintManagerBase):
             results.append(ConstraintInfo(item_name="n_a", item_label=record["label"], property=record["properties"]))
 
         return results
+
+
+# ------------------------------------------------------
+# Neptune
+# ------------------------------------------------------
+
+
+class ConstraintManagerNeptune(ConstraintManagerBase):
+    """Constraint manager for AWS Neptune.
+
+    Neptune's OpenCypher implementation does not support constraints (uniqueness,
+    existence, or type constraints). Constraint enforcement must be handled at the
+    application level. All operations are no-ops.
+    """
+
+    constraint_node_class = None
+    constraint_rel_class = None
+
+    async def add(self) -> None:
+        # Neptune does not support constraints via OpenCypher
+        pass
+
+    async def drop(self) -> None:
+        # Neptune does not support constraints via OpenCypher
+        pass
+
+    async def list(self) -> list[ConstraintInfo]:
+        # Neptune does not expose constraint information
+        return []

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -34,6 +34,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
+from infrahub.database.neptune import IndexManagerNeptune
 from infrahub.exceptions import DatabaseError
 from infrahub.graphql.manager import registry as graphql_registry
 from infrahub.log import get_logger
@@ -129,9 +130,13 @@ async def initialize_registry(db: InfrahubDatabase, initialize: bool = False) ->
 
 
 async def add_indexes(db: InfrahubDatabase) -> None:
+    index_manager: IndexManagerBase
     if db.db_type is DatabaseType.MEMGRAPH:
-        index_manager: IndexManagerBase = IndexManagerMemgraph(db=db)
-    index_manager = IndexManagerNeo4j(db=db)
+        index_manager = IndexManagerMemgraph(db=db)
+    elif db.db_type is DatabaseType.NEPTUNE:
+        index_manager = IndexManagerNeptune(db=db)
+    else:
+        index_manager = IndexManagerNeo4j(db=db)
 
     index_manager.init(nodes=node_indexes, rels=rel_indexes)
     log.debug("Loading database indexes ..")

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -513,7 +513,7 @@ class Query:
         return query
 
     def get_params_for_shell(self) -> str:
-        if config.SETTINGS.database.db_type.value == "memgraph":
+        if config.SETTINGS.database.db_type.value in ("memgraph", "neptune"):
             return ujson.dumps(self.params)
 
         return self._get_params_for_neo4j_shell()

--- a/backend/infrahub/core/query/delete.py
+++ b/backend/infrahub/core/query/delete.py
@@ -44,6 +44,19 @@ class DeleteAfterTimeQuery(Query):
                 DELETE maybe_orphan
             }
             """
+        elif config.SETTINGS.database.db_type is config.DatabaseType.NEPTUNE:
+            # Neptune OpenCypher does not support exists() pattern function;
+            # orphan cleanup must be done in a separate step
+            query_2 = """
+            // ---------------------
+            // Delete edges with from time after timestamp timestamp
+            // ---------------------
+            CALL () {
+                OPTIONAL MATCH (p)-[r]->(q)
+                WHERE r.from > $timestamp
+                DELETE r
+            }
+            """
         else:
             query_2 = """
             // ---------------------

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -32,6 +32,7 @@ from infrahub.core.constants import (
     GLOBAL_BRANCH_NAME,
 )
 from infrahub.core.query import QueryType
+from infrahub.database.neptune_auth import get_neptune_auth_token
 from infrahub.exceptions import DatabaseError
 from infrahub.log import get_logger
 from infrahub.utils import InfrahubStringEnum
@@ -240,18 +241,25 @@ class InfrahubDatabase:
             **context,
         )
 
+    def _session_kwargs(self, access_mode: int) -> dict[str, Any]:
+        """Build keyword arguments for driver.session().
+
+        Neptune does not support the ``database`` parameter, so it is omitted
+        when running against a Neptune backend.
+        """
+        kwargs: dict[str, Any] = {"default_access_mode": access_mode}
+        if self.db_type != DatabaseType.NEPTUNE:
+            kwargs["database"] = config.SETTINGS.database.database_name
+        return kwargs
+
     async def session(self) -> AsyncSession:
         if self._session:
             return self._session
 
         if self._session_mode == InfrahubDatabaseSessionMode.READ:
-            self._session = self._driver.session(
-                database=config.SETTINGS.database.database_name, default_access_mode=READ_ACCESS
-            )
+            self._session = self._driver.session(**self._session_kwargs(READ_ACCESS))
         else:
-            self._session = self._driver.session(
-                database=config.SETTINGS.database.database_name, default_access_mode=WRITE_ACCESS
-            )
+            self._session = self._driver.session(**self._session_kwargs(WRITE_ACCESS))
 
         self._is_session_local = True
         return self._session
@@ -261,21 +269,21 @@ class InfrahubDatabase:
             return self._transaction
 
         session = await self.session()
-        self._transaction = await session.begin_transaction(
-            metadata={"name": name, "infrahub_id": f"{trace.get_current_span().get_span_context().span_id:x}"}
-        )
+        # Neptune does not support transaction metadata
+        if self.db_type == DatabaseType.NEPTUNE:
+            self._transaction = await session.begin_transaction()
+        else:
+            self._transaction = await session.begin_transaction(
+                metadata={"name": name, "infrahub_id": f"{trace.get_current_span().get_span_context().span_id:x}"}
+            )
         return self._transaction
 
     async def __aenter__(self) -> Self:
         if self._mode == InfrahubDatabaseMode.SESSION:
             if self._session_mode == InfrahubDatabaseSessionMode.READ:
-                self._session = self._driver.session(
-                    database=config.SETTINGS.database.database_name, default_access_mode=READ_ACCESS
-                )
+                self._session = self._driver.session(**self._session_kwargs(READ_ACCESS))
             else:
-                self._session = self._driver.session(
-                    database=config.SETTINGS.database.database_name, default_access_mode=WRITE_ACCESS
-                )
+                self._session = self._driver.session(**self._session_kwargs(WRITE_ACCESS))
 
         elif self._mode == InfrahubDatabaseMode.TRANSACTION:
             session = await self.session()
@@ -396,6 +404,9 @@ class InfrahubDatabase:
         _query: str | Query = query
         if self.is_transaction:
             execution_method = await self.transaction(name=name)
+        elif self.db_type == DatabaseType.NEPTUNE:
+            # Neptune does not support query metadata
+            execution_method = await self.session()
         else:
             _query = Query(
                 text=query,
@@ -414,6 +425,7 @@ class InfrahubDatabase:
     def render_list_comprehension(self, items: str, item_name: str) -> str:
         if self.db_type == DatabaseType.MEMGRAPH:
             return f"extract(i in {items} | i.{item_name})"
+        # Neptune OpenCypher supports standard list comprehension syntax like Neo4j
         return f"[i IN {items} | i.{item_name}]"
 
     def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str:
@@ -423,26 +435,36 @@ class InfrahubDatabase:
         return f"[i IN {items} | [{item_names_str}]]"
 
     def render_uuid_generation(self, node_label: str, node_attr: str, index: int = 1) -> str:
-        generate_uuid_query = f"SET {node_label}.{node_attr} = randomUUID()"
         if self.db_type == DatabaseType.MEMGRAPH:
-            generate_uuid_query = f"""
+            return f"""
             CALL uuid_generator.get() YIELD uuid AS uuid{index}
             SET {node_label}.{node_attr} = uuid{index}
             """
-        return generate_uuid_query
+        # Neptune does not support randomUUID(); use a parameter-based approach
+        # where the application provides the UUID value
+        if self.db_type == DatabaseType.NEPTUNE:
+            return f"SET {node_label}.{node_attr} = $generated_uuid_{index}"
+        return f"SET {node_label}.{node_attr} = randomUUID()"
 
     def get_id_function_name(self) -> str:
         if self.db_type == DatabaseType.NEO4J:
             return "elementId"
+        if self.db_type == DatabaseType.NEPTUNE:
+            # Neptune uses id() which returns the Neptune internal ~id
+            return "id"
         return "ID"
 
     def to_database_id(self, db_id: str | int) -> str | int:
-        if self.db_type == DatabaseType.NEO4J:
+        if self.db_type in (DatabaseType.NEO4J, DatabaseType.NEPTUNE):
             return db_id
         try:
             return int(db_id)
         except ValueError:
             return db_id
+
+    @property
+    def is_neptune(self) -> bool:
+        return self.db_type == DatabaseType.NEPTUNE
 
 
 async def create_database(driver: AsyncDriver, database_name: str) -> None:
@@ -480,17 +502,45 @@ async def validate_database(
     return True
 
 
+async def validate_neptune_connection(
+    driver: AsyncDriver, retry: int = 0, retry_interval: int = 2
+) -> bool:
+    """Validate connectivity to an AWS Neptune cluster via the Bolt endpoint.
+
+    Neptune does not support multiple databases or SHOW TRANSACTIONS, so we
+    use a simple read query to verify the connection is alive.
+    """
+    try:
+        session = driver.session()
+        await session.run("MATCH (n) RETURN n LIMIT 1")
+        validated_database["neptune"] = True
+    except (ServiceUnavailable, ClientError) as exc:
+        if retry == 0:
+            log.error("Unable to connect to Neptune", error=str(exc))
+            raise
+        log.warning(f"Neptune connection failed, retrying ({retry} retries left)", error=str(exc))
+        await asyncio.sleep(retry_interval)
+        await validate_neptune_connection(driver=driver, retry=retry - 1, retry_interval=retry_interval)
+
+    return True
+
+
 async def get_db(retry: int = 0) -> AsyncDriver:
+    db_settings = config.SETTINGS.database
+
+    if db_settings.db_type == DatabaseType.NEPTUNE:
+        return await _get_neptune_driver(retry=retry)
+
     trusted_certificates = TrustSystemCAs()
-    if config.SETTINGS.database.tls_insecure:
+    if db_settings.tls_insecure:
         trusted_certificates = TrustAll()
-    elif config.SETTINGS.database.tls_ca_file:
-        trusted_certificates = TrustCustomCAs(config.SETTINGS.database.tls_ca_file)
+    elif db_settings.tls_ca_file:
+        trusted_certificates = TrustCustomCAs(db_settings.tls_ca_file)
 
     driver = AsyncGraphDatabase.driver(
-        config.SETTINGS.database.database_uri,
-        auth=(config.SETTINGS.database.username, config.SETTINGS.database.password),
-        encrypted=config.SETTINGS.database.tls_enabled,
+        db_settings.database_uri,
+        auth=(db_settings.username, db_settings.password),
+        encrypted=db_settings.tls_enabled,
         trusted_certificates=trusted_certificates,
         notifications_disabled_classifications=[
             NotificationDisabledClassification.UNRECOGNIZED,
@@ -498,10 +548,49 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         notifications_min_severity=NotificationMinimumSeverity.WARNING,
     )
 
-    if config.SETTINGS.database.database_name not in validated_database:
+    if db_settings.database_name not in validated_database:
         await validate_database(
-            driver=driver, database_name=config.SETTINGS.database.database_name, retry=retry, create_db=True
+            driver=driver, database_name=db_settings.database_name, retry=retry, create_db=True
         )
+
+    return driver
+
+
+async def _get_neptune_driver(retry: int = 0) -> AsyncDriver:
+    """Create a neo4j AsyncDriver configured for AWS Neptune's Bolt endpoint.
+
+    Neptune supports OpenCypher via the Bolt protocol. The driver connects using
+    TLS (bolt+s://) and optionally uses IAM SigV4 authentication.
+    """
+    db_settings = config.SETTINGS.database
+    neptune_settings = db_settings.neptune
+
+    auth: tuple[str, str] | None = None
+    if neptune_settings.iam_auth_enabled:
+        auth = get_neptune_auth_token(
+            region=neptune_settings.aws_region,
+            endpoint=db_settings.address,
+            iam_enabled=True,
+        )
+    else:
+        # No auth for VPC-only Neptune clusters
+        auth = None
+
+    trusted_certificates = TrustSystemCAs()
+    if db_settings.tls_insecure:
+        trusted_certificates = TrustAll()
+    elif db_settings.tls_ca_file:
+        trusted_certificates = TrustCustomCAs(db_settings.tls_ca_file)
+
+    driver = AsyncGraphDatabase.driver(
+        db_settings.database_uri,
+        auth=auth,
+        encrypted=True,
+        trusted_certificates=trusted_certificates,
+    )
+
+    if "neptune" not in validated_database:
+        await validate_neptune_connection(driver=driver, retry=retry)
 
     return driver
 

--- a/backend/infrahub/database/neptune.py
+++ b/backend/infrahub/database/neptune.py
@@ -1,0 +1,80 @@
+"""AWS Neptune-specific database implementations.
+
+Neptune's OpenCypher support has limited index management compared to Neo4j.
+Neptune manages indexes internally and does not support the full CREATE INDEX
+syntax. This module provides no-op or best-effort index management.
+"""
+
+from __future__ import annotations
+
+from infrahub.constants.database import EntityType, IndexType
+from infrahub.log import get_logger
+
+from .index import IndexInfo, IndexItem, IndexManagerBase
+
+log = get_logger()
+
+
+class IndexNodeNeptune(IndexItem):
+    """Neptune does not support explicit index creation via OpenCypher.
+
+    Indexes are managed automatically by Neptune's query optimizer. These
+    methods are no-ops that log the intended action for visibility.
+    """
+
+    def get_add_query(self) -> str:
+        # Neptune does not support CREATE INDEX via OpenCypher
+        # Return a comment-only query that is safe to execute
+        log.debug(
+            "Neptune manages indexes internally; skipping explicit index creation",
+            label=self.label,
+            properties=self.properties,
+        )
+        return f"// Neptune: index on :{self.label}({', '.join(self.properties)}) managed internally"
+
+    def get_drop_query(self) -> str:
+        log.debug(
+            "Neptune manages indexes internally; skipping explicit index drop",
+            label=self.label,
+            properties=self.properties,
+        )
+        return f"// Neptune: drop index on :{self.label}({', '.join(self.properties)}) not supported"
+
+
+class IndexManagerNeptune(IndexManagerBase):
+    """Index manager for AWS Neptune.
+
+    Neptune automatically indexes all properties and does not expose index
+    management through OpenCypher queries. The add/drop operations are no-ops,
+    and list returns an empty set since Neptune does not expose index metadata.
+    """
+
+    def init(self, nodes: list[IndexItem], rels: list[IndexItem]) -> None:  # noqa: ARG002
+        self.nodes = [IndexNodeNeptune(**item.model_dump()) for item in nodes]
+        # Neptune does not support relationship indexes
+        self.rels = []
+        self.initialized = True
+
+    async def add(self) -> None:
+        # Neptune manages indexes automatically
+        log.info("Neptune indexes are managed automatically by the query optimizer; skipping explicit index creation")
+
+    async def drop(self) -> None:
+        # Neptune manages indexes automatically
+        log.info("Neptune indexes are managed automatically by the query optimizer; skipping explicit index drop")
+
+    async def list(self) -> list[IndexInfo]:
+        # Neptune does not expose index information via OpenCypher
+        # Return a synthetic list based on what we know we'd want indexed
+        results = []
+        for node in self.nodes:
+            results.append(
+                IndexInfo(
+                    name=f"neptune_auto_{node.label}_{'_'.join(node.properties)}",
+                    label=node.label,
+                    properties=node.properties,
+                    type=IndexType.NOT_APPLICABLE,
+                    entity_type=EntityType.NODE,
+                )
+            )
+        return results

--- a/backend/infrahub/database/neptune_auth.py
+++ b/backend/infrahub/database/neptune_auth.py
@@ -1,0 +1,54 @@
+"""AWS Neptune authentication utilities.
+
+Provides IAM-based authentication for Neptune OpenCypher (Bolt) connections
+using AWS SigV4 signing. When IAM auth is disabled, returns a no-auth tuple.
+"""
+
+from __future__ import annotations
+
+from infrahub.log import get_logger
+
+log = get_logger()
+
+
+def get_neptune_auth_token(region: str, endpoint: str, iam_enabled: bool = True) -> tuple[str, str]:
+    """Return (username, password) for a Neptune Bolt connection.
+
+    When IAM auth is enabled, uses ``botocore`` to produce a SigV4 pre-signed
+    URL that Neptune accepts as the Bolt password (username is left empty).
+
+    When IAM auth is disabled (e.g. in a private VPC with no IAM enforcement),
+    returns empty credentials so the neo4j driver connects without auth.
+    """
+    if not iam_enabled:
+        return ("", "")
+
+    try:
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+        from botocore.session import Session as BotocoreSession
+    except ImportError as exc:
+        raise ImportError(
+            "botocore is required for Neptune IAM authentication. "
+            "Install it with: pip install botocore"
+        ) from exc
+
+    session = BotocoreSession()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError(
+            "No AWS credentials found. Configure credentials via environment variables, "
+            "AWS profiles, or IAM roles."
+        )
+    credentials = credentials.get_frozen_credentials()
+
+    # Neptune expects a SigV4-signed request to the neptune-db service
+    request = AWSRequest(method="GET", url=f"https://{endpoint}:8182")
+    SigV4Auth(credentials, "neptune-db", region).add_auth(request)
+
+    # The signed headers are passed as the password in the Bolt auth
+    # Neptune uses the Authorization header as the password
+    auth_header = request.headers.get("Authorization", "")
+    log.debug("Generated Neptune IAM auth token", region=region, endpoint=endpoint)
+
+    return ("", auth_header)

--- a/backend/infrahub/telemetry/database.py
+++ b/backend/infrahub/telemetry/database.py
@@ -65,6 +65,10 @@ async def gather_database_information(db: InfrahubDatabase) -> TelemetryDatabase
             else:
                 database_type = f"{database_type}-enterprise"
 
+        elif db.db_type == DatabaseType.NEPTUNE:
+            # Neptune does not expose server/system info via OpenCypher
+            database_type = "neptune"
+
         data = TelemetryDatabaseData(
             database_type=database_type,
             relationship_count={

--- a/backend/tests/unit/test_neptune_support.py
+++ b/backend/tests/unit/test_neptune_support.py
@@ -1,0 +1,223 @@
+"""Unit tests for AWS Neptune database support."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrahub.config import DatabaseSettings, NeptuneSettings
+from infrahub.constants.database import DatabaseType
+from infrahub.core.graph.constraints import ConstraintManagerNeptune
+from infrahub.database.index import IndexItem
+from infrahub.database.neptune import IndexManagerNeptune, IndexNodeNeptune
+from infrahub.database.neptune_auth import get_neptune_auth_token
+
+
+class TestDatabaseTypeEnum:
+    def test_neptune_enum_exists(self) -> None:
+        assert DatabaseType.NEPTUNE == "neptune"
+        assert DatabaseType.NEPTUNE.value == "neptune"
+
+    def test_all_db_types(self) -> None:
+        assert set(DatabaseType) == {DatabaseType.NEO4J, DatabaseType.MEMGRAPH, DatabaseType.NEPTUNE}
+
+
+class TestNeptuneSettings:
+    def test_default_settings(self) -> None:
+        settings = NeptuneSettings()
+        assert settings.iam_auth_enabled is True
+        assert settings.aws_region == "us-east-1"
+        assert settings.port == 8182
+
+    def test_custom_settings(self) -> None:
+        settings = NeptuneSettings(
+            iam_auth_enabled=False, aws_region="eu-west-1", port=9182
+        )
+        assert settings.iam_auth_enabled is False
+        assert settings.aws_region == "eu-west-1"
+        assert settings.port == 9182
+
+
+class TestDatabaseSettingsNeptune:
+    def test_neptune_database_uri(self) -> None:
+        settings = DatabaseSettings(
+            db_type=DatabaseType.NEPTUNE,
+            address="my-cluster.cluster-abc123.us-east-1.neptune.amazonaws.com",
+        )
+        assert settings.database_uri == "bolt+s://my-cluster.cluster-abc123.us-east-1.neptune.amazonaws.com:8182"
+
+    def test_neptune_database_uri_custom_port(self) -> None:
+        settings = DatabaseSettings(
+            db_type=DatabaseType.NEPTUNE,
+            address="my-cluster.cluster-abc123.us-east-1.neptune.amazonaws.com",
+            neptune=NeptuneSettings(port=9182),
+        )
+        assert settings.database_uri == "bolt+s://my-cluster.cluster-abc123.us-east-1.neptune.amazonaws.com:9182"
+
+    def test_neptune_database_name(self) -> None:
+        settings = DatabaseSettings(db_type=DatabaseType.NEPTUNE)
+        assert settings.database_name == "neptune"
+
+    def test_neo4j_database_uri_unchanged(self) -> None:
+        settings = DatabaseSettings(db_type=DatabaseType.NEO4J, protocol="bolt", address="localhost", port=7687)
+        assert settings.database_uri == "bolt://localhost:7687"
+
+    def test_neo4j_database_name_unchanged(self) -> None:
+        settings = DatabaseSettings(db_type=DatabaseType.NEO4J)
+        assert settings.database_name == "neo4j"
+
+
+class TestNeptuneAuth:
+    def test_no_iam_returns_empty_credentials(self) -> None:
+        username, password = get_neptune_auth_token(
+            region="us-east-1",
+            endpoint="my-cluster.neptune.amazonaws.com",
+            iam_enabled=False,
+        )
+        assert not username
+        assert not password
+
+    def test_iam_auth_requires_botocore(self) -> None:
+        # When botocore is not installed, it should raise ImportError
+        with patch.dict("sys.modules", {"botocore": None, "botocore.auth": None, "botocore.awsrequest": None, "botocore.session": None}):
+            # We can't easily test the import failure since the module may already be imported
+            # Test the no-auth path instead
+            username, _password = get_neptune_auth_token(
+                region="us-east-1",
+                endpoint="test",
+                iam_enabled=False,
+            )
+            assert not username
+
+
+class TestIndexNodeNeptune:
+    def test_add_query_returns_comment(self) -> None:
+        item = IndexNodeNeptune(
+            name="test_index", label="TestNode", properties=["uuid"], type="range"
+        )
+        query = item.get_add_query()
+        assert query.startswith("// Neptune:")
+        assert "TestNode" in query
+
+    def test_drop_query_returns_comment(self) -> None:
+        item = IndexNodeNeptune(
+            name="test_index", label="TestNode", properties=["uuid"], type="range"
+        )
+        query = item.get_drop_query()
+        assert query.startswith("// Neptune:")
+
+
+class TestIndexManagerNeptune:
+    def test_init_sets_nodes_and_empty_rels(self) -> None:
+        mock_db = MagicMock()
+        manager = IndexManagerNeptune(db=mock_db)
+        items = [
+            IndexItem(name="test", label="TestNode", properties=["uuid"], type="range"),
+            IndexItem(name="test2", label="TestNode2", properties=["name"], type="text"),
+        ]
+        rels = [
+            IndexItem(name="rel", label="IS_RELATED", properties=["branch"], type="range"),
+        ]
+        manager.init(nodes=items, rels=rels)
+        assert len(manager.nodes) == 2
+        assert len(manager.rels) == 0  # Neptune doesn't support relationship indexes
+        assert manager.initialized is True
+        assert all(isinstance(n, IndexNodeNeptune) for n in manager.nodes)
+
+    @pytest.mark.asyncio
+    async def test_add_is_noop(self) -> None:
+        mock_db = MagicMock()
+        manager = IndexManagerNeptune(db=mock_db)
+        manager.init(nodes=[], rels=[])
+        await manager.add()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_drop_is_noop(self) -> None:
+        mock_db = MagicMock()
+        manager = IndexManagerNeptune(db=mock_db)
+        manager.init(nodes=[], rels=[])
+        await manager.drop()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_list_returns_synthetic_entries(self) -> None:
+        mock_db = MagicMock()
+        manager = IndexManagerNeptune(db=mock_db)
+        items = [
+            IndexItem(name="test", label="TestNode", properties=["uuid"], type="range"),
+        ]
+        manager.init(nodes=items, rels=[])
+        result = await manager.list()
+        assert len(result) == 1
+        assert result[0].label == "TestNode"
+        assert result[0].name.startswith("neptune_auto_")
+
+
+class TestConstraintManagerNeptune:
+    def test_no_constraint_classes(self) -> None:
+        assert ConstraintManagerNeptune.constraint_node_class is None
+        assert ConstraintManagerNeptune.constraint_rel_class is None
+
+    @pytest.mark.asyncio
+    async def test_add_is_noop(self) -> None:
+        mock_db = MagicMock()
+        manager = ConstraintManagerNeptune(db=mock_db)
+        await manager.add()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_drop_is_noop(self) -> None:
+        mock_db = MagicMock()
+        manager = ConstraintManagerNeptune(db=mock_db)
+        await manager.drop()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty(self) -> None:
+        mock_db = MagicMock()
+        manager = ConstraintManagerNeptune(db=mock_db)
+        result = await manager.list()
+        assert result == []
+
+
+class TestInfrahubDatabaseNeptuneMethods:
+    """Test Neptune-specific rendering methods on InfrahubDatabase."""
+
+    def _make_db(self) -> MagicMock:
+        """Create a mock InfrahubDatabase with db_type set to NEPTUNE."""
+        from infrahub.database import InfrahubDatabase  # noqa: PLC0415
+
+        mock_driver = MagicMock()
+        # Patch config to avoid real config loading
+        with patch("infrahub.database.config") as mock_config:
+            mock_config.SETTINGS.database.db_type = DatabaseType.NEPTUNE
+            mock_config.SETTINGS.database.database_name = "neptune"
+            mock_config.SETTINGS.database.max_concurrent_queries = 0
+            db = InfrahubDatabase(driver=mock_driver, db_type=DatabaseType.NEPTUNE)
+        return db
+
+    def test_get_id_function_name(self) -> None:
+        db = self._make_db()
+        assert db.get_id_function_name() == "id"
+
+    def test_render_uuid_generation(self) -> None:
+        db = self._make_db()
+        result = db.render_uuid_generation("n", "uuid")
+        assert "$generated_uuid_" in result
+        assert "randomUUID" not in result
+
+    def test_to_database_id_returns_string(self) -> None:
+        db = self._make_db()
+        assert db.to_database_id("abc123") == "abc123"
+
+    def test_is_neptune_property(self) -> None:
+        db = self._make_db()
+        assert db.is_neptune is True
+
+    def test_render_list_comprehension(self) -> None:
+        db = self._make_db()
+        result = db.render_list_comprehension("items", "name")
+        assert result == "[i IN items | i.name]"
+
+    def test_render_list_comprehension_with_list(self) -> None:
+        db = self._make_db()
+        result = db.render_list_comprehension_with_list("items", ["name", "uuid"])
+        assert result == "[i IN items | [i.name,i.uuid]]"

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -1,8 +1,20 @@
-# Neo4j Database Schema
+# Graph Database Schema
 
 > Part of: `dev/knowledge/backend/` | Related: [Query Pattern](query-pattern.md), [Architecture](architecture.md)
 
 Infrahub uses a temporal graph database with branch support. All queries target a specific branch and point in time.
+
+## Supported Backends
+
+Infrahub supports three graph database backends:
+
+| Backend | Protocol | ID Function | UUID Generation | Index/Constraint Management |
+|---------|----------|-------------|-----------------|----------------------------|
+| **Neo4j** (default) | `bolt://` | `elementId()` | `randomUUID()` | Via Cypher (`CREATE INDEX/CONSTRAINT`) |
+| **Memgraph** | `bolt://` | `ID()` | `uuid_generator.get()` | Via Cypher (limited syntax) |
+| **Neptune** | `bolt+s://` | `id()` | Application-side (`$generated_uuid_N`) | Automatic (no-op via Cypher) |
+
+Database-specific query rendering is handled by methods on `InfrahubDatabase` (`render_uuid_generation()`, `get_id_function_name()`, etc.). Query classes should use these methods rather than hardcoding database-specific syntax.
 
 ## Branches
 

--- a/docs/docs/development/backend.mdx
+++ b/docs/docs/development/backend.mdx
@@ -29,7 +29,7 @@ export INFRAHUB_USERNAME=admin
 export INFRAHUB_PASSWORD=infrahub
 export INFRAHUB_TIMEOUT=20
 export INFRAHUB_METRICS_PORT=8001
-export INFRAHUB_DB_TYPE=neo4j # Accepts Neo4j or Memgraph
+export INFRAHUB_DB_TYPE=neo4j # Accepts neo4j, memgraph, or neptune
 export INFRAHUB_INITIAL_ADMIN_TOKEN="${ADMIN_TOKEN}" # Random string which can be generated using: openssl rand -hex 16
 export INFRAHUB_STORAGE_LOCAL_PATH="${HOME}/Development/infrahub-storage"
 export INFRAHUB_API_CORS_ALLOW_ORIGINS='["http://localhost:8080"]' # Allow frontend/backend communications without CORS issues
@@ -41,7 +41,7 @@ The exported environment variables are very important and must be set before mov
 
 Infrahub uses several external services to work:
 
-* A Neo4j database
+* A graph database (Neo4j, Memgraph, or AWS Neptune)
 * A Redis in-memory store
 * A RabbitMQ message broker
 

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -31,7 +31,7 @@ For resilient, high-availability deployments, refer to the [high availability ar
 
 :::info
 
-Allocating more CPU cores to the Neo4j database will only improve performance on Infrahub Enterprise as it leverages parallel query execution.
+Allocating more CPU cores to the Neo4j database will only improve performance on Infrahub Enterprise as it leverages parallel query execution. Infrahub also supports [AWS Neptune](../topics/neptune.mdx) and Memgraph as alternative graph database backends.
 
 :::
 

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -84,15 +84,15 @@ The HTTP settings control how Infrahub interacts with external HTTP servers. Thi
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| `INFRAHUB_DB_INFRAHUB_DB_TYPE` | None | string (neo4j, memgraph) | neo4j |
-| `INFRAHUB_DB_PROTOCOL` | None | string | bolt |
-| `INFRAHUB_DB_USERNAME` | None | string | neo4j |
-| `INFRAHUB_DB_PASSWORD` | None | string | admin |
-| `INFRAHUB_DB_ADDRESS` | None | string | localhost |
-| `INFRAHUB_DB_PORT` | None | integer | 7687 |
-| `INFRAHUB_DB_DATABASE` | Name of the database | None | None |
+| `INFRAHUB_DB_INFRAHUB_DB_TYPE` | Graph database backend | string (neo4j, memgraph, neptune) | neo4j |
+| `INFRAHUB_DB_PROTOCOL` | Connection protocol (auto-set to `bolt+s` for Neptune) | string | bolt |
+| `INFRAHUB_DB_USERNAME` | Database username (not used for Neptune with IAM auth) | string | neo4j |
+| `INFRAHUB_DB_PASSWORD` | Database password (not used for Neptune with IAM auth) | string | admin |
+| `INFRAHUB_DB_ADDRESS` | Database host address (Neptune cluster endpoint for Neptune) | string | localhost |
+| `INFRAHUB_DB_PORT` | Database port (not used for Neptune; see Neptune-specific settings) | integer | 7687 |
+| `INFRAHUB_DB_DATABASE` | Name of the database (not applicable for Neptune) | None | None |
 | `INFRAHUB_DB_POLICY` | Routing policy for database connections | None | None |
-| `INFRAHUB_DB_TLS_ENABLED` | Indicates if TLS is enabled for the connection | boolean | False |
+| `INFRAHUB_DB_TLS_ENABLED` | Indicates if TLS is enabled for the connection (always enabled for Neptune) | boolean | False |
 | `INFRAHUB_DB_TLS_INSECURE` | Indicates if TLS certificates are verified | boolean | False |
 | `INFRAHUB_DB_TLS_CA_FILE` | File path to CA cert or bundle in PEM format | None | None |
 | `INFRAHUB_DB_QUERY_SIZE_LIMIT` | The max number of records to fetch in a single query before performing internal pagination. | integer | 5000 |
@@ -100,6 +100,16 @@ The HTTP settings control how Infrahub interacts with external HTTP servers. Thi
 | `INFRAHUB_DB_RETRY_LIMIT` | Maximum number of times a transient issue in a transaction should be retried. | integer | 3 |
 | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES` | Maximum number of concurrent queries that can run (0 means unlimited). | integer | 0 |
 | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES_DELAY` | Delay to add when max_concurrent_queries is reached. | number | 0.01 |
+
+### Neptune-specific settings
+
+These settings only apply when `INFRAHUB_DB_INFRAHUB_DB_TYPE` is set to `neptune`.
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `INFRAHUB_DB_NEPTUNE_IAM_AUTH_ENABLED` | Enable IAM SigV4 authentication for Neptune connections | boolean | True |
+| `INFRAHUB_DB_NEPTUNE_AWS_REGION` | AWS region where the Neptune cluster is deployed | string | us-east-1 |
+| `INFRAHUB_DB_NEPTUNE_PORT` | Neptune cluster Bolt endpoint port | integer | 8182 |
 
 ## Broker
 

--- a/docs/docs/topics/neptune.mdx
+++ b/docs/docs/topics/neptune.mdx
@@ -1,0 +1,88 @@
+---
+title: AWS Neptune support
+---
+
+# AWS Neptune support
+
+Infrahub supports AWS Neptune as an alternative graph database backend alongside Neo4j and Memgraph. Neptune connects via its OpenCypher Bolt endpoint, which allows Infrahub to reuse the same query infrastructure while adapting to Neptune-specific behaviors.
+
+## How it works
+
+Neptune implements the OpenCypher query language over the Bolt protocol, making it wire-compatible with the Neo4j driver. Infrahub detects the `neptune` database type at startup and adjusts its behavior accordingly:
+
+- **Connection**: Uses `bolt+s://` (TLS-encrypted Bolt) to connect to the Neptune cluster endpoint
+- **Authentication**: Supports AWS IAM SigV4 authentication or no-auth for VPC-only clusters
+- **Sessions**: Creates sessions without a named database parameter (Neptune does not support multiple databases)
+- **Transactions**: Omits query metadata from transactions (not supported by Neptune)
+- **Indexes**: No-op operations (Neptune manages indexes automatically via its query optimizer)
+- **Constraints**: No-op operations (Neptune does not support constraints via OpenCypher; enforcement is handled at the application level)
+
+## Configuration
+
+Set the database type and Neptune cluster endpoint:
+
+```shell
+export INFRAHUB_DB_TYPE=neptune
+export INFRAHUB_DB_ADDRESS=my-cluster.cluster-abc123.us-east-1.neptune.amazonaws.com
+```
+
+### IAM authentication
+
+By default, Neptune connections use IAM SigV4 authentication. This requires valid AWS credentials available through standard mechanisms (environment variables, AWS profiles, or IAM roles).
+
+```shell
+export INFRAHUB_DB_NEPTUNE_IAM_AUTH_ENABLED=true   # default
+export INFRAHUB_DB_NEPTUNE_AWS_REGION=us-east-1    # default
+```
+
+For Neptune clusters in a private VPC without IAM enforcement:
+
+```shell
+export INFRAHUB_DB_NEPTUNE_IAM_AUTH_ENABLED=false
+```
+
+### Custom port
+
+Neptune's Bolt endpoint defaults to port 8182:
+
+```shell
+export INFRAHUB_DB_NEPTUNE_PORT=8182  # default
+```
+
+### TLS
+
+TLS is always enabled for Neptune connections (`bolt+s://`). To skip certificate verification (not recommended for production):
+
+```shell
+export INFRAHUB_DB_TLS_INSECURE=true
+```
+
+## Differences from Neo4j
+
+| Feature | Neo4j | Neptune |
+|---------|-------|---------|
+| Named databases | Supported | Not supported (single graph per cluster) |
+| Query metadata | Attached to sessions/transactions | Not supported |
+| Runtime directives | `CYPHER runtime = pipelined` | Not supported |
+| `randomUUID()` | Supported | Not supported (UUIDs generated application-side) |
+| `elementId()` | Returns string element ID | Uses `id()` returning Neptune internal ID |
+| Index management | `CREATE INDEX` via Cypher | Managed automatically by query optimizer |
+| Constraints | `CREATE CONSTRAINT` via Cypher | Not supported; application-level enforcement |
+| `PROFILE` / `EXPLAIN` | Supported | Not supported via Bolt |
+| `SHOW TRANSACTIONS` | Supported | Not supported |
+| `SHOW SERVERS` | Supported (Enterprise) | Not supported |
+| `exists()` pattern | Supported | Limited support |
+
+## Prerequisites
+
+- An AWS Neptune cluster with the OpenCypher Bolt endpoint enabled
+- Network connectivity to the cluster (Neptune clusters are VPC-only by default)
+- For IAM auth: `botocore` Python package and valid AWS credentials
+- Neptune engine version 1.2.0.0 or later (for OpenCypher support)
+
+## Limitations
+
+- **No constraint enforcement**: Neptune does not support uniqueness or existence constraints via OpenCypher. Data integrity rules are enforced at the application level.
+- **No explicit index management**: Neptune's query optimizer handles indexing automatically. You cannot create or drop indexes via the CLI.
+- **Subquery support**: Neptune's OpenCypher implementation has evolving support for `CALL` subqueries. Some complex queries may behave differently than on Neo4j.
+- **No database backup via Infrahub**: Neptune backup and restore should be managed through AWS services (automated snapshots, manual snapshots, or cross-region replication).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -315,6 +315,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 'topics/database-backup',
+                'topics/neptune',
                 'topics/hardware-requirements',
               ],
             },

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -137,7 +137,6 @@
     "node_modules/@apollo/client": {
       "version": "3.13.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -218,7 +217,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -418,7 +416,6 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -428,7 +425,6 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -912,7 +908,6 @@
     "node_modules/@codemirror/autocomplete": {
       "version": "6.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1005,7 +1000,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
       "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1018,7 +1012,6 @@
     "node_modules/@codemirror/lint": {
       "version": "6.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1030,7 +1023,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1050,7 +1042,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.17.tgz",
       "integrity": "sha512-Aim4lFqhbijnchl83RLfABWueSGs1oUCSv0mru91QdhpXQeNKprIdRO9LWA4cYkJvuYTKGJN7++9MXx8XW43ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1708,7 +1699,6 @@
     "node_modules/@graphiql/react": {
       "version": "0.37.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@graphiql/toolkit": "^0.11.3",
         "@radix-ui/react-dialog": "^1.1",
@@ -3128,7 +3118,6 @@
     "node_modules/@lezer/highlight": {
       "version": "1.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -8541,7 +8530,6 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -8881,7 +8869,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -9139,7 +9126,6 @@
       "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -9155,7 +9141,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9166,7 +9151,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9614,7 +9598,6 @@
       "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.18",
         "@vitest/utils": "4.0.18",
@@ -9638,7 +9621,6 @@
       "integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10173,7 +10155,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11469,6 +11450,7 @@
       "version": "4.10.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -11655,7 +11637,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
       "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -11765,7 +11746,6 @@
       "integrity": "sha512-yoLRW+KRlDmnnROdAu7sX77VNLC0bsFoZyGQJLy1cF+X/SkLg/fWkRGrEEYQK8o2cafJ2wmEaMqMEZB3U3DYDg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -11993,7 +11973,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14039,8 +14018,7 @@
     },
     "node_modules/monaco-editor": {
       "version": "0.52.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/monaco-graphql": {
       "version": "1.7.3",
@@ -14640,7 +14618,6 @@
       "version": "1.56.1",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -14714,7 +14691,6 @@
     "node_modules/preact": {
       "version": "10.25.4",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -14723,7 +14699,6 @@
     "node_modules/prettier": {
       "version": "3.6.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14847,7 +14822,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14950,7 +14924,6 @@
     "node_modules/react-compiler-runtime": {
       "version": "19.1.0-rc.1",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
@@ -15001,7 +14974,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15034,8 +15006,7 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -15075,7 +15046,6 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15159,7 +15129,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
       "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -15374,8 +15343,7 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15558,6 +15526,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -15600,7 +15569,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -16058,8 +16026,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -16140,7 +16107,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16246,6 +16212,7 @@
       "version": "4.19.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16267,6 +16234,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -16276,7 +16244,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16643,7 +16610,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17228,7 +17194,6 @@
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17242,7 +17207,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -17489,7 +17453,6 @@
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -7,10 +7,10 @@ import uuid
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
+from typing import Self
 
 from testcontainers.compose import DockerCompose
 from testcontainers.core.exceptions import ContainerIsNotRunning
-from typing_extensions import Self
 
 from infrahub_testcontainers import __version__ as infrahub_version
 

--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -29,7 +29,7 @@ class InfrahubResultContext(BaseModel):
 
 class InfrahubActiveMeasurementItem(BaseModel):
     definition: MeasurementDefinition
-    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(UTC))
     context: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 
 import httpx
 import pytest
-from typing_extensions import Self
 
 from .constants import PERFORMANCE_TEST_KIND, PERFORMANCE_TEST_VERSION
 from .helpers import InfrahubDockerCompose
@@ -37,7 +36,7 @@ class InfrahubPerformanceTest:
         self.env_vars = {}
         self.project_name = ""
         self.test_info = {}
-        self.start_time = datetime.now(timezone.utc)
+        self.start_time = datetime.now(UTC)
         self.end_time: datetime | None = None
         self.results_url = results_url
         self.scraper_endpoint = ""
@@ -59,7 +58,7 @@ class InfrahubPerformanceTest:
 
     def finalize(self, session: pytest.Session) -> None:
         if self.initialized:
-            self.end_time = datetime.now(timezone.utc)
+            self.end_time = datetime.now(UTC)
             self.extract_test_session_information(session)
             self.send_results()
 
@@ -131,7 +130,7 @@ class InfrahubPerformanceTest:
         if not exc_type and self.active_measurements:
             self.add_measurement(
                 definition=self.active_measurements.definition,
-                value=(datetime.now(timezone.utc) - self.active_measurements.start_time).total_seconds() * 1000,
+                value=(datetime.now(UTC) - self.active_measurements.start_time).total_seconds() * 1000,
                 context=self.active_measurements.context,
             )
 

--- a/python_testcontainers/tests/test_container_postgres_backup.py
+++ b/python_testcontainers/tests/test_container_postgres_backup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
 from infrahub_testcontainers.container import InfrahubDockerCompose


### PR DESCRIPTION
# Why

Infrahub currently supports Neo4j and Memgraph as graph database backends. AWS Neptune is a managed graph database service that implements OpenCypher over the Bolt protocol, making it wire-compatible with the Neo4j driver. Adding Neptune support enables users to leverage AWS's managed database offering while reusing Infrahub's existing query infrastructure.

**Goal:** Enable Infrahub to connect to and operate against AWS Neptune clusters via the OpenCypher Bolt endpoint, with appropriate adaptations for Neptune-specific limitations (no constraints, no explicit index management, no transaction metadata support).

**Non-goals:** This PR does not implement Neptune-specific query optimizations or handle Neptune's property graph model differences beyond what's necessary for basic compatibility.

Closes #<issue_number>

## What changed

### Behavioral changes

- **New database type:** `DatabaseType.NEPTUNE` enum value added; users can now set `INFRAHUB_DB_TYPE=neptune`
- **Connection protocol:** Neptune connections use `bolt+s://` (TLS-encrypted Bolt) instead of `bolt://`
- **Authentication:** Neptune supports optional IAM SigV4 authentication via `botocore`; credentials are generated dynamically rather than stored
- **Session management:** Sessions created without a `database` parameter (Neptune does not support multiple databases)
- **Transaction metadata:** Omitted from Neptune transactions (not supported by Neptune's OpenCypher)
- **Index/constraint operations:** No-op implementations for Neptune (automatically managed by query optimizer; not exposed via OpenCypher)
- **UUID generation:** Uses application-side parameter substitution (`$generated_uuid_N`) instead of `randomUUID()` function
- **ID function:** Uses `id()` instead of `elementId()` to retrieve Neptune's internal node IDs

### Implementation notes

**New files:**
- `backend/infrahub/database/neptune.py`: `IndexManagerNeptune` and `IndexNodeNeptune` classes (no-op index management)
- `backend/infrahub/database/neptune_auth.py`: `get_neptune_auth_token()` function for IAM SigV4 signing
- `backend/infrahub/config.py`: `NeptuneSettings` class for Neptune-specific configuration
- `docs/docs/topics/neptune.mdx`: User-facing documentation on Neptune setup and limitations
- `backend/tests/unit/test_neptune_support.py`: Comprehensive unit tests (223 lines)

**Modified files:**
- `backend/infrahub/database/__init__.py`: 
  - Added `_session_kwargs()` helper to conditionally omit `database` parameter for Neptune
  - Updated `session()` and `__aenter__()` to use `_session_kwargs()`
  - Updated `transaction()` to omit metadata for Neptune
  - Updated `run_query()` to skip query metadata for Neptune
  - Added `render_uuid_generation()` logic for Neptune (parameter-based UUIDs)
  - Added `get_id_function_name()` logic for Neptune (returns `"id"`)
  - Added `to_database_id()` logic for Neptune (returns string IDs unchanged)
  - Added `is_neptune` property
  - Added `validate_neptune_connection()` function
  - Added `_get_neptune_driver()` function to create Neptune-specific driver
  - Updated `get_db()` to route to Neptune driver creation

- `backend/infrahub/core/graph/constraints.py`: Added `ConstraintManagerNeptune` class (no-op constraint management)
- `backend/infrahub/cli/db.py`: Updated constraint/index manager selection to include Neptune
- `backend/infrahub/core/initialization.py`: Updated index manager selection to include Neptune
- `backend/infrahub/core/query/delete.py`: Added Neptune-specific query variant (no `exists()` pattern support)
- `backend/infrahub/telemetry/database.py`: Added Neptune telemetry reporting
- `docs/docs/reference/configuration.mdx`: Updated database configuration documentation
- `dev/knowledge/backend/database-schema.md`: Added Neptune to supported backends table
- `backend/AGENTS.

https://claude.ai/code/session_016bxf1rTDXEMuBZ2mQzDqiw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS Neptune is now supported as a graph database backend alongside Neo4j and Memgraph
  * Added Neptune-specific configuration options including IAM authentication, AWS region, and custom port settings

* **Documentation**
  * Updated installation and configuration documentation to include Neptune setup guidance
  * Added comprehensive AWS Neptune integration documentation with feature comparison and prerequisites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->