### PR TITLE
IFC-2380: Specification for local Jinja2 computed attribute recomputation

### DIFF
--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP01.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP01.md
@@ -19,7 +19,7 @@ Extend the computed attribute registry and Node peer-loading infrastructure to s
 - [ ] T001 Add `relationship_fields` property to `RegisteredNodeComputedAttribute` in `backend/infrahub/core/schema/schema_branch_computed.py`
 - [ ] T002 Add `get_local_jinja2_targets(kind, updates)` method to `ComputedAttributes` in `backend/infrahub/core/schema/schema_branch_computed.py`
 - [ ] T003 Extend `Node._collect_extra_filters()` in `backend/infrahub/core/node/__init__.py` to include computed attribute relationship_fields
-- [ ] T004 Add unit tests in `backend/tests/unit/core/schema/test_schema_branch_computed.py`
+- [ ] T004 Add tests in `backend/tests/unit/core/schema/test_schema_branch_computed.py` (or `backend/tests/component/` if schema registration dependencies require it)
 
 ## Implementation Prompt
 

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP01.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP01.md
@@ -1,0 +1,46 @@
+---
+id: WP01
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "RegisteredNodeComputedAttribute has relationship_fields property; ComputedAttributes has get_local_jinja2_targets(); _collect_extra_filters() includes computed attribute relationship fields; unit tests pass"
+activity_log:
+---
+
+# Work Package WP01: Registry & Extra Filters Foundation
+
+## Goal
+
+Extend the computed attribute registry and Node peer-loading infrastructure to support inline recomputation.
+
+## Tasks
+
+- [ ] T001 Add `relationship_fields` property to `RegisteredNodeComputedAttribute` in `backend/infrahub/core/schema/schema_branch_computed.py`
+- [ ] T002 Add `get_local_jinja2_targets(kind, updates)` method to `ComputedAttributes` in `backend/infrahub/core/schema/schema_branch_computed.py`
+- [ ] T003 Extend `Node._collect_extra_filters()` in `backend/infrahub/core/node/__init__.py` to include computed attribute relationship_fields
+- [ ] T004 Add unit tests in `backend/tests/unit/core/schema/test_schema_branch_computed.py`
+
+## Implementation Prompt
+
+You are implementing the foundational registry changes for IFC-2273 (local computation of Jinja2 computed attributes).
+
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R1, R2, R4) and `dev/knowledge/backend/display-labels-and-hfid.md` for the `_collect_extra_filters()` pattern.
+
+**Task 1 (T001)**: In `backend/infrahub/core/schema/schema_branch_computed.py`, add a `relationship_fields` property to `RegisteredNodeComputedAttribute` that returns `dict[str, set[str]]`. For each entry in `self.relationships`, extract the peer attribute names needed for template rendering. The relationship entries map relationship names to `ComputedAttributeTarget` lists — each target has an `attribute.computed_attribute.jinja2_template` that can be parsed with `InfrahubJinja2Template.get_variables()` to find which peer attributes are referenced. Build a mapping like `{"site": {"name"}, "owner": {"family_name"}}`.
+
+**Task 2 (T002)**: In `ComputedAttributes`, add `get_local_jinja2_targets(kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]` that calls `get_impacted_jinja2_targets(kind, updates)` then filters to only targets where `target.kind == kind`.
+
+**Task 3 (T003)**: In `backend/infrahub/core/node/__init__.py`, extend `_collect_extra_filters()` to also read `relationship_fields` from `schema_branch.computed_attributes` for the current node kind. Follow the exact same pattern used for display_labels and hfids. Gate it with: `if self._existing` (only on updates, not creates). Use `_merge_relationship_fields()` to merge.
+
+**Task 4 (T004)**: Write unit tests verifying: (a) `relationship_fields` correctly extracts peer attributes from template variables, (b) `get_local_jinja2_targets()` returns only self-targeting targets and filters out remote targets, (c) empty/missing cases return empty results.
+
+## Files To Modify
+
+- `backend/infrahub/core/schema/schema_branch_computed.py`
+- `backend/infrahub/core/node/__init__.py`
+- `backend/tests/unit/core/schema/test_schema_branch_computed.py`
+
+## Dependencies
+
+None — this is the foundation WP.

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP02.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP02.md
@@ -1,0 +1,63 @@
+---
+id: WP02
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "Node._recompute_local_jinja2() exists and is called from _update(); local attribute changes trigger inline Jinja2 recomputation; chained dependencies resolved in correct order; error handling logs and continues; functional tests pass"
+activity_log:
+---
+
+# Work Package WP02: Inline Recomputation for Local Attribute Changes (US1 — MVP)
+
+## Goal
+
+Implement the core `_recompute_local_jinja2()` method and integrate it into the update path so local attribute changes trigger immediate computed attribute recomputation.
+
+## Tasks
+
+- [ ] T005 [US1] Create `_recompute_local_jinja2()` method on `Node` in `backend/infrahub/core/node/__init__.py`
+- [ ] T006 [US1] Call `_recompute_local_jinja2()` from `Node._update()` in `backend/infrahub/core/node/__init__.py`
+- [ ] T007 [US1] Handle chained computed attribute dependencies in `_recompute_local_jinja2()`
+- [ ] T008 [US1] Functional test: local attribute change triggers inline recomputation
+- [ ] T009 [US1] Functional test: unrelated attribute change does NOT trigger recomputation
+- [ ] T010 [US1] Functional test: Jinja2 evaluation failure is handled gracefully
+
+## Implementation Prompt
+
+You are implementing the core inline recomputation for IFC-2273.
+
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R3, R6) and study the existing `_process_macros()` method in `backend/infrahub/core/node/__init__.py` (around line 645) — your implementation reuses the same variable resolution pattern.
+
+**Task T005**: Create `async def _recompute_local_jinja2(self, db: InfrahubDatabase, fields: list[str] | None, node_changelog: NodeChangelog, update_at: Timestamp, user_id: str) -> None` on `Node`:
+
+1. Get `schema_branch = db.schema.get_schema_branch(name=self.get_branch_based_on_support_type().name)`
+2. Call `targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind, updates=fields)`
+3. If no targets, return early
+4. Sort targets by dependency order: if target A's template references target B's attribute name, B must come first. Use iterative resolution (the set is small).
+5. For each target:
+   a. Get `attr_schema = self._schema.get_attribute(name=target.attribute.name)`
+   b. Create `InfrahubJinja2Template(template=attr_schema.computed_attribute.jinja2_template)`
+   c. Extract variables via `get_variables()`
+   d. Resolve each variable: for attribute-type paths, read from `self` (e.g., `getattr(getattr(self, attr_name), prop_name)`); for relationship-type paths, read from the resolved peer (via `RelationshipManager.get_peer()` → peer node attribute)
+   e. Render: `value = await jinja_template.render(variables=variables)`
+   f. Compare with current value. If different, update the attribute on self and call `attr.save(db=db, user_id=user_id, at=update_at)`, then record in `node_changelog`
+6. Wrap the per-target loop body in try/except: on any Jinja2 error, log a warning with the node kind, attribute name, and error, then continue to next target
+
+**Task T006**: In `_update()`, after the relationship save loop (after line ~924, before the HFID recomputation at line ~934), add:
+```python
+await self._recompute_local_jinja2(db=db, fields=fields, node_changelog=node_changelog, update_at=update_at, user_id=user_id)
+```
+
+**Task T007**: The dependency sorting in T005 step 4: collect all target attribute names into a set. For each target, parse its template variables. If any variable name matches another target's attribute name, that target is a dependency. Topological sort (or simple iterative: keep resolving targets whose deps are all resolved).
+
+**Tasks T008-T010**: Create `backend/tests/functional/computed_attribute/test_local_computation.py`. Use the existing test infrastructure (look at existing computed_attribute tests for patterns). Create a test schema with a Jinja2 computed attribute. Test: (1) updating the referenced attribute updates the computed value inline, (2) updating an unrelated attribute doesn't trigger recomputation, (3) a broken Jinja2 template logs error but mutation succeeds.
+
+## Files To Modify
+
+- `backend/infrahub/core/node/__init__.py`
+- `backend/tests/functional/computed_attribute/test_local_computation.py` (new)
+
+## Dependencies
+
+WP01

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
@@ -4,34 +4,36 @@ lane: planned
 feature: ifc-2273-local-computation-jinja2
 assigned_to: ""
 agent: ""
-acceptance_criteria: "Prefect automation triggers skip targets_self=True trigger nodes; remote triggers preserved; unit tests pass"
+acceptance_criteria: "Self-targeting computed attribute triggers use _trigger_placeholder fields (matching HFID/display label pattern); remote triggers preserved with real fields; unit tests pass"
 activity_log:
 ---
 
-# Work Package WP03: Suppress Background Tasks for Local Changes (US3)
+# Work Package WP03: Convert Self-Targeting Triggers to Placeholders (US3)
 
 ## Goal
 
-Modify Prefect automation trigger creation to skip local (self-targeting) triggers, ensuring background tasks only fire for remote changes.
+Convert self-targeting computed attribute triggers from real field names to `_trigger_placeholder`, matching the existing HFID and display label pattern. This keeps the trigger definitions in Prefect for schema-change detection while preventing per-change background task firing for local changes.
 
 ## Tasks
 
-- [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify the caller loop in `gather_trigger_computed_attribute_jinja2()` (lines 122-130) to skip `trigger_node` entries where `targets_self=True` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`
-- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` for trigger suppression
+- [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify `gather_trigger_computed_attribute_jinja2()` (lines 122-130) so that when `trigger_node.targets_self is True`, the trigger node's fields are replaced with `["_trigger_placeholder"]` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`. This matches the pattern used by HFID (`hfid/models.py:59-61`) and display labels (`display_labels/models.py:59-61`). Remote trigger nodes (`targets_self=False`) keep their real field names unchanged.
+- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` verifying the placeholder pattern
 - [ ] T017 [US3] Add functional test verifying remote changes still trigger background tasks
 
 ## Implementation Prompt
 
-You are implementing background task suppression for local changes in IFC-2273.
+You are converting self-targeting computed attribute triggers to placeholders for IFC-2273.
 
-**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R5) and study `backend/infrahub/computed_attribute/gather.py`, specifically the `gather_trigger_computed_attribute_jinja2()` function (lines 104-132), and `backend/infrahub/computed_attribute/models.py` for `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`.
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R5). Study the existing placeholder pattern in `backend/infrahub/hfid/models.py:53-65` and `backend/infrahub/display_labels/models.py:53-65` — both create self-targeting triggers with `fields=["_trigger_placeholder"]` so the Prefect automation never matches real `NodeUpdatedEvent`s, while the trigger definition still exists for schema-change detection in the setup flow (`computed_attribute/tasks.py:336-340`).
 
-**Task T015**: In `gather_trigger_computed_attribute_jinja2()` in `gather.py`, the inner loop (lines 123-130) iterates over `trigger_nodes` and calls `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` for each one. Add a check at the top of that inner loop: if `trigger_node.targets_self` is `True`, `continue` to skip it before calling `from_computed_attribute()`. This ensures Prefect automations are only created for remote changes (peer node kinds), not for changes to the node's own attributes/relationships. The skip belongs in the caller loop — not inside `from_computed_attribute()` — because that classmethod processes a single trigger node and has no iteration to skip within.
+Currently, `gather_trigger_computed_attribute_jinja2()` in `gather.py` has a single loop (lines 122-130) that passes all trigger nodes — both self and remote — to `from_computed_attribute()` with their real field names. This means self-targeting triggers fire on every per-node change via Prefect.
+
+**Task T015**: In the inner loop (lines 123-130), when `trigger_node.targets_self is True`, replace the trigger node's fields with `["_trigger_placeholder"]` before calling `from_computed_attribute()`. The simplest approach: create a copy of the trigger node with overridden fields. Remote trigger nodes pass through unchanged with their real field names.
 
 **Task T016**: In `backend/tests/unit/computed_attribute/test_trigger_definition.py` (create if needed), test:
-- A computed attribute with template `{{ local_attr__value }}-{{ rel__peer_attr__value }}` should NOT create a trigger for the node's own kind (targets_self=True) but SHOULD create a trigger for the peer kind (targets_self=False)
-- A computed attribute with only local dependencies should create zero triggers (all self-targeting)
-- A computed attribute with only remote dependencies should create triggers as before
+- A computed attribute with mixed local+remote dependencies creates a trigger for the self-targeting kind with `_trigger_placeholder` fields, and a trigger for the peer kind with real field names
+- A computed attribute with only local dependencies creates one trigger with `_trigger_placeholder` fields (not zero triggers)
+- A computed attribute with only remote dependencies creates triggers with real field names as before
 
 **Task T017**: Add a functional test that updates a peer node's attribute and verifies the computed attributes on related nodes are updated via background tasks (existing Prefect path preserved).
 

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
@@ -16,7 +16,7 @@ Modify Prefect automation trigger creation to skip local (self-targeting) trigge
 
 ## Tasks
 
-- [ ] T015 [US3] Modify `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` in `backend/infrahub/computed_attribute/models.py` to skip triggers where `targets_self=True`
+- [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify the caller loop in `gather_trigger_computed_attribute_jinja2()` (lines 122-130) to skip `trigger_node` entries where `targets_self=True` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`
 - [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` for trigger suppression
 - [ ] T017 [US3] Add functional test verifying remote changes still trigger background tasks
 
@@ -24,11 +24,9 @@ Modify Prefect automation trigger creation to skip local (self-targeting) trigge
 
 You are implementing background task suppression for local changes in IFC-2273.
 
-**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R5) and study `backend/infrahub/computed_attribute/models.py`, specifically `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` (around line 118-206).
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R5) and study `backend/infrahub/computed_attribute/gather.py`, specifically the `gather_trigger_computed_attribute_jinja2()` function (lines 104-132), and `backend/infrahub/computed_attribute/models.py` for `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`.
 
-**Task T015**: In `from_computed_attribute()`, the method iterates over `trigger_nodes` from `computed_attributes.get_jinja2_trigger_nodes()`. For each `ComputedAttributeTriggerNode`, it creates a Prefect automation. Add a check: if `trigger_node.targets_self` is `True`, skip creating the trigger for that trigger node. This means the Prefect automation will only fire for remote changes (peer node kinds), not for changes to the node's own attributes/relationships.
-
-The key change is adding a `continue` when `trigger_node.targets_self` is `True` in the iteration loop that builds trigger definitions.
+**Task T015**: In `gather_trigger_computed_attribute_jinja2()` in `gather.py`, the inner loop (lines 123-130) iterates over `trigger_nodes` and calls `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` for each one. Add a check at the top of that inner loop: if `trigger_node.targets_self` is `True`, `continue` to skip it before calling `from_computed_attribute()`. This ensures Prefect automations are only created for remote changes (peer node kinds), not for changes to the node's own attributes/relationships. The skip belongs in the caller loop — not inside `from_computed_attribute()` — because that classmethod processes a single trigger node and has no iteration to skip within.
 
 **Task T016**: In `backend/tests/unit/computed_attribute/test_trigger_definition.py` (create if needed), test:
 - A computed attribute with template `{{ local_attr__value }}-{{ rel__peer_attr__value }}` should NOT create a trigger for the node's own kind (targets_self=True) but SHOULD create a trigger for the peer kind (targets_self=False)
@@ -39,7 +37,7 @@ The key change is adding a `continue` when `trigger_node.targets_self` is `True`
 
 ## Files To Modify
 
-- `backend/infrahub/computed_attribute/models.py`
+- `backend/infrahub/computed_attribute/gather.py`
 - `backend/tests/unit/computed_attribute/test_trigger_definition.py` (new or existing)
 - `backend/tests/functional/computed_attribute/test_local_computation.py`
 

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
@@ -17,7 +17,7 @@ Convert self-targeting computed attribute triggers from real field names to `_tr
 ## Tasks
 
 - [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify `gather_trigger_computed_attribute_jinja2()` (lines 122-130) so that when `trigger_node.targets_self is True`, the trigger node's fields are replaced with `["_trigger_placeholder"]` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()`. This matches the pattern used by HFID (`hfid/models.py:59-61`) and display labels (`display_labels/models.py:59-61`). Remote trigger nodes (`targets_self=False`) keep their real field names unchanged.
-- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` verifying the placeholder pattern
+- [ ] T016 [US3] Add test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` (or `backend/tests/component/` if needed) verifying the placeholder pattern
 - [ ] T017 [US3] Add functional test verifying remote changes still trigger background tasks
 
 ## Implementation Prompt

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP03.md
@@ -1,0 +1,48 @@
+---
+id: WP03
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "Prefect automation triggers skip targets_self=True trigger nodes; remote triggers preserved; unit tests pass"
+activity_log:
+---
+
+# Work Package WP03: Suppress Background Tasks for Local Changes (US3)
+
+## Goal
+
+Modify Prefect automation trigger creation to skip local (self-targeting) triggers, ensuring background tasks only fire for remote changes.
+
+## Tasks
+
+- [ ] T015 [US3] Modify `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` in `backend/infrahub/computed_attribute/models.py` to skip triggers where `targets_self=True`
+- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` for trigger suppression
+- [ ] T017 [US3] Add functional test verifying remote changes still trigger background tasks
+
+## Implementation Prompt
+
+You are implementing background task suppression for local changes in IFC-2273.
+
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R5) and study `backend/infrahub/computed_attribute/models.py`, specifically `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` (around line 118-206).
+
+**Task T015**: In `from_computed_attribute()`, the method iterates over `trigger_nodes` from `computed_attributes.get_jinja2_trigger_nodes()`. For each `ComputedAttributeTriggerNode`, it creates a Prefect automation. Add a check: if `trigger_node.targets_self` is `True`, skip creating the trigger for that trigger node. This means the Prefect automation will only fire for remote changes (peer node kinds), not for changes to the node's own attributes/relationships.
+
+The key change is adding a `continue` when `trigger_node.targets_self` is `True` in the iteration loop that builds trigger definitions.
+
+**Task T016**: In `backend/tests/unit/computed_attribute/test_trigger_definition.py` (create if needed), test:
+- A computed attribute with template `{{ local_attr__value }}-{{ rel__peer_attr__value }}` should NOT create a trigger for the node's own kind (targets_self=True) but SHOULD create a trigger for the peer kind (targets_self=False)
+- A computed attribute with only local dependencies should create zero triggers (all self-targeting)
+- A computed attribute with only remote dependencies should create triggers as before
+
+**Task T017**: Add a functional test that updates a peer node's attribute and verifies the computed attributes on related nodes are updated via background tasks (existing Prefect path preserved).
+
+## Files To Modify
+
+- `backend/infrahub/computed_attribute/models.py`
+- `backend/tests/unit/computed_attribute/test_trigger_definition.py` (new or existing)
+- `backend/tests/functional/computed_attribute/test_local_computation.py`
+
+## Dependencies
+
+WP01

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP04.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP04.md
@@ -1,0 +1,55 @@
+---
+id: WP04
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "Relationship changes trigger inline recomputation; null relationship handled; functional tests pass for US2"
+activity_log:
+---
+
+# Work Package WP04: Inline Recomputation for Relationship Changes (US2)
+
+## Goal
+
+Ensure `_recompute_local_jinja2()` correctly handles relationship-type template variables, including null/empty relationships.
+
+## Tasks
+
+- [ ] T011 [US2] Ensure `_recompute_local_jinja2()` handles relationship-type template variables in `backend/infrahub/core/node/__init__.py`
+- [ ] T012 [US2] Handle null/empty relationship case in `_recompute_local_jinja2()`
+- [ ] T013 [US2] Functional test: relationship change triggers inline recomputation with new peer's attributes
+- [ ] T014 [US2] Functional test: null relationship renders template with null context
+
+## Implementation Prompt
+
+You are extending the inline recomputation (from WP02) to handle relationship changes for IFC-2273.
+
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R3, R4). Study how `_process_macros()` resolves relationship-type variables (around line 670-700 in `core/node/__init__.py`).
+
+**Task T011**: In `_recompute_local_jinja2()` (created in WP02), the variable resolution for relationship-type paths should:
+1. Get the `RelationshipManager` from `self` for the relationship name
+2. Get the peer via `relm.get_peer()` or iterate `relm._relationships` to find the resolved peer
+3. The peer's attributes should already be loaded because `_collect_extra_filters()` (extended in WP01) included computed attribute relationship fields
+4. Read the attribute value from the peer: `getattr(getattr(peer_node, attr_name), prop_name)`
+
+If WP02 already handled this as part of the generic variable resolution (following `_process_macros()` pattern), this task may just need verification and edge case handling.
+
+**Task T012**: When a relationship is being set to null/empty:
+- `relm.get_peer()` returns None
+- Pass `None` as the variable value to the Jinja2 template
+- The template will render with Jinja2's default handling of None values (empty string or "None" depending on template)
+- This is valid behavior per the spec edge case
+
+**Tasks T013-T014**: Add functional tests to `backend/tests/functional/computed_attribute/test_local_computation.py`:
+- T013: Create a Device with computed `name` template referencing both a local attr and a relationship peer attr. Assign to SiteA, then update to SiteB. Verify computed name reflects SiteB.
+- T014: Set a relationship to null on a node with a computed attribute referencing that relationship. Verify the template renders and mutation succeeds.
+
+## Files To Modify
+
+- `backend/infrahub/core/node/__init__.py`
+- `backend/tests/functional/computed_attribute/test_local_computation.py`
+
+## Dependencies
+
+WP01, WP02

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
@@ -4,7 +4,7 @@ lane: planned
 feature: ifc-2273-local-computation-jinja2
 assigned_to: ""
 agent: ""
-acceptance_criteria: "Single event per mutation with both original and computed attribute changes; bulk import spawns zero background tasks for local changes; functional tests pass for US4 and US5"
+acceptance_criteria: "Single event per mutation with both original and computed attribute changes; bulk update of existing nodes spawns zero background tasks for local changes; functional tests pass for US4 and US5"
 activity_log:
 ---
 
@@ -12,12 +12,12 @@ activity_log:
 
 ## Goal
 
-Verify event consolidation works automatically and validate bulk import performance (no background tasks for local changes).
+Verify event consolidation works automatically and validate bulk update performance (no background tasks for local changes).
 
 ## Tasks
 
 - [ ] T018 [US4] Functional test: verify single event emitted per mutation containing both original and computed attribute changes
-- [ ] T019 [US5] Functional test: bulk create/update nodes with computed attributes, verify zero background tasks and correct values
+- [ ] T019 [US5] Functional test: create nodes first, then bulk-update their local attributes, verify zero background tasks for computed attribute recomputation and correct values
 
 ## Implementation Prompt
 
@@ -36,9 +36,11 @@ You are implementing the validation tests for event consolidation and bulk perfo
 
 **Task T019**: In `backend/tests/functional/computed_attribute/test_local_computation.py`:
 1. Create a schema with a Jinja2 computed attribute depending on a local attribute
-2. Bulk-create or bulk-update 50+ nodes (adjust count for test speed) with varying local attribute values
-3. Assert: all computed attribute values are correct after the bulk operation
-4. Assert: no background tasks were submitted for computed attribute updates (mock/intercept the workflow submission or check that no `COMPUTED_ATTRIBUTE_PROCESS_JINJA2` flows were triggered)
+2. Create 50+ nodes with varying local attribute values (creation phase — Prefect events expected here, that's fine)
+3. Clear/reset any background task tracking
+4. Bulk-update a local attribute on each of the 50+ nodes (this is the phase under test)
+5. Assert: all computed attribute values are correct after the bulk update
+6. Assert: no background tasks were submitted for computed attribute updates during the update phase (mock/intercept the workflow submission or check that no `COMPUTED_ATTRIBUTE_PROCESS_JINJA2` flows were triggered)
 
 ## Files To Modify
 

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
@@ -36,11 +36,9 @@ You are implementing the validation tests for event consolidation and bulk perfo
 
 **Task T019**: In `backend/tests/functional/computed_attribute/test_local_computation.py`:
 1. Create a schema with a Jinja2 computed attribute depending on a local attribute
-2. Create 50+ nodes with varying local attribute values (creation phase — Prefect events expected here, that's fine)
-3. Clear/reset any background task tracking
-4. Bulk-update a local attribute on each of the 50+ nodes (this is the phase under test)
-5. Assert: all computed attribute values are correct after the bulk update
-6. Assert: no background tasks were submitted for computed attribute updates during the update phase (mock/intercept the workflow submission or check that no `COMPUTED_ATTRIBUTE_PROCESS_JINJA2` flows were triggered)
+2. Create 50+ nodes with varying local attribute values
+3. Bulk-update a local attribute on each of the 50+ nodes
+4. Assert: all computed attribute values are correct after the bulk update (functional tests have no Prefect server running automations, so correct values prove the inline path handled everything)
 
 ## Files To Modify
 

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP05.md
@@ -1,0 +1,49 @@
+---
+id: WP05
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "Single event per mutation with both original and computed attribute changes; bulk import spawns zero background tasks for local changes; functional tests pass for US4 and US5"
+activity_log:
+---
+
+# Work Package WP05: Event Consolidation & Bulk Validation (US4 + US5)
+
+## Goal
+
+Verify event consolidation works automatically and validate bulk import performance (no background tasks for local changes).
+
+## Tasks
+
+- [ ] T018 [US4] Functional test: verify single event emitted per mutation containing both original and computed attribute changes
+- [ ] T019 [US5] Functional test: bulk create/update nodes with computed attributes, verify zero background tasks and correct values
+
+## Implementation Prompt
+
+You are implementing the validation tests for event consolidation and bulk performance in IFC-2273.
+
+**Context**: Read `specs/ifc-2273-local-computation-jinja2/research.md` (R7) and `dev/knowledge/backend/events.md`. The key insight is that event consolidation should work automatically because `_recompute_local_jinja2()` records changes in the same `NodeChangelog` as the original mutation, and `generate_node_mutation_events()` emits a single event from that changelog.
+
+**Task T018**: In `backend/tests/functional/computed_attribute/test_local_computation.py`:
+1. Create a schema with a Jinja2 computed attribute
+2. Create a node
+3. Capture events emitted (mock or intercept `InfrahubEventService.send()`)
+4. Update the local attribute that triggers computed attribute recomputation
+5. Assert: exactly one `NodeUpdatedEvent` was emitted
+6. Assert: the event's `fields` / `updated_fields` contains BOTH the original attribute name AND the computed attribute name
+7. If two events were emitted, the test fails — this would indicate the event system needs changes
+
+**Task T019**: In `backend/tests/functional/computed_attribute/test_local_computation.py`:
+1. Create a schema with a Jinja2 computed attribute depending on a local attribute
+2. Bulk-create or bulk-update 50+ nodes (adjust count for test speed) with varying local attribute values
+3. Assert: all computed attribute values are correct after the bulk operation
+4. Assert: no background tasks were submitted for computed attribute updates (mock/intercept the workflow submission or check that no `COMPUTED_ATTRIBUTE_PROCESS_JINJA2` flows were triggered)
+
+## Files To Modify
+
+- `backend/tests/functional/computed_attribute/test_local_computation.py`
+
+## Dependencies
+
+WP02

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
@@ -1,0 +1,45 @@
+---
+id: WP06
+lane: planned
+feature: ifc-2273-local-computation-jinja2
+assigned_to: ""
+agent: ""
+acceptance_criteria: "Knowledge docs updated; changelog fragment added; existing test suite passes"
+activity_log:
+---
+
+# Work Package WP06: Documentation & Polish
+
+## Goal
+
+Update knowledge base documentation, add changelog fragment, and verify no regressions.
+
+## Tasks
+
+- [ ] T020 [P] Update `dev/knowledge/backend/` with computed attribute local computation documentation
+- [ ] T021 [P] Add towncrier changelog fragment in `changelog/`
+- [ ] T022 Run existing computed attribute test suite to verify no regressions
+
+## Implementation Prompt
+
+You are wrapping up IFC-2273 with documentation and validation.
+
+**Task T020**: Create or update a knowledge doc for computed attributes. If `dev/knowledge/backend/computed-attributes.md` doesn't exist, create it. Document:
+- The dual evaluation path: mandatory inline at creation (`_process_macros`), local changes inline at update (`_recompute_local_jinja2`), remote changes via Prefect background tasks
+- How `_collect_extra_filters()` now includes computed attribute relationship fields
+- How Prefect triggers skip `targets_self=True` trigger nodes
+- Key files: `core/node/__init__.py`, `core/schema/schema_branch_computed.py`, `computed_attribute/models.py`, `computed_attribute/tasks.py`
+- Follow the style of existing knowledge docs (e.g., `dev/knowledge/backend/display-labels-and-hfid.md`)
+
+**Task T021**: Add a towncrier changelog fragment. Use the `changed` type. Example filename: `changelog/8XXX.changed` (use next available number). Content: "Jinja2 computed attributes are now recalculated immediately when their dependent attributes or relationships change on the same node, eliminating background task overhead for local changes."
+
+**Task T022**: Run `uv run invoke backend.test-unit -- -k computed_attribute` and verify all existing tests pass.
+
+## Files To Modify
+
+- `dev/knowledge/backend/computed-attributes.md` (new)
+- `changelog/` (new fragment)
+
+## Dependencies
+
+WP02, WP03, WP04, WP05

--- a/dev/specs/ifc-2273-local-computation-jinja2/checklists/requirements.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Local Computation of Jinja2 Computed Attributes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/kitty-spec.plan`.
+- The spec deliberately avoids naming specific technologies (Prefect, Neo4j, etc.) in requirements and success criteria, using "background tasks" as the generic term. Domain-specific terms like "Jinja2" and "computed attribute" are retained as they are user-facing concepts in Infrahub's schema definition, not implementation details.

--- a/dev/specs/ifc-2273-local-computation-jinja2/contracts/README.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/contracts/README.md
@@ -1,0 +1,1 @@
+No API contract changes. This feature is a backend-internal optimization with no new endpoints, GraphQL mutations, or REST APIs.

--- a/dev/specs/ifc-2273-local-computation-jinja2/data-model.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/data-model.md
@@ -1,0 +1,32 @@
+# Data Model: Local Computation of Jinja2 Computed Attributes
+
+No new entities, database tables, or schema changes are required. This feature modifies the runtime behavior of existing data structures.
+
+## Modified Entities
+
+### RegisteredNodeComputedAttribute (schema_branch_computed.py)
+
+**Current fields**:
+- `local_fields: dict[str, list[ComputedAttributeTarget]]` — maps field names to targets
+- `relationships: dict[str, list[ComputedAttributeTarget]]` — maps relationship names to targets
+
+**New computed property**:
+- `relationship_fields: dict[str, set[str]]` — maps relationship names to the set of peer attribute names needed for template rendering. Derived from parsing the relationship entries' `ComputedAttributeTarget.attribute.computed_attribute.jinja2_template` variable paths. Used by `_collect_extra_filters()` to load peer attributes during `resolve_relationships()`.
+
+### Node (_update flow)
+
+**New runtime state** during `_update()`:
+- List of `ComputedAttributeTarget` objects for locally-affected computed attributes (transient, not persisted)
+- Recomputed attribute values saved via the same `attr.save()` mechanism used for regular attributes
+
+### ComputedAttrJinja2TriggerDefinition (models.py)
+
+**Behavioral change**: `from_computed_attribute()` skips creating Prefect automation triggers for `ComputedAttributeTriggerNode` entries where `targets_self=True`. These local triggers are handled inline instead.
+
+## Relationships
+
+No new relationships. The existing `computed_attribute` field on `AttributeSchema` and the `RegisteredNodeComputedAttribute` dependency graph are used as-is.
+
+## State Transitions
+
+No new state machines. The computed attribute value transitions from "stale" to "current" within the same mutation transaction (previously this happened asynchronously via background task).

--- a/dev/specs/ifc-2273-local-computation-jinja2/plan.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Optimize Jinja2 computed attribute updates by evaluating "local" changes (attribute or relationship changes on the same node) inline during the update mutation, reusing the existing `_process_macros()` template rendering pattern. Remote changes (peer node attribute changes) continue through Prefect background tasks. This eliminates thousands of unnecessary background tasks during bulk imports and provides immediate computed attribute results in mutation responses.
+Optimize Jinja2 computed attribute updates by evaluating "local" changes (attribute or relationship changes on the same node) inline during the update mutation, reusing the existing `_process_macros()` template rendering pattern. Remote changes (peer node attribute changes) continue through Prefect background tasks. This eliminates thousands of unnecessary background tasks during bulk updates and provides immediate computed attribute results in mutation responses.
 
 ## Technical Context
 
@@ -15,7 +15,7 @@ Optimize Jinja2 computed attribute updates by evaluating "local" changes (attrib
 **Testing**: pytest (unit, component, functional, integration_docker)
 **Target Platform**: Linux server (Docker)
 **Project Type**: Web application (backend-only change)
-**Performance Goals**: Zero background tasks for local computed attribute changes; bulk import of 2,000 nodes must not spawn background tasks for local changes
+**Performance Goals**: Zero background tasks for local computed attribute changes; bulk update of 2,000 nodes must not spawn background tasks for local changes
 **Constraints**: Must produce identical results to existing background task path; must not affect creation path or template instantiation
 **Scale/Scope**: Affects all node kinds with Jinja2 computed attributes across all branches
 

--- a/dev/specs/ifc-2273-local-computation-jinja2/plan.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Local Computation of Jinja2 Computed Attributes
+
+**Branch**: `ifc-2273-local-computation-jinja2` | **Date**: 2026-03-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/ifc-2273-local-computation-jinja2/spec.md`
+
+## Summary
+
+Optimize Jinja2 computed attribute updates by evaluating "local" changes (attribute or relationship changes on the same node) inline during the update mutation, reusing the existing `_process_macros()` template rendering pattern. Remote changes (peer node attribute changes) continue through Prefect background tasks. This eliminates thousands of unnecessary background tasks during bulk imports and provides immediate computed attribute results in mutation responses.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: FastAPI, Neo4j 5.28, Pydantic 2.10, Jinja2 (via `InfrahubJinja2Template`), Prefect
+**Storage**: Neo4j graph database
+**Testing**: pytest (unit, component, functional, integration_docker)
+**Target Platform**: Linux server (Docker)
+**Project Type**: Web application (backend-only change)
+**Performance Goals**: Zero background tasks for local computed attribute changes; bulk import of 2,000 nodes must not spawn background tasks for local changes
+**Constraints**: Must produce identical results to existing background task path; must not affect creation path or template instantiation
+**Scale/Scope**: Affects all node kinds with Jinja2 computed attributes across all branches
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Schema-Driven Integrity | PASS | No schema changes; uses existing computed_attribute schema definitions |
+| II. Branch-Safe by Default | PASS | Inline computation uses branch-aware `schema_branch` and `resolve_relationships()` |
+| III. Type Safety & Explicit Contracts | PASS | All new code will use typed dataclasses/Pydantic models; no new APIs |
+| IV. Test Discipline | PASS | Unit tests for dependency detection, functional tests for inline recomputation, integration_docker tests for computed attributes |
+| V. Query Performance & Efficiency | PASS | Eliminates background task DB queries; reuses existing `resolve_relationships()` peer loading |
+| VI. Security & Input Boundaries | PASS | No new user input; Jinja2 templates already validated at schema time |
+| VII. Simplicity & Maintainability | PASS | Follows existing `_update()` pattern for HFID/display_label recomputation |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/ifc-2273-local-computation-jinja2/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (empty — no API changes)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+backend/infrahub/core/
+├── node/
+│   └── __init__.py              # _update(), _collect_extra_filters(), new _recompute_local_jinja2()
+├── schema/
+│   └── schema_branch_computed.py  # get_local_jinja2_targets() helper
+├── computed_attribute/
+│   └── models.py                  # Skip triggers where targets_self=True
+└── events/
+    └── node_action.py             # No changes needed (changelog already consolidates)
+
+backend/tests/
+├── unit/core/schema/
+│   └── test_schema_branch_computed.py  # Test local target detection
+├── unit/core/node/
+│   └── test_computed_jinja2_update.py  # Test inline recomputation logic
+├── functional/computed_attribute/
+│   └── test_local_computation.py       # End-to-end local recomputation
+└── integration_docker/computed_attribute/
+    └── test_local_no_background_task.py  # Verify no Prefect tasks for local changes
+```
+
+**Structure Decision**: Backend-only changes in the existing `backend/infrahub/core/` tree. No new packages or directories needed. Tests follow existing structure mirroring.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/dev/specs/ifc-2273-local-computation-jinja2/quickstart.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Local Computation of Jinja2 Computed Attributes
+
+## What changes
+
+After this feature, Jinja2 computed attributes on a node are recalculated **immediately** when you update an attribute or relationship on that same node. Previously, all recomputation went through background Prefect tasks.
+
+## User impact
+
+- **No behavioral change**: Computed attributes work the same way. Users see results faster.
+- **Mutation responses**: Now include the updated computed attribute values immediately (no page refresh needed).
+- **Webhooks**: One event per mutation instead of potentially two (one for the change, one for the computed attribute update).
+- **Bulk imports**: No longer spawn thousands of background tasks for local computed attribute changes.
+
+## Developer impact
+
+### _update() now handles computed attributes
+
+The `Node._update()` method in `core/node/__init__.py` now includes a computed attribute recomputation step, following the same pattern as HFID and display_label recomputation:
+
+```python
+# In _update(), after attribute/relationship saves:
+# 1. Identify locally-affected Jinja2 computed attributes
+# 2. Render templates using current node state
+# 3. Save updated computed attribute values
+# 4. Record in NodeChangelog (same event)
+```
+
+### _collect_extra_filters() is extended
+
+The `_collect_extra_filters()` method now also includes relationship fields needed by Jinja2 computed attribute templates, ensuring peer attributes are loaded during `resolve_relationships()`.
+
+### Prefect triggers skip local changes
+
+`ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` no longer creates Prefect automations for trigger nodes where `targets_self=True`. Only remote triggers (peer node changes) go through background tasks.
+
+## Testing
+
+Run the existing computed attribute test suite plus new tests:
+
+```bash
+# Unit tests for local target detection
+uv run invoke backend.test-unit -- -k test_schema_branch_computed
+
+# Functional tests for inline recomputation
+uv run invoke backend.test-unit -- -k test_local_computation
+```

--- a/dev/specs/ifc-2273-local-computation-jinja2/quickstart.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/quickstart.md
@@ -9,7 +9,7 @@ After this feature, Jinja2 computed attributes on a node are recalculated **imme
 - **No behavioral change**: Computed attributes work the same way. Users see results faster.
 - **Mutation responses**: Now include the updated computed attribute values immediately (no page refresh needed).
 - **Webhooks**: One event per mutation instead of potentially two (one for the change, one for the computed attribute update).
-- **Bulk imports**: No longer spawn thousands of background tasks for local computed attribute changes.
+- **Bulk updates**: No longer spawn thousands of background tasks for local computed attribute changes.
 
 ## Developer impact
 

--- a/dev/specs/ifc-2273-local-computation-jinja2/research.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/research.md
@@ -1,0 +1,85 @@
+# Research: Local Computation of Jinja2 Computed Attributes
+
+## R1: Where to hook inline recomputation in the update path
+
+**Decision**: Add a `_recompute_local_jinja2()` method to `Node` and call it from `_update()`, after attribute and relationship saves but before HFID/display_label recomputation.
+
+**Rationale**: The `_update()` method in `core/node/__init__.py:901` already follows this pattern for HFID and display_label — it checks `needs_update(fields)`, calls `compute()`, then `save()`. Jinja2 computed attributes should follow the same pattern. Placing it before HFID/display_label ensures computed attributes are persisted before HFID/display_label recomputation (in case HFID/display_label depends on a computed attribute).
+
+**Alternatives considered**:
+- Hook at `Node.save()` level: Too high — `save()` delegates to `_create()` or `_update()` and we only want the update path.
+- Hook at `mutate_update()` level in `graphql/mutations/main.py`: Too high — would not cover SDK mutations or non-GraphQL update paths.
+- Separate post-save step: Requires an extra DB transaction; the existing in-`_update()` pattern is simpler and atomic.
+
+## R2: How to identify locally-affected computed attributes
+
+**Decision**: Use the existing `ComputedAttributes.get_impacted_jinja2_targets(kind, updates)` method with `updates` set to the list of changed fields, then filter for targets where `target.kind == self._schema.kind` (i.e., the computed attribute is on the same node being updated).
+
+**Rationale**: The registry already tracks which fields trigger which computed attributes. The `kind` field on `ComputedAttributeTarget` identifies where the computed attribute lives. When `target.kind == self._schema.kind`, the trigger and the computed attribute are on the same node — a local change. The registry stores entries for the node's own kind with local attribute names and relationship names as keys (see `register_computed_jinja2` lines 156-168).
+
+**Alternatives considered**:
+- Parsing the Jinja2 template on every update: Expensive and redundant — the registry already pre-computes dependencies.
+- Adding a new `targets_self` filter to `get_impacted_jinja2_targets()`: Cleaner but adds complexity to a method also used by the Prefect path. Simple post-filter is sufficient.
+
+## R3: How to render the Jinja2 template inline during updates
+
+**Decision**: Extract the template rendering logic from `_process_macros()` into a reusable helper, or directly reuse `_process_macros()` with a parameter to indicate which attributes to recompute (instead of using `self._computed_jinja2_attributes` which is only populated during creation).
+
+**Rationale**: `_process_macros()` (lines 645-719 of `core/node/__init__.py`) already handles:
+1. Getting the Jinja2 template from `attr_schema.computed_attribute.jinja2_template`
+2. Parsing variables via `InfrahubJinja2Template.get_variables()`
+3. Resolving local attributes from `self` and relationship peers via `get_peer()` + `get_one_by_id_or_default_filter()`
+4. Rendering via `jinja_template.render(variables=...)`
+
+For the update path, the node already has loaded attributes and resolved relationships (after `resolve_relationships()`). The variables can be resolved from the in-memory node state without extra DB queries (for local attributes) or from the already-resolved relationship peers (for relationship attributes, loaded via the extended `_collect_extra_filters()`).
+
+**Alternatives considered**:
+- Calling the same GraphQL-based approach used by `process_jinja2()` in the Prefect path: Overkill — that path issues a GraphQL query because it doesn't have the node in memory. During `_update()`, we already have the node.
+- Creating an entirely separate rendering path: Violates DRY. Better to reuse the existing template resolution logic.
+
+## R4: How to load peer attributes needed for relationship-referencing templates
+
+**Decision**: Extend `_collect_extra_filters()` to include computed attribute relationship fields from the `ComputedAttributes` registry, following the same pattern used for display labels and HFIDs.
+
+**Rationale**: `_collect_extra_filters()` already reads `relationship_fields` from `schema_branch.display_labels` and `schema_branch.hfids` registries and passes them to `RelationshipManager.resolve()` as `extra_filters`. The computed attributes registry (`schema_branch.computed_attributes`) needs a similar `relationship_fields` accessor that maps relationship names to the set of peer attribute names needed for template rendering.
+
+The `RegisteredNodeComputedAttribute.relationships` dict already maps relationship names to `ComputedAttributeTarget` lists. We need to also store which specific peer attributes are needed (currently only stored implicitly in the Jinja2 template). This can be extracted during `register_computed_jinja2()` by reading `schema_path.active_attribute_schema.name` for relationship-type paths.
+
+**Implementation detail**: Add a `relationship_fields` property to `RegisteredNodeComputedAttribute` (or a new registry class similar to `TemplateLabel`) that returns `dict[str, set[str]]` mapping relationship names to peer attribute names. Then in `_collect_extra_filters()`, merge these with the existing display_label/HFID extra_filters.
+
+**Alternatives considered**:
+- Fetching peers separately after `resolve_relationships()`: Extra DB queries per peer, defeats the purpose.
+- Assuming all peer attributes are always loaded: Not true — `resolve()` only loads fields explicitly requested.
+
+## R5: How to suppress background tasks for local changes
+
+**Decision**: Modify the Prefect automation trigger creation in `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` to skip trigger nodes where `targets_self=True`. This means the automation only fires for remote changes (peer node updates), not for changes to the node's own attributes/relationships.
+
+**Rationale**: The trigger system in `computed_attribute/models.py` creates separate Prefect automations per `ComputedAttributeTriggerNode`. Each trigger node has a `targets_self` flag that is `True` when the trigger node kind matches the computed attribute's node kind (i.e., a local change). By skipping these triggers, the Prefect automation will never fire for local changes — which is correct because they're handled inline.
+
+For computed attributes with mixed local+remote dependencies (e.g., `{{ instance__value }}-{{ site__name__value }}`), the trigger for the own node kind (`TestingDevice`) is skipped (handled inline), while the trigger for the peer kind (`BuiltinLocation`) is preserved (remote changes still go through background tasks).
+
+**Alternatives considered**:
+- Adding a `locally_recomputed` field to the event payload: More complex; requires both the event emitter and the Prefect trigger to coordinate.
+- Filtering at the Prefect flow level (skip if `node_kind == computed_attribute_kind` and `targets_self`): Wastes Prefect resources creating a flow run just to skip it.
+- No suppression — let both inline and background paths run: Would cause double computation and potential race conditions.
+
+## R6: How to handle chained computed attribute dependencies
+
+**Decision**: When multiple computed attributes on the same node need recomputation, sort them by dependency order using a topological sort on the template variable references. If computed attribute A references computed attribute B's value, B must be computed first.
+
+**Rationale**: The spec requires FR-007 (resolve dependency order). In practice, this is rare — most Jinja2 templates reference regular attributes and relationships, not other computed attributes. But it must be handled correctly.
+
+**Implementation**: After identifying affected computed attributes via `get_impacted_jinja2_targets()`, parse each attribute's template variables. If any variable references another computed attribute in the set, compute that one first. A simple iterative approach works (the set is small, typically 1-3 attributes): iterate until all are resolved, computing any attribute whose dependencies are already resolved.
+
+**Alternatives considered**:
+- Ignoring the problem: Spec explicitly requires FR-007.
+- Pre-computing dependency order at schema registration time: More efficient but adds complexity to the registry. Runtime sorting is simpler given the small set size.
+
+## R7: Event consolidation
+
+**Decision**: No changes needed. The existing event emission in `generate_node_mutation_events()` already emits a single `NodeUpdatedEvent` per mutation. Since inline-computed attribute updates happen within `_update()` and are recorded in the same `NodeChangelog`, they will be included in the same event automatically.
+
+**Rationale**: The `_update()` method builds a single `NodeChangelog` that accumulates all attribute and relationship changes. Adding computed attribute saves to this changelog means they appear as additional `updated_fields` in the event. The event is emitted once after `Node.save()` completes.
+
+**Alternatives considered**: None needed — the existing mechanism handles consolidation by design.

--- a/dev/specs/ifc-2273-local-computation-jinja2/spec.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Local Computation of Jinja2 Computed Attributes
+
+**Feature Branch**: `ifc-2273-local-computation-jinja2`
+**Created**: 2026-03-19
+**Status**: Draft
+**Input**: IFC-2273 — Optimize Jinja2 computed attribute updates by handling "local" changes immediately within the original mutation rather than as background tasks, while continuing to use Prefect for "remote" changes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Immediate Computed Attribute Updates on Local Attribute Changes (Priority: P1)
+
+A user updates an attribute on a node that has a Jinja2-based computed attribute depending on that same attribute. The computed attribute is recalculated and persisted as part of the same mutation. When the mutation response returns, the computed attribute already reflects the new value — no background task, no page refresh needed.
+
+**Why this priority**: This is the core value proposition. It eliminates the most common source of unnecessary background tasks (local attribute changes) and directly improves perceived performance and user experience.
+
+**Independent Test**: Can be fully tested by updating an attribute used in a computed attribute on the same node and verifying the computed value is correct in the mutation response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Device node with a computed attribute `name` using Jinja2 template `{{ instance__value }}-{{ site__name__value }}`, **When** the user updates `instance` on that Device, **Then** the `name` computed attribute is recalculated inline and the mutation response contains the updated computed value.
+2. **Given** a node with a computed attribute referencing a local attribute, **When** the user updates that local attribute, **Then** no background task is created for the computed attribute update.
+3. **Given** a node with a computed attribute, **When** the user updates an attribute that is NOT used by the computed attribute template, **Then** no recomputation occurs and no background task is created.
+
+---
+
+### User Story 2 - Immediate Computed Attribute Updates on Local Relationship Changes (Priority: P1)
+
+A user changes a relationship on a node that has a Jinja2-based computed attribute depending on that relationship (e.g., re-assigning a Device to a different Site). The computed attribute is recalculated inline using the new peer's attributes.
+
+**Why this priority**: Relationship changes are a common trigger for computed attribute recomputation. Handling them inline alongside attribute changes completes the "local change" coverage.
+
+**Independent Test**: Can be tested by changing a relationship on a node with a computed attribute that references that relationship's peer attributes, and verifying the computed value updates in the mutation response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Device with computed `name` = `{{ instance__value }}-{{ site__name__value }}` currently assigned to SiteA, **When** the user re-assigns the Device to SiteB, **Then** the `name` is recalculated using SiteB's name and the mutation response reflects the updated value.
+2. **Given** a node with a computed attribute referencing a relationship, **When** the user changes that relationship, **Then** no background task is created for the computed attribute update.
+
+---
+
+### User Story 3 - Remote Changes Continue Via Background Tasks (Priority: P2)
+
+When a user updates a peer node's attribute that is referenced by computed attributes on other nodes (a "remote" change), the system continues to handle recomputation via background tasks as it does today.
+
+**Why this priority**: Ensures backward compatibility and correctness for the remote case. This is not new functionality — it validates the existing path is preserved.
+
+**Independent Test**: Can be tested by updating a peer node attribute (e.g., renaming a Site) and verifying that computed attributes on related nodes (e.g., Devices assigned to that Site) are updated via background tasks.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Site referenced by multiple Device nodes with computed attributes using Site's name, **When** the user updates the Site's name, **Then** the computed attributes on related Devices are updated via background tasks (existing behavior preserved).
+2. **Given** a remote change triggers a background task, **When** the task completes, **Then** the computed attribute values are correct.
+
+---
+
+### User Story 4 - Consolidated Events for Local Changes (Priority: P2)
+
+When a user updates an attribute that triggers a local computed attribute recomputation, only a single event/webhook is emitted for the entire mutation — not separate events for the original change and the computed attribute update.
+
+**Why this priority**: Reduces notification noise for integrations and webhook consumers. Important for operational clarity but secondary to core computation correctness.
+
+**Independent Test**: Can be tested by subscribing to node change events, performing a local change that triggers computed attribute recomputation, and verifying only one consolidated event is received.
+
+**Acceptance Scenarios**:
+
+1. **Given** a webhook subscription on a node kind with computed attributes, **When** a user updates a local attribute that triggers computed attribute recomputation, **Then** exactly one webhook event is fired containing both the original change and the updated computed attribute.
+2. **Given** a bulk import updating many nodes with computed attributes via local changes, **When** the import completes, **Then** each node produces at most one event (not two separate events per node).
+
+---
+
+### User Story 5 - Bulk Import Performance (Priority: P2)
+
+When a bulk import updates thousands of nodes with computed attributes, the system handles local computed attribute recomputation inline within each mutation rather than spawning thousands of separate background tasks.
+
+**Why this priority**: This is the highest-impact performance scenario. Importing 2,000 interfaces currently triggers 2,000 background tasks, each independently querying the database.
+
+**Independent Test**: Can be tested by performing a bulk import of nodes with computed attributes and measuring that no background tasks are spawned for local changes, and that total processing time and resource consumption are reduced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bulk import of 2,000 nodes with Jinja2 computed attributes that depend on local attributes, **When** the import completes, **Then** zero background tasks are spawned for local computed attribute updates.
+2. **Given** the same bulk import, **When** the import completes, **Then** all computed attribute values are correct and immediately visible.
+
+---
+
+### Edge Cases
+
+- What happens when a computed attribute template references both local and remote attributes, and only a local attribute changes? The local recomputation should use the current persisted values for remote attributes (no need to re-fetch peer data beyond what is already loaded).
+- What happens when a computed attribute template references a relationship that is being set to null/empty? The computed attribute should be recalculated with the null relationship context, producing whatever the Jinja2 template renders for missing data.
+- What happens when multiple computed attributes on the same node depend on the same changed attribute? All affected computed attributes must be recalculated in one pass.
+- What happens when a computed attribute depends on another computed attribute on the same node (chained computation)? The system must resolve dependencies in the correct order.
+- How does this behave on non-default branches? The inline computation must respect branch context, using the correct schema and data for the active branch.
+- What happens for transform-based computed attributes? They are excluded from this optimization and continue using background tasks only.
+- What happens when inline Jinja2 template evaluation fails (e.g., missing attribute, type error)? The error is logged, the computed attribute value is left unchanged, and the mutation succeeds. This matches existing background task error semantics.
+
+## Clarifications
+
+### Session 2026-03-20
+
+- Q: What should happen if inline Jinja2 evaluation fails during a mutation? → A: Log the error, leave computed attribute unchanged, mutation succeeds.
+- Q: Does this optimization apply to node creation or only updates? → A: Update path only — the creation path (including `_process_macros` for mandatory attrs) remains unchanged.
+- Q: Should both optional and mandatory computed attributes recompute inline on local updates? → A: Yes, both recompute inline on local update changes regardless of optional/mandatory distinction.
+- Q: Is an additional DB query acceptable to fetch new peer attributes on relationship changes? → A: No extra query needed — the existing `_collect_extra_filters` pattern in `Node._collect_extra_filters()` can be extended to include computed attribute relationship fields, loading peer data during `resolve_relationships()`.
+- Q: Does this feature change the template instantiation path? → A: No, template instantiation is unchanged — out of scope like other creation paths.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recompute Jinja2-based computed attributes inline during the mutation when the changed attribute or relationship is on the same node as the computed attribute ("local change").
+- **FR-002**: System MUST NOT spawn a background task for computed attribute updates triggered by local changes.
+- **FR-003**: System MUST continue to use background tasks for computed attribute updates triggered by changes on related/peer nodes ("remote changes").
+- **FR-004**: System MUST emit a single consolidated event per node mutation, including both the original change and any inline-computed attribute updates.
+- **FR-005**: System MUST correctly identify which computed attributes on a node are affected by a given attribute or relationship change, and only recompute those.
+- **FR-006**: System MUST handle the case where a computed attribute template references both local and remote data — only local triggers cause inline recomputation.
+- **FR-007**: System MUST resolve dependency order when multiple computed attributes on the same node have interdependencies.
+- **FR-008**: System MUST NOT apply this optimization to transform-based computed attributes; those continue using background tasks exclusively.
+- **FR-009**: System MUST support inline recomputation across all branches, respecting branch-specific schema and data.
+- **FR-010**: The inline computation MUST produce identical results to the current background task computation for the same inputs.
+- **FR-011**: This optimization applies to the **update mutation path only**. Node creation and template instantiation paths remain unchanged.
+- **FR-012**: Both optional and mandatory Jinja2 computed attributes MUST recompute inline on local update changes.
+- **FR-013**: If inline Jinja2 evaluation fails, the system MUST log the error, leave the computed attribute value unchanged, and allow the mutation to succeed.
+
+### Key Entities
+
+- **Computed Attribute**: An attribute on a node whose value is derived from a Jinja2 template referencing other attributes or relationships on the same or related nodes. Has a computation type (Jinja2 or transform) and a template definition.
+- **Local Change**: A mutation to an attribute or relationship on the same node that owns the computed attribute. Triggers inline recomputation.
+- **Remote Change**: A mutation to an attribute on a peer/related node referenced by a computed attribute template. Continues to trigger background recomputation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Local attribute or relationship changes that affect computed attributes produce updated computed values in the mutation response with zero background tasks spawned.
+- **SC-002**: Bulk import of 2,000 nodes with local computed attributes completes without spawning background tasks for computed attribute updates, reducing total background task count to zero for local changes.
+- **SC-003**: Each node mutation that triggers local computed attribute recomputation emits exactly one event/webhook, not two.
+- **SC-004**: Remote changes continue to trigger background recomputation with no behavioral change from current system.
+- **SC-005**: Inline-computed attribute values are identical to values that would have been produced by the existing background task path for the same inputs.
+- **SC-006**: No user-facing behavioral change — users interact with computed attributes the same way, but see results faster.
+
+## Assumptions
+
+- INFP-441 (placeholder automation refactor) is NOT available — this work must integrate with the current automation structure as-is.
+- The existing Jinja2 template evaluation logic can be reused for inline computation without modification to the template engine itself.
+- Peer/relationship data needed for local recomputation is loaded via the existing `_collect_extra_filters` mechanism in `Node._collect_extra_filters()`, extended to include computed attribute relationship fields — no additional DB query beyond the existing `resolve_relationships()` call.
+- The performance overhead of inline computation during mutations is acceptable and results in net improvement over the background task approach.
+
+## Scope Exclusions
+
+- Transform-based computed attributes are explicitly out of scope.
+- Schema-change-triggered regeneration of all computed attributes for a node kind remains handled by the existing automation/background mechanism.
+- No changes to the Jinja2 template syntax or capabilities.
+- No changes to how users define computed attributes in schemas.
+- Node creation path (including `_process_macros` for mandatory computed attrs during `Node.new()`) is unchanged.
+- Template instantiation path (`handle_template_relationships` / `NodeTemplateApplier`) is unchanged.

--- a/dev/specs/ifc-2273-local-computation-jinja2/spec.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/spec.md
@@ -64,7 +64,7 @@ When a user updates an attribute that triggers a local computed attribute recomp
 **Acceptance Scenarios**:
 
 1. **Given** a webhook subscription on a node kind with computed attributes, **When** a user updates a local attribute that triggers computed attribute recomputation, **Then** exactly one webhook event is fired containing both the original change and the updated computed attribute.
-2. **Given** a bulk import updating many nodes with computed attributes via local changes, **When** the import completes, **Then** each node produces at most one event (not two separate events per node).
+2. **Given** a bulk update updating many nodes with computed attributes via local changes, **When** the import completes, **Then** each node produces at most one event (not two separate events per node).
 
 ---
 

--- a/dev/specs/ifc-2273-local-computation-jinja2/spec.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/spec.md
@@ -68,18 +68,18 @@ When a user updates an attribute that triggers a local computed attribute recomp
 
 ---
 
-### User Story 5 - Bulk Import Performance (Priority: P2)
+### User Story 5 - Bulk Update Performance (Priority: P2)
 
-When a bulk import updates thousands of nodes with computed attributes, the system handles local computed attribute recomputation inline within each mutation rather than spawning thousands of separate background tasks.
+When a bulk update modifies thousands of existing nodes with computed attributes, the system handles local computed attribute recomputation inline within each mutation rather than spawning thousands of separate background tasks.
 
-**Why this priority**: This is the highest-impact performance scenario. Importing 2,000 interfaces currently triggers 2,000 background tasks, each independently querying the database.
+**Why this priority**: This is the highest-impact performance scenario. Updating 2,000 interfaces currently triggers 2,000 background tasks, each independently querying the database.
 
-**Independent Test**: Can be tested by performing a bulk import of nodes with computed attributes and measuring that no background tasks are spawned for local changes, and that total processing time and resource consumption are reduced.
+**Independent Test**: Can be tested by bulk-updating existing nodes with computed attributes and measuring that no background tasks are spawned for local changes, and that total processing time and resource consumption are reduced.
 
 **Acceptance Scenarios**:
 
-1. **Given** a bulk import of 2,000 nodes with Jinja2 computed attributes that depend on local attributes, **When** the import completes, **Then** zero background tasks are spawned for local computed attribute updates.
-2. **Given** the same bulk import, **When** the import completes, **Then** all computed attribute values are correct and immediately visible.
+1. **Given** 2,000 existing nodes with Jinja2 computed attributes that depend on local attributes, **When** a bulk update modifies local attributes on all 2,000 nodes, **Then** zero background tasks are spawned for local computed attribute updates.
+2. **Given** the same bulk update, **When** the update completes, **Then** all computed attribute values are correct and immediately visible.
 
 ---
 
@@ -132,7 +132,7 @@ When a bulk import updates thousands of nodes with computed attributes, the syst
 ### Measurable Outcomes
 
 - **SC-001**: Local attribute or relationship changes that affect computed attributes produce updated computed values in the mutation response with zero background tasks spawned.
-- **SC-002**: Bulk import of 2,000 nodes with local computed attributes completes without spawning background tasks for computed attribute updates, reducing total background task count to zero for local changes.
+- **SC-002**: Bulk update of 2,000 existing nodes with local computed attributes completes without spawning background tasks for computed attribute updates, reducing total background task count to zero for local changes.
 - **SC-003**: Each node mutation that triggers local computed attribute recomputation emits exactly one event/webhook, not two.
 - **SC-004**: Remote changes continue to trigger background recomputation with no behavioral change from current system.
 - **SC-005**: Inline-computed attribute values are identical to values that would have been produced by the existing background task path for the same inputs.

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -1,0 +1,199 @@
+# Tasks: Local Computation of Jinja2 Computed Attributes
+
+**Input**: Design documents from `/specs/ifc-2273-local-computation-jinja2/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Test tasks included — computed attributes require integration_docker tests per constitution (Principle IV).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this modifies existing code. Skip to foundational.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Registry enhancements and extra_filters extension that ALL user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T001 Add `relationship_fields` property to `RegisteredNodeComputedAttribute` in `backend/infrahub/core/schema/schema_branch_computed.py` that returns `dict[str, set[str]]` mapping relationship names to peer attribute names needed for Jinja2 template rendering, derived from the relationship entries and their associated `ComputedAttributeTarget.attribute.computed_attribute.jinja2_template` variable paths
+- [ ] T002 Add `get_local_jinja2_targets(kind, updates)` method to `ComputedAttributes` in `backend/infrahub/core/schema/schema_branch_computed.py` that wraps `get_impacted_jinja2_targets()` and filters results to only return `ComputedAttributeTarget` entries where `target.kind == kind` (local changes only)
+- [ ] T003 Extend `Node._collect_extra_filters()` in `backend/infrahub/core/node/__init__.py` to include computed attribute `relationship_fields` from `schema_branch.computed_attributes`, merging them with existing display_label/HFID extra_filters via `_merge_relationship_fields()`, gated by a check that the node has Jinja2 computed attributes and is an update (existing node)
+- [ ] T004 [P] Add unit tests for `relationship_fields` property and `get_local_jinja2_targets()` in `backend/tests/unit/core/schema/test_schema_branch_computed.py` — test local vs remote target filtering, relationship field extraction, and empty/missing cases
+
+**Checkpoint**: Registry and peer loading infrastructure ready. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Immediate Computed Attribute Updates on Local Attribute Changes (Priority: P1) MVP
+
+**Goal**: When a user updates a local attribute that a Jinja2 computed attribute depends on, the computed attribute is recalculated inline within `_update()` and included in the mutation response.
+
+**Independent Test**: Update an attribute used by a computed attribute on the same node; verify the mutation response contains the updated computed value and no background task is spawned.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Create `_recompute_local_jinja2()` async method on `Node` in `backend/infrahub/core/node/__init__.py` that: (1) gets the schema_branch, (2) calls `computed_attributes.get_local_jinja2_targets(kind=self._schema.kind, updates=fields)`, (3) for each target, resolves Jinja2 template variables from the node's in-memory attribute values and resolved relationship peers (reusing the variable resolution pattern from `_process_macros()`), (4) renders the template via `InfrahubJinja2Template.render()`, (5) if value changed, updates the attribute on `self` and saves it via `attr.save()`, (6) records in `NodeChangelog`, (7) on Jinja2 rendering error: logs warning and leaves value unchanged (FR-013)
+- [ ] T006 [US1] Call `_recompute_local_jinja2()` from `Node._update()` in `backend/infrahub/core/node/__init__.py` — insert the call after attribute and relationship saves (after line ~924) but before HFID/display_label recomputation (before line ~934), passing the `fields` parameter to scope which computed attributes to check
+- [ ] T007 [US1] Handle chained computed attribute dependencies in `_recompute_local_jinja2()`: when multiple computed attributes on the same node are affected, sort by dependency order (if computed attr A references computed attr B, compute B first) using iterative resolution — in `backend/infrahub/core/node/__init__.py`
+- [ ] T008 [US1] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: create a schema with a Jinja2 computed attribute referencing a local attribute, create a node, update the local attribute, verify the computed attribute is recalculated in the same mutation and the response value is correct
+- [ ] T009 [US1] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: verify that updating an attribute NOT used by the computed attribute template does NOT trigger recomputation (FR-005 — acceptance scenario 3)
+- [ ] T010 [US1] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: verify that inline Jinja2 evaluation failure logs an error and leaves the computed attribute unchanged while the mutation succeeds (FR-013)
+
+**Checkpoint**: Local attribute changes trigger inline computed attribute recomputation. Core value proposition delivered.
+
+---
+
+## Phase 4: User Story 2 — Immediate Computed Attribute Updates on Local Relationship Changes (Priority: P1)
+
+**Goal**: When a user changes a relationship on a node, computed attributes referencing that relationship's peer attributes are recalculated inline.
+
+**Independent Test**: Re-assign a Device to a different Site; verify the computed `name` attribute reflects the new Site's name in the mutation response.
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Ensure `_recompute_local_jinja2()` handles relationship-type template variables in `backend/infrahub/core/node/__init__.py`: when a template variable references a relationship peer attribute (e.g., `site__name__value`), resolve the value from the already-resolved `RelationshipManager` peer objects loaded via the extended `_collect_extra_filters()` — the peer attributes should already be available after `resolve_relationships()`
+- [ ] T012 [US2] Handle null/empty relationship case in `_recompute_local_jinja2()` in `backend/infrahub/core/node/__init__.py`: when a relationship is being set to null, pass `None` for that variable to the Jinja2 template and let it render accordingly (edge case from spec)
+- [ ] T013 [US2] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: create a Device with computed `name` = `{{ instance__value }}-{{ site__name__value }}`, assign to SiteA, then re-assign to SiteB, verify computed name uses SiteB's name in mutation response
+- [ ] T014 [US2] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: set a relationship to null on a node with a computed attribute referencing that relationship, verify the template renders with null context and the mutation succeeds
+
+**Checkpoint**: Both local attribute and relationship changes trigger inline recomputation.
+
+---
+
+## Phase 5: User Story 3 — Remote Changes Continue Via Background Tasks (Priority: P2)
+
+**Goal**: Ensure remote changes (peer node attribute updates) still trigger background Prefect tasks for computed attribute recomputation. No regression.
+
+**Independent Test**: Update a Site's name; verify Devices referencing that Site have their computed attributes updated via background tasks.
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] Modify `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` in `backend/infrahub/computed_attribute/models.py` to skip creating Prefect automation triggers for `ComputedAttributeTriggerNode` entries where `targets_self=True` — only create triggers for remote changes (peer node kinds)
+- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py`: verify that trigger definitions for a computed attribute with mixed local+remote dependencies correctly exclude the self-targeting trigger node while preserving the remote trigger node
+- [ ] T017 [US3] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: update a peer node attribute (e.g., rename a Site) and verify that computed attributes on related nodes (Devices) are still updated via background tasks (existing behavior preserved)
+
+**Checkpoint**: Remote changes work via background tasks. Local changes handled inline. Both paths coexist correctly.
+
+---
+
+## Phase 6: User Story 4 — Consolidated Events for Local Changes (Priority: P2)
+
+**Goal**: Each node mutation that triggers local computed attribute recomputation emits exactly one event/webhook, not two.
+
+**Independent Test**: Subscribe to node change events, perform a local change triggering computed attribute recomputation, verify exactly one event is received.
+
+### Implementation for User Story 4
+
+- [ ] T018 [US4] Verify event consolidation works automatically: since `_recompute_local_jinja2()` saves computed attributes within `_update()` and records changes in the same `NodeChangelog`, the single `NodeUpdatedEvent` emitted by `generate_node_mutation_events()` should already include both the original change and the computed attribute update — add a functional test in `backend/tests/functional/computed_attribute/test_local_computation.py` that asserts only one event is emitted and it contains both the original field and the computed attribute field in `updated_fields`
+
+**Checkpoint**: Single consolidated event per mutation confirmed.
+
+---
+
+## Phase 7: User Story 5 — Bulk Import Performance (Priority: P2)
+
+**Goal**: Bulk import of nodes with computed attributes does not spawn background tasks for local changes.
+
+**Independent Test**: Import 100+ nodes with local computed attributes; verify zero background tasks spawned and all computed values are correct.
+
+### Implementation for User Story 5
+
+- [ ] T019 [US5] Add integration test in `backend/tests/functional/computed_attribute/test_local_computation.py`: bulk-create/update nodes with Jinja2 computed attributes depending on local attributes, verify no background tasks are spawned for local computed attribute updates and all computed values are correct post-import
+
+**Checkpoint**: Bulk import performance validated.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, knowledge base updates, and changelog.
+
+- [ ] T020 [P] Update `dev/knowledge/backend/` with computed attribute local computation documentation — add a section to an existing knowledge doc or create `dev/knowledge/backend/computed-attributes.md` covering the dual evaluation path (inline for local, Prefect for remote), the `_recompute_local_jinja2()` method, and the `_collect_extra_filters()` extension
+- [ ] T021 [P] Add towncrier changelog fragment in `changelog/` for the user-facing improvement: computed attributes now update immediately on local changes
+- [ ] T022 Run existing computed attribute test suite to verify no regressions: `uv run invoke backend.test-unit -- -k computed_attribute`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — can start immediately
+- **US1 (Phase 3)**: Depends on Phase 2 completion (T001-T004)
+- **US2 (Phase 4)**: Depends on Phase 3 completion (US1 provides the core `_recompute_local_jinja2()` method)
+- **US3 (Phase 5)**: Depends on Phase 2 completion only (trigger suppression is independent of inline recomputation)
+- **US4 (Phase 6)**: Depends on Phase 3 completion (needs inline recomputation working to verify event consolidation)
+- **US5 (Phase 7)**: Depends on Phase 3 completion (needs inline recomputation working for bulk test)
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational — core inline recomputation
+- **US2 (P1)**: Depends on US1 — extends `_recompute_local_jinja2()` for relationship variables
+- **US3 (P2)**: Depends on Foundational only — trigger suppression is independent
+- **US4 (P2)**: Depends on US1 — event verification needs inline recomputation
+- **US5 (P2)**: Depends on US1 — bulk test needs inline recomputation
+
+### Parallel Opportunities
+
+- **Phase 2**: T001 and T002 are sequential (T002 depends on registry), T003 depends on T001+T002, T004 can start after T001+T002
+- **After Phase 3 (US1)**: US2, US4, and US5 can all run in parallel (they touch different test files and different aspects)
+- **US3**: Can run in parallel with US1 (touches `computed_attribute/models.py`, not `core/node/__init__.py`)
+- **Phase 8**: T020 and T021 can run in parallel
+
+---
+
+## Parallel Example: After Foundational
+
+```bash
+# US1 and US3 can run in parallel (different files):
+# US1 agent: backend/infrahub/core/node/__init__.py (inline recomputation)
+# US3 agent: backend/infrahub/computed_attribute/models.py (trigger suppression)
+
+# After US1 completes, US2, US4, US5 can run in parallel:
+# US2: extends _recompute_local_jinja2() + relationship tests
+# US4: event consolidation test
+# US5: bulk import test
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (registry + extra_filters)
+2. Complete Phase 3: US1 (inline recomputation for local attribute changes)
+3. **STOP and VALIDATE**: Test US1 independently
+4. This alone eliminates the majority of unnecessary background tasks
+
+### Incremental Delivery
+
+1. Foundational → ready
+2. US1 → inline attr recomputation → Test → **(MVP!)**
+3. US1 + US2 → add relationship changes → Test
+4. US3 → suppress background tasks for local → Test
+5. US4 + US5 → verify events + bulk → Test
+6. Polish → docs, changelog
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All inline rendering reuses the existing `_process_macros()` variable resolution pattern
+- The `_collect_extra_filters()` extension ensures peer attributes are loaded without extra DB queries
+- Trigger suppression (US3) and inline recomputation (US1) are independent and can be developed in parallel

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -72,19 +72,19 @@
 
 ---
 
-## Phase 5: User Story 3 — Remote Changes Continue Via Background Tasks (Priority: P2)
+## Phase 5: User Story 3 — Convert Self-Targeting Triggers to Placeholders (Priority: P2)
 
-**Goal**: Ensure remote changes (peer node attribute updates) still trigger background Prefect tasks for computed attribute recomputation. No regression.
+**Goal**: Convert self-targeting computed attribute triggers to use `_trigger_placeholder` fields (matching the HFID/display label pattern), so they never fire on per-node changes but still exist for schema-change detection. Remote triggers keep real field names and continue firing via Prefect.
 
-**Independent Test**: Update a Site's name; verify Devices referencing that Site have their computed attributes updated via background tasks.
+**Independent Test**: Update a Site's name; verify Devices referencing that Site have their computed attributes updated via background tasks. Verify self-targeting triggers use `_trigger_placeholder`.
 
 ### Implementation for User Story 3
 
-- [ ] T015 [US3] Modify `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` in `backend/infrahub/computed_attribute/models.py` to skip creating Prefect automation triggers for `ComputedAttributeTriggerNode` entries where `targets_self=True` — only create triggers for remote changes (peer node kinds)
-- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py`: verify that trigger definitions for a computed attribute with mixed local+remote dependencies correctly exclude the self-targeting trigger node while preserving the remote trigger node
+- [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify `gather_trigger_computed_attribute_jinja2()` so that `targets_self=True` trigger nodes have their fields replaced with `["_trigger_placeholder"]` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` — matching the pattern in `hfid/models.py:59-61` and `display_labels/models.py:59-61`. Remote trigger nodes (`targets_self=False`) keep their real field names.
+- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py`: verify that self-targeting triggers are created with `_trigger_placeholder` fields, remote triggers keep real field names, and a computed attribute with only local dependencies still produces one placeholder trigger (not zero)
 - [ ] T017 [US3] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: update a peer node attribute (e.g., rename a Site) and verify that computed attributes on related nodes (Devices) are still updated via background tasks (existing behavior preserved)
 
-**Checkpoint**: Remote changes work via background tasks. Local changes handled inline. Both paths coexist correctly.
+**Checkpoint**: Self-targeting triggers are placeholders. Remote triggers work via background tasks. Both paths coexist correctly.
 
 ---
 

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -165,7 +165,7 @@
 # After US1 completes, US2, US4, US5 can run in parallel:
 # US2: extends _recompute_local_jinja2() + relationship tests
 # US4: event consolidation test
-# US5: bulk import test
+# US5: bulk update test
 ```
 
 ---

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -150,7 +150,7 @@
 
 - **Phase 2**: T001 and T002 are sequential (T002 depends on registry), T003 depends on T001+T002, T004 can start after T001+T002
 - **After Phase 3 (US1)**: US2, US4, and US5 can all run in parallel (they touch different test files and different aspects)
-- **US3**: Can run in parallel with US1 (touches `computed_attribute/models.py`, not `core/node/__init__.py`)
+- **US3**: Can run in parallel with US1 (touches `computed_attribute/gather.py`, not `core/node/__init__.py`)
 - **Phase 8**: T020 and T021 can run in parallel
 
 ---
@@ -160,7 +160,7 @@
 ```bash
 # US1 and US3 can run in parallel (different files):
 # US1 agent: backend/infrahub/core/node/__init__.py (inline recomputation)
-# US3 agent: backend/infrahub/computed_attribute/models.py (trigger suppression)
+# US3 agent: backend/infrahub/computed_attribute/gather.py (trigger placeholders)
 
 # After US1 completes, US2, US4, US5 can run in parallel:
 # US2: extends _recompute_local_jinja2() + relationship tests

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -102,17 +102,17 @@
 
 ---
 
-## Phase 7: User Story 5 — Bulk Import Performance (Priority: P2)
+## Phase 7: User Story 5 — Bulk Update Performance (Priority: P2)
 
-**Goal**: Bulk import of nodes with computed attributes does not spawn background tasks for local changes.
+**Goal**: Bulk update of existing nodes with computed attributes does not spawn background tasks for local changes.
 
-**Independent Test**: Import 100+ nodes with local computed attributes; verify zero background tasks spawned and all computed values are correct.
+**Independent Test**: Create 100+ nodes, then bulk-update their local attributes; verify zero background tasks spawned for computed attribute recomputation and all computed values are correct.
 
 ### Implementation for User Story 5
 
-- [ ] T019 [US5] Add integration test in `backend/tests/functional/computed_attribute/test_local_computation.py`: bulk-create/update nodes with Jinja2 computed attributes depending on local attributes, verify no background tasks are spawned for local computed attribute updates and all computed values are correct post-import
+- [ ] T019 [US5] Add integration test in `backend/tests/functional/computed_attribute/test_local_computation.py`: first create 50+ nodes with Jinja2 computed attributes depending on local attributes, then bulk-update a local attribute on each node, verify no background tasks are spawned for computed attribute updates and all computed values are correct post-update
 
-**Checkpoint**: Bulk import performance validated.
+**Checkpoint**: Bulk update performance validated.
 
 ---
 

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -30,7 +30,7 @@
 - [ ] T001 Add `relationship_fields` property to `RegisteredNodeComputedAttribute` in `backend/infrahub/core/schema/schema_branch_computed.py` that returns `dict[str, set[str]]` mapping relationship names to peer attribute names needed for Jinja2 template rendering, derived from the relationship entries and their associated `ComputedAttributeTarget.attribute.computed_attribute.jinja2_template` variable paths
 - [ ] T002 Add `get_local_jinja2_targets(kind, updates)` method to `ComputedAttributes` in `backend/infrahub/core/schema/schema_branch_computed.py` that wraps `get_impacted_jinja2_targets()` and filters results to only return `ComputedAttributeTarget` entries where `target.kind == kind` (local changes only)
 - [ ] T003 Extend `Node._collect_extra_filters()` in `backend/infrahub/core/node/__init__.py` to include computed attribute `relationship_fields` from `schema_branch.computed_attributes`, merging them with existing display_label/HFID extra_filters via `_merge_relationship_fields()`, gated by a check that the node has Jinja2 computed attributes and is an update (existing node)
-- [ ] T004 [P] Add unit tests for `relationship_fields` property and `get_local_jinja2_targets()` in `backend/tests/unit/core/schema/test_schema_branch_computed.py` — test local vs remote target filtering, relationship field extraction, and empty/missing cases
+- [ ] T004 [P] Add tests for `relationship_fields` property and `get_local_jinja2_targets()` in `backend/tests/unit/core/schema/test_schema_branch_computed.py` (or `backend/tests/component/` if schema registration dependencies require it) — test local vs remote target filtering, relationship field extraction, and empty/missing cases
 
 **Checkpoint**: Registry and peer loading infrastructure ready. User story implementation can begin.
 
@@ -81,7 +81,7 @@
 ### Implementation for User Story 3
 
 - [ ] T015 [US3] In `backend/infrahub/computed_attribute/gather.py`, modify `gather_trigger_computed_attribute_jinja2()` so that `targets_self=True` trigger nodes have their fields replaced with `["_trigger_placeholder"]` before calling `ComputedAttrJinja2TriggerDefinition.from_computed_attribute()` — matching the pattern in `hfid/models.py:59-61` and `display_labels/models.py:59-61`. Remote trigger nodes (`targets_self=False`) keep their real field names.
-- [ ] T016 [US3] Add unit test in `backend/tests/unit/computed_attribute/test_trigger_definition.py`: verify that self-targeting triggers are created with `_trigger_placeholder` fields, remote triggers keep real field names, and a computed attribute with only local dependencies still produces one placeholder trigger (not zero)
+- [ ] T016 [US3] Add test in `backend/tests/unit/computed_attribute/test_trigger_definition.py` (or `backend/tests/component/` if needed): verify that self-targeting triggers are created with `_trigger_placeholder` fields, remote triggers keep real field names, and a computed attribute with only local dependencies still produces one placeholder trigger (not zero)
 - [ ] T017 [US3] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: update a peer node attribute (e.g., rename a Site) and verify that computed attributes on related nodes (Devices) are still updated via background tasks (existing behavior preserved)
 
 **Checkpoint**: Self-targeting triggers are placeholders. Remote triggers work via background tasks. Both paths coexist correctly.

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -110,7 +110,7 @@
 
 ### Implementation for User Story 5
 
-- [ ] T019 [US5] Add integration test in `backend/tests/functional/computed_attribute/test_local_computation.py`: first create 50+ nodes with Jinja2 computed attributes depending on local attributes, then bulk-update a local attribute on each node, verify no background tasks are spawned for computed attribute updates and all computed values are correct post-update
+- [ ] T019 [US5] Add functional test in `backend/tests/functional/computed_attribute/test_local_computation.py`: create 50+ nodes with Jinja2 computed attributes depending on local attributes, then bulk-update a local attribute on each node, verify all computed values are correct post-update (functional tests have no Prefect server, so correct values prove the inline path handled everything)
 
 **Checkpoint**: Bulk update performance validated.
 


### PR DESCRIPTION
# Why

Jinja2 computed attribute updates triggered by local changes (same-node attribute or relationship mutations) currently spawn background tasks unnecessarily. This PR adds the full design documentation for optimizing local changes to recompute inline during the mutation.

Part of [IFC-2273](https://opsmill.atlassian.net/browse/IFC-2273)

## What changed

- **Feature spec**
- **Implementation plan** 
- **Tasks & work packages**

## How to review

This is a **specification & planning** PR — no functional code changes.

## Checklist

- [x] Internal .md docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2273]: https://opsmill.atlassian.net/browse/IFC-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added extensive specs, plan, quickstart, research, tasks, checklists, contracts, data-model and work-package documents describing inline/local recomputation of Jinja2 computed attributes, acceptance criteria, and rollout guidance.
  * Clarifies that local updates recompute and persist affected computed values within the same mutation, emit a single consolidated event, and avoid background tasks for local changes.
* **Tests**
  * Added/outlined unit and functional test plans for inline recomputation, relationship/null cases, dependency ordering, bulk updates, and error/logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->