### PR TITLE
Simplify key lookup in dictionaries

### DIFF
--- a/backend/tests/unit/message_bus/test_mappings.py
+++ b/backend/tests/unit/message_bus/test_mappings.py
@@ -14,8 +14,8 @@ def test_message_command_overlap() -> None:
     Verify that a command is defined for each message
     except events that don't need to be associated with a command
     """
-    messages = sorted([key for key in MESSAGE_MAP.keys() if not key.startswith("event.")])
-    commands = sorted([key for key in COMMAND_MAP.keys() if not key.startswith("event.")])
+    messages = sorted([key for key in MESSAGE_MAP if not key.startswith("event.")])
+    commands = sorted([key for key in COMMAND_MAP if not key.startswith("event.")])
 
     assert messages == commands
 

--- a/backend/tests/unit/test_types.py
+++ b/backend/tests/unit/test_types.py
@@ -8,7 +8,7 @@ from infrahub.types import ATTRIBUTE_TYPES
 
 @pytest.mark.parametrize(
     "test_case",
-    [pytest.param(attribute_name, id=attribute_name) for attribute_name in ATTRIBUTE_TYPES.keys()],
+    [pytest.param(attribute_name, id=attribute_name) for attribute_name in ATTRIBUTE_TYPES],
 )
 def test_attribute_types_allowed_property_path(test_case: str) -> None:
     """Validates that the get_allowed_property_in_path() method returns the correct fields for all types
@@ -42,7 +42,7 @@ def _get_path_field_list(include_binary_address: bool, fields: dict[str, Field])
         "updated_by",
     ]
     included = ["binary_address"] if include_binary_address else []
-    for name in fields.keys():
+    for name in fields:
         if name not in excluded_fields:
             included.append(name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1074,7 +1074,6 @@ allow-dunder-method-names = [
     "PLR6201",  # Use a `set` literal when testing for membership
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF029",   # Function is declared `async`, but doesn't `await`
-    "SIM118",   # Use `key in dict` instead of `key in dict.keys()`
 ]
 
 "backend/tests/integration_docker/test_schema_migration.py" = [


### PR DESCRIPTION
# Why

Remove linting violations for a cleaner pyproject.toml file, avoid new violations of the same kind

## What changed

* Fix linting issues with key lookup in dicts
* Update rules in pyproject.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test implementations for improved code clarity.

* **Chores**
  * Updated linting configuration to align with current code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->