### PR TITLE
Upgrade schema-visualizer with Jotai state, local storage management, collapsible cards, and UI refresh

### DIFF
--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -122,6 +122,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "html-to-image": "^1.11.11",
+        "jotai": "^2.18.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -130,6 +130,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "tailwindcss": "^4.1.17",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "setup": "git submodule update --init --recursive && npm install --prefix ../packages/schema-visualizer",
-    "submodule:update": "git submodule update --remote frontend/packages/schema-visualizer && npm install --prefix ../packages/schema-visualizer",
+    "setup": "git -C ../.. submodule update --init --recursive && npm install --prefix ../packages/schema-visualizer",
+    "submodule:update": "git -C ../.. submodule update --remote frontend/packages/schema-visualizer && npm install --prefix ../packages/schema-visualizer",
     "start": "vite",
     "dev": "VITE_DEVTOOLS=1 vite",
     "build": "npm install --prefix ../packages/schema-visualizer && vite build",


### PR DESCRIPTION
* Refactor schema-visualizer state management from React useState to Jotai atoms with granular localStorage persistence
* Decompose the monolithic SchemaVisualizer component (~1000 LOC) into focused hooks (use-graph-layout, use-node-highlighting, use-schema-data, use-dismiss, use-export) and extracted panels
* Add collapsible node cards (collapsed by default), viewport persistence, and "Show details" context menu action
* Refresh UI: flat card headers with colored top border/icon badges, updated color palette, React Compiler enabled

<img width="2587" height="1882" alt="46943" src="https://github.com/user-attachments/assets/8df79110-3bba-4644-a03c-fc89e4726b80" />

<img width="2584" height="1878" alt="73364" src="https://github.com/user-attachments/assets/5df8d144-edf8-463d-ac74-381c5d87f867" />

https://github.com/opsmill/infrahub-schema-visualizer/pull/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved submodule initialization during setup and installation processes.
  * Updated internal dependency package to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->