### PR TITLE
IFC-2380: Jinja2 local recomputation code documentation & code simplification

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -230,8 +230,10 @@ async def process_jinja2(
         computed_attribute_kind: Schema kind that owns the computed attribute (may differ from
                                 node_kind when the dependency crosses a relationship).
         context: Infrahub execution context.
-        updated_fields: Field names that changed on the trigger node. Passed through to
-                        get_impacted_jinja2_targets to narrow the lookup.
+        updated_fields: Field names that changed on the trigger node.
+
+    Returns:
+        None
     """
     log = get_run_logger()
     client = get_client()

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -220,6 +220,19 @@ async def process_jinja2(
     context: InfrahubContext,
     updated_fields: list[str] | None = None,
 ) -> None:
+    """Recompute a single Jinja2 computed attribute in response to a node mutation.
+
+    Args:
+        branch_name: Branch on which the triggering mutation occurred.
+        node_kind: Schema kind of the node that was modified (the trigger node).
+        object_id: ID of the modified node, used to scope GraphQL queries.
+        computed_attribute_name: Name of the computed attribute to recompute.
+        computed_attribute_kind: Schema kind that owns the computed attribute (may differ from
+                                node_kind when the dependency crosses a relationship).
+        context: Infrahub execution context.
+        updated_fields: Field names that changed on the trigger node. Passed through to
+                        get_impacted_jinja2_targets to narrow the lookup.
+    """
     log = get_run_logger()
     client = get_client()
 

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -164,15 +164,14 @@ class ComputedAttributes:
     ) -> None:
         """Register a Jinja2 computed attribute and its dependency graph.
 
-        Populates the ``_computed_jinja2_attribute_map`` so the system knows which nodes/fields
-        trigger recomputation of which computed attributes. The map is keyed by the kind of node
-        whose mutation should trigger recomputation.
-
         Args:
             node: The schema owning the computed attribute (e.g. InfraDevice).
             attribute: The computed attribute definition (e.g. ``computed_name``).
             schema_path: Parsed Jinja2 template token identifying the dependency — either a
                          local attribute or a relationship + peer attribute.
+
+        Returns:
+            None
         """
         # Determine the trigger key: for local attributes it's the node itself,
         # for relationship attributes it's the peer kind.

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -188,12 +188,10 @@ class ComputedAttributes:
         if schema_path.is_type_relationship:
             rel_name = schema_path.active_relationship_schema.name
 
-            # Record the relationship on the *peer* entry so get_targets() can
-            # build filter_keys (e.g. "site__ids") to locate affected owner nodes.
+            # Record the relationship on the *peer* entry
             trigger_node.relationships.setdefault(rel_name, []).append(deepcopy(source_attribute))
 
-            # Register on the *owner* entry so that a relationship re-assignment
-            # (e.g. changing which site a device points to) also triggers recomputation.
+            # Register on the *owner* entry so that a relationship re-assignment also triggers recomputation.
             owner_entry = self._computed_jinja2_attribute_map.setdefault(
                 source_attribute.kind, RegisteredNodeComputedAttribute()
             )

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -23,6 +23,14 @@ class PythonDefinition:
 
 
 class ComputedAttributeTarget(BaseModel):
+    """Identifies a computed attribute that needs recomputation.
+
+    Points to a specific (kind, attribute) pair — e.g. InfraDevice.computed_name — that should
+    be re-evaluated when a dependency changes. The ``filter_keys`` field carries relationship-based
+    query filters (e.g. ``site__ids``) used to locate affected nodes when the trigger comes from
+    a peer node rather than the owner itself.
+    """
+
     kind: str
     attribute: AttributeSchema
     filter_keys: list[str] = Field(default_factory=list)
@@ -54,6 +62,22 @@ class ComputedAttributeTriggerNode(BaseModel):
 
 
 class RegisteredNodeComputedAttribute(BaseModel):
+    """Dependency record for a single trigger node kind in the Jinja2 computed attribute registry.
+    Each instance describes what should happen when a node of a particular kind is mutated.
+
+    Example: InfraDevice has ``computed_name = "{{ name__value }}-{{ site__name__value }}"``.
+    This produces two entries in the map:
+
+    - **"InfraDevice"** (the owner): ``local_fields = {"name": [target], "site": [target]}``
+      A change to the device's own ``name`` or ``site`` relationship triggers recomputation.
+
+    - **"InfraSite"** (the peer): ``local_fields = {"name": [target]}``,
+      ``relationships = {"site": [target]}``
+      A change to the site's ``name`` triggers recomputation of devices linked via ``site``.
+      The ``relationships`` dict provides ``filter_keys`` (e.g. ``site__ids``) so the system
+      can locate which devices are affected.
+    """
+
     local_fields: dict[str, list[ComputedAttributeTarget]] = Field(
         default_factory=dict,
         description="These are fields local to the modified node, which can include the names of attributes and relationships",
@@ -64,6 +88,16 @@ class RegisteredNodeComputedAttribute(BaseModel):
     )
 
     def get_targets(self, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+        """Resolve which ComputedAttributeTargets are affected by changes to this node.
+
+        Args:
+            updates: Field names (attributes or relationships) that changed. When None, all
+                     registered local_fields are included.
+
+        Returns:
+            Deduplicated list of ComputedAttributeTarget, each enriched with any applicable
+            relationship-based filter_keys.
+        """
         targets: dict[str, ComputedAttributeTarget] = {}
         for attribute, entries in self.local_fields.items():
             if updates and attribute not in updates:
@@ -128,44 +162,43 @@ class ComputedAttributes:
     def register_computed_jinja2(
         self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
     ) -> None:
-        key = node.kind
-        if schema_path.is_type_relationship:
-            key = schema_path.active_relationship_schema.peer
+        """Register a Jinja2 computed attribute and its dependency graph.
 
-        if key not in self._computed_jinja2_attribute_map:
-            self._computed_jinja2_attribute_map[key] = RegisteredNodeComputedAttribute()
+        Populates the ``_computed_jinja2_attribute_map`` so the system knows which nodes/fields
+        trigger recomputation of which computed attributes. The map is keyed by the kind of node
+        whose mutation should trigger recomputation.
 
+        Args:
+            node: The schema owning the computed attribute (e.g. InfraDevice).
+            attribute: The computed attribute definition (e.g. ``computed_name``).
+            schema_path: Parsed Jinja2 template token identifying the dependency — either a
+                         local attribute or a relationship + peer attribute.
+        """
+        # Determine the trigger key: for local attributes it's the node itself,
+        # for relationship attributes it's the peer kind.
+        key = node.kind if not schema_path.is_type_relationship else schema_path.active_relationship_schema.peer
+
+        trigger_node = self._computed_jinja2_attribute_map.setdefault(key, RegisteredNodeComputedAttribute())
         source_attribute = ComputedAttributeTarget(kind=node.kind, attribute=attribute)
-        trigger_node = self._computed_jinja2_attribute_map[key]
-        if schema_path.is_type_attribute:
-            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
-                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
+        attr_name = schema_path.active_attribute_schema.name
 
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(deepcopy(source_attribute))
-        elif schema_path.is_type_relationship:
-            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
-                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
+        # Both cases: register the attribute as a local_field on the trigger node,
+        # so a change to this field triggers recomputation.
+        trigger_node.local_fields.setdefault(attr_name, []).append(deepcopy(source_attribute))
 
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(deepcopy(source_attribute))
+        if schema_path.is_type_relationship:
+            rel_name = schema_path.active_relationship_schema.name
 
-            if schema_path.active_relationship_schema.name not in trigger_node.relationships:
-                trigger_node.relationships[schema_path.active_relationship_schema.name] = []
+            # Record the relationship on the *peer* entry so get_targets() can
+            # build filter_keys (e.g. "site__ids") to locate affected owner nodes.
+            trigger_node.relationships.setdefault(rel_name, []).append(deepcopy(source_attribute))
 
-            trigger_node.relationships[schema_path.active_relationship_schema.name].append(deepcopy(source_attribute))
-
-            if source_attribute.kind not in self._computed_jinja2_attribute_map:
-                self._computed_jinja2_attribute_map[source_attribute.kind] = RegisteredNodeComputedAttribute()
-
-            if (
-                schema_path.active_relationship_schema.name
-                not in self._computed_jinja2_attribute_map[source_attribute.kind].local_fields
-            ):
-                self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
-                    schema_path.active_relationship_schema.name
-                ] = []
-            self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
-                schema_path.active_relationship_schema.name
-            ].append(deepcopy(source_attribute))
+            # Register on the *owner* entry so that a relationship re-assignment
+            # (e.g. changing which site a device points to) also triggers recomputation.
+            owner_entry = self._computed_jinja2_attribute_map.setdefault(
+                source_attribute.kind, RegisteredNodeComputedAttribute()
+            )
+            owner_entry.local_fields.setdefault(rel_name, []).append(deepcopy(source_attribute))
 
     def validate_generic_inheritance(
         self, node: NodeSchema, attribute: AttributeSchema, generic: GenericSchema
@@ -178,6 +211,19 @@ class ComputedAttributes:
         self._defined_from_generic[attribute_key] = generic.kind
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+        """Return computed Jinja2 attribute targets that need re-evaluation when a node of the given kind is modified.
+
+        Args:
+            kind: The schema kind of the node that was modified (e.g. "InfraInterface").
+            updates: Optional list of field names (attributes or relationships) that changed on the node.
+                     When provided, only targets whose Jinja2 templates reference these fields are returned.
+                     When None, all registered targets for this kind are returned.
+
+        Returns:
+            List of ComputedAttributeTarget entries, each identifying a (kind, attribute) pair whose
+            computed value depends on the modified node and may need recomputation. The target kind
+            can differ from the input kind when the dependency crosses a relationship.
+        """
         if mapping := self._computed_jinja2_attribute_map.get(kind):
             return mapping.get_targets(updates=updates)
 

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -241,27 +241,44 @@ class ComputedAttributes:
         return {key: list(value) for key, value in mapping.items()}
 
     def get_jinja2_trigger_nodes(self) -> dict[ComputedAttributeTarget, list[ComputedAttributeTriggerNode]]:
-        working_map: dict[ComputedAttributeTarget, dict[str, ComputedAttributeTriggerNode]] = {}
-        for node_kind, registered_computed_attribute in self._computed_jinja2_attribute_map.items():
-            for local_field, computed_attribute_targets in registered_computed_attribute.local_fields.items():
-                for computed_attribute_target in computed_attribute_targets:
-                    if computed_attribute_target not in working_map:
-                        working_map[computed_attribute_target] = {}
-                    if node_kind not in working_map[computed_attribute_target]:
-                        working_map[computed_attribute_target][node_kind] = ComputedAttributeTriggerNode(kind=node_kind)
-                    working_map[computed_attribute_target][node_kind].attributes.append(local_field)
-                    if computed_attribute_target.kind == node_kind:
-                        working_map[computed_attribute_target][node_kind].targets_self = True
-            for relationship, computed_attribute_targets in registered_computed_attribute.relationships.items():
-                for computed_attribute_target in computed_attribute_targets:
-                    if computed_attribute_target not in working_map:
-                        working_map[computed_attribute_target] = {}
-                    if node_kind not in working_map[computed_attribute_target]:
-                        working_map[computed_attribute_target][node_kind] = ComputedAttributeTriggerNode(kind=node_kind)
-                    working_map[computed_attribute_target][node_kind].relationships.append(relationship)
-                    if computed_attribute_target.kind == node_kind:
-                        working_map[computed_attribute_target][node_kind].targets_self = True
+        """Build a reverse index from computed attribute targets to the node mutations that trigger them.
 
-        return {
-            computed_attribute_target: list(nodes.values()) for computed_attribute_target, nodes in working_map.items()
-        }
+        Example: if InfraDevice.computed_name depends on its own ``name`` and on InfraSite's ``name``
+        (via a ``site`` relationship), the result includes::
+
+            ComputedAttributeTarget(kind="InfraDevice", attribute=computed_name) -> [
+                ComputedAttributeTriggerNode(
+                    kind="InfraDevice",
+                    attributes=["name", "site"],  # "site" is here because reassigning the relationship is a local change
+                    targets_self=True,
+                ),
+                ComputedAttributeTriggerNode(
+                    kind="InfraSite",
+                    attributes=["name"],       # the peer attribute referenced in the template
+                    relationships=["site"],    # the relationship used to locate affected InfraDevices
+                    targets_self=False,
+                ),
+            ]
+        """
+        # Intermediate map: target -> {trigger_kind -> trigger_node}
+        working_map: dict[ComputedAttributeTarget, dict[str, ComputedAttributeTriggerNode]] = {}
+
+        def _ensure_trigger(target: ComputedAttributeTarget, kind: str) -> ComputedAttributeTriggerNode:
+            """Get or create the trigger node for a (target, kind) pair."""
+            target_map = working_map.setdefault(target, {})
+            trigger = target_map.setdefault(kind, ComputedAttributeTriggerNode(kind=kind))
+            if target.kind == kind:
+                trigger.targets_self = True
+            return trigger
+
+        for node_kind, registered in self._computed_jinja2_attribute_map.items():
+            # Local fields: attributes and relationship names on the trigger node itself
+            for local_field, targets in registered.local_fields.items():
+                for target in targets:
+                    _ensure_trigger(target, node_kind).attributes.append(local_field)
+            # Relationships: the trigger node is a peer reached via this relationship
+            for relationship, targets in registered.relationships.items():
+                for target in targets:
+                    _ensure_trigger(target, node_kind).relationships.append(relationship)
+
+        return {target: list(nodes.values()) for target, nodes in working_map.items()}

--- a/backend/tests/unit/core/test_schema_branch_computed.py
+++ b/backend/tests/unit/core/test_schema_branch_computed.py
@@ -1,0 +1,142 @@
+from infrahub.core.schema import AttributeSchema
+from infrahub.core.schema.schema_branch_computed import (
+    ComputedAttributes,
+    ComputedAttributeTarget,
+    RegisteredNodeComputedAttribute,
+)
+
+
+def _attr(name: str) -> AttributeSchema:
+    return AttributeSchema(name=name, kind="Text")
+
+
+def _target(kind: str, attr_name: str, filter_keys: list[str] | None = None) -> ComputedAttributeTarget:
+    return ComputedAttributeTarget(kind=kind, attribute=_attr(attr_name), filter_keys=filter_keys or [])
+
+
+class TestGetJinja2TriggerNodes:
+    def test_empty_map(self) -> None:
+        computed = ComputedAttributes()
+        assert computed.get_jinja2_trigger_nodes() == {}
+
+    def test_single_local_field(self) -> None:
+        """A single node kind with one local field dependency."""
+        node_kind = "InfraDevice"
+        target = _target(node_kind, "computed_name")
+        computed = ComputedAttributes(
+            jinja2_attribute_map={
+                node_kind: RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target]},
+                ),
+            },
+        )
+
+        result = computed.get_jinja2_trigger_nodes()
+
+        assert len(result) == 1
+        trigger_nodes = result[target]
+        assert len(trigger_nodes) == 1
+        assert trigger_nodes[0].kind == node_kind
+        assert trigger_nodes[0].attributes == ["name"]
+        assert trigger_nodes[0].relationships == []
+        assert trigger_nodes[0].targets_self is True
+
+    def test_peer_relationship(self) -> None:
+        """A peer kind triggers recomputation via a relationship."""
+        local_kind = "InfraDevice"
+        target = _target("%s" % local_kind, "computed_name")
+        remote_kind = "InfraSite"
+        computed = ComputedAttributes(
+            jinja2_attribute_map={
+                ("%s" % remote_kind): RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target]},
+                    relationships={"site": [target]},
+                ),
+            },
+        )
+
+        result = computed.get_jinja2_trigger_nodes()
+
+        assert len(result) == 1
+        trigger_nodes = result[target]
+        assert len(trigger_nodes) == 1
+        node = trigger_nodes[0]
+        assert node.kind == remote_kind
+        assert node.attributes == ["name"]
+        assert node.relationships == ["site"]
+        assert node.targets_self is False
+
+    def test_multiple_trigger_kinds_for_same_target(self) -> None:
+        """Two different node kinds both trigger the same computed attribute."""
+        local_kind = "InfraDevice"
+        target = _target("%s" % local_kind, "computed_name")
+        remote_kind = "InfraSite"
+        computed = ComputedAttributes(
+            jinja2_attribute_map={
+                local_kind: RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target]},
+                ),
+                ("%s" % remote_kind): RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target]},
+                    relationships={"site": [target]},
+                ),
+            },
+        )
+
+        result = computed.get_jinja2_trigger_nodes()
+
+        assert len(result) == 1
+        trigger_nodes = result[target]
+        assert len(trigger_nodes) == 2
+        kinds = {n.kind for n in trigger_nodes}
+        assert kinds == {local_kind, remote_kind}
+
+        device_node = next(n for n in trigger_nodes if n.kind == local_kind)
+        assert device_node.targets_self is True
+        assert device_node.attributes == ["name"]
+        assert device_node.relationships == []
+
+        site_node = next(n for n in trigger_nodes if n.kind == remote_kind)
+        assert site_node.targets_self is False
+        assert site_node.attributes == ["name"]
+        assert site_node.relationships == ["site"]
+
+    def test_multiple_targets(self) -> None:
+        """One trigger node kind feeds into multiple computed attributes."""
+        target_a = _target("InfraDevice", "computed_name")
+        target_b = _target("InfraDevice", "computed_label")
+        computed = ComputedAttributes(
+            jinja2_attribute_map={
+                "InfraDevice": RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target_a, target_b]},
+                ),
+            },
+        )
+
+        result = computed.get_jinja2_trigger_nodes()
+
+        assert len(result) == 2
+        for target in (target_a, target_b):
+            trigger_nodes = result[target]
+            assert len(trigger_nodes) == 1
+            assert trigger_nodes[0].kind == "InfraDevice"
+            assert trigger_nodes[0].attributes == ["name"]
+            assert trigger_nodes[0].targets_self is True
+
+    def test_multiple_local_fields_same_trigger(self) -> None:
+        """Multiple local fields on the same trigger kind accumulate in attributes."""
+        target = _target("InfraDevice", "computed_name")
+        computed = ComputedAttributes(
+            jinja2_attribute_map={
+                "InfraDevice": RegisteredNodeComputedAttribute(
+                    local_fields={"name": [target], "description": [target]},
+                ),
+            },
+        )
+
+        result = computed.get_jinja2_trigger_nodes()
+
+        trigger_nodes = result[target]
+        assert len(trigger_nodes) == 1
+        assert set(trigger_nodes[0].attributes) == {"name", "description"}
+        assert trigger_nodes[0].targets_self is True

--- a/backend/tests/unit/core/test_schema_branch_computed.py
+++ b/backend/tests/unit/core/test_schema_branch_computed.py
@@ -1,13 +1,15 @@
-from typing import Any
-
 from infrahub.core.constants import RelationshipCardinality, RelationshipKind
-from infrahub.core.schema import AttributeSchema, RelationshipSchema
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
 from infrahub.core.schema.basenode_schema import SchemaAttributePath
 from infrahub.core.schema.schema_branch_computed import (
     ComputedAttributes,
     ComputedAttributeTarget,
     RegisteredNodeComputedAttribute,
 )
+
+
+def _node(name: str, namespace: str = "Infra") -> NodeSchema:
+    return NodeSchema(name=name, namespace=namespace)
 
 
 def _attr(name: str) -> AttributeSchema:
@@ -22,17 +24,6 @@ def _rel(name: str, peer: str) -> RelationshipSchema:
 
 def _target(kind: str, attr_name: str, filter_keys: list[str] | None = None) -> ComputedAttributeTarget:
     return ComputedAttributeTarget(kind=kind, attribute=_attr(attr_name), filter_keys=filter_keys or [])
-
-
-def _fake_node(kind: str) -> Any:
-    """Create a minimal object with a .kind attribute, sufficient for register_computed_jinja2."""
-
-    class _Node:
-        pass
-
-    node = _Node()
-    node.kind = kind  # type: ignore[attr-defined]
-    return node
 
 
 class TestGetJinja2TriggerNodes:
@@ -167,7 +158,7 @@ class TestRegisterComputedJinja2:
     def test_local_attribute(self) -> None:
         """Registering a local attribute (e.g. {{ name__value }}) creates one entry under the owner kind."""
         computed = ComputedAttributes()
-        node = _fake_node(kind="InfraDevice")
+        node = _node("Device")
         attr = _attr("computed_name")
         path = SchemaAttributePath(attribute_schema=_attr("name"))
 
@@ -185,12 +176,12 @@ class TestRegisterComputedJinja2:
     def test_relationship_attribute(self) -> None:
         """Registering a relationship path (e.g. {{ site__name__value }}) creates entries on both peer and owner."""
         computed = ComputedAttributes()
-        node = _fake_node(kind="InfraDevice")
+        node = _node("Device")
         attr = _attr("computed_name")
         rel = _rel("site", peer="InfraSite")
         path = SchemaAttributePath(
             relationship_schema=rel,
-            related_schema=_fake_node(kind="InfraSite"),
+            related_schema=_node("Site"),
             attribute_schema=_attr("name"),
         )
 
@@ -216,7 +207,7 @@ class TestRegisterComputedJinja2:
     def test_multiple_registrations_accumulate(self) -> None:
         """Calling register twice for the same node builds up the dependency map."""
         computed = ComputedAttributes()
-        node = _fake_node(kind="InfraDevice")
+        node = _node("Device")
         attr = _attr("computed_label")
 
         # First: local attribute "name"
@@ -231,7 +222,7 @@ class TestRegisterComputedJinja2:
             attribute=attr,
             schema_path=SchemaAttributePath(
                 relationship_schema=_rel("site", peer="InfraSite"),
-                related_schema=_fake_node(kind="InfraSite"),
+                related_schema=_node("Site"),
                 attribute_schema=_attr("name"),
             ),
         )

--- a/backend/tests/unit/core/test_schema_branch_computed.py
+++ b/backend/tests/unit/core/test_schema_branch_computed.py
@@ -1,4 +1,8 @@
-from infrahub.core.schema import AttributeSchema
+from typing import Any
+
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind
+from infrahub.core.schema import AttributeSchema, RelationshipSchema
+from infrahub.core.schema.basenode_schema import SchemaAttributePath
 from infrahub.core.schema.schema_branch_computed import (
     ComputedAttributes,
     ComputedAttributeTarget,
@@ -10,8 +14,25 @@ def _attr(name: str) -> AttributeSchema:
     return AttributeSchema(name=name, kind="Text")
 
 
+def _rel(name: str, peer: str) -> RelationshipSchema:
+    return RelationshipSchema(
+        name=name, peer=peer, cardinality=RelationshipCardinality.ONE, kind=RelationshipKind.ATTRIBUTE
+    )
+
+
 def _target(kind: str, attr_name: str, filter_keys: list[str] | None = None) -> ComputedAttributeTarget:
     return ComputedAttributeTarget(kind=kind, attribute=_attr(attr_name), filter_keys=filter_keys or [])
+
+
+def _fake_node(kind: str) -> Any:
+    """Create a minimal object with a .kind attribute, sufficient for register_computed_jinja2."""
+
+    class _Node:
+        pass
+
+    node = _Node()
+    node.kind = kind  # type: ignore[attr-defined]
+    return node
 
 
 class TestGetJinja2TriggerNodes:
@@ -140,3 +161,88 @@ class TestGetJinja2TriggerNodes:
         assert len(trigger_nodes) == 1
         assert set(trigger_nodes[0].attributes) == {"name", "description"}
         assert trigger_nodes[0].targets_self is True
+
+
+class TestRegisterComputedJinja2:
+    def test_local_attribute(self) -> None:
+        """Registering a local attribute (e.g. {{ name__value }}) creates one entry under the owner kind."""
+        computed = ComputedAttributes()
+        node = _fake_node(kind="InfraDevice")
+        attr = _attr("computed_name")
+        path = SchemaAttributePath(attribute_schema=_attr("name"))
+
+        computed.register_computed_jinja2(node=node, attribute=attr, schema_path=path)
+
+        registry = computed._computed_jinja2_attribute_map
+        assert set(registry.keys()) == {"InfraDevice"}
+        assert list(registry["InfraDevice"].local_fields.keys()) == ["name"]
+        assert registry["InfraDevice"].relationships == {}
+
+        target = registry["InfraDevice"].local_fields["name"][0]
+        assert target.kind == "InfraDevice"
+        assert target.attribute.name == "computed_name"
+
+    def test_relationship_attribute(self) -> None:
+        """Registering a relationship path (e.g. {{ site__name__value }}) creates entries on both peer and owner."""
+        computed = ComputedAttributes()
+        node = _fake_node(kind="InfraDevice")
+        attr = _attr("computed_name")
+        rel = _rel("site", peer="InfraSite")
+        path = SchemaAttributePath(
+            relationship_schema=rel,
+            related_schema=_fake_node(kind="InfraSite"),
+            attribute_schema=_attr("name"),
+        )
+
+        computed.register_computed_jinja2(node=node, attribute=attr, schema_path=path)
+
+        registry = computed._computed_jinja2_attribute_map
+
+        # Peer entry (InfraSite): local_fields has the peer attribute, relationships has the relationship name
+        assert "InfraSite" in registry
+        peer_entry = registry["InfraSite"]
+        assert list(peer_entry.local_fields.keys()) == ["name"]
+        assert list(peer_entry.relationships.keys()) == ["site"]
+        assert peer_entry.local_fields["name"][0].kind == "InfraDevice"
+        assert peer_entry.relationships["site"][0].kind == "InfraDevice"
+
+        # Owner entry (InfraDevice): local_fields has the relationship name (for re-assignment triggers)
+        assert "InfraDevice" in registry
+        owner_entry = registry["InfraDevice"]
+        assert list(owner_entry.local_fields.keys()) == ["site"]
+        assert owner_entry.relationships == {}
+        assert owner_entry.local_fields["site"][0].kind == "InfraDevice"
+
+    def test_multiple_registrations_accumulate(self) -> None:
+        """Calling register twice for the same node builds up the dependency map."""
+        computed = ComputedAttributes()
+        node = _fake_node(kind="InfraDevice")
+        attr = _attr("computed_label")
+
+        # First: local attribute "name"
+        computed.register_computed_jinja2(
+            node=node,
+            attribute=attr,
+            schema_path=SchemaAttributePath(attribute_schema=_attr("name")),
+        )
+        # Second: relationship attribute "site__name"
+        computed.register_computed_jinja2(
+            node=node,
+            attribute=attr,
+            schema_path=SchemaAttributePath(
+                relationship_schema=_rel("site", peer="InfraSite"),
+                related_schema=_fake_node(kind="InfraSite"),
+                attribute_schema=_attr("name"),
+            ),
+        )
+
+        registry = computed._computed_jinja2_attribute_map
+
+        # Owner entry should have both "name" (local attr) and "site" (relationship re-assignment)
+        owner = registry["InfraDevice"]
+        assert set(owner.local_fields.keys()) == {"name", "site"}
+
+        # Peer entry should have the peer attribute and the relationship
+        peer = registry["InfraSite"]
+        assert list(peer.local_fields.keys()) == ["name"]
+        assert list(peer.relationships.keys()) == ["site"]


### PR DESCRIPTION
## Summary

- Simplify `register_computed_jinja2` in `schema_branch_computed.py`: consolidate attribute and relationship dependency registration through unified control flow
- Refactor `get_jinja2_trigger_nodes` with extracted helper and clearer structure
- Add method-level docstrings to `schema_branch_computed.py` (classes, properties, methods)
- Add docstrings to Prefect task functions in `computed_attribute/tasks.py`
- Remove implementation details from docstrings (keep them focused on behavior, not internals)
- Add unit tests for `register_computed_jinja2` and `get_jinja2_trigger_nodes`

## Files Changed

- `backend/infrahub/core/schema/schema_branch_computed.py` — code simplification, docstrings, refactor
- `backend/infrahub/computed_attribute/tasks.py` — docstrings
- `backend/tests/unit/core/test_schema_branch_computed.py` — new unit tests

Closes [IFC-2380]

[IFC-2380]: https://opsmill.atlassian.net/browse/IFC-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ