### PR TITLE
Add "View in graph" button to schema viewer with node highlighting

### DIFF
--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -5,7 +5,8 @@ import type { CSSProperties } from "react";
 import { TabList, Tabs } from "react-aria-components";
 
 import { Badge } from "@/shared/components/ui/badge";
-import { Button } from "@/shared/components/ui/button";
+import { Button, LinkButton } from "@/shared/components/ui/button";
+import { Tooltip } from "@/shared/components/ui/tooltip";
 import { QSP } from "@/shared/config/qsp";
 import { classNames } from "@/shared/utils/common";
 
@@ -96,6 +97,19 @@ export const SchemaViewer = ({
         </div>
 
         <div className="flex items-center gap-2 text-gray-600">
+          {schema.kind && (
+            <Tooltip content="View in graph" enabled>
+              <LinkButton
+                to={`/schema/graph?${QSP.HIGHLIGHT}=${schema.kind}`}
+                size="icon"
+                variant="ghost"
+                aria-label="View in graph"
+              >
+                <Icon icon="mdi:graph-outline" className="text-xl" />
+              </LinkButton>
+            </Tooltip>
+          )}
+
           <SchemaHelpMenu schema={schema} />
 
           <Button size="icon" variant="ghost" aria-label="Close schema viewer" onClick={onClose}>

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -100,7 +100,7 @@ export const SchemaViewer = ({
           {schema.kind && (
             <Tooltip content="View in graph" enabled>
               <LinkButton
-                to={`/schema/graph?${QSP.HIGHLIGHT}=${schema.kind}`}
+                to={`/schema/graph?${QSP.HIGHLIGHT}=${encodeURIComponent(schema.kind)}`}
                 size="icon"
                 variant="ghost"
                 aria-label="View in graph"

--- a/frontend/app/src/pages/schema/graph.tsx
+++ b/frontend/app/src/pages/schema/graph.tsx
@@ -1,5 +1,8 @@
 import { SchemaVisualizer, type SchemaVisualizerData } from "infrahub-schema-visualizer";
 import { useAtomValue } from "jotai";
+import { parseAsString, useQueryState } from "nuqs";
+
+import { QSP } from "@/shared/config/qsp";
 
 import {
   genericSchemasAtom,
@@ -13,12 +16,18 @@ function SchemaGraph() {
   const generics = useAtomValue(genericSchemasAtom);
   const profiles = useAtomValue(profileSchemasAtom);
   const templates = useAtomValue(templateSchemasAtom);
+  const [highlightNodeId, setHighlightNodeId] = useQueryState(QSP.HIGHLIGHT, parseAsString);
 
   const schemaData: SchemaVisualizerData = { nodes, generics, profiles, templates };
 
   return (
     <div className="flex min-h-125 flex-1">
-      <SchemaVisualizer data={schemaData} className="flex-1" />
+      <SchemaVisualizer
+        data={schemaData}
+        className="flex-1"
+        highlightNodeId={highlightNodeId}
+        onClearHighlight={() => setHighlightNodeId(null)}
+      />
     </div>
   );
 }

--- a/frontend/app/src/pages/schema/graph.tsx
+++ b/frontend/app/src/pages/schema/graph.tsx
@@ -1,6 +1,6 @@
 import { SchemaVisualizer, type SchemaVisualizerData } from "infrahub-schema-visualizer";
 import { useAtomValue } from "jotai";
-import { parseAsString, useQueryState } from "nuqs";
+import { useQueryState } from "nuqs";
 
 import { QSP } from "@/shared/config/qsp";
 
@@ -16,7 +16,7 @@ function SchemaGraph() {
   const generics = useAtomValue(genericSchemasAtom);
   const profiles = useAtomValue(profileSchemasAtom);
   const templates = useAtomValue(templateSchemasAtom);
-  const [highlightNodeId, setHighlightNodeId] = useQueryState(QSP.HIGHLIGHT, parseAsString);
+  const [highlightNodeId, setHighlightNodeId] = useQueryState(QSP.HIGHLIGHT);
 
   const schemaData: SchemaVisualizerData = { nodes, generics, profiles, templates };
 

--- a/frontend/app/src/shared/config/qsp.ts
+++ b/frontend/app/src/shared/config/qsp.ts
@@ -13,4 +13,5 @@ export const QSP = {
   TASK_ID: "task_id",
   SEARCH: "search",
   STATUS: "status",
+  HIGHLIGHT: "highlight",
 } as const;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View in graph" button to the schema viewer with a tooltip for quick navigation to the interactive schema visualization.
  * Schema nodes opened from the viewer are highlighted in the graph via URL state; highlights can be cleared from the graph view for easier exploration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add a "View in graph" link button with tooltip to the `SchemaViewer` card header, linking to `/schema/graph?highlight=<kind>`
- Add `highlightNodeId` and `onClearHighlight` props to `SchemaVisualizer` plugin to support URL-driven node highlighting
- When a highlight param is present, the graph auto-unhides the node if hidden, centers/zooms on it, and applies the same glow + dim effect as filter panel hover
- Highlight clears on pane click or node click (one-shot focus behavior)

## Changes
- `frontend/app/src/shared/config/qsp.ts` — new `HIGHLIGHT` QSP constant
- `frontend/app/src/entities/schema/ui/schema-viewer.tsx` — graph link button in card header
- `frontend/app/src/pages/schema/graph.tsx` — read highlight QSP and pass to visualizer
- `frontend/packages/schema-visualizer/src/components/graph/schema-visualizer.tsx` — highlight props, unhide/focus/glow effects, clear on interaction

<img width="1551" height="986" alt="image" src="https://github.com/user-attachments/assets/bd14fa71-19e8-463f-9c97-6c4f360b4c8e" />
<img width="1551" height="984" alt="image" src="https://github.com/user-attachments/assets/971c9c52-d8f2-4799-bf53-21ca5c9344ba" />
<img width="1548" height="990" alt="image" src="https://github.com/user-attachments/assets/34836658-7dd2-4315-8640-dea600d84261" />
