### PR TITLE
Rename infrahub-bundle-dc to infrahub-demo-dc

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # Either a literal path, or the name of a secret...
         repo:
-          - "opsmill/infrahub-bundle-dc"
+          - "opsmill/infrahub-demo-dc"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
           - "INFRAHUB_CUSTOMER3_REPOSITORY"

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -237,7 +237,7 @@ Infrahub documentation is synced and ultimately published via the [`infrahub-doc
 
 Please note the following important points:
 
-- Today, spelling (the `.vale` directory) is authoritative in the `infrahub` repository, not the `infrahub-docs` repository. If you need to add a spelling exception in another repository (i.e. `infrahub-bundle-dc`), you have to add the exception to the `infrahub` repository.
+- Today, spelling (the `.vale` directory) is authoritative in the `infrahub` repository, not the `infrahub-docs` repository. If you need to add a spelling exception in another repository (i.e. `infrahub-demo-dc`), you have to add the exception to the `infrahub` repository.
 - All documentation URLs need to be relative:
   - Do this: `[some page](../path/to/file.mdx)`
   - Not this: `[some page](/absolute_path/to/file)`


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples to reference the correct target repository.

* **Chores**
  * Updated workflow configuration to reference the correct target repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Rename `infrahub-bundle-dc` to `infrahub-demo-dc` in the repository dispatch workflow and documentation to reflect the renamed demo repository.

## Test plan
- [ ] Verify repository dispatch workflow triggers correctly with the new repo name
- [ ] Confirm documentation references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)