### PR TITLE
add optional hostname settings for log forwarding

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -946,6 +946,10 @@ class LogForwardingDestination(BaseModel):
 
 class LogForwardingSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_LOG_FORWARDING_")
+    hostname: str | None = Field(
+        default=None,
+        description="Hostname to use in syslog message headers. If not set, defaults to the system FQDN.",
+    )
     destinations: list[LogForwardingDestination] = Field(
         default_factory=list,
         description="List of log forwarding destinations. (Enterprise only: not available in the community version.)",

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -317,6 +317,7 @@ Configuration settings for the message bus.
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
+| `INFRAHUB_LOG_FORWARDING_HOSTNAME` | Hostname to use in syslog message headers. If not set, defaults to the system FQDN. | None | None |
 | `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
 
 ### INFRAHUB_LOG_FORWARDING_DESTINATIONS


### PR DESCRIPTION
allows users to optionally set the HOSTNAME for log forwarding to whatever they want in an env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `INFRAHUB_LOG_FORWARDING_HOSTNAME` configuration variable to set the hostname in syslog message headers, with automatic fallback to system FQDN.

* **Documentation**
  * Updated configuration reference with the new hostname setting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->