### PR TITLE
Fix reconfiguration of webhooks in scheduled tasks

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -42,10 +43,13 @@ class WebhookTriggerDefinition(TriggerDefinition):
     @classmethod
     def from_object(cls, obj: CoreWebhook | CoreWebhookNode) -> Self:
         event_trigger = EventTrigger()
-        if obj.event_type.value == "all":
+        event_type = obj.event_type.value
+        if isinstance(obj.event_type.value, Enum):
+            event_type = obj.event_type.value.value
+        if event_type == "all":
             event_trigger.events.add("infrahub.*")
         else:
-            event_trigger.events.add(obj.event_type.value)
+            event_trigger.events.add(event_type)
 
         if obj.branch_scope.value == "default_branch":
             event_trigger.match_related = {

--- a/changelog/8694.fixed.md
+++ b/changelog/8694.fixed.md
@@ -1,0 +1,1 @@
+Fix scheduled reconfiguration of webhooks targeting "all" events


### PR DESCRIPTION
# Why

There's a scheduled task that reconfigured webhooks once a day, when this fires the paths compared to when we configure just one webhook is different. Because of this we're using direct database access instead of the SDK to read the information. Because of that we get back the event type as an Enum instead of a string, when that happens we fail to get a match on:

```python
        if event_type == "all":
            event_trigger.events.add("infrahub.*")
        else:
            event_trigger.events.add(event_type)
```

What happens is that Prefect ends up looking for events of kind "all" instead of `infrahub.*` and no event is called "all" so the webhook silently fails.


Closes #8694.

## What changed

Convert the enum to a string.

## How to review

* Consider impact for the changes to webhooks in 1.9, since the configure all part has been completely redesigned in 1.9 I didn't add any additional tests to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed webhook event type handling to ensure scheduled reconfiguration works correctly for webhooks targeting the "all" event set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->