### PR TITLE
IFC-2275 Allow using artifact composition Jinja2 filters

### DIFF
--- a/backend/infrahub/computed_attribute/jinja2.py
+++ b/backend/infrahub/computed_attribute/jinja2.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from infrahub_sdk import InfrahubClient
+
 __all__ = ["InfrahubJinja2Template"]
 
 
@@ -65,7 +67,11 @@ class InfrahubJinja2Template(Jinja2Template):
         template: str | Path,
         template_directory: Path | None = None,
         filters: dict[str, Callable[..., str]] | None = None,
+        client: InfrahubClient | None = None,
     ) -> None:
         super().__init__(
-            template=template, template_directory=template_directory, filters={**FILTERS, **(filters or {})}
+            template=template,
+            template_directory=template_directory,
+            filters={**FILTERS, **(filters or {})},
+            client=client,
         )

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1310,7 +1310,7 @@ class SchemaBranch:
         jinja_template = InfrahubJinja2Template(template=node.display_label)
         context = ExecutionContext.CORE
         if not config.SETTINGS.security.restrict_untrusted_jinja2_filters:
-            context = ExecutionContext.CORE | ExecutionContext.LOCAL
+            context |= ExecutionContext.LOCAL
         try:
             variables = jinja_template.get_variables()
             jinja_template.validate(context=context)
@@ -1370,7 +1370,7 @@ class SchemaBranch:
             jinja_template = InfrahubJinja2Template(template=attribute.computed_attribute.jinja2_template)
             context = ExecutionContext.CORE
             if not config.SETTINGS.security.restrict_untrusted_jinja2_filters:
-                context = ExecutionContext.CORE | ExecutionContext.LOCAL
+                context |= ExecutionContext.LOCAL
             try:
                 variables = jinja_template.get_variables()
                 jinja_template.validate(context=context)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1308,9 +1308,12 @@ class SchemaBranch:
             return
 
         jinja_template = InfrahubJinja2Template(template=node.display_label)
+        context = ExecutionContext.CORE
+        if not config.SETTINGS.security.restrict_untrusted_jinja2_filters:
+            context = ExecutionContext.CORE | ExecutionContext.LOCAL
         try:
             variables = jinja_template.get_variables()
-            jinja_template.validate(context=ExecutionContext.CORE)
+            jinja_template.validate(context=context)
         except (JinjaTemplateOperationViolationError, JinjaTemplateError) as exc:
             raise ValueError(
                 f"{node.kind}: display_label is set to a jinja2 template, but has an invalid template: {exc.message}"
@@ -1365,9 +1368,12 @@ class SchemaBranch:
             )
 
             jinja_template = InfrahubJinja2Template(template=attribute.computed_attribute.jinja2_template)
+            context = ExecutionContext.CORE
+            if not config.SETTINGS.security.restrict_untrusted_jinja2_filters:
+                context = ExecutionContext.CORE | ExecutionContext.LOCAL
             try:
                 variables = jinja_template.get_variables()
-                jinja_template.validate(context=ExecutionContext.CORE)
+                jinja_template.validate(context=context)
             except JinjaTemplateOperationViolationError as exc:
                 raise ValueError(
                     f"{node.kind}: Attribute {attribute.name!r} is assigned by a jinja2 template, but has an invalid template: {exc.message}"

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -9,6 +9,7 @@ from itertools import chain, combinations
 from typing import TYPE_CHECKING, Any
 
 from infrahub_sdk.template.exceptions import JinjaTemplateError, JinjaTemplateOperationViolationError
+from infrahub_sdk.template.filters import ExecutionContext
 from infrahub_sdk.topological_sort import DependencyCycleExistsError, topological_sort
 from infrahub_sdk.utils import compare_lists, deep_merge_dict, duplicates, intersection
 from typing_extensions import Self
@@ -1309,7 +1310,7 @@ class SchemaBranch:
         jinja_template = InfrahubJinja2Template(template=node.display_label)
         try:
             variables = jinja_template.get_variables()
-            jinja_template.validate(restricted=config.SETTINGS.security.restrict_untrusted_jinja2_filters)
+            jinja_template.validate(context=ExecutionContext.CORE)
         except (JinjaTemplateOperationViolationError, JinjaTemplateError) as exc:
             raise ValueError(
                 f"{node.kind}: display_label is set to a jinja2 template, but has an invalid template: {exc.message}"
@@ -1366,7 +1367,7 @@ class SchemaBranch:
             jinja_template = InfrahubJinja2Template(template=attribute.computed_attribute.jinja2_template)
             try:
                 variables = jinja_template.get_variables()
-                jinja_template.validate(restricted=config.SETTINGS.security.restrict_untrusted_jinja2_filters)
+                jinja_template.validate(context=ExecutionContext.CORE)
             except JinjaTemplateOperationViolationError as exc:
                 raise ValueError(
                     f"{node.kind}: Attribute {attribute.name!r} is assigned by a jinja2 template, but has an invalid template: {exc.message}"

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -35,6 +35,7 @@ from infrahub_sdk.spec.menu import MenuFile
 from infrahub_sdk.spec.object import ObjectFile
 from infrahub_sdk.template import Jinja2Template
 from infrahub_sdk.template.exceptions import JinjaTemplateError
+from infrahub_sdk.template.filters import ExecutionContext
 from infrahub_sdk.utils import compare_lists
 from infrahub_sdk.yaml import InfrahubFile, SchemaFile
 from prefect import flow, task
@@ -1212,6 +1213,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             template=Path(location), template_directory=Path(commit_worktree.directory), client=self.sdk
         )
         try:
+            jinja2_template.validate(context=ExecutionContext.CORE | ExecutionContext.WORKER)
             return await jinja2_template.render(variables=data)
         except JinjaTemplateError as exc:
             log.error(str(exc), exc_info=True)

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -1208,7 +1208,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         self.validate_location(commit=commit, worktree_directory=commit_worktree.directory, file_path=location)
 
-        jinja2_template = Jinja2Template(template=Path(location), template_directory=Path(commit_worktree.directory))
+        jinja2_template = Jinja2Template(
+            template=Path(location), template_directory=Path(commit_worktree.directory), client=self.sdk
+        )
         try:
             return await jinja2_template.render(variables=data)
         except JinjaTemplateError as exc:

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -45,6 +45,7 @@ from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
 from typing_extensions import Self
 
+from infrahub import config
 from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositoryObjects, RepositorySyncStatus
 from infrahub.core.registry import registry
 from infrahub.events.artifact_action import ArtifactCreatedEvent, ArtifactUpdatedEvent
@@ -1213,7 +1214,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             template=Path(location), template_directory=Path(commit_worktree.directory), client=self.sdk
         )
         try:
-            jinja2_template.validate(context=ExecutionContext.CORE | ExecutionContext.WORKER)
+            context = ExecutionContext.CORE | ExecutionContext.WORKER
+            if not config.SETTINGS.security.restrict_untrusted_jinja2_filters:
+                context = ExecutionContext.ALL
+            jinja2_template.validate(context=context)
             return await jinja2_template.render(variables=data)
         except JinjaTemplateError as exc:
             log.error(str(exc), exc_info=True)

--- a/backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py
+++ b/backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py
@@ -363,6 +363,60 @@ from infrahub.core.schema.schema_branch import SchemaBranch
             "TestingPerson: Attribute 'computed' is assigned by a jinja2 template, but has an invalid template: The 'pprint' filter isn't allowed to be used",  # noqa:E501
             id="template_invalid_format",
         ),
+        pytest.param(
+            SchemaRoot(
+                nodes=[
+                    NodeSchema(
+                        name="Person",
+                        namespace="Testing",
+                        attributes=[
+                            AttributeSchema(
+                                name="name",
+                                kind="Text",
+                            ),
+                            AttributeSchema(
+                                name="computed",
+                                kind="Text",
+                                read_only=True,
+                                computed_attribute=ComputedAttribute(
+                                    kind=ComputedAttributeKind.JINJA2,
+                                    jinja2_template="{{ name__value | artifact_content }}",
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            "TestingPerson: Attribute 'computed' is assigned by a jinja2 template, but has an invalid template: The 'artifact_content' filter isn't allowed to be used",  # noqa:E501
+            id="artifact_content_blocked_in_core",
+        ),
+        pytest.param(
+            SchemaRoot(
+                nodes=[
+                    NodeSchema(
+                        name="Person",
+                        namespace="Testing",
+                        attributes=[
+                            AttributeSchema(
+                                name="name",
+                                kind="Text",
+                            ),
+                            AttributeSchema(
+                                name="computed",
+                                kind="Text",
+                                read_only=True,
+                                computed_attribute=ComputedAttribute(
+                                    kind=ComputedAttributeKind.JINJA2,
+                                    jinja2_template="{{ name__value | file_object_content }}",
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            "TestingPerson: Attribute 'computed' is assigned by a jinja2 template, but has an invalid template: The 'file_object_content' filter isn't allowed to be used",  # noqa:E501
+            id="file_object_content_blocked_in_core",
+        ),
     ],
 )
 async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, expected_error: str) -> None:

--- a/backend/tests/component/git/test_artifact_composition.py
+++ b/backend/tests/component/git/test_artifact_composition.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from git import Repo
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.exceptions import TransformError
+from infrahub.git import InfrahubRepository
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.transformations.models import TransformJinjaTemplateData
+from infrahub.transformations.tasks import transform_render_jinja2_template
+from tests.helpers.test_client import dummy_async_request
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+async def init_service() -> InfrahubServices:
+    return await InfrahubServices.new(client=InfrahubClient(), workflow=WorkflowLocalExecution())
+
+
+@pytest.fixture
+async def git_repo_filter_tests(git_upstream_repo_02: dict[str, str | Path], git_repos_dir: Path) -> InfrahubRepository:
+    upstream = Repo(git_upstream_repo_02["path"])
+
+    templates = {
+        # Untrusted filter
+        "template_safe.tpl.j2": '{% for item in data["items"] %}{{ item | safe }}\n{% endfor %}\n',
+        # Trusted filter
+        "template_upper.tpl.j2": '{% for item in data["items"] %}{{ item | upper }}\n{% endfor %}\n',
+    }
+
+    for name, content in templates.items():
+        (git_upstream_repo_02["path"] / name).write_text(content, encoding="utf-8")
+        upstream.index.add(name)
+
+    upstream.index.commit("Add filter test templates")
+
+    return await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name=git_upstream_repo_02["name"],
+        location=str(git_upstream_repo_02["path"]),
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+
+
+def _make_message(repo: InfrahubRepository, template: str) -> TransformJinjaTemplateData:
+    """Craft a message to test the transform flow."""
+    return TransformJinjaTemplateData(
+        repository_id=str(repo.id),
+        repository_name=repo.name,
+        repository_kind=InfrahubKind.REPOSITORY,
+        commit=repo.get_commit_value(branch_name="main"),
+        branch="main",
+        template_location=template,
+        timeout=10,
+        data={"items": ["one", "two"]},
+    )
+
+
+async def test_worker_rejects_local_only_filter(
+    git_repo_filter_tests: InfrahubRepository, init_service: InfrahubServices, prefect_test_fixture: None
+) -> None:
+    with pytest.raises(TransformError, match="'safe' filter isn't allowed to be used"):
+        await transform_render_jinja2_template(message=_make_message(git_repo_filter_tests, "template_safe.tpl.j2"))
+
+
+async def test_worker_allows_trusted_filters(
+    git_repo_filter_tests: InfrahubRepository, init_service: InfrahubServices, prefect_test_fixture: None
+) -> None:
+    result = await transform_render_jinja2_template(
+        message=_make_message(git_repo_filter_tests, "template_upper.tpl.j2")
+    )
+    assert result == "ONE\nTWO\n"

--- a/backend/tests/integration_docker/test_artifact_composition.py
+++ b/backend/tests/integration_docker/test_artifact_composition.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.protocols import CoreArtifact
+from infrahub_sdk.schema import NodeSchema, SchemaRoot
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+from infrahub_sdk.testing.repository import GitRepo
+from infrahub_sdk.testing.schemas.car_person import SchemaCarPerson
+
+from infrahub.core.constants import ArtifactStatus, InfrahubKind
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+CURRENT_DIRECTORY = Path(__file__).parent.resolve()
+
+
+async def wait_for_artifacts(
+    client: InfrahubClient, expected_name: str | None = None, interval: int = 3, retries: int = 10
+) -> list[CoreArtifact]:
+    """Poll until all artifacts (or those matching expected_name) reach a terminal state."""
+    for _ in range(retries):
+        artifacts = await client.all(kind=CoreArtifact)
+
+        if expected_name:
+            artifacts = [a for a in artifacts if a.name.value == expected_name]
+
+        if artifacts and all(
+            a.status.value in (ArtifactStatus.READY.value, ArtifactStatus.ERROR.value) for a in artifacts
+        ):
+            return artifacts
+        await asyncio.sleep(interval)
+
+    raise TimeoutError(f"Artifacts not ready after {retries * interval}s (filter: {expected_name})")
+
+
+class TestArtifactComposition(TestInfrahubDockerClient, SchemaCarPerson):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    @pytest.fixture(scope="class")
+    def schema_person_artifact(self, schema_person_base: NodeSchema) -> NodeSchema:
+        person_schema = schema_person_base.model_copy(deep=True)
+        person_schema.inherit_from = [InfrahubKind.ARTIFACTTARGET]
+        return person_schema
+
+    @pytest.fixture(scope="class")
+    def initial_schema(
+        self, schema_car_base: NodeSchema, schema_person_artifact: NodeSchema, schema_manufacturer_base: NodeSchema
+    ) -> SchemaRoot:
+        return SchemaRoot(version="1.0", nodes=[schema_person_artifact, schema_car_base, schema_manufacturer_base])
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(self, client: InfrahubClient, default_branch: str, initial_schema: SchemaRoot) -> None:
+        """Load schema and create persons with a target group."""
+        await client.schema.wait_until_converged(branch=default_branch)
+        resp = await client.schema.load(
+            schemas=[initial_schema.to_schema_dict()], branch=default_branch, wait_until_converged=True
+        )
+        assert resp.errors == {}
+        persons = await self.create_persons(client=client, branch=default_branch)
+        group = await client.create(kind="CoreStandardGroup", name="people", members=[p.id for p in persons])
+        await group.save()
+
+    async def test_add_section_repo(
+        self, client: InfrahubClient, remote_repos_dir: Path, initial_dataset: None
+    ) -> None:
+        repo = GitRepo(
+            name="section-config",
+            src_directory=CURRENT_DIRECTORY / "test_files/repos/section-config",
+            dst_directory=remote_repos_dir,
+        )
+        await repo.add_to_infrahub(client=client)
+        assert await repo.wait_for_sync_to_complete(client=client, retries=12)
+
+    async def test_section_artifacts(self, client: InfrahubClient) -> None:
+        """Section artifacts are generated with the expected content."""
+        artifacts = await wait_for_artifacts(client=client, expected_name="person-section")
+        assert len(artifacts) == 2
+        assert all(a.status.value == ArtifactStatus.READY.value for a in artifacts)
+
+        contents = set()
+        for artifact in artifacts:
+            content = await client.object_store.get(identifier=artifact.storage_id.value)
+            contents.add(content)
+        assert contents == {"! Section config for John Doe", "! Section config for Jane Doe"}
+
+    async def test_add_composite_repo(self, client: InfrahubClient, remote_repos_dir: Path) -> None:
+        repo = GitRepo(
+            name="composite-config",
+            src_directory=CURRENT_DIRECTORY / "test_files/repos/composite-config",
+            dst_directory=remote_repos_dir,
+        )
+        await repo.add_to_infrahub(client=client)
+        assert await repo.wait_for_sync_to_complete(client=client, retries=12)
+
+    async def test_composite_artifacts(self, client: InfrahubClient) -> None:
+        """Composite artifacts inline section content via the artifact_content filter."""
+        artifacts = await wait_for_artifacts(client=client, expected_name="person-composite", retries=20)
+        assert len(artifacts) == 2
+        assert all(a.status.value == ArtifactStatus.READY.value for a in artifacts)
+
+        contents = set()
+        for artifact in artifacts:
+            content = await client.object_store.get(identifier=artifact.storage_id.value)
+            contents.add(content)
+        assert contents == {
+            "! Composite config for John Doe\n! Section config for John Doe\n! End composite",
+            "! Composite config for Jane Doe\n! Section config for Jane Doe\n! End composite",
+        }

--- a/backend/tests/integration_docker/test_files/repos/composite-config/.infrahub.yml
+++ b/backend/tests/integration_docker/test_files/repos/composite-config/.infrahub.yml
@@ -1,0 +1,18 @@
+---
+queries:
+  - name: person_composite
+    file_path: templates/person_composite.gql
+
+jinja2_transforms:
+  - name: person_composite_transform
+    query: person_composite
+    template_path: templates/person_composite.j2
+
+artifact_definitions:
+  - name: "Composite config"
+    artifact_name: "person-composite"
+    parameters:
+      name: "name__value"
+    content_type: "text/plain"
+    targets: "people"
+    transformation: "person_composite_transform"

--- a/backend/tests/integration_docker/test_files/repos/composite-config/templates/person_composite.gql
+++ b/backend/tests/integration_docker/test_files/repos/composite-config/templates/person_composite.gql
@@ -1,0 +1,23 @@
+query PersonComposite($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        name {
+          value
+        }
+        artifacts {
+          edges {
+            node {
+              name {
+                value
+              }
+              storage_id {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/integration_docker/test_files/repos/composite-config/templates/person_composite.j2
+++ b/backend/tests/integration_docker/test_files/repos/composite-config/templates/person_composite.j2
@@ -1,0 +1,7 @@
+! Composite config for {{ data.TestingPerson.edges[0].node.name.value }}
+{% for artifact in data.TestingPerson.edges[0].node.artifacts.edges %}
+{% if artifact.node.name.value == "person-section" and artifact.node.storage_id.value %}
+{{ artifact.node.storage_id.value | artifact_content }}
+{% endif %}
+{% endfor %}
+! End composite

--- a/backend/tests/integration_docker/test_files/repos/section-config/.infrahub.yml
+++ b/backend/tests/integration_docker/test_files/repos/section-config/.infrahub.yml
@@ -1,0 +1,18 @@
+---
+queries:
+  - name: person_section
+    file_path: templates/person_section.gql
+
+jinja2_transforms:
+  - name: person_section_transform
+    query: person_section
+    template_path: templates/person_section.j2
+
+artifact_definitions:
+  - name: "Section config"
+    artifact_name: "person-section"
+    parameters:
+      name: "name__value"
+    content_type: "text/plain"
+    targets: "people"
+    transformation: "person_section_transform"

--- a/backend/tests/integration_docker/test_files/repos/section-config/templates/person_section.gql
+++ b/backend/tests/integration_docker/test_files/repos/section-config/templates/person_section.gql
@@ -1,0 +1,11 @@
+query PersonSection($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/integration_docker/test_files/repos/section-config/templates/person_section.j2
+++ b/backend/tests/integration_docker/test_files/repos/section-config/templates/person_section.j2
@@ -1,0 +1,1 @@
+! Section config for {{ data.TestingPerson.edges[0].node.name.value }}

--- a/changelog/+ifc2275.added.md
+++ b/changelog/+ifc2275.added.md
@@ -1,0 +1,1 @@
+Added support for artifact content composition via Jinja2 filters. Templates running on Prefect workers can now use `artifact_content`, `file_object_content`, `from_json`, and `from_yaml` filters to inline and parse content from other artifacts and file objects. These filters are blocked in computed attributes for security.


### PR DESCRIPTION
# Why

The SDK now ships `artifact_content`, `file_object_content`, `from_json`, and `from_yaml` Jinja2 filters via https://github.com/opsmill/infrahub-sdk-python/pull/889. This PR wires them into the server so they actually work on Prefect workers, and makes sure they're properly blocked everywhere else.

## What changed

The main change is in `render_jinja2_template`. It now passes a SDK client when creating the Jinja2 template, which gives the new filters access to the object store API during rendering. It also validates the template against `ExecutionContext.CORE | ExecutionContext.WORKER` before rendering, which blocks `LOCAL`-only filters like from being used in artifact templates.

The schema validation now uses the `ExecutionContext.CORE` context instead of the old boolean `restrict_untrusted_jinja2_filters` config flag. This guarantees Jinja2 filters such as `artifact_content` and `file_object_content` are always rejected in computed attributes.


The SDK submodule is bumped to the `infrahub-develop` Python SDK commit which contains the filter implementations.

## How to test

```bash
uv run pytest backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py backend/tests/component/git/test_artifact_composition.py -v

uv run invoke dev.build # Needs a fresh build
GIT_CONFIG_GLOBAL=/dev/null INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest backend/tests/integration_docker/test_artifact_composition.py -v
```

The integration test generates section artifacts via one repo, adds a second repo whose templates use `artifact_content` to inline the section content, and verifies the composed output.

## Remaining question

The `restrict_untrusted_jinja2_filters` config setting is no longer referenced but still defined this might need to be either deprecated or to be wired in the logic (which it is not anymore).

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] I have reviewed AI generated content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for artifact content composition in Jinja2 templates with new filters (`artifact_content`, `file_object_content`, `from_json`, `from_yaml`) for worker-executed templates
  * Filters are restricted from use in computed attributes for security

* **Tests**
  * Added comprehensive component and integration tests for artifact composition workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->