### PR TITLE
Correct documentation jobs & trigger on python_sdk changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -92,6 +92,7 @@ documentation_all:
   - *doc_files
   - *markdown_all
   - *vale_files
+  - *sdk_files
 
 documentation_generated_all:
   - *infrahub_reference_generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,7 +834,8 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      (needs.files-changed.outputs.python == 'true') || (needs.files-changed.outputs.documentation == 'true')
+      (needs.files-changed.outputs.python == 'true' ||
+      needs.files-changed.outputs.documentation == 'true')
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
@@ -893,7 +894,8 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      (needs.files-changed.outputs.release == 'true') || (needs.files-changed.outputs.documentation == 'true')
+      (needs.files-changed.outputs.release == 'true' ||
+      needs.files-changed.outputs.documentation == 'true')
     needs: ["files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5


### PR DESCRIPTION
# Why

The validate-generated-documentation job was not running on PRs that only updated the python_sdk submodule pointer, because sdk_files was not included in any filter group that the job's condition checked

## What changed

* Added *sdk_files to documentation_all in file-filters.yml so submodule pointer updates trigger the documentation output
* Fixed operator precedence in the if conditions of validate-generated-documentation and validate-documentation-style in ci.yml, matching the style already used in backend-validate-generated