### PR TITLE
fix(backend): add db backoff retry for resolvers

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -306,6 +306,15 @@ class DatabaseSettings(BaseSettings):
     retry_limit: int = Field(
         default=3, description="Maximum number of times a transient issue in a transaction should be retried."
     )
+    retry_base_delay: float = Field(
+        default=0.1, ge=0, description="Base delay in seconds for exponential backoff on transaction retries."
+    )
+    retry_max_delay: float = Field(
+        default=2.0, ge=0, description="Maximum delay in seconds for exponential backoff on transaction retries."
+    )
+    retry_jitter_max: float = Field(
+        default=0.1, ge=0, description="Maximum jitter in seconds added to retry delay to avoid thundering herd."
+    )
     max_concurrent_queries: int = Field(
         default=0, ge=0, description="Maximum number of concurrent queries that can run (0 means unlimited)."
     )

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar
@@ -510,6 +511,7 @@ def retry_db_transaction(
     name: str,
 ) -> Callable[[Callable[..., Coroutine[Any, Any, R]]], Callable[..., Coroutine[Any, Any, R]]]:
     def func_wrapper(func: Callable[..., Coroutine[Any, Any, R]]) -> Callable[..., Coroutine[Any, Any, R]]:
+        @functools.wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> R:
             error = Exception()
             for attempt in range(1, config.SETTINGS.database.retry_limit + 1):
@@ -519,7 +521,10 @@ def retry_db_transaction(
                     if isinstance(exc, ClientError):
                         if exc.code != "Neo.ClientError.Statement.EntityNotFound":
                             raise exc
-                    retry_time: float = random.randrange(100, 500) / 1000
+                    base_delay = config.SETTINGS.database.retry_base_delay
+                    max_delay = config.SETTINGS.database.retry_max_delay
+                    jitter = random.uniform(0, config.SETTINGS.database.retry_jitter_max)
+                    retry_time = min(base_delay * (2 ** (attempt - 1)) + jitter, max_delay)
                     log.exception("Retry handler caught database error")
                     log.info(
                         f"Retrying database transaction, attempt {attempt}/{config.SETTINGS.database.retry_limit}",

--- a/backend/infrahub/graphql/resolvers/account_metadata.py
+++ b/backend/infrahub/graphql/resolvers/account_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from infrahub.database import retry_db_transaction
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.loaders.account import AccountDataLoader, AccountLoaderParams
 
@@ -74,6 +75,7 @@ class AccountMetadataResolver:
         return await loader.load(account_id)
 
 
+@retry_db_transaction(name="account_metadata_resolver")
 async def account_metadata_resolver(
     parent: dict[str, Any],
     info: GraphQLResolveInfo,

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -15,6 +15,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import BuiltinIPNamespace, BuiltinIPPrefix
 from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.database import retry_db_transaction
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.parser import extract_selection
 from infrahub.graphql.permissions import get_permissions
@@ -305,6 +306,7 @@ async def _annotate_result(
 
 
 @trace.get_tracer(__name__).start_as_current_span("ipam_paginated_list_resolver")
+@retry_db_transaction(name="ipam_paginated_list_resolver")
 async def ipam_paginated_list_resolver(  # noqa: PLR0915
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -9,6 +9,7 @@ from opentelemetry import trace
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipHierarchyDirection
 from infrahub.core.manager import NodeManager
 from infrahub.core.order import OrderModel
+from infrahub.database import retry_db_transaction
 from infrahub.exceptions import NodeNotFoundError
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.metadata import build_metadata_query_options
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
 
 
 @trace.get_tracer(__name__).start_as_current_span("account_resolver")
+@retry_db_transaction(name="account_resolver")
 async def account_resolver(
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,
@@ -50,6 +52,7 @@ async def account_resolver(
 
 
 @trace.get_tracer(__name__).start_as_current_span("default_resolver")
+@retry_db_transaction(name="default_resolver")
 async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
     """Not sure why but the default resolver returns sometime 4 positional args and sometime 2.
 
@@ -182,6 +185,7 @@ def _transform_metadata_day_filters(filters: dict[str, Any]) -> dict[str, Any]:
 
 
 @trace.get_tracer(__name__).start_as_current_span("default_paginated_list_resolver")
+@retry_db_transaction(name="default_paginated_list_resolver")
 async def default_paginated_list_resolver(
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,
@@ -282,6 +286,7 @@ async def default_paginated_list_resolver(
 
 
 @trace.get_tracer(__name__).start_as_current_span("single_relationship_resolver")
+@retry_db_transaction(name="single_relationship_resolver")
 async def single_relationship_resolver(parent: dict, info: GraphQLResolveInfo, **kwargs: Any) -> dict[str, Any]:
     graphql_context: GraphqlContext = info.context
     resolver = graphql_context.single_relationship_resolver
@@ -289,6 +294,7 @@ async def single_relationship_resolver(parent: dict, info: GraphQLResolveInfo, *
 
 
 @trace.get_tracer(__name__).start_as_current_span("many_relationship_resolver")
+@retry_db_transaction(name="many_relationship_resolver")
 async def many_relationship_resolver(
     parent: dict, info: GraphQLResolveInfo, include_descendants: bool | None = False, **kwargs: Any
 ) -> dict[str, Any]:
@@ -310,6 +316,7 @@ async def descendants_resolver(parent: dict, info: GraphQLResolveInfo, **kwargs)
 
 
 @trace.get_tracer(__name__).start_as_current_span("hierarchy_resolver")
+@retry_db_transaction(name="hierarchy_resolver")
 async def hierarchy_resolver(
     direction: RelationshipHierarchyDirection, parent: dict, info: GraphQLResolveInfo, **kwargs
 ) -> dict[str, Any]:

--- a/backend/tests/component/graphql/test_graphql_read_retry.py
+++ b/backend/tests/component/graphql/test_graphql_read_retry.py
@@ -1,0 +1,244 @@
+"""Component tests for GraphQL read resolver retry on transient Neo4j errors.
+
+These tests simulate Neo4j server-side Bolt thread pool exhaustion by spinning up
+a dedicated Neo4j container with server.bolt.thread_pool_max_size=10 and firing
+concurrent queries that hit many-cardinality relationship resolvers.
+
+All fixtures are module-scoped so xdist (--dist loadscope) runs them on a single
+worker and the dedicated container is stopped as soon as the module finishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, AsyncGenerator, Generator
+
+import pytest
+from neo4j.exceptions import TransientError
+
+from infrahub import config
+from infrahub.core import registry
+from infrahub.core.initialization import add_indexes
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase, get_db
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.conftest import (
+    do_car_person_schema_unregistered,
+    do_data_schema,
+    do_default_branch,
+    do_empty_database,
+    do_group_schema,
+    do_local_storage_dir,
+    do_reset_registry,
+)
+from tests.helpers.constants import INFRAHUB_USE_TEST_CONTAINERS, NEO4J_IMAGE, PORT_BOLT_NEO4J
+from tests.helpers.graphql import graphql
+from tests.helpers.utils import get_exposed_port, start_neo4j_container
+
+if TYPE_CHECKING:
+    from graphql.execution import ExecutionResult
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+
+NUM_CARS = 10
+
+QUERY_MANY_RELATIONSHIP = """
+query {
+    TestPerson {
+        edges {
+            node {
+                name { value }
+                cars {
+                    edges {
+                        node {
+                            name { value }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixtures for the dedicated small-thread-pool Neo4j container
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def neo4j_small_thread_pool(request: pytest.FixtureRequest) -> int:
+    """Start a dedicated Neo4j container with a minimal Bolt thread pool (size=10)."""
+    if not INFRAHUB_USE_TEST_CONTAINERS:
+        pytest.skip("Test containers are disabled")
+
+    container = start_neo4j_container(
+        neo4j_image=NEO4J_IMAGE,
+        extra_env={"NEO4J_server_bolt_thread__pool__max__size": "10"},
+    )
+    request.addfinalizer(container.stop)
+
+    return get_exposed_port(container, PORT_BOLT_NEO4J)
+
+
+@pytest.fixture(scope="module")
+async def db_small_thread_pool(
+    neo4j_small_thread_pool: int,
+) -> AsyncGenerator[InfrahubDatabase, None]:
+    """Create an InfrahubDatabase connected to the small-thread-pool Neo4j."""
+    original_address = config.SETTINGS.database.address
+    original_port = config.SETTINGS.database.port
+
+    config.SETTINGS.database.address = "localhost"
+    config.SETTINGS.database.port = neo4j_small_thread_pool
+
+    driver = await get_db(retry=5)
+    db = InfrahubDatabase(driver=driver)
+    await add_indexes(db=db)
+
+    yield db
+
+    await db.close()
+    config.SETTINGS.database.address = original_address
+    config.SETTINGS.database.port = original_port
+
+
+@pytest.fixture(scope="module")
+async def default_branch_stp(
+    db_small_thread_pool: InfrahubDatabase, tmp_path_factory: pytest.TempPathFactory
+) -> Branch:
+    """Create default branch on the small-thread-pool DB."""
+    tmp_path = tmp_path_factory.mktemp("storage_stp")
+    do_local_storage_dir(tmp_path=tmp_path)
+    await do_empty_database(db=db_small_thread_pool)
+    await do_reset_registry(db=db_small_thread_pool)
+    return await do_default_branch(db=db_small_thread_pool)
+
+
+@pytest.fixture(scope="module")
+async def car_person_schema_stp(
+    db_small_thread_pool: InfrahubDatabase,
+    default_branch_stp: Branch,
+) -> SchemaBranch:
+    """Register data_schema + node_group_schema + car_person_schema on the small-thread-pool DB."""
+    branch = default_branch_stp
+    do_data_schema(branch=branch)
+    do_group_schema(branch=branch)
+    car_person = do_car_person_schema_unregistered()
+    return registry.schema.register_schema(schema=car_person, branch=branch.name)
+
+
+# ---------------------------------------------------------------------------
+# Test data fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+async def test_data_stp(
+    db_small_thread_pool: InfrahubDatabase,
+    default_branch_stp: Branch,
+    car_person_schema_stp: SchemaBranch,
+) -> None:
+    """Create 1 person with multiple cars on the small-thread-pool DB."""
+    person_schema = car_person_schema_stp.get_node(name="TestPerson")
+    car_schema = car_person_schema_stp.get_node(name="TestCar")
+
+    person = await Node.init(db=db_small_thread_pool, schema=person_schema, branch=default_branch_stp)
+    await person.new(db=db_small_thread_pool, name="John", height=180)
+    await person.save(db=db_small_thread_pool)
+
+    for i in range(NUM_CARS):
+        car = await Node.init(db=db_small_thread_pool, schema=car_schema, branch=default_branch_stp)
+        await car.new(db=db_small_thread_pool, name=f"car{i}", nbr_seats=4, is_electric=True, owner=person)
+        await car.save(db=db_small_thread_pool)
+
+
+async def _run_graphql_query(db: InfrahubDatabase, branch: Branch) -> ExecutionResult:
+    """Run the many-relationship GraphQL query and return the result."""
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    return await graphql(
+        schema=gql_params.schema,
+        source=QUERY_MANY_RELATIONSHIP,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_many_relationship_queries_recover_from_pool_exhaustion(
+    db_small_thread_pool: InfrahubDatabase,
+    default_branch_stp: Branch,
+    test_data_stp: None,
+) -> None:
+    """Test that concurrent GraphQL queries hitting many-relationship resolvers
+    recover from Neo4j server thread pool exhaustion via retry_db_transaction."""
+    num_concurrent = 10
+    results = await asyncio.gather(
+        *[_run_graphql_query(db=db_small_thread_pool, branch=default_branch_stp) for _ in range(num_concurrent)],
+        return_exceptions=True,
+    )
+
+    successful = [r for r in results if not isinstance(r, BaseException) and r.errors is None]
+    assert len(successful) == num_concurrent, (
+        f"Expected all {num_concurrent} queries to succeed, but only {len(successful)} did. "
+        f"Errors: {[r.errors if hasattr(r, 'errors') else str(r) for r in results if r not in successful]}"
+    )
+
+    for result in successful:
+        person_data = result.data["TestPerson"]["edges"][0]["node"]
+        assert person_data["name"]["value"] == "John"
+        assert len(person_data["cars"]["edges"]) == NUM_CARS
+
+
+@pytest.fixture
+def _disable_retries() -> Generator[None, None, None]:
+    """Set retry_limit=1 (no retries) and restore after the test."""
+    original = config.SETTINGS.database.retry_limit
+    config.SETTINGS.database.retry_limit = 1
+    yield
+    config.SETTINGS.database.retry_limit = original
+
+
+@pytest.mark.skip(reason="Reproduction test for issue #8696 - not suitable for CI as it can be flaky")
+@pytest.mark.usefixtures("_disable_retries")
+async def test_concurrent_queries_fail_without_retries(
+    db_small_thread_pool: InfrahubDatabase,
+    default_branch_stp: Branch,
+    test_data_stp: None,
+) -> None:
+    """Test that without retries, concurrent queries on a small thread pool fail
+    with TransientError, proving the retry mechanism is needed."""
+    # Must be significantly higher than thread_pool_max_size to guarantee exhaustion.
+    # Each coroutine makes multiple sequential DB calls; we need enough concurrent
+    # coroutines so the total in-flight DB requests exceed the server's thread pool.
+    num_concurrent = 50
+    results = await asyncio.gather(
+        *[_run_graphql_query(db=db_small_thread_pool, branch=default_branch_stp) for _ in range(num_concurrent)],
+        return_exceptions=True,
+    )
+
+    # Collect TransientError failures: either raw exceptions or GraphQL errors wrapping TransientError
+    transient_failures = []
+    for r in results:
+        if isinstance(r, TransientError):
+            transient_failures.append(r)
+        elif hasattr(r, "errors") and r.errors:
+            for err in r.errors:
+                if isinstance(getattr(err, "original_error", None), TransientError):
+                    transient_failures.append(err.original_error)
+
+    # With thread_pool_max_size=10 and no retries, we expect at least some TransientError failures
+    assert len(transient_failures) > 0, (
+        f"Expected at least one TransientError from thread pool exhaustion, but got none. Results: {results}"
+    )
+
+    expected_message = "There are no available threads to serve this request at the moment"
+    for failure in transient_failures:
+        assert expected_message in str(failure), f"Expected thread pool exhaustion message, got: {failure}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -631,10 +631,7 @@ def do_group_schema(branch: Branch) -> None:
     registry.schema.register_schema(schema=schema, branch=branch.name)
 
 
-@pytest.fixture
-async def car_person_schema_unregistered(
-    db: InfrahubDatabase, node_group_schema: None, data_schema: None
-) -> SchemaRoot:
+def do_car_person_schema_unregistered() -> SchemaRoot:
     schema: dict[str, Any] = {
         "nodes": [
             {
@@ -701,6 +698,13 @@ async def car_person_schema_unregistered(
     }
 
     return SchemaRoot(**schema)
+
+
+@pytest.fixture
+async def car_person_schema_unregistered(
+    db: InfrahubDatabase, node_group_schema: None, data_schema: None
+) -> SchemaRoot:
+    return do_car_person_schema_unregistered()
 
 
 @pytest.fixture

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -20,7 +20,7 @@ def get_exposed_port(container: DockerContainer, port: int) -> int:
     return int(container.get_docker_client().port(container.get_wrapped_container().id, port))
 
 
-def start_neo4j_container(neo4j_image: str) -> DockerContainer:
+def start_neo4j_container(neo4j_image: str, extra_env: dict[str, str] | None = None) -> DockerContainer:
     container = (
         DockerContainer(image=neo4j_image)
         .with_env("NEO4J_AUTH", "neo4j/admin")
@@ -30,6 +30,9 @@ def start_neo4j_container(neo4j_image: str) -> DockerContainer:
         .with_exposed_ports(PORT_BOLT_NEO4J)
         .with_exposed_ports(PORT_HTTP_NEO4J)
     )
+
+    for key, value in (extra_env or {}).items():
+        container = container.with_env(key, value)
 
     container.start()
     wait_for_logs(container, "Started.")  # wait_container_is_ready does not seem to be enough

--- a/backend/tests/unit/test_retry_db_transaction.py
+++ b/backend/tests/unit/test_retry_db_transaction.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from neo4j.exceptions import ClientError, TransientError
+
+from infrahub import config
+from infrahub.database import retry_db_transaction
+from infrahub.database.metrics import TRANSACTION_RETRIES
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def _set_retry_limit() -> Generator[None, None, None]:
+    original_retry_limit = config.SETTINGS.database.retry_limit
+    original_base_delay = config.SETTINGS.database.retry_base_delay
+    original_max_delay = config.SETTINGS.database.retry_max_delay
+    original_jitter_max = config.SETTINGS.database.retry_jitter_max
+
+    config.SETTINGS.database.retry_limit = 3
+    config.SETTINGS.database.retry_base_delay = 0.1
+    config.SETTINGS.database.retry_max_delay = 2.0
+    config.SETTINGS.database.retry_jitter_max = 0.0
+    yield
+    config.SETTINGS.database.retry_limit = original_retry_limit
+    config.SETTINGS.database.retry_base_delay = original_base_delay
+    config.SETTINGS.database.retry_max_delay = original_max_delay
+    config.SETTINGS.database.retry_jitter_max = original_jitter_max
+
+
+@pytest.fixture
+def _set_high_retry_limit() -> Generator[None, None, None]:
+    original = config.SETTINGS.database.retry_limit
+    config.SETTINGS.database.retry_limit = 20
+    yield
+    config.SETTINGS.database.retry_limit = original
+
+
+def _make_transient_error(message: str = "pool exhausted") -> TransientError:
+    return TransientError(message)
+
+
+def _make_client_error(
+    message: str = "not found", code: str = "Neo.ClientError.Statement.EntityNotFound"
+) -> ClientError:
+    exc = ClientError(message)
+    parts = code.split(".")
+    exc._neo4j_code = code
+    exc._classification = parts[1] if len(parts) > 1 else ""
+    exc._category = parts[2] if len(parts) > 2 else ""
+    exc._title = parts[3] if len(parts) > 3 else ""
+    return exc
+
+
+@pytest.mark.usefixtures("_set_retry_limit")
+class TestRetryDbTransactionExponentialBackoff:
+    async def test_no_error_no_retry(self) -> None:
+        mock_fn = AsyncMock(return_value="ok")
+        decorated = retry_db_transaction(name="test_no_retry")(mock_fn)
+
+        result = await decorated()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 1
+
+    async def test_transient_error_triggers_retry(self) -> None:
+        mock_fn = AsyncMock(side_effect=[_make_transient_error(), "ok"])
+        decorated = retry_db_transaction(name="test_transient")(mock_fn)
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            result = await decorated()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+    async def test_client_error_entity_not_found_triggers_retry(self) -> None:
+        mock_fn = AsyncMock(side_effect=[_make_client_error(code="Neo.ClientError.Statement.EntityNotFound"), "ok"])
+        decorated = retry_db_transaction(name="test_entity_not_found")(mock_fn)
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            result = await decorated()
+
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+    async def test_client_error_other_code_raises_immediately(self) -> None:
+        other_error = _make_client_error(message="syntax error", code="Neo.ClientError.Statement.SyntaxError")
+        mock_fn = AsyncMock(side_effect=[other_error])
+        decorated = retry_db_transaction(name="test_other_client_error")(mock_fn)
+
+        with pytest.raises(ClientError, match="syntax error"):
+            await decorated()
+
+        assert mock_fn.call_count == 1
+
+    async def test_retry_exhaustion_raises_final_error(self) -> None:
+        errors = [_make_transient_error(f"error {i}") for i in range(3)]
+        mock_fn = AsyncMock(side_effect=errors)
+        decorated = retry_db_transaction(name="test_exhaustion")(mock_fn)
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock), pytest.raises(TransientError):
+            await decorated()
+
+        assert mock_fn.call_count == 3
+
+    async def test_exponential_backoff_timing(self) -> None:
+        errors = [_make_transient_error(f"error {i}") for i in range(3)]
+        mock_fn = AsyncMock(side_effect=errors)
+        decorated = retry_db_transaction(name="test_backoff")(mock_fn)
+
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(asyncio, "sleep", sleep_mock),
+            patch("infrahub.database.random.uniform", return_value=0.0),
+            pytest.raises(TransientError),
+        ):
+            await decorated()
+
+        # With jitter=0: attempt 1 -> 0.1 * 2^0 = 0.1, attempt 2 -> 0.1 * 2^1 = 0.2
+        # attempt 3 is the last so it breaks after incrementing metrics
+        assert sleep_mock.call_count == 3
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        assert abs(delays[0] - 0.1) < 0.001
+        assert abs(delays[1] - 0.2) < 0.001
+        assert abs(delays[2] - 0.4) < 0.001
+
+    @pytest.mark.usefixtures("_set_high_retry_limit")
+    async def test_max_delay_cap(self) -> None:
+        errors = [_make_transient_error(f"error {i}") for i in range(20)]
+        mock_fn = AsyncMock(side_effect=errors)
+        decorated = retry_db_transaction(name="test_max_delay")(mock_fn)
+
+        sleep_mock = AsyncMock()
+        with (
+            patch.object(asyncio, "sleep", sleep_mock),
+            patch("infrahub.database.random.uniform", return_value=0.0),
+            pytest.raises(TransientError),
+        ):
+            await decorated()
+
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        for delay in delays:
+            assert delay <= 2.0
+
+    async def test_transaction_retries_metric_incremented(self) -> None:
+        metric_name = "test_metric_increment"
+        initial_value = TRANSACTION_RETRIES.labels(metric_name)._value.get()
+
+        mock_fn = AsyncMock(side_effect=[_make_transient_error(), "ok"])
+        decorated = retry_db_transaction(name=metric_name)(mock_fn)
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            await decorated()
+
+        new_value = TRANSACTION_RETRIES.labels(metric_name)._value.get()
+        assert new_value == initial_value + 1
+
+    async def test_functools_wraps_preserves_metadata(self) -> None:
+        async def my_original_function() -> str:
+            """My docstring."""
+            return "ok"
+
+        decorated = retry_db_transaction(name="test_wraps")(my_original_function)
+        assert decorated.__name__ == "my_original_function"  # type: ignore[attr-defined]
+        assert decorated.__doc__ == "My docstring."  # type: ignore[attr-defined]

--- a/changelog/8696.fixed.md
+++ b/changelog/8696.fixed.md
@@ -1,0 +1,1 @@
+Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing backoff retry.

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -98,6 +98,9 @@ The HTTP settings control how Infrahub interacts with external HTTP servers. Thi
 | `INFRAHUB_DB_QUERY_SIZE_LIMIT` | The max number of records to fetch in a single query before performing internal pagination. | integer | 5000 |
 | `INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY` | Maximum number of level to search in a hierarchy. | integer | 5 |
 | `INFRAHUB_DB_RETRY_LIMIT` | Maximum number of times a transient issue in a transaction should be retried. | integer | 3 |
+| `INFRAHUB_DB_RETRY_BASE_DELAY` | Base delay in seconds for exponential backoff on transaction retries. | number | 0.1 |
+| `INFRAHUB_DB_RETRY_MAX_DELAY` | Maximum delay in seconds for exponential backoff on transaction retries. | number | 2.0 |
+| `INFRAHUB_DB_RETRY_JITTER_MAX` | Maximum jitter in seconds added to retry delay to avoid thundering herd. | number | 0.1 |
 | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES` | Maximum number of concurrent queries that can run (0 means unlimited). | integer | 0 |
 | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES_DELAY` | Delay to add when max_concurrent_queries is reached. | number | 0.01 |
 


### PR DESCRIPTION
This PR improves the retry_db_transaction decorator by having a configurable backoff retry.
It also enables the decorator on the graphql query resolvers.

Adds component tests to check the retry behavior solves hard failures
when neo4j thread pool exhausts: we must start a new container with a
low thread pool size.

I had to duplicate a few fixtures to have the new neo4j container working... I'm not very satisfied of the tests, looking for feedback on those. There's also high chance they are flaky... so we probably want to disable them in CI for now.

Fixes https://github.com/opsmill/infrahub/issues/8696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL read operations now automatically retry with exponential backoff and jitter to reduce transient failures.

* **New Features**
  * Three new configurable database retry parameters: base delay, max delay, and jitter.

* **Documentation**
  * Configuration reference updated with the new retry environment variables and defaults.

* **Tests**
  * Added unit and component tests validating retry behavior and backoff timing under contention.

* **Chores**
  * Minor test fixture refactor and changelog entry added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->