### PR TITLE
IFC-2386: Documentation & changelog for local computed attributes

### DIFF
--- a/changelog/+IFC-2273.changed.md
+++ b/changelog/+IFC-2273.changed.md
@@ -1,0 +1,1 @@
+Jinja2 computed attributes are now recalculated immediately when their dependent attributes or relationships change on the same node, eliminating background task overhead for local changes.

--- a/dev/knowledge/backend/architecture.md
+++ b/dev/knowledge/backend/architecture.md
@@ -59,6 +59,7 @@ Similar to pull requests, proposed changes allow reviewing and approving data mo
 - [Events System](events.md) - Event-driven architecture
 - [Async Tasks](async-tasks.md) - Background task processing
 - [Message Bus](message-bus.md) - Inter-service communication
+- [Computed Attributes](computed-attributes.md) - Jinja2 evaluation paths and schema registry
 
 ### Guidelines
 

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -201,3 +201,4 @@ Available dependencies:
 - [Events System](events.md) - Event-driven workflow triggers
 - [Webhooks](webhooks.md) - Primary consumer of events and async tasks
 - [Backend Architecture](architecture.md) - Overall backend structure
+- [Computed Attributes](computed-attributes.md) - Jinja2 local recomputation is inline, not async

--- a/dev/knowledge/backend/computed-attributes.md
+++ b/dev/knowledge/backend/computed-attributes.md
@@ -95,3 +95,9 @@ Key methods:
 | `computed_attribute/models.py` | `ComputedAttrJinja2TriggerDefinition`, `targets_self` property |
 | `computed_attribute/tasks.py` | Prefect task definitions for async recomputation |
 | `computed_attribute/gather.py` | Gathers computed attribute triggers from schema |
+
+## See Also
+
+- [Testing](testing.md) — integration_docker test patterns for computed attributes
+- [Mutations](mutations.md) — where `_recompute_local_jinja2()` fits in the update flow
+- [Display Labels & HFID](display-labels-and-hfid.md) — parallel `_collect_extra_filters()` pattern

--- a/dev/knowledge/backend/computed-attributes.md
+++ b/dev/knowledge/backend/computed-attributes.md
@@ -1,0 +1,97 @@
+# Computed Attributes (Jinja2)
+
+> Part of: `dev/knowledge/backend/` | Related: [display-labels-and-hfid.md](display-labels-and-hfid.md), [mutations.md](mutations.md)
+
+Jinja2 computed attributes are schema-defined attributes whose values are derived from other attributes or relationships on the same or related nodes. They use Jinja2 templates for rendering.
+
+## Evaluation Paths
+
+There are three distinct paths for evaluating computed attributes, depending on when and where the triggering change occurs.
+
+### 1. Creation — Inline via `_process_macros()`
+
+**When**: A new node is created (`Node.new()` → `_process_fields()` → `_process_macros()`)
+
+All mandatory Jinja2 computed attributes are evaluated synchronously during node creation. The method iterates over `_computed_jinja2_attributes`, renders each template with resolved variables, and sets the attribute value via a generator method (`_generate_attribute_default` or a custom `generate_<name>`).
+
+Optional computed attributes are **not** evaluated inline at creation — they are handled asynchronously via Prefect (path 3).
+
+### 2. Local Update — Inline via `_recompute_local_jinja2()`
+
+**When**: An existing node is updated and the changed fields include dependencies of a computed attribute on the **same node**.
+
+During `Node._update()`, after persisting attribute and relationship changes, `_recompute_local_jinja2()` is called. It:
+
+1. Queries `schema_branch.computed_attributes.get_local_jinja2_targets()` to find self-targeting computed attributes whose dependencies overlap with the changed fields
+2. Returns targets in **dependency order** — if computed attribute `fqdn` depends on `label`, and `label` depends on `name`, updating `name` recomputes `label` first, then `fqdn`
+3. For each target, renders the Jinja2 template, validates the result, and persists it
+4. Tracks failed attributes to prevent cascading from broken computations
+
+This path eliminates background task overhead for local changes and provides immediate results in mutation responses.
+
+### 3. Remote Update — Async via Prefect
+
+**When**: A peer node's attribute changes, affecting a computed attribute on a different node (e.g., changing a device's `role.name` triggers recomputation of the device's `label` which references `{{ role__name__value }}`).
+
+These changes are handled by Prefect background tasks triggered by `NodeCreatedEvent` / attribute change events. The async path uses `ComputedAttrJinja2TriggerDefinition` to match events to affected computed attributes.
+
+## Self-Targeting Filter (`targets_self`)
+
+`ComputedAttrJinja2TriggerDefinition` has a `targets_self` property that returns `True` when `trigger_kind == computed_attribute.kind` — meaning the trigger node kind is the same as the node kind owning the computed attribute.
+
+The async Prefect path **skips** triggers where `targets_self is True`, because those are already handled synchronously by `_recompute_local_jinja2()` during the update mutation. This prevents duplicate computation.
+
+## Extra Filters for Relationship Peers
+
+**Location**: `Node._collect_extra_filters()` in `core/node/__init__.py`
+
+When a computed attribute template references peer attributes (e.g., `{{ role__name__value }}`), those attributes must be loaded during `resolve_relationships()`. The `_collect_extra_filters()` method reads `relationship_fields` from three sources:
+
+```
+_collect_extra_filters(schema_branch)
+  -> HFID relationship fields       (for new nodes or when HFID is set)
+  -> Display label relationship fields (for new nodes or when display_label is set)
+  -> Computed attribute relationship fields (for existing nodes / updates)
+       via schema_branch.computed_attributes.get_registered_jinja2_node()
+```
+
+The computed attribute source is gated by `self._existing` — it only applies during updates, not creation (creation uses `_process_macros()` which resolves its own variables).
+
+## Schema Registration
+
+**Location**: `core/schema/schema_branch_computed/`
+
+The `ComputedAttributes` facade on `SchemaBranch` maintains a registry of Jinja2 computed attributes per node kind. Registration happens during schema processing via `register_computed_jinja2()`.
+
+Each registered node stores:
+
+- **`local_fields`**: Attribute dependencies on the same node (e.g., `{"name", "label"}`)
+- **`relationship_fields`**: Map of relationship name → peer attribute names (e.g., `{"role": {"name"}}`)
+- **Local dependency graph**: Tracks which computed attributes depend on other computed attributes on the same node, enabling correct evaluation order
+
+Key methods:
+
+| Method | Purpose |
+|--------|---------|
+| `get_registered_jinja2_node(kind)` | Returns the registered node definition for a kind |
+| `get_local_jinja2_targets(kind, updates)` | Returns self-targeting targets whose dependencies overlap with changed fields, in dependency order |
+
+## Lifecycle Summary
+
+| Event | Path | Method | Scope |
+|-------|------|--------|-------|
+| Node creation (mandatory attrs) | Inline | `_process_macros()` | All mandatory computed attrs |
+| Node creation (optional attrs) | Async | Prefect task | Optional computed attrs |
+| Local attribute/relationship change | Inline | `_recompute_local_jinja2()` | Self-targeting computed attrs |
+| Remote peer attribute change | Async | Prefect task | Cross-node computed attrs |
+
+## Key Files
+
+| File | What |
+|------|------|
+| `core/node/__init__.py` | `_process_macros()`, `_recompute_local_jinja2()`, `_collect_extra_filters()` |
+| `core/schema/schema_branch_computed/facade.py` | `ComputedAttributes` facade, `get_local_jinja2_targets()` |
+| `core/schema/schema_branch_computed/jinja2.py` | `RegisteredNodeComputedAttribute`, dependency ordering |
+| `computed_attribute/models.py` | `ComputedAttrJinja2TriggerDefinition`, `targets_self` property |
+| `computed_attribute/tasks.py` | Prefect task definitions for async recomputation |
+| `computed_attribute/gather.py` | Gathers computed attribute triggers from schema |

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -67,7 +67,7 @@ True distributed tests with multiple Docker containers running the full Infrahub
 - Slowest but most realistic testing
 - Tests real distributed behavior
 
-**When to use:** Testing behavior that requires actual distributed execution, like computed attributes, triggered actions, or schema migrations in production-like environments.
+**When to use:** Testing behavior that requires actual distributed execution, like [computed attributes](computed-attributes.md), triggered actions, or schema migrations in production-like environments.
 
 ```python
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
@@ -6,7 +6,8 @@ assigned_to: ""
 agent: ""
 acceptance_criteria: "Knowledge docs updated; changelog fragment added; existing test suite passes"
 activity_log:
-  - "2026-03-27T14:15:54Z: planned -> done"
+  - "2026-03-27T14:15:54Z: planned -> doing"
+  - "2026-03-30T00:00:00Z: doing -> done"
 ---
 
 # Work Package WP06: Documentation & Polish

--- a/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
+++ b/dev/spec-kitty/work-packages/ifc-2273-local-computation-jinja2/WP06.md
@@ -1,11 +1,12 @@
 ---
 id: WP06
-lane: planned
+lane: doing
 feature: ifc-2273-local-computation-jinja2
 assigned_to: ""
 agent: ""
 acceptance_criteria: "Knowledge docs updated; changelog fragment added; existing test suite passes"
 activity_log:
+  - "2026-03-27T14:15:54Z: planned -> done"
 ---
 
 # Work Package WP06: Documentation & Polish

--- a/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
+++ b/dev/specs/ifc-2273-local-computation-jinja2/tasks.md
@@ -120,9 +120,9 @@
 
 **Purpose**: Documentation, knowledge base updates, and changelog.
 
-- [ ] T020 [P] Update `dev/knowledge/backend/` with computed attribute local computation documentation — add a section to an existing knowledge doc or create `dev/knowledge/backend/computed-attributes.md` covering the dual evaluation path (inline for local, Prefect for remote), the `_recompute_local_jinja2()` method, and the `_collect_extra_filters()` extension
-- [ ] T021 [P] Add towncrier changelog fragment in `changelog/` for the user-facing improvement: computed attributes now update immediately on local changes
-- [ ] T022 Run existing computed attribute test suite to verify no regressions: `uv run invoke backend.test-unit -- -k computed_attribute`
+- [X] T020 [P] Update `dev/knowledge/backend/` with computed attribute local computation documentation — add a section to an existing knowledge doc or create `dev/knowledge/backend/computed-attributes.md` covering the dual evaluation path (inline for local, Prefect for remote), the `_recompute_local_jinja2()` method, and the `_collect_extra_filters()` extension
+- [X] T021 [P] Add towncrier changelog fragment in `changelog/` for the user-facing improvement: computed attributes now update immediately on local changes
+- [X] T022 Run existing computed attribute test suite to verify no regressions: `uv run invoke backend.test-unit -- -k computed_attribute`
 
 ---
 


### PR DESCRIPTION
# Why

[IFC-2386](https://opsmill.atlassian.net/browse/IFC-2386) — The local Jinja2 computed attribute feature (IFC-2273) needs knowledge documentation and a changelog fragment before merge.

## What changed

- **Knowledge doc**: Added `dev/knowledge/backend/computed-attributes.md` covering the dual evaluation path (inline for local, Prefect for remote), `_recompute_local_jinja2()`, `_collect_extra_filters()`, schema registration, and lifecycle summary.
- **Cross-references**: Updated `architecture.md` and `async-tasks.md` with links to the new doc; linked from `testing.md` inline.
- **Changelog fragment**: Added `changelog/+IFC-2273.changed.md` describing the user-facing improvement.

## How to review

1. `dev/knowledge/backend/computed-attributes.md` — main content

## How to test

```bash
uv run invoke docs.lint
```

## Checklist

- [x] Changelog entry added
- [x] Internal .md docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2386]: https://opsmill.atlassian.net/browse/IFC-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Jinja2 computed attributes now recalculate immediately when dependent attributes or relationships change on the same node, eliminating background-task processing overhead for local updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->