### PR TITLE
transforms --> transformations

### DIFF
--- a/docs/docs/overview/explore.mdx
+++ b/docs/docs/overview/explore.mdx
@@ -79,7 +79,7 @@ A bundle is an end-to-end reference implementation you can actually learn from. 
 - Containerlab integration — deploy to a virtual lab and actually test your configurations
 - Service Catalog — simplified provisioning for when clicking buttons is preferable to YAML
 
-<ReferenceLink title="Bundle DC" url="$(base_url)bundle-dc" openInNewTab />
+<ReferenceLink title="Demo DC" url="$(base_url)demo-dc" openInNewTab />
 
 - **Demo Service Catalog**
 

--- a/docs/docs/release-notes/infrahub/release-0_11.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_11.mdx
@@ -61,9 +61,9 @@ For now it is still required to rebuild the database between Infrahub versions a
 
 A new landing page is available to get more informations about Infrahub and its integrations. Links to the documentation are available for the main features and some help is available to get started with the product.
 
-### Renaming of Jinja2 Transforms
+### Renaming of Jinja2 Transformations
 
-The new name for Jinja2 rendered content is Jinja2 Transforms. The previous name "rfile" will no longer be used.
+The new name for Jinja2 rendered content is Jinja2 Transformations. The previous name "rfile" will no longer be used.
 
 ### Performance improvements
 

--- a/docs/docs/release-notes/infrahub/release-0_9.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_9.mdx
@@ -50,7 +50,7 @@ With the redesigned storage engine it's now possible to store artefacts in AWS S
 
 ## Extend IPHost and IPNetwork types
 
-Instead of just returning the ip interface (i.e., 172.16.1.1/24) or the ip network (i.e., 172.16.1.0/24) Infrahub now exposes additional options aside from value so you can query for ip, prefix_len, netmask etc. This should simplify some tasks when creating Jinja templates or Transforms.
+Instead of just returning the ip interface (i.e., 172.16.1.1/24) or the ip network (i.e., 172.16.1.0/24) Infrahub now exposes additional options aside from value so you can query for ip, prefix_len, netmask etc. This should simplify some tasks when creating Jinja templates or Transformations.
 
 ## Add markdown editor for textarea fields
 

--- a/docs/docs/topics/architecture.mdx
+++ b/docs/docs/topics/architecture.mdx
@@ -70,7 +70,7 @@ graph TB
         subgraph "Artifact System"
             ArtifactDef[Artifact Definitions]
             Templates[Jinja2 Templates]
-            Transforms[Transform Functions]
+            Transformations[Transform Functions]
             Generator[Artifact Generator]
         end
     end
@@ -146,9 +146,9 @@ graph TB
     %% Artifact Generation Flow
     Workers --> ArtifactDef
     ArtifactDef --> Templates
-    ArtifactDef --> Transforms
+    ArtifactDef --> Transformations
     Templates --> Generator
-    Transforms --> Generator
+    Transformations --> Generator
     Generator --> DBAdapter
     Generator --> StorageAdapter
     StorageAdapter --> Storage
@@ -178,7 +178,7 @@ graph TB
 
     class Client,GitRepo,ExtAuth external
     class UI,API presentation
-    class Schema,Branch,Node,Perm,Valid,Prefect,TaskManager,Workers,EventBus,Triggers,Actions,ArtifactDef,Templates,Transforms,Generator application
+    class Schema,Branch,Node,Perm,Valid,Prefect,TaskManager,Workers,EventBus,Triggers,Actions,ArtifactDef,Templates,Transformations,Generator application
     class GraphDB,TaskDB,Redis,MessageBus,Storage,Artifacts data
     class DBAdapter,CacheAdapter,MsgAdapter,StorageAdapter service
 ```

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -58,7 +58,7 @@ If you prefer to create your Infrahub repository manually, use the following fol
 │   └── integration
 │       ├── conftest.py
 │       └── test_infrahub.py
-├── transforms
+├── transformations
 │   └── templates
 └── uv.lock
 ```

--- a/docs/docs/topics/graphql.mdx
+++ b/docs/docs/topics/graphql.mdx
@@ -255,7 +255,7 @@ Stored GraphQL queries can be executed by using the `/api/query/{query_id}` REST
 
 ## Single-target query pattern
 
-When writing GraphQL queries for [transforms](./transformation.mdx), [generators](./generator.mdx), [artifacts](./artifact.mdx), and [computed attributes](./computed-attributes.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.
+When writing GraphQL queries for [transformations](./transformation.mdx), [generators](./generator.mdx), [artifacts](./artifact.mdx), and [computed attributes](./computed-attributes.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.
 
 ### What is a single-target query?
 
@@ -419,8 +419,8 @@ It's planned to add more integrated checks in the future to streamline the devel
 
 Single-target queries are **required** for:
 
-- **Python transforms** - See [Creating a Python transform](../guides/python-transform.mdx)
-- **Jinja2 transforms** - See [Creating a Jinja transform](../guides/jinja2-transform.mdx)
+- **Python transformations** - See [Creating a Python transformation](../guides/python-transform.mdx)
+- **Jinja2 transformations** - See [Creating a Jinja transformation](../guides/jinja2-transform.mdx)
 - **Generators** - See [Generators](./generator.mdx)
 - **Artifact definitions** - See [Artifacts](./artifact.mdx)
 - **Computed attributes** - See [Computed attributes](./computed-attributes.mdx)

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -34,7 +34,7 @@ A proposed change in Infrahub offers a more sophisticated approach by integratin
 - **Data differences**: See precisely what objects were added, modified, or deleted, along with the specific attribute changes.
 - **Schema differences**: Identify changes to the underlying data models that define your infrastructure.
 - **File differences**: Track modifications to implementation files like Transformations, generators, and templates.
-- **File differences**: Track modifications to implementation files like transforms, Generators, and templates.
+- **File differences**: Track modifications to implementation files like transformations, Generators, and templates.
 - **Artifact differences**: Compare the [artifacts](artifact) generated to understand output changes.
 
 ![Data tab showing differences between branches](../media/topics/proposed_change/pc_tab_data.png)

--- a/docs/docs/topics/resources-testing-framework.mdx
+++ b/docs/docs/topics/resources-testing-framework.mdx
@@ -72,7 +72,7 @@ jinja2_transforms:
 python_transforms:
   - name: mpls_l2circuit_report
     class_name: L2Circuit
-    file_path: transforms/mpls_services.py"
+    file_path: transformations/mpls_services.py"
 ```
 
 To tests all of these resources, we will write YAML formatted text in a file located at `tests/test_all.yml`. Test file names must start with the `test_` prefix in order to be detected and parsed.


### PR DESCRIPTION
Style guide cleanup: transforms --> transformations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation terminology to consistently use "Transformations" instead of "Transforms" across release notes, architecture guides, developer resources, and API documentation for improved clarity and naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->