### PR TITLE
Exclude fields with display "extra" from object list view table

### DIFF
--- a/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.test.ts
@@ -60,6 +60,21 @@ describe("getAttributesVisibleInListView", () => {
     expect(result).toEqual([]);
   });
 
+  it("should exclude attributes with display 'extra' even if kind is valid", () => {
+    // GIVEN
+    const attributes: AttributeSchema[] = [
+      generateAttributeSchema({ name: "visible", kind: "Text", label: "Visible", display: "default" }),
+      generateAttributeSchema({ name: "hidden", kind: "Text", label: "Hidden", display: "extra" }),
+      generateAttributeSchema({ name: "also_visible", kind: "Number", label: "Also Visible" }),
+    ];
+
+    // WHEN
+    const result = getAttributesVisibleInListView(attributes);
+
+    // THEN
+    expect(result.map((attr) => attr.name)).toEqual(["visible", "also_visible"]);
+  });
+
   it("should handle attributes with missing kind", () => {
     // GIVEN
     const attributes = [

--- a/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.test.ts
@@ -63,7 +63,12 @@ describe("getAttributesVisibleInListView", () => {
   it("should exclude attributes with display 'extra' even if kind is valid", () => {
     // GIVEN
     const attributes: AttributeSchema[] = [
-      generateAttributeSchema({ name: "visible", kind: "Text", label: "Visible", display: "default" }),
+      generateAttributeSchema({
+        name: "visible",
+        kind: "Text",
+        label: "Visible",
+        display: "default",
+      }),
       generateAttributeSchema({ name: "hidden", kind: "Text", label: "Hidden", display: "extra" }),
       generateAttributeSchema({ name: "also_visible", kind: "Number", label: "Also Visible" }),
     ];

--- a/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-attributes-visible-in-list-view.ts
@@ -3,6 +3,9 @@ import type { AttributeKind, AttributeSchema } from "@/entities/schema/types";
 
 export function getAttributesVisibleInListView(attributes: AttributeSchema[]): AttributeSchema[] {
   return attributes.filter((attribute) => {
-    return ATTRIBUTE_KINDS_FOR_LIST_VIEW.includes(attribute.kind as AttributeKind);
+    return (
+      attribute.display !== "extra" &&
+      ATTRIBUTE_KINDS_FOR_LIST_VIEW.includes(attribute.kind as AttributeKind)
+    );
   });
 }

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.test.ts
@@ -39,8 +39,16 @@ describe("getRelationshipsVisibleInListView", () => {
 
   it("should exclude relationships with display 'extra' even if kind is valid", () => {
     // GIVEN
-    const visible = generateRelationshipSchema({ kind: "Attribute", cardinality: "one", display: "default" });
-    const hidden = generateRelationshipSchema({ kind: "Attribute", cardinality: "one", display: "extra" });
+    const visible = generateRelationshipSchema({
+      kind: "Attribute",
+      cardinality: "one",
+      display: "default",
+    });
+    const hidden = generateRelationshipSchema({
+      kind: "Attribute",
+      cardinality: "one",
+      display: "extra",
+    });
     const alsoVisible = generateRelationshipSchema({ kind: "Parent", cardinality: "one" });
 
     // WHEN

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.test.ts
@@ -37,6 +37,19 @@ describe("getRelationshipsVisibleInListView", () => {
     expect(result).toEqual([attributeOne, attributeMany, hierarchyOne, parentOne, parentMany]);
   });
 
+  it("should exclude relationships with display 'extra' even if kind is valid", () => {
+    // GIVEN
+    const visible = generateRelationshipSchema({ kind: "Attribute", cardinality: "one", display: "default" });
+    const hidden = generateRelationshipSchema({ kind: "Attribute", cardinality: "one", display: "extra" });
+    const alsoVisible = generateRelationshipSchema({ kind: "Parent", cardinality: "one" });
+
+    // WHEN
+    const result = getRelationshipsVisibleInListView([visible, hidden, alsoVisible]);
+
+    // THEN
+    expect(result).toEqual([visible, alsoVisible]);
+  });
+
   it("should return empty array when no relationships are provided", () => {
     // WHEN
     const result = getRelationshipsVisibleInListView([]);

--- a/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationships-visible-in-list-view.ts
@@ -5,6 +5,8 @@ export function getRelationshipsVisibleInListView(
   relationships: RelationshipSchema[]
 ): RelationshipSchema[] {
   return relationships.filter((relationship) => {
+    if (relationship.display === "extra") return false;
+
     switch (relationship.kind) {
       case "Attribute":
       case "Parent":


### PR DESCRIPTION
Why

Fields marked with display: "extra" in the schema should not appear in the object list view table.

  What changed

  - Attributes and relationships with display: "extra" are now excluded from list view table columns.
    - getAttributesVisibleInListView checks attribute.display !== "extra" before the kind filter
    - getRelationshipsVisibleInListView rejects relationship.display === "extra" before the kind/cardinality switch

  How to review

  Two small source files and their corresponding test files — the logic is a single condition added to each filter function.

  How to test

define a schema with an attribute or relationship set to display: "extra", navigate to the object list view, and confirm the field no longer appears as a table column

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide fields with `display: "extra"` from the object list view table so only primary fields show. This aligns the table with schema display rules.

- **Bug Fixes**
  - Exclude attributes with `display: "extra"` before kind filtering in `getAttributesVisibleInListView`.
  - Exclude relationships with `display: "extra"` before kind/cardinality checks in `getRelationshipsVisibleInListView`.
  - Added tests and lint fixes for both attribute and relationship exclusions.

<sup>Written for commit 095f86b19a6357a303e4d3e53763fcf11cc557d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

