### PR TITLE
Artifact cascade delete

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/artifact.py
+++ b/backend/infrahub/core/schema/definitions/core/artifact.py
@@ -3,6 +3,7 @@ from infrahub.core.constants import (
     BranchSupportType,
     ContentType,
     InfrahubKind,
+    RelationshipDeleteBehavior,
 )
 from infrahub.core.constants import RelationshipCardinality as Cardinality
 from infrahub.core.constants import RelationshipKind as RelKind
@@ -28,6 +29,7 @@ core_artifact_target = GenericSchema(
             cardinality=Cardinality.MANY,
             kind=RelKind.GENERIC,
             identifier="artifact__node",
+            on_delete=RelationshipDeleteBehavior.CASCADE,
         ),
     ],
 )

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -5,7 +5,7 @@ from infrahub_sdk import InfrahubClient
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import BranchSupportType, RelationshipDeleteBehavior
+from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipDeleteBehavior
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -492,3 +492,61 @@ async def test_delete_branch_aware_node_with_agnostic_relationship(
     assert device_ids_on_branch3 == [device_id], (
         "Location's devices relationship SHOULD include the device on branch3 after device deleted on branch2"
     )
+
+
+async def test_delete_cascade_artifacts(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_data_generic: dict[str, Node],
+) -> None:
+    """Deleting a CoreArtifactTarget node must cascade-delete its associated artifacts."""
+    c1 = car_person_data_generic["c1"]
+    q1 = car_person_data_generic["q1"]
+    r1 = car_person_data_generic["r1"]
+
+    group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await group.new(db=db, name="artifact-target-group", members=[c1])
+    await group.save(db=db)
+
+    transform = await Node.init(db=db, schema=InfrahubKind.TRANSFORMPYTHON)
+    await transform.new(
+        db=db,
+        name="transform-cascade-test",
+        query=str(q1.id),
+        repository=str(r1.id),
+        file_path="transform.py",
+        class_name="Transform",
+    )
+    await transform.save(db=db)
+
+    definition = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await definition.new(
+        db=db,
+        name="artifactdef-cascade-test",
+        targets=group,
+        transformation=transform,
+        content_type="application/json",
+        artifact_name="cascade-artifact",
+        parameters={},
+    )
+    await definition.save(db=db)
+
+    artifact = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await artifact.new(
+        db=db,
+        name="cascade-artifact",
+        definition=definition,
+        status="Ready",
+        object=c1,
+        storage_id="00000000-0000-0000-0000-000000000001",
+        checksum="abc123",
+        content_type="application/json",
+    )
+    await artifact.save(db=db)
+
+    deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[c1])
+
+    assert c1.id in {d.id for d in deleted}
+    assert artifact.id in {d.id for d in deleted}
+    node_map = await NodeManager.get_many(db=db, ids=[c1.id, artifact.id])
+    assert node_map == {}

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -527,7 +527,7 @@ async def test_delete_cascade_artifacts(
         transformation=transform,
         content_type="application/json",
         artifact_name="cascade-artifact",
-        parameters={},
+        parameters={"value": {"name": "name__value"}},
     )
     await definition.save(db=db)
 

--- a/changelog/8735.fixed.md
+++ b/changelog/8735.fixed.md
@@ -1,0 +1,1 @@
+Deleting a node that inherits from `CoreArtifactTarget` now automatically deletes its associated artifacts.

--- a/docs/docs/topics/artifact.mdx
+++ b/docs/docs/topics/artifact.mdx
@@ -71,3 +71,7 @@ nodes:
     namespace: "Infra"
     inherit_from: ["CoreArtifactTarget"]
 ```
+
+:::warning Deletion behavior
+When a `CoreArtifactTarget` node is deleted, all artifacts associated with it are automatically deleted as well.
+:::


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically delete artifacts when their `CoreArtifactTarget` node is removed, preventing orphaned artifacts and keeping data consistent.

- **Bug Fixes**
  - Set `on_delete=RelationshipDeleteBehavior.CASCADE` on the `artifact__node` relationship for `CoreArtifact`.
  - Added and fixed a unit test to verify cascade deletion via `NodeManager.delete` (target and its artifacts are removed).
  - Updated docs to note the cascade deletion behavior.

<sup>Written for commit 1ebb55b33cb97288cba2e2c29945e19a8d57a100. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

