### PR TITLE
IFC-2411: Pass user_id to HFID and display label saves

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -802,6 +802,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         fields: set[str] | None,
         node_changelog: NodeChangelog,
         update_at: Timestamp,
+        user_id: str,
     ) -> None:
         """Recompute the human-friendly ID if one of its variables was updated."""
         if not self._human_friendly_id:
@@ -811,7 +812,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         await self._human_friendly_id.compute(db=db, node=self)
         updated_attribute = await self._human_friendly_id.get_node_attribute(node=self, at=update_at).save(
-            at=update_at, db=db
+            at=update_at, db=db, user_id=user_id
         )
         if updated_attribute:
             node_changelog.add_attribute(attribute=updated_attribute)
@@ -822,6 +823,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         fields: set[str] | None,
         node_changelog: NodeChangelog,
         update_at: Timestamp,
+        user_id: str,
     ) -> None:
         """Recompute the display label if one of its variables was updated."""
         if not self._display_label:
@@ -832,7 +834,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         await self._display_label.compute(db=db, node=self)
         self._display_label.get_node_attribute(node=self, at=update_at).get_create_data(node_schema=self._schema)
         updated_attribute = await self._display_label.get_node_attribute(node=self, at=update_at).save(
-            at=update_at, db=db
+            at=update_at, db=db, user_id=user_id
         )
         if updated_attribute:
             node_changelog.add_attribute(attribute=updated_attribute)
@@ -1063,10 +1065,12 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if fields is not None:
             updated_fields = set(fields) | set(node_changelog.updated_fields)
         # Recompute the human-friendly ID if one of its variables was updated
-        await self._recompute_hfid(db=db, fields=updated_fields, node_changelog=node_changelog, update_at=update_at)
+        await self._recompute_hfid(
+            db=db, fields=updated_fields, node_changelog=node_changelog, update_at=update_at, user_id=user_id
+        )
         # Recompute the display label if one of its variables was updated
         await self._recompute_display_label(
-            db=db, fields=updated_fields, node_changelog=node_changelog, update_at=update_at
+            db=db, fields=updated_fields, node_changelog=node_changelog, update_at=update_at, user_id=user_id
         )
 
         node_changelog.display_label = await self.get_display_label(db=db)


### PR DESCRIPTION
# Why

When recomputing HFID and display label during node updates, `_recompute_hfid()` and `_recompute_display_label()` don't pass `user_id` to the attribute `.save()` calls. This records derived-field writes under the save default instead of the actual mutating user.

Resolves [IFC-2411](https://opsmill.atlassian.net/browse/IFC-2411)

## What changed

- Added `user_id: str` parameter to `_recompute_hfid()` and `_recompute_display_label()`
- Forward `user_id` to the `.save()` calls in both methods
- Updated the call sites in `_update()` to pass `user_id` through

No schema changes. No API contract changes.

## How to review

Single file change in `backend/infrahub/core/node/__init__.py` — follows the same pattern already used in `_recompute_local_jinja2()`.

## How to test

```bash
uv run invoke backend.test-unit
```

## Checklist

- [ ] Tests added/updated
- [ ] I have reviewed AI generated content

[IFC-2411]: https://opsmill.atlassian.net/browse/IFC-2411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes user_id to HFID and display label recomputation saves so derived-field writes are attributed to the mutating user. Updates _recompute_hfid and _recompute_display_label to accept user_id and forwards it from _update, satisfying IFC-2411.

<sup>Written for commit 32bc17979c35b5450a7201984a9b5b17959fc0d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

