### PR TITLE
Clean up redundant get global permission call

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -469,10 +469,6 @@ exports[`fix ts error`] = {
     "src/pages/resource-manager/resource-pool-details.tsx:3316738274": [
       [159, 72, 4, "tsc: Property \'node\' does not exist on type \'NodeAttributeWithMetadata | NodeRelationshipManyWithMetadata | NodeRelationshipOneWithMetadata | string | string[]\'.\\n  Property \'node\' does not exist on type \'string\'.", "2087865285"]
     ],
-    "src/pages/role-management/index.tsx:30111790": [
-      [21, 28, 10, "tsc: Property \'statusCode\' does not exist on type \'Error | ServerError | ServerParseError\'.\\n  Property \'statusCode\' does not exist on type \'Error\'.", "3382497788"],
-      [22, 46, 6, "tsc: Property \'result\' does not exist on type \'Error | ServerError | ServerParseError\'.\\n  Property \'result\' does not exist on type \'Error\'.", "2123807084"]
-    ],
     "src/shared/api/graphql/graphqlClientApollo.tsx:4179510492": [
       [56, 33, 44, "tsc: Not all code paths return a value.", "2633054574"]
     ],

--- a/frontend/app/src/entities/permission/queries/getObjectPermissions.ts
+++ b/frontend/app/src/entities/permission/queries/getObjectPermissions.ts
@@ -3,7 +3,7 @@ import { jsonToGraphQLQuery } from "json-to-graphql-query";
 export const getObjectPermissionsQuery = (kind: string) => {
   const request = {
     query: {
-      __name: "getObjectPermissions",
+      __name: `getObjectPermissions_${kind}`,
       [kind]: {
         permissions: {
           edges: {

--- a/frontend/app/src/pages/role-management/index.tsx
+++ b/frontend/app/src/pages/role-management/index.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from "react-router";
+
 import Content from "@/shared/components/layout/content";
+
 import { RoleManagementNavigation } from "@/entities/role-manager/ui";
 
 export function Component() {

--- a/frontend/app/src/pages/role-management/index.tsx
+++ b/frontend/app/src/pages/role-management/index.tsx
@@ -1,33 +1,8 @@
-import { gql } from "@apollo/client";
 import { Outlet } from "react-router";
-
-import useQuery from "@/shared/api/graphql/useQuery";
-import ErrorScreen from "@/shared/components/errors/error-screen";
-import UnauthorizedScreen from "@/shared/components/errors/unauthorized-screen";
 import Content from "@/shared/components/layout/content";
-import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
-import { GLOBAL_PERMISSION_OBJECT } from "@/shared/config/constants";
-
-import { getObjectPermissionsQuery } from "@/entities/permission/queries/getObjectPermissions";
 import { RoleManagementNavigation } from "@/entities/role-manager/ui";
 
-function RoleManagement() {
-  const { loading, error } = useQuery(gql(getObjectPermissionsQuery(GLOBAL_PERMISSION_OBJECT)));
-
-  if (loading) {
-    return <LoadingIndicator message="Checking permissions..." className="h-full" />;
-  }
-
-  if (error) {
-    if (error.networkError?.statusCode === 403) {
-      const { message } = error.networkError?.result?.errors?.[0] ?? {};
-
-      return <UnauthorizedScreen message={message} />;
-    }
-
-    return <ErrorScreen message="Something went wrong when fetching the permissions." />;
-  }
-
+export function Component() {
   return (
     <Content.Card>
       <Content.CardTitle
@@ -41,8 +16,4 @@ function RoleManagement() {
       <Outlet />
     </Content.Card>
   );
-}
-
-export function Component() {
-  return <RoleManagement />;
 }


### PR DESCRIPTION
Why

The role management page made a redundant getObjectPermissions query for global permissions on mount. This query served no functional purpose, its result was never used to gate access or drive UI logic beyond a loading/error screen that duplicated handling already present elsewhere.

 What changed

  - Removed unused global permission query from the role management page (role-management/index.tsx), along with its loading/error handling that was effectively dead code
  - Simplified Component export by collapsing the wrapper RoleManagement component directly into the route Component
  - Made permission query names unique per kind (getObjectPermissions_${kind}) to avoid Apollo cache collisions when querying permissions for different object types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant global permissions fetch on the role management page and simplified the route component. Also set unique operation names per object kind to prevent Apollo cache collisions.

- **Refactors**
  - Removed the unused global permission query and its loading/error screens in `role-management/index.tsx`, and cleaned up unused imports + stale `.betterer.results` entries.
  - Inlined the wrapper `RoleManagement` component into the route `Component`.

- **Bug Fixes**
  - Set GraphQL operation names to `getObjectPermissions_${kind}` to avoid Apollo cache collisions between different object kinds.

<sup>Written for commit fe2449d539ecc2905d45190bba209ee2722e4adb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

