### PR TITLE
IFC-2413: Fix shared state mutation in get_targets()

### DIFF
--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -109,7 +109,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
 
             for entry in entries:
                 if entry.key_name not in targets:
-                    targets[entry.key_name] = entry
+                    targets[entry.key_name] = entry.model_copy(deep=True)
 
         for relationship_name, dep in self.relationship_dependencies.items():
             for entry in dep.targets:


### PR DESCRIPTION
# Why

While refactoring the code during the PR about Python/Jinja2 concerns separation (see https://github.com/opsmill/infrahub/pull/8681#discussion_r2979758763), CodeRabbit made a good remark about an object which were shared and directly referenced in the `get_targets()` method.
This isn't an issue at the moment, but if we end up using this method multiple times, it could become one.

Closes [IFC-2413](https://opsmill.atlassian.net/browse/IFC-2413)

[IFC-2413]: https://opsmill.atlassian.net/browse/IFC-2413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ