### PR TITLE
fix: guard Import latest commit for read-only repositories only

### DIFF
--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -12,6 +12,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreReadOnlyRepository
 from infrahub.core.registry import registry
 from infrahub.core.schema import NodeSchema
+from infrahub.exceptions import ValidationError
 from infrahub.git.models import (
     GitReadOnlyRepositoryImportCommit,
     GitRepositoryImportObjects,
@@ -251,7 +252,7 @@ class ReadOnlyRepositoryImportLastCommit(Mutation):
         )
 
         if repo.get_kind() != InfrahubKind.READONLYREPOSITORY:
-            raise ValueError(
+            raise ValidationError(
                 f"Node {data.id} is a {repo.get_kind()}, not a {InfrahubKind.READONLYREPOSITORY}. "
                 "Import latest commit is only supported for read-only repositories."
             )

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -250,6 +250,12 @@ class ReadOnlyRepositoryImportLastCommit(Mutation):
             branch=branch,
         )
 
+        if repo.get_kind() != InfrahubKind.READONLYREPOSITORY:
+            raise ValueError(
+                f"Node {data.id} is a {repo.get_kind()}, not a {InfrahubKind.READONLYREPOSITORY}. "
+                "Import latest commit is only supported for read-only repositories."
+            )
+
         model = GitReadOnlyRepositoryImportCommit(
             repository_id=repository_id,
             repository_name=str(repo.name.value),

--- a/backend/tests/component/graphql/mutations/test_repository.py
+++ b/backend/tests/component/graphql/mutations/test_repository.py
@@ -203,7 +203,7 @@ async def test_import_last_commit_rejects_non_read_only_repository(
     )
 
     assert result.errors
-    assert "not a CoreReadOnlyRepository" in result.errors[0]["message"]
+    assert "not a CoreReadOnlyRepository" in str(result.errors[0].message)
 
 
 async def test_import_read_only_repository_last_commit(

--- a/backend/tests/component/graphql/mutations/test_repository.py
+++ b/backend/tests/component/graphql/mutations/test_repository.py
@@ -163,6 +163,49 @@ def test_cleanup_payload(test_input: dict[str, Any], expected: dict[str, Any]) -
     assert test_input == expected
 
 
+async def test_import_last_commit_rejects_non_read_only_repository(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+    create_test_admin: Node,
+    default_permission_backend: None,
+) -> None:
+    """Calling InfrahubReadOnlyRepositoryImportLastCommit on a CoreRepository must fail
+    with a clear error instead of an AttributeError on the missing 'ref' attribute."""
+    repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
+    recorder = BusRecorder()
+    service = await InfrahubServices.new(database=db, message_bus=recorder, workflow=WorkflowLocalExecution())
+    account_session = AccountSession(
+        authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+    )
+
+    IMPORT_LAST_COMMIT = """
+    mutation InfrahubReadOnlyRepositoryImportLastCommit($id: String!) {
+        InfrahubReadOnlyRepositoryImportLastCommit(
+            data: {
+                id: $id
+            }) {
+            ok
+        }
+    }
+    """
+
+    repo = await Node.init(schema=repository_model, db=db, branch=default_branch)
+    await repo.new(db=db, name="test-regular-repo", location="/tmp/regular-repo")
+    await repo.save(db=db)
+
+    result = await graphql_mutation(
+        query=IMPORT_LAST_COMMIT,
+        db=db,
+        variables={"id": repo.id},
+        service=service,
+        account_session=account_session,
+    )
+
+    assert result.errors
+    assert "not a CoreReadOnlyRepository" in result.errors[0]["message"]
+
+
 async def test_import_read_only_repository_last_commit(
     db: InfrahubDatabase,
     register_core_models_schema: None,

--- a/changelog/+import-latest-commit-readonly-guard.fixed.md
+++ b/changelog/+import-latest-commit-readonly-guard.fixed.md
@@ -1,0 +1,1 @@
+Fixed "Import latest commit" action crashing with `'Node' object has no attribute 'ref'` when used on a regular Repository instead of a Read-Only Repository.

--- a/frontend/app/src/entities/repository/ui/repository-menu-section.test.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-menu-section.test.tsx
@@ -32,7 +32,7 @@ describe("RepositoryMenuSection", () => {
     } as unknown as ReturnType<typeof useImportCurrentCommitMutation>);
   });
 
-  test("renders Check connectivity and Import latest commit menu items", async () => {
+  test("renders Check connectivity for regular repositories", async () => {
     // GIVEN
     const component = await render(
       <Menu aria-label="Repository actions">
@@ -50,6 +50,23 @@ describe("RepositoryMenuSection", () => {
     await expect
       .element(component.getByRole("menuitem", { name: /Check connectivity/i }))
       .toBeVisible();
+    await expect.element(component.baseElement).not.toHaveTextContent("Import latest commit");
+  });
+
+  test("renders Import latest commit only for read-only repositories", async () => {
+    // GIVEN
+    const component = await render(
+      <Menu aria-label="Repository actions">
+        <RepositoryMenuSection
+          repositoryId="repo-1"
+          objectSchema={generateNodeSchema({ kind: "CoreReadOnlyRepository" })}
+          onCheckConnectivity={mockOnCheckConnectivity}
+          permission={generatePermission()}
+        />
+      </Menu>
+    );
+
+    // THEN
     await expect
       .element(component.getByRole("menuitem", { name: /Import latest commit/i }))
       .toBeVisible();
@@ -81,7 +98,7 @@ describe("RepositoryMenuSection", () => {
       <Menu aria-label="Repository actions">
         <RepositoryMenuSection
           repositoryId="repo-1"
-          objectSchema={generateNodeSchema({ kind: "CoreRepository" })}
+          objectSchema={generateNodeSchema({ kind: "CoreReadOnlyRepository" })}
           onCheckConnectivity={mockOnCheckConnectivity}
           permission={generatePermission()}
         />
@@ -101,7 +118,7 @@ describe("RepositoryMenuSection", () => {
       <Menu aria-label="Repository actions">
         <RepositoryMenuSection
           repositoryId="repo-1"
-          objectSchema={generateNodeSchema({ kind: "CoreRepository" })}
+          objectSchema={generateNodeSchema({ kind: "CoreReadOnlyRepository" })}
           onCheckConnectivity={mockOnCheckConnectivity}
           permission={generatePermission({ update: false })}
         />
@@ -112,6 +129,23 @@ describe("RepositoryMenuSection", () => {
     await expect
       .element(component.getByRole("menuitem", { name: /Import latest commit/i }))
       .toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("does not show Import latest commit for non-read-only repositories", async () => {
+    // GIVEN
+    const component = await render(
+      <Menu aria-label="Repository actions">
+        <RepositoryMenuSection
+          repositoryId="repo-1"
+          objectSchema={generateNodeSchema({ kind: "CoreRepository" })}
+          onCheckConnectivity={mockOnCheckConnectivity}
+          permission={generatePermission()}
+        />
+      </Menu>
+    );
+
+    // THEN
+    await expect.element(component.baseElement).not.toHaveTextContent("Import latest commit");
   });
 
   test("shows Reimport current commit only for read-only repositories", async () => {

--- a/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
@@ -96,10 +96,12 @@ export function RepositoryMenuSection({
         Check connectivity
       </MenuItem>
 
-      <MenuItem isDisabled={!isUpdateAllowed} onAction={() => reimportLastCommit({ repositoryId })}>
-        <Icon icon="mdi:source-commit" />
-        Import latest commit
-      </MenuItem>
+      {isReadOnlyRepository && (
+        <MenuItem isDisabled={!isUpdateAllowed} onAction={() => reimportLastCommit({ repositoryId })}>
+          <Icon icon="mdi:source-commit" />
+          Import latest commit
+        </MenuItem>
+      )}
 
       {isReadOnlyRepository && (
         <MenuItem onAction={() => importCurrentCommit({ repositoryId })}>

--- a/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
@@ -97,7 +97,10 @@ export function RepositoryMenuSection({
       </MenuItem>
 
       {isReadOnlyRepository && (
-        <MenuItem isDisabled={!isUpdateAllowed} onAction={() => reimportLastCommit({ repositoryId })}>
+        <MenuItem
+          isDisabled={!isUpdateAllowed}
+          onAction={() => reimportLastCommit({ repositoryId })}
+        >
           <Icon icon="mdi:source-commit" />
           Import latest commit
         </MenuItem>


### PR DESCRIPTION
## Summary
Fixes #8727 

- "Import latest commit" button was shown for **all** repository types but called `ReadOnlyRepositoryImportLastCommit`, which accesses `.ref` — an attribute only present on `CoreReadOnlyRepository`
- Clicking it on a `CoreRepository` caused `'Node' object has no attribute 'ref'`
- Regression introduced in #8183 when the frontend switched from `InfrahubRepositoryProcess` to `InfrahubReadOnlyRepositoryImportLastCommit` without adding a kind guard

## Changes
- **Frontend**: Guard "Import latest commit" button with `isReadOnlyRepository`
- **Backend**: Add kind validation in `ReadOnlyRepositoryImportLastCommit.mutate()` before accessing `.ref`
- **Tests**: Backend test for rejection case + updated frontend tests

## Test plan
- [ ] Verify "Import latest commit" button is **not shown** on `CoreRepository` detail page
- [ ] Verify "Import latest commit" button **is shown** on `CoreReadOnlyRepository` detail page
- [ ] Verify clicking "Import latest commit" on a read-only repo works as before
- [ ] Run `npx vitest run src/entities/repository/ui/repository-menu-section.test.tsx`
- [ ] Run backend component test `test_import_last_commit_rejects_non_read_only_repository`

