### PR TITLE
fix(backend): failing initial startup on task manager setup

### DIFF
--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -6,6 +6,7 @@ from prefect.client.schemas.objects import StateType
 from prefect.context import AsyncClientContext
 from prefect.deployments import run_deployment
 
+from infrahub import lock
 from infrahub.services.adapters.http.httpx import HttpxAdapter
 from infrahub.workers.utils import inject_context_parameter
 from infrahub.workflows.initialization import setup_task_manager, setup_task_manager_identifiers
@@ -28,11 +29,16 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
 
     @staticmethod
     async def initialize(component_is_primary_server: bool, is_initial_setup: bool = False) -> None:
-        if component_is_primary_server:
-            await setup_task_manager()
-
         if is_initial_setup:
+            await WorkflowWorkerExecution._setup_task_manager()
             await setup_task_manager_identifiers()
+        elif component_is_primary_server:
+            await WorkflowWorkerExecution._setup_task_manager()
+
+    @staticmethod
+    async def _setup_task_manager() -> None:
+        async with lock.registry.get(name="global.worker.taskmgr.init"):
+            await setup_task_manager()
 
     @overload
     async def execute_workflow(


### PR DESCRIPTION
Fixes #8740


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented flaky startup by serializing task manager initialization with a global lock and tightening the init flow. Fixes #8740.

- **Bug Fixes**
  - Wrapped `setup_task_manager()` in a global async lock `lock.registry.get("global.worker.taskmgr.init")` to prevent concurrent runs.
  - Ensured setup runs once during initial setup (then identifiers), otherwise only on the primary server.

<sup>Written for commit 947d5ca0297c83535c878515ee681a4065d4f2c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

