### PR TITLE
IFC-2414 Mutable object used in a hash code

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -246,25 +246,26 @@ async def process_jinja2(
     )
     schema_branch = registry.schema.get_schema_branch(name=target_branch_schema)
     node_schema = schema_branch.get_node(name=computed_attribute_kind, duplicate=False)
-    computed_macros = [
-        attrib
-        for attrib in schema_branch.computed_attributes.get_impacted_jinja2_targets(kind=node_kind, updates=updates)
-        if attrib.kind == computed_attribute_kind and attrib.attribute.name == computed_attribute_name
+    resolved_targets = [
+        resolved
+        for resolved in schema_branch.computed_attributes.get_impacted_jinja2_targets(kind=node_kind, updates=updates)
+        if resolved.target.kind == computed_attribute_kind and resolved.target.attribute.name == computed_attribute_name
     ]
-    for computed_macro in computed_macros:
+    for resolved in resolved_targets:
         found: list[ComputedAttrJinja2GraphQLResponse] = []
         template_string = "n/a"
-        if computed_macro.attribute.computed_attribute and computed_macro.attribute.computed_attribute.jinja2_template:
-            template_string = computed_macro.attribute.computed_attribute.jinja2_template
+        attribute = resolved.target.attribute
+        if attribute.computed_attribute and attribute.computed_attribute.jinja2_template:
+            template_string = attribute.computed_attribute.jinja2_template
 
         jinja_template = InfrahubJinja2Template(template=template_string)
         variables = jinja_template.get_variables()
 
         attribute_graphql = ComputedAttrJinja2GraphQL(
-            node_schema=node_schema, attribute_schema=computed_macro.attribute, variables=variables
+            node_schema=node_schema, attribute_schema=attribute, variables=variables
         )
 
-        for id_filter in computed_macro.node_filters:
+        for id_filter in resolved.node_filters:
             query = attribute_graphql.render_graphql_query(query_filter=id_filter, filter_id=object_id)
             try:
                 response = await client.execute_graphql(query=query, branch_name=branch_name)
@@ -286,7 +287,7 @@ async def process_jinja2(
                 branch_name=branch_name,
                 obj=node,
                 node_kind=node_schema.kind,
-                attribute_name=computed_macro.attribute.name,
+                attribute_name=attribute.name,
                 template=jinja_template,
                 context=context,
             )

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1274,20 +1274,32 @@ class SchemaBranch:
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()
+        self._validate_node_computed_attributes()
+        self._validate_generic_computed_attributes()
+
+    def _validate_node_computed_attributes(self) -> None:
+        """Validate and register computed attributes defined directly on nodes."""
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
+    def _validate_generic_computed_attributes(self) -> None:
+        """Ensure no node inherits the same computed attribute from multiple generics."""
+        defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)
             for attribute in generic_schema.attributes:
                 if attribute.computed_attribute and attribute.computed_attribute.kind != ComputedAttributeKind.USER:
                     for inheriting_node in generic_schema.used_by:
                         node_schema = self.get_node(name=inheriting_node, duplicate=False)
-                        self.computed_attributes.validate_generic_inheritance(
-                            node=node_schema, attribute=attribute, generic=generic_schema
-                        )
+                        attribute_key = f"{node_schema.kind}__{attribute.name}"
+                        if duplicate := defined_from_generic.get(attribute_key):
+                            raise ValueError(
+                                f"{node_schema.kind}: {attribute.name!r} is declared as a computed attribute"
+                                f" from multiple generics {sorted([duplicate, generic_schema.kind])}"
+                            )
+                        defined_from_generic[attribute_key] = generic_schema.kind
 
     def _validate_display_label(self, node: MainSchemaTypes) -> None:
         if not node.display_label:

--- a/backend/infrahub/core/schema/schema_branch_computed/__init__.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/__init__.py
@@ -2,6 +2,7 @@ from infrahub.core.schema.schema_branch_computed.facade import ComputedAttribute
 from infrahub.core.schema.schema_branch_computed.jinja2 import (
     ComputedAttributeTarget,
     ComputedAttributeTriggerNode,
+    ResolvedComputedTarget,
 )
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition
 
@@ -10,4 +11,5 @@ __all__ = [
     "ComputedAttributeTriggerNode",
     "ComputedAttributes",
     "PythonDefinition",
+    "ResolvedComputedTarget",
 ]

--- a/backend/infrahub/core/schema/schema_branch_computed/facade.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/facade.py
@@ -22,7 +22,7 @@ from infrahub.core.schema.schema_branch_computed.jinja2 import (
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition, PythonTransformRegistry
 
 if TYPE_CHECKING:
-    from infrahub.core.schema import GenericSchema, NodeSchema, SchemaAttributePath
+    from infrahub.core.schema import NodeSchema, SchemaAttributePath
 
 
 class ComputedAttributes:
@@ -33,7 +33,6 @@ class ComputedAttributes:
     ) -> None:
         self._python = PythonTransformRegistry(transform_attribute_map=transform_attribute_map)
         self._jinja2 = Jinja2ComputedRegistry(jinja2_attribute_map=jinja2_attribute_map)
-        self._defined_from_generic: dict[str, str] = {}
 
     def duplicate(self) -> ComputedAttributes:
         return self.__class__(
@@ -63,20 +62,6 @@ class ComputedAttributes:
         self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
     ) -> None:
         self._jinja2.register(node, attribute, schema_path)
-
-    def validate_generic_inheritance(
-        self, node: NodeSchema, attribute: AttributeSchema, generic: GenericSchema
-    ) -> None:
-        """Ensure a computed attribute is not inherited from multiple generics.
-
-        This validation applies to all computed attribute kinds.
-        """
-        attribute_key = f"{node.kind}__{attribute.name}"
-        if duplicate := self._defined_from_generic.get(attribute_key):
-            raise ValueError(
-                f"{node.kind}: {attribute.name!r} is declared as a computed attribute from multiple generics {sorted([duplicate, generic.kind])}"
-            )
-        self._defined_from_generic[attribute_key] = generic.kind
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         return self._jinja2.get_impacted_targets(kind, updates)

--- a/backend/infrahub/core/schema/schema_branch_computed/facade.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/facade.py
@@ -17,6 +17,7 @@ from infrahub.core.schema.schema_branch_computed.jinja2 import (
     ComputedAttributeTriggerNode,
     Jinja2ComputedRegistry,
     RegisteredNodeComputedAttribute,
+    ResolvedComputedTarget,
 )
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition, PythonTransformRegistry
 
@@ -77,7 +78,7 @@ class ComputedAttributes:
             )
         self._defined_from_generic[attribute_key] = generic.kind
 
-    def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         return self._jinja2.get_impacted_targets(kind, updates)
 
     def get_local_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:

--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -17,28 +17,30 @@ class ComputedAttributeTarget(BaseModel):
     """Identifies a computed attribute that needs recomputation.
 
     Points to a specific (kind, attribute) pair — e.g. InfraDevice.computed_name — that should
-    be re-evaluated when a dependency changes. The ``filter_keys`` field carries relationship-based
-    query filters (e.g. ``site__ids``) used to locate affected nodes when the trigger comes from
-    a peer node rather than the owner itself.
+    be re-evaluated when a dependency changes.
     """
 
     kind: str
     attribute: AttributeSchema
-    filter_keys: list[str] = Field(default_factory=list)
 
     @property
     def key_name(self) -> str:
         return f"{self.kind}_{self.attribute.name}"
 
-    @property
-    def node_filters(self) -> list[str]:
-        if self.filter_keys:
-            return self.filter_keys
-
-        return ["ids"]
-
     def __hash__(self) -> int:
-        return hash((self.kind, self.attribute, tuple(self.filter_keys)))
+        return hash((self.kind, self.attribute))
+
+
+class ResolvedComputedTarget(BaseModel):
+    """A ComputedAttributeTarget paired with the query filters needed to locate affected nodes.
+
+    The ``node_filters`` carry relationship-based query filters (e.g. ``site__ids``) built at
+    resolution time by :meth:`RegisteredNodeComputedAttribute.get_targets`. When the trigger comes
+    from the owner itself, the default ``["ids"]`` filter is used.
+    """
+
+    target: ComputedAttributeTarget
+    node_filters: list[str] = Field(default_factory=lambda: ["ids"])
 
 
 class ComputedAttributeTriggerNode(BaseModel):
@@ -73,7 +75,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
     - **"InfraSite"** (the peer): ``local_fields = {"name": [target]}``,
       ``relationships = {"site": [target]}``
       A change to the site's ``name`` triggers recomputation of devices linked via ``site``.
-      The ``relationships`` dict provides ``filter_keys`` (e.g. ``site__ids``) so the system
+      The ``relationships`` dict provides query filters (e.g. ``site__ids``) so the system
       can locate which devices are affected.
     """
 
@@ -91,7 +93,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
         """Return mapping of relationship names to peer attribute names needed for computed attribute templates."""
         return {rel: dep.peer_attributes for rel, dep in self.relationship_dependencies.items()}
 
-    def get_targets(self, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_targets(self, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         """Resolve which ComputedAttributeTargets are affected by changes to this node.
 
         Args:
@@ -99,25 +101,25 @@ class RegisteredNodeComputedAttribute(BaseModel):
                      registered local_fields are included.
 
         Returns:
-            Deduplicated list of ComputedAttributeTarget, each enriched with any applicable
-            relationship-based filter_keys.
+            Deduplicated list of ResolvedComputedTarget, each pairing a target with the
+            query filters needed to locate affected nodes.
         """
-        targets: dict[str, ComputedAttributeTarget] = {}
+        resolved: dict[str, ResolvedComputedTarget] = {}
         for attribute, entries in self.local_fields.items():
             if updates and attribute not in updates:
                 continue
 
             for entry in entries:
-                if entry.key_name not in targets:
-                    targets[entry.key_name] = entry.model_copy(deep=True)
+                if entry.key_name not in resolved:
+                    resolved[entry.key_name] = ResolvedComputedTarget(target=entry)
 
         for relationship_name, dep in self.relationship_dependencies.items():
             for entry in dep.targets:
                 filter_key = f"{relationship_name}__ids"
-                if entry.key_name in targets and filter_key not in targets[entry.key_name].filter_keys:
-                    targets[entry.key_name].filter_keys.append(filter_key)
+                if entry.key_name in resolved and filter_key not in resolved[entry.key_name].node_filters:
+                    resolved[entry.key_name].node_filters.append(filter_key)
 
-        return list(targets.values())
+        return list(resolved.values())
 
     def get_local_targets_in_dependency_order(self, kind: str, updates: list[str]) -> list[ComputedAttributeTarget]:
         """Walk local_fields wave by wave, returning self-targeting targets in dependency order.
@@ -249,7 +251,7 @@ class Jinja2ComputedRegistry:
             owner_dep = owner_entry.relationship_dependencies.setdefault(rel_name, RelationshipDependency())
             owner_dep.peer_attributes.add(schema_path.active_attribute_schema.name)
 
-    def get_impacted_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_impacted_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         """Return computed Jinja2 attribute targets that need re-evaluation when a node of the given kind is modified.
 
         Args:
@@ -259,9 +261,9 @@ class Jinja2ComputedRegistry:
                      When None, all registered targets for this kind are returned.
 
         Returns:
-            List of ComputedAttributeTarget entries, each identifying a (kind, attribute) pair whose
-            computed value depends on the modified node and may need recomputation. The target kind
-            can differ from the input kind when the dependency crosses a relationship.
+            List of ResolvedComputedTarget entries, each pairing a (kind, attribute) identity with the
+            query filters needed to locate affected nodes. The target kind can differ from the input
+            kind when the dependency crosses a relationship.
         """
         if mapping := self._map.get(kind):
             return mapping.get_targets(updates=updates)

--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -40,7 +40,7 @@ class ResolvedComputedTarget(BaseModel):
     """
 
     target: ComputedAttributeTarget
-    node_filters: list[str] = Field(default_factory=lambda: ["ids"])
+    node_filters: list[str] = Field(default_factory=list)
 
 
 class ComputedAttributeTriggerNode(BaseModel):
@@ -118,6 +118,11 @@ class RegisteredNodeComputedAttribute(BaseModel):
                 filter_key = f"{relationship_name}__ids"
                 if entry.key_name in resolved and filter_key not in resolved[entry.key_name].node_filters:
                     resolved[entry.key_name].node_filters.append(filter_key)
+
+        # Targets with no relationship filters need the default "ids" filter
+        for target in resolved.values():
+            if not target.node_filters:
+                target.node_filters.append("ids")
 
         return list(resolved.values())
 

--- a/backend/tests/unit/core/schema_branch_computed/conftest.py
+++ b/backend/tests/unit/core/schema_branch_computed/conftest.py
@@ -27,8 +27,8 @@ def make_rel() -> Callable[[str, str], RelationshipSchema]:
 
 @pytest.fixture
 def make_target(make_attr: Callable[[str], AttributeSchema]) -> Callable[..., ComputedAttributeTarget]:
-    def _make_target(kind: str, attr_name: str, filter_keys: list[str] | None = None) -> ComputedAttributeTarget:
-        return ComputedAttributeTarget(kind=kind, attribute=make_attr(attr_name), filter_keys=filter_keys or [])
+    def _make_target(kind: str, attr_name: str) -> ComputedAttributeTarget:
+        return ComputedAttributeTarget(kind=kind, attribute=make_attr(attr_name))
 
     return _make_target
 

--- a/backend/tests/unit/core/schema_branch_computed/test_jinja2_targets.py
+++ b/backend/tests/unit/core/schema_branch_computed/test_jinja2_targets.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.schema.schema_branch_computed import ComputedAttributes
-from infrahub.core.schema.schema_branch_computed.jinja2 import RegisteredNodeComputedAttribute, RelationshipDependency
+from infrahub.core.schema.schema_branch_computed.jinja2 import (
+    RegisteredNodeComputedAttribute,
+    RelationshipDependency,
+    ResolvedComputedTarget,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -74,6 +78,57 @@ class TestComputedAttributesGetLocalJinja2Targets:
 
         results = ca.get_local_jinja2_targets(kind=LOCAL_KIND)
         assert results == []
+
+
+class TestGetTargetsNodeFilters:
+    """Verify that node_filters on ResolvedComputedTarget are set correctly."""
+
+    def test_self_target_gets_ids_filter(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """A target triggered only by local fields should get the default ["ids"] filter."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert results[0].node_filters == ["ids"]
+
+    def test_peer_target_gets_only_relationship_filter(
+        self, make_target: Callable[..., ComputedAttributeTarget]
+    ) -> None:
+        """A peer-triggered target should only have relationship filters, not the spurious "ids" filter."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+            relationship_dependencies={
+                "site": RelationshipDependency(targets=[target]),
+            },
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert results[0].node_filters == ["site__ids"]
+
+    def test_multiple_relationship_filters(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """A target reachable via multiple relationships gets all relationship filters but no "ids"."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+            relationship_dependencies={
+                "site": RelationshipDependency(targets=[target]),
+                "region": RelationshipDependency(targets=[target]),
+            },
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert sorted(results[0].node_filters) == ["region__ids", "site__ids"]
+
+    def test_default_node_filters_is_empty(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """ResolvedComputedTarget should default to an empty node_filters list."""
+        resolved = ResolvedComputedTarget(target=make_target(kind=LOCAL_KIND, attr_name="some_attr"))
+        assert resolved.node_filters == []
 
 
 class TestComputedAttributesGetRegisteredJinja2Node:


### PR DESCRIPTION
FYI https://github.com/opsmill/infrahub/commit/500fcaf08f622391576efcc65d0abfc2dc683b43 commit from [IFC-2418] has been added to this PR, but has already been reviewed there https://github.com/opsmill/infrahub/pull/8750.

# Why

Based on a feedback from Code Rabbit [IFC-2389: Extract Jinja2 and Python computed attribute sub-registries by polmichel · Pull Request #8681 · opsmill/infrahub](https://github.com/opsmill/infrahub/pull/8681#discussion_r2979758763)

The `ComputedAttributeTarget` were using in its hash code a hash of `filter_keys` attribute which is a mutable object which was modified in the method`infrahub.core.schema.schema_branch_computed.jinja2.RegisteredNodeComputedAttribute.get_targets`

```
for relationship_name, dep in self.relationship_dependencies.items():
    for entry in dep.targets:
        filter_key = f"{relationship_name}__ids"
        if entry.key_name in resolved and filter_key not in resolved[entry.key_name].node_filters:
            resolved[entry.key_name].node_filters.append(filter_key)
```

This is fundamentally risky since this object is stored as a key in the following dictionaries:
1. As a return of `infrahub.core.schema.schema_branch_computed.jinja2.Jinja2ComputedRegistry.get_target_map` method
2. As a return of `infrahub.core.schema.schema_branch_computed.jinja2.Jinja2ComputedRegistry.get_trigger_nodes` method

Even if there is only one place where this attribute is modified right now, this could lead to future issues, as it is already used as a key.

Closes: [IFC-2414] 

## What changed

500fcaf08f622391576efcc65d0abfc2dc683b43 commit from [IFC-2418] has been added to this PR, but has already been reviewed there https://github.com/opsmill/infrahub/pull/8750.

A new object has been created: `infrahub.core.schema.schema_branch_computed.jinja2.ResolvedComputedTarget` which will pair a `infrahub.core.schema.schema_branch_computed.jinja2.ComputedAttributeTarget` with these _filter_keys_. This field has been renamed to `node_filters`, since it was the name of the accessor method.


### Changes

The code has been adapted in order to use this new object.
A new test protecting against `node_filter` default value regression has been added, since it has regressed during the refactoring.

### Implementation choices

The `ResolvedComputedTarget` is not hashable since it has this attribute, but this object is not used as a key, at least for now.

## How to test

```bash
uv run pytest backend/tests/unit/core/schema_branch_computed/ -v 
```


[IFC-2414]: https://opsmill.atlassian.net/browse/IFC-2414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IFC-2414 by removing a mutable field from a hashable key and introducing `ResolvedComputedTarget` to carry node filters. Also addresses IFC-2418 by moving computed-attribute inheritance validation into `SchemaBranch` with transient state.

- **Refactors**
  - Removed `filter_keys` from `ComputedAttributeTarget`; its hash now uses only `kind` and `attribute`.
  - Added `ResolvedComputedTarget` with `target` and `node_filters` (defaults to `[]`; `get_targets` adds `"ids"` when no relationship filters).
  - Updated `RegisteredNodeComputedAttribute.get_targets`, `Jinja2ComputedRegistry.get_impacted_targets`, and `ComputedAttributes.get_impacted_jinja2_targets` to return `ResolvedComputedTarget`.
  - Updated `process_jinja2` to use `resolved.target` and `resolved.node_filters`.
  - Exported `ResolvedComputedTarget` from `infrahub.core.schema.schema_branch_computed.__init__`.
  - Moved generic computed-attribute inheritance checks into `SchemaBranch` via `_validate_node_computed_attributes` and `_validate_generic_computed_attributes`; removed transient `_defined_from_generic` state and `validate_generic_inheritance` from `ComputedAttributes`.

- **Migration**
  - If you consume `get_impacted_jinja2_targets(...)`, expect `ResolvedComputedTarget` instead of `ComputedAttributeTarget`. Access the attribute via `resolved.target.attribute` and filters via `resolved.node_filters`; remove any usage of `ComputedAttributeTarget.filter_keys`.

<sup>Written for commit 500fcaf08f622391576efcc65d0abfc2dc683b43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





[IFC-2418]: https://opsmill.atlassian.net/browse/IFC-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ