### PR TITLE
IFC-2418: defined_from_generic should be a transient data validation collection

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1274,11 +1274,16 @@ class SchemaBranch:
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()
+        self._validate_node_computed_attributes()
+        self._validate_generic_computed_attributes()
+
+    def _validate_node_computed_attributes(self) -> None:
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
+    def _validate_generic_computed_attributes(self) -> None:
         defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1278,12 +1278,14 @@ class SchemaBranch:
         self._validate_generic_computed_attributes()
 
     def _validate_node_computed_attributes(self) -> None:
+        """Validate and register computed attributes defined directly on nodes."""
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
     def _validate_generic_computed_attributes(self) -> None:
+        """Ensure no node inherits the same computed attribute from multiple generics."""
         defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1279,15 +1279,20 @@ class SchemaBranch:
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
+        defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)
             for attribute in generic_schema.attributes:
                 if attribute.computed_attribute and attribute.computed_attribute.kind != ComputedAttributeKind.USER:
                     for inheriting_node in generic_schema.used_by:
                         node_schema = self.get_node(name=inheriting_node, duplicate=False)
-                        self.computed_attributes.validate_generic_inheritance(
-                            node=node_schema, attribute=attribute, generic=generic_schema
-                        )
+                        attribute_key = f"{node_schema.kind}__{attribute.name}"
+                        if duplicate := defined_from_generic.get(attribute_key):
+                            raise ValueError(
+                                f"{node_schema.kind}: {attribute.name!r} is declared as a computed attribute"
+                                f" from multiple generics {sorted([duplicate, generic_schema.kind])}"
+                            )
+                        defined_from_generic[attribute_key] = generic_schema.kind
 
     def _validate_display_label(self, node: MainSchemaTypes) -> None:
         if not node.display_label:

--- a/backend/infrahub/core/schema/schema_branch_computed/facade.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/facade.py
@@ -22,7 +22,7 @@ from infrahub.core.schema.schema_branch_computed.jinja2 import (
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition, PythonTransformRegistry
 
 if TYPE_CHECKING:
-    from infrahub.core.schema import GenericSchema, NodeSchema, SchemaAttributePath
+    from infrahub.core.schema import NodeSchema, SchemaAttributePath
 
 
 class ComputedAttributes:
@@ -33,7 +33,6 @@ class ComputedAttributes:
     ) -> None:
         self._python = PythonTransformRegistry(transform_attribute_map=transform_attribute_map)
         self._jinja2 = Jinja2ComputedRegistry(jinja2_attribute_map=jinja2_attribute_map)
-        self._defined_from_generic: dict[str, str] = {}
 
     def duplicate(self) -> ComputedAttributes:
         return self.__class__(
@@ -63,20 +62,6 @@ class ComputedAttributes:
         self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
     ) -> None:
         self._jinja2.register(node, attribute, schema_path)
-
-    def validate_generic_inheritance(
-        self, node: NodeSchema, attribute: AttributeSchema, generic: GenericSchema
-    ) -> None:
-        """Ensure a computed attribute is not inherited from multiple generics.
-
-        This validation applies to all computed attribute kinds.
-        """
-        attribute_key = f"{node.kind}__{attribute.name}"
-        if duplicate := self._defined_from_generic.get(attribute_key):
-            raise ValueError(
-                f"{node.kind}: {attribute.name!r} is declared as a computed attribute from multiple generics {sorted([duplicate, generic.kind])}"
-            )
-        self._defined_from_generic[attribute_key] = generic.kind
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         return self._jinja2.get_impacted_targets(kind, updates)


### PR DESCRIPTION
# Why
Following this discussion on the Jinja2 local recomputation related PR https://github.com/opsmill/infrahub/pull/8681#discussion_r2979758774.

I was wrong on the missing class attribute __defined_from_generic_ from method `infrahub.core.schema.schema_branch_computed.facade.ComputedAttributes.duplicate ` method.
However, this data collection is transient and is only meant to be used during the validation process of the method  `infrahub.core.schema.schema_branch.SchemaBranch.validate_computed_attributes`, and in my opinion, it should not be tied directly to the `ComputedAttributes` object as a class attribute.

This could lead to confusion and wasted time spent determining whether this attribute is missing from this type of generic meta method.

Closes [IFC-2418]

## What changed

The __defined_from_generic_ attribute has been moved as a local variable of the `infrahub.core.schema.schema_branch.SchemaBranch.validate_computed_attributes` method, and removed from class `ComputedAttributes`.

An encapsulation of the two parts of the `infrahub.core.schema.schema_branch.SchemaBranch.validate_computed_attributes` method has been done to encapsulate unnecessary exposed complexity.
- `infrahub.core.schema.schema_branch.SchemaBranch._validate_node_computed_attributes`: Validate and register computed attributes defined directly on nodes
- `infrahub.core.schema.schema_branch.SchemaBranch._validate_generic_computed_attributes`: 

## How to review

These are unitary commits.

## How to test

```bash
uv run pytest backend/tests/unit/core/schema_branch_computed/ -v
```

[IFC-2418]: https://opsmill.atlassian.net/browse/IFC-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the generic-inheritance check a transient local map during schema validation instead of state on `ComputedAttributes`, and split validation into two focused helpers. This reduces hidden state and clarifies how computed attributes from generics are validated (IFC-2418).

- **Refactors**
  - Move duplicate-inheritance tracking to `SchemaBranch._validate_generic_computed_attributes`; remove `_defined_from_generic` and `validate_generic_inheritance` from `ComputedAttributes` (and drop `GenericSchema` import).
  - Extract `SchemaBranch._validate_node_computed_attributes` and `SchemaBranch._validate_generic_computed_attributes` from `validate_computed_attributes` for clearer flow.

<sup>Written for commit fc14f02cde851d848df2f1b6ba5237f2851fa38a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

