### PR TITLE
chore: update gitignore for worktrees folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ python_testcontainers/infrahub_testcontainers.egg-info/*
 
 schema/node_modules/*
 
-# Spec-kitty
-dev/spec-kitty/.worktrees/
+# AI and SDD
+.worktrees/
+**/.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ development/docker-compose.dev-override.yml
 .DS_Store
 .python-version
 .venv/*
-.ruff_cache
 **/.ruff_cache
 **/.idea/**
 dist/*
@@ -50,5 +49,4 @@ python_testcontainers/infrahub_testcontainers.egg-info/*
 schema/node_modules/*
 
 # AI and SDD
-.worktrees/
 **/.worktrees/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore Git worktree directories across the repo to prevent accidental commits. Replace the scoped `dev/spec-kitty/.worktrees/` rule with a single `**/.worktrees/` pattern, and remove the duplicate `.ruff_cache` entry in favor of `**/.ruff_cache`.

<sup>Written for commit bce2c6b2a678c074f1506e6ba9416784f5195aa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

