### PR TITLE
Add query invalidation on bulk group mutations and separate onSuccess from onClose

### DIFF
--- a/changelog/+bulk-groups-invalidate.fixed.md
+++ b/changelog/+bulk-groups-invalidate.fixed.md
@@ -1,0 +1,1 @@
+Object table now refreshes automatically after adding or removing objects from groups in bulk

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups.test.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups.test.tsx
@@ -20,6 +20,7 @@ describe("BulkMutateGroups Component", () => {
 
   const mockMutationFn = vi.fn().mockResolvedValue(undefined);
   const mockOnSuccess = vi.fn();
+  const mockOnClose = vi.fn();
   const groupSchema = generateNodeSchema({ kind: "CoreGroup" });
 
   beforeEach(() => {
@@ -31,7 +32,11 @@ describe("BulkMutateGroups Component", () => {
   test("renders the group selector", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // THEN
@@ -41,7 +46,11 @@ describe("BulkMutateGroups Component", () => {
   test("adds a group to the selected groups panel when a group is selected", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN
@@ -61,7 +70,11 @@ describe("BulkMutateGroups Component", () => {
   test("removes a group when clicking the remove button", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN
@@ -75,7 +88,11 @@ describe("BulkMutateGroups Component", () => {
   test("filters out already selected groups", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN
@@ -100,7 +117,11 @@ describe("BulkMutateGroups Component", () => {
   test("transitions to processing state when validate button is clicked", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN
@@ -115,7 +136,11 @@ describe("BulkMutateGroups Component", () => {
   test("calls mutation function when processing", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={(group) => mockMutationFn(group)} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={(group) => mockMutationFn(group)}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN
@@ -126,10 +151,52 @@ describe("BulkMutateGroups Component", () => {
     expect(mockMutationFn).toHaveBeenCalledExactlyOnceWith(mockGroups[0]);
   });
 
+  test("calls onSuccess when all mutations complete", async () => {
+    // GIVEN
+    const component = await render(
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
+    );
+
+    // WHEN
+    await component.getByRole("option", { name: "Test Group 1" }).click();
+    await component.getByRole("button", { name: "Validate" }).click();
+
+    // THEN
+    await expect.poll(() => mockOnSuccess).toHaveBeenCalled();
+  });
+
+  test("calls onClose when close button is clicked", async () => {
+    // GIVEN
+    const component = await render(
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
+    );
+
+    // WHEN
+    await component.getByRole("option", { name: "Test Group 1" }).click();
+    await component.getByRole("button", { name: "Validate" }).click();
+    await expect.element(component.getByTestId("processing-groups-panel")).toBeVisible();
+    await component.getByRole("button", { name: "Close" }).click();
+
+    // THEN
+    expect(mockOnClose).toHaveBeenCalledOnce();
+  });
+
   test("handles multiple group selections", async () => {
     // GIVEN
     const component = await render(
-      <BulkMutateGroups mutationFn={mockMutationFn} onSuccess={mockOnSuccess} />
+      <BulkMutateGroups
+        mutationFn={mockMutationFn}
+        onSuccess={mockOnSuccess}
+        onClose={mockOnClose}
+      />
     );
 
     // WHEN

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups.tsx
@@ -18,6 +18,7 @@ export interface BulkMutateGroupsProps extends Omit<ProcessingGroupsPanelProps, 
 export function BulkMutateGroups({
   mutationFn,
   onSuccess,
+  onClose,
   groupsQueryFilter,
 }: BulkMutateGroupsProps) {
   const [selectedGroups, setSelectedGroups] = React.useState<RelationshipNode[]>([]);
@@ -29,6 +30,7 @@ export function BulkMutateGroups({
         selectedGroups={selectedGroups}
         mutationFn={mutationFn}
         onSuccess={onSuccess}
+        onClose={onClose}
       />
     );
   }
@@ -42,7 +44,7 @@ export function BulkMutateGroups({
           setSelectedGroups((prev) => [...prev, group]);
         }}
         filterItem={(node) => !selectedGroups.some((v) => v.id === node.id)}
-        className="max-h-[12rem] max-w-xs"
+        className="max-h-48 max-w-xs"
         data-testid="group-selector"
         filterQuery={groupsQueryFilter}
       />

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/processing-group-item.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/processing-group-item.tsx
@@ -10,7 +10,7 @@ import type { RelationshipNode } from "@/entities/nodes/relationships/domain/typ
 export interface ProcessingGroupItemProps {
   group: RelationshipNode;
   mutationFn: (group: RelationshipNode) => Promise<void>;
-  onSuccess: () => void;
+  onSuccess: () => Promise<void> | void;
 }
 
 export function ProcessingGroupItem({ group, mutationFn, onSuccess }: ProcessingGroupItemProps) {

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/processing-groups-panel.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/processing-groups-panel.tsx
@@ -17,20 +17,26 @@ import type { RelationshipNode } from "@/entities/nodes/relationships/domain/typ
 
 export interface ProcessingGroupsPanelProps extends Omit<ProcessingGroupItemProps, "group"> {
   selectedGroups: RelationshipNode[];
+  onClose: () => void;
 }
 
 export function ProcessingGroupsPanel({
   selectedGroups,
   mutationFn,
   onSuccess,
+  onClose,
 }: ProcessingGroupsPanelProps) {
   const [successCount, setSuccessCount] = React.useState(0);
+  const allDone = selectedGroups.length > 0 && successCount === selectedGroups.length;
+
+  React.useEffect(() => {
+    if (allDone) {
+      onSuccess()?.catch(console.error);
+    }
+  }, [allDone]);
 
   return (
-    <div
-      className="flex max-h-[12rem] min-w-[15rem] max-w-sm flex-col"
-      data-testid="processing-groups-panel"
-    >
+    <div className="flex max-h-48 min-w-60 max-w-sm flex-col" data-testid="processing-groups-panel">
       <GroupPanelHeader>
         {successCount} / {pluralize(selectedGroups.length, "group")} updated successfully
       </GroupPanelHeader>
@@ -53,7 +59,7 @@ export function ProcessingGroupsPanel({
       </GroupPanelBody>
 
       <GroupPanelFooter>
-        <Button size="xs" onClick={onSuccess}>
+        <Button size="xs" onClick={onClose}>
           Close
         </Button>
       </GroupPanelFooter>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-add-to-groups-action.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-add-to-groups-action.tsx
@@ -1,11 +1,13 @@
 import { DialogTrigger } from "react-aria-components";
 
+import { queryClient } from "@/shared/api/rest/client";
 import { Popover, PopoverDialog } from "@/shared/components/aria/popover";
 
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { BulkMutateGroups } from "@/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups";
 import { ToolbarButtonWithTooltip } from "@/entities/nodes/object/ui/object-table/toolbar/toolbar-button";
+import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
 import { addRelationships } from "@/entities/nodes/relationships/domain/add-relationships/add-relationships";
 import type { NodeCore } from "@/entities/nodes/types";
 
@@ -43,7 +45,10 @@ export function ToolbarAddToGroupsAction({ selectedRows }: ToolbarAddToGroupActi
                     branchName: currentBranch.name,
                   });
                 }}
-                onSuccess={close}
+                onSuccess={async () => {
+                  await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
+                }}
+                onClose={close}
               />
             );
           }}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-remove-from-groups-action.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-remove-from-groups-action.tsx
@@ -1,19 +1,21 @@
 import { DialogTrigger } from "react-aria-components";
 
+import { queryClient } from "@/shared/api/rest/client";
 import { Popover, PopoverDialog } from "@/shared/components/aria/popover";
 
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { BulkMutateGroups } from "@/entities/nodes/object/ui/object-table/toolbar/actions/groups/bulk-mutate-groups";
 import { ToolbarButtonWithTooltip } from "@/entities/nodes/object/ui/object-table/toolbar/toolbar-button";
+import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
 import { removeRelationships } from "@/entities/nodes/relationships/domain/remove-relationships/remove-relationships";
 import type { NodeCore } from "@/entities/nodes/types";
 
-export interface ToolBarRemoveFromGroupActionProps {
+export interface ToolbarRemoveFromGroupActionProps {
   selectedRows: Array<NodeCore>;
 }
 
-export function ToolBarRemoveFromGroupsAction({ selectedRows }: ToolBarRemoveFromGroupActionProps) {
+export function ToolbarRemoveFromGroupsAction({ selectedRows }: ToolbarRemoveFromGroupActionProps) {
   const { currentBranch } = useCurrentBranch();
   const { permission } = useObjectTableContext();
   const { isAllowed, message } = permission.update;
@@ -42,7 +44,10 @@ export function ToolBarRemoveFromGroupsAction({ selectedRows }: ToolBarRemoveFro
                   branchName: currentBranch.name,
                 });
               }}
-              onSuccess={close}
+              onSuccess={async () => {
+                await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
+              }}
+              onClose={close}
               groupsQueryFilter={{ members__ids: selectedRows.map((row) => row.id) }}
             />
           )}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/object-table-toolbar.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/toolbar/object-table-toolbar.tsx
@@ -3,7 +3,7 @@ import { XIcon } from "lucide-react";
 import { classNames } from "@/shared/utils/common";
 
 import { ToolbarAddToGroupsAction } from "@/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-add-to-groups-action";
-import { ToolBarRemoveFromGroupsAction } from "@/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-remove-from-groups-action";
+import { ToolbarRemoveFromGroupsAction } from "@/entities/nodes/object/ui/object-table/toolbar/actions/groups/toolbar-remove-from-groups-action";
 import { ToolbarDeleteAction } from "@/entities/nodes/object/ui/object-table/toolbar/actions/objects/toolbar-delete-action";
 import { ToolbarEditAction } from "@/entities/nodes/object/ui/object-table/toolbar/actions/objects/toolbar-edit-action";
 import { ToolbarButton } from "@/entities/nodes/object/ui/object-table/toolbar/toolbar-button";
@@ -41,7 +41,7 @@ export function ObjectTableToolbar({
 
       <ToolbarEditAction selectedRows={selectedRows} />
       <ToolbarAddToGroupsAction selectedRows={selectedRows} />
-      <ToolBarRemoveFromGroupsAction selectedRows={selectedRows} />
+      <ToolbarRemoveFromGroupsAction selectedRows={selectedRows} />
       <ToolbarDeleteAction selectedRows={selectedRows} />
 
       {renderMore && (


### PR DESCRIPTION
Why

  On the future account table in role management, we will use the data table components. Previously no "member_of_groups" column was visible so we did not refresh after bulk group mutations.

This PR makes the object table automatically refresh after bulk group mutations complete, which is required for the account table to correctly reflect group membership changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refresh the object table after bulk add/remove group actions by invalidating `objectQueryKeys` queries. Also decouples `onSuccess` (fires when all mutations complete) from `onClose` (dialog dismissal) for clearer UX.

- **Bug Fixes**
  - Invalidate `objectQueryKeys.all` after bulk add/remove groups to refresh the object table.
  - Group membership changes now appear immediately in the table.

- **Refactors**
  - Split `onSuccess` from `onClose`; close button now calls `onClose`, and `onSuccess` runs automatically when all groups finish processing (supports async).
  - Renamed `ToolBarRemoveFromGroupsAction` to `ToolbarRemoveFromGroupsAction`; added tests for success/close flows.
  - Small UI tweaks to processing panel sizing.

<sup>Written for commit 17ee6e5f1e9814b16f23a7eb264d2634c072c1e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

