### PR TITLE
Prep release 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.8.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.3) - 2026-03-31
+
+### Fixed
+
+- Corrected data diff view within a proposed change or branch view so that changes to profiles show up. ([#8529](https://github.com/opsmill/infrahub/issues/8529))
+- Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing backoff retry. ([#8696](https://github.com/opsmill/infrahub/issues/8696))
+- Fix object creation from a template when a resource pool is assigned to a required relationship or attribute field. ([#8701](https://github.com/opsmill/infrahub/issues/8701))
+- Deleting a node that inherits from `CoreArtifactTarget` now automatically deletes its associated artifacts. ([#8735](https://github.com/opsmill/infrahub/issues/8735))
+- Add missing `hfid` field to `RelatedIPAddressNodeInput` GraphQL type, allowing IP address relationships to be referenced by human-friendly ID
+- Fixed "Import latest commit" action crashing with `'Node' object has no attribute 'ref'` when used on a regular Repository instead of a Read-Only Repository.
+
+### Housekeeping
+
+- Migrated Node.js from version 22 to 24 LTS across CI workflows, Docker build, and package engine constraints.
+
 ## [Infrahub - v1.8.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.2) - 2026-03-25
 
 ### Changed

--- a/changelog/+8574-ip-address-hfid.fixed.md
+++ b/changelog/+8574-ip-address-hfid.fixed.md
@@ -1,1 +1,0 @@
-Add missing `hfid` field to `RelatedIPAddressNodeInput` GraphQL type, allowing IP address relationships to be referenced by human-friendly ID

--- a/changelog/+import-latest-commit-readonly-guard.fixed.md
+++ b/changelog/+import-latest-commit-readonly-guard.fixed.md
@@ -1,1 +1,0 @@
-Fixed "Import latest commit" action crashing with `'Node' object has no attribute 'ref'` when used on a regular Repository instead of a Read-Only Repository.

--- a/changelog/+node24-migration.housekeeping.md
+++ b/changelog/+node24-migration.housekeeping.md
@@ -1,1 +1,0 @@
-Migrated Node.js from version 22 to 24 LTS across CI workflows, Docker build, and package engine constraints.

--- a/changelog/8529.fixed.md
+++ b/changelog/8529.fixed.md
@@ -1,1 +1,0 @@
-Corrected data diff view within a proposed change or branch view so that changes to profiles show up.

--- a/changelog/8696.fixed.md
+++ b/changelog/8696.fixed.md
@@ -1,1 +1,0 @@
-Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing backoff retry.

--- a/changelog/8701.fixed.md
+++ b/changelog/8701.fixed.md
@@ -1,1 +1,0 @@
-Fix object creation from a template when a resource pool is assigned to a required relationship or attribute field.

--- a/changelog/8735.fixed.md
+++ b/changelog/8735.fixed.md
@@ -1,1 +1,0 @@
-Deleting a node that inherits from `CoreArtifactTarget` now automatically deletes its associated artifacts.

--- a/docs/docs/release-notes/infrahub/release-1_8_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_3.mdx
@@ -1,0 +1,32 @@
+---
+title: Release 1.8.3
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.8.3</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>March 25th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.8.3](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.8.3)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Corrected data diff view within a proposed change or branch view so that changes to profiles show up. ([#8529](https://github.com/opsmill/infrahub/issues/8529))
+- Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing backoff retry. ([#8696](https://github.com/opsmill/infrahub/issues/8696))
+- Fix object creation from a template when a resource pool is assigned to a required relationship or attribute field. ([#8701](https://github.com/opsmill/infrahub/issues/8701))
+- Deleting a node that inherits from `CoreArtifactTarget` now automatically deletes its associated artifacts. ([#8735](https://github.com/opsmill/infrahub/issues/8735))
+- Add missing `hfid` field to `RelatedIPAddressNodeInput` GraphQL type, allowing IP address relationships to be referenced by human-friendly ID
+- Fixed "Import latest commit" action crashing with `'Node' object has no attribute 'ref'` when used on a regular Repository instead of a Read-Only Repository.
+
+### Housekeeping
+
+- Migrated Node.js from version 22 to 24 LTS across CI workflows, Docker build, and package engine constraints.

--- a/docs/docs/release-notes/infrahub/release-1_8_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_3.mdx
@@ -9,7 +9,7 @@ title: Release 1.8.3
     </tr>
     <tr>
       <th>Release Date</th>
-      <td>March 25th, 2026</td>
+      <td>March 31st, 2026</td>
     </tr>
     <tr>
       <th>Tag</th>

--- a/docs/docs/release-notes/infrahub/release-1_8_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_3.mdx
@@ -20,8 +20,8 @@ title: Release 1.8.3
 
 ### Fixed
 
-- Corrected data diff view within a proposed change or branch view so that changes to profiles show up. ([#8529](https://github.com/opsmill/infrahub/issues/8529))
-- Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing backoff retry. ([#8696](https://github.com/opsmill/infrahub/issues/8696))
+- Corrected data diff view within a proposed change or branch view so that changes to Profiles show up. ([#8529](https://github.com/opsmill/infrahub/issues/8529))
+- Fixed hard failures on GraphQL queries that would exhaust Neo4j's server thread pool by implementing back off retry. ([#8696](https://github.com/opsmill/infrahub/issues/8696))
 - Fix object creation from a template when a resource pool is assigned to a required relationship or attribute field. ([#8701](https://github.com/opsmill/infrahub/issues/8701))
 - Deleting a node that inherits from `CoreArtifactTarget` now automatically deletes its associated artifacts. ([#8735](https://github.com/opsmill/infrahub/issues/8735))
 - Add missing `hfid` field to `RelatedIPAddressNodeInput` GraphQL type, allowing IP address relationships to be referenced by human-friendly ID

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -428,6 +428,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_8_3',
             'release-notes/infrahub/release-1_8_2',
             'release-notes/infrahub/release-1_8_1',
             'release-notes/infrahub/release-1_8_0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.8.2"
+version = "1.8.3"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.8.2"
+version = "1.8.3"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prep the 1.8.3 release: updated CHANGELOG (rolled up towncrier and set release date), bumped versions, and added docs release notes with a sidebar entry. Includes stability fixes and Node.js 24 LTS migration.

- **Bug Fixes**
  - Show profile changes in data diff for proposed changes/branches.
  - Add backoff retry to avoid Neo4j thread pool exhaustion on GraphQL queries.
  - Fix template-based creation when a resource pool is required on relationships/attributes.
  - Deleting nodes inheriting from `CoreArtifactTarget` also deletes their artifacts.
  - Add missing `hfid` to `RelatedIPAddressNodeInput` for IP relationship refs.
  - Prevent "Import latest commit" crash on non read-only repositories.

- **Housekeeping**
  - Migrate Node.js to 24 LTS in CI, Docker, and engines.
  - Bump `infrahub-server` and `infrahub-testcontainers` to 1.8.3 and update `uv.lock`.
  - Roll up towncrier fragments into CHANGELOG and add 1.8.3 docs release notes + sidebar; set release date.

<sup>Written for commit 509f78e8b6496f38364918fdeef7caa5977852fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

