### PR TITLE
Fix flaky artifact.spec.ts

### DIFF
--- a/frontend/app/tests/e2e/objects/artifact.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact.spec.ts
@@ -19,7 +19,11 @@ test.describe("/objects/CoreArtifact - Artifact page", () => {
     }
 
     await page.getByRole("link", { name: "startup-config" }).first().click();
-    await expect(page.getByText("no aaa root").first()).toBeVisible();
+    while (await page.getByText("no aaa root").first().isHidden()) {
+      if (await page.getByText("No artifact content available").isVisible()) {
+        await page.reload();
+      }
+    }
 
     await page.getByRole("button", { name: "View node metadata" }).click();
 

--- a/frontend/app/tests/e2e/objects/artifact.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact.spec.ts
@@ -20,7 +20,7 @@ test.describe("/objects/CoreArtifact - Artifact page", () => {
 
     await page.getByRole("link", { name: "startup-config" }).first().click();
     while (await page.getByText("no aaa root").first().isHidden()) {
-      await expect(page.getByRole("link", { name: "Openconfig Interface for" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "startup-config" })).toBeVisible();
       if (await page.getByText("No artifact content available").isVisible()) {
         await page.reload();
       }

--- a/frontend/app/tests/e2e/objects/artifact.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact.spec.ts
@@ -20,6 +20,7 @@ test.describe("/objects/CoreArtifact - Artifact page", () => {
 
     await page.getByRole("link", { name: "startup-config" }).first().click();
     while (await page.getByText("no aaa root").first().isHidden()) {
+      await expect(page.getByRole("link", { name: "Openconfig Interface for" })).toBeVisible();
       if (await page.getByText("No artifact content available").isVisible()) {
         await page.reload();
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes the artifact page e2e test to prevent flakes from delayed content and transient empty states.

- **Bug Fixes**
  - Replace the one-shot visibility check with a loop that waits for "no aaa root"; during retries, assert the "startup-config" heading is visible, and reload if "No artifact content available" appears.

<sup>Written for commit 814348f2ca3fcf4c7f48f055cb1b797defd506a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

