### PR TITLE
IFC-2406: node creation local computation

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -246,25 +246,26 @@ async def process_jinja2(
     )
     schema_branch = registry.schema.get_schema_branch(name=target_branch_schema)
     node_schema = schema_branch.get_node(name=computed_attribute_kind, duplicate=False)
-    computed_macros = [
-        attrib
-        for attrib in schema_branch.computed_attributes.get_impacted_jinja2_targets(kind=node_kind, updates=updates)
-        if attrib.kind == computed_attribute_kind and attrib.attribute.name == computed_attribute_name
+    resolved_targets = [
+        resolved
+        for resolved in schema_branch.computed_attributes.get_impacted_jinja2_targets(kind=node_kind, updates=updates)
+        if resolved.target.kind == computed_attribute_kind and resolved.target.attribute.name == computed_attribute_name
     ]
-    for computed_macro in computed_macros:
+    for resolved in resolved_targets:
         found: list[ComputedAttrJinja2GraphQLResponse] = []
         template_string = "n/a"
-        if computed_macro.attribute.computed_attribute and computed_macro.attribute.computed_attribute.jinja2_template:
-            template_string = computed_macro.attribute.computed_attribute.jinja2_template
+        attribute = resolved.target.attribute
+        if attribute.computed_attribute and attribute.computed_attribute.jinja2_template:
+            template_string = attribute.computed_attribute.jinja2_template
 
         jinja_template = InfrahubJinja2Template(template=template_string)
         variables = jinja_template.get_variables()
 
         attribute_graphql = ComputedAttrJinja2GraphQL(
-            node_schema=node_schema, attribute_schema=computed_macro.attribute, variables=variables
+            node_schema=node_schema, attribute_schema=attribute, variables=variables
         )
 
-        for id_filter in computed_macro.node_filters:
+        for id_filter in resolved.node_filters:
             query = attribute_graphql.render_graphql_query(query_filter=id_filter, filter_id=object_id)
             try:
                 response = await client.execute_graphql(query=query, branch_name=branch_name)
@@ -286,7 +287,7 @@ async def process_jinja2(
                 branch_name=branch_name,
                 obj=node,
                 node_kind=node_schema.kind,
-                attribute_name=computed_macro.attribute.name,
+                attribute_name=attribute.name,
                 template=jinja_template,
                 context=context,
             )

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -564,15 +564,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                         ValidationError({mandatory_rel: f"{mandatory_rel} is mandatory for {self.get_kind()}"})
                     )
 
-            if self._schema.is_node_schema:
-                schema_branch = db.schema.get_schema_branch(self._branch.name)
-                local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
-                for target in local_targets:
-                    if (
-                        target.attribute.name not in fields
-                        and target.attribute.name not in self._computed_jinja2_attributes
-                    ):
-                        self._computed_jinja2_attributes.append(target.attribute.name)
+            self._computed_jinja2_attributes.extend(self._get_optional_local_jinja2_attributes(db=db, fields=fields))
 
         if errors:
             raise ValidationError(errors)

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -564,6 +564,16 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                         ValidationError({mandatory_rel: f"{mandatory_rel} is mandatory for {self.get_kind()}"})
                     )
 
+            if self._schema.is_node_schema:
+                schema_branch = db.schema.get_schema_branch(self._branch.name)
+                local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
+                for target in local_targets:
+                    if (
+                        target.attribute.name not in fields
+                        and target.attribute.name not in self._computed_jinja2_attributes
+                    ):
+                        self._computed_jinja2_attributes.append(target.attribute.name)
+
         if errors:
             raise ValidationError(errors)
 
@@ -680,8 +690,14 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def _process_macros(self, db: InfrahubDatabase) -> None:
         schema_branch = db.schema.get_schema_branch(self._branch.name)
+
+        local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
+        ordered_macros = [
+            t.attribute.name for t in local_targets if t.attribute.name in self._computed_jinja2_attributes
+        ]
+
         errors = []
-        for macro in self._computed_jinja2_attributes:
+        for macro in ordered_macros:
             attr_schema = self._schema.get_attribute(name=macro)
             if not attr_schema.computed_attribute:
                 errors.append(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -539,13 +539,16 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 self._profile_provided_rels,
             ) = await self._get_profile_provided_mandatory_fields(db=db, fields=fields)
 
-            self._validate_mandatory_relationships(fields=fields, errors=errors)
+            errors.extend(self._validate_mandatory_attributes(fields=fields))
+            errors.extend(self._validate_mandatory_relationships(fields=fields))
 
-            self._computed_jinja2_attributes.extend(self._get_mandatory_jinja2_attributes(fields=fields, errors=errors))
-            self._computed_jinja2_attributes.extend(self._get_optional_local_jinja2_attributes(db=db, fields=fields))
+            if errors:
+                raise ValidationError(errors)
 
-        if errors:
-            raise ValidationError(errors)
+            if self._schema.is_node_schema:
+                schema_branch = db.schema.get_schema_branch(self._branch.name)
+                local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
+                self._computed_jinja2_attributes = [t.attribute.name for t in local_targets]
 
         # -------------------------------------------
         # Generate Attribute and Relationship and assign them
@@ -562,10 +565,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             if hasattr(self, f"process_{name}"):
                 await getattr(self, f"process_{name}")(db=db)
 
-    def _get_mandatory_jinja2_attributes(self, fields: dict, errors: list[ValidationError]) -> list[str]:
-        """Validate that all mandatory attributes are provided and return mandatory Jinja2 computed attribute names."""
-        computed_jinja2: list[str] = []
-
+    def _validate_mandatory_attributes(self, fields: dict) -> list[ValidationError]:
+        """Validate that all mandatory attributes are provided."""
+        errors: list[ValidationError] = []
         for mandatory_attr in self._schema.mandatory_attribute_names:
             if mandatory_attr not in fields.keys() and mandatory_attr not in self._profile_provided_attrs:
                 if self._schema.is_node_schema:
@@ -574,34 +576,21 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                         mandatory_attribute.computed_attribute
                         and mandatory_attribute.computed_attribute.kind == ComputedAttributeKind.JINJA2
                     ):
-                        computed_jinja2.append(mandatory_attr)
                         continue
 
                     if mandatory_attribute.kind == "NumberPool":
                         continue
 
                 errors.append(ValidationError({mandatory_attr: f"{mandatory_attr} is mandatory for {self.get_kind()}"}))
+        return errors
 
-        return computed_jinja2
-
-    def _validate_mandatory_relationships(self, fields: dict, errors: list[ValidationError]) -> None:
+    def _validate_mandatory_relationships(self, fields: dict) -> list[ValidationError]:
         """Validate that all mandatory relationships are provided."""
+        errors: list[ValidationError] = []
         for mandatory_rel in self._schema.mandatory_relationship_names:
             if mandatory_rel not in fields.keys() and mandatory_rel not in self._profile_provided_rels:
                 errors.append(ValidationError({mandatory_rel: f"{mandatory_rel} is mandatory for {self.get_kind()}"}))
-
-    def _get_optional_local_jinja2_attributes(self, db: InfrahubDatabase, fields: dict) -> list[str]:
-        """Return optional local Jinja2 computed attribute names not already collected."""
-        if not self._schema.is_node_schema:
-            return []
-
-        schema_branch = db.schema.get_schema_branch(self._branch.name)
-        local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
-        return [
-            target.attribute.name
-            for target in local_targets
-            if target.attribute.name not in fields and target.attribute.name not in self._computed_jinja2_attributes
-        ]
+        return errors
 
     async def _process_fields_relationships(self, fields: dict, db: InfrahubDatabase) -> list[ValidationError]:
         errors: list[ValidationError] = []
@@ -701,14 +690,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def _process_macros(self, db: InfrahubDatabase) -> None:
         schema_branch = db.schema.get_schema_branch(self._branch.name)
-
-        local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
-        ordered_macros = [
-            t.attribute.name for t in local_targets if t.attribute.name in self._computed_jinja2_attributes
-        ]
-
         errors = []
-        for macro in ordered_macros:
+        for macro in self._computed_jinja2_attributes:
             attr_schema = self._schema.get_attribute(name=macro)
             if not attr_schema.computed_attribute:
                 errors.append(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -514,8 +514,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         )
 
     async def _process_fields(self, fields: dict, db: InfrahubDatabase, process_pools: bool = True) -> None:
-        errors = []
-
         if "_source" in fields.keys():
             self._source = fields["_source"]
         if "_owner" in fields.keys():
@@ -531,6 +529,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             if field_name not in self._schema.valid_input_names:
                 log.error(f"{field_name} is not a valid input for {self.get_kind()}")
 
+        errors = []
         # Backfill fields with the ones from the template if there's one
         await self.handle_object_template(fields=fields, db=db, errors=errors, process_pools=process_pools)
 
@@ -540,30 +539,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 self._profile_provided_rels,
             ) = await self._get_profile_provided_mandatory_fields(db=db, fields=fields)
 
-            for mandatory_attr in self._schema.mandatory_attribute_names:
-                if mandatory_attr not in fields.keys() and mandatory_attr not in self._profile_provided_attrs:
-                    if self._schema.is_node_schema:
-                        mandatory_attribute = self._schema.get_attribute(name=mandatory_attr)
-                        if (
-                            mandatory_attribute.computed_attribute
-                            and mandatory_attribute.computed_attribute.kind == ComputedAttributeKind.JINJA2
-                        ):
-                            self._computed_jinja2_attributes.append(mandatory_attr)
-                            continue
+            self._validate_mandatory_relationships(fields=fields, errors=errors)
 
-                        if mandatory_attribute.kind == "NumberPool":
-                            continue
-
-                    errors.append(
-                        ValidationError({mandatory_attr: f"{mandatory_attr} is mandatory for {self.get_kind()}"})
-                    )
-
-            for mandatory_rel in self._schema.mandatory_relationship_names:
-                if mandatory_rel not in fields.keys() and mandatory_rel not in self._profile_provided_rels:
-                    errors.append(
-                        ValidationError({mandatory_rel: f"{mandatory_rel} is mandatory for {self.get_kind()}"})
-                    )
-
+            self._computed_jinja2_attributes.extend(self._get_mandatory_jinja2_attributes(fields=fields, errors=errors))
             self._computed_jinja2_attributes.extend(self._get_optional_local_jinja2_attributes(db=db, fields=fields))
 
         if errors:
@@ -583,6 +561,47 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         for name in self._attributes + self._relationships:
             if hasattr(self, f"process_{name}"):
                 await getattr(self, f"process_{name}")(db=db)
+
+    def _get_mandatory_jinja2_attributes(self, fields: dict, errors: list[ValidationError]) -> list[str]:
+        """Validate that all mandatory attributes are provided and return mandatory Jinja2 computed attribute names."""
+        computed_jinja2: list[str] = []
+
+        for mandatory_attr in self._schema.mandatory_attribute_names:
+            if mandatory_attr not in fields.keys() and mandatory_attr not in self._profile_provided_attrs:
+                if self._schema.is_node_schema:
+                    mandatory_attribute = self._schema.get_attribute(name=mandatory_attr)
+                    if (
+                        mandatory_attribute.computed_attribute
+                        and mandatory_attribute.computed_attribute.kind == ComputedAttributeKind.JINJA2
+                    ):
+                        computed_jinja2.append(mandatory_attr)
+                        continue
+
+                    if mandatory_attribute.kind == "NumberPool":
+                        continue
+
+                errors.append(ValidationError({mandatory_attr: f"{mandatory_attr} is mandatory for {self.get_kind()}"}))
+
+        return computed_jinja2
+
+    def _validate_mandatory_relationships(self, fields: dict, errors: list[ValidationError]) -> None:
+        """Validate that all mandatory relationships are provided."""
+        for mandatory_rel in self._schema.mandatory_relationship_names:
+            if mandatory_rel not in fields.keys() and mandatory_rel not in self._profile_provided_rels:
+                errors.append(ValidationError({mandatory_rel: f"{mandatory_rel} is mandatory for {self.get_kind()}"}))
+
+    def _get_optional_local_jinja2_attributes(self, db: InfrahubDatabase, fields: dict) -> list[str]:
+        """Return optional local Jinja2 computed attribute names not already collected."""
+        if not self._schema.is_node_schema:
+            return []
+
+        schema_branch = db.schema.get_schema_branch(self._branch.name)
+        local_targets = schema_branch.computed_attributes.get_local_jinja2_targets(kind=self._schema.kind)
+        return [
+            target.attribute.name
+            for target in local_targets
+            if target.attribute.name not in fields and target.attribute.name not in self._computed_jinja2_attributes
+        ]
 
     async def _process_fields_relationships(self, fields: dict, db: InfrahubDatabase) -> list[ValidationError]:
         errors: list[ValidationError] = []

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1274,11 +1274,16 @@ class SchemaBranch:
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()
+        self._validate_node_computed_attributes()
+        self._validate_generic_computed_attributes()
+
+    def _validate_node_computed_attributes(self) -> None:
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
+    def _validate_generic_computed_attributes(self) -> None:
         defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1278,12 +1278,14 @@ class SchemaBranch:
         self._validate_generic_computed_attributes()
 
     def _validate_node_computed_attributes(self) -> None:
+        """Validate and register computed attributes defined directly on nodes."""
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
     def _validate_generic_computed_attributes(self) -> None:
+        """Ensure no node inherits the same computed attribute from multiple generics."""
         defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1279,15 +1279,20 @@ class SchemaBranch:
             for attribute in node_schema.attributes:
                 self._validate_computed_attribute(node=node_schema, attribute=attribute)
 
+        defined_from_generic: dict[str, str] = {}
         for name in self.generics.keys():
             generic_schema = self.get_generic(name=name, duplicate=False)
             for attribute in generic_schema.attributes:
                 if attribute.computed_attribute and attribute.computed_attribute.kind != ComputedAttributeKind.USER:
                     for inheriting_node in generic_schema.used_by:
                         node_schema = self.get_node(name=inheriting_node, duplicate=False)
-                        self.computed_attributes.validate_generic_inheritance(
-                            node=node_schema, attribute=attribute, generic=generic_schema
-                        )
+                        attribute_key = f"{node_schema.kind}__{attribute.name}"
+                        if duplicate := defined_from_generic.get(attribute_key):
+                            raise ValueError(
+                                f"{node_schema.kind}: {attribute.name!r} is declared as a computed attribute"
+                                f" from multiple generics {sorted([duplicate, generic_schema.kind])}"
+                            )
+                        defined_from_generic[attribute_key] = generic_schema.kind
 
     def _validate_display_label(self, node: MainSchemaTypes) -> None:
         if not node.display_label:

--- a/backend/infrahub/core/schema/schema_branch_computed/__init__.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/__init__.py
@@ -2,6 +2,7 @@ from infrahub.core.schema.schema_branch_computed.facade import ComputedAttribute
 from infrahub.core.schema.schema_branch_computed.jinja2 import (
     ComputedAttributeTarget,
     ComputedAttributeTriggerNode,
+    ResolvedComputedTarget,
 )
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition
 
@@ -10,4 +11,5 @@ __all__ = [
     "ComputedAttributeTriggerNode",
     "ComputedAttributes",
     "PythonDefinition",
+    "ResolvedComputedTarget",
 ]

--- a/backend/infrahub/core/schema/schema_branch_computed/facade.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/facade.py
@@ -22,7 +22,7 @@ from infrahub.core.schema.schema_branch_computed.jinja2 import (
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition, PythonTransformRegistry
 
 if TYPE_CHECKING:
-    from infrahub.core.schema import GenericSchema, NodeSchema, SchemaAttributePath
+    from infrahub.core.schema import NodeSchema, SchemaAttributePath
 
 
 class ComputedAttributes:
@@ -33,7 +33,6 @@ class ComputedAttributes:
     ) -> None:
         self._python = PythonTransformRegistry(transform_attribute_map=transform_attribute_map)
         self._jinja2 = Jinja2ComputedRegistry(jinja2_attribute_map=jinja2_attribute_map)
-        self._defined_from_generic: dict[str, str] = {}
 
     def duplicate(self) -> ComputedAttributes:
         return self.__class__(
@@ -63,20 +62,6 @@ class ComputedAttributes:
         self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
     ) -> None:
         self._jinja2.register(node, attribute, schema_path)
-
-    def validate_generic_inheritance(
-        self, node: NodeSchema, attribute: AttributeSchema, generic: GenericSchema
-    ) -> None:
-        """Ensure a computed attribute is not inherited from multiple generics.
-
-        This validation applies to all computed attribute kinds.
-        """
-        attribute_key = f"{node.kind}__{attribute.name}"
-        if duplicate := self._defined_from_generic.get(attribute_key):
-            raise ValueError(
-                f"{node.kind}: {attribute.name!r} is declared as a computed attribute from multiple generics {sorted([duplicate, generic.kind])}"
-            )
-        self._defined_from_generic[attribute_key] = generic.kind
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         return self._jinja2.get_impacted_targets(kind, updates)

--- a/backend/infrahub/core/schema/schema_branch_computed/facade.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/facade.py
@@ -17,6 +17,7 @@ from infrahub.core.schema.schema_branch_computed.jinja2 import (
     ComputedAttributeTriggerNode,
     Jinja2ComputedRegistry,
     RegisteredNodeComputedAttribute,
+    ResolvedComputedTarget,
 )
 from infrahub.core.schema.schema_branch_computed.python_transform import PythonDefinition, PythonTransformRegistry
 
@@ -77,7 +78,7 @@ class ComputedAttributes:
             )
         self._defined_from_generic[attribute_key] = generic.kind
 
-    def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         return self._jinja2.get_impacted_targets(kind, updates)
 
     def get_local_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:

--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -17,28 +17,30 @@ class ComputedAttributeTarget(BaseModel):
     """Identifies a computed attribute that needs recomputation.
 
     Points to a specific (kind, attribute) pair — e.g. InfraDevice.computed_name — that should
-    be re-evaluated when a dependency changes. The ``filter_keys`` field carries relationship-based
-    query filters (e.g. ``site__ids``) used to locate affected nodes when the trigger comes from
-    a peer node rather than the owner itself.
+    be re-evaluated when a dependency changes.
     """
 
     kind: str
     attribute: AttributeSchema
-    filter_keys: list[str] = Field(default_factory=list)
 
     @property
     def key_name(self) -> str:
         return f"{self.kind}_{self.attribute.name}"
 
-    @property
-    def node_filters(self) -> list[str]:
-        if self.filter_keys:
-            return self.filter_keys
-
-        return ["ids"]
-
     def __hash__(self) -> int:
-        return hash((self.kind, self.attribute, tuple(self.filter_keys)))
+        return hash((self.kind, self.attribute))
+
+
+class ResolvedComputedTarget(BaseModel):
+    """A ComputedAttributeTarget paired with the query filters needed to locate affected nodes.
+
+    The ``node_filters`` carry relationship-based query filters (e.g. ``site__ids``) built at
+    resolution time by :meth:`RegisteredNodeComputedAttribute.get_targets`. When the trigger comes
+    from the owner itself, the default ``["ids"]`` filter is used.
+    """
+
+    target: ComputedAttributeTarget
+    node_filters: list[str] = Field(default_factory=lambda: ["ids"])
 
 
 class ComputedAttributeTriggerNode(BaseModel):
@@ -73,7 +75,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
     - **"InfraSite"** (the peer): ``local_fields = {"name": [target]}``,
       ``relationships = {"site": [target]}``
       A change to the site's ``name`` triggers recomputation of devices linked via ``site``.
-      The ``relationships`` dict provides ``filter_keys`` (e.g. ``site__ids``) so the system
+      The ``relationships`` dict provides query filters (e.g. ``site__ids``) so the system
       can locate which devices are affected.
     """
 
@@ -91,7 +93,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
         """Return mapping of relationship names to peer attribute names needed for computed attribute templates."""
         return {rel: dep.peer_attributes for rel, dep in self.relationship_dependencies.items()}
 
-    def get_targets(self, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_targets(self, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         """Resolve which ComputedAttributeTargets are affected by changes to this node.
 
         Args:
@@ -99,25 +101,25 @@ class RegisteredNodeComputedAttribute(BaseModel):
                      registered local_fields are included.
 
         Returns:
-            Deduplicated list of ComputedAttributeTarget, each enriched with any applicable
-            relationship-based filter_keys.
+            Deduplicated list of ResolvedComputedTarget, each pairing a target with the
+            query filters needed to locate affected nodes.
         """
-        targets: dict[str, ComputedAttributeTarget] = {}
+        resolved: dict[str, ResolvedComputedTarget] = {}
         for attribute, entries in self.local_fields.items():
             if updates and attribute not in updates:
                 continue
 
             for entry in entries:
-                if entry.key_name not in targets:
-                    targets[entry.key_name] = entry.model_copy(deep=True)
+                if entry.key_name not in resolved:
+                    resolved[entry.key_name] = ResolvedComputedTarget(target=entry)
 
         for relationship_name, dep in self.relationship_dependencies.items():
             for entry in dep.targets:
                 filter_key = f"{relationship_name}__ids"
-                if entry.key_name in targets and filter_key not in targets[entry.key_name].filter_keys:
-                    targets[entry.key_name].filter_keys.append(filter_key)
+                if entry.key_name in resolved and filter_key not in resolved[entry.key_name].node_filters:
+                    resolved[entry.key_name].node_filters.append(filter_key)
 
-        return list(targets.values())
+        return list(resolved.values())
 
     def get_local_targets_in_dependency_order(self, kind: str, updates: list[str]) -> list[ComputedAttributeTarget]:
         """Walk local_fields wave by wave, returning self-targeting targets in dependency order.
@@ -249,7 +251,7 @@ class Jinja2ComputedRegistry:
             owner_dep = owner_entry.relationship_dependencies.setdefault(rel_name, RelationshipDependency())
             owner_dep.peer_attributes.add(schema_path.active_attribute_schema.name)
 
-    def get_impacted_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+    def get_impacted_targets(self, kind: str, updates: list[str] | None = None) -> list[ResolvedComputedTarget]:
         """Return computed Jinja2 attribute targets that need re-evaluation when a node of the given kind is modified.
 
         Args:
@@ -259,9 +261,9 @@ class Jinja2ComputedRegistry:
                      When None, all registered targets for this kind are returned.
 
         Returns:
-            List of ComputedAttributeTarget entries, each identifying a (kind, attribute) pair whose
-            computed value depends on the modified node and may need recomputation. The target kind
-            can differ from the input kind when the dependency crosses a relationship.
+            List of ResolvedComputedTarget entries, each pairing a (kind, attribute) identity with the
+            query filters needed to locate affected nodes. The target kind can differ from the input
+            kind when the dependency crosses a relationship.
         """
         if mapping := self._map.get(kind):
             return mapping.get_targets(updates=updates)

--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -40,7 +40,7 @@ class ResolvedComputedTarget(BaseModel):
     """
 
     target: ComputedAttributeTarget
-    node_filters: list[str] = Field(default_factory=lambda: ["ids"])
+    node_filters: list[str] = Field(default_factory=list)
 
 
 class ComputedAttributeTriggerNode(BaseModel):
@@ -118,6 +118,11 @@ class RegisteredNodeComputedAttribute(BaseModel):
                 filter_key = f"{relationship_name}__ids"
                 if entry.key_name in resolved and filter_key not in resolved[entry.key_name].node_filters:
                     resolved[entry.key_name].node_filters.append(filter_key)
+
+        # Targets with no relationship filters need the default "ids" filter
+        for target in resolved.values():
+            if not target.node_filters:
+                target.node_filters.append("ids")
 
         return list(resolved.values())
 

--- a/backend/tests/component/computed_attribute/test_local_computation.py
+++ b/backend/tests/component/computed_attribute/test_local_computation.py
@@ -157,105 +157,115 @@ async def _create_device(
     return device
 
 
-async def test_all_jinja2_flavours_computed_at_creation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
-) -> None:
-    """All four Jinja2 computed attributes are evaluated inline during creation."""
-    owner = await _create_owner(db=db, default_branch=default_branch)
-    device = await _create_device(db=db, default_branch=default_branch, owner=owner)
+class TestNodeCreation:
+    async def test_all_jinja2_flavours_computed_at_creation(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
+    ) -> None:
+        """All four Jinja2 computed attributes are evaluated inline during creation."""
+        owner = await _create_owner(db=db, default_branch=default_branch)
+        device = await _create_device(db=db, default_branch=default_branch, owner=owner)
 
-    assert device.get_attribute("local_label").value == "switch01-spine"
-    assert device.get_attribute("local_tag").value == "spine:switch01"
-    assert device.get_attribute("remote_label").value == "Alice's switch01"
-    assert device.get_attribute("remote_tag").value == "Alice-spine"
+        assert device.get_attribute("local_label").value == "switch01-spine"
+        assert device.get_attribute("local_tag").value == "spine:switch01"
+        assert device.get_attribute("remote_label").value == "Alice's switch01"
+        assert device.get_attribute("remote_tag").value == "Alice-spine"
 
-    reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
-    assert reloaded.get_attribute("local_label").value == "switch01-spine"
-    assert reloaded.get_attribute("local_tag").value == "spine:switch01"
-    assert reloaded.get_attribute("remote_label").value == "Alice's switch01"
-    assert reloaded.get_attribute("remote_tag").value == "Alice-spine"
+        reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
+        assert reloaded.get_attribute("local_label").value == "switch01-spine"
+        assert reloaded.get_attribute("local_tag").value == "spine:switch01"
+        assert reloaded.get_attribute("remote_label").value == "Alice's switch01"
+        assert reloaded.get_attribute("remote_tag").value == "Alice-spine"
 
+    async def test_chained_jinja2_cascade(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_chained_jinja2: None
+    ) -> None:
+        """Chained computed attributes cascade: name -> label -> fqdn all computed at creation."""
+        server = await Node.init(db=db, schema="TestComputeServer", branch=default_branch)
+        await server.new(db=db, name="web01", role="frontend")
+        await server.save(db=db)
 
-async def test_local_attr_change_triggers_recomputation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
-) -> None:
-    """Updating a local attribute recomputes all computed attributes that depend on it."""
-    owner = await _create_owner(db=db, default_branch=default_branch)
-    device = await _create_device(db=db, default_branch=default_branch, owner=owner)
+        assert server.get_attribute("label").value == "web01-frontend"
+        assert server.get_attribute("fqdn").value == "web01-frontend.example.com"
 
-    device.get_attribute("name").value = "switch02"
-    await device.save(db=db, fields=["name"])
-
-    # local_label and local_tag depend on name
-    assert device.get_attribute("local_label").value == "switch02-spine"
-    assert device.get_attribute("local_tag").value == "spine:switch02"
-    # remote_label depends on name too
-    assert device.get_attribute("remote_label").value == "Alice's switch02"
-    # remote_tag depends on role, not name — unchanged
-    assert device.get_attribute("remote_tag").value == "Alice-spine"
-
-    reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
-    assert reloaded.get_attribute("local_label").value == "switch02-spine"
-    assert reloaded.get_attribute("local_tag").value == "spine:switch02"
-    assert reloaded.get_attribute("remote_label").value == "Alice's switch02"
+        reloaded = await NodeManager.get_one(db=db, id=server.id, branch=default_branch)
+        assert reloaded.get_attribute("fqdn").value == "web01-frontend.example.com"
 
 
-async def test_unrelated_attr_change_does_not_trigger_recomputation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
-) -> None:
-    """Updating an attribute not referenced by any template does NOT trigger recomputation."""
-    owner = await _create_owner(db=db, default_branch=default_branch)
-    device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="switch01", role="spine")
+class TestNodeUpdate:
+    async def test_local_attr_change_triggers_recomputation(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
+    ) -> None:
+        """Updating a local attribute recomputes all computed attributes that depend on it."""
+        owner = await _create_owner(db=db, default_branch=default_branch)
+        device = await _create_device(db=db, default_branch=default_branch, owner=owner)
 
-    with patch.object(
-        InfrahubJinja2Template,
-        "render",
-        new_callable=AsyncMock,
-    ) as mock_render:
-        device.get_attribute("description").value = "updated"
-        await device.save(db=db, fields=["description"])
-        mock_render.assert_not_called()
-
-    assert device.get_attribute("local_label").value == "switch01-spine"
-
-
-async def test_chained_jinja2_cascade(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_chained_jinja2: None
-) -> None:
-    """Chained computed attributes cascade: name -> label -> fqdn all recomputed inline."""
-    server = await Node.init(db=db, schema="TestComputeServer", branch=default_branch)
-    await server.new(db=db, name="web01", role="frontend")
-    await server.save(db=db)
-
-    assert server.get_attribute("label").value == "web01-frontend"
-    assert server.get_attribute("fqdn").value == "web01-frontend.example.com"
-
-    server.get_attribute("name").value = "web02"
-    await server.save(db=db, fields=["name"])
-
-    assert server.get_attribute("label").value == "web02-frontend"
-    assert server.get_attribute("fqdn").value == "web02-frontend.example.com"
-
-    reloaded = await NodeManager.get_one(db=db, id=server.id, branch=default_branch)
-    assert reloaded.get_attribute("fqdn").value == "web02-frontend.example.com"
-
-
-async def test_jinja2_error_handled_gracefully(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
-) -> None:
-    """A Jinja2 evaluation failure is logged but the mutation succeeds."""
-    owner = await _create_owner(db=db, default_branch=default_branch)
-    device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="gear01", role="red")
-
-    assert device.get_attribute("local_label").value == "gear01-red"
-
-    with patch(
-        "infrahub.core.node.InfrahubJinja2Template.render",
-        new_callable=AsyncMock,
-        side_effect=JinjaTemplateError(message="Simulated Jinja2 rendering failure"),
-    ):
-        device.get_attribute("name").value = "gear02"
+        device.get_attribute("name").value = "switch02"
         await device.save(db=db, fields=["name"])
 
-    assert device.get_attribute("name").value == "gear02"
-    assert device.get_attribute("local_label").value == "gear01-red"
+        # local_label and local_tag depend on name
+        assert device.get_attribute("local_label").value == "switch02-spine"
+        assert device.get_attribute("local_tag").value == "spine:switch02"
+        # remote_label depends on name too
+        assert device.get_attribute("remote_label").value == "Alice's switch02"
+        # remote_tag depends on role, not name — unchanged
+        assert device.get_attribute("remote_tag").value == "Alice-spine"
+
+        reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
+        assert reloaded.get_attribute("local_label").value == "switch02-spine"
+        assert reloaded.get_attribute("local_tag").value == "spine:switch02"
+        assert reloaded.get_attribute("remote_label").value == "Alice's switch02"
+
+    async def test_unrelated_attr_change_does_not_trigger_recomputation(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
+    ) -> None:
+        """Updating an attribute not referenced by any template does NOT trigger recomputation."""
+        owner = await _create_owner(db=db, default_branch=default_branch)
+        device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="switch01", role="spine")
+
+        with patch.object(
+            InfrahubJinja2Template,
+            "render",
+            new_callable=AsyncMock,
+        ) as mock_render:
+            device.get_attribute("description").value = "updated"
+            await device.save(db=db, fields=["description"])
+            mock_render.assert_not_called()
+
+        assert device.get_attribute("local_label").value == "switch01-spine"
+
+    async def test_chained_jinja2_cascade(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_chained_jinja2: None
+    ) -> None:
+        """Chained computed attributes cascade on update: name -> label -> fqdn."""
+        server = await Node.init(db=db, schema="TestComputeServer", branch=default_branch)
+        await server.new(db=db, name="web01", role="frontend")
+        await server.save(db=db)
+
+        server.get_attribute("name").value = "web02"
+        await server.save(db=db, fields=["name"])
+
+        assert server.get_attribute("label").value == "web02-frontend"
+        assert server.get_attribute("fqdn").value == "web02-frontend.example.com"
+
+        reloaded = await NodeManager.get_one(db=db, id=server.id, branch=default_branch)
+        assert reloaded.get_attribute("fqdn").value == "web02-frontend.example.com"
+
+    async def test_jinja2_error_handled_gracefully(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
+    ) -> None:
+        """A Jinja2 evaluation failure is logged but the mutation succeeds."""
+        owner = await _create_owner(db=db, default_branch=default_branch)
+        device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="gear01", role="red")
+
+        assert device.get_attribute("local_label").value == "gear01-red"
+
+        with patch(
+            "infrahub.core.node.InfrahubJinja2Template.render",
+            new_callable=AsyncMock,
+            side_effect=JinjaTemplateError(message="Simulated Jinja2 rendering failure"),
+        ):
+            device.get_attribute("name").value = "gear02"
+            await device.save(db=db, fields=["name"])
+
+        assert device.get_attribute("name").value == "gear02"
+        assert device.get_attribute("local_label").value == "gear01-red"

--- a/backend/tests/component/computed_attribute/test_local_computation.py
+++ b/backend/tests/component/computed_attribute/test_local_computation.py
@@ -6,11 +6,13 @@ from infrahub_sdk.template.exceptions import JinjaTemplateError
 from infrahub.computed_attribute.jinja2 import InfrahubJinja2Template
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import (
     AttributeSchema,
     NodeSchema,
+    RelationshipSchema,
     SchemaRoot,
 )
 from infrahub.core.schema.computed_attribute import ComputedAttribute, ComputedAttributeKind
@@ -18,12 +20,25 @@ from infrahub.database import InfrahubDatabase
 
 
 @pytest.fixture
-async def schema_with_local_jinja2(
+async def schema_with_jinja2(
     db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
 ) -> None:
-    """Single computed attribute (label) derived from two local attributes (name, role)."""
+    """Schema with all four flavours of Jinja2 computed attributes:
+    - local_label: mandatory, depends on local attrs (name, role)
+    - local_tag: optional, depends on local attrs (name, role)
+    - remote_label: mandatory, depends on peer attr (owner.name) + local attr (name)
+    - remote_tag: optional, depends on peer attr (owner.name) + local attr (role)
+    Plus an unrelated attribute (description) for negative tests.
+    """
     schema = SchemaRoot(
         nodes=[
+            NodeSchema(
+                name="ComputeOwner",
+                namespace="Test",
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                ],
+            ),
             NodeSchema(
                 name="ComputeDevice",
                 namespace="Test",
@@ -32,13 +47,50 @@ async def schema_with_local_jinja2(
                     AttributeSchema(name="role", kind="Text"),
                     AttributeSchema(name="description", kind="Text", optional=True),
                     AttributeSchema(
-                        name="label",
+                        name="local_label",
                         kind="Text",
                         read_only=True,
                         computed_attribute=ComputedAttribute(
                             kind=ComputedAttributeKind.JINJA2,
                             jinja2_template="{{ name__value }}-{{ role__value }}",
                         ),
+                    ),
+                    AttributeSchema(
+                        name="local_tag",
+                        kind="Text",
+                        optional=True,
+                        read_only=True,
+                        computed_attribute=ComputedAttribute(
+                            kind=ComputedAttributeKind.JINJA2,
+                            jinja2_template="{{ role__value }}:{{ name__value }}",
+                        ),
+                    ),
+                    AttributeSchema(
+                        name="remote_label",
+                        kind="Text",
+                        read_only=True,
+                        computed_attribute=ComputedAttribute(
+                            kind=ComputedAttributeKind.JINJA2,
+                            jinja2_template="{{ owner__name__value }}'s {{ name__value }}",
+                        ),
+                    ),
+                    AttributeSchema(
+                        name="remote_tag",
+                        kind="Text",
+                        optional=True,
+                        read_only=True,
+                        computed_attribute=ComputedAttribute(
+                            kind=ComputedAttributeKind.JINJA2,
+                            jinja2_template="{{ owner__name__value }}-{{ role__value }}",
+                        ),
+                    ),
+                ],
+                relationships=[
+                    RelationshipSchema(
+                        name="owner",
+                        peer="TestComputeOwner",
+                        optional=False,
+                        cardinality=RelationshipCardinality.ONE,
                     ),
                 ],
             ),
@@ -89,115 +141,72 @@ async def schema_with_chained_jinja2(
     await default_branch.save(db=db)
 
 
-@pytest.fixture
-async def schema_with_render_test(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+async def _create_owner(db: InfrahubDatabase, default_branch: Branch, name: str = "Alice") -> Node:
+    owner = await Node.init(db=db, schema="TestComputeOwner", branch=default_branch)
+    await owner.new(db=db, name=name)
+    await owner.save(db=db)
+    return owner
+
+
+async def _create_device(
+    db: InfrahubDatabase, default_branch: Branch, owner: Node, name: str = "switch01", role: str = "spine"
+) -> Node:
+    device = await Node.init(db=db, schema="TestComputeDevice", branch=default_branch)
+    await device.new(db=db, name=name, role=role, owner=owner)
+    await device.save(db=db)
+    return device
+
+
+async def test_all_jinja2_flavours_computed_at_creation(
+    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
 ) -> None:
-    """Simple computed attribute used to test graceful handling of Jinja2 render errors."""
-    schema = SchemaRoot(
-        nodes=[
-            NodeSchema(
-                name="ComputeWidget",
-                namespace="Test",
-                attributes=[
-                    AttributeSchema(name="name", kind="Text", unique=True),
-                    AttributeSchema(name="color", kind="Text"),
-                    AttributeSchema(
-                        name="computed_label",
-                        kind="Text",
-                        read_only=True,
-                        computed_attribute=ComputedAttribute(
-                            kind=ComputedAttributeKind.JINJA2,
-                            jinja2_template="{{ name__value }}-{{ color__value }}",
-                        ),
-                    ),
-                ],
-            ),
-        ]
-    )
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
+    """All four Jinja2 computed attributes are evaluated inline during creation."""
+    owner = await _create_owner(db=db, default_branch=default_branch)
+    device = await _create_device(db=db, default_branch=default_branch, owner=owner)
 
+    assert device.get_attribute("local_label").value == "switch01-spine"
+    assert device.get_attribute("local_tag").value == "spine:switch01"
+    assert device.get_attribute("remote_label").value == "Alice's switch01"
+    assert device.get_attribute("remote_tag").value == "Alice-spine"
 
-@pytest.fixture
-async def schema_with_optional_local_jinja2(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
-) -> None:
-    """Optional computed attribute (label) derived from two local attributes (name, role)."""
-    schema = SchemaRoot(
-        nodes=[
-            NodeSchema(
-                name="ComputeGadget",
-                namespace="Test",
-                attributes=[
-                    AttributeSchema(name="name", kind="Text", unique=True),
-                    AttributeSchema(name="role", kind="Text"),
-                    AttributeSchema(
-                        name="label",
-                        kind="Text",
-                        optional=True,
-                        read_only=True,
-                        computed_attribute=ComputedAttribute(
-                            kind=ComputedAttributeKind.JINJA2,
-                            jinja2_template="{{ name__value }}-{{ role__value }}",
-                        ),
-                    ),
-                ],
-            ),
-        ]
-    )
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
-
-
-async def test_optional_local_jinja2_computed_at_creation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_optional_local_jinja2: None
-) -> None:
-    """An optional local Jinja2 computed attribute is evaluated inline during creation."""
-    gadget = await Node.init(db=db, schema="TestComputeGadget", branch=default_branch)
-    await gadget.new(db=db, name="widget01", role="sensor")
-    await gadget.save(db=db)
-
-    assert gadget.get_attribute("label").value == "widget01-sensor"
-
-    reloaded = await NodeManager.get_one(db=db, id=gadget.id, branch=default_branch)
-    assert reloaded.get_attribute("label").value == "widget01-sensor"
+    reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
+    assert reloaded.get_attribute("local_label").value == "switch01-spine"
+    assert reloaded.get_attribute("local_tag").value == "spine:switch01"
+    assert reloaded.get_attribute("remote_label").value == "Alice's switch01"
+    assert reloaded.get_attribute("remote_tag").value == "Alice-spine"
 
 
 async def test_local_attr_change_triggers_recomputation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_local_jinja2: None
+    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
 ) -> None:
-    """Updating a referenced attribute triggers inline Jinja2 recomputation."""
-    device = await Node.init(db=db, schema="TestComputeDevice", branch=default_branch)
-    await device.new(db=db, name="switch01", role="spine")
-    await device.save(db=db)
-
-    assert device.get_attribute("label").value == "switch01-spine"
+    """Updating a local attribute recomputes all computed attributes that depend on it."""
+    owner = await _create_owner(db=db, default_branch=default_branch)
+    device = await _create_device(db=db, default_branch=default_branch, owner=owner)
 
     device.get_attribute("name").value = "switch02"
-
-    # Act
     await device.save(db=db, fields=["name"])
 
-    # Assert local computation
-    assert device.get_attribute("label").value == "switch02-spine"
+    # local_label and local_tag depend on name
+    assert device.get_attribute("local_label").value == "switch02-spine"
+    assert device.get_attribute("local_tag").value == "spine:switch02"
+    # remote_label depends on name too
+    assert device.get_attribute("remote_label").value == "Alice's switch02"
+    # remote_tag depends on role, not name — unchanged
+    assert device.get_attribute("remote_tag").value == "Alice-spine"
 
-    # Assert saved in the database
     reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch)
-    assert reloaded.get_attribute("label").value == "switch02-spine"
+    assert reloaded.get_attribute("local_label").value == "switch02-spine"
+    assert reloaded.get_attribute("local_tag").value == "spine:switch02"
+    assert reloaded.get_attribute("remote_label").value == "Alice's switch02"
 
 
 async def test_unrelated_attr_change_does_not_trigger_recomputation(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_local_jinja2: None
+    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
 ) -> None:
-    """Updating an attribute not referenced by the template does NOT trigger recomputation."""
-    device = await Node.init(db=db, schema="TestComputeDevice", branch=default_branch)
-    await device.new(db=db, name="switch01", role="spine", description="original")
-    await device.save(db=db)
+    """Updating an attribute not referenced by any template does NOT trigger recomputation."""
+    owner = await _create_owner(db=db, default_branch=default_branch)
+    device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="switch01", role="spine")
 
-    # Save only an unrelated attribute and verify no Jinja2 render occurs
     with patch.object(
         InfrahubJinja2Template,
         "render",
@@ -206,10 +215,11 @@ async def test_unrelated_attr_change_does_not_trigger_recomputation(
         device.get_attribute("description").value = "updated"
         await device.save(db=db, fields=["description"])
         mock_render.assert_not_called()
-    assert device.get_attribute("label").value == "switch01-spine"
+
+    assert device.get_attribute("local_label").value == "switch01-spine"
 
 
-async def test_chained_jinja2_only_direct_deps_recomputed_inline(
+async def test_chained_jinja2_cascade(
     db: InfrahubDatabase, default_branch: Branch, schema_with_chained_jinja2: None
 ) -> None:
     """Chained computed attributes cascade: name -> label -> fqdn all recomputed inline."""
@@ -221,36 +231,31 @@ async def test_chained_jinja2_only_direct_deps_recomputed_inline(
     assert server.get_attribute("fqdn").value == "web01-frontend.example.com"
 
     server.get_attribute("name").value = "web02"
-
-    # Act
     await server.save(db=db, fields=["name"])
 
-    # Assert local computation
     assert server.get_attribute("label").value == "web02-frontend"
     assert server.get_attribute("fqdn").value == "web02-frontend.example.com"
 
-    # Assert saved in the database
     reloaded = await NodeManager.get_one(db=db, id=server.id, branch=default_branch)
     assert reloaded.get_attribute("fqdn").value == "web02-frontend.example.com"
 
 
 async def test_jinja2_error_handled_gracefully(
-    db: InfrahubDatabase, default_branch: Branch, schema_with_render_test: None
+    db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None
 ) -> None:
     """A Jinja2 evaluation failure is logged but the mutation succeeds."""
-    widget = await Node.init(db=db, schema="TestComputeWidget", branch=default_branch)
-    await widget.new(db=db, name="gear01", color="red")
-    await widget.save(db=db)
+    owner = await _create_owner(db=db, default_branch=default_branch)
+    device = await _create_device(db=db, default_branch=default_branch, owner=owner, name="gear01", role="red")
 
-    assert widget.get_attribute("computed_label").value == "gear01-red"
+    assert device.get_attribute("local_label").value == "gear01-red"
 
     with patch(
         "infrahub.core.node.InfrahubJinja2Template.render",
         new_callable=AsyncMock,
         side_effect=JinjaTemplateError(message="Simulated Jinja2 rendering failure"),
     ):
-        widget.get_attribute("name").value = "gear02"
-        await widget.save(db=db, fields=["name"])
+        device.get_attribute("name").value = "gear02"
+        await device.save(db=db, fields=["name"])
 
-    assert widget.get_attribute("name").value == "gear02"
-    assert widget.get_attribute("computed_label").value == "gear01-red"
+    assert device.get_attribute("name").value == "gear02"
+    assert device.get_attribute("local_label").value == "gear01-red"

--- a/backend/tests/component/computed_attribute/test_local_computation.py
+++ b/backend/tests/component/computed_attribute/test_local_computation.py
@@ -214,6 +214,7 @@ class TestNodeUpdate:
         assert reloaded.get_attribute("local_label").value == "switch02-spine"
         assert reloaded.get_attribute("local_tag").value == "spine:switch02"
         assert reloaded.get_attribute("remote_label").value == "Alice's switch02"
+        assert reloaded.get_attribute("remote_tag").value == "Alice-spine"
 
     async def test_unrelated_attr_change_does_not_trigger_recomputation(
         self, db: InfrahubDatabase, default_branch: Branch, schema_with_jinja2: None

--- a/backend/tests/component/computed_attribute/test_local_computation.py
+++ b/backend/tests/component/computed_attribute/test_local_computation.py
@@ -120,6 +120,52 @@ async def schema_with_render_test(
     await default_branch.save(db=db)
 
 
+@pytest.fixture
+async def schema_with_optional_local_jinja2(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+) -> None:
+    """Optional computed attribute (label) derived from two local attributes (name, role)."""
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="ComputeGadget",
+                namespace="Test",
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                    AttributeSchema(name="role", kind="Text"),
+                    AttributeSchema(
+                        name="label",
+                        kind="Text",
+                        optional=True,
+                        read_only=True,
+                        computed_attribute=ComputedAttribute(
+                            kind=ComputedAttributeKind.JINJA2,
+                            jinja2_template="{{ name__value }}-{{ role__value }}",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+
+async def test_optional_local_jinja2_computed_at_creation(
+    db: InfrahubDatabase, default_branch: Branch, schema_with_optional_local_jinja2: None
+) -> None:
+    """An optional local Jinja2 computed attribute is evaluated inline during creation."""
+    gadget = await Node.init(db=db, schema="TestComputeGadget", branch=default_branch)
+    await gadget.new(db=db, name="widget01", role="sensor")
+    await gadget.save(db=db)
+
+    assert gadget.get_attribute("label").value == "widget01-sensor"
+
+    reloaded = await NodeManager.get_one(db=db, id=gadget.id, branch=default_branch)
+    assert reloaded.get_attribute("label").value == "widget01-sensor"
+
+
 async def test_local_attr_change_triggers_recomputation(
     db: InfrahubDatabase, default_branch: Branch, schema_with_local_jinja2: None
 ) -> None:

--- a/backend/tests/unit/core/schema_branch_computed/conftest.py
+++ b/backend/tests/unit/core/schema_branch_computed/conftest.py
@@ -27,8 +27,8 @@ def make_rel() -> Callable[[str, str], RelationshipSchema]:
 
 @pytest.fixture
 def make_target(make_attr: Callable[[str], AttributeSchema]) -> Callable[..., ComputedAttributeTarget]:
-    def _make_target(kind: str, attr_name: str, filter_keys: list[str] | None = None) -> ComputedAttributeTarget:
-        return ComputedAttributeTarget(kind=kind, attribute=make_attr(attr_name), filter_keys=filter_keys or [])
+    def _make_target(kind: str, attr_name: str) -> ComputedAttributeTarget:
+        return ComputedAttributeTarget(kind=kind, attribute=make_attr(attr_name))
 
     return _make_target
 

--- a/backend/tests/unit/core/schema_branch_computed/test_jinja2_targets.py
+++ b/backend/tests/unit/core/schema_branch_computed/test_jinja2_targets.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.schema.schema_branch_computed import ComputedAttributes
-from infrahub.core.schema.schema_branch_computed.jinja2 import RegisteredNodeComputedAttribute, RelationshipDependency
+from infrahub.core.schema.schema_branch_computed.jinja2 import (
+    RegisteredNodeComputedAttribute,
+    RelationshipDependency,
+    ResolvedComputedTarget,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -74,6 +78,57 @@ class TestComputedAttributesGetLocalJinja2Targets:
 
         results = ca.get_local_jinja2_targets(kind=LOCAL_KIND)
         assert results == []
+
+
+class TestGetTargetsNodeFilters:
+    """Verify that node_filters on ResolvedComputedTarget are set correctly."""
+
+    def test_self_target_gets_ids_filter(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """A target triggered only by local fields should get the default ["ids"] filter."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert results[0].node_filters == ["ids"]
+
+    def test_peer_target_gets_only_relationship_filter(
+        self, make_target: Callable[..., ComputedAttributeTarget]
+    ) -> None:
+        """A peer-triggered target should only have relationship filters, not the spurious "ids" filter."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+            relationship_dependencies={
+                "site": RelationshipDependency(targets=[target]),
+            },
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert results[0].node_filters == ["site__ids"]
+
+    def test_multiple_relationship_filters(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """A target reachable via multiple relationships gets all relationship filters but no "ids"."""
+        target = make_target(kind=LOCAL_KIND, attr_name="computed_name")
+        registered = RegisteredNodeComputedAttribute(
+            local_fields={"name": [target]},
+            relationship_dependencies={
+                "site": RelationshipDependency(targets=[target]),
+                "region": RelationshipDependency(targets=[target]),
+            },
+        )
+
+        results = registered.get_targets(updates=["name"])
+        assert len(results) == 1
+        assert sorted(results[0].node_filters) == ["region__ids", "site__ids"]
+
+    def test_default_node_filters_is_empty(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
+        """ResolvedComputedTarget should default to an empty node_filters list."""
+        resolved = ResolvedComputedTarget(target=make_target(kind=LOCAL_KIND, attr_name="some_attr"))
+        assert resolved.node_filters == []
 
 
 class TestComputedAttributesGetRegisteredJinja2Node:


### PR DESCRIPTION
# Why

During the development of the Jinja2 local computation feature [IFC-2273], I worked on the node update path, making all local Jinja2 computed attributes recompute inline instead of dispatching events to Prefect for asynchronous computation. 
The goal is to reduce the volume of recomputation events that Prefect has to manage.
                                                                                                                                                                        
"Local" here means that the Jinja2 template's dependencies can be resolved from the node itself (its own attributes or its relationship references). If a peer node is updated and that change affects a computed attribute on another node, the recomputation still goes through the async Prefect path.                                   
                                                                                                                                                                        
The node creation path already computed mandatory Jinja2 attributes inline during `Node.new()`. This change extends that to also compute optional Jinja2 attributes inline at creation time and ensure correct dependency ordering for chained computations.

Closes [IFC-2420]

## What changed

During node creation, `_process_fields `now collects all Jinja2 computed attributes (mandatory and optional, local and remote-referencing) in dependency order. Previously, only mandatory Jinja2 attributes were collected and computed inline, optional ones were left for the async Prefect path.  
                                                                                                                                                                 
The validation logic in `_process_fields` has been extracted into dedicated methods:                                                                                    
- `_validate_mandatory_attributes`: validates mandatory attributes are provided, skipping Jinja2 computed and NumberPool attributes
- `_validate_mandatory_relationships`: validates mandatory relationships are provided                                                                                   
                                                                                   
`  _process_macros` now iterates _computed_jinja2_attributes directly, since the list is already dependency-ordered by the registry, removing the need for a second  registry lookup.        


## How to review

Commits are unitary.

## How to test

```bash
uv run pytest tests/component/computed_attribute/test_local_computation.py -xvs
```

## Checklist

- [x] Tests added/updated


[IFC-2420]: https://opsmill.atlassian.net/browse/IFC-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IFC-2273]: https://opsmill.atlassian.net/browse/IFC-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ