### PR TITLE
Add typehints to diff tests

### DIFF
--- a/backend/tests/component/core/diff/test_diff_and_merge.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge.py
@@ -609,9 +609,9 @@ class TestDiffAndMerge:
         db: InfrahubDatabase,
         diff_repository: DiffRepository,
         default_branch: Branch,
-        person_john_main,
-        person_jane_main,
-        new_height,
+        person_john_main: Node,
+        person_jane_main: Node,
+        new_height: int | None,
     ) -> None:
         # Capture initial metadata before any changes
         person_before = await NodeManager.get_one(
@@ -827,9 +827,9 @@ class TestDiffAndMerge:
         db: InfrahubDatabase,
         diff_repository: DiffRepository,
         default_branch: Branch,
-        person_john_main,
-        person_jane_main,
-        car_camry_main,
+        person_john_main: Node,
+        person_jane_main: Node,
+        car_camry_main: Node,
     ) -> None:
         # Capture person_jane's updated_at before adding the relationship
         person_jane_before = await NodeManager.get_one(
@@ -924,7 +924,11 @@ class TestDiffAndMerge:
         await verify_no_duplicate_paths(db=db)
 
     async def test_relationship_set_to_null(
-        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, animal_person_schema
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        animal_person_schema: SchemaBranch,
     ) -> None:
         person_main = await Node.init(db=db, schema="TestPerson")
         await person_main.new(db=db, name="Dude")
@@ -1153,7 +1157,11 @@ class TestDiffAndMerge:
         await verify_no_duplicate_paths(db=db)
 
     async def test_agnostic_and_aware_nodes_added_on_branch(
-        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, car_person_schema_global
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        car_person_schema_global: None,
     ) -> None:
         branch2 = await create_branch(db=db, branch_name="branch2")
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
@@ -1304,10 +1312,10 @@ class TestDiffAndMerge:
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        person_john_main,
-        person_jane_main,
-        car_accord_main,
-        car_camry_main,
+        person_john_main: Node,
+        person_jane_main: Node,
+        car_accord_main: Node,
+        car_camry_main: Node,
     ) -> None:
         before_test_start = Timestamp()
         person_schema = db.schema.get(name="TestPerson", duplicate=False)
@@ -1391,11 +1399,11 @@ class TestDiffAndMerge:
         db: InfrahubDatabase,
         default_branch: Branch,
         diff_repository: DiffRepository,
-        person_john_main,
-        person_jane_main,
-        person_alfred_main,
-        car_accord_main,
-        car_camry_main,
+        person_john_main: Node,
+        person_jane_main: Node,
+        person_alfred_main: Node,
+        car_accord_main: Node,
+        car_camry_main: Node,
     ) -> None:
         car_created_at = car_accord_main._get_created_at()
 
@@ -1556,11 +1564,11 @@ class TestDiffAndMerge:
         db: InfrahubDatabase,
         default_branch: Branch,
         diff_repository: DiffRepository,
-        person_john_main,
-        person_jane_main,
-        person_alfred_main,
-        car_accord_main,
-        car_camry_main,
+        person_john_main: Node,
+        person_jane_main: Node,
+        person_alfred_main: Node,
+        car_accord_main: Node,
+        car_camry_main: Node,
     ) -> None:
         car_created_at = car_accord_main._get_created_at()
 

--- a/backend/tests/component/core/diff/test_diff_calculator.py
+++ b/backend/tests/component/core/diff/test_diff_calculator.py
@@ -21,6 +21,7 @@ from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigra
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -50,7 +51,11 @@ def low_query_size_limit() -> Generator[None, None, None]:
 
 
 async def test_diff_attribute_branch_update(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -137,7 +142,11 @@ async def test_diff_attribute_branch_update(
 
 
 async def test_attribute_property_main_update(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     from_time = Timestamp()
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -179,7 +188,7 @@ async def test_attribute_property_main_update(
     assert before_change < property_diff.changed_at < after_change
 
 
-async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: Branch, car_accord_main) -> None:
+async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
@@ -268,7 +277,7 @@ async def test_attribute_branch_update_from_null(
 
 @pytest.mark.parametrize("use_branch", [True, False])
 async def test_node_delete(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main, use_branch
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, person_john_main: Node, use_branch: bool
 ) -> None:
     if use_branch:
         branch = await create_branch(db=db, branch_name="branch")
@@ -348,7 +357,7 @@ async def test_node_delete(
 
 
 async def test_node_base_delete_branch_update(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, person_john_main: Node
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
@@ -398,7 +407,7 @@ async def test_node_base_delete_branch_update(
     assert diff_property.new_value == 10
 
 
-async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car_accord_main) -> None:
+async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
     new_person = await Node.init(db=db, schema="TestPerson", branch=branch)
@@ -440,7 +449,11 @@ async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car
 
 
 async def test_attribute_property_multiple_branch_updates(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -496,7 +509,11 @@ async def test_attribute_property_multiple_branch_updates(
 
 
 async def test_attribute_property_branch_create_multiple_updates(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -576,10 +593,10 @@ async def test_attribute_property_branch_create_multiple_updates(
 async def test_relationship_one_peer_branch_and_main_update(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_jane_main,
-    person_john_main,
-    car_accord_main,
+    person_alfred_main: Node,
+    person_jane_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -782,10 +799,10 @@ async def test_relationship_one_peer_branch_and_main_update(
 async def test_relationship_one_property_branch_update(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_jane_main,
-    person_john_main,
-    car_accord_main,
+    person_alfred_main: Node,
+    person_jane_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -943,10 +960,10 @@ async def test_relationship_one_property_branch_update(
 async def test_add_node_branch(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_jane_main,
-    person_john_main,
-    car_accord_main,
+    person_alfred_main: Node,
+    person_jane_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1039,9 +1056,9 @@ async def test_add_node_branch(
 async def test_many_relationship_property_update(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1112,10 +1129,10 @@ async def test_many_relationship_property_update(
 async def test_cardinality_one_peer_conflicting_updates(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_john_main,
-    person_jane_main,
-    person_albert_main,
-    car_accord_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    person_albert_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1335,8 +1352,8 @@ async def test_cardinality_one_peer_conflicting_updates(
 async def test_relationship_property_owner_conflicting_updates(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_john_main,
-    car_accord_main,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1464,7 +1481,7 @@ async def test_relationship_property_owner_conflicting_updates(
 async def test_agnostic_source_relationship_update(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_person_schema_global,
+    car_person_schema_global: None,
 ) -> None:
     person_1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await person_1.new(db=db, name="Herb", height=165)
@@ -1520,7 +1537,7 @@ async def test_agnostic_source_relationship_update(
 async def test_agnostic_owner_relationship_added(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_person_schema_global,
+    car_person_schema_global: None,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1613,7 +1630,7 @@ async def test_agnostic_owner_relationship_added(
 async def test_update_attribute_under_agnostic_node(
     db: InfrahubDatabase,
     default_branch: Branch,
-    fruit_tag_schema_global,
+    fruit_tag_schema_global: SchemaRoot,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -1660,7 +1677,11 @@ async def test_update_attribute_under_agnostic_node(
 
 
 async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     # change that will be ignored
@@ -1725,7 +1746,11 @@ async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
 
 
 async def test_diff_attribute_branch_update_with_concurrent_base_update_captured(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
@@ -1819,7 +1844,11 @@ async def test_diff_attribute_branch_update_with_concurrent_base_update_captured
 
 
 async def test_diff_attribute_branch_update_with_previous_base_update_captured(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     # change that will be ignored
@@ -1910,7 +1939,11 @@ async def test_diff_attribute_branch_update_with_previous_base_update_captured(
 
 
 async def test_diff_attribute_branch_update_with_separate_previous_base_update_captured(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -2025,7 +2058,7 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
 
 
 async def test_branch_node_delete_with_base_updates(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main, person_john_main, person_jane_main
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, person_john_main: Node, person_jane_main: Node
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
@@ -2309,7 +2342,11 @@ async def test_branch_relationship_delete_with_property_update(
 
 
 async def test_node_deleted_on_base_update_on_branch(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -2379,7 +2416,11 @@ async def test_node_deleted_on_base_update_on_branch(
 
 
 async def test_node_deleted_on_both(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -2420,11 +2461,11 @@ async def test_node_deleted_on_both(
 async def test_relationship_updated_then_node_deleted(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -2605,11 +2646,11 @@ async def test_relationship_updated_then_node_deleted(
 async def test_node_added_and_deleted_on_branch(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -2637,11 +2678,11 @@ async def test_node_added_and_deleted_on_branch(
 async def test_property_update_then_relationship_deleted(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_alfred_main,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp(branch.created_at)
@@ -2903,7 +2944,11 @@ async def test_hierarchy_with_same_kind_parent_and_child(
 
 
 async def test_diff_unchanged_included_when_not_first_diff(
-    db: InfrahubDatabase, default_branch: Branch, person_alfred_main, person_john_main, car_accord_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     alfred_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_alfred_main.id)
@@ -3050,7 +3095,7 @@ async def test_create_local_and_aware_nodes_on_branch(
 
 
 async def test_create_aware_and_agnostic_nodes_on_branch(
-    db: InfrahubDatabase, default_branch: Branch, car_person_schema_global
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema_global: None
 ) -> None:
     branch = await create_branch(db=db, branch_name="branch")
     from_time = Timestamp()
@@ -3266,12 +3311,12 @@ async def test_diff_relationship_property_update_on_main(
 async def test_calculate_with_migrated_kind_node(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_accord_main,
-    car_camry_main,
-    person_john_main,
-    person_jane_main,
-    person_alfred_main,
-    person_albert_main,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    person_alfred_main: Node,
+    person_albert_main: Node,
 ) -> None:
     """Test that the diff can correctly handle a schema kind migration, which results in 2 nodes with the same UUID"""
     branch = await create_branch(db=db, branch_name="branch-migrated-kind")
@@ -3863,7 +3908,12 @@ async def test_calculate_with_migrated_kind_node(
 
 
 async def test_calculate_with_migrated_attr_name(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
 ) -> None:
     """Test that the diff can correctly handle an attribute name migration"""
     branch = await create_branch(db=db, branch_name="branch")
@@ -3944,7 +3994,12 @@ async def test_calculate_with_migrated_attr_name(
 
 
 async def test_calculate_with_renamed_relationships(
-    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
 ) -> None:
     """Test that the diff can correctly handle an attribute name migration"""
     branch = await create_branch(db=db, branch_name="branch")
@@ -4101,12 +4156,12 @@ async def test_calculate_with_renamed_relationships(
 async def test_migrated_kind_node_then_peer_delete(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_accord_main,
-    car_camry_main,
-    person_john_main,
-    person_jane_main,
-    person_alfred_main,
-    person_albert_main,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    person_alfred_main: Node,
+    person_albert_main: Node,
 ) -> None:
     # migrate TestPerson kind on main
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
@@ -4186,11 +4241,11 @@ async def test_migrated_kind_node_then_peer_delete(
 async def test_migrated_kind_with_property_level_changes(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_accord_main,
-    car_camry_main,
-    person_john_main,
-    person_jane_main,
-    person_alfred_main,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    person_alfred_main: Node,
 ) -> None:
     branch = await create_branch(db=db, branch_name="lets-migrate")
 
@@ -4380,12 +4435,12 @@ async def test_migrated_kind_with_property_level_changes(
 async def test_migrated_kind_on_main_then_relationship_update_on_branch(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_accord_main,
-    car_camry_main,
-    person_john_main,
-    person_jane_main,
-    person_alfred_main,
-    person_albert_main,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+    person_alfred_main: Node,
+    person_albert_main: Node,
 ) -> None:
     """Test that when a schema kind is migrated on the default branch, relationships to instances
     of the migrated node can be updated on a branch before the diff is calculated."""
@@ -4535,9 +4590,9 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
 async def test_diff_attribute_single_source_property_change(
     db: InfrahubDatabase,
     default_branch: Branch,
-    person_john_main,
-    person_alfred_main,
-    person_jane_main,
+    person_john_main: Node,
+    person_alfred_main: Node,
+    person_jane_main: Node,
     new_source: bool,
     expected_action: DiffAction,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -981,11 +981,8 @@ allow-dunder-method-names = [
 # backend/tests/component/. Split from the broad section above to allow incremental fixes.       #
 # Remove each entry below once all ANN001 violations in that path have been resolved.            #
 ##################################################################################################
-# backend/tests/component/core/diff/ (236 violations)
 "backend/tests/component/core/diff/query/**.py" = ["ANN001"]                   # 6 violations
 "backend/tests/component/core/diff/repository/**.py" = ["ANN001"]              # 26 violations
-"backend/tests/component/core/diff/test_diff_calculator.py" = ["ANN001"]       # 114 violations
-"backend/tests/component/core/diff/test_diff_and_merge.py" = ["ANN001"]        # 22 violations
 "backend/tests/component/core/diff/test_diff_merger.py" = ["ANN001"]           # 18 violations
 "backend/tests/component/core/diff/test_diff_combiner.py" = ["ANN001"]         # 17 violations
 "backend/tests/component/core/diff/test_conflicts_enricher.py" = ["ANN001"]    # 11 violations
@@ -996,7 +993,6 @@ allow-dunder-method-names = [
 "backend/tests/component/core/diff/test_diff_init.py" = ["ANN001"]             # 1 violation
 "backend/tests/component/core/diff/test_coordinator.py" = ["ANN001"]           # 1 violation
 "backend/tests/component/core/ipam/**.py" = ["ANN001"]                         # 42 violations
-# backend/tests/component/core/migrations/ (174 violations)
 "backend/tests/component/core/migrations/schema/**.py" = ["ANN001"]            # 33 violations
 "backend/tests/component/core/migrations/graph/test_012.py" = ["ANN001"]       # 32 violations
 "backend/tests/component/core/migrations/graph/test_013.py" = ["ANN001"]       # 29 violations
@@ -1020,7 +1016,6 @@ allow-dunder-method-names = [
 "backend/tests/component/core/migrations/graph/test_034.py" = ["ANN001"]       # 1 violation
 "backend/tests/component/core/migrations/graph/test_032.py" = ["ANN001"]       # 1 violation
 "backend/tests/component/core/migrations/graph/test_027.py" = ["ANN001"]       # 1 violation
-# backend/tests/component/core/schema_manager/ (114 violations)
 "backend/tests/component/core/schema_manager/test_manager_schema.py" = ["ANN001"]                # 100 violations
 "backend/tests/component/core/test_node_get_list_query.py" = ["ANN001"]        # 96 violations
 "backend/tests/component/core/test_relationship_query.py" = ["ANN001"]        # 59 violations


### PR DESCRIPTION
# Why

Add missing typehints in diff component tests

## What changed

* Add missing types
* Remove violations from pyproject.toml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing type hints to diff component tests to improve type safety and satisfy `ANN001`. Removed per-file `ANN001` suppressions in `pyproject.toml` for these tests.

- **Refactors**
  - Annotated fixtures and params in `test_diff_calculator.py` and `test_diff_and_merge.py` (e.g., `Node`, `bool`, `int | None`, and schema fixtures as `SchemaBranch`, `SchemaRoot`, or `None`).
  - Removed `ANN001` ignores for these files from `pyproject.toml`.

<sup>Written for commit a195e66a6e6147c86e90138e36d2f2b46ba6c728. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

