### PR TITLE
#8772 webhook match statements lost during scheduled reconfiguration

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -44,7 +44,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
     def from_object(cls, obj: CoreWebhook | CoreWebhookNode) -> Self:
         event_trigger = EventTrigger()
         event_type = obj.event_type.value
-        if isinstance(obj.event_type.value, Enum):
+        if isinstance(event_type, Enum):
             event_type = obj.event_type.value.value
         if event_type == "all":
             event_trigger.events.add("infrahub.*")
@@ -62,7 +62,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
                 "infrahub.resource.label": f"!{registry.default_branch}",
             }
 
-        if obj.node_kind.value and obj.event_type.value in get_all_infrahub_node_kind_events():
+        if obj.node_kind.value and event_type in get_all_infrahub_node_kind_events():
             event_trigger.match = {"infrahub.node.kind": obj.node_kind.value}
 
         definition = cls(

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -9,7 +9,10 @@ from prefect.client.orchestration import PrefectClient, get_client
 from prefect.events.actions import RunDeployment
 
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreWebhook as CoreWebhookNode
+from infrahub.trigger.models import ExecuteWorkflow, TriggerType
 from infrahub.trigger.setup import gather_all_automations
 from infrahub.webhook.gather import gather_trigger_webhook
 from infrahub.webhook.models import EventContext, WebhookTriggerDefinition
@@ -417,4 +420,40 @@ class TestWebhookTasks(TestInfrahubApp):
     ) -> None:
         webhook = await client.get(kind=CoreStandardWebhook, id=webhook4.id)
         trigger_definition = WebhookTriggerDefinition.from_object(obj=webhook)
+
+        assert trigger_definition.id == webhook4.id
+        assert trigger_definition.name == "Webhook4"
+        assert trigger_definition.type == TriggerType.WEBHOOK
+        assert trigger_definition.trigger.events == {"infrahub.node.created"}
         assert trigger_definition.trigger.match == {"infrahub.node.kind": "BuiltinTag"}
+        assert trigger_definition.trigger.match_related == {}
+        assert len(trigger_definition.actions) == 1
+        action = trigger_definition.actions[0]
+        assert isinstance(action, ExecuteWorkflow)
+        assert action.workflow == WEBHOOK_PROCESS
+        assert action.parameters["webhook_id"] == webhook4.id
+        assert action.parameters["webhook_name"] == "Webhook4"
+        assert action.parameters["webhook_kind"] == "CoreStandardWebhook"
+
+    async def test_trigger_definition_node_kind_match_via_node_manager(
+        self,
+        db: InfrahubDatabase,
+        webhook4: Node,
+    ) -> None:
+        webhooks = await NodeManager.query(db=db, schema=CoreWebhookNode)
+        webhook = next(w for w in webhooks if w.id == webhook4.id)
+        trigger_definition = WebhookTriggerDefinition.from_object(obj=webhook)
+
+        assert trigger_definition.id == webhook4.id
+        assert trigger_definition.name == "Webhook4"
+        assert trigger_definition.type == TriggerType.WEBHOOK
+        assert trigger_definition.trigger.events == {"infrahub.node.created"}
+        assert trigger_definition.trigger.match == {"infrahub.node.kind": "BuiltinTag"}
+        assert trigger_definition.trigger.match_related == {}
+        assert len(trigger_definition.actions) == 1
+        action = trigger_definition.actions[0]
+        assert isinstance(action, ExecuteWorkflow)
+        assert action.workflow == WEBHOOK_PROCESS
+        assert action.parameters["webhook_id"] == webhook4.id
+        assert action.parameters["webhook_name"] == "Webhook4"
+        assert action.parameters["webhook_kind"] == "CoreStandardWebhook"

--- a/changelog/8772.fixed.md
+++ b/changelog/8772.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where webhook match statements (node kind filters) were lost during scheduled reconfiguration.


### PR DESCRIPTION
**EDIT:** While working to unify the data source from which we query the web hooks (always using the database via the `NodeManager` and no longer using the SDK client queries), I realised that I had confused the root cause in both sources.
_"The SDK client is not deserializing Enum object as Enum, but as strings. The database query does"_ **->** _"The SDK client is not deserializing `Enum` object as string, but as Python `Enum`. The database query does."_

# Why

When configuring web hooks Prefect trigger definitions, web hooks can be configured through two different flows in 1.8.X:
- `infrahub.webhook.gather.gather_trigger_webhook`: which is querying the web hook object from the database through: `await NodeManager.query(db=db, schema=CoreWebhook)`.
- `infrahub.webhook.tasks.configure_webhook_one`: which is querying the web hook object from the SDK client through `await get_client().get(kind=CoreWebhook, id=event_data["node_id"])`.

The SDK client is not deserializing `Enum` object as string, but as Python `Enum`. The database query does.
This is the source of the following bug https://github.com/opsmill/infrahub/issues/8694. 

## Problem
In the same method, `obj.event_type.value` is reused later on in this condition:
```
  if obj.node_kind.value and obj.event_type.value in get_all_infrahub_node_kind_events():
      event_trigger.match = {"infrahub.node.kind": obj.node_kind.value}
```

## What's next
The larger picture is that we should not, in my opinion, manage both data format and only use one of them. This will be another task for a future release materialized in this internal issue https://opsmill.atlassian.net/browse/IFC-2434.

Jira: https://opsmill.atlassian.net/browse/IFC-2430
Closes https://github.com/opsmill/infrahub/issues/8772

## What changed

- `obj.event_type.value` usage has been totally removed from the method.
- The existing unit test regarding the Web hook trigger definition generation through SDK client has been enhanced and test all the important attributes of a web hook trigger definition.
- Another unit test has been created, doing the same thing but from a web hook queried from the database.


## How to test

<!-- Make it runnable and specific -->

```bash
uv run pytest tests/functional/webhook/test_task.py -k "test_trigger_definition_node_kind_match" -v
```

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of webhook node-kind match statements during scheduled reconfiguration so triggers keep their filters when webhooks are reloaded from the DB or SDK.

- **Bug Fixes**
  - Normalized `event_type` in `WebhookTriggerDefinition.from_object` and used it for event checks, preserving node-kind `match={"infrahub.node.kind": <kind>}` in both SDK (`CoreStandardWebhook`) and DB (`NodeManager`/`CoreWebhook`) paths.
  - Added functional tests with full assertions for both paths and included a changelog fragment.

<sup>Written for commit e0eb2959e79897922af030e8345e1d3b6f706a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





