### PR TITLE
feat(frontend): add version/UUID toggle to account menu info line [IFC-2433]

### DIFF
--- a/frontend/app/src/entities/config/ui/app-info.test.tsx
+++ b/frontend/app/src/entities/config/ui/app-info.test.tsx
@@ -16,6 +16,11 @@ vi.mock("@/entities/config/ui/config-provider", () => ({
 import { useConfig } from "@/entities/config/ui/config-provider";
 import { useGetAppInfo } from "@/entities/config/ui/queries/get-app-info.query";
 
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText },
+});
+
 describe("AppInstallationType", () => {
   const useConfigMock = vi.mocked(useConfig);
 
@@ -53,50 +58,36 @@ describe("AppInstallationType", () => {
 });
 
 describe("AppVersion", () => {
-  const useGetAppInfoMock = vi.mocked(useGetAppInfo);
-
   test("should not display version or error while loading", async () => {
-    // GIVEN
-    useGetAppInfoMock.mockReturnValue({
-      data: undefined,
-      isPending: true,
-      isError: false,
-    } as any);
-
     // WHEN
-    const component = await render(<AppVersion />);
+    const component = await render(
+      <AppVersion data={undefined} isPending={true} isError={false} />
+    );
 
     // THEN
-    // Version text and error state are not visible while loading
     expect(component.getByText("N/A").query()).toBeNull();
     expect(component.getByText(/v\d/).query()).toBeNull();
   });
 
   test('should display "N/A" on error', async () => {
-    // GIVEN
-    useGetAppInfoMock.mockReturnValue({
-      data: undefined,
-      isPending: false,
-      isError: true,
-    } as any);
-
     // WHEN
-    const component = await render(<AppVersion />);
+    const component = await render(
+      <AppVersion data={undefined} isPending={false} isError={true} />
+    );
 
     // THEN
     await expect.element(component.getByText("N/A")).toBeVisible();
   });
 
   test("should display version when loaded successfully", async () => {
-    // GIVEN
-    useGetAppInfoMock.mockReturnValue({
-      data: { version: "1.2.3" },
-      isPending: false,
-      isError: false,
-    } as any);
-
     // WHEN
-    const component = await render(<AppVersion />);
+    const component = await render(
+      <AppVersion
+        data={{ version: "1.2.3", deployment_id: "abc-123" }}
+        isPending={false}
+        isError={false}
+      />
+    );
 
     // THEN
     await expect.element(component.getByText("v1.2.3")).toBeVisible();
@@ -117,7 +108,7 @@ describe("AppInfo", () => {
     } as any);
 
     useGetAppInfoMock.mockReturnValue({
-      data: { version: "1.2.3" },
+      data: { version: "1.2.3", deployment_id: "abc-123" },
       isPending: false,
       isError: false,
     } as any);
@@ -129,5 +120,146 @@ describe("AppInfo", () => {
     await expect
       .element(component.getByText("Infrahub - Community Edition - v1.2.3"))
       .toBeVisible();
+  });
+
+  test("should show 'Copied!' and copy UUID to clipboard when clicked", async () => {
+    // GIVEN
+    mockWriteText.mockClear();
+    useConfigMock.mockReturnValue({
+      installation_type: "community",
+      main_menu_mode: "default",
+      main_menu_size: 14,
+      experimental_features: {},
+    } as any);
+
+    useGetAppInfoMock.mockReturnValue({
+      data: {
+        version: "1.2.3",
+        deployment_id: "d4e5f6a7-b8c9-1234-5678-abcdef012345",
+      },
+      isPending: false,
+      isError: false,
+    } as any);
+
+    // WHEN
+    const component = await render(<AppInfo />);
+    const toggle = component.getByTestId("app-info-toggle");
+    await toggle.click();
+
+    // THEN
+    await expect.element(component.getByText("Copied!")).toBeVisible();
+    expect(mockWriteText).toHaveBeenCalledWith("d4e5f6a7-b8c9-1234-5678-abcdef012345");
+  });
+
+  test("should show UUID with prefix after 'Copied!' fades", async () => {
+    // GIVEN
+    vi.useFakeTimers();
+    useConfigMock.mockReturnValue({
+      installation_type: "community",
+      main_menu_mode: "default",
+      main_menu_size: 14,
+      experimental_features: {},
+    } as any);
+
+    useGetAppInfoMock.mockReturnValue({
+      data: {
+        version: "1.2.3",
+        deployment_id: "d4e5f6a7-b8c9-1234-5678-abcdef012345",
+      },
+      isPending: false,
+      isError: false,
+    } as any);
+
+    // WHEN
+    const component = await render(<AppInfo />);
+    const toggle = component.getByTestId("app-info-toggle");
+    await toggle.click();
+    vi.advanceTimersByTime(2000);
+
+    // THEN
+    await expect
+      .element(component.getByText("UUID: d4e5f6a7-b8c9-1234-5678-abcdef012345"))
+      .toBeVisible();
+
+    vi.useRealTimers();
+  });
+
+  test("should toggle back to default info line when clicked twice", async () => {
+    // GIVEN
+    useConfigMock.mockReturnValue({
+      installation_type: "community",
+      main_menu_mode: "default",
+      main_menu_size: 14,
+      experimental_features: {},
+    } as any);
+
+    useGetAppInfoMock.mockReturnValue({
+      data: {
+        version: "1.2.3",
+        deployment_id: "d4e5f6a7-b8c9-1234-5678-abcdef012345",
+      },
+      isPending: false,
+      isError: false,
+    } as any);
+
+    // WHEN
+    const component = await render(<AppInfo />);
+    const toggle = component.getByTestId("app-info-toggle");
+    await toggle.click();
+    await toggle.click();
+
+    // THEN
+    await expect
+      .element(component.getByText("Infrahub - Community Edition - v1.2.3"))
+      .toBeVisible();
+  });
+
+  test("should not be interactive when API request fails", async () => {
+    // GIVEN
+    useConfigMock.mockReturnValue({
+      installation_type: "community",
+      main_menu_mode: "default",
+      main_menu_size: 14,
+      experimental_features: {},
+    } as any);
+
+    useGetAppInfoMock.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+    } as any);
+
+    // WHEN
+    const component = await render(<AppInfo />);
+    const toggle = component.getByTestId("app-info-toggle");
+
+    // THEN
+    await expect.element(toggle).not.toHaveAttribute("role", "button");
+  });
+
+  test("should show N/A when deployment_id is empty in toggled state", async () => {
+    // GIVEN
+    mockWriteText.mockClear();
+    useConfigMock.mockReturnValue({
+      installation_type: "community",
+      main_menu_mode: "default",
+      main_menu_size: 14,
+      experimental_features: {},
+    } as any);
+
+    useGetAppInfoMock.mockReturnValue({
+      data: { version: "1.2.3", deployment_id: "" },
+      isPending: false,
+      isError: false,
+    } as any);
+
+    // WHEN
+    const component = await render(<AppInfo />);
+    const toggle = component.getByTestId("app-info-toggle");
+    await toggle.click();
+
+    // THEN
+    await expect.element(component.getByText("N/A")).toBeVisible();
+    expect(mockWriteText).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/entities/config/ui/app-info.tsx
+++ b/frontend/app/src/entities/config/ui/app-info.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import { Skeleton } from "@/shared/components/loading/skeleton";
 import { capitalizeFirstLetter } from "@/shared/utils/string";
 
@@ -5,9 +7,69 @@ import { useConfig } from "@/entities/config/ui/config-provider";
 import { useGetAppInfo } from "@/entities/config/ui/queries/get-app-info.query";
 
 export function AppInfo() {
+  const [showUuid, setShowUuid] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { data, isPending, isError } = useGetAppInfo();
+
+  const isInteractive = !isPending && !isError && !!data;
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
+
+  const handleClick = () => {
+    if (!isInteractive) return;
+
+    if (!showUuid) {
+      setShowUuid(true);
+      const uuid = data?.deployment_id;
+      if (uuid) {
+        navigator.clipboard.writeText(uuid);
+        setCopied(true);
+        if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
+      }
+    } else {
+      setShowUuid(false);
+      setCopied(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  const uuidDisplay = data?.deployment_id ? `UUID: ${data.deployment_id}` : "N/A";
+
   return (
-    <div className="inline-flex w-full items-center justify-end text-gray-400 text-xs">
-      Infrahub - <AppInstallationType /> - <AppVersion />
+    <div
+      className={`inline-flex w-full items-center justify-end text-xs ${isInteractive ? "cursor-pointer text-gray-400 hover:text-gray-300" : "text-gray-400"}`}
+      data-testid="app-info-toggle"
+      onClick={isInteractive ? handleClick : undefined}
+      onKeyDown={isInteractive ? handleKeyDown : undefined}
+      role={isInteractive ? "button" : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+    >
+      {showUuid ? (
+        copied ? (
+          <span className="text-green-400" data-testid="app-info-copied">
+            Copied!
+          </span>
+        ) : (
+          uuidDisplay
+        )
+      ) : (
+        <>
+          Infrahub - <AppInstallationType /> -{" "}
+          <AppVersion data={data} isPending={isPending} isError={isError} />
+        </>
+      )}
     </div>
   );
 }
@@ -18,12 +80,16 @@ export function AppInstallationType() {
   return `${capitalizeFirstLetter(config.installation_type)} Edition`;
 }
 
-export function AppVersion() {
-  const { data, isPending, isError } = useGetAppInfo();
+interface AppVersionProps {
+  data: { version: string; deployment_id: string } | undefined;
+  isPending: boolean;
+  isError: boolean;
+}
 
+export function AppVersion({ data, isPending, isError }: AppVersionProps) {
   if (isPending) return <Skeleton className="h-4 w-14" />;
 
-  if (isError) return "N/A";
+  if (isError || !data) return "N/A";
 
   return `v${data.version}`;
 }

--- a/frontend/app/tests/e2e/profile/profile.spec.ts
+++ b/frontend/app/tests/e2e/profile/profile.spec.ts
@@ -23,6 +23,31 @@ test.describe("/profile", () => {
   test.describe("when logged in as admin account", () => {
     test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
 
+    test("should copy UUID to clipboard and toggle app info line", async ({ page, context }) => {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+      await page.goto("/");
+      await page.getByTestId("authenticated-menu-trigger").click();
+
+      const appInfoToggle = page.getByTestId("app-info-toggle");
+      await expect(appInfoToggle).toBeVisible();
+
+      // Default state: shows version info line
+      await expect(appInfoToggle).toContainText("Infrahub");
+      await expect(appInfoToggle).toContainText(/v\d/);
+
+      // Click to toggle — should show "Copied!" and copy UUID
+      await appInfoToggle.click();
+      await expect(page.getByTestId("app-info-copied")).toContainText("Copied!");
+
+      // After "Copied!" fades, should show "UUID: <value>"
+      await expect(appInfoToggle).toContainText("UUID:", { timeout: 3000 });
+
+      // Click to toggle back to default
+      await appInfoToggle.click();
+      await expect(appInfoToggle).toContainText("Infrahub");
+      await expect(appInfoToggle).toContainText(/v\d/);
+    });
+
     test("should access the profile page", async ({ page }) => {
       await test.step("go to profile page", async () => {
         await page.goto("/");


### PR DESCRIPTION
## Summary

- Clicking the app info line ("Infrahub - ... Edition - v...") in the account menu toggles the entire line to display the instance UUID
- Copies the UUID to clipboard automatically with a green "Copied!" indicator (2s)
- After the indicator fades, shows "UUID: <deployment_id>"
- Clicking again returns to the default version display
- Keyboard accessible (Enter/Space), non-interactive when API fails

## Files Changed

- `frontend/app/src/entities/config/ui/app-info.tsx` — toggle state, clipboard copy, "Copied!" indicator
- `frontend/app/src/entities/config/ui/app-info.test.tsx` — 7 unit tests (toggle, clipboard, error states)
- `frontend/app/tests/e2e/profile/profile.spec.ts` — E2E test for full toggle flow

## Test plan

- [x] `pnpm test` — 578/578 passing
- [ ] E2E test against running instance
- [ ] Manual verification per quickstart steps

Jira: [IFC-2433](https://opsmill.atlassian.net/browse/IFC-2433)

[IFC-2433]: https://opsmill.atlassian.net/browse/IFC-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a version/UUID toggle to the account menu info line so users can quickly identify and share the instance. Clicking shows and copies the UUID, then returns to the version display on the next click. Meets IFC-2433.

- **New Features**
  - Toggle between "Infrahub - <Edition> - vX.Y.Z" and the instance UUID by clicking the info line.
  - On first toggle, copy the UUID to clipboard and show a green "Copied!" for 2s; then display "UUID: <id>".
  - Click again to return to the default version view.
  - Keyboard accessible (Enter/Space) and non-interactive when the API fails; shows "N/A" if UUID is missing.
  - Added unit and E2E tests for toggle, clipboard, and error states.

<sup>Written for commit b3b00b23e83317eb592c7e34f4df66db90c56d53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

