### PR TITLE
fix component test to not inherit from integration test

### DIFF
--- a/backend/tests/component/core/schema_manager/namespace_restriction/test_restricted_namespaces_validation.py
+++ b/backend/tests/component/core/schema_manager/namespace_restriction/test_restricted_namespaces_validation.py
@@ -1,4 +1,4 @@
-"""Integration tests for restricted_namespaces validation.
+"""Component tests for restricted_namespaces validation.
 
 These tests verify that changing restricted_namespaces on a generic
 is properly validated when existing nodes would violate the new restriction.
@@ -11,39 +11,37 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
+from infrahub.database import InfrahubDatabase
 
 if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.database import InfrahubDatabase
-from tests.integration.schema_lifecycle.shared import TestSchemaLifecycleBase
-from tests.integration.shared import load_schema
 
 
-class TestRestrictedNamespacesValidation(TestSchemaLifecycleBase):
+class TestRestrictedNamespacesValidation:
     """Test that modifying restricted_namespaces is validated against existing nodes."""
 
-    async def test_change_restriction_should_fail(
-        self,
-        initial_dataset: dict[str, str],
-        schema_with_cat_restriction: dict[str, Any],
-    ) -> None:
-        """Test that changing restricted_namespaces is rejected when existing nodes violate the new restriction.
-
-        Scenario:
-        - Initial: generic Animal (restricted_namespaces: ["Dog"]) and node Dog
-        - Update: Animal's restricted_namespaces changed to ["Cat"]
-        - Expected: Validation fails because Dog node (namespace: Dog) doesn't comply
-        """
-        schema_branch: SchemaBranch = registry.schema.get_schema_branch(name=registry.default_branch)
-
-        # The validation happens during schema processing when a node inherits from a generic
-        # with restricted_namespaces that doesn't include the node's namespace
-        with pytest.raises(ValueError, match=r"(?s)restricted namespaces(?=.*Dog)(?=.*Cat)"):
-            candidate_schema: SchemaBranch = schema_branch.duplicate()
-            candidate_schema.load_schema(schema=SchemaRoot(**schema_with_cat_restriction))
-            candidate_schema.process()
-
     # Fixtures
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: "Branch",
+        register_core_models_schema_scope_class: "SchemaBranch",
+        schema_with_dog_restriction: dict[str, Any],
+    ) -> dict[str, str]:
+        """Register the dog-restriction schema and create a Dog instance."""
+        registry.schema.register_schema(
+            schema=SchemaRoot(**schema_with_dog_restriction),
+            branch=default_branch_scope_class.name,
+        )
+
+        dog: Node = await Node.init(schema="DogDog", db=db)
+        await dog.new(db=db, name="Yann", breed="Brittany Spaniel")
+        await dog.save(db=db)
+
+        return {"dog": dog.id}
 
     @pytest.fixture(scope="class")
     def schema_with_dog_restriction(
@@ -74,19 +72,23 @@ class TestRestrictedNamespacesValidation(TestSchemaLifecycleBase):
             "nodes": [schema_dog_node],
         }
 
-    @pytest.fixture(scope="class")
-    async def initial_dataset(
+    async def test_change_restriction_should_fail(
         self,
-        db: InfrahubDatabase,
-        initialize_registry: None,
-        schema_with_dog_restriction: dict[str, Any],
-    ) -> dict[str, str]:
-        """Create initial schema and a Dog instance."""
-        await load_schema(db=db, schema=schema_with_dog_restriction)
+        initial_dataset: dict[str, str],
+        schema_with_cat_restriction: dict[str, Any],
+    ) -> None:
+        """Test that changing restricted_namespaces is rejected when existing nodes violate the new restriction.
 
-        # Create a Dog instance
-        dog: Node = await Node.init(schema="DogDog", db=db)
-        await dog.new(db=db, name="Yann", breed="Brittany Spaniel")
-        await dog.save(db=db)
+        Scenario:
+        - Initial: generic Animal (restricted_namespaces: ["Dog"]) and node Dog
+        - Update: Animal's restricted_namespaces changed to ["Cat"]
+        - Expected: Validation fails because Dog node (namespace: Dog) doesn't comply
+        """
+        schema_branch: SchemaBranch = registry.schema.get_schema_branch(name=registry.default_branch)
 
-        return {"dog": dog.id}
+        # The validation happens during schema processing when a node inherits from a generic
+        # with restricted_namespaces that doesn't include the node's namespace
+        with pytest.raises(ValueError, match=r"(?s)restricted namespaces(?=.*Dog)(?=.*Cat)"):
+            candidate_schema: SchemaBranch = schema_branch.duplicate()
+            candidate_schema.load_schema(schema=SchemaRoot(**schema_with_cat_restriction))
+            candidate_schema.process()


### PR DESCRIPTION
this component test was unnecessarily inheriting from an integration test class, which, surprisingly, worked in the CI. integration tests generally do a lot more "stuff" than component tests, so component tests should not use integration test classes. if a component test needs integration test logic, then the component test should probably be an integration test

this unexpected import broke the CI in the enterprise version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the restricted_namespaces component test to stop inheriting from an integration test base, restoring proper test scope and fixing CI failures in the enterprise pipeline.

- **Bug Fixes**
  - Removed `TestSchemaLifecycleBase` inheritance and integration-only helpers.
  - Added class-scoped fixtures to register schema via `registry.schema.register_schema` and create a `DogDog` node.
  - Preserved validation flow with `SchemaBranch.duplicate/load_schema/process` and the `pytest.raises` assertion.
  - Updated docstring to clarify this is a component test.

<sup>Written for commit 34be80c6841590cbc7777f56b7d68d4fed921bd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

