### PR TITLE
link merging pc to diff

### DIFF
--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -129,17 +129,17 @@ class DiffCoordinator:
         )
 
     async def _get_proposed_change_id_for_branch(self, branch_name: str) -> str | None:
-        """Look up the ID of an OPEN CoreProposedChange for the given source branch."""
-        open_proposed_changes = await NodeManager.query(
+        """Look up the ID of an active CoreProposedChange for the given source branch."""
+        active_proposed_changes = await NodeManager.query(
             db=self.db,
             schema=CoreProposedChange,
             filters={
                 "source_branch__value": branch_name,
-                "state__value": ProposedChangeState.OPEN.value,
+                "state__values": [ProposedChangeState.OPEN.value, ProposedChangeState.MERGING.value],
             },
         )
-        if open_proposed_changes:
-            return open_proposed_changes[0].id
+        if active_proposed_changes:
+            return active_proposed_changes[0].id
         return None
 
     async def _link_diff_to_proposed_change(
@@ -150,8 +150,8 @@ class DiffCoordinator:
     ) -> str | None:
         """Link a diff root to a proposed change if needed.
 
-        If proposed_change_id is not provided, attempts to find an OPEN
-        CoreProposedChange for the given diff_branch_name.
+        If proposed_change_id is not provided, attempts to find an active
+        (OPEN or MERGING) CoreProposedChange for the given diff_branch_name.
 
         Updates the database link and the in-memory object's proposed_change_id.
         Returns the resolved proposed_change_id (may be None).

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -535,23 +535,25 @@ class TestDiffCoordinator:
         for metadata in retrieved_metadata:
             assert metadata.proposed_change_id == proposed_change_id
 
-    async def test_open_proposed_change_discovered_when_not_provided(
+    @pytest.mark.parametrize("pc_state", [ProposedChangeState.OPEN, ProposedChangeState.MERGING])
+    async def test_active_proposed_change_discovered_when_not_provided(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
         person_john_main: Node,
+        pc_state: ProposedChangeState,
     ) -> None:
-        """When update_branch_diff is called without proposed_change_id but an OPEN
+        """When update_branch_diff is called without proposed_change_id but an OPEN or MERGING
         CoreProposedChange exists for the branch, the diff should be linked to it."""
         branch = await create_branch(db=db, branch_name="branch")
 
-        # Create a real OPEN CoreProposedChange for this branch
         proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE, branch=default_branch)
         await proposed_change.new(
             db=db,
-            name="test-pc",
+            name=f"test-pc-{pc_state.value}",
             source_branch=branch.name,
             destination_branch=default_branch.name,
+            state=pc_state.value,
         )
         await proposed_change.save(db=db)
 
@@ -567,7 +569,6 @@ class TestDiffCoordinator:
         # Update branch diff WITHOUT providing proposed_change_id
         diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
 
-        # The diff should have discovered and linked the open proposed change
         assert diff_metadata.proposed_change_id == proposed_change.id
 
         # Verify both diff roots are linked via the repository
@@ -588,7 +589,7 @@ class TestDiffCoordinator:
         """Diffs should not be linked to CLOSED, CANCELED, or MERGED proposed changes."""
         branch = await create_branch(db=db, branch_name="branch")
 
-        # Create proposed changes in non-open states for this branch
+        # Create proposed changes in terminal states for this branch
         for state in (ProposedChangeState.CLOSED, ProposedChangeState.CANCELED, ProposedChangeState.MERGED):
             pc = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE, branch=default_branch)
             await pc.new(
@@ -611,7 +612,7 @@ class TestDiffCoordinator:
         # Update branch diff WITHOUT providing proposed_change_id
         diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
 
-        # The diff should NOT be linked to any of the non-open proposed changes
+        # The diff should NOT be linked to any of the terminal proposed changes
         assert diff_metadata.proposed_change_id is None
 
     async def test_parent_reassigned_then_deleted(

--- a/changelog/8769.fixed.md
+++ b/changelog/8769.fixed.md
@@ -1,0 +1,1 @@
+Link a merging proposed change to its diff during the merge operation if it has not been linked yet


### PR DESCRIPTION
fixes #8769 

the logic to link a proposed change to a diff did not correctly handle the case where a pc was merged without the diff ever having been generated. the logic only looked for an OPEN pc, but the pc would be in a MERGING state already in this case

fix is just to also look for MERGING pcs when linking to a diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link diffs to a proposed change when it’s in MERGING state, not just OPEN, so merges without a pre-generated diff still attach correctly. Fixes #8769.

<sup>Written for commit 4fd319a87da60a4e065b8d31fd2b42cc21ecad89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

