### PR TITLE
Add missing annotations to core component tests

### DIFF
--- a/backend/tests/component/core/test_node_get_list_query.py
+++ b/backend/tests/component/core/test_node_get_list_query.py
@@ -14,8 +14,9 @@ from infrahub.core.node import Node
 from infrahub.core.order import NodeMetaOrder, OrderModel
 from infrahub.core.query.node import NodeGetListQuery
 from infrahub.core.registry import registry
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import NodeSchema, SchemaRoot
 from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.profiles.node_applier import NodeProfilesApplier
@@ -23,7 +24,12 @@ from tests.helpers.schema import WIDGET
 
 
 async def test_query_NodeGetListQuery(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jim_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
@@ -33,7 +39,12 @@ async def test_query_NodeGetListQuery(
 
 
 async def test_query_NodeGetListQuery_filter_id(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jim_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"id": person_john_main.id})
@@ -42,7 +53,12 @@ async def test_query_NodeGetListQuery_filter_id(
 
 
 async def test_query_NodeGetListQuery_filter_ids(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jim_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    branch: Branch,
 ) -> None:
     node_to_delete = await NodeManager.get_one(id=person_jim_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
@@ -60,7 +76,7 @@ async def test_query_NodeGetListQuery_filter_ids(
 
 
 async def test_query_NodeGetListQuery_filter_attribute_isnull(
-    db: InfrahubDatabase, person_albert_main, person_alfred_main, person_jane_main, branch: Branch
+    db: InfrahubDatabase, person_albert_main: Node, person_alfred_main: Node, person_jane_main: Node, branch: Branch
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch, duplicate=False)
     person_branch = await NodeManager.get_one(db=db, branch=branch, id=person_albert_main.id)
@@ -109,7 +125,12 @@ async def test_query_NodeGetListQuery_filter_attribute_isnull(
 
 
 async def test_query_NodeGetListQuery_filter_relationship_isnull_one(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, person_jane_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    person_jane_main: Node,
+    branch: Branch,
 ) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
     owner_rel = car_schema.get_relationship(name="owner")
@@ -161,12 +182,12 @@ async def test_query_NodeGetListQuery_filter_relationship_isnull_one(
 
 async def test_query_NodeGetListQuery_filter_relationship_isnull_many(
     db: InfrahubDatabase,
-    car_accord_main,
-    car_camry_main,
-    person_albert_main,
-    person_alfred_main,
-    person_jane_main,
-    person_john_main,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    person_jane_main: Node,
+    person_john_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
@@ -195,7 +216,7 @@ async def test_query_NodeGetListQuery_filter_relationship_isnull_many(
 
 
 async def test_query_NodeGetListQuery_filter_relationship_attribute_isnull_not_allowed(
-    db: InfrahubDatabase, car_person_schema, default_branch
+    db: InfrahubDatabase, car_person_schema: SchemaBranch, default_branch: Branch
 ) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=default_branch, duplicate=False)
 
@@ -209,7 +230,12 @@ async def test_query_NodeGetListQuery_filter_relationship_attribute_isnull_not_a
 
 
 async def test_query_NodeGetListQuery_filter_height(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jim_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestPerson", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"height__value": 160})
@@ -247,7 +273,12 @@ async def test_query_NodeGetListQuery_filter_owner(
 
 
 async def test_query_NodeGetListQuery_filter_boolean(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"is_electric__value": False})
@@ -256,7 +287,12 @@ async def test_query_NodeGetListQuery_filter_boolean(
 
 
 async def test_query_NodeGetListQuery_deleted_node(
-    db: InfrahubDatabase, car_accord_main, car_camry_main: Node, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     node_to_delete = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
@@ -270,7 +306,12 @@ async def test_query_NodeGetListQuery_deleted_node(
 
 
 async def test_query_NodeGetListQuery_deleted_node_no_filter(
-    db: InfrahubDatabase, car_accord_main, car_camry_main: Node, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     node_to_delete = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
     await node_to_delete.delete(db=db)
@@ -284,7 +325,12 @@ async def test_query_NodeGetListQuery_deleted_node_no_filter(
 
 
 async def test_query_NodeGetListQuery_filter_relationship(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema, filters={"owner__name__value": "John"})
@@ -294,11 +340,11 @@ async def test_query_NodeGetListQuery_filter_relationship(
 
 async def test_query_NodeGetListQuery_filter_relationship_ids(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
@@ -311,12 +357,12 @@ async def test_query_NodeGetListQuery_filter_relationship_ids(
 
 async def test_query_NodeGetListQuery_filter_relationship_ids_with_update(
     db: InfrahubDatabase,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_yaris_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
@@ -333,7 +379,12 @@ async def test_query_NodeGetListQuery_filter_relationship_ids_with_update(
 
 
 async def test_query_NodeGetListQuery_filter_and_sort(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "is_electric__value"]
@@ -349,7 +400,12 @@ async def test_query_NodeGetListQuery_filter_and_sort(
 
 
 async def test_query_NodeGetListQuery_filter_and_sort_with_revision(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     node = await NodeManager.get_one(id=car_volt_main.id, db=db, branch=branch)
     node.is_electric.value = False
@@ -368,7 +424,9 @@ async def test_query_NodeGetListQuery_filter_and_sort_with_revision(
     assert len(query.get_node_ids()) == 2
 
 
-async def test_query_NodeGetListQuery_with_generics(db: InfrahubDatabase, group_group1_main, branch: Branch) -> None:
+async def test_query_NodeGetListQuery_with_generics(
+    db: InfrahubDatabase, group_group1_main: Node, branch: Branch
+) -> None:
     schema = registry.schema.get(name=InfrahubKind.GENERICGROUP, branch=branch)
     query = await NodeGetListQuery.init(
         db=db,
@@ -380,7 +438,12 @@ async def test_query_NodeGetListQuery_with_generics(db: InfrahubDatabase, group_
 
 
 async def test_query_NodeGetListQuery_order_by(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "name__value"]
@@ -395,7 +458,12 @@ async def test_query_NodeGetListQuery_order_by(
 
 
 async def test_query_NodeGetListQuery_order_by_disabled(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch)
     schema.order_by = ["owner__name__value", "name__value"]
@@ -411,7 +479,12 @@ async def test_query_NodeGetListQuery_order_by_disabled(
 
 
 async def test_query_NodeGetListQuery_order_by_optional_relationship_nulls(
-    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+    db: InfrahubDatabase,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
+    branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
     schema.relationships.append(
@@ -450,12 +523,12 @@ async def test_query_NodeGetListQuery_order_by_optional_relationship_nulls(
 
 async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
     db: InfrahubDatabase,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_yaris_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     schema = registry.schema.get(name="TestCar", branch=branch, duplicate=False)
@@ -505,7 +578,12 @@ async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
 
 
 async def test_query_NodeGetListQuery_filter_with_profiles(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jim_main: Node,
+    person_albert_main: Node,
+    person_alfred_main: Node,
+    branch: Branch,
 ) -> None:
     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
@@ -550,7 +628,7 @@ async def test_query_NodeGetListQuery_filter_with_profiles(
 
 
 async def test_query_NodeGetListQuery_filter_with_generic_profiles(
-    db: InfrahubDatabase, animal_person_schema, default_branch: Branch
+    db: InfrahubDatabase, animal_person_schema: SchemaBranch, default_branch: Branch
 ) -> None:
     animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
     animal_profile = await Node.init(db=db, schema=animal_profile_schema)
@@ -614,7 +692,7 @@ async def test_query_NodeGetListQuery_filter_with_generic_profiles(
 
 
 async def test_query_NodeGetListQuery_order_with_profiles(
-    db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
+    db: InfrahubDatabase, car_camry_main: Node, car_accord_main: Node, car_volt_main: Node, branch: Branch
 ) -> None:
     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
@@ -651,7 +729,7 @@ async def test_query_NodeGetListQuery_order_with_profiles(
 
 
 async def test_query_NodeGetListQuery_pagination_order_by(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None
 ) -> None:
     """Validate that pagination works for nodes which have an order_by clause on non unique attributes."""
     schema_root = SchemaRoot(nodes=[WIDGET])
@@ -680,7 +758,7 @@ async def test_query_NodeGetListQuery_pagination_order_by(
 
 
 async def test_query_NodeGetListQuery_metadata_order_pagination(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None
 ) -> None:
     """Test that pagination works correctly with metadata ordering on default and user branches."""
     schema_root = SchemaRoot(nodes=[WIDGET])
@@ -837,7 +915,7 @@ async def test_query_NodeGetListQuery_metadata_order_pagination(
 
 
 async def test_query_NodeGetListQuery_metadata_filtering(
-    db: InfrahubDatabase, criticality_schema, branch: Branch
+    db: InfrahubDatabase, criticality_schema: NodeSchema, branch: Branch
 ) -> None:
     """Test all metadata filtering scenarios without ordering."""
     schema = registry.schema.get(name="TestCriticality", branch=branch, duplicate=False)
@@ -945,7 +1023,7 @@ async def test_query_NodeGetListQuery_metadata_filtering(
 
 
 async def test_query_NodeGetListQuery_metadata_ordering(
-    db: InfrahubDatabase, criticality_schema, branch: Branch
+    db: InfrahubDatabase, criticality_schema: NodeSchema, branch: Branch
 ) -> None:
     """Test metadata ordering without filtering."""
     schema = registry.schema.get(name="TestCriticality", branch=branch, duplicate=False)
@@ -1014,7 +1092,7 @@ async def test_query_NodeGetListQuery_metadata_ordering(
 
 
 async def test_query_NodeGetListQuery_metadata_filter_and_order(
-    db: InfrahubDatabase, criticality_schema, branch: Branch
+    db: InfrahubDatabase, criticality_schema: NodeSchema, branch: Branch
 ) -> None:
     """Test combined filtering and ordering scenarios."""
     schema = registry.schema.get(name="TestCriticality", branch=branch, duplicate=False)

--- a/backend/tests/component/core/test_relationship_query.py
+++ b/backend/tests/component/core/test_relationship_query.py
@@ -475,7 +475,7 @@ async def test_query_RelationshipDeleteQuery(
                 )
                 assert active_on_main or deleted_on_branch or active_on_branch
 
-    def get_active_path_and_rel(all_paths, previous_rel: str):
+    def get_active_path_and_rel(all_paths: list[Any], previous_rel: str):
         for path in all_paths:
             for node in path[0]._nodes:
                 if "Relationship" in node.labels and node.get("uuid") != previous_rel:
@@ -710,7 +710,7 @@ async def test_query_RelationshipUpdatePropertyQuery_updates_node_metadata(
     assert dest_node._get_updated_at() == update_time
 
 
-async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch, tag_blue_main: Node) -> None:
+async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node) -> None:
     person = await Node.init(db=db, branch=default_branch, schema="TestPerson")
     await person.new(db=db, firstname="Kara", lastname="Thrace", tags=[tag_blue_main])
     create_before = Timestamp()
@@ -845,7 +845,7 @@ async def test_main_delete_with_updated_branch_relationship(
 
 
 async def test_relationship_update_with_delete_peer(
-    db: InfrahubDatabase, default_branch, tag_blue_main: Node, tag_red_main: Node
+    db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, tag_red_main: Node
 ) -> None:
     person = await Node.init(db=db, branch=default_branch, schema="TestPerson")
     await person.new(db=db, firstname="Kara", lastname="Thrace", tags=[tag_blue_main])
@@ -907,12 +907,12 @@ async def test_query_RelationshipGetPeerQuery(
 
 async def test_query_RelationshipGetPeerQuery_with_filter(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson")
@@ -935,12 +935,12 @@ async def test_query_RelationshipGetPeerQuery_with_filter(
 
 async def test_query_RelationshipGetPeerQuery_with_id(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson")
@@ -962,12 +962,12 @@ async def test_query_RelationshipGetPeerQuery_with_id(
 
 async def test_query_RelationshipGetPeerQuery_with_ids(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson")
@@ -989,12 +989,12 @@ async def test_query_RelationshipGetPeerQuery_with_ids(
 
 async def test_query_RelationshipGetPeerQuery_with_sort(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     car_schema = registry.schema.get(name="TestCar", branch=branch)
@@ -1020,12 +1020,12 @@ async def test_query_RelationshipGetPeerQuery_with_sort(
 
 async def test_query_RelationshipGetPeerQuery_deleted_node(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     node = await NodeManager.get_one(id=car_volt_main.id, db=db, branch=branch)
@@ -1049,12 +1049,12 @@ async def test_query_RelationshipGetPeerQuery_deleted_node(
 
 async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson")
@@ -1077,12 +1077,12 @@ async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
 
 async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
     db: InfrahubDatabase,
-    person_john_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get_node_schema(name="TestPerson")
@@ -1213,13 +1213,13 @@ async def test_query_RelationshipDeleteQuery_on_migrated_kind_node_2(
 
 async def test_query_RelationshipCountPerNodeQuery(
     db: InfrahubDatabase,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     person_schema = registry.schema.get(name="TestPerson")
@@ -1267,13 +1267,13 @@ async def test_query_RelationshipCountPerNodeQuery(
 
 async def test_query_RelationshipGetByIdentifierQuery(
     db: InfrahubDatabase,
-    person_john_main,
-    person_jane_main,
-    car_accord_main,
-    car_camry_main,
-    car_volt_main,
-    car_prius_main,
-    car_yaris_main,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_camry_main: Node,
+    car_volt_main: Node,
+    car_prius_main: Node,
+    car_yaris_main: Node,
     branch: Branch,
 ) -> None:
     with pytest.raises(ValueError) as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1017,8 +1017,6 @@ allow-dunder-method-names = [
 "backend/tests/component/core/migrations/graph/test_032.py" = ["ANN001"]       # 1 violation
 "backend/tests/component/core/migrations/graph/test_027.py" = ["ANN001"]       # 1 violation
 "backend/tests/component/core/schema_manager/test_manager_schema.py" = ["ANN001"]                # 100 violations
-"backend/tests/component/core/test_node_get_list_query.py" = ["ANN001"]        # 96 violations
-"backend/tests/component/core/test_relationship_query.py" = ["ANN001"]        # 59 violations
 
 "backend/tests/query_benchmark/**.py" = [
     ##################################################################################################


### PR DESCRIPTION
# Why

Improve typing within tests

## What changed

* Add missing type annotations
* Update rules in pyproject.toml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing type annotations to core component tests to satisfy ANN001 and improve editor hints. No behavior changes; removes linter ignores in `pyproject.toml`.

- **Refactors**
  - Added explicit types to fixtures and params in `backend/tests/component/core/test_node_get_list_query.py` and `backend/tests/component/core/test_relationship_query.py` (e.g., `Node`, `Branch`, `NodeSchema`, `SchemaBranch`, `list[Any]`).
  - Updated imports to use the correct schema and branch types.
  - Removed ANN001 ignore entries for these files from `pyproject.toml`.

<sup>Written for commit f4434307e5fcb5157aff8f6e35245a8e8ec77b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

