### PR TITLE
Split apart linting violations into sections testcontainers

### DIFF
--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -58,10 +58,14 @@ ignore = [
     "ISC",      # flake8-implicit-str-concat
     "COM812",   # missing-trailing-comma
     "S101",     # Use of assert allowed as the producation code is used within tests
+]
+
+[tool.ruff.lint.per-file-ignores]
+
+"infrahub_testcontainers/**.py" = [
     ##################################################################################################
     # Rules below needs to be Investigated                                                           #
     ##################################################################################################
-    "A001",     # Variable `format` is shadowing a Python builtin
     "BLE001",   # Do not catch blind exception: `Exception`
     "C901",     # `database_restore_backup` is too complex (22 > 10)
     "E501",     # Line too long
@@ -71,7 +75,6 @@ ignore = [
     "FBT002",   # Boolean default positional argument in function definition
     "FIX002",   # Line contains TODO, consider resolving the issue
     "PERF203",  # `try`-`except` within a loop incurs performance overhead
-    "PGH003",   # Use specific rule codes when ignoring type issues
     "PLR0912",  # Too many branches
     "PLR0914",  # Too many local variables
     "PLR6301",  # Method `infrahub_app` could be a function, class method, or static method
@@ -87,6 +90,17 @@ ignore = [
     "TRY002",   # Create your own exception
     "TRY003",   # Avoid specifying long messages outside the exception class
 ]
+
+"tests/**.py" = [
+    ##################################################################################################
+    # Rules below needs to be Investigated                                                           #
+    ##################################################################################################
+    "EM101",    # Exception must not use a string literal, assign to variable first
+    "PGH003",   # Use specific rule codes when ignoring type issues
+    "RUF067",   # `__init__` module should only contain docstrings and re-exports
+    "TC003",    # Move standard library import into a type-checking block
+]
+
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/python_testcontainers/tasks.py
+++ b/python_testcontainers/tasks.py
@@ -5,8 +5,8 @@ from invoke import Context, task
 MAIN_DIRECTORY_PATH = Path(__file__).parent
 
 
-@task
-def format(context: Context) -> None:
+@task(name="format")
+def format_code(context: Context) -> None:
     """Run RUFF to format all Python files."""
 
     exec_cmds = ["ruff format .", "ruff check . --fix"]


### PR DESCRIPTION
# Why

Make it easier to fix linting violations in sections

## What changed

* Split apart linting exceptions into the sections where the violations occur
* Fix trivial builtin override within tasks.py (Variable `format` is shadowing a Python builtin)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `ruff` linting ignores into per-file sections to target violations by area, and fixed a builtin shadowing in the formatting task while keeping the CLI task name the same.

- **Refactors**
  - Added `[tool.ruff.lint.per-file-ignores]` for `infrahub_testcontainers/**.py` and `tests/**.py` to scope ignores by directory.
  - Removed global `A001`; moved `PGH003` under `tests/**.py` per-file ignores.

- **Bug Fixes**
  - Renamed the `format` function to `format_code` and set `@task(name="format")` to avoid shadowing the Python builtin while preserving the `invoke format` command.

<sup>Written for commit 2c8d5f0d9e63d92219e86d569b99416bccec0dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

