### PR TITLE
Update SDK commit to infrahub-develop head

### DIFF
--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -11,6 +11,7 @@ from git import Repo
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.branch import BranchData
 from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.schema import NodeSchemaAPI
 from infrahub_sdk.schema import SchemaRootAPI as ClientSchemaRoot
 from infrahub_sdk.uuidt import UUIDT
 from pytest_httpx import HTTPXMock
@@ -801,7 +802,8 @@ async def schema_02(client: InfrahubClient, helper: TestHelper, car_data_01: dic
 
 @pytest.fixture
 async def gql_query_node_03(client: InfrahubClient, gql_query_data_03: dict[str, Any]) -> InfrahubNode:
-    schema = [model for model in SchemaRoot(**core_models).nodes if model.kind == InfrahubKind.GRAPHQLQUERY][0]
+    backend_schema = [model for model in SchemaRoot(**core_models).nodes if model.kind == InfrahubKind.GRAPHQLQUERY][0]
+    schema = NodeSchemaAPI(**backend_schema.model_dump())
     node = InfrahubNode(client=client, schema=schema, data=gql_query_data_03)
     return node
 


### PR DESCRIPTION
### Why 

In order to synchronize `infrahub` project containing this PR https://github.com/opsmill/infrahub/pull/8319 with `infrahub-sdk-python` containing this PR https://github.com/opsmill/infrahub-sdk-python/pull/807.

Both PRs related to Namespace restriction feature.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `python_sdk` submodule to the latest `infrahub-sdk-python` develop head and fixes tests to use the correct SDK schema type (`NodeSchemaAPI`) when constructing an `InfrahubNode`. This aligns `infrahub` with the SDK for the namespace restriction work.

<sup>Written for commit 1e89c281a584e3226f6f943a60cc0d3de728a638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



