### PR TITLE
Use `yield` instead of `request.addfinalizer`

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/helpers.py
+++ b/python_testcontainers/infrahub_testcontainers/helpers.py
@@ -4,6 +4,7 @@ import os
 import subprocess  # noqa: S404
 import uuid
 import warnings
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -94,20 +95,10 @@ class TestInfrahubDocker:
         )
 
     @pytest.fixture(scope="class")
-    def infrahub_app(self, request: pytest.FixtureRequest, infrahub_compose: InfrahubDockerCompose) -> dict[str, int]:
+    def infrahub_app(
+        self, request: pytest.FixtureRequest, infrahub_compose: InfrahubDockerCompose
+    ) -> Generator[dict[str, int], None, None]:
         tests_failed_before_class = request.session.testsfailed
-
-        def cleanup() -> None:
-            tests_failed_during_class = request.session.testsfailed - tests_failed_before_class
-            if tests_failed_during_class > 0:
-                stdout, stderr = infrahub_compose.get_logs("infrahub-server", "task-worker")
-                warnings.warn(
-                    f"Container logs:\nStdout:\n{stdout}\nStderr:\n{stderr}",
-                    stacklevel=2,
-                )
-            infrahub_compose.stop()
-
-        request.addfinalizer(cleanup)
 
         try:
             infrahub_compose.start()
@@ -115,7 +106,16 @@ class TestInfrahubDocker:
             stdout, stderr = infrahub_compose.get_logs()
             raise Exception(f"Failed to start docker compose:\nStdout:\n{stdout}\nStderr:\n{stderr}") from exc
 
-        return infrahub_compose.get_services_port()
+        yield infrahub_compose.get_services_port()
+
+        tests_failed_during_class = request.session.testsfailed - tests_failed_before_class
+        if tests_failed_during_class > 0:
+            stdout, stderr = infrahub_compose.get_logs("infrahub-server", "task-worker")
+            warnings.warn(
+                f"Container logs:\nStdout:\n{stdout}\nStderr:\n{stderr}",
+                stacklevel=2,
+            )
+        infrahub_compose.stop()
 
     @pytest.fixture(scope="class")
     def infrahub_port(self, infrahub_app: dict[str, int]) -> int:

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -78,7 +78,6 @@ ignore = [
     "PLR0912",  # Too many branches
     "PLR0914",  # Too many local variables
     "PLR6301",  # Method `infrahub_app` could be a function, class method, or static method
-    "PT021",    # Use `yield` instead of `request.addfinalizer`
     "RUF067",   # `__init__` module should only contain docstrings and re-exports
     "SLF001",   # Private member accessed: `_session`
     "TC001",    # Move application import `.helpers.InfrahubDockerCompose` into a type-checking block


### PR DESCRIPTION
# Why

Slight improvement to readability within testcontainers pytest setup

## What changed

Change function to use yield instead of a `.addfinalizer()` call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `infrahub_app` `pytest` fixture to a `yield`-based teardown for clearer flow and alignment with pytest best practices. Teardown now captures logs on failures and cleanly stops the compose stack.

- **Refactors**
  - Replace `request.addfinalizer` with `yield` in `helpers.py`; move log warnings and `infrahub_compose.stop()` to the teardown path.
  - Annotate fixture with `Generator[dict[str, int], None, None]`.
  - Remove `PT021` ignore from `pyproject.toml`.

<sup>Written for commit c234b37ce5f9a1d412f3984f93db10787bb38512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

