### PR TITLE
Remove filter popovers from table column headers

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/actions-header-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/actions-header-cell.tsx
@@ -4,11 +4,7 @@ import { classNames } from "@/shared/utils/common";
 export function ActionsHeaderCell() {
   return (
     <div
-      className={classNames(
-        cellsStyle,
-        cellHeaderStyle,
-        "right-0 z-10 -ml-px size-10 border-l hover:bg-white"
-      )}
+      className={classNames(cellsStyle, cellHeaderStyle, "right-0 z-10 -ml-px size-10 border-l")}
     />
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/generics/kind-header-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/generics/kind-header-cell.tsx
@@ -13,7 +13,7 @@ export interface KindHeaderCellProps extends React.HTMLAttributes<HTMLDivElement
 export function KindHeaderCell({ schema, className, ...props }: KindHeaderCellProps) {
   return (
     <div
-      className={classNames(cellsStyle, cellHeaderStyle, "hover:bg-white", className)}
+      className={classNames(cellsStyle, cellHeaderStyle, className)}
       data-testid="kind-header-cell"
       {...props}
     >

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header-simple.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header-simple.tsx
@@ -11,7 +11,7 @@ export interface TableColumnHeaderSimpleProps {
 
 export function TableColumnHeaderSimple({ columnSchema, className }: TableColumnHeaderSimpleProps) {
   return (
-    <div className={classNames(cellsStyle, cellHeaderStyle, "hover:bg-white", className)}>
+    <div className={classNames(cellsStyle, cellHeaderStyle, className)}>
       <FieldSchemaIcon fieldSchema={columnSchema} />
       <span className="mr-2 truncate">{columnSchema.label ?? columnSchema.name}</span>
     </div>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
@@ -1,56 +1,20 @@
-import { Icon } from "@iconify-icon/react";
-import type { PopoverTriggerProps } from "@radix-ui/react-popover";
-import { useState } from "react";
-
 import { cellHeaderStyle, cellsStyle } from "@/shared/components/table/style";
-import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
-import useFilters from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";
 
-import { AttributeFilterForm } from "@/entities/nodes/object/ui/filters/attribute-filter-form";
-import { RelationshipFilterForm } from "@/entities/nodes/object/ui/filters/relationship-filter-form";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 
-export interface TableColumnHeaderProps extends PopoverTriggerProps {
+export interface TableColumnHeaderProps {
   columnSchema: AttributeSchema | RelationshipSchema;
   className?: string;
 }
 
-export function TableColumnHeader({ columnSchema, className, ...props }: TableColumnHeaderProps) {
-  const [filters] = useFilters();
-  const [showFilters, setShowFilters] = useState(false);
-  const currentColumnFilters = filters.find((f) => f.name.startsWith(columnSchema.name));
-
-  const closePopover = () => {
-    setShowFilters(false);
-  };
-
+export function TableColumnHeader({ columnSchema, className }: TableColumnHeaderProps) {
   return (
-    <Popover open={showFilters} onOpenChange={setShowFilters}>
-      <PopoverTrigger className={classNames(cellsStyle, cellHeaderStyle, className)} {...props}>
-        <FieldSchemaIcon fieldSchema={columnSchema} />
+    <div className={classNames(cellsStyle, cellHeaderStyle, className)}>
+      <FieldSchemaIcon fieldSchema={columnSchema} />
 
-        <span className="mr-2 truncate">{columnSchema.label ?? columnSchema.name}</span>
-        <Icon
-          icon="mdi:filter-variant"
-          className={classNames(
-            "ml-auto text-lg",
-            currentColumnFilters ? "text-indigo-700" : "invisible"
-          )}
-        />
-      </PopoverTrigger>
-
-      <PopoverContent className="relative rounded-tl-none p-0" align="start">
-        <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-gray-200 border-b-0 bg-white px-2 py-1 font-semibold">
-          Filter by {columnSchema.label ?? columnSchema.name}
-        </div>
-        {"peer" in columnSchema ? (
-          <RelationshipFilterForm relationshipSchema={columnSchema} onSuccess={closePopover} />
-        ) : (
-          <AttributeFilterForm attributeSchema={columnSchema} onSuccess={closePopover} />
-        )}
-      </PopoverContent>
-    </Popover>
+      <span className="mr-2 truncate">{columnSchema.label ?? columnSchema.name}</span>
+    </div>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-header.tsx
@@ -17,9 +17,7 @@ export function TableIdentifierHeader({ schema, className, ...props }: TableIden
   const { isAuthenticated } = useAuth();
 
   return (
-    <div
-      className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10 hover:bg-white", className)}
-    >
+    <div className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10", className)}>
       {isAuthenticated && <Checkbox {...props} data-testid="select-all-rows" />}
 
       <Row className="mx-2 gap-1.5">

--- a/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
@@ -1,4 +1,3 @@
-import type { PopoverTriggerProps } from "@radix-ui/react-popover";
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
 import { FROM_RESOURCE_POOL_SUFFIX } from "@/shared/components/form/constants";
@@ -87,8 +86,7 @@ export function getObjectGenericColumns(schema: ModelSchema): Array<ColumnDef<No
 }
 
 export function getObjectFieldsColumns(
-  schema: ModelSchema,
-  headerProps?: PopoverTriggerProps
+  schema: ModelSchema
 ): Array<ColumnDef<NodeObject, NodeAttribute | NodeRelationship>> {
   const attributes = getAttributesVisibleInListView(schema.attributes ?? []);
   const relationships = getRelationshipsVisibleInListView(schema.relationships ?? []).filter(
@@ -99,7 +97,7 @@ export function getObjectFieldsColumns(
   return sortedColumns.map((columnSchema) => {
     return columnHelper.accessor(columnSchema.name, {
       header: () => {
-        return <TableColumnHeader columnSchema={columnSchema} {...headerProps} />;
+        return <TableColumnHeader columnSchema={columnSchema} />;
       },
       cell: ({ cell, row }) => {
         const value = cell.getValue();
@@ -143,13 +141,10 @@ export function getObjectFieldsColumns(
   });
 }
 
-export const getObjectTableColumns = (
-  schema: ModelSchema,
-  headerProps?: PopoverTriggerProps
-): Array<ColumnDef<NodeObject>> => {
+export const getObjectTableColumns = (schema: ModelSchema): Array<ColumnDef<NodeObject>> => {
   return [
     ...getObjectIdentifierColumns(schema),
     ...getObjectGenericColumns(schema),
-    ...getObjectFieldsColumns(schema, headerProps),
+    ...getObjectFieldsColumns(schema),
   ] as Array<ColumnDef<NodeObject>>;
 };

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
@@ -50,7 +50,7 @@ export function RelationshipTable({
 
   const flatData = data?.pages?.flat() ?? [];
   const columns = [
-    ...getObjectTableColumns(relationshipSchema, { disabled: true }),
+    ...getObjectTableColumns(relationshipSchema),
     getRelationshipActionsColumn({
       parentId,
       parentKind,

--- a/frontend/app/src/shared/components/table/style.tsx
+++ b/frontend/app/src/shared/components/table/style.tsx
@@ -1,7 +1,6 @@
 export const cellsStyle = "flex items-center gap-1.5 p-2 text-sm h-10 bg-white disabled:bg-white";
 
-export const cellHeaderStyle =
-  "z-1 sticky top-0 border-r border-y border-gray-200 hover:bg-gray-100 font-medium";
+export const cellHeaderStyle = "z-1 sticky top-0 border-r border-y border-gray-200 font-medium";
 
 export const cellBodyStyle = "bg-gray-50 border-r border-b border-gray-200";
 


### PR DESCRIPTION
Filters are moving to a dedicated filter menu in the toolbar. This removes the per-column filter popover, associated imports, and cleans up header styles and unused props.