### PR TITLE
wire in log forwarding for PermissionDeniedErrors

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -73,11 +73,13 @@ async def get_refresh_token(
 
 
 async def get_branch_params(
+    request: Request,
     db: InfrahubDatabase = Depends(get_db),
     branch_name: str | None = Query(None, alias="branch", description="Name of the branch to use for the query"),
     at: str | None = Query(None, description="Time to use for the query, in absolute or relative format"),
 ) -> BranchParams:
     branch = await registry.get_branch(db=db, branch=branch_name)
+    request.state.branch_name = branch.name
 
     return BranchParams(branch=branch, at=Timestamp(at))
 
@@ -110,6 +112,7 @@ async def get_current_user(
         or request.url.path.startswith("/graphql")
         or (config.SETTINGS.main.allow_anonymous_access and request.method.lower() in ["get", "options"])
     ):
+        request.state.account_session = account_session
         return account_session
 
     raise AuthorizationError("Authentication is required")

--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -7,14 +7,11 @@ from pydantic import ValidationError
 
 from infrahub.auth import AccountSession
 from infrahub.exceptions import Error, PermissionDeniedError
-from infrahub.log import get_logger
 from infrahub.log_forwarding.models import LogForwardingContext
 from infrahub.services import InfrahubServices
 
 if TYPE_CHECKING:
     from starlette.requests import Request
-
-logger = get_logger()
 
 
 async def generic_api_exception_handler(_: Request, exc: Exception, http_code: int = 500) -> JSONResponse:
@@ -46,28 +43,25 @@ async def permission_denied_exception_handler(request: Request, exc: Exception) 
 
 
 def _forward_permission_denied(request: Request, exc: PermissionDeniedError) -> None:
-    try:
-        service = getattr(request.app.state, "service", None)
-        if not isinstance(service, InfrahubServices):
-            return
+    service = getattr(request.app.state, "service", None)
+    if not isinstance(service, InfrahubServices):
+        return
 
-        log_forwarding = service.log_forwarding
-        if log_forwarding is None:
-            return
+    log_forwarding = service.log_forwarding
+    if log_forwarding is None:
+        return
 
-        raw_account_session = getattr(request.state, "account_session", None)
-        account_session = raw_account_session if isinstance(raw_account_session, AccountSession) else None
-        branch_name: str = getattr(request.state, "branch_name", "")
+    raw_account_session = getattr(request.state, "account_session", None)
+    account_session = raw_account_session if isinstance(raw_account_session, AccountSession) else None
+    branch_name: str = getattr(request.state, "branch_name", "")
 
-        context = LogForwardingContext(
-            account_session=account_session,
-            branch_name=branch_name,
-            operation_name="",
-            query_type="",
-            ip_address=request.client.host if request.client else "",
-            graphql_operations=[],
-            request_path=request.url.path,
-        )
-        log_forwarding.forward_exception(exception=exc, context=context)
-    except Exception:
-        logger.debug("Failed to forward PermissionDeniedError to syslog", exc_info=True)
+    context = LogForwardingContext(
+        account_session=account_session,
+        branch_name=branch_name,
+        operation_name="",
+        query_type="",
+        ip_address=request.client.host if request.client else "",
+        graphql_operations=[],
+        request_path=request.url.path,
+    )
+    log_forwarding.forward_exception(exception=exc, context=context)

--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -58,10 +58,7 @@ def _forward_permission_denied(request: Request, exc: PermissionDeniedError) -> 
     context = LogForwardingContext(
         account_session=account_session,
         branch_name=branch_name,
-        operation_name="",
-        query_type="",
         ip_address=request.client.host if request.client else "",
-        graphql_operations=[],
         request_path=request.url.path,
     )
     log_forwarding.forward_exception(exception=exc, context=context)

--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -1,12 +1,23 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
-from infrahub.exceptions import Error
+from infrahub.auth import AccountSession
+from infrahub.exceptions import Error, PermissionDeniedError
+from infrahub.log import get_logger
+from infrahub.log_forwarding.models import LogForwardingContext
+from infrahub.services import InfrahubServices
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+logger = get_logger()
 
 
-async def generic_api_exception_handler(_: Any, exc: Exception, http_code: int = 500) -> JSONResponse:
+async def generic_api_exception_handler(_: Request, exc: Exception, http_code: int = 500) -> JSONResponse:
     """Generic API Exception handler."""
     if isinstance(exc, Error):
         if exc.HTTP_CODE:
@@ -19,9 +30,44 @@ async def generic_api_exception_handler(_: Any, exc: Exception, http_code: int =
         messages = [ed["msg"] for ed in exc.errors()]
     else:
         messages = [str(exc)]
-    error_dict = {
+    error_dict: dict[str, Any] = {
         "data": None,
         "errors": [{"message": message, "extensions": {"code": http_code}} for message in messages],
     }
 
     return JSONResponse(status_code=http_code, content=error_dict)
+
+
+async def permission_denied_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Forward PermissionDeniedError to log forwarding, then delegate to the generic handler."""
+    if isinstance(exc, PermissionDeniedError):
+        _forward_permission_denied(request, exc)
+    return await generic_api_exception_handler(request, exc)
+
+
+def _forward_permission_denied(request: Request, exc: PermissionDeniedError) -> None:
+    try:
+        service = getattr(request.app.state, "service", None)
+        if not isinstance(service, InfrahubServices):
+            return
+
+        log_forwarding = service.log_forwarding
+        if log_forwarding is None:
+            return
+
+        raw_account_session = getattr(request.state, "account_session", None)
+        account_session = raw_account_session if isinstance(raw_account_session, AccountSession) else None
+        branch_name: str = getattr(request.state, "branch_name", "")
+
+        context = LogForwardingContext(
+            account_session=account_session,
+            branch_name=branch_name,
+            operation_name="",
+            query_type="",
+            ip_address=request.client.host if request.client else "",
+            graphql_operations=[],
+            request_path=request.url.path,
+        )
+        log_forwarding.forward_exception(exception=exc, context=context)
+    except Exception:
+        logger.debug("Failed to forward PermissionDeniedError to syslog", exc_info=True)

--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
 from infrahub.auth import AccountSession
-from infrahub.exceptions import Error, PermissionDeniedError
+from infrahub.exceptions import Error, ForwardableError
 from infrahub.log_forwarding.models import LogForwardingContext
 from infrahub.services import InfrahubServices
 
@@ -35,14 +35,14 @@ async def generic_api_exception_handler(_: Request, exc: Exception, http_code: i
     return JSONResponse(status_code=http_code, content=error_dict)
 
 
-async def permission_denied_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    """Forward PermissionDeniedError to log forwarding, then delegate to the generic handler."""
-    if isinstance(exc, PermissionDeniedError):
-        _forward_permission_denied(request, exc)
+async def log_forwarding_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Forward ForwardableError to log forwarding, then delegate to the generic handler."""
+    if isinstance(exc, ForwardableError) and not exc.log_forwarded:
+        _forward_exception(request, exc)
     return await generic_api_exception_handler(request, exc)
 
 
-def _forward_permission_denied(request: Request, exc: PermissionDeniedError) -> None:
+def _forward_exception(request: Request, exc: ForwardableError) -> None:
     service = getattr(request.app.state, "service", None)
     if not isinstance(service, InfrahubServices):
         return
@@ -62,3 +62,4 @@ def _forward_permission_denied(request: Request, exc: PermissionDeniedError) -> 
         request_path=request.url.path,
     )
     log_forwarding.forward_exception(exception=exc, context=context)
+    exc.log_forwarded = True

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -246,7 +246,13 @@ class AuthorizationError(Error):
         super().__init__(self.message)
 
 
-class PermissionDeniedError(Error):
+class ForwardableError(Error):
+    """Base class for exceptions that can be forwarded to log forwarding destinations."""
+
+    log_forwarded: bool = False
+
+
+class PermissionDeniedError(ForwardableError):
     HTTP_CODE: int = 403
     message: str = "The requested operation was not authorized"
 

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -377,6 +377,7 @@ class InfrahubGraphQLApp:
             graphql_operations=[op.name for op in analyzed_query.operations if op.name],
         )
         service.log_forwarding.forward_exception(exception=exception, context=context)
+        exception.log_forwarded = True
 
     def _log_error(self, error: Exception) -> None:
         if isinstance(error, Error):

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -370,11 +370,11 @@ class InfrahubGraphQLApp:
         context = LogForwardingContext(
             account_session=account_session,
             branch_name=branch.name,
-            operation_name=analyzed_query.operation_name or "",
-            query_type="mutation" if analyzed_query.contains_mutation else "query",
             ip_address=request.client.host if request.client else "",
-            graphql_operations=[op.name for op in analyzed_query.operations if op.name],
             request_path=request.url.path,
+            operation_name=analyzed_query.operation_name,
+            query_type="mutation" if analyzed_query.contains_mutation else "query",
+            graphql_operations=[op.name for op in analyzed_query.operations if op.name],
         )
         service.log_forwarding.forward_exception(exception=exception, context=context)
 

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -364,22 +364,19 @@ class InfrahubGraphQLApp:
         request: Request,
         graphql_params: GraphqlParams,
     ) -> None:
-        try:
-            service = graphql_params.context.service
-            if not service or not service.log_forwarding:
-                return
-            context = LogForwardingContext(
-                account_session=account_session,
-                branch_name=branch.name,
-                operation_name=analyzed_query.operation_name or "",
-                query_type="mutation" if analyzed_query.contains_mutation else "query",
-                ip_address=request.client.host if request.client else "",
-                graphql_operations=[op.name for op in analyzed_query.operations if op.name],
-                request_path=request.url.path,
-            )
-            service.log_forwarding.forward_exception(exception=exception, context=context)
-        except Exception:
-            self.logger.debug("Failed to forward exception to syslog", exc_info=True)
+        service = graphql_params.context.service
+        if not service or not service.log_forwarding:
+            return
+        context = LogForwardingContext(
+            account_session=account_session,
+            branch_name=branch.name,
+            operation_name=analyzed_query.operation_name or "",
+            query_type="mutation" if analyzed_query.contains_mutation else "query",
+            ip_address=request.client.host if request.client else "",
+            graphql_operations=[op.name for op in analyzed_query.operations if op.name],
+            request_path=request.url.path,
+        )
+        service.log_forwarding.forward_exception(exception=exception, context=context)
 
     def _log_error(self, error: Exception) -> None:
         if isinstance(error, Error):

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -40,11 +40,12 @@ from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_sc
 from infrahub.auth import AccountSession, authentication_token
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import BranchNotFoundError, Error
+from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse, execute_graphql_query
 from infrahub.graphql.initialization import GraphqlParams, prepare_graphql_params
 from infrahub.log import get_logger
+from infrahub.log_forwarding.models import LogForwardingContext
 
 from .metrics import (
     GRAPHQL_DURATION_METRICS,
@@ -231,14 +232,25 @@ class InfrahubGraphQLApp:
             )
         impacted_models = analyzed_query.query_report.impacted_models
 
-        await self._evaluate_permissions(
-            db=db,
-            request=request,
-            query=analyzed_query,
-            query_parameters=graphql_params,
-            account_session=account_session,
-            branch=branch,
-        )
+        try:
+            await self._evaluate_permissions(
+                db=db,
+                request=request,
+                query=analyzed_query,
+                query_parameters=graphql_params,
+                account_session=account_session,
+                branch=branch,
+            )
+        except PermissionDeniedError as exc:
+            self._forward_exception_log(
+                exception=exc,
+                account_session=account_session,
+                branch=branch,
+                analyzed_query=analyzed_query,
+                request=request,
+                graphql_params=graphql_params,
+            )
+            raise
 
         if operation_name == "IntrospectionQuery":
             nbr_object_in_schema = len(graphql_params.schema.type_map)
@@ -265,10 +277,15 @@ class InfrahubGraphQLApp:
 
         response: dict[str, Any] = {"data": result.data}
         if result.errors:
-            GRAPHQL_QUERY_ERRORS_METRICS.labels(**labels).observe(len(result.errors))
-            for error in result.errors:
-                if error.original_error:
-                    self._log_error(error=error.original_error)
+            self._process_graphql_errors(
+                errors=result.errors,
+                labels=labels,
+                account_session=account_session,
+                branch=branch,
+                analyzed_query=analyzed_query,
+                request=request,
+                graphql_params=graphql_params,
+            )
             response["errors"] = [self.error_formatter(error) for error in result.errors]
 
         json_response = JSONResponse(
@@ -311,6 +328,58 @@ class InfrahubGraphQLApp:
             query_parameters=query_parameters,
             branch=branch,
         )
+
+    def _process_graphql_errors(
+        self,
+        errors: list[GraphQLError],
+        labels: dict[str, Any],
+        account_session: AccountSession,
+        branch: Branch,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        request: Request,
+        graphql_params: GraphqlParams,
+    ) -> None:
+        GRAPHQL_QUERY_ERRORS_METRICS.labels(**labels).observe(len(errors))
+        for error in errors:
+            if not error.original_error:
+                continue
+            self._log_error(error=error.original_error)
+            if not isinstance(error.original_error, PermissionDeniedError):
+                continue
+            self._forward_exception_log(
+                exception=error.original_error,
+                account_session=account_session,
+                branch=branch,
+                analyzed_query=analyzed_query,
+                request=request,
+                graphql_params=graphql_params,
+            )
+
+    def _forward_exception_log(
+        self,
+        exception: PermissionDeniedError,
+        account_session: AccountSession,
+        branch: Branch,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        request: Request,
+        graphql_params: GraphqlParams,
+    ) -> None:
+        try:
+            service = graphql_params.context.service
+            if not service or not service.log_forwarding:
+                return
+            context = LogForwardingContext(
+                account_session=account_session,
+                branch_name=branch.name,
+                operation_name=analyzed_query.operation_name or "",
+                query_type="mutation" if analyzed_query.contains_mutation else "query",
+                ip_address=request.client.host if request.client else "",
+                graphql_operations=[op.name for op in analyzed_query.operations if op.name],
+                request_path=request.url.path,
+            )
+            service.log_forwarding.forward_exception(exception=exception, context=context)
+        except Exception:
+            self.logger.debug("Failed to forward exception to syslog", exc_info=True)
 
     def _log_error(self, error: Exception) -> None:
         if isinstance(error, Error):

--- a/backend/infrahub/log_forwarding/models.py
+++ b/backend/infrahub/log_forwarding/models.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime  # noqa: TC003
 from enum import IntEnum, StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
 
 LOG_AUTH = 4
 LOG_LOCAL0 = 16
@@ -42,3 +46,14 @@ class SyslogMessage:
             MessageType.AUDIT_EVENT: LOG_AUTH,
             MessageType.APPLICATION_LOG: LOG_LOCAL0,
         }.get(self.message_type, LOG_LOCAL0)
+
+
+@dataclass(slots=True)
+class LogForwardingContext:
+    account_session: AccountSession | None
+    branch_name: str
+    operation_name: str
+    query_type: str
+    ip_address: str
+    graphql_operations: list[str]
+    request_path: str

--- a/backend/infrahub/log_forwarding/models.py
+++ b/backend/infrahub/log_forwarding/models.py
@@ -52,8 +52,22 @@ class SyslogMessage:
 class LogForwardingContext:
     account_session: AccountSession | None
     branch_name: str
-    operation_name: str
-    query_type: str
     ip_address: str
-    graphql_operations: list[str]
     request_path: str
+    operation_name: str | None = None
+    query_type: str | None = None
+    graphql_operations: list[str] | None = None
+
+
+@dataclass(slots=True)
+class PermissionDeniedPayload:
+    event: str
+    message: str
+    account_id: str
+    auth_type: str
+    branch: str
+    ip_address: str
+    request_path: str
+    operation: str | None = None
+    query_type: str | None = None
+    graphql_operations: list[str] | None = None

--- a/backend/infrahub/log_forwarding/models.py
+++ b/backend/infrahub/log_forwarding/models.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime  # noqa: TC003
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from infrahub.auth import AccountSession
+    from infrahub.auth import AccountSession, AuthType
 
 LOG_AUTH = 4
 LOG_LOCAL0 = 16
@@ -59,15 +59,29 @@ class LogForwardingContext:
     graphql_operations: list[str] | None = None
 
 
+class ExceptionLogType(StrEnum):
+    PERMISSION_DENIED = "infrahub.permission.denied"
+
+
 @dataclass(slots=True)
-class PermissionDeniedPayload:
-    event: str
-    message: str
-    account_id: str
-    auth_type: str
-    branch: str
-    ip_address: str
-    request_path: str
-    operation: str | None = None
-    query_type: str | None = None
-    graphql_operations: list[str] | None = None
+class ExceptionLogPayload:
+    event: ExceptionLogType = field(metadata={"doc": "Event name for the specific exception type"})
+    message: str = field(metadata={"doc": "Detailed message describing the exception"})
+    branch: str = field(metadata={"doc": "Branch on which the operation was attempted"})
+
+
+@dataclass(slots=True)
+class PermissionDeniedPayload(ExceptionLogPayload):
+    account_id: str = field(metadata={"doc": "ID of the account associated with the request"})
+    auth_type: AuthType = field(metadata={"doc": "Authentication type used for the request"})
+    ip_address: str = field(metadata={"doc": "IP address from which the request originated"})
+    request_path: str = field(metadata={"doc": "API endpoint or path for the request"})
+    operation: str | None = field(
+        default=None, metadata={"doc": "Name of the operation being performed, GraphQL requests only"}
+    )
+    query_type: str | None = field(
+        default=None, metadata={"doc": "Type of the query being executed: mutation or query, GraphQL requests only"}
+    )
+    graphql_operations: list[str] | None = field(
+        default=None, metadata={"doc": "List of GraphQL operations requested, GraphQL requests only"}
+    )

--- a/backend/infrahub/log_forwarding/service.py
+++ b/backend/infrahub/log_forwarding/service.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from infrahub.events import InfrahubEvent
-    from infrahub.log_forwarding.models import SyslogMessage
+    from infrahub.exceptions import PermissionDeniedError
+    from infrahub.log_forwarding.models import LogForwardingContext, SyslogMessage
 
 
 class LogForwardingService(ABC):
@@ -24,6 +25,10 @@ class LogForwardingService(ABC):
         """Convert an InfrahubEvent to a syslog message and enqueue it. Should not block."""
 
     @abstractmethod
+    def forward_exception(self, exception: PermissionDeniedError, context: LogForwardingContext) -> None:
+        """Convert a PermissionDeniedError to a syslog message and enqueue it. Should not block."""
+
+    @abstractmethod
     async def shutdown(self) -> None:
         """Signal consumers to drain queues, then force close."""
 
@@ -38,6 +43,9 @@ class LogForwardingServiceCommunity(LogForwardingService):
         pass
 
     def forward_event(self, event: InfrahubEvent) -> None:
+        pass
+
+    def forward_exception(self, exception: PermissionDeniedError, context: LogForwardingContext) -> None:
         pass
 
     async def shutdown(self) -> None:

--- a/backend/infrahub/log_forwarding/service.py
+++ b/backend/infrahub/log_forwarding/service.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from infrahub.events import InfrahubEvent
-    from infrahub.exceptions import PermissionDeniedError
+    from infrahub.exceptions import ForwardableError
     from infrahub.log_forwarding.models import LogForwardingContext, SyslogMessage
 
 
@@ -25,8 +25,8 @@ class LogForwardingService(ABC):
         """Convert an InfrahubEvent to a syslog message and enqueue it. Should not block."""
 
     @abstractmethod
-    def forward_exception(self, exception: PermissionDeniedError, context: LogForwardingContext) -> None:
-        """Convert a PermissionDeniedError to a syslog message and enqueue it. Should not block."""
+    def forward_exception(self, exception: ForwardableError, context: LogForwardingContext) -> None:
+        """Convert a ForwardableError to a syslog message and enqueue it. Should not block."""
 
     @abstractmethod
     async def shutdown(self) -> None:
@@ -45,7 +45,7 @@ class LogForwardingServiceCommunity(LogForwardingService):
     def forward_event(self, event: InfrahubEvent) -> None:
         pass
 
-    def forward_exception(self, exception: PermissionDeniedError, context: LogForwardingContext) -> None:
+    def forward_exception(self, exception: ForwardableError, context: LogForwardingContext) -> None:
         pass
 
     async def shutdown(self) -> None:

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -20,13 +20,13 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 from infrahub import __version__, config
 from infrahub.api import router as api
-from infrahub.api.exception_handlers import generic_api_exception_handler
+from infrahub.api.exception_handlers import generic_api_exception_handler, permission_denied_exception_handler
 from infrahub.components import ComponentType
 from infrahub.constants.environment import INSTALLATION_TYPE
 from infrahub.core.initialization import initialization
 from infrahub.database.graph import validate_graph_version
 from infrahub.dependencies.registry import build_component_registry
-from infrahub.exceptions import Error, ValidationError
+from infrahub.exceptions import Error, PermissionDeniedError, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
 from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
@@ -210,6 +210,7 @@ app.add_middleware(
     ),
 )
 
+app.add_exception_handler(PermissionDeniedError, permission_denied_exception_handler)
 app.add_exception_handler(Error, generic_api_exception_handler)
 app.add_exception_handler(TimestampFormatError, partial(generic_api_exception_handler, http_code=400))
 app.add_exception_handler(ValidationError, partial(generic_api_exception_handler, http_code=400))

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -20,13 +20,13 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 from infrahub import __version__, config
 from infrahub.api import router as api
-from infrahub.api.exception_handlers import generic_api_exception_handler, permission_denied_exception_handler
+from infrahub.api.exception_handlers import generic_api_exception_handler, log_forwarding_exception_handler
 from infrahub.components import ComponentType
 from infrahub.constants.environment import INSTALLATION_TYPE
 from infrahub.core.initialization import initialization
 from infrahub.database.graph import validate_graph_version
 from infrahub.dependencies.registry import build_component_registry
-from infrahub.exceptions import Error, PermissionDeniedError, ValidationError
+from infrahub.exceptions import Error, ForwardableError, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
 from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
@@ -210,7 +210,7 @@ app.add_middleware(
     ),
 )
 
-app.add_exception_handler(PermissionDeniedError, permission_denied_exception_handler)
+app.add_exception_handler(ForwardableError, log_forwarding_exception_handler)
 app.add_exception_handler(Error, generic_api_exception_handler)
 app.add_exception_handler(TimestampFormatError, partial(generic_api_exception_handler, http_code=400))
 app.add_exception_handler(ValidationError, partial(generic_api_exception_handler, http_code=400))

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -171,6 +171,10 @@ class InfrahubServices:
 
         return self._database
 
+    @property
+    def log_forwarding(self) -> LogForwardingService | None:
+        return self._log_forwarding
+
     async def shutdown(self) -> None:
         if self._log_forwarding is not None:
             await self._log_forwarding.shutdown()

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -193,13 +193,6 @@ class TestPermissionDeniedForwarding:
 
         assert response.status_code == 403
 
-    async def test_forwarding_failure_does_not_affect_response(self, request_fixture: RequestFixture) -> None:
-        request_fixture.mock_log_forwarding.forward_exception.side_effect = RuntimeError("boom")
-
-        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
-
-        assert response.status_code == 403
-
     async def test_missing_account_session_on_state(self, request_fixture: RequestFixture) -> None:
         del request_fixture.request.state.account_session
 

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -13,7 +13,7 @@ from starlette.datastructures import State
 from starlette.requests import Request
 from ujson import loads
 
-from infrahub.api.exception_handlers import generic_api_exception_handler, permission_denied_exception_handler
+from infrahub.api.exception_handlers import generic_api_exception_handler, log_forwarding_exception_handler
 from infrahub.auth import AccountSession, AuthType
 from infrahub.exceptions import Error, PermissionDeniedError
 from infrahub.log_forwarding.models import LogForwardingContext
@@ -153,11 +153,11 @@ class TestAPIExceptionHandler:
         assert error_dict["errors"] == [{"message": "the teapot error", "extensions": {"code": 418}}]
 
 
-class TestPermissionDeniedForwarding:
+class TestLogForwardingExceptionHandler:
     async def test_forwards_permission_denied_to_log_forwarding(self, request_fixture: RequestFixture) -> None:
         exc = PermissionDeniedError("not allowed")
 
-        await permission_denied_exception_handler(request_fixture.request, exc)
+        await log_forwarding_exception_handler(request_fixture.request, exc)
 
         request_fixture.mock_log_forwarding.forward_exception.assert_called_once()
         call_kwargs = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs
@@ -170,7 +170,7 @@ class TestPermissionDeniedForwarding:
         assert ctx.request_path == "/api/schema/load"
 
     async def test_returns_403_response(self, request_fixture: RequestFixture) -> None:
-        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+        response = await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
 
         error_dict = get_response_body(response)
         assert response.status_code == 403
@@ -181,7 +181,7 @@ class TestPermissionDeniedForwarding:
         app_state.service = None
         request = _make_request(app_state=app_state)
 
-        response = await permission_denied_exception_handler(request, PermissionDeniedError("denied"))
+        response = await log_forwarding_exception_handler(request, PermissionDeniedError("denied"))
 
         assert response.status_code == 403
 
@@ -189,14 +189,14 @@ class TestPermissionDeniedForwarding:
         request_fixture.mock_log_forwarding = None  # type: ignore[assignment]
         request_fixture.request.app.state.service.log_forwarding = None
 
-        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+        response = await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
 
         assert response.status_code == 403
 
     async def test_missing_account_session_on_state(self, request_fixture: RequestFixture) -> None:
         del request_fixture.request.state.account_session
 
-        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+        await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
 
         ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
         assert ctx.account_session is None
@@ -204,7 +204,7 @@ class TestPermissionDeniedForwarding:
     async def test_missing_branch_name_on_state(self, request_fixture: RequestFixture) -> None:
         del request_fixture.request.state.branch_name
 
-        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+        await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
 
         ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
         assert not ctx.branch_name
@@ -212,7 +212,7 @@ class TestPermissionDeniedForwarding:
     async def test_no_client_uses_empty_ip(self, request_fixture: RequestFixture) -> None:
         request_fixture.request.scope["client"] = None
 
-        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+        await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
 
         ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
         assert not ctx.ip_address

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -1,11 +1,24 @@
-from typing import Any
+from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    from starlette.responses import JSONResponse
+
+import pytest
 from pydantic import BaseModel, ValidationError, field_validator
-from starlette.responses import JSONResponse
+from starlette.datastructures import State
+from starlette.requests import Request
 from ujson import loads
 
-from infrahub.api.exception_handlers import generic_api_exception_handler
-from infrahub.exceptions import Error
+from infrahub.api.exception_handlers import generic_api_exception_handler, permission_denied_exception_handler
+from infrahub.auth import AccountSession, AuthType
+from infrahub.exceptions import Error, PermissionDeniedError
+from infrahub.log_forwarding.models import LogForwardingContext
+from infrahub.log_forwarding.service import LogForwardingService
+from infrahub.services import InfrahubServices
 
 
 def get_response_body(response: JSONResponse) -> dict[str, Any]:
@@ -38,6 +51,55 @@ class MockError(Error):
         self.message = message or ""
 
 
+@dataclass
+class RequestFixture:
+    request: Request
+    mock_log_forwarding: MagicMock
+    account_session: AccountSession
+
+
+def _make_request(
+    *,
+    path: str = "/api/test",
+    client_host: str = "10.0.0.1",
+    app_state: State | None = None,
+) -> Request:
+    return Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+            "server": ("testserver", 80),
+            "client": (client_host, 12345),
+            "app": MagicMock(state=app_state or State()),
+        },
+    )
+
+
+@pytest.fixture
+def request_fixture() -> RequestFixture:
+    mock_lf = MagicMock(spec=LogForwardingService)
+    account_session = AccountSession(account_id="user-1", auth_type=AuthType.JWT)
+
+    service_mock = MagicMock(spec=InfrahubServices)
+    service_mock.log_forwarding = mock_lf
+    app_state = State()
+    app_state.service = service_mock
+
+    request = _make_request(path="/api/schema/load", app_state=app_state)
+    request.state.account_session = account_session
+    request.state.branch_name = "main"
+
+    return RequestFixture(
+        request=request,
+        mock_log_forwarding=mock_lf,
+        account_session=account_session,
+    )
+
+
 class TestAPIExceptionHandler:
     def setup_method(self) -> None:
         self.error_message = "Value error, this is the error message"
@@ -45,7 +107,7 @@ class TestAPIExceptionHandler:
     async def test_plain_exception_error(self) -> None:
         exception = ValueError(self.error_message)
 
-        error_response = await generic_api_exception_handler(None, exception)
+        error_response = await generic_api_exception_handler(_make_request(), exception)
 
         error_dict = get_response_body(error_response)
         assert error_dict["errors"] == [{"message": self.error_message, "extensions": {"code": 500}}]
@@ -59,7 +121,7 @@ class TestAPIExceptionHandler:
             exception = exc
 
         assert exception is not None
-        error_response = await generic_api_exception_handler(None, exception, http_code=400)
+        error_response = await generic_api_exception_handler(_make_request(), exception, http_code=400)
 
         error_dict = get_response_body(error_response)
         assert {"message": self.error_message, "extensions": {"code": 400}} in error_dict["errors"]
@@ -69,7 +131,7 @@ class TestAPIExceptionHandler:
     async def test_infrahub_api_error(self) -> None:
         exception = MockError(self.error_message)
 
-        error_response = await generic_api_exception_handler(None, exception)
+        error_response = await generic_api_exception_handler(_make_request(), exception)
 
         error_dict = get_response_body(error_response)
         assert error_dict["errors"] == [{"message": self.error_message, "extensions": {"code": 418}}]
@@ -77,7 +139,7 @@ class TestAPIExceptionHandler:
     async def test_infrahub_api_error_default_message(self) -> None:
         exception = MockError(None)
 
-        error_response = await generic_api_exception_handler(None, exception)
+        error_response = await generic_api_exception_handler(_make_request(), exception)
 
         error_dict = get_response_body(error_response)
         assert error_dict["errors"] == [{"message": "the teapot error", "extensions": {"code": 418}}]
@@ -85,7 +147,79 @@ class TestAPIExceptionHandler:
     async def test_infrahub_api_error_code_override(self) -> None:
         exception = MockError(None)
 
-        error_response = await generic_api_exception_handler(None, exception, http_code=500)
+        error_response = await generic_api_exception_handler(_make_request(), exception, http_code=500)
 
         error_dict = get_response_body(error_response)
         assert error_dict["errors"] == [{"message": "the teapot error", "extensions": {"code": 418}}]
+
+
+class TestPermissionDeniedForwarding:
+    async def test_forwards_permission_denied_to_log_forwarding(self, request_fixture: RequestFixture) -> None:
+        exc = PermissionDeniedError("not allowed")
+
+        await permission_denied_exception_handler(request_fixture.request, exc)
+
+        request_fixture.mock_log_forwarding.forward_exception.assert_called_once()
+        call_kwargs = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs
+        assert call_kwargs["exception"] is exc
+        ctx = call_kwargs["context"]
+        assert isinstance(ctx, LogForwardingContext)
+        assert ctx.account_session is request_fixture.account_session
+        assert ctx.branch_name == "main"
+        assert ctx.ip_address == "10.0.0.1"
+        assert ctx.request_path == "/api/schema/load"
+
+    async def test_returns_403_response(self, request_fixture: RequestFixture) -> None:
+        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        error_dict = get_response_body(response)
+        assert response.status_code == 403
+        assert error_dict["errors"] == [{"message": "denied", "extensions": {"code": 403}}]
+
+    async def test_no_service_does_not_raise(self) -> None:
+        app_state = State()
+        app_state.service = None
+        request = _make_request(app_state=app_state)
+
+        response = await permission_denied_exception_handler(request, PermissionDeniedError("denied"))
+
+        assert response.status_code == 403
+
+    async def test_no_log_forwarding_does_not_raise(self, request_fixture: RequestFixture) -> None:
+        request_fixture.mock_log_forwarding = None  # type: ignore[assignment]
+        request_fixture.request.app.state.service.log_forwarding = None
+
+        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        assert response.status_code == 403
+
+    async def test_forwarding_failure_does_not_affect_response(self, request_fixture: RequestFixture) -> None:
+        request_fixture.mock_log_forwarding.forward_exception.side_effect = RuntimeError("boom")
+
+        response = await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        assert response.status_code == 403
+
+    async def test_missing_account_session_on_state(self, request_fixture: RequestFixture) -> None:
+        del request_fixture.request.state.account_session
+
+        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
+        assert ctx.account_session is None
+
+    async def test_missing_branch_name_on_state(self, request_fixture: RequestFixture) -> None:
+        del request_fixture.request.state.branch_name
+
+        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
+        assert not ctx.branch_name
+
+    async def test_no_client_uses_empty_ip(self, request_fixture: RequestFixture) -> None:
+        request_fixture.request.scope["client"] = None
+
+        await permission_denied_exception_handler(request_fixture.request, PermissionDeniedError("denied"))
+
+        ctx = request_fixture.mock_log_forwarding.forward_exception.call_args.kwargs["context"]
+        assert not ctx.ip_address


### PR DESCRIPTION
IFC-2359

adds handling for sending `PermissionDeniedError`s to `LogForwardingService`. handles if the error is raised from a REST API endpoint or during graphql execution. the actual log forwarding is still a no-op in the community repo.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `PermissionDeniedError` events to the configured log forwarding service with rich request/GraphQL context; responses remain 403. Adds a `ForwardableError` base to avoid duplicate forwarding. Implements IFC-2359.

- **New Features**
  - Added `ForwardableError` with `log_forwarded` flag and registered a handler that forwards then returns the normal error response.
  - REST: handler builds `LogForwardingContext` from `request.state.account_session`, `request.state.branch_name`, IP, and path; safe no-ops if service is missing.
  - GraphQL: forwards on permission checks and when execution errors contain `PermissionDeniedError`, including operation name/type and operations.
  - Added `LogForwardingService.forward_exception(exception, context)` and payload models (`ExceptionLogPayload`, `PermissionDeniedPayload`) with field docs; exposed `InfrahubServices.log_forwarding`; stored `account_session` and `branch_name` on `request.state`; tests added.

- **Migration**
  - If you maintain a custom `LogForwardingService`, implement `forward_exception(self, exception, context)` (no-op is fine).

<sup>Written for commit 32c5b1fa7e3db803633d8ef1e017e17e70d25bf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



