### PR TITLE
Prepare release 1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.8.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.4) - 2026-04-02
+
+### Fixed
+
+- Link a merging proposed change to its diff during the merge operation if it has not been linked yet ([#8769](https://github.com/opsmill/infrahub/issues/8769))
+- Fixed an issue where webhook match statements (node kind filters) were lost during scheduled reconfiguration. ([#8772](https://github.com/opsmill/infrahub/issues/8772))
+
 ## [Infrahub - v1.8.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.3) - 2026-03-31
 
 ### Fixed

--- a/changelog/8769.fixed.md
+++ b/changelog/8769.fixed.md
@@ -1,1 +1,0 @@
-Link a merging proposed change to its diff during the merge operation if it has not been linked yet

--- a/changelog/8772.fixed.md
+++ b/changelog/8772.fixed.md
@@ -1,1 +1,0 @@
-Fixed an issue where webhook match statements (node kind filters) were lost during scheduled reconfiguration.

--- a/docs/docs/release-notes/infrahub/release-1_8_4.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_4.mdx
@@ -1,0 +1,24 @@
+---
+title: Release 1.8.4
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.8.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 3rd, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.8.4](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.8.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Link a merging proposed change to its diff during the merge operation if it has not been linked yet ([#8769](https://github.com/opsmill/infrahub/issues/8769))
+- Fixed an issue where webhook match statements (node kind filters) were lost during scheduled reconfiguration. ([#8772](https://github.com/opsmill/infrahub/issues/8772))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -428,6 +428,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_8_4',
             'release-notes/infrahub/release-1_8_3',
             'release-notes/infrahub/release-1_8_2',
             'release-notes/infrahub/release-1_8_1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.8.3"
+version = "1.8.4"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.8.3"
+version = "1.8.4"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.3"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.8.3"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
1.8.4 release preparation.

### Fixed

- Link a merging proposed change to its diff during the merge operation if it has not been linked yet ([#8769](https://github.com/opsmill/infrahub/issues/8769))
- Fixed an issue where webhook match statements (node kind filters) were lost during scheduled reconfiguration. ([#8772](https://github.com/opsmill/infrahub/issues/8772))


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the Infrahub 1.8.4 release. Bumps `infrahub-server` and `infrahub-testcontainers` to 1.8.4 and adds release notes with the new entry in the docs sidebar.

- **Bug Fixes**
  - Link a merging proposed change to its diff if it wasn’t linked yet (#8769).
  - Preserve webhook node kind filters during scheduled reconfiguration (#8772).

<sup>Written for commit e2c993ff13213d037fc7eb75c157a8e362ef9b58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

