### PR TITLE
Fix stale tab query param causing error when navigating between objects

### DIFF
--- a/changelog/+stale-tab-param.fixed.md
+++ b/changelog/+stale-tab-param.fixed.md
@@ -1,0 +1,1 @@
+Fixed spurious "Relationship not found" error toast when navigating from an object relationship tab to a related object.

--- a/frontend/app/src/pages/objects/object-details-page.tsx
+++ b/frontend/app/src/pages/objects/object-details-page.tsx
@@ -28,7 +28,7 @@ function ObjectDetailsPage() {
   }
 
   return (
-    <Content.Card className="flex grow flex-col">
+    <Content.Card key={`${objectKind}-${objectId}`} className="flex grow flex-col">
       <RequireObjectPermissions objectKind={schema.kind!} loadingClassName="h-full">
         {({ permission }) => (
           <>


### PR DESCRIPTION
# Why

When navigating from an object's relationship tab to a related object (e.g., clicking a FileObject from a Device's "files" tab), a spurious error toast appears: **"Relationship files not found in \<target\> schema"**. This does not happen when navigating directly to the target object.

The goal is to eliminate the false error by fixing the stale query state that causes it.

Non-goals: this PR does not refactor nuqs usage, change the relationship tab system, or address other potential nuqs/React Router sync issues elsewhere in the app.

## What changed

- **Added a `key` prop to the root container in `ObjectDetailsPage`**, keyed on `objectKind` and `objectId`. This forces React to unmount and remount the component subtree when navigating between objects, ensuring no stale nuqs query state carries over.

**Root cause:** nuqs' React Router v7 adapter patches `history.pushState` and defers search params updates via `startTransition`. When navigating between two objects on the same route pattern (`/objects/:kind/:id`), React Router's `useParams` updates immediately with the new object, but nuqs' `useQueryState("tab")` still holds the previous page's value for one render cycle. This torn state causes `ObjectRelationshipsManager` to look up the old tab name (e.g., `"files"`) on the new object's schema (e.g., DebugFileObject, which has no `"files"` relationship), triggering the error toast.

**What stayed the same:** No schema changes, no API contract changes, no changes to relationship tab logic or URL construction. The fix is isolated to the object details page mount lifecycle.

## How to review

- Single file change in `frontend/app/src/pages/objects/object-details-page.tsx` — one line added (`key` prop).
- Consider whether the forced remount could have undesirable side effects (e.g., losing scroll position or resetting UI state when the URL params change). In practice this only triggers on object-to-object navigation, where a fresh render is expected.
- Alternative considered: validating the tab name against the current schema before rendering `ObjectRelationshipsManager`. Rejected because it would add a redundant check and only suppress the symptom rather than fixing the stale state.

## How to test

1. Load a schema with two related objects where the relationship is visible as a tab on the source but not on the target. Minimal repro schema:

```yaml
---
version: "1.0"
nodes:
  - name: Device
    namespace: Debug
    label: "Debug Device"
    attributes:
      - name: name
        kind: Text
        unique: true
    relationships:
      - name: files
        peer: DebugFileObject
        identifier: debug__device__files
        cardinality: many
        kind: Generic

  - name: FileObject
    namespace: Debug
    label: "Debug File Object"
    inherit_from:
      - CoreFileObject
    relationships:
      - name: device
        peer: DebugDevice
        identifier: debug__device__files
        cardinality: one
        kind: Attribute
```

2. Create a DebugDevice and associate a DebugFileObject with it.
3. Navigate to the DebugDevice detail page → click the **Files** tab → click on the FileObject link.
4. **Before fix:** error toast "Relationship files not found in Debug File Object schema". **After fix:** FileObject detail page loads cleanly with no error.

## Impact & rollout

- **Backward compatibility:** None. Adding a `key` prop is a React rendering concern only.
- **Performance:** The forced remount on object navigation adds negligible overhead — it replaces a React reconciliation (which already re-renders the full subtree) with an unmount/mount cycle. No measurable user-facing difference.
- **Config/env changes:** None.
- **Deployment notes:** Safe to deploy independently.

## Checklist

- [ ] Tests added/updated
- [X] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)