### PR TITLE
Local test AI bug pipeline #5: prevent branch creation TOCTOU race condition (closes #8368)

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -503,6 +503,14 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             raise ValidationError("\n".join(error_msgs)) from exc
 
         async with lock.registry.local_schema_lock():
+            # Re-check existence inside the lock to prevent TOCTOU race conditions.
+            # The check above is a fast-fail optimization; this is the authoritative check.
+            try:
+                await Branch.get_by_name(db=db, name=model.name)
+                raise ValidationError(f"The branch {model.name} already exists")
+            except BranchNotFoundError:
+                pass
+
             # Copy the schema from the origin branch and set the hash and the schema_changed_at value
             origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
             new_schema = origin_schema.duplicate(name=obj.name)

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -1,0 +1,129 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fast_depends import Provider
+
+from infrahub import lock
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core.branch import Branch
+from infrahub.core.branch.tasks import create_branch
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.graphql.mutations.models import BranchCreateModel
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_database
+
+
+class TestBranchCreateRaceCondition:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
+        return
+
+    @pytest.fixture(autouse=True)
+    async def _setup_lock(self, default_branch: Branch, car_person_schema: SchemaBranch) -> None:
+        lock.initialize_lock(local_only=True)
+
+    @pytest.fixture
+    def context(self, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext.init(
+            branch=default_branch,
+            account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+        )
+
+    @pytest.fixture
+    def branch_model(self) -> BranchCreateModel:
+        return BranchCreateModel(
+            name="race-test-branch",
+            sync_with_git=False,
+            origin_branch="main",
+        )
+
+    async def test_concurrent_create_same_branch_only_one_succeeds(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        workflow_local: WorkflowLocalExecution,
+        dependency_provider: Provider,
+        context: InfrahubContext,
+        branch_model: BranchCreateModel,
+    ) -> None:
+        """Two concurrent create_branch calls with the same name must result in exactly one branch.
+
+        The second call should raise a ValidationError. This test simulates the TOCTOU race
+        condition: both coroutines pass the existence check (Branch.get_by_name raises
+        BranchNotFoundError for both) before either creates the branch.
+
+        To force the interleaving, we patch Branch.get_by_name so it always raises
+        BranchNotFoundError on the first two calls (simulating what happens when both
+        concurrent checks happen before any branch is persisted), and we introduce an
+        asyncio.Event-based synchronization to ensure both coroutines have passed the
+        check before either proceeds to the save path.
+        """
+        mock_event_service = AsyncMock()
+        mock_event_service.send = AsyncMock()
+        mock_component = AsyncMock()
+        mock_component.refresh_schema_hash = AsyncMock()
+
+        real_get_by_name = Branch.get_by_name
+
+        # Synchronization: both coroutines must pass the existence check before either proceeds
+        check_passed_count = 0
+        both_passed = asyncio.Event()
+
+        async def interleaved_get_by_name(**kwargs):
+            """Ensure both coroutines see 'branch not found' before either proceeds."""
+            nonlocal check_passed_count
+
+            if kwargs.get("name") == branch_model.name:
+                # Try the real check first
+                try:
+                    await real_get_by_name(**kwargs)
+                    # Branch already exists — if a proper lock were in place, the second
+                    # caller would find it here. Raise normally.
+                    raise ValidationError(f"The branch {kwargs['name']} already exists")
+                except BranchNotFoundError:
+                    pass
+
+                # Branch not found — signal that this coroutine passed the check
+                check_passed_count += 1
+                if check_passed_count >= 2:
+                    both_passed.set()
+                else:
+                    # Wait for the other coroutine to also pass the check
+                    await both_passed.wait()
+
+                # Now raise BranchNotFoundError as the original code expects
+                raise BranchNotFoundError(identifier=kwargs["name"])
+
+            return await real_get_by_name(**kwargs)
+
+        with (
+            dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+            patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
+            patch(
+                "infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock, return_value=mock_event_service
+            ),
+            patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock, return_value=mock_component),
+            patch.object(Branch, "get_by_name", side_effect=interleaved_get_by_name),
+        ):
+            results = await asyncio.gather(
+                create_branch(model=branch_model, context=context),
+                create_branch(model=branch_model, context=context),
+                return_exceptions=True,
+            )
+
+        # Exactly one should succeed and one should fail with a ValidationError or
+        # database-level constraint error
+        successes = [r for r in results if r is None]
+        failures = [r for r in results if isinstance(r, Exception)]
+
+        assert len(successes) == 1, (
+            f"Expected exactly 1 successful branch creation, got {len(successes)}. "
+            f"Both concurrent calls succeeded, proving the race condition exists. "
+            f"Results: {results}"
+        )
+        assert len(failures) == 1, f"Expected exactly 1 failure, got {len(failures)}. Results: {results}"


### PR DESCRIPTION
# Why

The branch creation flow (`create_branch` in `backend/infrahub/core/branch/tasks.py`) has a TOCTOU (time-of-check-time-of-use) race condition. The existence check (`Branch.get_by_name`) and the branch creation (`obj.save`) are not atomic — two concurrent `create_branch` calls can both pass the existence check before either persists the branch, resulting in duplicate branches with the same name.

Closes #8368

## Fix strategy

This is a shallow concurrency bug, not a design flaw. The `local_schema_lock` already exists and serializes the critical section (schema duplication, save, registry update). The existence check simply needs to be repeated inside that lock scope.

The fix adds a second `Branch.get_by_name` check inside the `local_schema_lock` context manager. The original check outside the lock remains as a fast-fail optimization (avoids acquiring the lock when the branch already exists). The check inside the lock is the authoritative one that prevents the race: the second concurrent caller will block on the lock, and when it proceeds, its `get_by_name` call will find the branch already created by the first caller and raise `ValidationError`.

## What changed

- **Behavioral change:** Two concurrent `create_branch` calls with the same name now correctly result in exactly one branch being created. The second call receives a `ValidationError`.
- **Implementation:** Added a second `Branch.get_by_name` existence check inside the `local_schema_lock` scope in `create_branch()`.
- **What stayed the same:** The API contract is unchanged. The `local_schema_lock` scope and its existing contents are unchanged. The fast-fail check outside the lock is preserved.

## How to review

Focus on `backend/infrahub/core/branch/tasks.py` — the only production code change is 8 lines added inside the `local_schema_lock` scope (a duplicate existence check).

## How to test

```bash
uv run pytest backend/tests/component/core/test_branch_create_race.py::TestBranchCreateRaceCondition::test_concurrent_create_same_branch_only_one_succeeds -x -v
```

The test simulates the race window using an `asyncio.Event` barrier that forces both coroutines past the outer existence check before either proceeds. With the fix, the inner check (inside the lock) catches the duplicate.

## Impact & rollout

- **Backward compatibility:** No breaking changes.
- **Performance:** Negligible — adds one extra DB query inside an already-held lock, only during branch creation.
- **Config/env changes:** None.
- **Deployment notes:** Safe to deploy. No migration required.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- AGENT_FIX_COMPLETE -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TOCTOU race in branch creation by re-checking existence inside the schema lock so concurrent requests create only one branch. Satisfies #8368 without changing the API.

- **Bug Fixes**
  - Added a second `Branch.get_by_name` inside `lock.registry.local_schema_lock()` in `create_branch`; kept the outer check for fast-fail.
  - Under concurrent creates with the same name, one succeeds and the other raises `ValidationError`.
  - Added `backend/tests/component/core/test_branch_create_race.py` to reproduce the race and verify the fix.

<sup>Written for commit 3fb232bbb41f32e7434f23a878fc21901f2f6451. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

