### PR TITLE
Local test AI bug pipeline #7: allow General Access role to create Proposed Changes (closes #8755)

### DIFF
--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -23,6 +23,8 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         "InfrahubAccountSelfUpdate",
         "InfrahubAccountTokenCreate",
         "InfrahubAccountTokenDelete",
+        "ProposedChangeCreate",
+        "ProposedChangeUpdate",
     ]
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:  # noqa: ARG002

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core.account import ObjectPermission
+from infrahub.core.constants import (
+    GlobalPermissions,
+    InfrahubKind,
+    PermissionAction,
+    PermissionDecision,
+)
+from infrahub.core.node import Node
+from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
+from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
+from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
+from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
+from infrahub.permissions import PermissionManager
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from tests.component.graphql.conftest import PermissionsHelper
+
+
+class TestProposedChangeGeneralAccessDefaultBranch:
+    """Test that a user with General Access role permissions can create a ProposedChange.
+
+    The General Access role does NOT include EDIT_DEFAULT_BRANCH permission.
+    ProposedChange creation is a mutation on the default branch, so the
+    DefaultBranchPermissionChecker must exempt it, similar to BranchCreate.
+    """
+
+    async def test_setup(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        register_core_models_schema: None,
+        default_branch: Branch,
+        first_account: CoreAccount,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        permissions_helper._default_branch = default_branch
+
+        # Set up permissions matching the General Access role:
+        # - MANAGE_REPOSITORIES, MANAGE_SCHEMA, MERGE_PROPOSED_CHANGE (global)
+        # - VIEW */* ALLOW_ALL (object)
+        # - ANY */* ALLOW_OTHER (object)
+        # Notably NO EDIT_DEFAULT_BRANCH permission.
+        global_permissions = []
+        for action in (
+            GlobalPermissions.MANAGE_REPOSITORIES,
+            GlobalPermissions.MANAGE_SCHEMA,
+            GlobalPermissions.MERGE_PROPOSED_CHANGE,
+        ):
+            perm = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
+            await perm.new(db=db, action=action.value, decision=PermissionDecision.ALLOW_ALL.value)
+            await perm.save(db=db)
+            global_permissions.append(perm)
+
+        view_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await view_permission.new(
+            db=db,
+            namespace="*",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecision.ALLOW_ALL.value,
+        )
+        await view_permission.save(db=db)
+
+        modify_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await modify_permission.new(
+            db=db,
+            namespace="*",
+            name="*",
+            action=PermissionAction.ANY.value,
+            decision=PermissionDecision.ALLOW_OTHER.value,
+        )
+        await modify_permission.save(db=db)
+
+        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+        await role.new(
+            db=db,
+            name="General Access",
+            permissions=[*global_permissions, view_permission, modify_permission],
+        )
+        await role.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+        await group.new(db=db, name="general_access_group", roles=[role])
+        await group.save(db=db)
+
+        await group.members.add(db=db, data={"id": first_account.id})
+        await group.members.save(db=db)
+
+        permissions_helper._first = first_account
+
+    async def test_proposed_change_create_not_blocked_by_default_branch_checker(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        """A General Access user creating a ProposedChange should not be blocked by the
+        DefaultBranchPermissionChecker, because ProposedChangeCreate should be exempt
+        from the EDIT_DEFAULT_BRANCH requirement (like BranchCreate is)."""
+        checker = DefaultBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        permission_manager = PermissionManager(account_session=session)
+        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+
+        graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
+        graphql_query.branch = MagicMock()
+        graphql_query.branch.name = "main"
+        graphql_query.contains_mutation = True
+        graphql_query.operation_names = ["ProposedChangeCreate"]
+
+        graphql_context = GraphqlContext(
+            db=MagicMock(),
+            branch=MagicMock(),
+            types=MagicMock(),
+            single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
+            account_metadata_resolver=AccountMetadataResolver(),
+            account_session=session,
+            permissions=permission_manager,
+        )
+        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+
+        # This should NOT raise PermissionDeniedError - the checker should let it through
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=graphql_query,
+            query_parameters=query_parameters,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-import pytest
-
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core.account import ObjectPermission
 from infrahub.core.constants import (
     GlobalPermissions,
     InfrahubKind,
@@ -15,7 +12,6 @@ from infrahub.core.constants import (
     PermissionDecision,
 )
 from infrahub.core.node import Node
-from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution


### PR DESCRIPTION
# Why

Users with the default "General Access" role cannot create Proposed Changes. The `DefaultBranchPermissionChecker` requires `EDIT_DEFAULT_BRANCH` permission for any mutation on the default branch, but the General Access role does not include this permission. Since ProposedChanges inherently operate on the default branch (they propose merging a branch *into* it), blocking their creation contradicts their purpose.

Closes #8755

## What changed

- Added `ProposedChangeCreate` and `ProposedChangeUpdate` to the `exempt_operations` list in `DefaultBranchPermissionChecker`, matching the existing exemption pattern used for `BranchCreate`
- No schema changes, no API contract changes, no changes to the General Access role definition itself

## How to review

Single file change: `backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py`

The fix follows the same pattern as the existing `BranchCreate` exemption — operations that by definition target the default branch should not require `EDIT_DEFAULT_BRANCH`.

## How to test

```bash
uv run pytest backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py -x -v
```

## Impact & rollout

- **Backward compatibility:** No breaking changes. Users who previously could not create Proposed Changes will now be able to.
- **Performance:** No impact.
- **Deployment notes:** Safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated

<!-- AGENT_FIX_COMPLETE -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow General Access users to create and update Proposed Changes by exempting these mutations from default-branch edit checks. Fixes a permission gate in `DefaultBranchPermissionChecker` that wrongly required `EDIT_DEFAULT_BRANCH` (closes #8755).

- **Bug Fixes**
  - Added `ProposedChangeCreate` and `ProposedChangeUpdate` to `exempt_operations` in `DefaultBranchPermissionChecker`, matching `BranchCreate`.
  - Added test: `backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py`.

<sup>Written for commit 3894597c4020dfe05574aa5539eed6c645b7295d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

