### PR TITLE
polling and longer wait for flaky tests in the CI

### DIFF
--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -438,7 +438,10 @@ async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: Fake
 
     with patch("infrahub.message_bus.operations.send.echo.get_logger", return_value=fake_log):
         await bus.send(message=messages.SendEchoRequest(message="Hello there"))
-        await asyncio.sleep(delay=1)
+        for _ in range(50):
+            if fake_log.info_logs:
+                break
+            await asyncio.sleep(delay=0.2)
         await bus.shutdown()
 
     assert fake_log.info_logs == ["Received message: Hello there"]
@@ -457,7 +460,10 @@ async def test_rabbitmq_on_message_invalid_routing_key(rabbitmq_api: RabbitMQMan
         await bus.publish(
             routing_key="request.something.invalid", message=messages.SendEchoRequest(message="Hello there")
         )
-        await asyncio.sleep(delay=1)
+        for _ in range(50):
+            if fake_log.error_logs:
+                break
+            await asyncio.sleep(delay=0.2)
         await bus.shutdown()
 
     assert fake_log.info_logs == []

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from asyncio import sleep
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -257,11 +258,18 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         # Validate that the schema is in sync after loading the device and interface schema
         assert await client.schema.in_sync()
 
-        await sleep(1)
-        await wait_for_all_tasks_to_be_completed(client)
+        # Wait for the computed attribute tasks to be created and completed
+        # Tasks may not be created immediately after schema load, so poll for them
+        nbr_task_after_related = nbr_task_after_not_related
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            await sleep(1)
+            await wait_for_all_tasks_to_be_completed(client)
+            nbr_task_after_related = await client.task.count(
+                filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name])
+            )
+            if nbr_task_after_related >= nbr_task_after_not_related + 2:
+                break
 
         # The computed attribute of type Jinja2 should be updated on the sites but NOT on the continents
-        nbr_task_after_related = await client.task.count(
-            filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name])
-        )
         assert nbr_task_after_related == nbr_task_after_not_related + 2

--- a/backend/tests/integration_docker/test_schema_migration.py
+++ b/backend/tests/integration_docker/test_schema_migration.py
@@ -1,8 +1,11 @@
+import asyncio
+import time
 from pathlib import Path
 
 import pytest
 import yaml
 from infrahub_sdk import InfrahubClient
+from infrahub_sdk.exceptions import GraphQLError
 from infrahub_sdk.schema.main import AttributeKind, AttributeSchema, NodeSchema, SchemaRoot
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.schemas.car_person import (
@@ -91,7 +94,7 @@ class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
         assert await self.schema_in_sync(client=client, branch=device_branch.name)
 
     @staticmethod
-    async def schema_in_sync(client: InfrahubClient, branch: str | None) -> bool:
+    async def schema_in_sync(client: InfrahubClient, branch: str | None, wait_for_seconds: int = 30) -> bool:
         SCHEMA_HASH_SYNC_STATUS = """
         query {
         InfrahubStatus {
@@ -101,5 +104,16 @@ class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
         }
         }
         """
-        response = await client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
-        return response["InfrahubStatus"]["summary"]["schema_hash_synced"]
+        deadline = time.monotonic() + wait_for_seconds
+        while True:
+            try:
+                response = await client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
+                if response["InfrahubStatus"]["summary"]["schema_hash_synced"]:
+                    return True
+            except GraphQLError:
+                pass
+
+            if time.monotonic() >= deadline:
+                return False
+
+            await asyncio.sleep(1)

--- a/backend/tests/integration_docker/test_schema_migration.py
+++ b/backend/tests/integration_docker/test_schema_migration.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import time
 from pathlib import Path
 
@@ -106,12 +107,10 @@ class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
         """
         deadline = time.monotonic() + wait_for_seconds
         while True:
-            try:
+            with contextlib.suppress(GraphQLError):
                 response = await client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
                 if response["InfrahubStatus"]["summary"]["schema_hash_synced"]:
                     return True
-            except GraphQLError:
-                pass
 
             if time.monotonic() >= deadline:
                 return False


### PR DESCRIPTION
more likely to see these 3 tests fail in the integration tests in the enterprise repo for some reason


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky CI integration tests by replacing fixed sleeps with polling and timeouts across RabbitMQ, computed attributes, and schema sync checks.

- **Bug Fixes**
  - RabbitMQ: In `test_rabbitmq_on_message` and `test_rabbitmq_on_message_invalid_routing_key`, poll every 200ms (up to 10s) for expected logs before shutdown.
  - Computed attributes: In `test_update_schema_not_related_to_computed_attribute`, poll up to 30s (1s interval) for two `COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE` tasks to appear and complete before asserting.
  - Schema migration: `schema_in_sync` now polls up to 30s (1s interval), returns early on success, and ignores transient GraphQL errors using `contextlib.suppress(GraphQLError)`.

<sup>Written for commit 5adfda8a559c7ed08b49634c3f998c843747487b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



