### PR TITLE
feat(ci): switch to arm runners and sign images

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -1,5 +1,5 @@
 ---
-# yamllint disable rule:truthy
+# yamllint disable rule:truthy rule:line-length
 name: Build And Push Docker image
 
 # When calling this workflow, ensure you use
@@ -35,6 +35,11 @@ on:
         required: false
         description: Comma separated platform list to build the image for
         default: "linux/amd64,linux/arm64"
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref }}
@@ -125,6 +130,8 @@ jobs:
     needs: build
     if: inputs.publish
     runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.inspect.outputs.digest }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -153,3 +160,89 @@ jobs:
             TAGS="$TAGS --tag $tag"
           done <<< "${{ inputs.tags }}"
           docker buildx imagetools create $TAGS $SOURCES
+
+      - name: Inspect manifest
+        id: inspect
+        run: |
+          FIRST_TAG=""
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            FIRST_TAG="$tag"
+            break
+          done <<< "${{ inputs.tags }}"
+          digest=$(docker buildx imagetools inspect "$FIRST_TAG" \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  sign:
+    needs: merge
+    if: inputs.publish
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Login to Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.HARBOR_HOST }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Sign manifest
+        run: |
+          cosign sign --yes --recursive --new-bundle-format=false --use-signing-config=false \
+            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
+
+  sbom:
+    needs: merge
+    if: inputs.publish
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+
+      - name: Login to Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.HARBOR_HOST }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Generate SBOM (SPDX)
+        run: |
+          syft \
+            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}" \
+            --output spdx-json=infrahub-sbom.spdx.json
+
+      - name: Generate SBOM (CycloneDX)
+        run: |
+          syft \
+            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}" \
+            --output cyclonedx-json=infrahub-sbom.cdx.json
+
+      - name: Attest SBOM (SPDX)
+        run: |
+          cosign attest --yes \
+            --type spdxjson \
+            --predicate infrahub-sbom.spdx.json \
+            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
+
+      - name: Attest SBOM (CycloneDX)
+        run: |
+          cosign attest --yes \
+            --type cyclonedx \
+            --predicate infrahub-sbom.cdx.json \
+            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-${{ inputs.version }}
+          path: |
+            infrahub-sbom.spdx.json
+            infrahub-sbom.cdx.json
+          retention-days: 90

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -46,36 +46,52 @@ env:
 jobs:
   prepare-environment:
     uses: ./.github/workflows/define-versions.yml
+
   build:
     needs: prepare-environment
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     env:
       UV_VERSION: ${{ needs.prepare-environment.outputs.UV_VERSION }}
-    runs-on:
-      group: huge-runners
     steps:
+      - name: Check if platform is requested
+        id: check
+        run: |
+          if [[ "${{ inputs.platforms }}" != *"${{ matrix.platform }}"* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.check.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           submodules: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
+        if: steps.check.outputs.skip == 'false'
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        if: ${{ inputs.publish }}
+        if: steps.check.outputs.skip == 'false' && inputs.publish
         uses: docker/login-action@v4
-        id: login
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Build and push by digest
+        if: steps.check.outputs.skip == 'false'
+        uses: docker/build-push-action@v7
         id: push
         with:
           context: .
@@ -83,8 +99,57 @@ jobs:
           provenance: false   # To avoid cross platform "unknown"
           push: ${{ inputs.publish }}
           target: "backend"
-          platforms: ${{ inputs.platforms }}
-          tags: ${{ inputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ inputs.labels }}
           build-args: |
             UV_VER=${{ env.UV_VERSION }}
+          outputs: ${{ inputs.publish && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', vars.HARBOR_HOST, github.repository) || '' }}
+
+      - name: Export digest
+        if: steps.check.outputs.skip == 'false' && inputs.publish
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: steps.check.outputs.skip == 'false' && inputs.publish
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: inputs.publish
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.HARBOR_HOST }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          SOURCES=$(printf '${{ vars.HARBOR_HOST }}/${{ github.repository }}@sha256:%s ' *)
+          TAGS=""
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            TAGS="$TAGS --tag $tag"
+          done <<< "${{ inputs.tags }}"
+          docker buildx imagetools create $TAGS $SOURCES

--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -25,6 +25,11 @@ on:
         default: ''
         required: false
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   meta_data:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -27,8 +27,7 @@ on:
 
 jobs:
   meta_data:
-    runs-on:
-      group: huge-runners
+    runs-on: ubuntu-24.04
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-preview-dev-docker-image.yml
+++ b/.github/workflows/publish-preview-dev-docker-image.yml
@@ -8,6 +8,11 @@ on:
       - labeled
       - synchronize
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   meta_data:
     if: contains(github.event.pull_request.labels.*.name, 'cd/preview')

--- a/.github/workflows/publish-preview-dev-docker-image.yml
+++ b/.github/workflows/publish-preview-dev-docker-image.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   meta_data:
     if: contains(github.event.pull_request.labels.*.name, 'cd/preview')
-    runs-on:
-      group: huge-runners
+    runs-on: ubuntu-24.04
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-bench-image.yml
+++ b/.github/workflows/push-bench-image.yml
@@ -10,14 +10,18 @@ env:
 
 jobs:
   build:
-    runs-on:
-      group: huge-runners
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -36,14 +40,10 @@ jobs:
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/opsmill/bench
-          tags: |
-            type=raw,value=latest
           labels: |
             org.opencontainers.image.source=opsmill/bench
-          flavor: |
-            latest=true
 
-      - name: Build and push
+      - name: Build and push by digest
         uses: docker/build-push-action@v6
         id: push
         with:
@@ -51,8 +51,67 @@ jobs:
           file: ${{ env.DOCKERFILE }}
           provenance: false   # To avoid cross platform "unknown"
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=bench-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=bench-${{ matrix.platform }}
+          outputs: type=image,name=${{ vars.HARBOR_HOST }}/opsmill/bench,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: bench-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ vars.HARBOR_HOST }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Set docker image meta data
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ vars.HARBOR_HOST }}/opsmill/bench
+          tags: |
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.source=opsmill/bench
+          flavor: |
+            latest=true
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          SOURCES=$(printf '${{ vars.HARBOR_HOST }}/opsmill/bench@sha256:%s ' *)
+          TAGS=""
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            TAGS="$TAGS --tag $tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
+          docker buildx imagetools create $TAGS $SOURCES

--- a/.github/workflows/push-bench-image.yml
+++ b/.github/workflows/push-bench-image.yml
@@ -1,5 +1,5 @@
 ---
-# yamllint disable rule:truthy
+# yamllint disable rule:truthy rule:line-length
 name: Build And Push Bench image
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   prepare-environment:
     uses: ./.github/workflows/define-versions.yml

--- a/.github/workflows/schedule-publish-docker-image.yml
+++ b/.github/workflows/schedule-publish-docker-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   meta_data:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
@@ -57,7 +57,7 @@ jobs:
       labels: ${{needs.meta_data.outputs.labels}}
 
   meta_data_stable:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/schedule-publish-docker-image.yml
+++ b/.github/workflows/schedule-publish-docker-image.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   meta_data:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
4x faster builds


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI to build and publish multi-arch images on GitHub-hosted `amd64` and `arm64` runners, merge into a manifest, sign with `cosign`, and attach SBOMs. Adds OIDC permissions to enable signing and attestations across publish, preview, schedule, and release workflows.

- **New Features**
  - Sign merged image manifests with `sigstore/cosign` (legacy bundle; signing config disabled until Harbor 2.15).
  - Generate SBOMs with `anchore/sbom-action` (`syft`) in SPDX and CycloneDX, then attest with `cosign`.

- **Refactors**
  - Build per-arch natively on `ubuntu-24.04` and `ubuntu-24.04-arm`; removed QEMU; skip unrequested arch builds.
  - Push per-arch by digest and assemble/push manifest via `docker buildx imagetools`; export manifest digest for signing and SBOMs.
  - Align bench image to the same per-arch + manifest flow with scoped GHA caches.
  - Standardize to GitHub-hosted `ubuntu-24.04` runners in publish, preview, schedule, and release workflows; add OIDC and `packages: write` permissions.

<sup>Written for commit cbaeeec46a64ae879d8b31eaf366de8c76d5134f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



