### PR TITLE
support timezones in graphql filters

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -10,7 +10,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Generator
 
 import ujson
-from whenever import ZonedDateTime
 
 from infrahub import config
 from infrahub.constants.enums import OrderDirection
@@ -1994,8 +1993,7 @@ WITH %(tracked_vars)s,
     ) -> FieldAttributeRequirement:
         """Build a FieldAttributeRequirement for a metadata filter."""
         if isinstance(value, datetime):
-            timestamp = Timestamp(ZonedDateTime.from_py_datetime(value))
-            value = timestamp.to_string()
+            value = Timestamp(value.isoformat()).to_string()
         return FieldAttributeRequirement(
             field_name=field_name,
             field=None,

--- a/backend/tests/component/graphql/test_graphql_query_metadata.py
+++ b/backend/tests/component/graphql/test_graphql_query_metadata.py
@@ -8,6 +8,7 @@ This module contains tests for:
 """
 
 from dataclasses import dataclass, field
+from datetime import timedelta, timezone
 from typing import Any
 
 import pytest
@@ -1236,3 +1237,46 @@ class TestMetadataFilters:
         # node2 was updated on the branch after branch-node5 was created
         assert names == ["node2", "branch-node5"]
         assert timestamps == sorted(timestamps, reverse=True)
+
+
+async def test_graphql_metadata_filter_with_non_utc_timezone_offset(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
+    """Test that metadata datetime filters work when the client sends a non-UTC timezone offset."""
+    obj1 = await Node.init(db=db, schema=criticality_schema)
+    await obj1.new(db=db, name="tz-first", level=1)
+    await obj1.save(db=db)
+
+    cutoff_ts = Timestamp()
+
+    obj2 = await Node.init(db=db, schema=criticality_schema)
+    await obj2.new(db=db, name="tz-second", level=2)
+    await obj2.save(db=db)
+
+    # Convert the UTC cutoff to an equivalent -05:00 offset string.
+    eastern = timezone(timedelta(hours=-5))
+    cutoff_str = cutoff_ts.to_datetime().astimezone(eastern).isoformat()
+
+    query = """
+    query($cutoff: DateTime!) {
+        TestCriticality(node_metadata__created_at__after: $cutoff) {
+            count
+            edges { node { name { value } } }
+        }
+    }
+    """
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"cutoff": cutoff_str},
+    )
+
+    assert result.errors is None, f"GraphQL errors: {result.errors}"
+    assert result.data
+    assert result.data["TestCriticality"]["count"] == 1
+    names = {e["node"]["name"]["value"] for e in result.data["TestCriticality"]["edges"]}
+    assert names == {"tz-second"}

--- a/changelog/+c4187898.fixed.md
+++ b/changelog/+c4187898.fixed.md
@@ -1,0 +1,1 @@
+Support non-UTC timezones in filters for GraphQL queries


### PR DESCRIPTION
we did not correctly support non-UTC timezones in filters to GraphQL queries. 

for example, this query 
```
    query($cutoff: DateTime!) {
        TestCriticality(node_metadata__created_at__after: "2026-04-06T12:46:03.614613-05:00") {
            count
            edges { node { name { value } } }
        }
    }
```
would end up raising an error like this
```
  File "~l/infrahub/backend/infrahub/core/query/node.py", line 2000, in _build_metadata_filter_requirement
    timestamp = Timestamp(ZonedDateTime.from_py_datetime(value))
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
ValueError: tzinfo must be of type ZoneInfo (exactly), got tzoffset(None, -18000)
```

fix is to just let `Timestamp` parse the string version of the datetime that includes the timezone suffix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GraphQL metadata datetime filters to correctly handle non‑UTC timezone offsets in ISO‑8601 strings. Prevents errors and returns the right results when using filters like created_at__after with offsets (e.g., -05:00).

- **Bug Fixes**
  - Parse datetimes with timezone via `Timestamp(value.isoformat())`, avoiding `ZonedDateTime` and ZoneInfo errors.
  - Added test for `node_metadata__created_at__after` with a -05:00 cutoff to verify correct filtering.

<sup>Written for commit ac1427d21d65dcd0d8778cbf800ade012c20beea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

