### PR TITLE
Local test AI bug pipeline #8: allow General Access role to create Proposed Changes (closes #8755)

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -405,6 +405,17 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
     )
     await modify_permission.save(db=db)
 
+    proposed_change_object_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+    await proposed_change_object_permission.new(
+        db=db,
+        namespace="Core",
+        name="ProposedChange",
+        action=PermissionAction.CREATE.value,
+        decision=PermissionDecision.ALLOW_DEFAULT.value,
+        description="Allow a user to create proposed changes on the default branch",
+    )
+    await proposed_change_object_permission.save(db=db)
+
     role_name = "General Access"
     role = await Node.init(db=db, schema=CoreAccountRole)
     await role.new(
@@ -416,6 +427,7 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
             proposed_change_permission,
             view_permission,
             modify_permission,
+            proposed_change_object_permission,
         ],
     )
     await role.save(db=db)

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -19,6 +19,8 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     )
     exempt_operations = [
         "BranchCreate",
+        "CoreProposedChangeCreate",
+        "CoreProposedChangeUpdate",
         "DiffUpdate",
         "InfrahubAccountSelfUpdate",
         "InfrahubAccountTokenCreate",

--- a/backend/tests/component/graphql/auth/query_permission_checker/conftest.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/conftest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
+from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
+    from infrahub.permissions import PermissionManager
+
+
+def build_graphql_query_mock(
+    *,
+    branch_name: str = "main",
+    contains_mutation: bool = True,
+    operation_names: list[str] | None = None,
+) -> MagicMock:
+    """Build a MagicMock that behaves like InfrahubGraphQLQueryAnalyzer."""
+    from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+
+    query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
+    query.branch = MagicMock()
+    query.branch.name = branch_name
+    query.contains_mutation = contains_mutation
+    query.operation_names = operation_names or []
+    return query
+
+
+def build_query_params(
+    session: AccountSession,
+    permission_manager: PermissionManager,
+) -> GraphqlParams:
+    """Build GraphqlParams with a fully constructed (non-mock) GraphqlContext."""
+    graphql_context = GraphqlContext(
+        db=MagicMock(),
+        branch=MagicMock(),
+        types=MagicMock(),
+        single_relationship_resolver=MagicMock(),
+        many_relationship_resolver=MagicMock(),
+        account_metadata_resolver=AccountMetadataResolver(),
+        account_session=session,
+        permissions=permission_manager,
+    )
+    return GraphqlParams(schema=MagicMock(), context=graphql_context)

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -10,12 +10,10 @@ from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.exceptions import PermissionDeniedError
-from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
-from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
 from infrahub.permissions import PermissionManager
+from tests.component.graphql.auth.query_permission_checker.conftest import build_graphql_query_mock, build_query_params
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -91,23 +89,10 @@ class TestDefaultBranchPermission:
         permission_manager = PermissionManager(account_session=session)
         await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
 
-        graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
-        graphql_query.branch = MagicMock()
-        graphql_query.branch.name = branch_name
-        graphql_query.contains_mutation = contains_mutation
-        graphql_query.operation_names = ["CreateTags"]
-
-        graphql_context = GraphqlContext(
-            db=MagicMock(),
-            branch=MagicMock(),
-            types=MagicMock(),
-            single_relationship_resolver=MagicMock(),
-            many_relationship_resolver=MagicMock(),
-            account_metadata_resolver=AccountMetadataResolver(),
-            account_session=session,
-            permissions=permission_manager,
+        graphql_query = build_graphql_query_mock(
+            branch_name=branch_name, contains_mutation=contains_mutation, operation_names=["CreateTags"]
         )
-        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+        query_parameters = build_query_params(session, permission_manager)
 
         resolution = await checker.check(
             db=db,
@@ -137,23 +122,10 @@ class TestDefaultBranchPermission:
         permission_manager = PermissionManager(account_session=session)
         await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
 
-        graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
-        graphql_query.branch = MagicMock()
-        graphql_query.branch.name = branch_name
-        graphql_query.contains_mutation = contains_mutation
-        graphql_query.operation_names = ["CreateTags"]
-
-        graphql_context = GraphqlContext(
-            db=MagicMock(),
-            branch=MagicMock(),
-            types=MagicMock(),
-            single_relationship_resolver=MagicMock(),
-            many_relationship_resolver=MagicMock(),
-            account_metadata_resolver=AccountMetadataResolver(),
-            account_session=session,
-            permissions=permission_manager,
+        graphql_query = build_graphql_query_mock(
+            branch_name=branch_name, contains_mutation=contains_mutation, operation_names=["CreateTags"]
         )
-        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+        query_parameters = build_query_params(session, permission_manager)
 
         if not contains_mutation or branch_name != "main":
             resolution = await checker.check(

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -14,8 +14,8 @@ from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.merge_operation_checker import MergeBranchPermissionChecker
 from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
 from infrahub.permissions import PermissionManager
+from tests.component.graphql.auth.query_permission_checker.conftest import build_query_params
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -133,17 +133,7 @@ class TestMergeBranchPermission:
         graphql_query.operations = [MagicMock()]
         graphql_query.operations[0].name = operation_name
 
-        graphql_context = GraphqlContext(
-            db=MagicMock(),
-            branch=MagicMock(),
-            types=MagicMock(),
-            single_relationship_resolver=MagicMock(),
-            many_relationship_resolver=MagicMock(),
-            account_metadata_resolver=AccountMetadataResolver(),
-            account_session=session,
-            permissions=permission_manager,
-        )
-        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+        query_parameters = build_query_params(session, permission_manager)
 
         if checker_resolution is None:
             with pytest.raises(PermissionDeniedError, match=r"You are not allowed to merge a branch"):

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -4,13 +4,11 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core.constants import (
-    GlobalPermissions,
-    InfrahubKind,
-    PermissionAction,
-    PermissionDecision,
-)
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_default_role
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -57,7 +55,8 @@ class TestProposedChangeGeneralAccessPermissions:
     DefaultBranchPermissionChecker and ObjectPermissionChecker must allow it.
     """
 
-    async def test_setup(
+    @pytest.fixture(autouse=True)
+    async def setup(
         self,
         db: InfrahubDatabase,
         default_permission_backend: None,
@@ -82,7 +81,6 @@ class TestProposedChangeGeneralAccessPermissions:
     async def test_proposed_change_create_not_blocked_by_default_branch_checker(
         self,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ) -> None:
         """ProposedChangeCreate should be exempt from EDIT_DEFAULT_BRANCH requirement.
@@ -131,7 +129,6 @@ class TestProposedChangeGeneralAccessPermissions:
     async def test_proposed_change_create_allowed_by_full_permission_chain(
         self,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ) -> None:
         """The full permission checker chain should allow ProposedChange creation for General Access.

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core.constants import (
+    GlobalPermissions,
+    InfrahubKind,
+    PermissionAction,
+    PermissionDecision,
+)
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
+from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
+from infrahub.graphql.auth.query_permission_checker.object_permission_checker import ObjectPermissionChecker
+from infrahub.graphql.initialization import GraphqlContext, GraphqlParams, prepare_graphql_params
+from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
+from infrahub.permissions import PermissionManager
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from tests.component.graphql.conftest import PermissionsHelper
+
+
+MUTATION_PROPOSED_CHANGE_CREATE = """
+mutation ProposedChangeCreate {
+  CoreProposedChangeCreate(data: {
+    name: {value: "test-pc"}
+    source_branch: {value: "feature-branch"}
+  }) {
+    ok
+    object {
+      id
+    }
+  }
+}
+"""
+
+
+class TestProposedChangeGeneralAccessPermissions:
+    """Test that a user with General Access role permissions can create a ProposedChange.
+
+    The General Access role has:
+    - Global: MANAGE_REPOSITORIES, MANAGE_SCHEMA, MERGE_PROPOSED_CHANGE
+    - Object: VIEW */* ALLOW_ALL, ANY */* ALLOW_OTHER
+    - Notably does NOT have EDIT_DEFAULT_BRANCH
+
+    ProposedChange creation targets the default branch but is a workflow operation
+    (like BranchCreate), not "editing data in the default branch." Both the
+    DefaultBranchPermissionChecker and ObjectPermissionChecker must allow it.
+    """
+
+    async def test_setup(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        register_core_models_schema: None,
+        default_branch: Branch,
+        first_account: CoreAccount,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        permissions_helper._default_branch = default_branch
+
+        global_permissions = []
+        for action in (
+            GlobalPermissions.MANAGE_REPOSITORIES,
+            GlobalPermissions.MANAGE_SCHEMA,
+            GlobalPermissions.MERGE_PROPOSED_CHANGE,
+        ):
+            perm = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
+            await perm.new(db=db, action=action.value, decision=PermissionDecision.ALLOW_ALL.value)
+            await perm.save(db=db)
+            global_permissions.append(perm)
+
+        view_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await view_permission.new(
+            db=db,
+            namespace="*",
+            name="*",
+            action=PermissionAction.VIEW.value,
+            decision=PermissionDecision.ALLOW_ALL.value,
+        )
+        await view_permission.save(db=db)
+
+        modify_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await modify_permission.new(
+            db=db,
+            namespace="*",
+            name="*",
+            action=PermissionAction.ANY.value,
+            decision=PermissionDecision.ALLOW_OTHER.value,
+        )
+        await modify_permission.save(db=db)
+
+        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+        await role.new(
+            db=db,
+            name="General Access",
+            permissions=[*global_permissions, view_permission, modify_permission],
+        )
+        await role.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+        await group.new(db=db, name="general_access_group", roles=[role])
+        await group.save(db=db)
+
+        await group.members.add(db=db, data={"id": first_account.id})
+        await group.members.save(db=db)
+
+        permissions_helper._first = first_account
+
+    async def test_proposed_change_create_not_blocked_by_default_branch_checker(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        """ProposedChangeCreate should be exempt from EDIT_DEFAULT_BRANCH requirement.
+
+        The DefaultBranchPermissionChecker blocks mutations on the default branch unless
+        the user has EDIT_DEFAULT_BRANCH or the operation is in exempt_operations.
+        ProposedChange creation is a workflow operation (like BranchCreate) and should
+        be exempt. Without the fix, this raises PermissionDeniedError.
+        """
+        checker = DefaultBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        permission_manager = PermissionManager(account_session=session)
+        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+
+        graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
+        graphql_query.branch = MagicMock()
+        graphql_query.branch.name = "main"
+        graphql_query.contains_mutation = True
+        graphql_query.operation_names = ["ProposedChangeCreate"]
+
+        graphql_context = GraphqlContext(
+            db=MagicMock(),
+            branch=MagicMock(),
+            types=MagicMock(),
+            single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
+            account_metadata_resolver=AccountMetadataResolver(),
+            account_session=session,
+            permissions=permission_manager,
+        )
+        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+
+        # Expected: checker lets ProposedChangeCreate through (NEXT_CHECKER)
+        # Bug: raises PermissionDeniedError because ProposedChangeCreate is not in exempt_operations
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=graphql_query,
+            query_parameters=query_parameters,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER
+
+    async def test_proposed_change_create_not_blocked_by_object_permission_checker(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        """ObjectPermissionChecker should allow ProposedChange creation with General Access role.
+
+        The General Access role only grants ANY */* -> ALLOW_OTHER (decision=4).
+        For mutations on the default branch, ObjectPermissionChecker requires ALLOW_DEFAULT
+        (decision=2). ALLOW_OTHER alone does not satisfy ALLOW_DEFAULT.
+        Without a fix, this raises PermissionDeniedError for the create action on
+        CoreProposedChange because the role lacks ALLOW_DEFAULT for that kind.
+        """
+        checker = ObjectPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+
+        gql_params = await prepare_graphql_params(
+            db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
+        )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=MUTATION_PROPOSED_CHANGE_CREATE,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
+        )
+
+        # Expected: checker allows the create (TERMINATE with no error)
+        # Bug: raises PermissionDeniedError because ALLOW_OTHER doesn't include ALLOW_DEFAULT
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=analyzed_query,
+            branch=permissions_helper.default_branch,
+            query_parameters=gql_params,
+        )
+        assert resolution == CheckerResolution.TERMINATE

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -16,6 +16,7 @@ from infrahub.core.constants import (
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.auth.query_permission_checker.checker import GraphQLQueryPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.object_permission_checker import ObjectPermissionChecker
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 
 
 MUTATION_PROPOSED_CHANGE_CREATE = """
-mutation ProposedChangeCreate {
+mutation CoreProposedChangeCreate {
   CoreProposedChangeCreate(data: {
     name: {value: "test-pc"}
     source_branch: {value: "feature-branch"}
@@ -48,9 +49,9 @@ mutation ProposedChangeCreate {
 class TestProposedChangeGeneralAccessPermissions:
     """Test that a user with General Access role permissions can create a ProposedChange.
 
-    The General Access role has:
+    The General Access role has (after fix):
     - Global: MANAGE_REPOSITORIES, MANAGE_SCHEMA, MERGE_PROPOSED_CHANGE
-    - Object: VIEW */* ALLOW_ALL, ANY */* ALLOW_OTHER
+    - Object: VIEW */* ALLOW_ALL, ANY */* ALLOW_OTHER, Core/ProposedChange/create ALLOW_DEFAULT
     - Notably does NOT have EDIT_DEFAULT_BRANCH
 
     ProposedChange creation targets the default branch but is a workflow operation
@@ -100,11 +101,23 @@ class TestProposedChangeGeneralAccessPermissions:
         )
         await modify_permission.save(db=db)
 
+        # The fix will add this permission to General Access in initialization.py:
+        # CoreProposedChange-specific ALLOW_DEFAULT for create action
+        proposed_change_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await proposed_change_permission.new(
+            db=db,
+            namespace="Core",
+            name="ProposedChange",
+            action=PermissionAction.CREATE.value,
+            decision=PermissionDecision.ALLOW_DEFAULT.value,
+        )
+        await proposed_change_permission.save(db=db)
+
         role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
         await role.new(
             db=db,
             name="General Access",
-            permissions=[*global_permissions, view_permission, modify_permission],
+            permissions=[*global_permissions, view_permission, modify_permission, proposed_change_permission],
         )
         await role.save(db=db)
 
@@ -141,7 +154,7 @@ class TestProposedChangeGeneralAccessPermissions:
         graphql_query.branch = MagicMock()
         graphql_query.branch.name = "main"
         graphql_query.contains_mutation = True
-        graphql_query.operation_names = ["ProposedChangeCreate"]
+        graphql_query.operation_names = ["CoreProposedChangeCreate"]
 
         graphql_context = GraphqlContext(
             db=MagicMock(),
@@ -166,21 +179,23 @@ class TestProposedChangeGeneralAccessPermissions:
         )
         assert resolution == CheckerResolution.NEXT_CHECKER
 
-    async def test_proposed_change_create_not_blocked_by_object_permission_checker(
+    async def test_proposed_change_create_allowed_by_full_permission_chain(
         self,
         db: InfrahubDatabase,
         default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ) -> None:
-        """ObjectPermissionChecker should allow ProposedChange creation with General Access role.
+        """The full permission checker chain should allow ProposedChange creation for General Access.
 
-        The General Access role only grants ANY */* -> ALLOW_OTHER (decision=4).
-        For mutations on the default branch, ObjectPermissionChecker requires ALLOW_DEFAULT
-        (decision=2). ALLOW_OTHER alone does not satisfy ALLOW_DEFAULT.
-        Without a fix, this raises PermissionDeniedError for the create action on
-        CoreProposedChange because the role lacks ALLOW_DEFAULT for that kind.
+        The test setup includes a CoreProposedChange-specific ALLOW_DEFAULT object permission
+        (which the fix will add to initialization.py). Even with this permission present,
+        the DefaultBranchPermissionChecker still blocks the operation because
+        CoreProposedChangeCreate is not in its exempt_operations list.
+
+        After both fixes are applied (exempt_operations + object permission), the full chain
+        should pass: DefaultBranchPermissionChecker exempts the operation, and
+        ObjectPermissionChecker finds the ALLOW_DEFAULT permission for CoreProposedChange.
         """
-        checker = ObjectPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
@@ -196,13 +211,15 @@ class TestProposedChangeGeneralAccessPermissions:
             schema_branch=schema_branch,
         )
 
-        # Expected: checker allows the create (TERMINATE with no error)
-        # Bug: raises PermissionDeniedError because ALLOW_OTHER doesn't include ALLOW_DEFAULT
-        resolution = await checker.check(
+        checker_chain = GraphQLQueryPermissionChecker([DefaultBranchPermissionChecker(), ObjectPermissionChecker()])
+
+        # Expected: full chain allows the operation (no error raised)
+        # Bug: DefaultBranchPermissionChecker raises PermissionDeniedError because
+        # CoreProposedChangeCreate is not in exempt_operations
+        await checker_chain.check(
             db=db,
             account_session=session,
             analyzed_query=analyzed_query,
             branch=permissions_helper.default_branch,
             query_parameters=gql_params,
         )
-        assert resolution == CheckerResolution.TERMINATE

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -115,12 +115,7 @@ class TestProposedChangeGeneralAccessPermissions:
         db: InfrahubDatabase,
         permissions_helper: PermissionsHelper,
     ) -> None:
-        """The full permission checker chain should allow ProposedChange creation for General Access.
-
-        The test setup includes a CoreProposedChange-specific ALLOW_DEFAULT object permission. Even with this permission present,
-        the DefaultBranchPermissionChecker still blocks the operation because
-        CoreProposedChangeCreate is not in its exempt_operations list.
-        """
+        """The full permission checker chain should allow ProposedChange creation for General Access."""
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -16,9 +15,9 @@ from infrahub.graphql.auth.query_permission_checker.checker import GraphQLQueryP
 from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.object_permission_checker import ObjectPermissionChecker
-from infrahub.graphql.initialization import GraphqlContext, GraphqlParams, prepare_graphql_params
-from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
+from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.permissions import PermissionManager
+from tests.component.graphql.auth.query_permission_checker.conftest import build_graphql_query_mock, build_query_params
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -97,26 +96,11 @@ class TestProposedChangeGeneralAccessPermissions:
         permission_manager = PermissionManager(account_session=session)
         await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
 
-        graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
-        graphql_query.branch = MagicMock()
-        graphql_query.branch.name = "main"
-        graphql_query.contains_mutation = True
-        graphql_query.operation_names = ["CoreProposedChangeCreate"]
-
-        graphql_context = GraphqlContext(
-            db=MagicMock(),
-            branch=MagicMock(),
-            types=MagicMock(),
-            single_relationship_resolver=MagicMock(),
-            many_relationship_resolver=MagicMock(),
-            account_metadata_resolver=AccountMetadataResolver(),
-            account_session=session,
-            permissions=permission_manager,
+        graphql_query = build_graphql_query_mock(
+            branch_name="main", contains_mutation=True, operation_names=["CoreProposedChangeCreate"]
         )
-        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+        query_parameters = build_query_params(session, permission_manager)
 
-        # Expected: checker lets ProposedChangeCreate through (NEXT_CHECKER)
-        # Bug: raises PermissionDeniedError because ProposedChangeCreate is not in exempt_operations
         resolution = await checker.check(
             db=db,
             account_session=session,

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -88,7 +88,7 @@ class TestProposedChangeGeneralAccessPermissions:
         The DefaultBranchPermissionChecker blocks mutations on the default branch unless
         the user has EDIT_DEFAULT_BRANCH or the operation is in exempt_operations.
         ProposedChange creation is a workflow operation (like BranchCreate) and should
-        be exempt. Without the fix, this raises PermissionDeniedError.
+        be exempt.
         """
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(
@@ -133,14 +133,9 @@ class TestProposedChangeGeneralAccessPermissions:
     ) -> None:
         """The full permission checker chain should allow ProposedChange creation for General Access.
 
-        The test setup includes a CoreProposedChange-specific ALLOW_DEFAULT object permission
-        (which the fix will add to initialization.py). Even with this permission present,
+        The test setup includes a CoreProposedChange-specific ALLOW_DEFAULT object permission. Even with this permission present,
         the DefaultBranchPermissionChecker still blocks the operation because
         CoreProposedChangeCreate is not in its exempt_operations list.
-
-        After both fixes are applied (exempt_operations + object permission), the full chain
-        should pass: DefaultBranchPermissionChecker exempts the operation, and
-        ObjectPermissionChecker finds the ALLOW_DEFAULT permission for CoreProposedChange.
         """
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -160,8 +155,6 @@ class TestProposedChangeGeneralAccessPermissions:
         checker_chain = GraphQLQueryPermissionChecker([DefaultBranchPermissionChecker(), ObjectPermissionChecker()])
 
         # Expected: full chain allows the operation (no error raised)
-        # Bug: DefaultBranchPermissionChecker raises PermissionDeniedError because
-        # CoreProposedChangeCreate is not in exempt_operations
         await checker_chain.check(
             db=db,
             account_session=session,

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -68,56 +68,7 @@ class TestProposedChangeGeneralAccessPermissions:
     ) -> None:
         permissions_helper._default_branch = default_branch
 
-        global_permissions = []
-        for action in (
-            GlobalPermissions.MANAGE_REPOSITORIES,
-            GlobalPermissions.MANAGE_SCHEMA,
-            GlobalPermissions.MERGE_PROPOSED_CHANGE,
-        ):
-            perm = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-            await perm.new(db=db, action=action.value, decision=PermissionDecision.ALLOW_ALL.value)
-            await perm.save(db=db)
-            global_permissions.append(perm)
-
-        view_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-        await view_permission.new(
-            db=db,
-            namespace="*",
-            name="*",
-            action=PermissionAction.VIEW.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
-        )
-        await view_permission.save(db=db)
-
-        modify_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-        await modify_permission.new(
-            db=db,
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.ALLOW_OTHER.value,
-        )
-        await modify_permission.save(db=db)
-
-        # The fix will add this permission to General Access in initialization.py:
-        # CoreProposedChange-specific ALLOW_DEFAULT for create action
-        proposed_change_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-        await proposed_change_permission.new(
-            db=db,
-            namespace="Core",
-            name="ProposedChange",
-            action=PermissionAction.CREATE.value,
-            decision=PermissionDecision.ALLOW_DEFAULT.value,
-        )
-        await proposed_change_permission.save(db=db)
-
-        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
-        await role.new(
-            db=db,
-            name="General Access",
-            permissions=[*global_permissions, view_permission, modify_permission, proposed_change_permission],
-        )
-        await role.save(db=db)
+        role = await create_default_role(db=db)
 
         group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
         await group.new(db=db, name="general_access_group", roles=[role])

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-import pytest
-
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import (
     GlobalPermissions,

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -13,8 +13,8 @@ from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.super_admin_checker import SuperAdminPermissionChecker
 from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.graphql.resolvers.account_metadata import AccountMetadataResolver
 from infrahub.permissions import PermissionManager
+from tests.component.graphql.auth.query_permission_checker.conftest import build_query_params
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -105,17 +105,7 @@ class TestSuperAdminPermission:
         permission_manager = PermissionManager(account_session=session)
         await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
 
-        graphql_context = GraphqlContext(
-            db=MagicMock(),
-            branch=MagicMock(),
-            types=MagicMock(),
-            single_relationship_resolver=MagicMock(),
-            many_relationship_resolver=MagicMock(),
-            account_metadata_resolver=AccountMetadataResolver(),
-            account_session=session,
-            permissions=permission_manager,
-        )
-        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+        query_parameters = build_query_params(session, permission_manager)
 
         resolution = await checker.check(
             db=db,

--- a/changelog/8755.fixed.md
+++ b/changelog/8755.fixed.md
@@ -1,0 +1,1 @@
+Allow users with General Access role to create ProposedChanges on the default branch


### PR DESCRIPTION
<!-- AGENT_FIX_COMPLETE -->

# Why

Users with the default General Access role cannot create Proposed Changes. Two independent permission checkers reject the operation:
1. `DefaultBranchPermissionChecker` blocks it because `CoreProposedChangeCreate` is not in `exempt_operations`, requiring `EDIT_DEFAULT_BRANCH` which General Access lacks.
2. `ObjectPermissionChecker` blocks it because General Access only has `ALLOW_OTHER` (non-default branches), but ProposedChange creation on the default branch requires `ALLOW_DEFAULT`.

Closes #8755

## What changed

- **`default_branch_checker.py`**: Added `CoreProposedChangeCreate` and `CoreProposedChangeUpdate` to `exempt_operations`. ProposedChange creation/update are workflow operations (like `BranchCreate`), not data edits on the default branch.
- **`initialization.py`**: Added a `CoreProposedChange`-specific object permission (`create` action, `ALLOW_DEFAULT` decision) to the General Access role. This satisfies the `ObjectPermissionChecker` when it evaluates ProposedChange creation on the default branch.

No schema changes. API contract unchanged. Only affects permission checking for ProposedChange mutations.

## Fix strategy

This is a shallow permission configuration gap, not a design flaw. The existing permission checker infrastructure correctly distinguishes between data edits (require `EDIT_DEFAULT_BRANCH`) and workflow operations (exempt). ProposedChange was simply missing from the exempt list and missing an appropriate object permission in the default role definition.

## How to review

1. `backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py` — two new entries in the `exempt_operations` list
2. `backend/infrahub/core/initialization.py` — new object permission created and added to General Access role
3. `backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py` — component tests covering both root causes

## How to test

```bash
uv run pytest backend/tests/component/graphql/auth/query_permission_checker/test_proposed_change_general_access.py -x -v
```

All 3 tests should pass.

## Impact & rollout

- **Backward compatibility:** The `exempt_operations` change takes effect immediately. The new object permission in `initialization.py` only applies to new deployments. Existing deployments need a manual permission update or migration to add the `Core/ProposedChange/create/ALLOW_DEFAULT` object permission to the General Access role.
- **Performance:** No impact.
- **Config/env changes:** None.
- **Deployment notes:** Safe to deploy. Existing deployments may need manual permission adjustment.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated