### PR TITLE
Fix test linting issues

### DIFF
--- a/backend/tests/unit/test_lock.py
+++ b/backend/tests/unit/test_lock.py
@@ -1,3 +1,4 @@
+import operator
 import time
 from asyncio import gather, sleep
 
@@ -35,7 +36,7 @@ async def test_simple_infrahub_lock() -> None:
         )
     )
 
-    results.sort(key=lambda x: x[1])
+    results.sort(key=operator.itemgetter(1))
     assert results[0][2] <= results[1][1]
 
 

--- a/backend/tests/unit/test_types.py
+++ b/backend/tests/unit/test_types.py
@@ -19,7 +19,7 @@ def test_attribute_types_allowed_property_path(test_case: str) -> None:
     attribute_type = ATTRIBUTE_TYPES[test_case]
 
     graphql_query_type = getattr(types, attribute_type.graphql_query)
-    include_binary_address = test_case in ["IPHost", "IPNetwork"]
+    include_binary_address = test_case in {"IPHost", "IPNetwork"}
     path_list = _get_path_field_list(
         include_binary_address=include_binary_address, fields=graphql_query_type._meta.fields
     )
@@ -42,8 +42,6 @@ def _get_path_field_list(include_binary_address: bool, fields: dict[str, Field])
         "updated_by",
     ]
     included = ["binary_address"] if include_binary_address else []
-    for name in fields:
-        if name not in excluded_fields:
-            included.append(name)
+    included.extend(name for name in fields if name not in excluded_fields)
 
     return sorted(included)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1030,13 +1030,9 @@ allow-dunder-method-names = [
     ##################################################################################################
     # Rules with violations in unit tests                                                            #
     ##################################################################################################
-    "FURB118",  # Use `operator.itemgetter(1)` instead of defining a lambda
-    "PERF401",  # Use a list comprehension to create a transformed list
     "PLC2701",  # Private name import from external module
     "PLR2004",  # Magic value used in comparison
-    "PLR6201",  # Use a `set` literal when testing for membership
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
-    "RUF029",   # Function is declared `async`, but doesn't `await`
 ]
 
 "backend/tests/integration_docker/test_schema_migration.py" = [


### PR DESCRIPTION
# Why

Resolve trivial linting issues within unittests

## What changed

* Remove ruff violations from pyproject.toml
* Implement trivial fixes for identified violations