### PR TITLE
Add packer repository in repository dispatch

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -36,6 +36,7 @@ jobs:
         # Either a literal path, or the name of a secret...
         repo:
           - "opsmill/infrahub-demo-dc"
+          - "INFRAHUB_PACKER_REPOSITORY"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
           - "INFRAHUB_CUSTOMER3_REPOSITORY"


### PR DESCRIPTION
- Add the Packer repository to trigger a new image build for instruqt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `INFRAHUB_PACKER_REPOSITORY` to `.github/workflows/repository-dispatch.yml` so the workflow can trigger Packer image builds for Instruqt.

<sup>Written for commit e4dfdcc4ed9183fab8b29c245f74001877e72305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

