### PR TITLE
Fix minor linting issues in benchmark tests

### DIFF
--- a/backend/tests/query_benchmark/conftest.py
+++ b/backend/tests/query_benchmark/conftest.py
@@ -110,7 +110,7 @@ async def graph_generator() -> GraphProfileGenerator:
     return GraphProfileGenerator()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 async def increase_query_size_limit() -> None:
     original_query_size_limit = config.SETTINGS.database.query_size_limit
     config.SETTINGS.database.query_size_limit = 1_000_000

--- a/backend/tests/query_benchmark/test_diff_query.py
+++ b/backend/tests/query_benchmark/test_diff_query.py
@@ -50,7 +50,7 @@ async def test_diff(
     diff_branch = await create_branch(branch_name="diff_branch", db=db_profiling_queries)
 
     # Build function to profile
-    async def init_and_execute():
+    async def init_and_execute() -> None:
         # Need this function to avoid loading data between `init` and `execute` methods.
         diff_calculator = DiffCalculator(db=db_profiling_queries)
         calculated_diffs = await diff_calculator.calculate_diff(

--- a/backend/tests/query_benchmark/test_node_get_list.py
+++ b/backend/tests/query_benchmark/test_node_get_list.py
@@ -23,7 +23,7 @@ log = get_logger()
 
 @pytest.mark.timeout(36000)  # 10 hours
 @pytest.mark.parametrize(
-    "benchmark_config, ordering",
+    ("benchmark_config", "ordering"),
     [
         (
             BenchmarkConfig(
@@ -54,7 +54,7 @@ async def test_node_get_list_ordering(
     registry.schema.register_schema(schema=car_person_schema_root, branch=default_branch.name)
 
     # Build function to profile
-    async def init_and_execute():
+    async def init_and_execute() -> None:
         car_node_schema = registry.get_node_schema(name="TestCar", branch=default_branch.name)
         query = await NodeGetListQuery.init(
             db=db_profiling_queries,
@@ -62,8 +62,7 @@ async def test_node_get_list_ordering(
             branch=default_branch,
             ordering=ordering,
         )
-        res = await query.execute(db=db_profiling_queries)
-        return res
+        await query.execute(db=db_profiling_queries)
 
     nb_cars = 10_000
     cars_generator = CarGenerator(db=db_profiling_queries)

--- a/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
+++ b/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
@@ -51,7 +51,7 @@ async def benchmark_uniqueness_query(
     registry.schema.register_schema(schema=car_person_schema_root, branch=default_branch.name)
 
     # Build function to profile
-    async def init_and_execute():
+    async def init_and_execute() -> None:
         # Need this function to avoid loading data between `init` and `execute` methods.
         query = await NodeUniqueAttributeConstraintQuery.init(
             db=db_profiling_queries,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -980,13 +980,8 @@ allow-dunder-method-names = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
     ##################################################################################################
-    "ANN202",   # Missing return type annotation for private function
     "PLR0913",  # Too many arguments in function definition
     "PLR0917",  # Too many positional arguments
-    "PT003",    # `scope='function'` is implied in `@pytest.fixture()`
-    "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`
-    "RET504",   # Unnecessary assignment before `return` statement
-    "RUF029",   # Function is declared `async`, but doesn't `await`
 ]
 
 "backend/tests/integration_docker/**.py" = [


### PR DESCRIPTION

# Why

Clean up linting issues in query benchmark tests

## What changed

* Tighten rules
* Trivial code changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed minor linting issues in query benchmark tests and tightened rules to enforce them. No behavior changes.

- **Refactors**
  - Removed ignores for `ANN202`, `PT003`, `PT006`, `RET504`, `RUF029` in `pyproject.toml`.
  - Updated tests to satisfy rules: default `@pytest.fixture` scope, tuple arg names in `@pytest.mark.parametrize`, local async helpers annotated `-> None` and awaiting calls, and removed unnecessary returns.

<sup>Written for commit 8d68c4c7e28f182f2bd618799defd0f458e3ea2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

