### PR TITLE
IFC-2440: Add unittest that fails on wrong graph version

### DIFF
--- a/backend/tests/unit/core/graph/test_graph_version.py
+++ b/backend/tests/unit/core/graph/test_graph_version.py
@@ -1,0 +1,16 @@
+from infrahub.core.graph import GRAPH_VERSION
+from infrahub.core.migrations.graph import MIGRATIONS
+
+
+def test_graph_version_matches_migration_count() -> None:
+    assert len(MIGRATIONS) == GRAPH_VERSION, (
+        f"GRAPH_VERSION ({GRAPH_VERSION}) must equal to the number of migrations "
+        f"({len(MIGRATIONS)}). Update GRAPH_VERSION or add/remove a migration."
+    )
+
+
+def test_last_migration_minimum_version() -> None:
+    last = MIGRATIONS[-1].init()
+    assert last.minimum_version == GRAPH_VERSION - 1, (
+        f"Last migration minimum_version ({last.minimum_version}) must be GRAPH_VERSION - 1 ({GRAPH_VERSION - 1})."
+    )

--- a/backend/tests/unit/core/graph/test_graph_version.py
+++ b/backend/tests/unit/core/graph/test_graph_version.py
@@ -14,3 +14,9 @@ def test_last_migration_minimum_version() -> None:
     assert last.minimum_version == GRAPH_VERSION - 1, (
         f"Last migration minimum_version ({last.minimum_version}) must be GRAPH_VERSION - 1 ({GRAPH_VERSION - 1})."
     )
+
+
+def test_no_duplicate_migration_minimum_versions() -> None:
+    minimum_versions = [m.init().minimum_version for m in MIGRATIONS]
+    duplicate_versions = [v for v in minimum_versions if minimum_versions.count(v) > 1]
+    assert not duplicate_versions, f"Duplicate minimum_version values found: {sorted(set(duplicate_versions))}"

--- a/backend/tests/unit/core/graph/test_graph_version.py
+++ b/backend/tests/unit/core/graph/test_graph_version.py
@@ -17,7 +17,9 @@ def test_last_migration_minimum_version() -> None:
     )
 
 
-def test_no_duplicate_migration_minimum_versions() -> None:
-    minimum_versions = [m.init().minimum_version for m in MIGRATIONS]
-    duplicate_versions = [v for v in minimum_versions if minimum_versions.count(v) > 1]
-    assert not duplicate_versions, f"Duplicate minimum_version values found: {sorted(set(duplicate_versions))}"
+def test_no_duplicate_migration_minimum_versions_and_number() -> None:
+    minimum_versions = [(m.init().minimum_version, m.init().number) for m in MIGRATIONS]
+    duplicate_versions = [(v, n) for v, n in minimum_versions if minimum_versions.count((v, n)) > 1]
+    assert not duplicate_versions, (
+        f"Duplicate minimum_version and number values found: {sorted(set(duplicate_versions))}"
+    )

--- a/backend/tests/unit/core/graph/test_graph_version.py
+++ b/backend/tests/unit/core/graph/test_graph_version.py
@@ -3,9 +3,10 @@ from infrahub.core.migrations.graph import MIGRATIONS
 
 
 def test_graph_version_matches_migration_count() -> None:
-    assert len(MIGRATIONS) == GRAPH_VERSION, (
+    last = MIGRATIONS[-1].init()
+    assert last.number == GRAPH_VERSION, (
         f"GRAPH_VERSION ({GRAPH_VERSION}) must equal to the number of migrations "
-        f"({len(MIGRATIONS)}). Update GRAPH_VERSION or add/remove a migration."
+        f"({last.number}). Update GRAPH_VERSION or add/remove a migration."
     )
 
 


### PR DESCRIPTION
# Why

Adds a safety net to catch version drift between `GRAPH_VERSION` and the graph migration list. Without this, it's possible to add a migration without bumping `GRAPH_VERSION` (or vice versa) and have no automated signal that the two are out of sync.

## How to test

```bash
uv run pytest backend/tests/unit/core/graph/test_graph_version.py -v
```

To verify the tests actually catch drift, temporarily set `GRAPH_VERSION` in `backend/infrahub/core/graph/__init__.py` and re-run — both tests should fail with descriptive messages.

## Checklist

- [x] Tests added/updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests to catch graph-version drift (IFC-2440). The tests ensure `GRAPH_VERSION` matches the latest migration `number`, the last migration’s `minimum_version` is `GRAPH_VERSION - 1`, and there are no duplicate `(minimum_version, number)` pairs in the migration list.

<sup>Written for commit 3a15f9f42c30eceae98424552dd5fc7f12dada39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

