### PR TITLE
Fix event display label for computed attribute and hfid mutations

### DIFF
--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -83,7 +83,7 @@ class UpdateComputedAttribute(Mutation):
                 kind=node_schema.kind,
                 id=str(data.id),
                 branch=graphql_context.branch,
-                fields={target_attribute.name: None},
+                fields={target_attribute.name: None, "display_label": None},
             )
         ):
             raise NodeNotFoundError(

--- a/backend/infrahub/graphql/mutations/hfid.py
+++ b/backend/infrahub/graphql/mutations/hfid.py
@@ -86,7 +86,7 @@ class UpdateHFID(Mutation):
                 kind=node_schema.kind,
                 id=str(data.id),
                 branch=graphql_context.branch,
-                fields={"human_friendly_id": None},
+                fields={"human_friendly_id": None, "display_label": None},
             )
         ):
             raise NodeNotFoundError(

--- a/backend/tests/component/graphql/mutations/test_computed_attribute.py
+++ b/backend/tests/component/graphql/mutations/test_computed_attribute.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.account import ObjectPermission
+from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.events.node_action import NodeUpdatedEvent
+from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from tests.adapters.event import MemoryInfrahubEvent
+from tests.helpers.graphql import graphql
+from tests.helpers.permissions import define_permissions
+from tests.helpers.schema import COLOR, TSHIRT, load_schema
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+UPDATE_COMPUTED_ATTRIBUTE_MUTATION = """
+mutation UpdateComputed($id: String!, $kind: String!, $attribute: String!, $value: String!) {
+    InfrahubUpdateComputedAttribute(data: {id: $id, kind: $kind, attribute: $attribute, value: $value}) {
+        ok
+    }
+}
+"""
+
+
+async def test_update_computed_attribute_sends_node_updated_event(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    default_permission_backend: None,
+    session_first_account: AccountSession,
+    first_account: Node,
+) -> None:
+    """UpdateComputedAttribute emits a NodeUpdatedEvent with the correct node, fields and display_label."""
+    await load_schema(db, schema=SchemaRoot(nodes=[COLOR, TSHIRT]))
+
+    await define_permissions(
+        account=first_account,
+        db=db,
+        object_permissions=[
+            ObjectPermission(
+                namespace=TSHIRT.namespace,
+                name=TSHIRT.name,
+                action=PermissionAction.UPDATE.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ],
+    )
+
+    color = await Node.init(db=db, schema=COLOR.kind, branch=default_branch)
+    await color.new(db=db, name="Blue", description="A vibrant blue")
+    await color.save(db=db)
+
+    tshirt = await Node.init(db=db, schema=TSHIRT.kind, branch=default_branch)
+    await tshirt.new(db=db, name="Ocean", color=color)
+    await tshirt.save(db=db)
+
+    assert tshirt.description.value == "A Blue Ocean t-shirt. A vibrant blue"
+
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, service=service, account_session=session_first_account
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_COMPUTED_ATTRIBUTE_MUTATION,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": tshirt.id,
+            "kind": TSHIRT.kind,
+            "attribute": "description",
+            "value": "A Blue Ocean t-shirt. A vibrant blue - updated",
+        },
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["InfrahubUpdateComputedAttribute"]["ok"] is True
+
+    assert len(memory_event.events) == 1
+    event = memory_event.events[0]
+    assert isinstance(event, NodeUpdatedEvent)
+    assert event.node_id == tshirt.id
+    assert event.kind == TSHIRT.kind
+    assert "description" in event.fields
+    # The display label of the node within the event must include the correct label
+    # even if the display label contains a related node
+    assert event.changelog.display_label == "Ocean Blue"

--- a/backend/tests/component/graphql/mutations/test_hfid.py
+++ b/backend/tests/component/graphql/mutations/test_hfid.py
@@ -10,6 +10,7 @@ from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.database import InfrahubDatabase
+from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from tests.adapters.event import MemoryInfrahubEvent
@@ -175,6 +176,77 @@ query MyTShirt($id: ID!) {
     }
 }
 """
+
+
+async def test_update_hfid_sends_node_updated_event(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+    default_permission_backend: None,
+    session_first_account: AccountSession,
+    first_account: Node,
+) -> None:
+    """UpdateHFID emits a NodeUpdatedEvent whose changelog contains the correct display label,
+    even when the display label template references attributes on the far side of a relationship."""
+    schema_root = SchemaRoot(nodes=[COLOR, TSHIRT])
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    await define_permissions(
+        account=first_account,
+        db=db,
+        global_permissions=[
+            GlobalPermission(
+                action=GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            )
+        ],
+        object_permissions=[
+            ObjectPermission(
+                namespace=TSHIRT.namespace,
+                name=TSHIRT.name,
+                action=PermissionAction.UPDATE.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ],
+    )
+
+    color = await Node.init(db=db, schema=COLOR.kind)
+    await color.new(db=db, name="Blue", description="A vibrant blue")
+    await color.save(db=db)
+
+    tshirt = await Node.init(db=db, schema=TSHIRT.kind)
+    await tshirt.new(db=db, name="Ocean", color=color)
+    await tshirt.save(db=db)
+
+    # TSHIRT.display_label is "{{ name__value }} {{ color__name__value }}"
+    # so display_label traverses the relationship to the color node
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, account_session=session_first_account, service=service
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_HFID,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": tshirt.get_id(), "kind": TSHIRT.kind, "value": ["Space"]},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["InfrahubUpdateHFID"]["ok"] is True
+
+    assert len(memory_event.events) == 1
+    event = memory_event.events[0]
+    assert isinstance(event, NodeUpdatedEvent)
+    assert event.node_id == tshirt.id
+    assert event.kind == TSHIRT.kind
+    assert "human_friendly_id" in event.fields
+    # The display label in the changelog must reflect the relationship traversal
+    assert event.changelog.display_label == "Ocean Blue"
 
 
 async def test_create_nodes_with_relational_hfids(

--- a/changelog/8837.fixed.md
+++ b/changelog/8837.fixed.md
@@ -1,0 +1,1 @@
+Correct the display label on events sent from the mutations to update computed attributes and HFIDs when the display label contains attributes from related nodes.


### PR DESCRIPTION
# Why

The display label of the changelog within the events sent by the mutations to update the HFID or a computed attribute could be incorrect depending on the schema.

Fixes #8837.

## What changed

* Ensure that we include "display_label" within the query to get the node
* Add tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect display labels in NodeUpdatedEvent changelogs from computed-attribute and HFID mutations. Labels now resolve relationship-based fields per schema (e.g., "Ocean Blue"); addresses Linear IFC-2444.

- **Bug Fixes**
  - Include "display_label" in node field selection for both mutations.
  - Add tests verifying correct display label and fields in emitted events.

<sup>Written for commit c1c5c38549419d0ea7bc0641c00c927944dfe930. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

