### PR TITLE
Fix node changelog on changes to password attributes

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -55,16 +55,19 @@ class AttributeChangelog(BaseModel):
         default_factory=dict, description="The properties that were updated during this update"
     )
     kind: str = Field(..., description="The attribute kind")
+    _sensitive_value_changed: bool = PrivateAttr(default=False)
 
     @computed_field
     def value_update_status(self) -> DiffAction:
         """Indicate how the peer was changed during this update"""
-        if self.value == self.value_previous:
-            return DiffAction.UNCHANGED
         if self.value_previous is not None and self.value is None:
             return DiffAction.REMOVED
         if self.value_previous is None and self.value is not None:
             return DiffAction.ADDED
+        if self.kind in ["HashedPassword", "Password"] and self._sensitive_value_changed:
+            return DiffAction.UPDATED
+        if self.value == self.value_previous:
+            return DiffAction.UNCHANGED
 
         return DiffAction.UPDATED
 
@@ -99,6 +102,7 @@ class AttributeChangelog(BaseModel):
     @model_validator(mode="after")
     def filter_sensitive(self) -> Self:
         if self.kind in ["HashedPassword", "Password"]:
+            self._sensitive_value_changed = self.value != self.value_previous
             if self.value is not None:
                 self.value = "***"
             if self.value_previous is not None:

--- a/backend/tests/unit/core/changelog/test_models.py
+++ b/backend/tests/unit/core/changelog/test_models.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from infrahub.core.changelog.models import AttributeChangelog
+from infrahub.core.constants import DiffAction
+
+
+@dataclass
+class SensitiveAttributeTestCase:
+    name: str
+    kind: str
+    value: Any
+    value_previous: Any
+    expected_status: DiffAction
+    expected_has_updates: bool
+
+
+SENSITIVE_ATTRIBUTE_TEST_CASES: list[SensitiveAttributeTestCase] = [
+    SensitiveAttributeTestCase(
+        name="hashed_password_changed",
+        kind="HashedPassword",
+        value="new_secret",
+        value_previous="old_secret",
+        expected_status=DiffAction.UPDATED,
+        expected_has_updates=True,
+    ),
+    SensitiveAttributeTestCase(
+        name="hashed_password_unchanged",
+        kind="HashedPassword",
+        value="same_secret",
+        value_previous="same_secret",
+        expected_status=DiffAction.UNCHANGED,
+        expected_has_updates=False,
+    ),
+    SensitiveAttributeTestCase(
+        name="hashed_password_added",
+        kind="HashedPassword",
+        value="new_secret",
+        value_previous=None,
+        expected_status=DiffAction.ADDED,
+        expected_has_updates=True,
+    ),
+    SensitiveAttributeTestCase(
+        name="hashed_password_removed",
+        kind="HashedPassword",
+        value=None,
+        value_previous="old_secret",
+        expected_status=DiffAction.REMOVED,
+        expected_has_updates=True,
+    ),
+    SensitiveAttributeTestCase(
+        name="password_changed",
+        kind="Password",
+        value="new_secret",
+        value_previous="old_secret",
+        expected_status=DiffAction.UPDATED,
+        expected_has_updates=True,
+    ),
+    SensitiveAttributeTestCase(
+        name="password_unchanged",
+        kind="Password",
+        value="same_secret",
+        value_previous="same_secret",
+        expected_status=DiffAction.UNCHANGED,
+        expected_has_updates=False,
+    ),
+    SensitiveAttributeTestCase(
+        name="password_added",
+        kind="Password",
+        value="new_secret",
+        value_previous=None,
+        expected_status=DiffAction.ADDED,
+        expected_has_updates=True,
+    ),
+    SensitiveAttributeTestCase(
+        name="password_removed",
+        kind="Password",
+        value=None,
+        value_previous="old_secret",
+        expected_status=DiffAction.REMOVED,
+        expected_has_updates=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in SENSITIVE_ATTRIBUTE_TEST_CASES],
+)
+def test_sensitive_attribute_update_status(test_case: SensitiveAttributeTestCase) -> None:
+    attr = AttributeChangelog(
+        name="password",
+        value=test_case.value,
+        value_previous=test_case.value_previous,
+        kind=test_case.kind,
+    )
+
+    assert attr.value_update_status == test_case.expected_status
+    assert attr.has_updates == test_case.expected_has_updates

--- a/changelog/6909.fixed.md
+++ b/changelog/6909.fixed.md
@@ -1,0 +1,1 @@
+Ensure that changes to a password attribute counts as a mutation event for a node.


### PR DESCRIPTION
# Why

Node mutations where we only changed a password attribute for example the secret_key of a webhook didn't get registered as a change event for the node due to the fact that we were masking the password values so both the new and previous password looked identical `***`, this could cause some problems with the changelog and when a mutation event gets sent which can impact things like webhook reconfiguration or just webhooks in general if someone wants to trigger on these fields.

Closes #6909.

## What changed

* Update to the node changelog to correctly register changes for these sensitive attributes
* Add tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes node changelog so changes to password-like attributes are registered as updates and emit mutation events. Prevents missed triggers when secrets (e.g., webhook keys) change.

- **Bug Fixes**
  - For `Password` and `HashedPassword`, compare values before masking via a private flag so `value_update_status` returns `UPDATED` and `has_updates` is true when they change; ADDED/REMOVED remain accurate and values stay masked.
  - Added unit tests covering changed/unchanged/added/removed and `has_updates`, plus a changelog entry.

<sup>Written for commit f487f5938cfe664f7981a558975bcfdd9ff01a15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

