### PR TITLE
Raise version to 1.9.0 beta 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.8.4"
+version = "1.9.b0"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.8.4"
+version = "1.9.b0"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.4"
+version = "1.9b0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.8.4"
+version = "1.9b0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

* Prepare for Infrahub 1.9 beta 0

## What changed

* Version changes in pyproject.toml and uv.lock files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare for the Infrahub 1.9 beta release by bumping `infrahub-server` and `infrahub-testcontainers` to 1.9b0. Updated `pyproject.toml` and `uv.lock` in the root and `python_testcontainers` to align versions for the beta.

<sup>Written for commit 9bf7559f8543c6de1ba0de5c86afed8fbc9a00d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

