### PR TITLE
Bump version to Infrahub 1.9.0beta0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.8.4"
+version = "1.9.0b0"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.8.4"
+version = "1.9.0b0"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.4"
+version = "1.9.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.8.4"
+version = "1.9.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

Prepare Infrahub 1.9.0 beta 0

## What changed

* Bump versions in pyproject.toml and uv.lock files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the 1.9.0 beta 0 release by bumping `infrahub-server` and `infrahub-testcontainers` to 1.9.0b0 and syncing `uv.lock` entries. No functional changes.

<sup>Written for commit b3d861c58ebcddb1402e8b75ce6d51c1f4c86d25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

