### PR TITLE
Fix false-positive conflict detection in git sync

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -541,34 +541,49 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         raise NotImplementedError()
 
     def has_conflicting_changes(self, target_branch: str, source_branch: str) -> bool:
-        """Use merge tree to spot conflicts and tell if there is any."""
+        """Check if merging source_branch into target_branch would produce conflicts.
+
+        Uses the modern ``git merge-tree --write-tree`` form (git 2.38+) which
+        returns exit code 0 for a clean merge and exit code 1 for conflicts,
+        avoiding false positives from naive string matching of conflict markers
+        in file content.
+        """
         repo = self.get_git_repo_main()
 
         if repo.remotes:
-            # Ensure we have the latest changes from the remote
-            info = repo.remotes.origin.fetch(source_branch)
-
-            target = repo.branches[target_branch]
-            source = repo.commit(info[0].ref)
-
-            merge_base = repo.merge_base(target.commit, source)[0]
-            merge_tree_output = repo.git.merge_tree(merge_base.hexsha, target.commit.hexsha, source.hexsha)
+            repo.remotes.origin.fetch(source_branch)
+            source_ref = f"origin/{source_branch}"
         else:
-            target = repo.branches[target_branch]
-            source = repo.branches[source_branch]
+            source_ref = source_branch
 
-            merge_base = repo.merge_base(target.commit, source)[0]
-            merge_tree_output = repo.git.merge_tree(merge_base.hexsha, target.commit.hexsha, source.commit.hexsha)
+        target_ref = target_branch
 
-        log.debug(
-            f"Merging {source_branch} into {target_branch} will bring changes",
-            repository=self.name,
-            source=source_branch,
-            target=target_branch,
-            merge_structure=merge_tree_output,
-        )
-
-        return any(marker in merge_tree_output for marker in ("<<<<<<<", "=======", ">>>>>>>"))
+        try:
+            repo.git.merge_tree("--write-tree", target_ref, source_ref)
+            log.debug(
+                f"Merging {source_branch} into {target_branch} has no conflicts",
+                repository=self.name,
+                source=source_branch,
+                target=target_branch,
+            )
+            return False
+        except GitCommandError as exc:
+            if exc.status == 1:
+                log.debug(
+                    f"Merging {source_branch} into {target_branch} would produce conflicts",
+                    repository=self.name,
+                    source=source_branch,
+                    target=target_branch,
+                )
+                return True
+            log.error(
+                f"Unexpected error running git merge-tree for {source_branch} into {target_branch}",
+                repository=self.name,
+                source=source_branch,
+                target=target_branch,
+                error=str(exc),
+            )
+            raise
 
     async def update_commit_value(self, branch_name: str, commit: str) -> bool:
         """Compare the value of the commit in the graph with the current commit on the filesystem.
@@ -828,7 +843,18 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             return False
 
         # Make sure the branch won't conflict on merge
-        if self.has_conflicting_changes(target_branch=self.default_branch, source_branch=branch_name):
+        try:
+            has_conflicts = self.has_conflicting_changes(target_branch=self.default_branch, source_branch=branch_name)
+        except GitCommandError as exc:
+            log.error(
+                "Unable to determine merge conflicts for branch",
+                branch=branch_name,
+                repository=self.name,
+                error=str(exc),
+            )
+            return False
+
+        if has_conflicts:
             get_run_logger().warning(
                 f"Remote branch {branch_name} will cause conflicts, they need to be resolved before importing the branch into Infrahub"
             )

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -350,28 +350,6 @@ async def test_has_conflicting_changes(git_repos_source_dir_module_scope: Path) 
     assert repository.has_conflicting_changes(target_branch="main", source_branch="change1")
 
 
-async def test_has_conflicting_changes_no_false_positive(
-    git_repos_source_dir_module_scope: Path,
-) -> None:
-    """has_conflicting_changes() should not report false positives when
-    file content contains conflict marker characters like '======='."""
-    registry._default_branch = "main"
-
-    test_repo = MultipleStagesFileRepo(
-        name="false-positive-conflicts", sources_directory=git_repos_source_dir_module_scope
-    )
-    repository = await InfrahubRepository.new(
-        id=UUIDT.new(),
-        name=test_repo.name,
-        location=test_repo.path,
-        default_branch_name="main",
-        client=InfrahubClient(config=Config(requester=dummy_async_request)),
-    )
-
-    # The branch adds a file containing ======= but has no actual conflicts with main
-    assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")
-
-
 async def test_pull_branch(git_repo_04: InfrahubRepository) -> None:
     repo = git_repo_04
     await repo.fetch()

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -350,6 +350,28 @@ async def test_has_conflicting_changes(git_repos_source_dir_module_scope: Path) 
     assert repository.has_conflicting_changes(target_branch="main", source_branch="change1")
 
 
+async def test_has_conflicting_changes_no_false_positive(
+    git_repos_source_dir_module_scope: Path,
+) -> None:
+    """has_conflicting_changes() should not report false positives when
+    file content contains conflict marker characters like '======='."""
+    registry._default_branch = "main"
+
+    test_repo = MultipleStagesFileRepo(
+        name="false-positive-conflicts", sources_directory=git_repos_source_dir_module_scope
+    )
+    repository = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name=test_repo.name,
+        location=test_repo.path,
+        default_branch_name="main",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+
+    # The branch adds a file containing ======= but has no actual conflicts with main
+    assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")
+
+
 async def test_pull_branch(git_repo_04: InfrahubRepository) -> None:
     repo = git_repo_04
     await repo.fetch()

--- a/backend/tests/fixtures/repos/false-positive-conflicts/initial__main/commit1/test.gql
+++ b/backend/tests/fixtures/repos/false-positive-conflicts/initial__main/commit1/test.gql
@@ -1,0 +1,10 @@
+query tags {
+  BuiltinTag {
+    edges {
+      node {
+        id
+        hfid
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/false-positive-conflicts/pr_0001__change1/commit1/separator.md
+++ b/backend/tests/fixtures/repos/false-positive-conflicts/pr_0001__change1/commit1/separator.md
@@ -1,0 +1,12 @@
+# Table of data
+
+| Header 1 | Header 2 |
+|==========|==========|
+| value1   | value2   |
+
+=======
+
+## Section separator
+
+This file contains ======= as literal content.
+It should NOT trigger a false positive in conflict detection.

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
+
+from infrahub import config
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from tests.helpers.file_repo import MultipleStagesFileRepo
+from tests.helpers.test_client import dummy_async_request
+
+
+async def test_has_conflicting_changes_no_false_positive(
+    tmp_path: Path,
+) -> None:
+    """has_conflicting_changes() should not report false positives when
+    file content contains conflict marker characters like '======='."""
+    old_default_branch = getattr(registry, "_default_branch", None)
+    old_repos_dir = config.SETTINGS.git.repositories_directory
+
+    try:
+        registry._default_branch = "main"
+
+        repos_dir = tmp_path / "repositories"
+        repos_dir.mkdir()
+        config.SETTINGS.git.repositories_directory = str(repos_dir)
+
+        sources_dir = tmp_path / "source"
+        sources_dir.mkdir()
+
+        test_repo = MultipleStagesFileRepo(name="false-positive-conflicts", sources_directory=sources_dir)
+        repository = await InfrahubRepository.new(
+            id=UUIDT.new(),
+            name=test_repo.name,
+            location=test_repo.path,
+            default_branch_name="main",
+            client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        )
+
+        # The branch adds a file containing ======= but has no actual conflicts with main
+        assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")
+    finally:
+        config.SETTINGS.git.repositories_directory = old_repos_dir
+        if old_default_branch is not None:
+            registry._default_branch = old_default_branch

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,5 +1,8 @@
+import os
+from collections.abc import Generator
 from pathlib import Path
 
+import pytest
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 
@@ -10,36 +13,62 @@ from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
 
-async def test_has_conflicting_changes_no_false_positive(
-    tmp_path: Path,
-) -> None:
-    """has_conflicting_changes() should not report false positives when
-    file content contains conflict marker characters like '======='."""
+@pytest.fixture
+def git_identity() -> Generator[None, None, None]:
+    """Ensure git author/committer identity is set for environments without global git config (e.g. CI)."""
+    env_vars = ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL")
+    original = {var: os.environ.get(var) for var in env_vars}
+
+    os.environ["GIT_AUTHOR_NAME"] = "Test"
+    os.environ["GIT_AUTHOR_EMAIL"] = "test@test.com"
+    os.environ["GIT_COMMITTER_NAME"] = "Test"
+    os.environ["GIT_COMMITTER_EMAIL"] = "test@test.com"
+
+    yield
+
+    for var, value in original.items():
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+
+
+@pytest.fixture
+def git_repo_environment(tmp_path: Path) -> Generator[Path, None, None]:
+    """Set up repositories directory and default branch for git tests."""
     old_default_branch = getattr(registry, "_default_branch", None)
     old_repos_dir = config.SETTINGS.git.repositories_directory
 
-    try:
-        registry._default_branch = "main"
+    registry._default_branch = "main"
 
-        repos_dir = tmp_path / "repositories"
-        repos_dir.mkdir()
-        config.SETTINGS.git.repositories_directory = str(repos_dir)
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    config.SETTINGS.git.repositories_directory = str(repos_dir)
 
-        sources_dir = tmp_path / "source"
-        sources_dir.mkdir()
+    yield tmp_path
 
-        test_repo = MultipleStagesFileRepo(name="false-positive-conflicts", sources_directory=sources_dir)
-        repository = await InfrahubRepository.new(
-            id=UUIDT.new(),
-            name=test_repo.name,
-            location=test_repo.path,
-            default_branch_name="main",
-            client=InfrahubClient(config=Config(requester=dummy_async_request)),
-        )
+    config.SETTINGS.git.repositories_directory = old_repos_dir
+    if old_default_branch is not None:
+        registry._default_branch = old_default_branch
 
-        # The branch adds a file containing ======= but has no actual conflicts with main
-        assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")
-    finally:
-        config.SETTINGS.git.repositories_directory = old_repos_dir
-        if old_default_branch is not None:
-            registry._default_branch = old_default_branch
+
+async def test_has_conflicting_changes_no_false_positive(
+    git_identity: None,
+    git_repo_environment: Path,
+) -> None:
+    """has_conflicting_changes() should not report false positives when
+    file content contains conflict marker characters like '======='."""
+    sources_dir = git_repo_environment / "source"
+    sources_dir.mkdir()
+
+    test_repo = MultipleStagesFileRepo(name="false-positive-conflicts", sources_directory=sources_dir)
+    repository = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name=test_repo.name,
+        location=test_repo.path,
+        default_branch_name="main",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+
+    # The branch adds a file containing ======= but has no actual conflicts with main
+    assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")

--- a/changelog/8848.fixed.md
+++ b/changelog/8848.fixed.md
@@ -1,0 +1,1 @@
+Fix false-positive conflict detection during git sync caused by naive string matching of conflict markers in file content.


### PR DESCRIPTION
## Summary

- Replace the old 3-way `merge-tree` + conflict-marker string matching with the modern `git merge-tree --write-tree` form (git 2.38+), which uses exit codes to reliably detect conflicts instead of scanning output for `<<<<<<<`/`=======`/`>>>>>>>` strings
- Wrap `has_conflicting_changes` in `validate_remote_branch` with a try/except so an unexpected git error on one branch doesn't abort the entire sync cycle
- Add a test with a fixture repo whose file content contains `=======` to verify no false positive

Fixes #8848

## Test plan

- [x] Existing `test_has_conflicting_changes` still passes (real conflicts detected)
- [x] New `test_has_conflicting_changes_no_false_positive` passes (no false positive on marker-like content)
- [x] Verified on live instance that the sync issue is resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false-positive conflict detection in git sync by switching to `git merge-tree --write-tree` and hardening branch validation. Adds a unit test to ensure files with "=======" don't trigger conflicts and stabilizes tests in CI.

- **Bug Fixes**
  - Use `git merge-tree --write-tree` (git 2.38+) and rely on exit codes instead of scanning conflict markers.
  - Wrap conflict check in `validate_remote_branch` with try/except so a git error on one branch doesn’t stop the sync cycle.
  - Add fixture repo and unit test; add CI fixtures for git identity and repo env; restore `registry._default_branch` and `repositories_directory`; add changelog entry.

<sup>Written for commit 22abf6e5d98dd44023f3cca208c949afaf8cf0b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

