### PR TITLE
chore(ci): version upgrade from 1.8

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -6,6 +6,9 @@ ci_config: &ci_config
 github_workflows: &github_workflows
   - ".github/workflows/*.yml"
 
+version_upgrade_workflow:
+  - ".github/workflows/version-upgrade.yml"
+
 development_files: &development_files
   - "development/**"
   - "tasks/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       yaml: ${{ steps.changes.outputs.yaml_all }}
       infrahub_uv_files: ${{ steps.changes.outputs.infrahub_uv_files }}
       github_workflows: ${{ steps.changes.outputs.github_workflows }}
+      version_upgrade_workflow: ${{ steps.changes.outputs.version_upgrade_workflow }}
       e2e_tests: ${{ steps.changes.outputs.e2e_test_files }}
       testcontainers: ${{ steps.changes.outputs.testcontainers_files }}
       openapi_schema: ${{ steps.changes.outputs.openapi_schema_all }}
@@ -1286,7 +1287,8 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      needs.files-changed.outputs.e2e == 'true'
+      (needs.files-changed.outputs.e2e == 'true' ||
+      needs.files-changed.outputs.version_upgrade_workflow == 'true')
     uses: ./.github/workflows/version-upgrade.yml
 
   # ------------------------------------------ Benchmarks ------------------------------------------------

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -37,12 +37,12 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - name: From 1.7.0
-            source_version: 1.7.0
+          - name: From 1.8.0
+            source_version: 1.8.0
             neo4j_image: "neo4j:2025.10.1-enterprise"
             redis_image: "redis:8.4.0"
             rabbitmq_image: "rabbitmq:4.2.1-management"
-            postgres_image: "pgautoupgrade/pgautoupgrade:18-alpine"
+            postgres_image: "postgres:18-alpine"
             postgres_datadir: "/var/lib/postgresql/18/data"
     name: ${{ matrix.name }}
     runs-on:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the CI version-upgrade workflow to test upgrades starting from 1.8.0 instead of 1.7.0. Also switch the Postgres container to the official `postgres:18-alpine` image in the matrix.

<sup>Written for commit 9f9c1765eade3a46e260bed6340fd1740b8b7a87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

