### PR TITLE
Forbid to null an attribute with a default_value in the schema

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -617,6 +617,8 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                 value_to_set = self.schema.convert_value_to_enum(data["value"])
             else:
                 value_to_set = data["value"]
+            if value_to_set is None and self.schema.default_value is not None:
+                raise ValidationError({self.name: f"'{self.name}' has a default value and cannot be set to null"})
             if value_to_set != self.value:
                 self.value = value_to_set
                 changed = True

--- a/backend/tests/component/graphql/test_mutation_update.py
+++ b/backend/tests/component/graphql/test_mutation_update.py
@@ -1764,3 +1764,36 @@ async def test_updating_relationship_when_peer_side_is_optional(
     updated_dog2 = updated_nodes[dog2.id]
     best_friend = await updated_dog2.best_friend.get(db=db)
     assert best_friend.peer_id == person1.id
+
+
+async def test_update_null_value_rejected_for_attribute_with_default(
+    db: InfrahubDatabase, person_john_main: Node, car_accord_main: Node, branch: Branch
+) -> None:
+    """Setting an attribute with a default_value to null via update must be rejected."""
+    query = """
+    mutation {
+        TestCarUpdate(data: {id: "%s", color: { value: null }}) {
+            ok
+            object {
+                color {
+                    value
+                }
+            }
+        }
+    }
+    """ % (car_accord_main.id)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors
+    assert any("has a default value and cannot be set to null" in e.message for e in result.errors)
+
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    assert car.color.value == "#444444"

--- a/backend/tests/component/graphql/test_mutation_upsert.py
+++ b/backend/tests/component/graphql/test_mutation_upsert.py
@@ -857,6 +857,39 @@ async def test_upsert_preserves_relationship_display_label_and_hfid(
     assert result_upsert.data["TestingTShirtUpsert"]["object"]["hfid"] == ["Classic", "Red"]
 
 
+async def test_upsert_null_value_rejected_for_attribute_with_default(
+    db: InfrahubDatabase, person_john_main: Node, car_accord_main: Node, branch: Branch
+) -> None:
+    """Setting an attribute with a default_value to null via upsert (update path) must be rejected."""
+    query = """
+    mutation {
+        TestCarUpsert(data: {id: "%s", name: { value: "accord" }, color: { value: null }}) {
+            ok
+            object {
+                color {
+                    value
+                }
+            }
+        }
+    }
+    """ % (car_accord_main.id)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors
+    assert any("has a default value and cannot be set to null" in e.message for e in result.errors)
+
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    assert car.color.value == "#444444"
+
+
 def _basic_asserts(result_upsert: ExecutionResult) -> None:
     assert result_upsert.errors is None
     assert result_upsert.data

--- a/changelog/+87f8df7a.changed.md
+++ b/changelog/+87f8df7a.changed.md
@@ -1,0 +1,1 @@
+Updated mutation logic to forbid to update an attribute to a `null` value if that attribute has a default_value assigned in the schema.


### PR DESCRIPTION
# Why

Currently Infrahub will update the mandatory/optional properties of an attribute if that attribute has a default_value assigned in the schema. Because we do this it also means that we'd allow that attribute to be updated to have a `null` value. On creation it would still have a default value but after the fact we can update it to a `null` value which is not always what a user would expect.

With some additional validations we will instead look at fixing this behaviour within Infrahub. For now this PR will assume that the intention of these attributes is to disallow updates that would set a `null` value.

## What changed

* Extra validation to raise an error if a user tries to violate this
* Tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent updates that set an attribute with a schema `default_value` to null, so these attributes can’t be nulled after creation. This avoids unexpected nulls and keeps updates aligned with schema intent.

- **Bug Fixes**
  - Added validation to reject `value: null` when the attribute has a `default_value`.
  - Added GraphQL tests for update and upsert to ensure errors are raised and existing values are preserved.

<sup>Written for commit 2cd8046d78e812624fd907e7a6e2befebf23f61c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

