### PR TITLE
Fix event filter prefix

### DIFF
--- a/backend/infrahub/task_manager/models.py
+++ b/backend/infrahub/task_manager/models.py
@@ -19,7 +19,7 @@ from prefect.events.schemas.events import ResourceSpecification
 from pydantic import BaseModel, Field
 
 from infrahub.core.timestamp import Timestamp
-from infrahub.events.constants import EventSortOrder
+from infrahub.events.constants import EVENT_NAMESPACE, EventSortOrder
 
 from .constants import LOG_LEVEL_MAPPING
 
@@ -161,7 +161,7 @@ class InfrahubEventFilter(EventFilter):
         if event_type:
             self.event = EventNameFilter(name=event_type)
         elif not event_type and exclude_prefixes:
-            self.event = EventNameFilter(exclude_prefix=exclude_prefixes)
+            self.event = EventNameFilter(prefix=[f"{EVENT_NAMESPACE}."], exclude_prefix=exclude_prefixes)
 
     def add_primary_node_filter(self, primary_node__ids: list[str] | None) -> None:
         if primary_node__ids:

--- a/backend/tests/unit/task_manager/test_models.py
+++ b/backend/tests/unit/task_manager/test_models.py
@@ -1,0 +1,28 @@
+from infrahub.task_manager.models import InfrahubEventFilter
+
+
+class TestInfrahubEventFilter:
+    def test_add_event_type_filter_with_exclude_prefixes_only(self) -> None:
+        """When only exclude_prefixes is provided, the filter should scope to the infrahub namespace prefix."""
+        event_filter = InfrahubEventFilter()
+        event_filter.add_event_type_filter(exclude_prefixes=["infrahub.account."])
+
+        assert event_filter.event is not None
+        assert event_filter.event.prefix == ["infrahub."]
+        assert event_filter.event.exclude_prefix == ["infrahub.account."]
+
+    def test_add_event_type_filter_with_event_type_only(self) -> None:
+        """When event_type is provided, it takes priority and no prefix is set."""
+        event_filter = InfrahubEventFilter()
+        event_filter.add_event_type_filter(event_type=["infrahub.branch.created"])
+
+        assert event_filter.event is not None
+        assert event_filter.event.name == ["infrahub.branch.created"]
+        assert not event_filter.event.prefix
+
+    def test_add_event_type_filter_with_no_args(self) -> None:
+        """When no arguments are provided, the event filter is not set."""
+        event_filter = InfrahubEventFilter()
+        event_filter.add_event_type_filter()
+
+        assert event_filter.event is None


### PR DESCRIPTION
# Why

Event filter should return `infrahub.*` events only if no event type is set.

## How to test

```bash
pytest -v backend/tests/unit/task_manager/test_models.py
```

## Checklist

- [x] Tests added/updated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope event filtering to `infrahub.*` when no `event_type` is provided to prevent non-Infrahub events from matching. Added unit tests for prefix behavior, explicit type taking priority, and no-arg case.

<sup>Written for commit de91a0b6dce5eccce8d17c8c92c8db1dfa0210b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

