### PR TITLE
Small updates to git test

### DIFF
--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def git_identity() -> None:
+    """Ensure git author/committer identity is set for environments without global git config (e.g. CI)."""
+    defaults = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    }
+    for var, value in defaults.items():
+        if var not in os.environ:
+            os.environ[var] = value

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,5 +1,3 @@
-import os
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -13,52 +11,18 @@ from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
 
-@pytest.fixture
-def git_identity() -> Generator[None, None, None]:
-    """Ensure git author/committer identity is set for environments without global git config (e.g. CI)."""
-    env_vars = ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL")
-    original = {var: os.environ.get(var) for var in env_vars}
-
-    os.environ["GIT_AUTHOR_NAME"] = "Test"
-    os.environ["GIT_AUTHOR_EMAIL"] = "test@test.com"
-    os.environ["GIT_COMMITTER_NAME"] = "Test"
-    os.environ["GIT_COMMITTER_EMAIL"] = "test@test.com"
-
-    yield
-
-    for var, value in original.items():
-        if value is None:
-            os.environ.pop(var, None)
-        else:
-            os.environ[var] = value
-
-
-@pytest.fixture
-def git_repo_environment(tmp_path: Path) -> Generator[Path, None, None]:
-    """Set up repositories directory and default branch for git tests."""
-    old_default_branch = getattr(registry, "_default_branch", None)
-    old_repos_dir = config.SETTINGS.git.repositories_directory
-
-    registry._default_branch = "main"
-
-    repos_dir = tmp_path / "repositories"
-    repos_dir.mkdir()
-    config.SETTINGS.git.repositories_directory = str(repos_dir)
-
-    yield tmp_path
-
-    config.SETTINGS.git.repositories_directory = old_repos_dir
-    if old_default_branch is not None:
-        registry._default_branch = old_default_branch
-
-
 async def test_has_conflicting_changes_no_false_positive(
-    git_identity: None,
-    git_repo_environment: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """has_conflicting_changes() should not report false positives when
     file content contains conflict marker characters like '======='."""
-    sources_dir = git_repo_environment / "source"
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    monkeypatch.setattr(config.SETTINGS.git, "repositories_directory", str(repos_dir))
+
+    sources_dir = tmp_path / "source"
     sources_dir.mkdir()
 
     test_repo = MultipleStagesFileRepo(name="false-positive-conflicts", sources_directory=sources_dir)
@@ -69,6 +33,10 @@ async def test_has_conflicting_changes_no_false_positive(
         default_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
+
+    # Confirm the diff between the branches actually contains ======= to validate the test premise
+    diff = test_repo.repo.git.diff("main", "change1")
+    assert "=======" in diff
 
     # The branch adds a file containing ======= but has no actual conflicts with main
     assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")


### PR DESCRIPTION
# Why

Small cleanup to remove some overhead within git unit tests

## What changed

* Create an autouse fixture for git identities to avoid having to add the same fixture to future git unittests
* git_repo_environment and favor local overrides directly in the test

## Other notes

* We're looking at some larger refactoring for the way the git integration works, with that change we'll also be able to remove the connection to the registry from the git integration, when that happens we can also remove the way we set the default branch for this test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up git unit tests to cut boilerplate and improve reliability in CI by using an autouse fixture for git identity and localizing repo setup within the test.

- **Refactors**
  - Added `conftest.py` autouse `git_identity` fixture to set git author/committer env vars for CI.
  - Simplified `test_git_repository.py`: replaced shared fixtures with `tmp_path` and `monkeypatch` to set `registry._default_branch` and `config.SETTINGS.git.repositories_directory` per test.
  - Added a check that the diff between `main` and `change1` contains "=======" to validate the test premise.

<sup>Written for commit 66e0a723ba1974d8cf3caf730cbaadee999584bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

