### PR TITLE
fix(backend): schema diff issue

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import keyword
-import os
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -259,11 +258,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
         # Process element b
         for name in sorted(present_both):
-            # If the element doesn't have an ID on either side
-            # this most likely means it was added recently from the internal schema.
-            if os.environ.get("PYTEST_RUNNING", "") != "true" and local_map[name] is None and other_map[name] is None:
-                elements_diff.added[name] = None
-                continue
             local_element: obj_type = get_func(self, name=name)
             other_element: obj_type = get_func(other, name=name)
             element_diff = local_element.diff(other_element)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect schema diffs where elements missing IDs on both sides were wrongly marked as added. We now always compute the full diff for those elements to avoid false positives.

- **Bug Fixes**
  - Removed the env-gated shortcut in `_diff_element` that marked missing-ID items as added for non-test runs, ensuring consistent diffs; also removed the unused `os` import.

<sup>Written for commit 866302baf14c1a6d39961bb817bb8b33614f156f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

