### PR TITLE
Refine docs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,7 @@
 /frontend/ @opsmill/frontend
 /frontend/app/src/shared/api/graphql/generated/**
 /frontend/app/src/shared/api/rest/types.generated.ts
-/docs/ @opsmill/frontend
-/docs/sidebars.ts @opsmill/sa
+/docs/ @opsmill/sa @opsmill/product
 /docs/docs @opsmill/sa @opsmill/backend @opsmill/frontend
 /docs/docs/reference/ @opsmill/backend @opsmill/frontend
 /docker-compose.yml @opsmill/cloud

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,10 @@
 /frontend/ @opsmill/frontend
 /frontend/app/src/shared/api/graphql/generated/**
 /frontend/app/src/shared/api/rest/types.generated.ts
-/docs/ @opsmill/sa @opsmill/backend @opsmill/frontend
+/docs/ @opsmill/frontend
+/docs/sidebars.ts @opsmill/sa
+/docs/docs @opsmill/sa @opsmill/backend @opsmill/frontend
+/docs/docs/reference/ @opsmill/backend @opsmill/frontend
 /docker-compose.yml @opsmill/cloud
 uv.lock @opsmill/backend
 pyproject.toml @opsmill/backend


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines `CODEOWNERS` for docs to reflect actual ownership and route reviews to the right teams.

`/docs/` → `@opsmill/sa` `@opsmill/product`; `/docs/docs` → `@opsmill/sa` `@opsmill/backend` `@opsmill/frontend`; `/docs/docs/reference/` → `@opsmill/backend` `@opsmill/frontend`.

<sup>Written for commit e28ac425d9d569628b26b2457b03d05e93759533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



