### PR TITLE
Authorize id-token to write access which is used by Claude Code action

### DIFF
--- a/.github/workflows/bug-agent-analyst.yml
+++ b/.github/workflows/bug-agent-analyst.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
+      id-token: write
       issues: write
       contents: write
 

--- a/.github/workflows/bug-agent-fix.yml
+++ b/.github/workflows/bug-agent-fix.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write
@@ -194,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write

--- a/.github/workflows/bug-agent-review.yml
+++ b/.github/workflows/bug-agent-review.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/bug-agent-test.yml
+++ b/.github/workflows/bug-agent-test.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write
@@ -168,6 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Why

Bug-agent pipeline is not working: https://github.com/opsmill/infrahub/actions/runs/24247388642/job/70797243364.

### Why am I getting OIDC authentication errors?

See -> https://github.com/anthropics/claude-code-action/blob/c26cb6427d54362f5fd9834ac6818cbaaf82490a/docs/faq.md?plain=1#L19

"If you're using the default GitHub App authentication, you must add the `id-token: write` permission to your workflow:"

```yaml
permissions:
  contents: read
  id-token: write # Required for OIDC authentication
``` 
 
## Solution 

The claude-code-action@v1 uses OIDC tokens to authenticate with Anthropic's API. Without id-token: write, the GitHub Actions runner can't request the OIDC token, which is what caused the Unable to get `ACTIONS_ID_TOKEN_REQUEST_URL` env variable error.

This is written in the logs
_**Attempt 2 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?**_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize OIDC in bug-agent workflows by adding `id-token: write` to job permissions, fixing authentication failures. This unblocks `claude-code-action@v1` and restores the bug-agent pipeline.

- **Bug Fixes**
  - Added `id-token: write` to `.github/workflows/bug-agent-analyst.yml`, `bug-agent-fix.yml`, `bug-agent-review.yml`, and `bug-agent-test.yml`.
  - Enables OIDC token retrieval for `claude-code-action@v1` and resolves “Unable to get ACTIONS_ID_TOKEN_REQUEST_URL” errors.

<sup>Written for commit fb056b2dd12a664e3b0af1000fb1f3bd658cda09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

