### PR TITLE
Unify object list and detail page headers

### DIFF
--- a/changelog/+object-list-header.changed.md
+++ b/changelog/+object-list-header.changed.md
@@ -1,0 +1,1 @@
+Consistent headers across object list and detail pages. Object list pages now share the same header style as detail pages, with easy access to schema, docs, and refresh actions.

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-header.tsx
@@ -1,6 +1,7 @@
 import { CopyToClipboardButton } from "@/shared/components/aria/copy-to-clipboard-button";
-import { Row } from "@/shared/components/container";
+import { Row, type RowProps } from "@/shared/components/container";
 import { Skeleton } from "@/shared/components/loading/skeleton";
+import { classNames } from "@/shared/utils/common";
 
 import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
 import { ObjectDetailsMenu } from "@/entities/nodes/object/ui/object-details/object-details-menu";
@@ -37,7 +38,7 @@ export function ObjectDetailsHeader({
 
   return (
     <HeaderContainer>
-      <h2 className="truncate font-semibold text-xl">{getNodeLabel(objectData)}</h2>
+      <h1 className="truncate font-bold text-xl">{getNodeLabel(objectData)}</h1>
       <CopyToClipboardButton data={getNodeLabel(objectData)} />
       <NodeMetadataPopover objectId={objectId} objectKind={objectSchema.kind!} />
 
@@ -58,10 +59,12 @@ export function ObjectDetailsHeader({
   );
 }
 
-export function HeaderContainer({ children }: { children: React.ReactNode }) {
+export function HeaderContainer({ className, ...props }: RowProps) {
   return (
-    <Row className="w-full p-3 pb-1.5" data-testid="object-header">
-      {children}
-    </Row>
+    <Row
+      className={classNames("w-full p-3 pb-1.5", className)}
+      data-testid="object-header"
+      {...props}
+    />
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-items-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-items-header.tsx
@@ -1,11 +1,12 @@
-import { queryClient } from "@/shared/api/rest/client";
-import { removeFiltersNotInSchema } from "@/shared/components/filters/utils/remove-filters-not-in-schema";
-import Content from "@/shared/components/layout/content";
-import useFilters from "@/shared/hooks/useFilters";
+import { Icon } from "@iconify-icon/react";
+import { BookTextIcon } from "lucide-react";
 
-import { ObjectHelpButton } from "@/entities/nodes/object/ui/object-help-button";
-import { useObjectsCount } from "@/entities/nodes/object/ui/queries/get-objects-count.query";
-import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
+import { constructPath } from "@/shared/api/rest/fetch";
+import { LinkButton } from "@/shared/components/ui/button";
+import { INFRAHUB_DOC_LOCAL } from "@/shared/config/config";
+
+import { HeaderContainer } from "@/entities/nodes/object/ui/object-details/object-details-header";
+import { RefreshButton } from "@/entities/nodes/object/ui/object-details/refresh-button";
 import type { ModelSchema } from "@/entities/schema/types";
 
 interface ObjectItemsHeaderProps {
@@ -13,36 +14,39 @@ interface ObjectItemsHeaderProps {
 }
 
 export function ObjectItemsHeader({ schema }: ObjectItemsHeaderProps) {
-  const [filters] = useFilters();
-  const {
-    data: count,
-    isPending,
-    isRefetching,
-    isError,
-  } = useObjectsCount({
-    objectKind: schema.kind!,
-    filters: removeFiltersNotInSchema(filters, schema),
-  });
-
-  const refetchObjects = async () => {
-    await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
-  };
-
   return (
-    <Content.CardTitle
-      title={schema.label || schema.name}
-      badgeContent={isPending && !isError ? "..." : count}
-      description={schema.description}
-      isReloadLoading={isRefetching}
-      reload={refetchObjects}
-      data-testid="object-header"
-      end={
-        <ObjectHelpButton
-          kind={schema.kind}
-          documentationUrl={schema.documentation}
-          className="ml-auto"
-        />
-      }
-    />
+    <HeaderContainer className="items-start">
+      <div>
+        <h1 className="truncate font-bold text-xl">{schema.label}</h1>
+        <div className="text-sm">{schema.description}</div>
+      </div>
+
+      <RefreshButton className="ml-auto" />
+      <LinkButton
+        variant="outline"
+        size="sm"
+        to={constructPath("/schema", [{ name: "kind", value: schema.kind }])}
+      >
+        <Icon icon="mdi:code-json" className="mr-1" />
+        Schema
+      </LinkButton>
+      {schema.documentation && (
+        <LinkButton
+          variant="outline"
+          size="sm"
+          to={
+            schema.documentation.startsWith("http")
+              ? INFRAHUB_DOC_LOCAL
+              : INFRAHUB_DOC_LOCAL + schema.documentation
+          }
+          className="gap-1"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <BookTextIcon className="size-3.5" />
+          Docs
+        </LinkButton>
+      )}
+    </HeaderContainer>
   );
 }

--- a/frontend/app/tests/e2e/schema/schema.spec.ts
+++ b/frontend/app/tests/e2e/schema/schema.spec.ts
@@ -5,8 +5,7 @@ import { saveScreenshotForDocs } from "../../utils";
 test.describe("/schema - Schema visualizer", () => {
   test("redirect to schema page using object help menu", async ({ page }) => {
     await page.goto("/objects/InfraInterface");
-    await page.getByRole("button", { name: "?" }).click();
-    await page.getByRole("menuitem", { name: "Schema" }).click();
+    await page.getByRole("link", { name: "Schema" }).click();
     await expect(page.getByTestId("schema-viewer")).toBeVisible();
     await expect(page.getByText("KindInfraInterface")).toBeVisible();
     await expect(page).toHaveURL(/\/schema\?kind=InfraInterface/);


### PR DESCRIPTION

<img width="2816" height="1096" alt="image" src="https://github.com/user-attachments/assets/248a34d1-d586-4a60-ba55-87d3700268a9" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies headers across object list and detail pages for a consistent UI. List pages now match detail headers and surface quick actions: Refresh, Schema, and Docs.

- New Features
  - Added Refresh button to object list headers.
  - Added Schema link (JSON icon) and Docs link (opens in new tab; uses `INFRAHUB_DOC_LOCAL` when relative).

- Refactors
  - Shared `HeaderContainer` for list and details; now accepts `RowProps`, forwards props, and merges classes with `classNames`.
  - Promoted titles to <h1> and aligned typography.
  - Removed object count and related query/filter logic from the list header.
  - Updated e2e schema test to use the new Schema link.

<sup>Written for commit 0e864a15e6009e639102c58a8abbcc54457e9f17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



