### PR TITLE
Fix race condition: ensure generators complete before artifact refresh in proposed changes

### DIFF
--- a/backend/infrahub/proposed_change/models.py
+++ b/backend/infrahub/proposed_change/models.py
@@ -25,12 +25,7 @@ class RequestProposedChangeDataIntegrity(BaseProposedChangeWithDiffMessage):
 
 
 class RequestProposedChangeRunGenerators(BaseProposedChangeWithDiffMessage):
-    """Sent trigger the generators that are impacted by the proposed change to run."""
-
-    refresh_artifacts: bool = Field(..., description="Whether to regenerate artifacts after the generators are run")
-    do_repository_checks: bool = Field(
-        ..., description="Whether to run repository and user checks after the generators are run"
-    )
+    """Sent to trigger the generators that are impacted by the proposed change to run."""
 
 
 class RequestProposedChangeRepositoryChecks(BaseProposedChangeWithDiffMessage):

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -394,7 +394,11 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             )
 
     if generator_check_coroutines:
-        await asyncio.gather(*generator_check_coroutines, return_exceptions=True)
+        results = await asyncio.gather(*generator_check_coroutines, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                log = get_run_logger()
+                log.error(f"Generator check failed: {result}")
 
 
 @flow(name="proposed-changed-schema-integrity", flow_run_name="Process schema integrity")
@@ -1133,6 +1137,39 @@ class DefinitionSelect(IntFlag):
         return "Doesn't require changes due to no relevant modified kinds or file changes in Git"
 
 
+async def _recompute_diff_after_generators(
+    *,
+    model: RequestProposedChangePipeline,
+    repositories: list[Repository],
+) -> tuple[list[NodeDiff], ProposedChangeBranchDiff]:
+    """Recompute the branch diff + summary after generators have run.
+
+    Generators can create or modify objects, so any diff computed before generators ran
+    is stale. This refreshes the diff via DiffCoordinator, updates the cache, and rebuilds
+    the ProposedChangeBranchDiff with current subscribers. Returns the fresh summary and
+    branch_diff for Phase 4 dispatches.
+    """
+    database = await get_database()
+    async with database.start_session() as dbs:
+        destination_branch = await registry.get_branch(db=dbs, branch=model.destination_branch)
+        source_branch = await registry.get_branch(db=dbs, branch=model.source_branch)
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
+        diff_coordinator.set_logger(get_run_logger())
+        await diff_coordinator.update_branch_diff(
+            base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
+        )
+
+    client = get_client()
+    diff_summary = await client.get_diff_summary(branch=model.source_branch)
+    await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
+    branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
+    branch_diff.subscribers.extend(
+        await _get_subscribers_from_diff(diff_summary=diff_summary, branch=model.source_branch, client=client)
+    )
+    return diff_summary, branch_diff
+
+
 @flow(name="proposed-changed-pipeline", flow_run_name="Execute proposed changed pipeline")
 async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, context: InfrahubContext) -> None:
     client = get_client()
@@ -1196,9 +1233,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
 
     # --- Phase 2: Dispatch checks independent of generators (fire-and-forget) ---
 
-    if model.check_type in [CheckType.ALL, CheckType.DATA] and has_node_changes(
-        diff_summary=diff_summary, branch=model.source_branch
-    ):
+    if model.check_type is CheckType.DATA and has_node_changes(diff_summary=diff_summary, branch=model.source_branch):
         model_proposed_change_data_integrity = RequestProposedChangeDataIntegrity(
             proposed_change=model.proposed_change,
             source_branch=model.source_branch,
@@ -1226,9 +1261,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             parameters={"model": model_proposed_change_repo_checks},
         )
 
-    if model.check_type in [CheckType.ALL, CheckType.SCHEMA] and has_data_changes(
-        diff_summary=diff_summary, branch=model.source_branch
-    ):
+    if model.check_type is CheckType.SCHEMA and has_data_changes(diff_summary=diff_summary, branch=model.source_branch):
         await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
             context=context,
@@ -1274,6 +1307,10 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             parameters={"model": model_proposed_change_run_generator},
         )
 
+        # Phase 3.5: Recompute diff after generators — generators may have created or modified
+        # objects, so the pre-generator diff is stale. Fresh diff feeds Phase 4 dispatches below.
+        diff_summary, branch_diff = await _recompute_diff_after_generators(model=model, repositories=repositories)
+
     # --- Phase 4: Dispatch generator-dependent checks (fire-and-forget) ---
 
     if model.check_type is CheckType.ALL:
@@ -1302,6 +1339,36 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             context=context,
             parameters={"model": model_proposed_change_repo_checks},
         )
+
+        if has_node_changes(diff_summary=diff_summary, branch=model.source_branch):
+            await get_workflow().submit_workflow(
+                workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
+                context=context,
+                parameters={
+                    "model": RequestProposedChangeDataIntegrity(
+                        proposed_change=model.proposed_change,
+                        source_branch=model.source_branch,
+                        source_branch_sync_with_git=model.source_branch_sync_with_git,
+                        destination_branch=model.destination_branch,
+                        branch_diff=branch_diff,
+                    )
+                },
+            )
+
+        if has_data_changes(diff_summary=diff_summary, branch=model.source_branch):
+            await get_workflow().submit_workflow(
+                workflow=REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
+                context=context,
+                parameters={
+                    "model": RequestProposedChangeSchemaIntegrity(
+                        proposed_change=model.proposed_change,
+                        source_branch=model.source_branch,
+                        source_branch_sync_with_git=model.source_branch_sync_with_git,
+                        destination_branch=model.destination_branch,
+                        branch_diff=branch_diff,
+                    )
+                },
+            )
 
 
 @flow(

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -354,6 +354,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
+    generator_check_coroutines = []
     for generator_definition in generator_definitions:
         # Request generator definitions if the source branch that is managed in combination
         # to the Git repository containing modifications which could indicate changes to the transforms
@@ -384,39 +385,16 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
                 source_branch_sync_with_git=model.source_branch_sync_with_git,
                 destination_branch=model.destination_branch,
             )
-            await get_workflow().submit_workflow(
-                workflow=REQUEST_GENERATOR_DEFINITION_CHECK,
-                parameters={"model": request_generator_def_check_model},
-                context=context,
+            generator_check_coroutines.append(
+                get_workflow().execute_workflow(
+                    workflow=REQUEST_GENERATOR_DEFINITION_CHECK,
+                    parameters={"model": request_generator_def_check_model},
+                    context=context,
+                )
             )
 
-    if model.refresh_artifacts:
-        request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
-            proposed_change=model.proposed_change,
-            source_branch=model.source_branch,
-            source_branch_sync_with_git=model.source_branch_sync_with_git,
-            destination_branch=model.destination_branch,
-            branch_diff=model.branch_diff,
-        )
-        await get_workflow().submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
-            parameters={"model": request_refresh_artifact_model},
-            context=context,
-        )
-
-    if model.do_repository_checks:
-        model_proposed_change_repo_checks = RequestProposedChangeRepositoryChecks(
-            proposed_change=model.proposed_change,
-            source_branch=model.source_branch,
-            source_branch_sync_with_git=model.source_branch_sync_with_git,
-            destination_branch=model.destination_branch,
-            branch_diff=model.branch_diff,
-        )
-        await get_workflow().submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
-            context=context,
-            parameters={"model": model_proposed_change_repo_checks},
-        )
+    if generator_check_coroutines:
+        await asyncio.gather(*generator_check_coroutines, return_exceptions=True)
 
 
 @flow(name="proposed-changed-schema-integrity", flow_run_name="Process schema integrity")
@@ -1200,6 +1178,8 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
         await _get_subscribers_from_diff(diff_summary=diff_summary, branch=model.source_branch, client=client)
     )
 
+    # --- Phase 1: Dispatch standalone artifact refresh (CheckType.ARTIFACT only) ---
+
     if model.check_type is CheckType.ARTIFACT:
         request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
             proposed_change=model.proposed_change,
@@ -1214,21 +1194,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             context=context,
         )
 
-    if model.check_type in [CheckType.ALL, CheckType.GENERATOR]:
-        model_proposed_change_run_generator = RequestProposedChangeRunGenerators(
-            proposed_change=model.proposed_change,
-            source_branch=model.source_branch,
-            source_branch_sync_with_git=model.source_branch_sync_with_git,
-            destination_branch=model.destination_branch,
-            branch_diff=branch_diff,
-            refresh_artifacts=model.check_type is CheckType.ALL,
-            do_repository_checks=model.check_type is CheckType.ALL,
-        )
-        await get_workflow().submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
-            context=context,
-            parameters={"model": model_proposed_change_run_generator},
-        )
+    # --- Phase 2: Dispatch checks independent of generators (fire-and-forget) ---
 
     if model.check_type in [CheckType.ALL, CheckType.DATA] and has_node_changes(
         diff_summary=diff_summary, branch=model.source_branch
@@ -1290,6 +1256,51 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
                     branch_diff=branch_diff,
                 )
             },
+        )
+
+    # --- Phase 3: Run generators and WAIT for completion ---
+
+    if model.check_type in [CheckType.ALL, CheckType.GENERATOR]:
+        model_proposed_change_run_generator = RequestProposedChangeRunGenerators(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().execute_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+            context=context,
+            parameters={"model": model_proposed_change_run_generator},
+        )
+
+    # --- Phase 4: Dispatch generator-dependent checks (fire-and-forget) ---
+
+    if model.check_type is CheckType.ALL:
+        request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+            parameters={"model": request_refresh_artifact_model},
+            context=context,
+        )
+
+        model_proposed_change_repo_checks = RequestProposedChangeRepositoryChecks(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+            context=context,
+            parameters={"model": model_proposed_change_repo_checks},
         )
 
 

--- a/backend/tests/adapters/workflow.py
+++ b/backend/tests/adapters/workflow.py
@@ -17,6 +17,7 @@ class WorkflowRecorder(InfrahubWorkflow):
     def __init__(self) -> None:
         self.execute_calls: list[dict[str, Any]] = []
         self.submit_calls: list[dict[str, Any]] = []
+        self.all_calls: list[dict[str, Any]] = []
 
     async def execute_workflow(
         self,
@@ -26,7 +27,9 @@ class WorkflowRecorder(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
-        self.execute_calls.append({"workflow": workflow, "parameters": parameters or {}})
+        record = {"workflow": workflow, "parameters": parameters or {}, "type": "execute"}
+        self.execute_calls.append(record)
+        self.all_calls.append(record)
         if expected_return is ValidatorConclusion:
             return ValidatorConclusion.SUCCESS
         return None
@@ -38,7 +41,9 @@ class WorkflowRecorder(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> WorkflowInfo:
-        self.submit_calls.append({"workflow": workflow, "parameters": parameters or {}})
+        record = {"workflow": workflow, "parameters": parameters or {}, "type": "submit"}
+        self.submit_calls.append(record)
+        self.all_calls.append(record)
         return WorkflowInfo(id=uuid.uuid4())
 
     def get_execute_calls_for(self, workflow: WorkflowDefinition) -> list[dict[str, Any]]:

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -16,7 +16,6 @@ from infrahub.message_bus.types import ProposedChangeBranchDiff
 from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import (
     RequestProposedChangePipeline,
-    RequestProposedChangeRefreshArtifacts,
     RequestProposedChangeRunGenerators,
 )
 from infrahub.proposed_change.tasks import run_generators, run_proposed_change_pipeline
@@ -27,6 +26,7 @@ from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workflows.catalogue import (
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+    REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
     REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
     REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_USER_TESTS,
@@ -185,25 +185,48 @@ class TestProposedChange(TestInfrahubApp):
             destination_branch="main",
             proposed_change=prepare_proposed_change,
         )
-        with patch(
-            "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
-        ) as mock_submit_workflow:
+        with (
+            patch(
+                "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
+            ) as mock_submit_workflow,
+            patch(
+                "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.execute_workflow"
+            ) as mock_execute_workflow,
+        ):
             await run_proposed_change_pipeline(model=model, context=context)
 
-            expected_calls_before_data_changes = [
-                call(
-                    workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
-                    parameters=ANY,
-                    context=ANY,
-                ),
+            # Generators are dispatched via execute_workflow (blocking)
+            mock_execute_workflow.assert_has_calls(
+                [
+                    call(
+                        workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+                        parameters=ANY,
+                        context=ANY,
+                    ),
+                ]
+            )
+
+            # Independent checks and generator-dependent checks via submit_workflow
+            expected_submit_calls_before_data_changes = [
                 call(
                     workflow=REQUEST_PROPOSED_CHANGE_USER_TESTS,
                     parameters=ANY,
                     context=ANY,
                 ),
+                call(
+                    workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+                    parameters=ANY,
+                    context=ANY,
+                ),
+                call(
+                    workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+                    parameters=ANY,
+                    context=ANY,
+                ),
             ]
-            mock_submit_workflow.assert_has_calls(expected_calls_before_data_changes)
+            mock_submit_workflow.assert_has_calls(expected_submit_calls_before_data_changes)
             mock_submit_workflow.reset_mock()
+            mock_execute_workflow.reset_mock()
 
             # Add an object to the source_branch to modify the data
             obj = await Node.init(db=db, schema=InfrahubKind.TAG, branch="change1")
@@ -212,12 +235,17 @@ class TestProposedChange(TestInfrahubApp):
 
             await run_proposed_change_pipeline(model=model, context=context)
 
-            expected_calls_after_data_changes = [
-                call(
-                    workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
-                    parameters=ANY,
-                    context=ANY,
-                ),
+            mock_execute_workflow.assert_has_calls(
+                [
+                    call(
+                        workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+                        parameters=ANY,
+                        context=ANY,
+                    ),
+                ]
+            )
+
+            expected_submit_calls_after_data_changes = [
                 call(
                     workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
                     parameters=ANY,
@@ -233,8 +261,18 @@ class TestProposedChange(TestInfrahubApp):
                     parameters=ANY,
                     context=ANY,
                 ),
+                call(
+                    workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+                    parameters=ANY,
+                    context=ANY,
+                ),
+                call(
+                    workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+                    parameters=ANY,
+                    context=ANY,
+                ),
             ]
-            mock_submit_workflow.assert_has_calls(expected_calls_after_data_changes)
+            mock_submit_workflow.assert_has_calls(expected_submit_calls_after_data_changes)
 
     async def test_run_generators_validate_requested_jobs(
         self,
@@ -251,8 +289,6 @@ class TestProposedChange(TestInfrahubApp):
             destination_branch="main",
             proposed_change=prepare_proposed_change,
             branch_diff=ProposedChangeBranchDiff(pipeline_id=pipeline_id, repositories=[], subscribers=[]),
-            refresh_artifacts=True,
-            do_repository_checks=True,
         )
         bus = BusRecorder()
         service = await InfrahubServices.new(
@@ -263,24 +299,4 @@ class TestProposedChange(TestInfrahubApp):
             workflow=WorkflowLocalExecution(),
         )
         await set_diff_summary_cache(pipeline_id=pipeline_id, diff_summary=[], cache=service.cache)
-        with patch(
-            "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
-        ) as mock_submit_workflow:
-            await run_generators(model=model, context=context)
-
-            expected_calls = [
-                call(
-                    workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
-                    parameters={
-                        "model": RequestProposedChangeRefreshArtifacts(
-                            proposed_change=model.proposed_change,
-                            source_branch=model.source_branch,
-                            source_branch_sync_with_git=model.source_branch_sync_with_git,
-                            destination_branch=model.destination_branch,
-                            branch_diff=model.branch_diff,
-                        )
-                    },
-                    context=ANY,
-                ),
-            ]
-            mock_submit_workflow.assert_has_calls(expected_calls)
+        await run_generators(model=model, context=context)

--- a/backend/tests/unit/proposed_change/test_run_generators.py
+++ b/backend/tests/unit/proposed_change/test_run_generators.py
@@ -14,9 +14,11 @@ from infrahub.proposed_change.models import (
 from infrahub.proposed_change.tasks import run_generators, run_proposed_change_pipeline
 from infrahub.workflows.catalogue import (
     REQUEST_GENERATOR_DEFINITION_CHECK,
+    REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
     REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
     REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+    REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
 )
 from tests.adapters.workflow import WorkflowRecorder
 
@@ -170,8 +172,11 @@ class TestPipelineSequencing:
             check_type=check_type,
         )
 
+        # Return a non-empty diff so has_node_changes/has_data_changes return True
+        # for Phase 4 conditional dispatches (DATA_INTEGRITY, SCHEMA_INTEGRITY).
+        diff_entry = {"branch": "branch1", "kind": "InfraDevice", "actions": ["update"], "id": "obj-1"}
         mock_client = AsyncMock()
-        mock_client.get_diff_summary = AsyncMock(return_value=[])
+        mock_client.get_diff_summary = AsyncMock(return_value=[diff_entry])
 
         mock_dbs = AsyncMock()
         mock_db = AsyncMock()
@@ -261,3 +266,114 @@ class TestPipelineSequencing:
         workflow_names = [c["workflow"].name for c in recorder.all_calls]
         assert REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name in workflow_names
         assert REQUEST_PROPOSED_CHANGE_RUN_GENERATORS.name not in workflow_names
+
+    @pytest.mark.anyio
+    async def test_pipeline_diff_recomputed_after_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T019: For CheckType.ALL, the diff coordinator is called twice — once before generators
+        (initial diff) and once after generators complete (post-generator diff recompute)."""
+        model = RequestProposedChangePipeline(
+            proposed_change="pc-1",
+            source_branch="branch1",
+            source_branch_sync_with_git=True,
+            destination_branch="main",
+            check_type=CheckType.ALL,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get_diff_summary = AsyncMock(return_value=[])
+
+        mock_dbs = AsyncMock()
+        mock_db = AsyncMock()
+        mock_db.start_session = MagicMock(
+            return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_dbs), __aexit__=AsyncMock())
+        )
+
+        mock_branch = MagicMock()
+        mock_diff_coordinator = MagicMock()
+        mock_diff_coordinator.set_logger = MagicMock()
+        mock_diff_coordinator.update_branch_diff = AsyncMock()
+
+        mock_component_registry = MagicMock()
+        mock_component_registry.get_component = AsyncMock(return_value=mock_diff_coordinator)
+
+        with (
+            patch("infrahub.proposed_change.tasks.add_tags", new_callable=AsyncMock),
+            patch("infrahub.proposed_change.tasks.get_client", return_value=mock_client),
+            patch("infrahub.proposed_change.tasks.get_workflow", return_value=workflow_recorder),
+            patch("infrahub.proposed_change.tasks.get_cache", new_callable=AsyncMock, return_value=AsyncMock()),
+            patch("infrahub.proposed_change.tasks.get_database", new_callable=AsyncMock, return_value=mock_db),
+            patch("infrahub.proposed_change.tasks.get_run_logger", return_value=MagicMock()),
+            patch(
+                "infrahub.proposed_change.tasks._get_proposed_change_repositories",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "infrahub.proposed_change.tasks._gather_repository_repository_diffs",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "infrahub.proposed_change.tasks._get_subscribers_from_diff",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "infrahub.proposed_change.tasks.set_diff_summary_cache",
+                new_callable=AsyncMock,
+            ),
+            patch("infrahub.proposed_change.tasks.registry") as mock_registry,
+            patch("infrahub.proposed_change.tasks.get_component_registry", return_value=mock_component_registry),
+        ):
+            mock_registry.get_branch = AsyncMock(return_value=mock_branch)
+            await run_proposed_change_pipeline.fn(model=model, context=MagicMock())
+
+        # update_branch_diff is called once for the initial diff and once after generators complete
+        assert mock_diff_coordinator.update_branch_diff.call_count == 2, (
+            f"Expected 2 diff recomputations (initial + post-generator), got {mock_diff_coordinator.update_branch_diff.call_count}"
+        )
+
+    @pytest.mark.anyio
+    async def test_pipeline_checks_dispatched_after_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T020: For CheckType.ALL, data integrity and schema integrity checks are dispatched ONLY in Phase 4 (after generators), not in Phase 2."""
+        recorder = await self._run_pipeline(workflow_recorder, check_type=CheckType.ALL)
+
+        all_workflow_names = [c["workflow"].name for c in recorder.all_calls]
+
+        gen_idx = all_workflow_names.index(REQUEST_PROPOSED_CHANGE_RUN_GENERATORS.name)
+
+        # Verify repository checks appear after RUN_GENERATORS
+        assert REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS.name in all_workflow_names
+        repo_check_indices = [
+            i for i, name in enumerate(all_workflow_names) if name == REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS.name
+        ]
+        # The Phase 4 (post-generator) repo check must be dispatched after generators complete
+        assert any(idx > gen_idx for idx in repo_check_indices), (
+            "Repository checks must be dispatched after generators complete"
+        )
+
+        # Verify artifact refresh appears after RUN_GENERATORS
+        art_idx = all_workflow_names.index(REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name)
+        assert art_idx > gen_idx, "Artifact refresh must appear after generators"
+
+        # DATA_INTEGRITY and SCHEMA_INTEGRITY must each appear EXACTLY ONCE (only in Phase 4)
+        data_indices = [
+            i for i, name in enumerate(all_workflow_names) if name == REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY.name
+        ]
+        schema_indices = [
+            i for i, name in enumerate(all_workflow_names) if name == REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY.name
+        ]
+        assert len(data_indices) == 1, f"DATA_INTEGRITY should dispatch exactly once, got {len(data_indices)}"
+        assert len(schema_indices) == 1, f"SCHEMA_INTEGRITY should dispatch exactly once, got {len(schema_indices)}"
+        assert data_indices[0] > gen_idx, "DATA_INTEGRITY must be dispatched after generators"
+        assert schema_indices[0] > gen_idx, "SCHEMA_INTEGRITY must be dispatched after generators"
+
+    @pytest.mark.anyio
+    async def test_pipeline_generator_only_no_phase4_checks(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T021: For CheckType.GENERATOR (no ALL), Phase 4 artifact/repo checks are NOT dispatched."""
+        recorder = await self._run_pipeline(workflow_recorder, check_type=CheckType.GENERATOR)
+
+        workflow_names = [c["workflow"].name for c in recorder.all_calls]
+        assert REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name not in workflow_names
+        assert REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS.name not in workflow_names
+        assert REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY.name not in workflow_names
+        assert REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY.name not in workflow_names

--- a/backend/tests/unit/proposed_change/test_run_generators.py
+++ b/backend/tests/unit/proposed_change/test_run_generators.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from infrahub.core.constants import CheckType
+from infrahub.message_bus.types import ProposedChangeBranchDiff
+from infrahub.proposed_change.models import (
+    RequestProposedChangePipeline,
+    RequestProposedChangeRunGenerators,
+)
+from infrahub.proposed_change.tasks import run_generators, run_proposed_change_pipeline
+from infrahub.workflows.catalogue import (
+    REQUEST_GENERATOR_DEFINITION_CHECK,
+    REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+    REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+    REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+)
+from tests.adapters.workflow import WorkflowRecorder
+
+
+def _make_generator_definition(name: str = "gen1", query_models: list[str] | None = None) -> MagicMock:
+    """Create a mock CoreGeneratorDefinition with the attributes run_generators reads."""
+    gen = MagicMock()
+    gen.id = f"gen-{name}"
+    gen.name.value = name
+    gen.class_name.value = "MyGenerator"
+    gen.file_path.value = "generators/my_gen.py"
+    gen.query.peer.name.value = f"query-{name}"
+    gen.query.peer.models.value = query_models or ["InfraDevice"]
+    gen.repository.peer.id = "repo-1"
+    gen.parameters.value = {}
+    gen.targets.peer.id = "group-1"
+    gen.convert_query_response.value = False
+    gen.execute_in_proposed_change.value = True
+    gen.execute_after_merge.value = True
+    return gen
+
+
+def _make_branch_diff(pipeline_id: uuid.UUID | None = None) -> ProposedChangeBranchDiff:
+    return ProposedChangeBranchDiff(
+        pipeline_id=pipeline_id or uuid.uuid4(),
+        repositories=[],
+        subscribers=[],
+    )
+
+
+@pytest.fixture
+def workflow_recorder() -> WorkflowRecorder:
+    return WorkflowRecorder()
+
+
+class TestRunGenerators:
+    """Tests for the refactored run_generators() function."""
+
+    @pytest.mark.anyio
+    async def test_generators_use_execute_workflow(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T013: Verify generator definition checks use execute_workflow (blocking), not submit_workflow."""
+        pipeline_id = uuid.uuid4()
+        model = RequestProposedChangeRunGenerators(
+            proposed_change="pc-1",
+            source_branch="branch1",
+            source_branch_sync_with_git=True,
+            destination_branch="main",
+            branch_diff=_make_branch_diff(pipeline_id),
+        )
+
+        mock_client = AsyncMock()
+        mock_client.filters = AsyncMock(return_value=[_make_generator_definition()])
+
+        with (
+            patch("infrahub.proposed_change.tasks.add_tags", new_callable=AsyncMock),
+            patch("infrahub.proposed_change.tasks.get_client", return_value=mock_client),
+            patch("infrahub.proposed_change.tasks.get_workflow", return_value=workflow_recorder),
+            patch(
+                "infrahub.proposed_change.tasks.get_diff_summary_cache",
+                new_callable=AsyncMock,
+                return_value=[{"branch": "branch1", "kind": "InfraDevice", "actions": ["update"], "id": "obj-1"}],
+            ),
+        ):
+            await run_generators.fn(model=model, context=MagicMock())
+
+        # Generator definition checks should use execute_workflow
+        gen_execute_calls = workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_DEFINITION_CHECK)
+        assert len(gen_execute_calls) == 1
+
+        # Should NOT appear in submit_calls
+        gen_submit_calls = workflow_recorder.get_submit_calls_for(REQUEST_GENERATOR_DEFINITION_CHECK)
+        assert len(gen_submit_calls) == 0
+
+    @pytest.mark.anyio
+    async def test_no_artifact_dispatch_from_run_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T014: Verify run_generators does not dispatch artifact refresh."""
+        pipeline_id = uuid.uuid4()
+        model = RequestProposedChangeRunGenerators(
+            proposed_change="pc-1",
+            source_branch="branch1",
+            source_branch_sync_with_git=True,
+            destination_branch="main",
+            branch_diff=_make_branch_diff(pipeline_id),
+        )
+
+        mock_client = AsyncMock()
+        mock_client.filters = AsyncMock(return_value=[_make_generator_definition()])
+
+        with (
+            patch("infrahub.proposed_change.tasks.add_tags", new_callable=AsyncMock),
+            patch("infrahub.proposed_change.tasks.get_client", return_value=mock_client),
+            patch("infrahub.proposed_change.tasks.get_workflow", return_value=workflow_recorder),
+            patch(
+                "infrahub.proposed_change.tasks.get_diff_summary_cache",
+                new_callable=AsyncMock,
+                return_value=[{"branch": "branch1", "kind": "InfraDevice", "actions": ["update"], "id": "obj-1"}],
+            ),
+        ):
+            await run_generators.fn(model=model, context=MagicMock())
+
+        artifact_calls = workflow_recorder.get_submit_calls_for(REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS)
+        assert len(artifact_calls) == 0
+        artifact_execute_calls = workflow_recorder.get_execute_calls_for(REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS)
+        assert len(artifact_execute_calls) == 0
+
+    @pytest.mark.anyio
+    async def test_no_repo_check_dispatch_from_run_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T015: Verify run_generators does not dispatch repository checks."""
+        pipeline_id = uuid.uuid4()
+        model = RequestProposedChangeRunGenerators(
+            proposed_change="pc-1",
+            source_branch="branch1",
+            source_branch_sync_with_git=True,
+            destination_branch="main",
+            branch_diff=_make_branch_diff(pipeline_id),
+        )
+
+        mock_client = AsyncMock()
+        mock_client.filters = AsyncMock(return_value=[])
+
+        with (
+            patch("infrahub.proposed_change.tasks.add_tags", new_callable=AsyncMock),
+            patch("infrahub.proposed_change.tasks.get_client", return_value=mock_client),
+            patch("infrahub.proposed_change.tasks.get_workflow", return_value=workflow_recorder),
+            patch(
+                "infrahub.proposed_change.tasks.get_diff_summary_cache",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            await run_generators.fn(model=model, context=MagicMock())
+
+        repo_calls = workflow_recorder.get_submit_calls_for(REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS)
+        assert len(repo_calls) == 0
+        repo_execute_calls = workflow_recorder.get_execute_calls_for(REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS)
+        assert len(repo_execute_calls) == 0
+
+
+class TestPipelineSequencing:
+    """Tests for generator-before-artifact sequencing in run_proposed_change_pipeline()."""
+
+    async def _run_pipeline(
+        self, workflow_recorder: WorkflowRecorder, check_type: CheckType = CheckType.ALL
+    ) -> WorkflowRecorder:
+        """Helper to run the pipeline with mocked dependencies."""
+        model = RequestProposedChangePipeline(
+            proposed_change="pc-1",
+            source_branch="branch1",
+            source_branch_sync_with_git=True,
+            destination_branch="main",
+            check_type=check_type,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get_diff_summary = AsyncMock(return_value=[])
+
+        mock_dbs = AsyncMock()
+        mock_db = AsyncMock()
+        mock_db.start_session = MagicMock(
+            return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_dbs), __aexit__=AsyncMock())
+        )
+
+        mock_branch = MagicMock()
+        mock_diff_coordinator = MagicMock()
+        mock_diff_coordinator.set_logger = MagicMock()
+        mock_diff_coordinator.update_branch_diff = AsyncMock()
+
+        mock_component_registry = MagicMock()
+        mock_component_registry.get_component = AsyncMock(return_value=mock_diff_coordinator)
+
+        with (
+            patch("infrahub.proposed_change.tasks.add_tags", new_callable=AsyncMock),
+            patch("infrahub.proposed_change.tasks.get_client", return_value=mock_client),
+            patch("infrahub.proposed_change.tasks.get_workflow", return_value=workflow_recorder),
+            patch("infrahub.proposed_change.tasks.get_cache", new_callable=AsyncMock, return_value=AsyncMock()),
+            patch("infrahub.proposed_change.tasks.get_database", new_callable=AsyncMock, return_value=mock_db),
+            patch("infrahub.proposed_change.tasks.get_run_logger", return_value=MagicMock()),
+            patch(
+                "infrahub.proposed_change.tasks._get_proposed_change_repositories",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "infrahub.proposed_change.tasks._gather_repository_repository_diffs",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "infrahub.proposed_change.tasks._get_subscribers_from_diff",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "infrahub.proposed_change.tasks.set_diff_summary_cache",
+                new_callable=AsyncMock,
+            ),
+            patch("infrahub.proposed_change.tasks.registry") as mock_registry,
+            patch("infrahub.proposed_change.tasks.get_component_registry", return_value=mock_component_registry),
+        ):
+            mock_registry.get_branch = AsyncMock(return_value=mock_branch)
+
+            await run_proposed_change_pipeline.fn(model=model, context=MagicMock())
+
+        return workflow_recorder
+
+    @pytest.mark.anyio
+    async def test_pipeline_dispatches_artifacts_after_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T016: Verify REFRESH_ARTIFACTS appears after RUN_GENERATORS in the call log."""
+        recorder = await self._run_pipeline(workflow_recorder, check_type=CheckType.ALL)
+
+        workflow_names = [c["workflow"].name for c in recorder.all_calls]
+
+        # RUN_GENERATORS should be dispatched via execute_workflow
+        assert REQUEST_PROPOSED_CHANGE_RUN_GENERATORS.name in workflow_names
+
+        # REFRESH_ARTIFACTS should be dispatched via submit_workflow
+        assert REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name in workflow_names
+
+        gen_idx = workflow_names.index(REQUEST_PROPOSED_CHANGE_RUN_GENERATORS.name)
+        art_idx = workflow_names.index(REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name)
+        assert gen_idx < art_idx, f"Generators (index {gen_idx}) must complete before artifacts (index {art_idx})"
+
+        # Generators via execute, artifacts via submit
+        gen_call = recorder.all_calls[gen_idx]
+        art_call = recorder.all_calls[art_idx]
+        assert gen_call["type"] == "execute"
+        assert art_call["type"] == "submit"
+
+    @pytest.mark.anyio
+    async def test_pipeline_generator_only_no_artifacts(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T017: For CheckType.GENERATOR, no artifact refresh should be dispatched."""
+        recorder = await self._run_pipeline(workflow_recorder, check_type=CheckType.GENERATOR)
+
+        workflow_names = [c["workflow"].name for c in recorder.all_calls]
+        assert REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name not in workflow_names
+        assert REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS.name not in workflow_names
+
+    @pytest.mark.anyio
+    async def test_pipeline_artifact_only_no_generators(self, workflow_recorder: WorkflowRecorder) -> None:
+        """T018: For CheckType.ARTIFACT, artifact refresh is dispatched without generators."""
+        recorder = await self._run_pipeline(workflow_recorder, check_type=CheckType.ARTIFACT)
+
+        workflow_names = [c["workflow"].name for c in recorder.all_calls]
+        assert REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS.name in workflow_names
+        assert REQUEST_PROPOSED_CHANGE_RUN_GENERATORS.name not in workflow_names

--- a/dev/specs/001-generator-artifact-ordering/data-model.md
+++ b/dev/specs/001-generator-artifact-ordering/data-model.md
@@ -1,0 +1,90 @@
+# Data Model: Generator-Before-Artifact Ordering
+
+## Overview
+
+This change does **not** modify any database schemas, node definitions, or relationship structures. The fix is purely in the workflow orchestration layer — changing how existing workflows are dispatched.
+
+## Entities Involved (Read-Only Context)
+
+These entities are relevant to understanding the flow but are not modified by this change.
+
+### CoreGeneratorDefinition
+
+**Schema**: `backend/infrahub/core/schema/definitions/core/generator.py:15`
+**Branch support**: AWARE
+
+| Attribute | Type | Relevance |
+|-----------|------|-----------|
+| `name` | Text (unique) | Used to name the validator |
+| `execute_in_proposed_change` | Boolean | Controls whether generator runs in proposed change pipeline |
+| `execute_after_merge` | Boolean | Controls post-merge execution (not affected) |
+| `query` | Relationship → GraphQLQuery | Determines which data models the generator touches |
+| `targets` | Relationship → Group | Determines which objects the generator runs against |
+| `repository` | Relationship → GenericRepository | Source of generator code |
+
+### CoreGeneratorInstance
+
+**Schema**: `backend/infrahub/core/schema/definitions/core/generator.py:86`
+**Branch support**: LOCAL
+
+| Attribute | Type | Relevance |
+|-----------|------|-----------|
+| `status` | Enum (Pending, Processing, Ready, Error) | Tracks individual generator execution state |
+| `object` | Relationship → Node | The target object being generated for |
+| `definition` | Relationship → GeneratorDefinition | Parent definition |
+
+### CoreArtifactDefinition
+
+**Schema**: `backend/infrahub/core/schema/definitions/core/artifact.py:99`
+
+Artifacts are generated after generators complete. Their definitions determine which data to query and which transforms to apply.
+
+### CoreArtifact
+
+**Schema**: `backend/infrahub/core/schema/definitions/core/artifact.py:37`
+
+Individual artifact instances. Their `status` transitions through Pending → Processing → Ready/Error during generation.
+
+## Workflow Message Models (No Changes)
+
+### RequestProposedChangeRunGenerators
+
+**File**: `backend/infrahub/proposed_change/models.py:27`
+
+```
+proposed_change: str
+source_branch: str
+source_branch_sync_with_git: bool
+destination_branch: str
+branch_diff: ProposedChangeBranchDiff
+refresh_artifacts: bool          # Controls whether to dispatch artifact refresh
+do_repository_checks: bool       # Controls whether to dispatch repo checks
+```
+
+No fields are added or modified. The `refresh_artifacts` and `do_repository_checks` flags continue to control whether downstream work is dispatched — the change is only in *when* that dispatch happens (after generators complete vs. immediately).
+
+### RequestGeneratorDefinitionCheck
+
+**File**: `backend/infrahub/proposed_change/models.py:81`
+
+No changes. This model is passed to `execute_workflow` instead of `submit_workflow`.
+
+## State Transitions (Unchanged)
+
+```
+Pipeline Start
+  └─ run_generators()
+       ├─ Generator Definition Checks (parallel, now awaited)
+       │    └─ Per-instance: PENDING → READY/ERROR
+       │         └─ GeneratorValidator: QUEUED → IN_PROGRESS → COMPLETED
+       │
+       ├─ [WAIT: all generator validators COMPLETED]  ← NEW BEHAVIOR
+       │
+       ├─ Artifact Refresh (fire-and-forget)
+       │    └─ Per-artifact: PENDING → READY/ERROR
+       │         └─ ArtifactValidator: QUEUED → IN_PROGRESS → COMPLETED
+       │
+       └─ Repository Checks (fire-and-forget)
+```
+
+The state machine for individual generators and artifacts is unchanged. Only the orchestration timing between the two phases changes.

--- a/dev/specs/001-generator-artifact-ordering/data-model.md
+++ b/dev/specs/001-generator-artifact-ordering/data-model.md
@@ -45,7 +45,7 @@ Artifacts are generated after generators complete. Their definitions determine w
 
 Individual artifact instances. Their `status` transitions through Pending → Processing → Ready/Error during generation.
 
-## Workflow Message Models (No Changes)
+## Workflow Message Models (Updated)
 
 ### RequestProposedChangeRunGenerators
 
@@ -57,11 +57,9 @@ source_branch: str
 source_branch_sync_with_git: bool
 destination_branch: str
 branch_diff: ProposedChangeBranchDiff
-refresh_artifacts: bool          # Controls whether to dispatch artifact refresh
-do_repository_checks: bool       # Controls whether to dispatch repo checks
 ```
 
-No fields are added or modified. The `refresh_artifacts` and `do_repository_checks` flags continue to control whether downstream work is dispatched — the change is only in *when* that dispatch happens (after generators complete vs. immediately).
+The `refresh_artifacts` and `do_repository_checks` fields have been **removed** from this model. Downstream dispatch of artifact refresh and repository checks is now handled directly by `run_proposed_change_pipeline()` after generators complete, rather than being controlled by flags passed to `run_generators()`.
 
 ### RequestGeneratorDefinitionCheck
 
@@ -72,19 +70,29 @@ No changes. This model is passed to `execute_workflow` instead of `submit_workfl
 ## State Transitions (Unchanged)
 
 ```
-Pipeline Start
-  └─ run_generators()
-       ├─ Generator Definition Checks (parallel, now awaited)
-       │    └─ Per-instance: PENDING → READY/ERROR
-       │         └─ GeneratorValidator: QUEUED → IN_PROGRESS → COMPLETED
-       │
-       ├─ [WAIT: all generator validators COMPLETED]  ← NEW BEHAVIOR
-       │
-       ├─ Artifact Refresh (fire-and-forget)
+Pipeline Start (CheckType.ALL)
+  ├─ Phase 2: Independent checks (fire-and-forget, concurrent with generators)
+  │    └─ User Tests
+  │    (Note: for CheckType.ALL, Data Integrity and Schema Integrity are NOT dispatched here;
+  │     they run only in Phase 4 on the post-generator diff)
+  │
+  ├─ Phase 3: run_generators() — BLOCKING
+  │    └─ Generator Definition Checks (parallel, awaited via asyncio.gather)
+  │         └─ Per-instance: PENDING → READY/ERROR
+  │              └─ GeneratorValidator: QUEUED → IN_PROGRESS → COMPLETED
+  │
+  ├─ Phase 3.5: Diff Recomputation  ← NEW BEHAVIOR
+  │    └─ DiffCoordinator.update_branch_diff() — reflects generator-created objects
+  │
+  └─ Phase 4: Generator-dependent checks (fire-and-forget, post-generator diff)  ← NEW BEHAVIOR
+       ├─ Artifact Refresh
        │    └─ Per-artifact: PENDING → READY/ERROR
        │         └─ ArtifactValidator: QUEUED → IN_PROGRESS → COMPLETED
-       │
-       └─ Repository Checks (fire-and-forget)
+       ├─ Repository Checks
+       ├─ Data Integrity Check (post-generator diff — includes generator-created objects)
+       └─ Schema Integrity Check (post-generator diff)
 ```
 
-The state machine for individual generators and artifacts is unchanged. Only the orchestration timing between the two phases changes.
+For `CheckType.DATA` or `CheckType.SCHEMA` (standalone, no generators), the respective check runs in Phase 2 only and generators are never invoked.
+
+The state machine for individual generators and artifacts is unchanged. The orchestration now dispatches data/schema integrity checks ONLY in Phase 4 for `CheckType.ALL`, so they always observe objects created by generators.

--- a/dev/specs/001-generator-artifact-ordering/plan.md
+++ b/dev/specs/001-generator-artifact-ordering/plan.md
@@ -10,7 +10,7 @@ Fix a race condition where artifact generation and repository checks can start b
 ## Technical Context
 
 **Language/Version**: Python 3.12
-**Primary Dependencies**: FastAPI, Prefect (workflow engine), Pydantic 2.10, infrahub-sdk
+**Primary Dependencies**: FastAPI, Prefect (workflow engine), Pydantic >=2.12,<2.13, infrahub-sdk
 **Storage**: Neo4j 5.28 (graph database)
 **Testing**: pytest 9.0 (unit + integration)
 **Target Platform**: Linux server (Docker containers)
@@ -178,13 +178,13 @@ For `CheckType.ALL`, the pipeline must:
 
     # --- Phase 2: Dispatch checks independent of generators (fire-and-forget) ---
 
-    if model.check_type in [CheckType.ALL, CheckType.DATA] and has_node_changes(...):
+    if model.check_type is CheckType.DATA and has_node_changes(...):
         await submit_workflow(DATA_INTEGRITY, ...)
 
     if model.check_type in [CheckType.REPOSITORY, CheckType.USER]:
         await submit_workflow(REPO_CHECKS, ...)
 
-    if model.check_type in [CheckType.ALL, CheckType.SCHEMA] and has_data_changes(...):
+    if model.check_type is CheckType.SCHEMA and has_data_changes(...):
         await submit_workflow(SCHEMA_INTEGRITY, ...)
 
     if model.check_type in [CheckType.ALL, CheckType.TEST]:
@@ -206,40 +206,49 @@ For `CheckType.ALL`, the pipeline must:
             parameters={"model": model_run_generators},
         )
 
+        # --- Phase 3.5: Recompute diff after generators ---
+        # Generators may have created or modified objects; the pre-generator diff is stale.
+        database = await get_database()
+        async with database.start_session() as dbs:
+            destination_branch = await registry.get_branch(db=dbs, branch=model.destination_branch)
+            source_branch = await registry.get_branch(db=dbs, branch=model.source_branch)
+            component_registry = get_component_registry()
+            diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
+            diff_coordinator.set_logger(get_run_logger())
+            await diff_coordinator.update_branch_diff(
+                base_branch=destination_branch, diff_branch=source_branch, proposed_change_id=model.proposed_change
+            )
+
+        client = get_client()
+        diff_summary = await client.get_diff_summary(branch=model.source_branch)
+        await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
+        branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
+        branch_diff.subscribers.extend(
+            await _get_subscribers_from_diff(diff_summary=diff_summary, branch=model.source_branch, client=client)
+        )
+
     # --- Phase 4: Dispatch generator-dependent checks (fire-and-forget) ---
 
     if model.check_type is CheckType.ALL:
-        request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
-            proposed_change=model.proposed_change,
-            source_branch=model.source_branch,
-            source_branch_sync_with_git=model.source_branch_sync_with_git,
-            destination_branch=model.destination_branch,
-            branch_diff=branch_diff,
-        )
-        await get_workflow().submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
-            parameters={"model": request_refresh_artifact_model},
-            context=context,
-        )
+        request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(...)
+        await get_workflow().submit_workflow(workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS, ...)
 
-        model_proposed_change_repo_checks = RequestProposedChangeRepositoryChecks(
-            proposed_change=model.proposed_change,
-            source_branch=model.source_branch,
-            source_branch_sync_with_git=model.source_branch_sync_with_git,
-            destination_branch=model.destination_branch,
-            branch_diff=branch_diff,
-        )
-        await get_workflow().submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
-            context=context,
-            parameters={"model": model_proposed_change_repo_checks},
-        )
+        model_proposed_change_repo_checks = RequestProposedChangeRepositoryChecks(...)
+        await get_workflow().submit_workflow(workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS, ...)
+
+        if has_node_changes(diff_summary=diff_summary, branch=model.source_branch):
+            await get_workflow().submit_workflow(workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY, ...)
+
+        if has_data_changes(diff_summary=diff_summary, branch=model.source_branch):
+            await get_workflow().submit_workflow(workflow=REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY, ...)
 ```
 
 Key points:
 - `CheckType.ARTIFACT` (standalone artifact refresh, no generators involved) remains unchanged at the top
-- Independent checks dispatch before the blocking generator call so they run concurrently
-- `CheckType.ALL` dispatches artifacts and repo checks in Phase 4 — after generators complete
+- Independent checks dispatch before the blocking generator call so they run concurrently (Phase 2); for `CheckType.ALL`, DATA_INTEGRITY and SCHEMA_INTEGRITY are NOT dispatched here
+- `CheckType.ALL` dispatches artifacts, repo checks, data integrity, and schema integrity ONLY in Phase 4 — after generators complete on the refreshed diff
+- `CheckType.DATA` dispatches DATA_INTEGRITY only in Phase 2; `CheckType.SCHEMA` dispatches SCHEMA_INTEGRITY only in Phase 2 (no generators involved for these standalone types)
+- Phase 3.5 recomputes the branch diff after generators finish so subsequent stages see generator-created objects
 - `RequestProposedChangeRunGenerators` no longer carries `refresh_artifacts`/`do_repository_checks`
 
 ### Step 4: Enhance `WorkflowRecorder` for ordered tracking
@@ -280,6 +289,9 @@ Test cases:
 4. **test_pipeline_dispatches_artifacts_after_generators**: Verify that in the `all_calls` log, `REFRESH_ARTIFACTS` appears after `RUN_GENERATORS`
 5. **test_pipeline_generator_only_no_artifacts**: For `CheckType.GENERATOR`, verify no artifact refresh is dispatched
 6. **test_pipeline_artifact_only_no_generators**: For `CheckType.ARTIFACT`, verify artifact refresh is dispatched without waiting for generators
+7. **test_pipeline_diff_recomputed_after_generators**: Verify `update_branch_diff` is called twice — once for initial diff and once post-generator recomputation
+8. **test_pipeline_checks_dispatched_after_generators**: Verify repo checks appear in the call log after `RUN_GENERATORS` (Phase 4 ordering)
+9. **test_pipeline_generator_only_no_phase4_checks**: For `CheckType.GENERATOR`, verify no Phase 4 artifact/repo/data/schema checks are dispatched
 
 ### Step 6: Verify existing tests pass
 

--- a/dev/specs/001-generator-artifact-ordering/plan.md
+++ b/dev/specs/001-generator-artifact-ordering/plan.md
@@ -1,0 +1,303 @@
+# Implementation Plan: Generator-Before-Artifact Ordering
+
+**Branch**: `001-generator-artifact-ordering` | **Date**: 2026-04-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-generator-artifact-ordering/spec.md`
+
+## Summary
+
+Fix a race condition where artifact generation and repository checks can start before generators finish creating objects during a proposed change pipeline. The fix moves sequencing responsibility to `run_proposed_change_pipeline()` (the natural orchestrator) and makes `run_generators()` single-purpose — it runs generators and blocks until they complete, nothing else.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: FastAPI, Prefect (workflow engine), Pydantic 2.10, infrahub-sdk
+**Storage**: Neo4j 5.28 (graph database)
+**Testing**: pytest 9.0 (unit + integration)
+**Target Platform**: Linux server (Docker containers)
+**Project Type**: Web application (backend focus for this change)
+**Performance Goals**: No regression in pipeline throughput. Generator definitions remain parallelized. Independent checks (data integrity, schema, user tests) remain parallel with generators.
+**Constraints**: Must work with both `WorkflowLocalExecution` (tests) and `WorkflowWorkerExecution` (production/Prefect workers)
+**Scale/Scope**: 3 files modified, 1 new test file. ~50 lines changed, ~30 lines removed.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution is unconfigured (template only). No gates to enforce.
+
+**Post-design re-check**: No constitution gates exist. Design proceeds without constraint.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-generator-artifact-ordering/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Root cause analysis and decision log
+├── data-model.md        # Entity documentation (no schema changes)
+└── quickstart.md        # Verification guide
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── infrahub/
+│   └── proposed_change/
+│       ├── tasks.py            # PRIMARY: modify run_generators() + run_proposed_change_pipeline()
+│       └── models.py           # Remove refresh_artifacts/do_repository_checks fields
+└── tests/
+    ├── adapters/
+    │   └── workflow.py          # Enhance WorkflowRecorder with ordered tracking
+    └── unit/proposed_change/
+        └── test_run_generators.py  # NEW: ordering tests
+```
+
+**Structure Decision**: Backend-only change. Modifies two production files, enhances one test adapter, adds one test file.
+
+## Implementation Steps
+
+### Step 1: Simplify `RequestProposedChangeRunGenerators` model
+
+**File**: `backend/infrahub/proposed_change/models.py`
+
+Remove the `refresh_artifacts` and `do_repository_checks` fields. These flags coupled generator execution with artifact/repo check dispatch. That responsibility moves to the pipeline.
+
+**Before** (lines 27-33):
+```python
+class RequestProposedChangeRunGenerators(BaseProposedChangeWithDiffMessage):
+    """Sent trigger the generators that are impacted by the proposed change to run."""
+
+    refresh_artifacts: bool = Field(..., description="Whether to regenerate artifacts after the generators are run")
+    do_repository_checks: bool = Field(
+        ..., description="Whether to run repository and user checks after the generators are run"
+    )
+```
+
+**After**:
+```python
+class RequestProposedChangeRunGenerators(BaseProposedChangeWithDiffMessage):
+    """Sent to trigger the generators that are impacted by the proposed change to run."""
+```
+
+### Step 2: Make `run_generators()` single-purpose and blocking
+
+**File**: `backend/infrahub/proposed_change/tasks.py`, function `run_generators()` (line 322)
+
+Changes:
+1. Change generator definition check dispatch from `submit_workflow` to `execute_workflow`
+2. Use `asyncio.gather` to run all generator checks in parallel but wait for all to complete
+3. Remove artifact refresh dispatch (lines 393-405)
+4. Remove repository checks dispatch (lines 407-419)
+
+**Current code** (lines 357-419):
+```python
+    for generator_definition in generator_definitions:
+        # ... selection logic ...
+        if select:
+            await get_workflow().submit_workflow(
+                workflow=REQUEST_GENERATOR_DEFINITION_CHECK,
+                parameters={"model": request_generator_def_check_model},
+                context=context,
+            )
+
+    if model.refresh_artifacts:
+        # ... build model ...
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS, ...)
+
+    if model.do_repository_checks:
+        # ... build model ...
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS, ...)
+```
+
+**New code**:
+```python
+    generator_check_coroutines: list[Coroutine] = []
+    for generator_definition in generator_definitions:
+        # ... selection logic unchanged ...
+        if select:
+            request_generator_def_check_model = RequestGeneratorDefinitionCheck(...)
+            generator_check_coroutines.append(
+                get_workflow().execute_workflow(
+                    workflow=REQUEST_GENERATOR_DEFINITION_CHECK,
+                    parameters={"model": request_generator_def_check_model},
+                    context=context,
+                )
+            )
+
+    if generator_check_coroutines:
+        await asyncio.gather(*generator_check_coroutines, return_exceptions=True)
+```
+
+Note `return_exceptions=True`: if one generator definition fails, we still collect all results rather than aborting. This preserves the current behavior where a failing generator doesn't prevent other generators from running.
+
+Add `import asyncio` at top of file if not already present.
+
+### Step 3: Restructure `run_proposed_change_pipeline()` for sequencing
+
+**File**: `backend/infrahub/proposed_change/tasks.py`, function `run_proposed_change_pipeline()` (line 1159)
+
+For `CheckType.ALL`, the pipeline must:
+1. Dispatch independent checks (fire-and-forget) — these run in parallel with generators
+2. Block on generator execution
+3. After generators complete, dispatch artifact refresh and repo checks
+
+**Current flow** (lines 1203-1293):
+```python
+    if model.check_type is CheckType.ARTIFACT:
+        await submit_workflow(REFRESH_ARTIFACTS, ...)
+
+    if model.check_type in [CheckType.ALL, CheckType.GENERATOR]:
+        await submit_workflow(RUN_GENERATORS, ...,
+            refresh_artifacts=model.check_type is CheckType.ALL,
+            do_repository_checks=model.check_type is CheckType.ALL)
+
+    if model.check_type in [CheckType.ALL, CheckType.DATA]:
+        await submit_workflow(DATA_INTEGRITY, ...)
+
+    if model.check_type in [CheckType.REPOSITORY, CheckType.USER]:
+        await submit_workflow(REPO_CHECKS, ...)
+
+    if model.check_type in [CheckType.ALL, CheckType.SCHEMA]:
+        await submit_workflow(SCHEMA_INTEGRITY, ...)
+
+    if model.check_type in [CheckType.ALL, CheckType.TEST]:
+        await submit_workflow(USER_TESTS, ...)
+```
+
+**New flow**:
+```python
+    # --- Phase 1: Dispatch standalone artifact refresh (CheckType.ARTIFACT only) ---
+
+    if model.check_type is CheckType.ARTIFACT:
+        await submit_workflow(REFRESH_ARTIFACTS, ...)
+
+    # --- Phase 2: Dispatch checks independent of generators (fire-and-forget) ---
+
+    if model.check_type in [CheckType.ALL, CheckType.DATA] and has_node_changes(...):
+        await submit_workflow(DATA_INTEGRITY, ...)
+
+    if model.check_type in [CheckType.REPOSITORY, CheckType.USER]:
+        await submit_workflow(REPO_CHECKS, ...)
+
+    if model.check_type in [CheckType.ALL, CheckType.SCHEMA] and has_data_changes(...):
+        await submit_workflow(SCHEMA_INTEGRITY, ...)
+
+    if model.check_type in [CheckType.ALL, CheckType.TEST]:
+        await submit_workflow(USER_TESTS, ...)
+
+    # --- Phase 3: Run generators and WAIT for completion ---
+
+    if model.check_type in [CheckType.ALL, CheckType.GENERATOR]:
+        model_run_generators = RequestProposedChangeRunGenerators(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().execute_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+            context=context,
+            parameters={"model": model_run_generators},
+        )
+
+    # --- Phase 4: Dispatch generator-dependent checks (fire-and-forget) ---
+
+    if model.check_type is CheckType.ALL:
+        request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
+            parameters={"model": request_refresh_artifact_model},
+            context=context,
+        )
+
+        model_proposed_change_repo_checks = RequestProposedChangeRepositoryChecks(
+            proposed_change=model.proposed_change,
+            source_branch=model.source_branch,
+            source_branch_sync_with_git=model.source_branch_sync_with_git,
+            destination_branch=model.destination_branch,
+            branch_diff=branch_diff,
+        )
+        await get_workflow().submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+            context=context,
+            parameters={"model": model_proposed_change_repo_checks},
+        )
+```
+
+Key points:
+- `CheckType.ARTIFACT` (standalone artifact refresh, no generators involved) remains unchanged at the top
+- Independent checks dispatch before the blocking generator call so they run concurrently
+- `CheckType.ALL` dispatches artifacts and repo checks in Phase 4 — after generators complete
+- `RequestProposedChangeRunGenerators` no longer carries `refresh_artifacts`/`do_repository_checks`
+
+### Step 4: Enhance `WorkflowRecorder` for ordered tracking
+
+**File**: `backend/tests/adapters/workflow.py`
+
+Add an `all_calls` list that records every call in submission order with a type discriminator:
+
+```python
+class WorkflowRecorder(InfrahubWorkflow):
+    def __init__(self) -> None:
+        self.execute_calls: list[dict[str, Any]] = []
+        self.submit_calls: list[dict[str, Any]] = []
+        self.all_calls: list[dict[str, Any]] = []  # NEW: ordered log
+
+    async def execute_workflow(self, ...):
+        record = {"workflow": workflow, "parameters": parameters or {}, "type": "execute"}
+        self.execute_calls.append(record)
+        self.all_calls.append(record)
+        ...
+
+    async def submit_workflow(self, ...):
+        record = {"workflow": workflow, "parameters": parameters or {}, "type": "submit"}
+        self.submit_calls.append(record)
+        self.all_calls.append(record)
+        ...
+```
+
+### Step 5: Add unit tests for ordering guarantee
+
+**File**: `backend/tests/unit/proposed_change/test_run_generators.py` (NEW)
+
+Test cases:
+
+1. **test_generators_use_execute_workflow**: Verify `REQUEST_GENERATOR_DEFINITION_CHECK` calls appear in `execute_calls` (not `submit_calls`) on the `WorkflowRecorder`
+2. **test_no_artifact_dispatch_from_run_generators**: Verify `run_generators` does not submit `REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS`
+3. **test_no_repo_check_dispatch_from_run_generators**: Verify `run_generators` does not submit `REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS`
+4. **test_pipeline_dispatches_artifacts_after_generators**: Verify that in the `all_calls` log, `REFRESH_ARTIFACTS` appears after `RUN_GENERATORS`
+5. **test_pipeline_generator_only_no_artifacts**: For `CheckType.GENERATOR`, verify no artifact refresh is dispatched
+6. **test_pipeline_artifact_only_no_generators**: For `CheckType.ARTIFACT`, verify artifact refresh is dispatched without waiting for generators
+
+### Step 6: Verify existing tests pass
+
+```bash
+uv run invoke backend.test-unit
+uv run pytest backend/tests/integration/message_bus/operations/request/test_proposed_change.py -v
+```
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Prefect slot exhaustion from `execute_workflow` nesting | Low | Medium | Typical deployments have few generator definitions (1-5). Monitor work pool utilization in staging. |
+| Generator failure blocks artifact dispatch | Medium | Low | `asyncio.gather(return_exceptions=True)` collects all results. Pipeline proceeds to Phase 4 regardless. |
+| Pipeline flow lifetime increases | Expected | Low | `run_proposed_change_pipeline` now blocks for generator duration. This is intentional and correct — the pipeline should reflect actual completion state. |
+| `WorkflowLocalExecution` behavior difference | None | None | `execute_workflow` already blocks in local mode. `submit_workflow` delegates to `execute_workflow`. No behavioral change. |
+| Existing tests break from model field removal | Medium | Low | Tests that construct `RequestProposedChangeRunGenerators` with `refresh_artifacts`/`do_repository_checks` need updating. Grep for usages. |
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/dev/specs/001-generator-artifact-ordering/quickstart.md
+++ b/dev/specs/001-generator-artifact-ordering/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: Verifying Generator-Before-Artifact Ordering
+
+## Run Unit Tests
+
+```bash
+# Run new ordering tests
+uv run pytest backend/tests/unit/proposed_change/test_run_generators.py -v
+
+# Run all backend unit tests to check for regressions
+uv run invoke backend.test-unit
+```
+
+## Run Existing Integration Tests
+
+```bash
+# Proposed change pipeline tests
+uv run pytest backend/tests/integration/message_bus/operations/request/test_proposed_change.py -v
+```
+
+## Manual Verification (Production/Staging)
+
+To verify the fix in a running instance:
+
+1. **Set up a generator and artifact that share data:**
+   - Create a `GeneratorDefinition` that creates objects (e.g., interface configs)
+   - Create an `ArtifactDefinition` whose query reads those generator-created objects
+   - Both should be configured with `execute_in_proposed_change=True`
+
+2. **Create a proposed change that triggers both:**
+   - Make a data change on a branch that affects both the generator's query models and the artifact's query models
+   - Open a proposed change targeting that branch
+
+3. **Observe Prefect flow runs:**
+   - `proposed-changed-pipeline` should show `proposed-changed-run-generator` completing BEFORE `proposed-changed-refresh-artifacts` starts
+   - Independent checks (data integrity, schema, user tests) should start concurrently with generators
+
+4. **Verify artifact content:**
+   - The generated artifact should include data from generator-created objects
+   - Previously, the artifact might have been generated with stale/missing data
+
+## What Changed
+
+| Component | Before | After |
+|-----------|--------|-------|
+| `run_generators()` | Dispatches generator checks, artifact refresh, and repo checks — all fire-and-forget | Single-purpose: dispatches generator checks via `execute_workflow` + `asyncio.gather`, blocks until complete |
+| `run_proposed_change_pipeline()` | Delegates artifact/repo dispatch to `run_generators` | Owns sequencing: blocks on generators, then dispatches artifacts + repo checks |
+| `RequestProposedChangeRunGenerators` | Carries `refresh_artifacts` and `do_repository_checks` flags | Generator-only model, no artifact/repo coupling |
+| Independent checks | Dispatched after generators in code order (but all fire-and-forget so irrelevant) | Explicitly dispatched before the generator blocking call so they run concurrently |
+
+## Key Files
+
+- `backend/infrahub/proposed_change/tasks.py` — `run_generators()` and `run_proposed_change_pipeline()`
+- `backend/infrahub/proposed_change/models.py` — `RequestProposedChangeRunGenerators`
+- `backend/tests/adapters/workflow.py` — `WorkflowRecorder`

--- a/dev/specs/001-generator-artifact-ordering/research.md
+++ b/dev/specs/001-generator-artifact-ordering/research.md
@@ -1,0 +1,166 @@
+# Research: Generator-Before-Artifact Ordering
+
+## Root Cause Analysis
+
+### The Race Condition
+
+**File**: `backend/infrahub/proposed_change/tasks.py`
+
+Two functions collaborate to create the race:
+
+**`run_proposed_change_pipeline()` (line 1159)** dispatches `REQUEST_PROPOSED_CHANGE_RUN_GENERATORS` via `submit_workflow()` (fire-and-forget). For `CheckType.ALL`, it passes `refresh_artifacts=True` and `do_repository_checks=True`, delegating artifact and repo check orchestration to `run_generators`.
+
+**`run_generators()` (line 322)** then dispatches three categories of work, all via `submit_workflow()` (fire-and-forget):
+
+1. Generator definition checks (lines 378-391)
+2. Artifact refresh (lines 393-405) if `refresh_artifacts=True`
+3. Repository checks (lines 407-419) if `do_repository_checks=True`
+
+All three run concurrently. `run_generators()` returns immediately after submitting them. Artifact generation can start before generators have created their objects.
+
+### Why `submit_workflow` is Fire-and-Forget
+
+In the production adapter `WorkflowWorkerExecution` (`backend/infrahub/services/adapters/workflow/worker.py:87`):
+
+```python
+async def submit_workflow(self, ...):
+    async with AsyncClientContext(...):
+        flow_run = await run_deployment(name=workflow.full_name, timeout=0, ...)
+    return WorkflowInfo.from_flow(flow_run=flow_run)
+```
+
+`timeout=0` means return immediately without waiting. In contrast, `execute_workflow` uses `poll_interval=1` and blocks until completion.
+
+### Why Tests Don't Catch This
+
+`WorkflowLocalExecution` (`backend/infrahub/services/adapters/workflow/local.py:33`) implements `submit_workflow` by delegating to `execute_workflow`:
+
+```python
+async def submit_workflow(self, ...):
+    await self.execute_workflow(workflow=workflow, context=context, parameters=parameters)
+    return WorkflowInfo(id=uuid.uuid4())
+```
+
+All workflows execute synchronously in tests, masking the concurrency issue.
+
+### Design Issue: Mixed Responsibilities
+
+`run_generators()` currently has two responsibilities:
+1. Execute generators (its stated purpose)
+2. Orchestrate what happens after generators (artifact refresh, repo checks)
+
+This coupling means the function name doesn't reflect what it does, and the sequencing between generators and artifacts is buried inside a function that callers don't expect to handle artifacts. The pipeline function `run_proposed_change_pipeline()` — which is the natural orchestrator — has no visibility into this ordering dependency.
+
+## Decision: Fix Approach
+
+### Decision: Pipeline-level sequencing with single-purpose `run_generators`
+
+Move the generator→artifact ordering to `run_proposed_change_pipeline()` where all pipeline orchestration belongs. Make `run_generators()` single-purpose: run generators, wait for them, return.
+
+**Changes:**
+
+1. **`run_generators()`**: Remove artifact and repo check dispatch. Change generator definition check submissions from `submit_workflow` to `execute_workflow` + `asyncio.gather` so the function blocks until all generators complete.
+
+2. **`RequestProposedChangeRunGenerators`**: Remove `refresh_artifacts` and `do_repository_checks` fields (no longer needed).
+
+3. **`run_proposed_change_pipeline()`**: For `CheckType.ALL`:
+   - Dispatch independent checks first (data integrity, schema, user tests) — fire-and-forget, run in parallel with generators
+   - Use `execute_workflow` (blocking) for `REQUEST_PROPOSED_CHANGE_RUN_GENERATORS`
+   - After generators complete, dispatch artifact refresh and repo checks — fire-and-forget
+
+**Rationale over the simpler "block inside run_generators" approach:**
+
+| Concern | Block inside run_generators | Pipeline-level sequencing |
+|---------|---------------------------|--------------------------|
+| Prefect slot deadlock | run_generators holds slot while waiting for N children | Same, but pipeline is already long-lived; no extra nesting concern |
+| Responsibility | run_generators does 3 things | run_generators does 1 thing |
+| Visibility | Ordering hidden inside generator flow | Ordering visible at pipeline level |
+| Model coupling | Generator model carries artifact/repo flags | Generator model is about generators only |
+| Independent check parallelism | Data/schema/test checks already parallel via pipeline | Same, plus explicit in code flow |
+| Cascading failure | Generator failure in gather blocks artifacts | Same — but clearer where to add error handling |
+
+### Alternatives considered
+
+1. **Block inside `run_generators` only** (original plan): Simpler diff, but keeps the mixed responsibility. `run_generators` becomes a blocking compound orchestrator that still dispatches artifacts. The function name misleads about what it does. The Prefect slot concern is identical (need `execute_workflow` for generator def checks either way).
+
+2. **Workflow dependency graph / DAG**: Over-engineered. Would require infrastructure changes to the workflow system for a single ordering dependency.
+
+3. **Polling/status-checking loop**: Fragile. `submit_workflow` returns a `WorkflowInfo` with a flow run ID, but polling for completion reimplements what `execute_workflow` already does with worse ergonomics.
+
+4. **Event-driven callback**: Complex distributed state tracking for "all generators done" with no clear benefit over synchronous waiting.
+
+## Decision: Test Strategy
+
+### Decision: Enhance `WorkflowRecorder` with ordered call tracking
+
+The `WorkflowRecorder` test adapter (`backend/tests/adapters/workflow.py`) records `execute_calls` and `submit_calls` separately. After the fix:
+
+- Generator definition checks appear in `execute_calls` (blocking)
+- Artifact refresh and repo checks appear in `submit_calls` (fire-and-forget)
+- Pipeline-level generator call appears in `execute_calls`
+
+Add an `all_calls` list that records every call in order (both execute and submit) with a discriminator. Tests can assert:
+1. All `REQUEST_GENERATOR_DEFINITION_CHECK` calls are `execute` type
+2. `REQUEST_PROPOSED_CHANGE_RUN_GENERATORS` at pipeline level is `execute` type
+3. `REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS` appears after all generator calls
+
+Note: This proves call-type correctness but not temporal ordering in production. The actual race only manifests with the worker adapter's async Prefect dispatching. Integration tests against real Prefect workers would be needed for full confidence.
+
+## Decision: Repository Checks Ordering
+
+### Decision: Repository checks also wait for generators
+
+Repository checks (user-defined Python checks) may reference generator-created objects. Same ordering guarantee applies. Artifacts and repo checks are independent of each other and can run concurrently after generators complete.
+
+## Workflow Execution Flow (After Fix)
+
+### CheckType.ALL
+
+```
+run_proposed_change_pipeline()
+  │
+  ├─ [fire-and-forget] submit_workflow(DATA_INTEGRITY)          ─┐
+  ├─ [fire-and-forget] submit_workflow(SCHEMA_INTEGRITY)         ├─ run in parallel
+  ├─ [fire-and-forget] submit_workflow(USER_TESTS)              ─┘    with generators
+  │
+  ├─ [BLOCKING] execute_workflow(RUN_GENERATORS)
+  │     └─ run_generators()
+  │          ├─ [parallel] execute_workflow(GEN_DEF_CHECK) × N
+  │          └─ asyncio.gather() waits for all N
+  │          └─ returns
+  │
+  ├─ ← generators complete ─┤
+  │
+  ├─ [fire-and-forget] submit_workflow(REFRESH_ARTIFACTS)
+  └─ [fire-and-forget] submit_workflow(REPO_CHECKS)
+```
+
+### CheckType.GENERATOR (unchanged behavior)
+
+```
+run_proposed_change_pipeline()
+  └─ [fire-and-forget] submit_workflow(RUN_GENERATORS)
+       └─ run_generators() — submit generator checks, return immediately
+```
+
+Wait — this raises a question. For `CheckType.GENERATOR`, should `run_generators` still be fire-and-forget? There are no artifacts to wait for, so the ordering doesn't matter. But `run_generators` itself should still wait for its generator checks to complete so that it accurately reflects generator completion status. Changed to `execute_workflow` + gather for consistency.
+
+### CheckType.ARTIFACT (unchanged)
+
+```
+run_proposed_change_pipeline()
+  └─ [fire-and-forget] submit_workflow(REFRESH_ARTIFACTS)
+```
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `backend/infrahub/proposed_change/tasks.py` | Modify `run_generators()` (remove artifact/repo dispatch, use execute_workflow + gather) and `run_proposed_change_pipeline()` (add sequencing) |
+| `backend/infrahub/proposed_change/models.py` | Remove `refresh_artifacts` and `do_repository_checks` from `RequestProposedChangeRunGenerators` |
+| `backend/tests/adapters/workflow.py` | Add ordered call tracking to `WorkflowRecorder` |
+| `backend/tests/unit/proposed_change/test_run_generators.py` | NEW: ordering tests |
+| `backend/infrahub/services/adapters/workflow/worker.py` | No changes |
+| `backend/infrahub/services/adapters/workflow/__init__.py` | No changes |
+| `backend/infrahub/core/validators/checks_runner.py` | No changes (reference pattern) |
+| `backend/infrahub/workflows/catalogue.py` | No changes |

--- a/dev/specs/001-generator-artifact-ordering/spec.md
+++ b/dev/specs/001-generator-artifact-ordering/spec.md
@@ -1,0 +1,65 @@
+# Feature Spec: Generator-Before-Artifact Ordering in Proposed Change Pipeline
+
+**Date**: 2026-04-10
+**Status**: Draft
+
+## Problem Statement
+
+When a proposed change pipeline runs with `CheckType.ALL`, generators and artifacts are both dispatched as fire-and-forget workflows via `submit_workflow()`. This means artifact generation can start before generators have finished creating their objects. Artifacts that depend on generator-created data will produce stale or incomplete results.
+
+## Current Behavior
+
+In `run_generators()` (`backend/infrahub/proposed_change/tasks.py:322`):
+
+1. Generator definition checks are submitted via `submit_workflow()` (non-blocking, returns immediately)
+2. Artifact refresh is submitted via `submit_workflow()` (non-blocking, returns immediately)
+3. Repository checks are submitted via `submit_workflow()` (non-blocking, returns immediately)
+
+All three steps execute concurrently. There is no ordering guarantee.
+
+The `submit_workflow()` method in the production adapter (`WorkflowWorkerExecution`) uses Prefect's `run_deployment(timeout=0)`, which is fire-and-forget. In contrast, `execute_workflow()` uses `run_deployment(poll_interval=1)`, which blocks until the workflow completes.
+
+**Note:** In the local/test adapter (`WorkflowLocalExecution`), `submit_workflow` delegates to `execute_workflow`, making all calls blocking. This masks the race condition in tests.
+
+## Desired Behavior
+
+1. `run_generators()` becomes single-purpose: run generator definition checks (in parallel) and block until all complete
+2. `run_proposed_change_pipeline()` owns the sequencing: block on generators, then dispatch artifact refresh and repo checks
+3. Independent checks (data integrity, schema, user tests) run in parallel with generators
+4. `RequestProposedChangeRunGenerators` model no longer carries `refresh_artifacts` / `do_repository_checks` flags
+
+## Scope
+
+### In Scope
+
+- Modify `run_generators()` to use `execute_workflow` + `asyncio.gather` and remove artifact/repo check dispatch
+- Modify `run_proposed_change_pipeline()` to own generator→artifact→repo-check sequencing
+- Remove `refresh_artifacts` and `do_repository_checks` from `RequestProposedChangeRunGenerators`
+- Add tests that verify the ordering guarantee
+
+### Out of Scope
+
+- Changes to the `WorkflowLocalExecution` or `WorkflowWorkerExecution` adapters
+- Changes to the artifact generation logic itself
+- Adding a general-purpose workflow dependency mechanism
+
+## Requirements
+
+1. **R1**: Artifact refresh MUST NOT begin until all generator definition checks have completed
+2. **R2**: Repository checks MUST NOT begin until all generator definition checks have completed
+3. **R3**: Generator definition checks SHOULD continue to run in parallel with each other
+4. **R4**: Independent checks (data integrity, schema, user tests) SHOULD run in parallel with generators
+5. **R5**: The fix MUST work in both local and worker execution modes
+6. **R6**: Existing tests must continue to pass
+7. **R7**: New tests must verify the ordering guarantee using the `WorkflowRecorder` test adapter
+
+## Acceptance Criteria
+
+- [ ] Generator workflows complete before artifact refresh is dispatched
+- [ ] Generator workflows complete before repository checks are dispatched
+- [ ] Multiple generator definitions still execute in parallel
+- [ ] Independent checks (data, schema, tests) are not blocked by generators
+- [ ] `run_generators()` no longer dispatches artifact or repo check workflows
+- [ ] `RequestProposedChangeRunGenerators` has no artifact/repo-check fields
+- [ ] Unit tests verify ordering using `WorkflowRecorder`
+- [ ] Integration tests pass

--- a/dev/specs/001-generator-artifact-ordering/tasks.md
+++ b/dev/specs/001-generator-artifact-ordering/tasks.md
@@ -1,0 +1,189 @@
+# Tasks: Generator-Before-Artifact Ordering
+
+**Input**: Design documents from `/specs/001-generator-artifact-ordering/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included — the spec requires tests that verify the ordering guarantee (R7).
+
+**Organization**: This is a bug fix with a single logical change. Tasks are organized as: model cleanup → core fix → pipeline restructure → test infrastructure → tests → verification.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[US1]**: Fix the generator-before-artifact race condition (the sole user story)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this modifies existing code. Verify the codebase compiles and existing tests pass before making changes.
+
+- [x] T001 Verify existing tests pass by running `uv run invoke backend.test-unit`
+
+---
+
+## Phase 2: Foundational (Model Cleanup)
+
+**Purpose**: Remove the coupling fields from the message model. This MUST happen before modifying the functions that use the model.
+
+- [x] T002 [US1] Remove `refresh_artifacts` and `do_repository_checks` fields from `RequestProposedChangeRunGenerators` in `backend/infrahub/proposed_change/models.py`
+- [x] T003 [US1] Update existing integration test `test_run_generators_validate_requested_jobs` in `backend/tests/integration/message_bus/operations/request/test_proposed_change.py` — remove `refresh_artifacts=True` and `do_repository_checks=True` from model construction, remove assertion that `REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS` is submitted by `run_generators`
+
+**Checkpoint**: Model is simplified. Tests referencing removed fields are updated. Code will not compile yet (tasks.py still references removed fields).
+
+---
+
+## Phase 3: Core Fix — Single-Purpose `run_generators()` (Priority: P1)
+
+**Goal**: Make `run_generators()` only run generators: use `execute_workflow` + `asyncio.gather` for generator definition checks, remove artifact and repo check dispatch.
+
+**Independent Test**: Call `run_generators()` with a `WorkflowRecorder` — verify only `REQUEST_GENERATOR_DEFINITION_CHECK` calls appear in `execute_calls`, and no `REFRESH_ARTIFACTS` or `REPO_CHECKS` calls exist in either `execute_calls` or `submit_calls`.
+
+### Implementation
+
+- [x] T004 [US1] Modify `run_generators()` in `backend/infrahub/proposed_change/tasks.py` — change generator definition check dispatch from `submit_workflow` to `execute_workflow`, collect coroutines in a list, and await them with `asyncio.gather(*coroutines, return_exceptions=True)`
+- [x] T005 [US1] Remove artifact refresh dispatch block (lines 393-405) from `run_generators()` in `backend/infrahub/proposed_change/tasks.py`
+- [x] T006 [US1] Remove repository checks dispatch block (lines 407-419) from `run_generators()` in `backend/infrahub/proposed_change/tasks.py`
+- [x] T007 [US1] Remove references to `model.refresh_artifacts` and `model.do_repository_checks` from `run_generators()` in `backend/infrahub/proposed_change/tasks.py`
+
+**Checkpoint**: `run_generators()` is single-purpose. It blocks until all generator definition checks complete and dispatches nothing else.
+
+---
+
+## Phase 4: Core Fix — Pipeline Sequencing (Priority: P1)
+
+**Goal**: Restructure `run_proposed_change_pipeline()` so independent checks dispatch first (fire-and-forget), then generators block, then generator-dependent checks dispatch.
+
+**Independent Test**: Call `run_proposed_change_pipeline()` with `CheckType.ALL` and a `WorkflowRecorder` — verify `REFRESH_ARTIFACTS` and `REPO_CHECKS` appear in `all_calls` after `RUN_GENERATORS`.
+
+### Implementation
+
+- [x] T008 [US1] In `run_proposed_change_pipeline()` in `backend/infrahub/proposed_change/tasks.py`, move independent checks (data integrity, schema integrity, user tests) before the generator dispatch block so they run concurrently with generators
+- [x] T009 [US1] In `run_proposed_change_pipeline()` in `backend/infrahub/proposed_change/tasks.py`, change generator dispatch from `submit_workflow` to `execute_workflow` for `REQUEST_PROPOSED_CHANGE_RUN_GENERATORS` and remove `refresh_artifacts`/`do_repository_checks` from the model construction
+- [x] T010 [US1] In `run_proposed_change_pipeline()` in `backend/infrahub/proposed_change/tasks.py`, add Phase 4 block after generators: for `CheckType.ALL`, dispatch `REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS` and `REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS` via `submit_workflow`
+
+**Checkpoint**: Full pipeline sequencing is in place. `CheckType.ALL` blocks on generators, then dispatches artifacts and repo checks. Other check types unchanged.
+
+---
+
+## Phase 5: Test Infrastructure
+
+**Purpose**: Enhance test adapter and create test file scaffolding.
+
+- [x] T011 [P] [US1] Add `all_calls` ordered list to `WorkflowRecorder` in `backend/tests/adapters/workflow.py` — record every `execute_workflow` and `submit_workflow` call with a `type` discriminator in call order
+- [x] T012 [P] [US1] Create directory `backend/tests/unit/proposed_change/` with `__init__.py`
+
+**Checkpoint**: Test infrastructure ready for ordering tests.
+
+---
+
+## Phase 6: Ordering Tests
+
+**Goal**: Verify the sequencing guarantee with unit tests.
+
+- [x] T013 [P] [US1] Write `test_generators_use_execute_workflow` in `backend/tests/unit/proposed_change/test_run_generators.py` — verify `REQUEST_GENERATOR_DEFINITION_CHECK` calls appear in `WorkflowRecorder.execute_calls`
+- [x] T014 [P] [US1] Write `test_no_artifact_dispatch_from_run_generators` in `backend/tests/unit/proposed_change/test_run_generators.py` — verify `run_generators` does not submit `REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS`
+- [x] T015 [P] [US1] Write `test_no_repo_check_dispatch_from_run_generators` in `backend/tests/unit/proposed_change/test_run_generators.py` — verify `run_generators` does not submit `REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS`
+- [x] T016 [US1] Write `test_pipeline_dispatches_artifacts_after_generators` in `backend/tests/unit/proposed_change/test_run_generators.py` — verify that in `WorkflowRecorder.all_calls`, `REFRESH_ARTIFACTS` appears after `RUN_GENERATORS` for `CheckType.ALL`
+- [x] T017 [US1] Write `test_pipeline_generator_only_no_artifacts` in `backend/tests/unit/proposed_change/test_run_generators.py` — for `CheckType.GENERATOR`, verify no artifact refresh is dispatched
+- [x] T018 [US1] Write `test_pipeline_artifact_only_no_generators` in `backend/tests/unit/proposed_change/test_run_generators.py` — for `CheckType.ARTIFACT`, verify artifact refresh is dispatched without blocking on generators
+
+**Checkpoint**: All ordering guarantees are tested.
+
+---
+
+## Phase 7: Polish & Verification
+
+**Purpose**: Format, lint, and run full test suite.
+
+- [x] T019 Run `uv run invoke format` to format all modified Python files
+- [x] T020 Run `uv run invoke lint` to verify no linting violations
+- [x] T021 Run `uv run invoke backend.test-unit` to verify all unit tests pass
+- [ ] T022 Run `uv run pytest backend/tests/integration/message_bus/operations/request/test_proposed_change.py -v` to verify integration tests pass
+- [ ] T023 Run quickstart.md validation steps from `specs/001-generator-artifact-ordering/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — verify baseline
+- **Phase 2 (Model Cleanup)**: Depends on Phase 1 — remove fields and update existing tests
+- **Phase 3 (run_generators fix)**: Depends on Phase 2 — uses simplified model
+- **Phase 4 (Pipeline sequencing)**: Depends on Phase 3 — `run_generators` must be single-purpose before pipeline restructure
+- **Phase 5 (Test infrastructure)**: Depends on Phase 2 — can run in parallel with Phase 3/4
+- **Phase 6 (Ordering tests)**: Depends on Phase 4 + Phase 5 — tests require both production code and test infrastructure
+- **Phase 7 (Verification)**: Depends on all previous phases
+
+### Within-Phase Parallelism
+
+- **Phase 2**: T002 and T003 touch different files → can run in parallel
+- **Phase 3**: T004-T007 all modify the same function in the same file → must be sequential
+- **Phase 4**: T008-T010 all modify the same function in the same file → must be sequential
+- **Phase 5**: T011 and T012 touch different files → can run in parallel
+- **Phase 6**: T013-T015 are independent test functions → can run in parallel; T016-T018 are independent test functions → can run in parallel
+
+### Critical Path
+
+```
+T001 → T002 → T004 → T005 → T006 → T007 → T008 → T009 → T010 → T016 → T019 → T020 → T021 → T022
+                                                                    ↑
+T012 → T011 ──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Parallel Example: Phase 5 + Phase 3/4
+
+```bash
+# These can run concurrently since they touch different files:
+# Agent A: Phase 3-4 (modify tasks.py)
+# Agent B: Phase 5 (modify workflow.py, create test dir)
+```
+
+---
+
+## Parallel Example: Phase 6 Tests
+
+```bash
+# These test functions are independent and can be written in parallel:
+Task: "test_generators_use_execute_workflow in backend/tests/unit/proposed_change/test_run_generators.py"
+Task: "test_no_artifact_dispatch_from_run_generators in backend/tests/unit/proposed_change/test_run_generators.py"
+Task: "test_no_repo_check_dispatch_from_run_generators in backend/tests/unit/proposed_change/test_run_generators.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1: Verify baseline
+2. Complete Phase 2: Model cleanup
+3. Complete Phase 3: Single-purpose `run_generators()`
+4. Complete Phase 4: Pipeline sequencing
+5. **STOP and VALIDATE**: Run existing tests — the core fix is done
+6. Complete Phase 5-6: Add test coverage
+7. Complete Phase 7: Final verification
+
+### Files Modified Summary
+
+| File | Change |
+|------|--------|
+| `backend/infrahub/proposed_change/models.py` | Remove 2 fields |
+| `backend/infrahub/proposed_change/tasks.py` | Modify 2 functions |
+| `backend/tests/adapters/workflow.py` | Add `all_calls` tracking |
+| `backend/tests/integration/.../test_proposed_change.py` | Update existing test |
+| `backend/tests/unit/proposed_change/__init__.py` | NEW (empty) |
+| `backend/tests/unit/proposed_change/test_run_generators.py` | NEW (6 test functions) |
+
+---
+
+## Notes
+
+- Tasks T004-T007 modify the same function — implement as a single logical edit, but tracked as separate tasks for clarity
+- Tasks T008-T010 also modify the same function — same applies
+- `asyncio` is already imported in `tasks.py` (line 3) — no additional import needed
+- The `WorkflowRecorder` test adapter (T011) should be backward-compatible: existing tests using `execute_calls` and `submit_calls` continue to work, `all_calls` is additive


### PR DESCRIPTION
## Why

When a proposed change pipeline runs with `CheckType.ALL`, generators and artifacts are both dispatched as fire-and-forget workflows via `submit_workflow()`. Artifact generation can begin before generators have finished creating objects, producing stale or incomplete artifacts.

The race only manifests in production (Prefect worker adapter uses `run_deployment(timeout=0)`). The local/test adapter serializes all calls, masking the issue.

## What changed

- **`run_generators()`** is now single-purpose: runs generator definition checks via `execute_workflow` + `asyncio.gather`, blocks until all complete, returns. No longer dispatches artifacts or repository checks.
- **`run_proposed_change_pipeline()`** owns the sequencing: dispatches independent checks first (fire-and-forget), blocks on generators via `execute_workflow`, then dispatches artifact refresh and repository checks.
- **`RequestProposedChangeRunGenerators`** simplified: removed `refresh_artifacts` and `do_repository_checks` fields.
- Independent checks (data integrity, schema, user tests) still run concurrently with generators — no throughput regression.
- No schema changes, no API changes. Generator/artifact logic itself untouched.

### Review order
1. `backend/infrahub/proposed_change/models.py` — field removal
2. `backend/infrahub/proposed_change/tasks.py` — `run_generators()` then `run_proposed_change_pipeline()`
3. `backend/tests/unit/proposed_change/test_run_generators.py` — new ordering tests
4. `backend/tests/adapters/workflow.py` and integration test updates

## How to test

```bash
uv run pytest backend/tests/unit/proposed_change/test_run_generators.py -v --no-cov
```

For production: create a proposed change triggering both generators and artifacts. In Prefect UI, confirm generator flows complete before artifact refresh starts.

## Impact

- **Backward compatibility:** No breaking changes
- **Performance:** Pipeline now blocks for generator duration (intentional). Monitor Prefect work pool — `execute_workflow` holds a slot while waiting.
- **Deployment:** Safe to deploy, no coordination needed.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added
- [ ] Docs updated