### PR TITLE
schema remove migration left orphaned edges

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core.constants import RelationshipStatus
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, RelationshipStatus
 
 from ..query import MigrationQuery
 from ..shared import SchemaMigration
@@ -11,42 +11,36 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-# Cypher fragment to compute the (branch, branch_level) of a new "deleted" edge given an
-# existing edge variable: agnostic edges stay on -global-, otherwise on the migration branch.
-_BRANCH_FROM_EXISTING = (
-    'CASE WHEN {existing}.branch = "-global-" THEN "-global-" ELSE $branch END AS new_branch, '
-    'CASE WHEN {existing}.branch = "-global-" '
-    "THEN {existing}.branch_level ELSE $branch_level END AS new_branch_level"
-)
-
-
 class NodeRemoveMigrationBaseQuery(MigrationQuery):
     """Shared parameter setup for node-remove migrations."""
 
-    QUERY_TEMPLATE: str = ""
+    def _branch_from_existing(self, existing: str) -> str:
+        """Return a Cypher fragment that computes (new_branch, new_branch_level) for a new
+        "deleted" edge based on an existing edge variable. Agnostic edges stay on the global
+        branch; all others go on the migration branch."""
+        return (
+            f"CASE WHEN {existing}.branch = $global_branch THEN $global_branch ELSE $branch END AS new_branch, "
+            f"CASE WHEN {existing}.branch = $global_branch "
+            f"THEN {existing}.branch_level ELSE $branch_level END AS new_branch_level"
+        )
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
-        self.params.update(branch_params)
-
-        self.params["current_time"] = self.at.to_string()
-        self.params["branch_name"] = self.branch.name
-        self.params["branch"] = self.branch.name
-        self.params["branch_level"] = self.branch.hierarchy_level
-        self.params["user_id"] = self.user_id
-        self.params["rel_props"] = {
-            "status": RelationshipStatus.DELETED.value,
-            "from": self.at.to_string(),
-            "from_user_id": self.user_id,
+    def _build_params(self) -> dict[str, Any]:
+        """Return shared Cypher parameters for node-remove migration queries."""
+        return {
+            "current_time": self.at.to_string(),
+            "branch_name": self.branch.name,
+            "branch": self.branch.name,
+            "branch_level": self.branch.hierarchy_level,
+            "user_id": self.user_id,
+            "global_branch": GLOBAL_BRANCH_NAME,
+            "rel_props": {
+                "status": RelationshipStatus.DELETED.value,
+                "from": self.at.to_string(),
+                "from_user_id": self.user_id,
+            },
+            # Set metadata for vertex properties on default/global branch
+            "set_metadata": self.branch.is_default or self.branch.is_global,
         }
-        # Set metadata for vertex properties on default/global branch
-        self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
-
-        query = self.QUERY_TEMPLATE % {
-            "branch_filter": branch_filter,
-            "node_kind": self.migration.previous_schema.kind,
-        }
-        self.add_to_query(query)
 
     def get_nbr_migrations_executed(self) -> int:
         return self.stats.get_counter(name="nodes_created")
@@ -75,8 +69,13 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     name = "migration_node_remove_in"
     insert_return: bool = False
 
-    QUERY_TEMPLATE = (
-        """
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params.update(self._build_params())
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        query = (
+            """
     // ----------------------------------------------------------
     // Find all active nodes of the kind being removed
     // ----------------------------------------------------------
@@ -116,9 +115,9 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     }
 
     WITH active_node, rel_inbound, peer_node,
-         """
-        + _BRANCH_FROM_EXISTING.format(existing="rel_inbound")
-        + """
+            """
+            + self._branch_from_existing("rel_inbound")
+            + """
 
     // ----------------------------------------------------------
     // Create a "deleted" edge of the same type and direction
@@ -133,7 +132,7 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     // ----------------------------------------------------------
     CALL (rel_inbound) {
         WITH rel_inbound
-        WHERE rel_inbound.branch IN ["-global-", $branch]
+        WHERE rel_inbound.branch IN [$global_branch, $branch]
         SET rel_inbound.to = $current_time, rel_inbound.to_user_id = $user_id
     }
 
@@ -158,8 +157,8 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     }
     WITH peer_node, sub_peer, sub_edge,
             """
-        + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
-        + """,
+            + self._branch_from_existing("sub_edge")
+            + """,
             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
     WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
@@ -176,11 +175,15 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     // ----------------------------------------------------------
     CALL (sub_edge) {
         WITH sub_edge
-        WHERE sub_edge.branch IN ["-global-", $branch]
+        WHERE sub_edge.branch IN [$global_branch, $branch]
         SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
     }
     """
-    )
+        ) % {
+            "branch_filter": branch_filter,
+            "node_kind": self.migration.previous_schema.kind,
+        }
+        self.add_to_query(query)
 
     def get_nbr_migrations_executed(self) -> int:
         return 0
@@ -203,8 +206,13 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     name = "migration_node_remove_out"
     insert_return: bool = False
 
-    QUERY_TEMPLATE = (
-        """
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params.update(self._build_params())
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        query = (
+            """
     // ----------------------------------------------------------
     // Find all active nodes of the kind being removed
     // ----------------------------------------------------------
@@ -254,9 +262,9 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     }
 
     WITH active_node, rel_outbound, peer_node,
-         """
-        + _BRANCH_FROM_EXISTING.format(existing="rel_outbound")
-        + """
+            """
+            + self._branch_from_existing("rel_outbound")
+            + """
 
     // ----------------------------------------------------------
     // Create a "deleted" edge of the same type and direction
@@ -271,7 +279,7 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // ----------------------------------------------------------
     CALL (rel_outbound) {
         WITH rel_outbound
-        WHERE rel_outbound.branch IN ["-global-", $branch]
+        WHERE rel_outbound.branch IN [$global_branch, $branch]
         SET rel_outbound.to = $current_time, rel_outbound.to_user_id = $user_id
     }
 
@@ -291,8 +299,8 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     }
     WITH active_node, peer_node, sub_peer, sub_edge,
             """
-        + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
-        + """,
+            + self._branch_from_existing("sub_edge")
+            + """,
             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
     WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
@@ -309,13 +317,17 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // ----------------------------------------------------------
     CALL (sub_edge) {
         WITH sub_edge
-        WHERE sub_edge.branch IN ["-global-", $branch]
+        WHERE sub_edge.branch IN [$global_branch, $branch]
         SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
     }
 
     RETURN DISTINCT active_node
     """
-    )
+        ) % {
+            "branch_filter": branch_filter,
+            "node_kind": self.migration.previous_schema.kind,
+        }
+        self.add_to_query(query)
 
     def get_nbr_migrations_executed(self) -> int:
         """Only in the outbound query b/c only the outbound query is guaranteed to run"""

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -3,45 +3,27 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core.constants import RelationshipStatus
-from infrahub.core.graph.schema import GraphNodeRelationships, GraphRelDirection
 
 from ..query import MigrationQuery
 from ..shared import SchemaMigration
 
 if TYPE_CHECKING:
-    from pydantic.fields import FieldInfo
-
     from infrahub.database import InfrahubDatabase
 
 
-class NodeRemoveMigrationBaseQuery(MigrationQuery):
-    def render_sub_query_per_rel_type(
-        self,
-        rel_name: str,
-        rel_type: str,
-        rel_def: FieldInfo,
-    ) -> str:
-        subquery = [
-            f"WITH peer_node, {rel_name}, active_node",
-            f'WHERE type({rel_name}) = "{rel_type}"',
-        ]
-        if rel_def.default.direction in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]:
-            subquery.append(f"""
-                CREATE (active_node)-[edge:{rel_type} $rel_props ]->(peer_node)
-                SET edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
-                SET edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
-                """)
-        elif rel_def.default.direction in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]:
-            subquery.append(f"""
-                CREATE (active_node)<-[edge:{rel_type} $rel_props ]-(peer_node)
-                SET edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
-                SET edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
-                """)
-        subquery.append("RETURN peer_node as p2")
-        return "\n".join(subquery)
+# Cypher fragment to compute the (branch, branch_level) of a new "deleted" edge given an
+# existing edge variable: agnostic edges stay on -global-, otherwise on the migration branch.
+_BRANCH_FROM_EXISTING = (
+    'CASE WHEN {existing}.branch = "-global-" THEN "-global-" ELSE $branch END AS new_branch, '
+    'CASE WHEN {existing}.branch = "-global-" '
+    "THEN {existing}.branch_level ELSE $branch_level END AS new_branch_level"
+)
 
-    def render_node_remove_query(self, branch_filter: str) -> str:
-        raise NotImplementedError()
+
+class NodeRemoveMigrationBaseQuery(MigrationQuery):
+    """Shared parameter setup for node-remove migrations."""
+
+    QUERY_TEMPLATE: str = ""
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
@@ -52,42 +34,16 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
         self.params["user_id"] = self.user_id
-
         self.params["rel_props"] = {
             "status": RelationshipStatus.DELETED.value,
             "from": self.at.to_string(),
             "from_user_id": self.user_id,
         }
-
         # Set metadata for vertex properties on default/global branch
         self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
 
-        node_remove_query = self.render_node_remove_query(branch_filter=branch_filter)
-
-        query = """
-        // Find all the active nodes
-        MATCH (node:%(node_kind)s)
-        CALL (node) {
-            MATCH (root:Root)<-[r:IS_PART_OF]-(node)
-            WHERE %(branch_filter)s
-            RETURN node as n1, r as r1
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH n1 as active_node, r1 as rb
-        WHERE rb.status = "active"
-        %(node_remove_query)s
-        WITH active_node
-        // Set metadata on Node vertex if on default/global branch
-        CALL (active_node) {
-            WITH active_node
-            WHERE $set_metadata
-            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
-        }
-        RETURN DISTINCT active_node
-        """ % {
+        query = self.QUERY_TEMPLATE % {
             "branch_filter": branch_filter,
-            "node_remove_query": node_remove_query,
             "node_kind": self.migration.previous_schema.kind,
         }
         self.add_to_query(query)
@@ -97,104 +53,259 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
 
 
 class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
+    """Close inbound edges that point to nodes of the removed kind.
+
+    Inbound edge types from another Node/Attribute/Relationship to our active_node:
+      - HAS_SOURCE  (Attribute|Relationship -> Node)        : peer is the Attribute/Rel
+      - HAS_OWNER   (Attribute|Relationship -> Node)        : peer is the Attribute/Rel
+      - IS_RELATED  (Node <-> Relationship, either dir)     : peer is the Relationship
+
+    For each such edge we close it on the migration branch and create a matching deleted
+    edge so that downstream branches see the removal.
+
+    For inbound IS_RELATED, the peer is a Relationship vertex that connects active_node
+    and another Node — when active_node is removed, the Relationship is torn down entirely.
+    We close its other sub-edges (IS_PROTECTED, HAS_SOURCE, HAS_OWNER, far-side IS_RELATED)
+    on the same branch.
+
+    For inbound HAS_SOURCE/HAS_OWNER the peer is an Attribute/Relationship belonging to a
+    different Node, so its sub-edges are left alone; only the inbound pointer itself is closed.
+    """
+
     name = "migration_node_remove_in"
     insert_return: bool = False
 
-    def render_node_remove_query(self, branch_filter: str) -> str:
-        sub_query, sub_query_args = self.render_sub_query_in()
-        query = """
-        // Process Inbound Relationship
-        WITH active_node
-        MATCH (active_node)<-[]-(peer)
-        CALL (active_node, peer) {
-            MATCH (active_node)-[r]->(peer)
+    QUERY_TEMPLATE = (
+        """
+    // ----------------------------------------------------------
+    // Find all active nodes of the kind being removed
+    // ----------------------------------------------------------
+    MATCH (node:%(node_kind)s)
+    CALL (node) {
+        MATCH (root:Root)<-[r:IS_PART_OF]-(node)
+        WHERE %(branch_filter)s
+        RETURN r AS root_edge
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH node AS active_node, root_edge
+    WHERE root_edge.status = "active"
+
+    // ----------------------------------------------------------
+    // For each inbound edge to active_node, find the latest active edge on the branch
+    // ----------------------------------------------------------
+    MATCH (active_node)<-[r]-(peer)
+    WITH DISTINCT active_node, type(r) AS edge_type, peer
+    CALL (active_node, edge_type, peer) {
+        MATCH (active_node)<-[r:$(edge_type)]-(peer)
+        WHERE %(branch_filter)s
+        RETURN r AS rel_inbound, peer AS peer_node
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH active_node, rel_inbound, peer_node
+    WHERE rel_inbound.status = "active"
+
+    // ----------------------------------------------------------
+    // Set updated metadata on the peer vertex on default/global branch
+    // ----------------------------------------------------------
+    CALL (peer_node) {
+        WITH peer_node
+        WHERE $set_metadata
+        SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
+    }
+
+    WITH active_node, rel_inbound, peer_node,
+         """
+        + _BRANCH_FROM_EXISTING.format(existing="rel_inbound")
+        + """,
+         startNode(rel_inbound) AS existing_start, endNode(rel_inbound) AS existing_end
+
+    // ----------------------------------------------------------
+    // Create a "deleted" edge of the same type and direction
+    // ----------------------------------------------------------
+    CALL (existing_start, existing_end, rel_inbound, new_branch, new_branch_level) {
+        CREATE (existing_start)-[new_edge:$(type(rel_inbound))]->(existing_end)
+        SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+    }
+
+    // ----------------------------------------------------------
+    // Close the existing edge if it lives on the migration branch (or is global)
+    // ----------------------------------------------------------
+    CALL (rel_inbound) {
+        WITH rel_inbound
+        WHERE rel_inbound.branch IN ["-global-", $branch]
+        SET rel_inbound.to = $current_time, rel_inbound.to_user_id = $user_id
+    }
+
+    // ----------------------------------------------------------
+    // For inbound IS_RELATED, the Relationship vertex (peer_node) is being torn down.
+    // Close its other sub-edges (IS_PROTECTED, HAS_SOURCE, HAS_OWNER, far-side IS_RELATED)
+    // on the same branch. HAS_SOURCE/HAS_OWNER inbound do NOT need this — their peer
+    // belongs to another Node and stays active.
+    // ----------------------------------------------------------
+    WITH DISTINCT active_node, peer_node, rel_inbound
+    CALL (active_node, peer_node, rel_inbound) {
+        WITH active_node, peer_node
+        WHERE type(rel_inbound) = "IS_RELATED"
+        MATCH (peer_node)-[]-(sub_peer)
+        WHERE NOT (sub_peer = active_node)
+        WITH DISTINCT peer_node, sub_peer
+        CALL (peer_node, sub_peer) {
+            MATCH (peer_node)-[r]-(sub_peer)
             WHERE %(branch_filter)s
-            RETURN active_node as n1, r as rel_inband1, peer as p1
+            RETURN r AS sub_edge
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH n1 as active_node, rel_inband1 as rel_inband, p1 as peer_node
-        WHERE rel_inband.status = "active"
-        CALL (peer_node) {
-            WITH peer_node
-            WHERE $set_metadata
-            SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
-        }
-        CALL (%(sub_query_args)s) {
-            %(sub_query)s
-        }
-        WITH p2 as peer_node, rel_inband, active_node
-        FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_inband.to = $current_time, rel_inband.to_user_id = $user_id
-        )
-        """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
-        return query
+        WITH peer_node, sub_peer, sub_edge,
+             """
+        + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
+        + """,
+             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
+        WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
-    def render_sub_query_in(self) -> tuple[str, str]:
-        rel_name = "rel_inband"
-        sub_query_in_args = f"peer_node, {rel_name}, active_node"
-        sub_queries_in = [
-            self.render_sub_query_per_rel_type(
-                rel_name=rel_name,
-                rel_type=rel_type,
-                rel_def=rel_def,
-            )
-            for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
-        ]
-        sub_query_in = "\nUNION\n".join(sub_queries_in)
-        return sub_query_in, sub_query_in_args
+        CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
+            CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
+            SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+        }
+
+        CALL (sub_edge) {
+            WITH sub_edge
+            WHERE sub_edge.branch IN ["-global-", $branch]
+            SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
+        }
+    }
+    """
+    )
 
     def get_nbr_migrations_executed(self) -> int:
         return 0
 
 
 class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
-    name = "migration_node_remove_in"
+    """Close outbound edges from nodes of the removed kind, plus their second-level sub-edges.
+
+    Outbound edge types from active_node:
+      - HAS_ATTRIBUTE (Node -> Attribute)
+      - IS_PART_OF    (Node -> Root)
+      - IS_RELATED    (Node <-> Relationship, either dir)
+
+    After closing the parent HAS_ATTRIBUTE/IS_RELATED edge, the Attribute/Relationship
+    vertex is orphaned from active_node's perspective. We must also close any active
+    sub-edges hanging off that Attribute/Relationship (HAS_VALUE, HAS_SOURCE, HAS_OWNER,
+    IS_PROTECTED, far-side IS_RELATED) on the same branch
+    """
+
+    name = "migration_node_remove_out"
     insert_return: bool = False
 
-    def render_node_remove_query(self, branch_filter: str) -> str:
-        sub_query, sub_query_args = self.render_sub_query_out()
-        query = """
-        // Process Outbound Relationship
+    QUERY_TEMPLATE = (
+        """
+    // ----------------------------------------------------------
+    // Find all active nodes of the kind being removed
+    // ----------------------------------------------------------
+    MATCH (node:%(node_kind)s)
+    CALL (node) {
+        MATCH (root:Root)<-[r:IS_PART_OF]-(node)
+        WHERE %(branch_filter)s
+        RETURN r AS root_edge
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH node AS active_node, root_edge
+    WHERE root_edge.status = "active"
+
+    // Set updated metadata on the Node vertex on default/global branch
+    CALL (active_node) {
         WITH active_node
-        MATCH (active_node)-[]->(peer)
-        CALL (active_node, peer) {
-            MATCH (active_node)-[r]->(peer)
+        WHERE $set_metadata
+        SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+    }
+
+    // ----------------------------------------------------------
+    // For each outbound edge from active_node, find the latest active edge on the branch
+    // ----------------------------------------------------------
+    WITH active_node
+    MATCH (active_node)-[]->(peer)
+    CALL (active_node, peer) {
+        MATCH (active_node)-[r]->(peer)
+        WHERE %(branch_filter)s
+        RETURN r AS rel_outbound, peer AS peer_node
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH active_node, rel_outbound, peer_node
+    WHERE rel_outbound.status = "active"
+
+    // Set updated metadata on the peer vertex on default/global branch
+    CALL (peer_node) {
+        WITH peer_node
+        WHERE $set_metadata
+        SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
+    }
+
+    WITH active_node, rel_outbound, peer_node,
+         """
+        + _BRANCH_FROM_EXISTING.format(existing="rel_outbound")
+        + """,
+         startNode(rel_outbound) AS existing_start, endNode(rel_outbound) AS existing_end
+
+    // Create a "deleted" edge of the same type and direction. Dynamic relationship type
+    // via $(type(rel_outbound)) requires Neo4j 5.26+.
+    CALL (existing_start, existing_end, rel_outbound, new_branch, new_branch_level) {
+        CREATE (existing_start)-[new_edge:$(type(rel_outbound))]->(existing_end)
+        SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+    }
+
+    // Close the existing parent edge if it lives on the migration branch (or is global)
+    CALL (rel_outbound) {
+        WITH rel_outbound
+        WHERE rel_outbound.branch IN ["-global-", $branch]
+        SET rel_outbound.to = $current_time, rel_outbound.to_user_id = $user_id
+    }
+
+    // ----------------------------------------------------------
+    // Close sub-edges hanging off the Attribute/Relationship peer vertex
+    // ----------------------------------------------------------
+    WITH DISTINCT active_node, peer_node
+    CALL (active_node, peer_node) {
+        WITH active_node, peer_node
+        WHERE peer_node:Attribute OR peer_node:Relationship
+        MATCH (peer_node)-[]-(sub_peer)
+        WHERE NOT (sub_peer = active_node)
+        WITH DISTINCT peer_node, sub_peer
+        CALL (peer_node, sub_peer) {
+            MATCH (peer_node)-[r]-(sub_peer)
             WHERE %(branch_filter)s
-            RETURN active_node as n1, r as rel_outband1, peer as p1
+            RETURN r AS sub_edge
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH n1 as active_node, rel_outband1 as rel_outband, p1 as peer_node
-        WHERE rel_outband.status = "active"
-        CALL (peer_node) {
-            WITH peer_node
-            WHERE $set_metadata
-            SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
-        }
-        CALL (%(sub_query_args)s) {
-            %(sub_query)s
-        }
-        FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
-            SET rel_outband.to = $current_time, rel_outband.to_user_id = $user_id
-        )
-        """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
+        WITH peer_node, sub_peer, sub_edge,
+             """
+        + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
+        + """,
+             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
+        WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
-        return query
+        // Create a deleted sub-edge of the same type and direction.
+        CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
+            CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
+            SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+        }
 
-    def render_sub_query_out(self) -> tuple[str, str]:
-        rel_name = "rel_outband"
-        sub_query_out_args = f"peer_node, {rel_name}, active_node"
-        sub_queries_out = [
-            self.render_sub_query_per_rel_type(
-                rel_name=rel_name,
-                rel_type=rel_type,
-                rel_def=rel_def,
-            )
-            for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
-        ]
-        sub_query_out = "\nUNION\n".join(sub_queries_out)
-        return sub_query_out, sub_query_out_args
+        // Close the existing sub-edge if it lives on the migration branch (or is global)
+        CALL (sub_edge) {
+            WITH sub_edge
+            WHERE sub_edge.branch IN ["-global-", $branch]
+            SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
+        }
+    }
+
+    RETURN DISTINCT active_node
+    """
+    )
 
     def get_nbr_migrations_executed(self) -> int:
         return self.num_of_results

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -94,7 +94,7 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     // ----------------------------------------------------------
     // For each inbound edge to active_node, find the latest active edge on the branch
     // ----------------------------------------------------------
-    MATCH (active_node)<-[r]-(peer)
+    MATCH (active_node)<-[r:IS_RELATED|HAS_SOURCE|HAS_OWNER]-(peer:Attribute|Relationship)
     WITH DISTINCT active_node, type(r) AS edge_type, peer
     CALL (active_node, edge_type, peer) {
         MATCH (active_node)<-[r:$(edge_type)]-(peer)
@@ -118,14 +118,13 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     WITH active_node, rel_inbound, peer_node,
          """
         + _BRANCH_FROM_EXISTING.format(existing="rel_inbound")
-        + """,
-         startNode(rel_inbound) AS existing_start, endNode(rel_inbound) AS existing_end
+        + """
 
     // ----------------------------------------------------------
     // Create a "deleted" edge of the same type and direction
     // ----------------------------------------------------------
-    CALL (existing_start, existing_end, rel_inbound, new_branch, new_branch_level) {
-        CREATE (existing_start)-[new_edge:$(type(rel_inbound))]->(existing_end)
+    CALL (peer_node, active_node, rel_inbound, new_branch, new_branch_level) {
+        CREATE (peer_node)-[new_edge:$(type(rel_inbound))]->(active_node)
         SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
     }
 
@@ -145,36 +144,40 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     // belongs to another Node and stays active.
     // ----------------------------------------------------------
     WITH DISTINCT active_node, peer_node, rel_inbound
-    CALL (active_node, peer_node, rel_inbound) {
-        WITH active_node, peer_node
-        WHERE type(rel_inbound) = "IS_RELATED"
-        MATCH (peer_node)-[]-(sub_peer)
-        WHERE NOT (sub_peer = active_node)
-        WITH DISTINCT peer_node, sub_peer
-        CALL (peer_node, sub_peer) {
-            MATCH (peer_node)-[r]-(sub_peer)
-            WHERE %(branch_filter)s
-            RETURN r AS sub_edge
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH peer_node, sub_peer, sub_edge,
-             """
+    WHERE type(rel_inbound) = "IS_RELATED"
+
+    MATCH (peer_node:Relationship)-[sub_edge]-(sub_peer)
+    WHERE sub_peer <> active_node
+    WITH DISTINCT peer_node, type(sub_edge) AS sub_edge_type, sub_peer
+    CALL (peer_node, sub_edge_type, sub_peer) {
+        MATCH (peer_node)-[r:$(sub_edge_type)]-(sub_peer)
+        WHERE %(branch_filter)s
+        RETURN r AS sub_edge
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH peer_node, sub_peer, sub_edge,
+            """
         + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
         + """,
-             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
-        WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
+            startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
+    WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
-        CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
-            CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
-            SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
-        }
+    // ----------------------------------------------------------
+    // Create a deleted sub-edge of the same type and direction
+    // ----------------------------------------------------------
+    CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
+        CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
+        SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+    }
 
-        CALL (sub_edge) {
-            WITH sub_edge
-            WHERE sub_edge.branch IN ["-global-", $branch]
-            SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
-        }
+    // ----------------------------------------------------------
+    // Close the existing sub-edge if it lives on the migration branch or is global
+    // ----------------------------------------------------------
+    CALL (sub_edge) {
+        WITH sub_edge
+        WHERE sub_edge.branch IN ["-global-", $branch]
+        SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
     }
     """
     )
@@ -216,7 +219,9 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     WITH node AS active_node, root_edge
     WHERE root_edge.status = "active"
 
+    // ----------------------------------------------------------
     // Set updated metadata on the Node vertex on default/global branch
+    // ----------------------------------------------------------
     CALL (active_node) {
         WITH active_node
         WHERE $set_metadata
@@ -227,7 +232,7 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // For each outbound edge from active_node, find the latest active edge on the branch
     // ----------------------------------------------------------
     WITH active_node
-    MATCH (active_node)-[]->(peer)
+    MATCH (active_node)-[:HAS_ATTRIBUTE|IS_RELATED|IS_PART_OF]->(peer:Attribute|Relationship|Root)
     CALL (active_node, peer) {
         MATCH (active_node)-[r]->(peer)
         WHERE %(branch_filter)s
@@ -238,27 +243,31 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     WITH active_node, rel_outbound, peer_node
     WHERE rel_outbound.status = "active"
 
+    // ----------------------------------------------------------
     // Set updated metadata on the peer vertex on default/global branch
+    // ----------------------------------------------------------
     CALL (peer_node) {
         WITH peer_node
-        WHERE $set_metadata
+        WHERE $set_metadata AND (peer_node:Attribute OR peer_node:Relationship)
         SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
     }
 
     WITH active_node, rel_outbound, peer_node,
          """
         + _BRANCH_FROM_EXISTING.format(existing="rel_outbound")
-        + """,
-         startNode(rel_outbound) AS existing_start, endNode(rel_outbound) AS existing_end
+        + """
 
-    // Create a "deleted" edge of the same type and direction. Dynamic relationship type
-    // via $(type(rel_outbound)) requires Neo4j 5.26+.
-    CALL (existing_start, existing_end, rel_outbound, new_branch, new_branch_level) {
-        CREATE (existing_start)-[new_edge:$(type(rel_outbound))]->(existing_end)
+    // ----------------------------------------------------------
+    // Create a "deleted" edge of the same type and direction
+    // ----------------------------------------------------------
+    CALL (active_node, peer_node, rel_outbound, new_branch, new_branch_level) {
+        CREATE (active_node)-[new_edge:$(type(rel_outbound))]->(peer_node)
         SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
     }
 
+    // ----------------------------------------------------------
     // Close the existing parent edge if it lives on the migration branch (or is global)
+    // ----------------------------------------------------------
     CALL (rel_outbound) {
         WITH rel_outbound
         WHERE rel_outbound.branch IN ["-global-", $branch]
@@ -269,38 +278,38 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // Close sub-edges hanging off the Attribute/Relationship peer vertex
     // ----------------------------------------------------------
     WITH DISTINCT active_node, peer_node
-    CALL (active_node, peer_node) {
-        WITH active_node, peer_node
-        WHERE peer_node:Attribute OR peer_node:Relationship
-        MATCH (peer_node)-[]-(sub_peer)
-        WHERE NOT (sub_peer = active_node)
-        WITH DISTINCT peer_node, sub_peer
-        CALL (peer_node, sub_peer) {
-            MATCH (peer_node)-[r]-(sub_peer)
-            WHERE %(branch_filter)s
-            RETURN r AS sub_edge
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH peer_node, sub_peer, sub_edge,
-             """
+    MATCH (peer_node:Attribute|Relationship)-[]-(sub_peer)
+    WHERE sub_peer <> active_node
+    WITH DISTINCT active_node, peer_node, sub_peer
+    CALL (peer_node, sub_peer) {
+        MATCH (peer_node)-[r]-(sub_peer)
+        WHERE %(branch_filter)s
+        RETURN r AS sub_edge
+        ORDER BY r.branch_level DESC, r.from DESC
+        LIMIT 1
+    }
+    WITH active_node, peer_node, sub_peer, sub_edge,
+            """
         + _BRANCH_FROM_EXISTING.format(existing="sub_edge")
         + """,
-             startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
-        WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
+            startNode(sub_edge) AS sub_start, endNode(sub_edge) AS sub_end
+    WHERE sub_edge.status = "active" AND sub_edge.to IS NULL
 
-        // Create a deleted sub-edge of the same type and direction.
-        CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
-            CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
-            SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
-        }
+    // ----------------------------------------------------------
+    // Create a deleted sub-edge of the same type and direction.
+    // ----------------------------------------------------------
+    CALL (sub_start, sub_end, sub_edge, new_branch, new_branch_level) {
+        CREATE (sub_start)-[new_edge:$(type(sub_edge))]->(sub_end)
+        SET new_edge = $rel_props, new_edge.branch = new_branch, new_edge.branch_level = new_branch_level
+    }
 
-        // Close the existing sub-edge if it lives on the migration branch (or is global)
-        CALL (sub_edge) {
-            WITH sub_edge
-            WHERE sub_edge.branch IN ["-global-", $branch]
-            SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
-        }
+    // ----------------------------------------------------------
+    // Close the existing sub-edge if it lives on the migration branch (or is global)
+    // ----------------------------------------------------------
+    CALL (sub_edge) {
+        WITH sub_edge
+        WHERE sub_edge.branch IN ["-global-", $branch]
+        SET sub_edge.to = $current_time, sub_edge.to_user_id = $user_id
     }
 
     RETURN DISTINCT active_node
@@ -308,6 +317,7 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     )
 
     def get_nbr_migrations_executed(self) -> int:
+        """Only in the outbound query b/c only the outbound query is guaranteed to run"""
         return self.num_of_results
 
 

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -232,9 +232,10 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // For each outbound edge from active_node, find the latest active edge on the branch
     // ----------------------------------------------------------
     WITH active_node
-    MATCH (active_node)-[:HAS_ATTRIBUTE|IS_RELATED|IS_PART_OF]->(peer:Attribute|Relationship|Root)
-    CALL (active_node, peer) {
-        MATCH (active_node)-[r]->(peer)
+    MATCH (active_node)-[e:HAS_ATTRIBUTE|IS_RELATED|IS_PART_OF]->(peer:Attribute|Relationship|Root)
+    WITH DISTINCT active_node, type(e) AS edge_type, peer
+    CALL (active_node, edge_type, peer) {
+        MATCH (active_node)-[r:$(edge_type)]->(peer)
         WHERE %(branch_filter)s
         RETURN r AS rel_outbound, peer AS peer_node
         ORDER BY r.branch_level DESC, r.from DESC

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -278,11 +278,11 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     // Close sub-edges hanging off the Attribute/Relationship peer vertex
     // ----------------------------------------------------------
     WITH DISTINCT active_node, peer_node
-    MATCH (peer_node:Attribute|Relationship)-[]-(sub_peer)
+    MATCH (peer_node:Attribute|Relationship)-[e]-(sub_peer)
     WHERE sub_peer <> active_node
-    WITH DISTINCT active_node, peer_node, sub_peer
-    CALL (peer_node, sub_peer) {
-        MATCH (peer_node)-[r]-(sub_peer)
+    WITH DISTINCT active_node, peer_node, type(e) AS sub_edge_type, sub_peer
+    CALL (peer_node, sub_edge_type, sub_peer) {
+        MATCH (peer_node)-[r:$(sub_edge_type)]-(sub_peer)
         WHERE %(branch_filter)s
         RETURN r AS sub_edge
         ORDER BY r.branch_level DESC, r.from DESC

--- a/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
+++ b/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
@@ -1,12 +1,17 @@
 """Test that the diff includes nodes deleted by a NodeRemoveMigration.
 
 Reproduces a scenario where:
-1. A node is created on the default branch
+1. Nodes (with relationships between them) are created on the default branch
 2. A branch is created
 3. A different object is changed on the branch (so the diff has content)
-4. A NodeRemoveMigration runs on the branch, deleting the node
+4. A NodeRemoveMigration runs on the branch, deleting the nodes of a kind that
+   has active relationships to instances of another kind
 5. The diff is updated
-6. The deleted node should appear in the diff as REMOVED
+6. The deleted nodes should appear in the diff as REMOVED
+
+Note: We delete TestCar (rather than TestPerson) because TestCar.owner is a
+required relationship to TestPerson — removing TestPerson while TestCar instances
+exist would violate that constraint.
 """
 
 from unittest.mock import AsyncMock
@@ -28,6 +33,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
+from tests.helpers.db_validation import verify_graph
 
 
 class TestDiffAfterNodeRemoveMigration:
@@ -41,16 +47,19 @@ class TestDiffAfterNodeRemoveMigration:
         default_branch: Branch,
         car_person_schema: SchemaBranch,
     ) -> None:
-        # Step 1: Create a person on the default branch
+        # Step 1: Create a person and a car (with owner=person) on the default branch
         person = await Node.init(db=db, schema="TestPerson")
         await person.new(db=db, name="BluePerson", height=180)
         await person.save(db=db, user_id="test-user")
+
+        car = await Node.init(db=db, schema="TestCar")
+        await car.new(db=db, name="accord", nbr_seats=5, is_electric=False, owner=person.id)
+        await car.save(db=db, user_id="test-user")
 
         # Step 2: Create a branch
         branch = await create_branch(db=db, branch_name="test-branch")
 
         # Step 3: Make an unrelated change on the branch (so the diff has content)
-        # Update the person's height on the branch — but use a DIFFERENT person
         other_person = await Node.init(db=db, schema="TestPerson", branch=branch)
         await other_person.new(db=db, name="OtherPerson", height=160)
         await other_person.save(db=db, user_id="branch-user")
@@ -65,19 +74,21 @@ class TestDiffAfterNodeRemoveMigration:
             base_branch=default_branch, diff_branch=branch
         )
 
-        # Verify person is NOT in the diff yet (it was created on main, not changed on branch)
+        # Verify car is NOT in the diff yet (it was created on main, not changed on branch)
         enriched_diff = await diff_repository.get_one(
             diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
         )
-        person_in_diff = [n for n in enriched_diff.nodes if n.uuid == person.id]
-        assert len(person_in_diff) == 0, "Person should not be in the diff before migration"
+        car_in_diff = [n for n in enriched_diff.nodes if n.uuid == car.id]
+        assert len(car_in_diff) == 0, "Car should not be in the diff before migration"
 
-        # Step 5: Run NodeRemoveMigration on the branch to delete TestPerson nodes
-        person_schema = car_person_schema.get(name="TestPerson")
+        # Step 5: Run NodeRemoveMigration on the branch to delete TestCar nodes
+        # TestCar has an active outbound `owner` relationship to TestPerson, so this
+        # exercises the deletion path for nodes with active relationships.
+        car_schema = car_person_schema.get(name="TestCar")
         migration = NodeRemoveMigration(
-            previous_node_schema=person_schema,
+            previous_node_schema=car_schema,
             new_node_schema=None,
-            schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestPerson"),
+            schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
         )
         migration_at = Timestamp()
         result = await migration.execute(
@@ -86,22 +97,24 @@ class TestDiffAfterNodeRemoveMigration:
         )
         assert result.success, f"Migration failed: {result.errors}"
 
-        # Verify person is deleted on the branch
-        person_on_branch = await NodeManager.get_one(db=db, branch=branch, id=person.id)
-        assert person_on_branch is None, "Person should be deleted on the branch after migration"
+        # Verify car is deleted on the branch
+        car_on_branch = await NodeManager.get_one(db=db, branch=branch, id=car.id)
+        assert car_on_branch is None, "Car should be deleted on the branch after migration"
+
+        await verify_graph(db=db)
 
         # Step 6: Update the diff again
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(
             base_branch=default_branch, diff_branch=branch
         )
 
-        # Step 7: Verify the deleted person appears in the updated diff
+        # Step 7: Verify the deleted car appears in the updated diff
         enriched_diff = await diff_repository.get_one(
             diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
         )
-        person_in_diff = [n for n in enriched_diff.nodes if n.uuid == person.id]
-        assert len(person_in_diff) == 1, (
-            f"Person should appear in the diff after being deleted by migration. "
+        car_in_diff = [n for n in enriched_diff.nodes if n.uuid == car.id]
+        assert len(car_in_diff) == 1, (
+            f"Car should appear in the diff after being deleted by migration. "
             f"Diff node UUIDs: {[n.uuid for n in enriched_diff.nodes]}"
         )
-        assert person_in_diff[0].action is DiffAction.REMOVED
+        assert car_in_diff[0].action is DiffAction.REMOVED

--- a/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
+++ b/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
@@ -1,0 +1,107 @@
+"""Test that the diff includes nodes deleted by a NodeRemoveMigration.
+
+Reproduces a scenario where:
+1. A node is created on the default branch
+2. A branch is created
+3. A different object is changed on the branch (so the diff has content)
+4. A NodeRemoveMigration runs on the branch, deleting the node
+5. The diff is updated
+6. The deleted node should appear in the diff as REMOVED
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import DiffAction, SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_remove import NodeRemoveMigration
+from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+class TestDiffAfterNodeRemoveMigration:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
+        return
+
+    async def test_deleted_node_appears_in_diff(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_person_schema: SchemaBranch,
+    ) -> None:
+        # Step 1: Create a person on the default branch
+        person = await Node.init(db=db, schema="TestPerson")
+        await person.new(db=db, name="BluePerson", height=180)
+        await person.save(db=db, user_id="test-user")
+
+        # Step 2: Create a branch
+        branch = await create_branch(db=db, branch_name="test-branch")
+
+        # Step 3: Make an unrelated change on the branch (so the diff has content)
+        # Update the person's height on the branch — but use a DIFFERENT person
+        other_person = await Node.init(db=db, schema="TestPerson", branch=branch)
+        await other_person.new(db=db, name="OtherPerson", height=160)
+        await other_person.save(db=db, user_id="branch-user")
+
+        # Step 4: Generate the initial diff
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch
+        )
+
+        # Verify person is NOT in the diff yet (it was created on main, not changed on branch)
+        enriched_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
+        )
+        person_in_diff = [n for n in enriched_diff.nodes if n.uuid == person.id]
+        assert len(person_in_diff) == 0, "Person should not be in the diff before migration"
+
+        # Step 5: Run NodeRemoveMigration on the branch to delete TestPerson nodes
+        person_schema = car_person_schema.get(name="TestPerson")
+        migration = NodeRemoveMigration(
+            previous_node_schema=person_schema,
+            new_node_schema=None,
+            schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestPerson"),
+        )
+        migration_at = Timestamp()
+        result = await migration.execute(
+            migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"),
+            branch=branch,
+        )
+        assert result.success, f"Migration failed: {result.errors}"
+
+        # Verify person is deleted on the branch
+        person_on_branch = await NodeManager.get_one(db=db, branch=branch, id=person.id)
+        assert person_on_branch is None, "Person should be deleted on the branch after migration"
+
+        # Step 6: Update the diff again
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch
+        )
+
+        # Step 7: Verify the deleted person appears in the updated diff
+        enriched_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
+        )
+        person_in_diff = [n for n in enriched_diff.nodes if n.uuid == person.id]
+        assert len(person_in_diff) == 1, (
+            f"Person should appear in the diff after being deleted by migration. "
+            f"Diff node UUIDs: {[n.uuid for n in enriched_diff.nodes]}"
+        )
+        assert person_in_diff[0].action is DiffAction.REMOVED

--- a/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
+++ b/backend/tests/component/core/diff/test_diff_after_node_remove_migration.py
@@ -16,8 +16,6 @@ exist would violate that constraint.
 
 from unittest.mock import AsyncMock
 
-import pytest
-
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, SchemaPathType
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -37,14 +35,11 @@ from tests.helpers.db_validation import verify_graph
 
 
 class TestDiffAfterNodeRemoveMigration:
-    @pytest.fixture(autouse=True)
-    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
-        return
-
     async def test_deleted_node_appears_in_diff(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
         car_person_schema: SchemaBranch,
     ) -> None:
         # Step 1: Create a person and a car (with owner=person) on the default branch

--- a/backend/tests/component/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_remove.py
@@ -3,6 +3,7 @@ from typing import Any
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import SchemaPathType
+from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_remove import (
     NodeRemoveMigration,
     NodeRemoveMigrationQueryIn,
@@ -17,6 +18,7 @@ from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.test_node_kind_update import validate_node_relationships
 from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import load_schema
 
@@ -42,16 +44,18 @@ async def test_query_out_default_branch(
     await query.execute(db=db)
     assert query.get_nbr_migrations_executed() == 2
 
-    # we expect 9 new relationships per TestCar, 18 TOTAL
-    # 7 attributes, 1 relationship & 1 for the root node
-    assert await count_relationships(db=db) == count_rels + 18
+    # we expect 25 new relationships per TestCar, 50 TOTAL:
+    # - 9 deleted parent edges (7 attributes, 1 outbound relationship, 1 IS_PART_OF)
+    # - 16 deleted sub-edges (HAS_VALUE + IS_PROTECTED per attribute = 14, plus
+    #   far-side IS_RELATED + IS_PROTECTED per outbound relationship = 2)
+    assert await count_relationships(db=db) == count_rels + 50
     assert await count_nodes(db=db, label="TestCar") == 2
 
     # Re-execute the query once to ensure that it won't change anything
     query = await NodeRemoveMigrationQueryOut.init(db=db, branch=default_branch, migration=migration)
     await query.execute(db=db)
     assert query.get_nbr_migrations_executed() == 0
-    assert await count_relationships(db=db) == count_rels + 18
+    assert await count_relationships(db=db) == count_rels + 50
     assert await count_nodes(db=db, label="TestCar") == 2
 
 
@@ -120,7 +124,7 @@ async def test_migration_aware(
     assert execution_result.nbr_migrations_executed == 2
 
     # 5. Validate nodes and relationships after migration
-    assert await count_relationships(db=db) == count_rels + 18
+    assert await count_relationships(db=db) == count_rels + 50
     assert await count_nodes(db=db, label="TestCar") == 2
 
     # 6. Validate edge timestamps
@@ -130,6 +134,43 @@ async def test_migration_aware(
     # 7. Validate node relationships
     await validate_node_relationships(node=car_accord_main, db=db, branch=default_branch)
     await validate_node_relationships(node=car_camry_main, db=db, branch=default_branch)
+
+    # 8. Validate graph integrity
+    await verify_graph(db=db)
+
+
+async def test_migration_aware_inbound_relationship(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
+) -> None:
+    """Remove TestPerson, exercising the IN query path for IS_RELATED.
+
+    TestPerson.cars is defined with `direction: inbound`, so IS_RELATED edges from
+    TestPerson's perspective are stored as `Relationship -> TestPerson`. Removing
+    TestPerson must close the Relationship vertex's other sub-edges (IS_PROTECTED,
+    far-side IS_RELATED to TestCar) — verify_graph would otherwise flag orphaned
+    active sub-edges.
+    """
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    candidate_schema.delete(name="TestPerson")
+
+    # car_accord_main creates person_john_main, car_camry_main creates person_jane_main
+    assert await count_nodes(db=db, label="TestPerson") == 2
+    assert await count_nodes(db=db, label="TestCar") == 2
+
+    migration = NodeRemoveMigration(
+        previous_node_schema=schema.get(name="TestPerson"),
+        new_node_schema=None,
+        schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestPerson"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    # Cars themselves remain; only TestPerson nodes' edges are torn down.
+    assert await NodeManager.count(db=db, schema="TestCar", branch=default_branch) == 2
+    assert await NodeManager.count(db=db, schema="TestPerson", branch=default_branch) == 0
+
+    await verify_graph(db=db)
 
 
 async def test_migration_agnostic_relationship(
@@ -165,6 +206,8 @@ async def test_migration_agnostic_relationship(
     await validate_node_relationships(node=person_john, db=db, branch=registry.get_global_branch())
     await validate_node_relationships(node=car, db=db, branch=registry.get_global_branch())
 
+    await verify_graph(db=db)
+
 
 async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
     """Test that metadata is set correctly when removing a node."""
@@ -184,6 +227,8 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
     )
     assert not execution_result.errors
+
+    await verify_graph(db=db)
 
     # Query for the deleted Node and its edge metadata
     query = """

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -207,7 +207,6 @@ RETURN DISTINCT
     """
     params = {
         "default_branch": registry.default_branch,
-        "global_branch": GLOBAL_BRANCH_NAME,
     }
     records = await db.execute_query(query=query, params=params)
     for record in records:

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, BranchSupportType
 from infrahub.core.node import Node
@@ -130,6 +131,152 @@ RETURN node_id1, branch, from_time, edge_type, node_id2, num_paths
         num_paths = record.get("num_paths")
         raise ValueError(
             f"{num_paths} paths ({branch=},{edge_type=},{from_time=}) between nodes '{node_id1}' and '{node_id2}'"
+        )
+
+
+async def verify_graph(db: InfrahubDatabase) -> None:
+    """Run all post-merge graph validation checks."""
+    await verify_no_duplicate_paths(db=db)
+    await verify_no_orphaned_active_edges(db=db)
+    await verify_relationship_edge_counts(db=db)
+
+
+async def verify_no_orphaned_active_edges(db: InfrahubDatabase) -> None:
+    """Verify that no active second-level edges exist under deleted first-level edges.
+
+    If a HAS_ATTRIBUTE or IS_RELATED edge is deleted/closed on a branch, then all
+    sub-edges (HAS_VALUE, IS_PROTECTED, HAS_OWNER, HAS_SOURCE, far-side IS_RELATED)
+    hanging off the same Attribute/Relationship vertex on the same branch should also
+    be deleted/closed.
+    """
+    query = """
+// ----------------
+// Find deleted/closed first-level edges (HAS_ATTRIBUTE or IS_RELATED)
+// ----------------
+MATCH (n:Node)-[r1:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+WHERE (r1.status = "deleted" AND r1.to IS NULL)
+   OR (r1.status = "active" AND r1.to IS NOT NULL)
+WITH n, field, r1,
+    CASE WHEN r1.status = "deleted" THEN r1.from ELSE r1.to END AS r1_deleted_at
+// ----------------
+// Exclude cases where another active first-level edge to this field exists on the same branch
+// (e.g. migrated-kind nodes where old vertex HAS_ATTRIBUTE is deleted but new vertex's is active)
+// ----------------
+WHERE NOT EXISTS {
+    MATCH (other:Node)-[active_r1:HAS_ATTRIBUTE|IS_RELATED {branch: r1.branch, status: "active"}]-(field)
+    WHERE active_r1.to IS NULL
+}
+// ----------------
+// Find all second-level peers of this field, then get the latest edge to each
+// visible from the deleted first-level edge's branch
+// ----------------
+WITH n, field, r1, r1_deleted_at
+MATCH (field)-[prop_edge:HAS_VALUE|IS_PROTECTED|HAS_OWNER|HAS_SOURCE|IS_RELATED]-(peer)
+WHERE peer <> n
+WITH DISTINCT n, field, r1, r1_deleted_at, type(prop_edge) AS prop_edge_type, peer
+// ----------------
+// Get the branched_from time if r1.branch is a user branch
+// ----------------
+OPTIONAL MATCH (r1_br:Branch {name: r1.branch})
+// Use created_at instead of branched_from because branched_from is updated after a merge
+WITH n, field, r1, r1_deleted_at, prop_edge_type, peer, r1_br.created_at AS r1_branch_created_at
+// ----------------
+// Get the latest edge to this peer visible from the first-level edge's branch
+// ----------------
+CALL (field, r1, r1_branch_created_at, prop_edge_type, peer) {
+    MATCH (field)-[r2:HAS_VALUE|IS_PROTECTED|HAS_OWNER|HAS_SOURCE|IS_RELATED]-(peer)
+    WHERE (
+        r2.branch = r1.branch
+        OR (r1_branch_created_at IS NOT NULL AND r2.branch = $default_branch AND r2.from < r1_branch_created_at)
+    )
+    AND type(r2) = prop_edge_type
+    RETURN r2
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC
+    LIMIT 1
+}
+// ----------------
+// Flag if the latest visible edge is active — it should have been deleted/closed
+// ----------------
+WITH field, r1, r2
+WHERE r2.status = "active" AND r2.to IS NULL
+RETURN DISTINCT
+    field.name AS field_name,
+    r1.branch AS branch,
+    labels(field)[0] AS field_type,
+    type(r2) AS child_type
+    """
+    params = {
+        "default_branch": registry.default_branch,
+        "global_branch": GLOBAL_BRANCH_NAME,
+    }
+    records = await db.execute_query(query=query, params=params)
+    for record in records:
+        field_name = record.get("field_name")
+        branch = record.get("branch")
+        field_type = record.get("field_type")
+        child_type = record.get("child_type")
+        raise ValueError(
+            f"Orphaned active {child_type} edge on {field_type} '{field_name}' "
+            f"where all parent edges are deleted on branch '{branch}'"
+        )
+
+
+async def verify_relationship_edge_counts(db: InfrahubDatabase) -> None:
+    """Verify that every Relationship vertex has exactly 0 or 2 active IS_RELATED edges per branch.
+
+    A Relationship vertex connects two Node vertices. For any given branch, there should be
+    either 0 active IS_RELATED edges (relationship not active on that branch) or exactly 2
+    (one to each Node). Having 1 or 3+ is always invalid.
+    """
+    query = """
+MATCH (rel:Relationship)
+// ----------------
+// Get all distinct branches from any edge connected to this Relationship
+// ----------------
+CALL (rel) {
+    MATCH (rel)-[e]-()
+    RETURN DISTINCT e.branch AS branch
+}
+// ----------------
+// Get created_at for user branches (NULL for default)
+// Use created_at instead of branched_from because branched_from is updated after a merge
+// ----------------
+OPTIONAL MATCH (br:Branch {name: branch})
+WITH rel, branch, br.created_at AS branch_created_at
+// ----------------
+// Find all peer Nodes this Relationship might connect to
+// ----------------
+MATCH (rel)-[:IS_RELATED]-(peer:Node)
+WITH DISTINCT rel, branch, branch_created_at, peer
+// ----------------
+// For each (rel, branch, peer), get the latest IS_RELATED edge visible from this branch
+// ----------------
+CALL (rel, branch, branch_created_at, peer) {
+    MATCH (rel)-[r:IS_RELATED]-(peer)
+    WHERE (r.branch = branch)
+       OR (branch_created_at IS NOT NULL AND r.branch = $default_branch AND r.from < branch_created_at)
+    RETURN r
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+// ----------------
+// Count peers where the latest visible edge is active
+// ----------------
+WITH rel, branch,
+    CASE WHEN r.status = "active" AND r.to IS NULL THEN 1 ELSE NULL END AS is_active
+WITH rel, branch, count(is_active) AS active_count
+WHERE active_count <> 0 AND active_count <> 2
+RETURN rel.name AS rel_name, rel.uuid AS rel_uuid, branch, active_count
+    """
+    records = await db.execute_query(query=query, params={"default_branch": registry.default_branch})
+    for record in records:
+        rel_name = record.get("rel_name")
+        rel_uuid = record.get("rel_uuid")
+        branch = record.get("branch")
+        active_count = record.get("active_count")
+        raise ValueError(
+            f"Relationship '{rel_name}' ({rel_uuid}) has {active_count} active "
+            f"IS_RELATED edges on branch '{branch}' (expected 0 or 2)"
         )
 
 

--- a/changelog/+5e60aea2.fixed.md
+++ b/changelog/+5e60aea2.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in schema remove migration that could cause removed instances of the schema to be excluded from the diff. Would not cause a functional issue because the schema remove migration would run on the default branch when merged.


### PR DESCRIPTION
the `NodeRemoveMigration` that we run when deleting a schema, did not fully delete objects at the database level. the migration only deleted the edges touching the Nodes to delete (`HAS_ATTRIBUTE`, `IS_RELATED`, `IS_PART_OF` edges), but left the lower-level edges (`HAS_VALUE`, `IS_PROTECTED`, far-side `IS_RELATED`) un-deleted. this did not cause an issue for the end user b/c this partial delete was enough to prevent the objects from being returned by the regular database get queries we use for querying for and retrieving objects.

however, it could cause a deleted object to not be included in the diff. and the only reason that the object would be deleted on the default branch after a merge is because the `NodeRemoveMigration` would run again as part of the branch merge workflow.

only found the issue while working on improvements to the merge logic and troubleshooting a failing test led me to this bug.

the fix is a rewrite of the `NodeRemoveMigration` to make sure that it gets all of the edges "under" a given object when deleting it, which requires traversing one level deeper into the graph so the query is bigger. I also chose to rewrite the query as more of a static string instead of the Python-based construction it was using before. I find one large query easier to read than many smaller pieces constructed in memory

also adds some more cypher queries that validate the database to find illegal data