### PR TITLE
Add separator above actions buttons

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -289,7 +289,7 @@ exports[`fix ts error`] = {
     "src/entities/proposed-changes/ui/conversations/add-comment.tsx:3479187327": [
       [36, 9, 13, "tsc: Property \'attribute\' is missing in type \'\\"Required\\"; }; }; } | { name: string; label: string; placeholder: string; rules: { validate: { required: ({ value }: Pick<FormFieldValue, \\"value\\">) => true\' but required in type \'FormFieldProps\'.", "941754925"]
     ],
-    "src/entities/proposed-changes/ui/proposed-change-details.tsx:354180157": [
+    "src/entities/proposed-changes/ui/proposed-change-details.tsx:858710107": [
       [35, 2, 10, "tsc: Property \'tasksCount\' does not exist on type \'ProposedChangeDetailsProps\'.", "3126552024"],
       [68, 59, 5, "tsc: Argument of type \'null | string | undefined\' is not assignable to parameter of type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "195031250"],
       [198, 18, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
@@ -222,7 +222,7 @@ export const ProposedChangeDetails = ({
 
           <PropertyList properties={proposedChangeProperties} />
 
-          <div className="flex grow gap-2 p-2">
+          <div className="flex grow gap-2 border-gray-200 border-t p-2">
             <PcReviewButton />
             <PcActionButton />
           </div>


### PR DESCRIPTION
<img width="1555" height="991" alt="image" src="https://github.com/user-attachments/assets/1f47ccc3-fa36-4c8a-aedc-2fd72a7c128a" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top border above the action buttons in Proposed Change details to clearly separate them from the properties list and improve readability. Updates Betterer results to reflect the file change.

<sup>Written for commit d56a4313eacd5b6a83007a38a036f7aae1ce81aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

