### PR TITLE
Merge stable into release1.9

### DIFF
--- a/.github/workflows/bug-agent-analyst.yml
+++ b/.github/workflows/bug-agent-analyst.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
+      id-token: write
       issues: write
       contents: write
 

--- a/.github/workflows/bug-agent-fix.yml
+++ b/.github/workflows/bug-agent-fix.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write
@@ -194,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write

--- a/.github/workflows/bug-agent-review.yml
+++ b/.github/workflows/bug-agent-review.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/bug-agent-test.yml
+++ b/.github/workflows/bug-agent-test.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write
@@ -168,6 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       issues: write
       contents: write
       pull-requests: write

--- a/backend/infrahub/core/branch/creator.py
+++ b/backend/infrahub/core/branch/creator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pydantic
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.events.branch_action import BranchCreatedEvent
+from infrahub.events.models import EventMeta
+from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.workflows.catalogue import GIT_REPOSITORIES_CREATE_BRANCH
+
+if TYPE_CHECKING:
+    from infrahub.context import InfrahubContext
+    from infrahub.database import InfrahubDatabase
+    from infrahub.graphql.mutations.models import BranchCreateModel
+    from infrahub.lock import InfrahubLockRegistry
+    from infrahub.services.adapters.event import InfrahubEventService
+    from infrahub.services.adapters.workflow import InfrahubWorkflow
+    from infrahub.services.component import InfrahubComponent
+
+
+class BranchCreator:
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        lock_registry: InfrahubLockRegistry,
+        component: InfrahubComponent,
+        event_service: InfrahubEventService,
+        workflow: InfrahubWorkflow,
+    ) -> None:
+        self.db = db
+        self.lock_registry = lock_registry
+        self.component = component
+        self.event_service = event_service
+        self.workflow = workflow
+
+    async def create(self, model: BranchCreateModel, context: InfrahubContext) -> None:
+        try:
+            await Branch.get_by_name(db=self.db, name=model.name)
+            raise ValidationError(f"The branch {model.name} already exists")
+        except BranchNotFoundError:
+            pass
+
+        data_dict: dict[str, Any] = dict(model)
+        data_dict.pop("is_isolated", None)
+
+        try:
+            obj = Branch(**data_dict)
+        except pydantic.ValidationError as exc:
+            error_msgs = [f"invalid field {error['loc'][0]}: {error['msg']}" for error in exc.errors()]
+            raise ValidationError("\n".join(error_msgs)) from exc
+
+        # distributed lock to prevent creating multiple branches with the same name
+        async with self.lock_registry.get(name=model.name, namespace="branch_create", local=False):
+            # Re-check existence under the lock to prevent TOCTOU race
+            try:
+                await Branch.get_by_name(db=self.db, name=model.name)
+                raise ValidationError(f"The branch {model.name} already exists")
+            except BranchNotFoundError:
+                pass
+
+            async with self.lock_registry.local_schema_lock():
+                # Copy the schema from the origin branch and set the hash and the schema_changed_at value
+                origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
+                new_schema = origin_schema.duplicate(name=obj.name)
+                registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
+                obj.update_schema_hash()
+                await obj.save(db=self.db, user_id=context.account.account_id)
+
+                # Add Branch to registry
+                registry.branch[obj.name] = obj
+                await self.component.refresh_schema_hash(branches=[obj.name])
+
+        event = BranchCreatedEvent(
+            branch_name=obj.name,
+            branch_id=str(obj.uuid),
+            sync_with_git=obj.sync_with_git,
+            meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
+        )
+        await self.event_service.send(event=event)
+
+        if obj.sync_with_git:
+            await self.workflow.submit_workflow(
+                workflow=GIT_REPOSITORIES_CREATE_BRANCH,
+                context=context,
+                parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
+            )

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -502,18 +502,31 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             error_msgs = [f"invalid field {error['loc'][0]}: {error['msg']}" for error in exc.errors()]
             raise ValidationError("\n".join(error_msgs)) from exc
 
-        async with lock.registry.local_schema_lock():
-            # Copy the schema from the origin branch and set the hash and the schema_changed_at value
-            origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
-            new_schema = origin_schema.duplicate(name=obj.name)
-            registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
-            obj.update_schema_hash()
-            await obj.save(db=db, user_id=context.account.account_id)
+        # Use a distributed lock to prevent TOCTOU race conditions when creating branches.
+        # The lock is scoped to the branch name so different branches can be created concurrently.
+        # The existence check above is a fast-fail optimization; the authoritative check is
+        # inside the lock to prevent the race where two callers both pass the check above
+        # before either creates the branch.
+        async with lock.registry.get(name=model.name, namespace="branch_create", local=False):
+            # Re-check existence under the lock to prevent TOCTOU race
+            try:
+                await Branch.get_by_name(db=db, name=model.name)
+                raise ValidationError(f"The branch {model.name} already exists")
+            except BranchNotFoundError:
+                pass
 
-            # Add Branch to registry
-            registry.branch[obj.name] = obj
-            component = await get_component()
-            await component.refresh_schema_hash(branches=[obj.name])
+            async with lock.registry.local_schema_lock():
+                # Copy the schema from the origin branch and set the hash and the schema_changed_at value
+                origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
+                new_schema = origin_schema.duplicate(name=obj.name)
+                registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
+                obj.update_schema_hash()
+                await obj.save(db=db, user_id=context.account.account_id)
+
+                # Add Branch to registry
+                registry.branch[obj.name] = obj
+                component = await get_component()
+                await component.refresh_schema_hash(branches=[obj.name])
 
         event = BranchCreatedEvent(
             branch_name=obj.name,

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -63,6 +63,10 @@ if TYPE_CHECKING:
 
     from infrahub.core.changelog.models import NodeChangelog
     from infrahub.database import InfrahubDatabase
+    from infrahub.lock import InfrahubLockRegistry
+    from infrahub.services.adapters.event import InfrahubEventService
+    from infrahub.services.adapters.workflow import InfrahubWorkflow
+    from infrahub.services.component import InfrahubComponent
 
 
 @flow(name="branch-migrate", flow_run_name="Apply migrations to branch {branch}")
@@ -481,14 +485,24 @@ async def validate_branch(branch: str) -> State:
         return Completed(message="branch is valid")
 
 
-@flow(name="create-branch", flow_run_name="Create branch {model.name}")
-async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> None:
-    await add_tags(branches=[model.name])
+class BranchCreator:
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        lock_registry: InfrahubLockRegistry,
+        component: InfrahubComponent,
+        event_service: InfrahubEventService,
+        workflow: InfrahubWorkflow,
+    ) -> None:
+        self.db = db
+        self.lock_registry = lock_registry
+        self.component = component
+        self.event_service = event_service
+        self.workflow = workflow
 
-    database = await get_database()
-    async with database.start_session() as db:
+    async def create(self, model: BranchCreateModel, context: InfrahubContext) -> None:
         try:
-            await Branch.get_by_name(db=db, name=model.name)
+            await Branch.get_by_name(db=self.db, name=model.name)
             raise ValidationError(f"The branch {model.name} already exists")
         except BranchNotFoundError:
             pass
@@ -503,26 +517,25 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             raise ValidationError("\n".join(error_msgs)) from exc
 
         # distributed lock to prevent creating multiple branches with the same name
-        async with lock.registry.get(name=model.name, namespace="branch_create", local=False):
+        async with self.lock_registry.get(name=model.name, namespace="branch_create", local=False):
             # Re-check existence under the lock to prevent TOCTOU race
             try:
-                await Branch.get_by_name(db=db, name=model.name)
+                await Branch.get_by_name(db=self.db, name=model.name)
                 raise ValidationError(f"The branch {model.name} already exists")
             except BranchNotFoundError:
                 pass
 
-            async with lock.registry.local_schema_lock():
+            async with self.lock_registry.local_schema_lock():
                 # Copy the schema from the origin branch and set the hash and the schema_changed_at value
                 origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
                 new_schema = origin_schema.duplicate(name=obj.name)
                 registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
                 obj.update_schema_hash()
-                await obj.save(db=db, user_id=context.account.account_id)
+                await obj.save(db=self.db, user_id=context.account.account_id)
 
                 # Add Branch to registry
                 registry.branch[obj.name] = obj
-                component = await get_component()
-                await component.refresh_schema_hash(branches=[obj.name])
+                await self.component.refresh_schema_hash(branches=[obj.name])
 
         event = BranchCreatedEvent(
             branch_name=obj.name,
@@ -530,15 +543,34 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             sync_with_git=obj.sync_with_git,
             meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
         )
-        event_service = await get_event_service()
-        await event_service.send(event=event)
+        await self.event_service.send(event=event)
 
         if obj.sync_with_git:
-            await get_workflow().submit_workflow(
+            await self.workflow.submit_workflow(
                 workflow=GIT_REPOSITORIES_CREATE_BRANCH,
                 context=context,
                 parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
             )
+
+
+@flow(name="create-branch", flow_run_name="Create branch {model.name}")
+async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> None:
+    await add_tags(branches=[model.name])
+
+    database = await get_database()
+    component = await get_component()
+    event_service = await get_event_service()
+    workflow = get_workflow()
+
+    async with database.start_session() as db:
+        creator = BranchCreator(
+            db=db,
+            lock_registry=lock.registry,
+            component=component,
+            event_service=event_service,
+            workflow=workflow,
+        )
+        await creator.create(model=model, context=context)
 
 
 async def _get_diff_root(

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Sequence
 from uuid import uuid4
 
-import pydantic
 from prefect import flow, get_run_logger
 from prefect.client.schemas.objects import State  # noqa: TC002
 from prefect.states import Completed, Failed
@@ -12,6 +11,7 @@ from infrahub import config, lock
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.creator import BranchCreator
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
 from infrahub.core.constants import DiffAction, MutationAction
@@ -34,7 +34,6 @@ from infrahub.core.validators.models.validate_migration import SchemaValidateMig
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events.branch_action import (
-    BranchCreatedEvent,
     BranchDeletedEvent,
     BranchMergedEvent,
     BranchMigratedEvent,
@@ -42,7 +41,7 @@ from infrahub.events.branch_action import (
 )
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
-from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.exceptions import ValidationError
 from infrahub.generators.constants import GeneratorDefinitionRunSource
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
 from infrahub.workers.dependencies import get_component, get_database, get_event_service, get_workflow
@@ -51,7 +50,6 @@ from infrahub.workflows.catalogue import (
     BRANCH_MERGE_POST_PROCESS,
     DIFF_REFRESH_ALL,
     DIFF_UPDATE,
-    GIT_REPOSITORIES_CREATE_BRANCH,
     IPAM_RECONCILIATION,
     TRIGGER_ARTIFACT_DEFINITION_GENERATE,
     TRIGGER_GENERATOR_DEFINITION_RUN,
@@ -63,10 +61,6 @@ if TYPE_CHECKING:
 
     from infrahub.core.changelog.models import NodeChangelog
     from infrahub.database import InfrahubDatabase
-    from infrahub.lock import InfrahubLockRegistry
-    from infrahub.services.adapters.event import InfrahubEventService
-    from infrahub.services.adapters.workflow import InfrahubWorkflow
-    from infrahub.services.component import InfrahubComponent
 
 
 @flow(name="branch-migrate", flow_run_name="Apply migrations to branch {branch}")
@@ -483,74 +477,6 @@ async def validate_branch(branch: str) -> State:
         if has_conflicts:
             return Failed(message="branch has some conflicts")
         return Completed(message="branch is valid")
-
-
-class BranchCreator:
-    def __init__(
-        self,
-        db: InfrahubDatabase,
-        lock_registry: InfrahubLockRegistry,
-        component: InfrahubComponent,
-        event_service: InfrahubEventService,
-        workflow: InfrahubWorkflow,
-    ) -> None:
-        self.db = db
-        self.lock_registry = lock_registry
-        self.component = component
-        self.event_service = event_service
-        self.workflow = workflow
-
-    async def create(self, model: BranchCreateModel, context: InfrahubContext) -> None:
-        try:
-            await Branch.get_by_name(db=self.db, name=model.name)
-            raise ValidationError(f"The branch {model.name} already exists")
-        except BranchNotFoundError:
-            pass
-
-        data_dict: dict[str, Any] = dict(model)
-        data_dict.pop("is_isolated", None)
-
-        try:
-            obj = Branch(**data_dict)
-        except pydantic.ValidationError as exc:
-            error_msgs = [f"invalid field {error['loc'][0]}: {error['msg']}" for error in exc.errors()]
-            raise ValidationError("\n".join(error_msgs)) from exc
-
-        # distributed lock to prevent creating multiple branches with the same name
-        async with self.lock_registry.get(name=model.name, namespace="branch_create", local=False):
-            # Re-check existence under the lock to prevent TOCTOU race
-            try:
-                await Branch.get_by_name(db=self.db, name=model.name)
-                raise ValidationError(f"The branch {model.name} already exists")
-            except BranchNotFoundError:
-                pass
-
-            async with self.lock_registry.local_schema_lock():
-                # Copy the schema from the origin branch and set the hash and the schema_changed_at value
-                origin_schema = registry.schema.get_schema_branch(name=obj.origin_branch)
-                new_schema = origin_schema.duplicate(name=obj.name)
-                registry.schema.set_schema_branch(name=obj.name, schema=new_schema)
-                obj.update_schema_hash()
-                await obj.save(db=self.db, user_id=context.account.account_id)
-
-                # Add Branch to registry
-                registry.branch[obj.name] = obj
-                await self.component.refresh_schema_hash(branches=[obj.name])
-
-        event = BranchCreatedEvent(
-            branch_name=obj.name,
-            branch_id=str(obj.uuid),
-            sync_with_git=obj.sync_with_git,
-            meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
-        )
-        await self.event_service.send(event=event)
-
-        if obj.sync_with_git:
-            await self.workflow.submit_workflow(
-                workflow=GIT_REPOSITORIES_CREATE_BRANCH,
-                context=context,
-                parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
-            )
 
 
 @flow(name="create-branch", flow_run_name="Create branch {model.name}")

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -502,11 +502,7 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             error_msgs = [f"invalid field {error['loc'][0]}: {error['msg']}" for error in exc.errors()]
             raise ValidationError("\n".join(error_msgs)) from exc
 
-        # Use a distributed lock to prevent TOCTOU race conditions when creating branches.
-        # The lock is scoped to the branch name so different branches can be created concurrently.
-        # The existence check above is a fast-fail optimization; the authoritative check is
-        # inside the lock to prevent the race where two callers both pass the check above
-        # before either creates the branch.
+        # distributed lock to prevent creating multiple branches with the same name
         async with lock.registry.get(name=model.name, namespace="branch_create", local=False):
             # Re-check existence under the lock to prevent TOCTOU race
             try:

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -1,34 +1,21 @@
 import asyncio
-from contextlib import contextmanager
-from typing import Any, Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-from fast_depends import Provider
 
 from infrahub import lock
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
-from infrahub.core.branch.tasks import create_branch
+from infrahub.core.branch.tasks import BranchCreator
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.exceptions import ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_database
-
-
-@contextmanager
-def stub_branch_task_infrastructure() -> Generator[None, Any, None]:
-    """Stub out infrastructure services (event bus, tags, components) not available in component tests."""
-    with (
-        patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
-        patch("infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock),
-        patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock),
-    ):
-        yield
+from infrahub.services.adapters.event import InfrahubEventService
+from infrahub.services.adapters.workflow import InfrahubWorkflow
+from infrahub.services.component import InfrahubComponent
 
 
 class TestBranchCreateRaceCondition:
@@ -54,48 +41,30 @@ class TestBranchCreateRaceCondition:
     async def test_concurrent_create_same_branch_only_one_succeeds(
         self,
         db: InfrahubDatabase,
-        default_branch: Branch,
-        workflow_local: WorkflowLocalExecution,
-        dependency_provider: Provider,
         context: InfrahubContext,
         branch_model: BranchCreateModel,
     ) -> None:
-        """Simulate a TOCTOU race: both coroutines see 'branch not found' before either creates it.
-        Exactly one should succeed and the other should fail."""
-        real_get_by_name_method = Branch.get_by_name
-        both_saw_not_found = asyncio.Barrier(2)
-        race_triggered = False
+        """Two concurrent branch creations with the same name: exactly one should succeed."""
+        component = AsyncMock(spec=InfrahubComponent)
+        event_service = AsyncMock(spec=InfrahubEventService)
+        workflow = AsyncMock(spec=InfrahubWorkflow)
 
-        async def get_by_name_with_forced_race(**kwargs):
-            """Force both coroutines to see 'branch not found' before either proceeds."""
-            nonlocal race_triggered
-            if classic_method_call_required(kwargs, race_triggered):
-                return await real_get_by_name_method(**kwargs)
+        async def run_creator() -> None:
+            async with db.start_session() as session:
+                creator = BranchCreator(
+                    db=session,
+                    lock_registry=lock.registry,
+                    component=component,
+                    event_service=event_service,
+                    workflow=workflow,
+                )
+                await creator.create(model=branch_model, context=context)
 
-            # We want to make the two methods wait one another after they have checked that the branch
-            # was not existing in the database
-            try:
-                return await real_get_by_name_method(**kwargs)
-            except BranchNotFoundError:
-                await both_saw_not_found.wait()
-                race_triggered = True
-                raise
-
-        def classic_method_call_required(kwargs: dict[str, Any], race_triggered: bool) -> bool | Any:
-            # If the branch is not the branch of the test, or if the race situation has already been triggered,
-            # we do not need to fake the behavior
-            return kwargs.get("name") != branch_model.name or race_triggered
-
-        with (
-            dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
-            stub_branch_task_infrastructure(),
-            patch.object(Branch, "get_by_name", side_effect=get_by_name_with_forced_race),
-        ):
-            results = await asyncio.gather(
-                create_branch(model=branch_model, context=context),
-                create_branch(model=branch_model, context=context),
-                return_exceptions=True,
-            )
+        results = await asyncio.gather(
+            run_creator(),
+            run_creator(),
+            return_exceptions=True,
+        )
 
         successes = [r for r in results if r is None]
         failures = [r for r in results if isinstance(r, ValidationError)]
@@ -105,3 +74,5 @@ class TestBranchCreateRaceCondition:
         )
         assert len(failures) == 1, f"Expected exactly 1 failure, got {len(failures)}. Results: {results}"
         assert "already exists" in str(failures[0])
+        component.refresh_schema_hash.assert_awaited_once_with(branches=[branch_model.name])
+        event_service.send.assert_awaited_once()

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -12,17 +12,13 @@ from infrahub.core.branch import Branch
 from infrahub.core.branch.tasks import create_branch
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.exceptions import BranchNotFoundError
 from infrahub.graphql.mutations.models import BranchCreateModel
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_database
 
 
 class TestBranchCreateRaceCondition:
-    @pytest.fixture(autouse=True)
-    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
-        return
-
     @pytest.fixture(autouse=True)
     async def _setup_lock(self, default_branch: Branch, car_person_schema: SchemaBranch) -> None:
         lock.initialize_lock(local_only=True)
@@ -51,63 +47,34 @@ class TestBranchCreateRaceCondition:
         context: InfrahubContext,
         branch_model: BranchCreateModel,
     ) -> None:
-        """Two concurrent create_branch calls with the same name must result in exactly one branch.
+        """Simulate a TOCTOU race: both coroutines see 'branch not found' before either creates it.
 
-        The second call should raise a ValidationError. This test simulates the TOCTOU race
-        condition: both coroutines pass the existence check (Branch.get_by_name raises
-        BranchNotFoundError for both) before either creates the branch.
-
-        To force the interleaving, we patch Branch.get_by_name so it always raises
-        BranchNotFoundError on the first two calls (simulating what happens when both
-        concurrent checks happen before any branch is persisted), and we introduce an
-        asyncio.Event-based synchronization to ensure both coroutines have passed the
-        check before either proceeds to the save path.
+        With the distributed lock in place, exactly one should succeed and the other should fail.
         """
-        mock_event_service = AsyncMock()
-        mock_event_service.send = AsyncMock()
-        mock_component = AsyncMock()
-        mock_component.refresh_schema_hash = AsyncMock()
-
         real_get_by_name = Branch.get_by_name
-
-        # Synchronization: both coroutines must pass the existence check before either proceeds
-        check_passed_count = 0
-        both_passed = asyncio.Event()
+        barrier = asyncio.Barrier(2)
+        synchronized = False
 
         async def interleaved_get_by_name(**kwargs):
-            """Ensure both coroutines see 'branch not found' before either proceeds."""
-            nonlocal check_passed_count
+            nonlocal synchronized
+            # Classic behavior case
+            if kwargs.get("name") != branch_model.name or synchronized:
+                return await real_get_by_name(**kwargs)
 
-            if kwargs.get("name") == branch_model.name:
-                # Try the real check first
-                try:
-                    await real_get_by_name(**kwargs)
-                    # Branch already exists — if a proper lock were in place, the second
-                    # caller would find it here. Raise normally.
-                    raise ValidationError(f"The branch {kwargs['name']} already exists")
-                except BranchNotFoundError:
-                    pass
-
-                # Branch not found — signal that this coroutine passed the check
-                check_passed_count += 1
-                if check_passed_count >= 2:
-                    both_passed.set()
-                else:
-                    # Wait for the other coroutine to also pass the check
-                    await both_passed.wait()
-
-                # Now raise BranchNotFoundError as the original code expects
-                raise BranchNotFoundError(identifier=kwargs["name"])
-
-            return await real_get_by_name(**kwargs)
+            # Both coroutines must see "not found" before either proceeds.
+            # After synchronization, all subsequent calls go to the real implementation.
+            try:
+                return await real_get_by_name(**kwargs)
+            except BranchNotFoundError:
+                await barrier.wait()
+                synchronized = True
+                raise
 
         with (
             dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
             patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
-            patch(
-                "infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock, return_value=mock_event_service
-            ),
-            patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock, return_value=mock_component),
+            patch("infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock),
+            patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock),
             patch.object(Branch, "get_by_name", side_effect=interleaved_get_by_name),
         ):
             results = await asyncio.gather(
@@ -116,14 +83,10 @@ class TestBranchCreateRaceCondition:
                 return_exceptions=True,
             )
 
-        # Exactly one should succeed and one should fail with a ValidationError or
-        # database-level constraint error
         successes = [r for r in results if r is None]
         failures = [r for r in results if isinstance(r, Exception)]
 
         assert len(successes) == 1, (
-            f"Expected exactly 1 successful branch creation, got {len(successes)}. "
-            f"Both concurrent calls succeeded, proving the race condition exists. "
-            f"Results: {results}"
+            f"Expected exactly 1 successful branch creation, got {len(successes)}. Results: {results}"
         )
         assert len(failures) == 1, f"Expected exactly 1 failure, got {len(failures)}. Results: {results}"

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -1,0 +1,129 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fast_depends import Provider
+
+from infrahub import lock
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core.branch import Branch
+from infrahub.core.branch.tasks import create_branch
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.graphql.mutations.models import BranchCreateModel
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_database
+
+
+class TestBranchCreateRaceCondition:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
+        return
+
+    @pytest.fixture(autouse=True)
+    async def _setup_lock(self, default_branch: Branch, car_person_schema: SchemaBranch) -> None:
+        lock.initialize_lock(local_only=True)
+
+    @pytest.fixture
+    def context(self, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext.init(
+            branch=default_branch,
+            account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+        )
+
+    @pytest.fixture
+    def branch_model(self) -> BranchCreateModel:
+        return BranchCreateModel(
+            name="race-test-branch",
+            sync_with_git=False,
+            origin_branch="main",
+        )
+
+    async def test_concurrent_create_same_branch_only_one_succeeds(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        workflow_local: WorkflowLocalExecution,
+        dependency_provider: Provider,
+        context: InfrahubContext,
+        branch_model: BranchCreateModel,
+    ) -> None:
+        """Two concurrent create_branch calls with the same name must result in exactly one branch.
+
+        The second call should raise a ValidationError. This test simulates the TOCTOU race
+        condition: both coroutines pass the existence check (Branch.get_by_name raises
+        BranchNotFoundError for both) before either creates the branch.
+
+        To force the interleaving, we patch Branch.get_by_name so it always raises
+        BranchNotFoundError on the first two calls (simulating what happens when both
+        concurrent checks happen before any branch is persisted), and we introduce an
+        asyncio.Event-based synchronization to ensure both coroutines have passed the
+        check before either proceeds to the save path.
+        """
+        mock_event_service = AsyncMock()
+        mock_event_service.send = AsyncMock()
+        mock_component = AsyncMock()
+        mock_component.refresh_schema_hash = AsyncMock()
+
+        real_get_by_name = Branch.get_by_name
+
+        # Synchronization: both coroutines must pass the existence check before either proceeds
+        check_passed_count = 0
+        both_passed = asyncio.Event()
+
+        async def interleaved_get_by_name(**kwargs):
+            """Ensure both coroutines see 'branch not found' before either proceeds."""
+            nonlocal check_passed_count
+
+            if kwargs.get("name") == branch_model.name:
+                # Try the real check first
+                try:
+                    await real_get_by_name(**kwargs)
+                    # Branch already exists — if a proper lock were in place, the second
+                    # caller would find it here. Raise normally.
+                    raise ValidationError(f"The branch {kwargs['name']} already exists")
+                except BranchNotFoundError:
+                    pass
+
+                # Branch not found — signal that this coroutine passed the check
+                check_passed_count += 1
+                if check_passed_count >= 2:
+                    both_passed.set()
+                else:
+                    # Wait for the other coroutine to also pass the check
+                    await both_passed.wait()
+
+                # Now raise BranchNotFoundError as the original code expects
+                raise BranchNotFoundError(identifier=kwargs["name"])
+
+            return await real_get_by_name(**kwargs)
+
+        with (
+            dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+            patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
+            patch(
+                "infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock, return_value=mock_event_service
+            ),
+            patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock, return_value=mock_component),
+            patch.object(Branch, "get_by_name", side_effect=interleaved_get_by_name),
+        ):
+            results = await asyncio.gather(
+                create_branch(model=branch_model, context=context),
+                create_branch(model=branch_model, context=context),
+                return_exceptions=True,
+            )
+
+        # Exactly one should succeed and one should fail with a ValidationError or
+        # database-level constraint error
+        successes = [r for r in results if r is None]
+        failures = [r for r in results if isinstance(r, Exception)]
+
+        assert len(successes) == 1, (
+            f"Expected exactly 1 successful branch creation, got {len(successes)}. "
+            f"Both concurrent calls succeeded, proving the race condition exists. "
+            f"Results: {results}"
+        )
+        assert len(failures) == 1, f"Expected exactly 1 failure, got {len(failures)}. Results: {results}"

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -45,9 +45,9 @@ class TestBranchCreateRaceCondition:
         branch_model: BranchCreateModel,
     ) -> None:
         """Two concurrent branch creations with the same name: exactly one should succeed."""
-        component = create_autospec(spec=InfrahubComponent)
-        event_service = create_autospec(spec=InfrahubEventService)
-        workflow = create_autospec(spec=InfrahubWorkflow)
+        component = create_autospec(spec=InfrahubComponent, spec_set=True)
+        event_service = create_autospec(spec=InfrahubEventService, spec_set=True)
+        workflow = create_autospec(spec=InfrahubWorkflow, spec_set=True)
 
         async def run_creator() -> None:
             async with db.start_session() as session:

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -12,7 +12,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.branch.tasks import create_branch
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import BranchNotFoundError
+from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_database
@@ -84,9 +84,10 @@ class TestBranchCreateRaceCondition:
             )
 
         successes = [r for r in results if r is None]
-        failures = [r for r in results if isinstance(r, Exception)]
+        failures = [r for r in results if isinstance(r, ValidationError)]
 
         assert len(successes) == 1, (
             f"Expected exactly 1 successful branch creation, got {len(successes)}. Results: {results}"
         )
         assert len(failures) == 1, f"Expected exactly 1 failure, got {len(failures)}. Results: {results}"
+        assert "already exists" in str(failures[0])

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import create_autospec
 from uuid import uuid4
 
 import pytest
@@ -45,9 +45,9 @@ class TestBranchCreateRaceCondition:
         branch_model: BranchCreateModel,
     ) -> None:
         """Two concurrent branch creations with the same name: exactly one should succeed."""
-        component = AsyncMock(spec=InfrahubComponent)
-        event_service = AsyncMock(spec=InfrahubEventService)
-        workflow = AsyncMock(spec=InfrahubWorkflow)
+        component = create_autospec(spec=InfrahubComponent)
+        event_service = create_autospec(spec=InfrahubEventService)
+        workflow = create_autospec(spec=InfrahubWorkflow)
 
         async def run_creator() -> None:
             async with db.start_session() as session:

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -8,7 +8,7 @@ from infrahub import lock
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
-from infrahub.core.branch.tasks import BranchCreator
+from infrahub.core.branch.creator import BranchCreator
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError

--- a/backend/tests/component/core/test_branch_create_race.py
+++ b/backend/tests/component/core/test_branch_create_race.py
@@ -1,4 +1,6 @@
 import asyncio
+from contextlib import contextmanager
+from typing import Any, Generator
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -16,6 +18,17 @@ from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_database
+
+
+@contextmanager
+def stub_branch_task_infrastructure() -> Generator[None, Any, None]:
+    """Stub out infrastructure services (event bus, tags, components) not available in component tests."""
+    with (
+        patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
+        patch("infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock),
+        patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock),
+    ):
+        yield
 
 
 class TestBranchCreateRaceCondition:
@@ -48,34 +61,35 @@ class TestBranchCreateRaceCondition:
         branch_model: BranchCreateModel,
     ) -> None:
         """Simulate a TOCTOU race: both coroutines see 'branch not found' before either creates it.
+        Exactly one should succeed and the other should fail."""
+        real_get_by_name_method = Branch.get_by_name
+        both_saw_not_found = asyncio.Barrier(2)
+        race_triggered = False
 
-        With the distributed lock in place, exactly one should succeed and the other should fail.
-        """
-        real_get_by_name = Branch.get_by_name
-        barrier = asyncio.Barrier(2)
-        synchronized = False
+        async def get_by_name_with_forced_race(**kwargs):
+            """Force both coroutines to see 'branch not found' before either proceeds."""
+            nonlocal race_triggered
+            if classic_method_call_required(kwargs, race_triggered):
+                return await real_get_by_name_method(**kwargs)
 
-        async def interleaved_get_by_name(**kwargs):
-            nonlocal synchronized
-            # Classic behavior case
-            if kwargs.get("name") != branch_model.name or synchronized:
-                return await real_get_by_name(**kwargs)
-
-            # Both coroutines must see "not found" before either proceeds.
-            # After synchronization, all subsequent calls go to the real implementation.
+            # We want to make the two methods wait one another after they have checked that the branch
+            # was not existing in the database
             try:
-                return await real_get_by_name(**kwargs)
+                return await real_get_by_name_method(**kwargs)
             except BranchNotFoundError:
-                await barrier.wait()
-                synchronized = True
+                await both_saw_not_found.wait()
+                race_triggered = True
                 raise
+
+        def classic_method_call_required(kwargs: dict[str, Any], race_triggered: bool) -> bool | Any:
+            # If the branch is not the branch of the test, or if the race situation has already been triggered,
+            # we do not need to fake the behavior
+            return kwargs.get("name") != branch_model.name or race_triggered
 
         with (
             dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
-            patch("infrahub.core.branch.tasks.add_tags", new_callable=AsyncMock),
-            patch("infrahub.core.branch.tasks.get_event_service", new_callable=AsyncMock),
-            patch("infrahub.core.branch.tasks.get_component", new_callable=AsyncMock),
-            patch.object(Branch, "get_by_name", side_effect=interleaved_get_by_name),
+            stub_branch_task_infrastructure(),
+            patch.object(Branch, "get_by_name", side_effect=get_by_name_with_forced_race),
         ):
             results = await asyncio.gather(
                 create_branch(model=branch_model, context=context),

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def git_identity() -> None:
+    """Ensure git author/committer identity is set for environments without global git config (e.g. CI)."""
+    defaults = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    }
+    for var, value in defaults.items():
+        if var not in os.environ:
+            os.environ[var] = value

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,5 +1,3 @@
-import os
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -13,52 +11,18 @@ from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
 
-@pytest.fixture
-def git_identity() -> Generator[None, None, None]:
-    """Ensure git author/committer identity is set for environments without global git config (e.g. CI)."""
-    env_vars = ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL")
-    original = {var: os.environ.get(var) for var in env_vars}
-
-    os.environ["GIT_AUTHOR_NAME"] = "Test"
-    os.environ["GIT_AUTHOR_EMAIL"] = "test@test.com"
-    os.environ["GIT_COMMITTER_NAME"] = "Test"
-    os.environ["GIT_COMMITTER_EMAIL"] = "test@test.com"
-
-    yield
-
-    for var, value in original.items():
-        if value is None:
-            os.environ.pop(var, None)
-        else:
-            os.environ[var] = value
-
-
-@pytest.fixture
-def git_repo_environment(tmp_path: Path) -> Generator[Path, None, None]:
-    """Set up repositories directory and default branch for git tests."""
-    old_default_branch = getattr(registry, "_default_branch", None)
-    old_repos_dir = config.SETTINGS.git.repositories_directory
-
-    registry._default_branch = "main"
-
-    repos_dir = tmp_path / "repositories"
-    repos_dir.mkdir()
-    config.SETTINGS.git.repositories_directory = str(repos_dir)
-
-    yield tmp_path
-
-    config.SETTINGS.git.repositories_directory = old_repos_dir
-    if old_default_branch is not None:
-        registry._default_branch = old_default_branch
-
-
 async def test_has_conflicting_changes_no_false_positive(
-    git_identity: None,
-    git_repo_environment: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """has_conflicting_changes() should not report false positives when
     file content contains conflict marker characters like '======='."""
-    sources_dir = git_repo_environment / "source"
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    monkeypatch.setattr(config.SETTINGS.git, "repositories_directory", str(repos_dir))
+
+    sources_dir = tmp_path / "source"
     sources_dir.mkdir()
 
     test_repo = MultipleStagesFileRepo(name="false-positive-conflicts", sources_directory=sources_dir)
@@ -69,6 +33,10 @@ async def test_has_conflicting_changes_no_false_positive(
         default_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
+
+    # Confirm the diff between the branches actually contains ======= to validate the test premise
+    diff = test_repo.repo.git.diff("main", "change1")
+    assert "=======" in diff
 
     # The branch adds a file containing ======= but has no actual conflicts with main
     assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")

--- a/changelog/8368.fixed.md
+++ b/changelog/8368.fixed.md
@@ -1,0 +1,1 @@
+Add distributed lock around branch creation to prevent race condition


### PR DESCRIPTION
Manual merge of stable into release1.9.
Replaces: https://github.com/opsmill/infrahub/pull/8870

### Conflicts

Imports in `backend/infrahub/core/branch/tasks.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a branch creation race condition by adding a distributed lock and moving the logic into a new BranchCreator. Also enables OIDC by granting id-token: write in bug-agent workflows.

- **Bug Fixes**
  - Prevent duplicate branches by locking per branch name and re-checking existence inside the lock.
  - Extract creation flow into `BranchCreator` with injected dependencies; `create_branch` now delegates to it.
  - Add a concurrency test to ensure only one of two simultaneous creates succeeds; stabilize git tests via a shared conftest for author identity and simpler setup.

<sup>Written for commit a43455ca01448034777876ebcf84aebbb91a4dee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

