### PR TITLE
Added sticky search bar and collapse/expand all to the schema list view

### DIFF
--- a/changelog/+schema-selector-toolbar.added.md
+++ b/changelog/+schema-selector-toolbar.added.md
@@ -1,0 +1,1 @@
+Schema selector search bar is now sticky at the top, with new collapse all and expand all buttons to quickly toggle every namespace section.

--- a/frontend/app/src/entities/schema/ui/schema-selector.test.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-selector.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import {
+  genericSchemasAtom,
+  nodeSchemasAtom,
+  profileSchemasAtom,
+  templateSchemasAtom,
+} from "@/entities/schema/stores/schema.atom";
+
+import { render } from "../../../../tests/components/render";
+import { generateNodeSchema } from "../../../../tests/fake/schema";
+import { SchemaSelector } from "./schema-selector";
+
+describe("SchemaSelector Component", () => {
+  const builtinTag = generateNodeSchema({
+    kind: "BuiltinTag",
+    name: "TagItem",
+    namespace: "Builtin",
+    label: "TagItem",
+    description: "builtin-description",
+  });
+  const coreAccount = generateNodeSchema({
+    kind: "CoreAccount",
+    name: "AccountItem",
+    namespace: "Core",
+    label: "AccountItem",
+    description: "core-description",
+  });
+
+  beforeEach(() => {
+    store.set(nodeSchemasAtom, [builtinTag, coreAccount]);
+    store.set(genericSchemasAtom, []);
+    store.set(profileSchemasAtom, []);
+    store.set(templateSchemasAtom, []);
+  });
+
+  test("renders namespaces expanded by default", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+
+    // THEN
+    await expect.element(component.getByText("TagItem")).toBeVisible();
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+  });
+
+  test("collapses all namespaces when clicking the collapse button", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // THEN
+    await expect.element(component.getByText("TagItem")).not.toBeInTheDocument();
+    await expect.element(component.getByText("AccountItem")).not.toBeInTheDocument();
+  });
+
+  test("expands all namespaces when clicking the expand button after collapsing", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // WHEN
+    await component.getByRole("button", { name: "Expand all" }).click();
+
+    // THEN
+    await expect.element(component.getByText("TagItem")).toBeVisible();
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+  });
+
+  test("collapse button hides all open sections even if only some are open", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    await component.getByText("Builtin").first().click();
+
+    // WHEN
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // THEN
+    await expect.element(component.getByText("TagItem")).not.toBeInTheDocument();
+    await expect.element(component.getByText("AccountItem")).not.toBeInTheDocument();
+  });
+
+  test("auto-expands sections containing a search match", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // WHEN
+    await component.getByPlaceholder("Search schema").fill("account");
+
+    // THEN
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+  });
+
+  test("restores pre-search state when the search is cleared", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // WHEN
+    const searchInput = component.getByPlaceholder("Search schema");
+    await searchInput.fill("account");
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+    await searchInput.fill("");
+
+    // THEN
+    await expect.element(component.getByText("AccountItem")).not.toBeInTheDocument();
+    await expect.element(component.getByText("TagItem")).not.toBeInTheDocument();
+  });
+
+  test("preserves collapse-all action from within search after the search is cleared", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    const searchInput = component.getByPlaceholder("Search schema");
+    await searchInput.fill("account");
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+
+    // WHEN
+    await component.getByRole("button", { name: "Collapse all" }).click();
+    await searchInput.fill("");
+
+    // THEN
+    await expect.element(component.getByText("AccountItem")).not.toBeInTheDocument();
+    await expect.element(component.getByText("TagItem")).not.toBeInTheDocument();
+  });
+
+  test("allows collapsing matching sections while searching", async () => {
+    // GIVEN
+    const component = await render(<SchemaSelector />);
+    await component.getByPlaceholder("Search schema").fill("account");
+    await expect.element(component.getByText("AccountItem")).toBeVisible();
+
+    // WHEN
+    await component.getByRole("button", { name: "Collapse all" }).click();
+
+    // THEN
+    await expect.element(component.getByText("AccountItem")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/src/entities/schema/ui/schema-selector.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-selector.tsx
@@ -9,7 +9,7 @@ import { Col, Row } from "@/shared/components/container";
 import Accordion from "@/shared/components/display/accordion";
 import { SearchInput } from "@/shared/components/inputs/search-input";
 import { Badge } from "@/shared/components/ui/badge";
-import { Button } from "@/shared/components/ui/button";
+import { ButtonWithTooltip } from "@/shared/components/ui/button";
 import { QSP } from "@/shared/config/qsp";
 import { classNames } from "@/shared/utils/common";
 
@@ -92,11 +92,13 @@ export function SchemaSelector({ className }: SchemaSelectorProps) {
     <Col className={classNames("bg-white", className)}>
       <Row className="sticky top-0 z-1 border-gray-200 border-b bg-white p-4">
         <SearchInput placeholder="Search schema" value={search} onChange={handleSearchChange} />
-        <Button
+        <ButtonWithTooltip
           size="square"
           variant="outline"
           className="size-10 rounded-md border-gray-300"
           onClick={toggleAll}
+          tooltipContent={anyOpen ? "Collapse all" : "Expand all"}
+          tooltipEnabled
           aria-label={anyOpen ? "Collapse all" : "Expand all"}
         >
           {anyOpen ? (
@@ -104,7 +106,7 @@ export function SchemaSelector({ className }: SchemaSelectorProps) {
           ) : (
             <ListChevronsUpDown className="size-4" />
           )}
-        </Button>
+        </ButtonWithTooltip>
       </Row>
 
       {Object.entries(schemasPerNamespace).map(([namespace, schemas]) => {

--- a/frontend/app/src/entities/schema/ui/schema-selector.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-selector.tsx
@@ -1,12 +1,15 @@
 import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
+import { ListChevronsDownUpIcon, ListChevronsUpDown } from "lucide-react";
 import { parseAsNativeArrayOf, parseAsString, useQueryState } from "nuqs";
 import { useEffect, useRef, useState } from "react";
 import * as R from "remeda";
 
+import { Col, Row } from "@/shared/components/container";
 import Accordion from "@/shared/components/display/accordion";
 import { SearchInput } from "@/shared/components/inputs/search-input";
 import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
 import { QSP } from "@/shared/config/qsp";
 import { classNames } from "@/shared/utils/common";
 
@@ -19,26 +22,29 @@ import {
 import type { ModelSchema } from "@/entities/schema/types";
 import { isGenericSchema } from "@/entities/schema/utils/is-generic-schema";
 
-type SchemaSelectorProps = {
+interface SchemaSelectorProps {
   className?: string;
-};
-export const SchemaSelector = ({ className = "" }: SchemaSelectorProps) => {
+}
+
+export function SchemaSelector({ className }: SchemaSelectorProps) {
   const [selectedKind, setKind] = useQueryState(QSP.KIND, parseAsNativeArrayOf(parseAsString));
   const nodes = useAtomValue(nodeSchemasAtom);
   const generics = useAtomValue(genericSchemasAtom);
   const profiles = useAtomValue(profileSchemasAtom);
   const templates = useAtomValue(templateSchemasAtom);
   const [search, setSearch] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
+  const [openByNamespace, setOpenByNamespace] = useState<Record<string, boolean>>({});
+  const preSearchStateRef = useRef<Record<string, boolean> | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!ref.current) return;
-
-    ref.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }, [selectedKind?.length]);
 
-  const schemas: ModelSchema[] = [...nodes, ...generics, ...profiles, ...templates].filter(
-    ({ kind }) => kind?.toLowerCase().includes(search.toLowerCase())
+  const allSchemas: ModelSchema[] = [...nodes, ...generics, ...profiles, ...templates];
+
+  const schemas = allSchemas.filter(({ kind }) =>
+    kind?.toLowerCase().includes(search.toLowerCase())
   );
 
   const schemasPerNamespace = R.pipe(
@@ -47,18 +53,72 @@ export const SchemaSelector = ({ className = "" }: SchemaSelectorProps) => {
     R.groupBy((schema) => schema.namespace)
   );
 
+  const visibleNamespaces = Object.keys(schemasPerNamespace);
+  const anyOpen = visibleNamespaces.some((ns) => openByNamespace[ns] ?? true);
+
+  const handleSearchChange = (value: string) => {
+    const wasSearching = search.length > 0;
+    const isNowSearching = value.length > 0;
+
+    if (!wasSearching && isNowSearching) {
+      preSearchStateRef.current = openByNamespace;
+      const matchingNamespaces = new Set(
+        allSchemas
+          .filter((s) => s.kind?.toLowerCase().includes(value.toLowerCase()))
+          .map((s) => s.namespace)
+      );
+      setOpenByNamespace((prev) => ({
+        ...prev,
+        ...Object.fromEntries([...matchingNamespaces].map((ns) => [ns, true])),
+      }));
+    } else if (wasSearching && !isNowSearching && preSearchStateRef.current) {
+      setOpenByNamespace(preSearchStateRef.current);
+      preSearchStateRef.current = null;
+    }
+
+    setSearch(value);
+  };
+
+  const toggleAll = () => {
+    preSearchStateRef.current = null;
+    const allNamespaces = new Set(allSchemas.map((s) => s.namespace));
+    setOpenByNamespace((prev) => ({
+      ...prev,
+      ...Object.fromEntries([...allNamespaces].map((ns) => [ns, !anyOpen])),
+    }));
+  };
+
   return (
-    <section className={classNames("space-y-2 bg-white p-4", className)}>
-      <SearchInput
-        className="mb-4"
-        placeholder="Search schema"
-        value={search}
-        onChange={setSearch}
-      />
+    <Col className={classNames("bg-white", className)}>
+      <Row className="sticky top-0 z-1 border-gray-200 border-b bg-white p-4">
+        <SearchInput placeholder="Search schema" value={search} onChange={handleSearchChange} />
+        <Button
+          size="square"
+          variant="outline"
+          className="size-10 rounded-md border-gray-300"
+          onClick={toggleAll}
+          aria-label={anyOpen ? "Collapse all" : "Expand all"}
+        >
+          {anyOpen ? (
+            <ListChevronsDownUpIcon className="size-4" />
+          ) : (
+            <ListChevronsUpDown className="size-4" />
+          )}
+        </Button>
+      </Row>
 
       {Object.entries(schemasPerNamespace).map(([namespace, schemas]) => {
+        const open = openByNamespace[namespace] ?? true;
+
         return (
-          <Accordion key={namespace} title={namespace} defaultOpen>
+          <Accordion
+            key={namespace}
+            title={namespace}
+            open={open}
+            onOpenChange={(next) => {
+              setOpenByNamespace((prev) => ({ ...prev, [namespace]: next }));
+            }}
+          >
             <div className="divide-y divide-gray-200 px-4">
               {schemas.map((schema) => {
                 const isSelected =
@@ -67,10 +127,12 @@ export const SchemaSelector = ({ className = "" }: SchemaSelectorProps) => {
 
                 return (
                   <div
-                    {...(isSelectedLast && { ref })}
+                    ref={isSelectedLast ? scrollRef : undefined}
                     key={schema.kind}
-                    className={`relative flex h-24 cursor-pointer items-center overflow-hidden pr-2 pl-9 mix-blend-multiply hover:rounded-sm hover:bg-gray-100 ${isSelected ? "rounded-sm shadow-lg ring-1 ring-custom-blue-600" : ""}
-                    `}
+                    className={classNames(
+                      "relative flex h-24 cursor-pointer items-center overflow-hidden pr-2 pl-9 mix-blend-multiply hover:rounded-sm hover:bg-gray-100",
+                      isSelected && "rounded-sm shadow-lg ring-1 ring-custom-blue-600"
+                    )}
                     onClick={() => setKind([schema.kind!])}
                   >
                     {schema.icon && (
@@ -100,6 +162,6 @@ export const SchemaSelector = ({ className = "" }: SchemaSelectorProps) => {
           </Accordion>
         );
       })}
-    </section>
+    </Col>
   );
-};
+}

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -38,7 +38,7 @@ export const SchemaViewerStack = ({ className = "" }: { className: string }) => 
   const schemas = [...nodes, ...generics, ...profiles, ...templates];
 
   return (
-    <div className={classNames("relative", className)}>
+    <div className={classNames("relative z-1", className)}>
       {selectedKind.map((kind, index) => {
         const position = selectedKind.length - index - 1;
         const schema = schemas.find((s) => s.kind === kind);

--- a/frontend/app/src/shared/components/display/accordion.tsx
+++ b/frontend/app/src/shared/components/display/accordion.tsx
@@ -10,6 +10,8 @@ export type AccordionProps = {
   titleClassName?: string;
   iconClassName?: string;
   defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   style?: CSSProperties;
   hideChevron?: boolean;
   ref?: Ref<HTMLDivElement>;
@@ -18,6 +20,8 @@ export type AccordionProps = {
 export default function Accordion({
   title,
   defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
   children,
   className,
   hideChevron,
@@ -26,13 +30,20 @@ export default function Accordion({
   ref,
   ...props
 }: AccordionProps) {
-  const [isOpen, setIsOpen] = useState<boolean>();
+  const [internalOpen, setInternalOpen] = useState<boolean>();
 
-  const open = isOpen === undefined ? defaultOpen : isOpen;
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : (internalOpen ?? defaultOpen);
+
+  const toggle = () => {
+    const next = !open;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
 
   return (
     <div ref={ref} className={className} {...props}>
-      <div className="relative flex cursor-pointer items-center" onClick={() => setIsOpen(!open)}>
+      <div className="relative flex cursor-pointer items-center" onClick={toggle}>
         <span
           className={classNames(
             "relative mx-2 flex items-center",
@@ -43,7 +54,7 @@ export default function Accordion({
           {open ? <Icon icon={"mdi:chevron-down"} /> : <Icon icon={"mdi:chevron-right"} />}
         </span>
 
-        <span className={classNames("flex-1 justify-start text-left font-semibold")}>{title}</span>
+        <span className="flex-1 justify-start text-left font-semibold">{title}</span>
       </div>
 
       {open && children}


### PR DESCRIPTION

<img width="2884" height="1416" alt="image" src="https://github.com/user-attachments/assets/0ef12b81-9158-4edd-ab4c-3a90eda965ce" />

## Why

The schema selector had no collapse/expand all button, users had no way to quickly hide or show all namespace sections.

## What changed

- Schema selector search bar is now sticky at the top of the panel while scrolling through namespaces.
- Added a working collapse all / expand all button to the schema selector toolbar. Icon reflects the next action: if any section is open the button collapses all; otherwise it expands all.
- When searching, namespaces containing matches auto-expand. Clearing the search restores the user's prior collapsed/expanded state.
  - If the user clicks collapse/expand all during a search, that state persists after the search is cleared (the pre-search snapshot is discarded).
  - The shared `Accordion` component now supports optional controlled props (`open`, `onOpenChange`) in addition to its existing uncontrolled behavior. All existing call sites are unaffected.

  ## How to review

  Key files:
  - `frontend/app/src/entities/schema/ui/schema-selector.tsx` — state, button wiring, search auto-expand/restore logic
  - `frontend/app/src/shared/components/display/accordion.tsx` — added optional controlled props
  - `frontend/app/src/entities/schema/ui/schema-selector.test.tsx` — new component tests

  ## How to test

  Manual check:
  1. Open any page using the schema selector (e.g., schema visualization).
  2. Scroll — the search bar stays pinned at the top.
  3. Click the collapse-all button — all namespace sections collapse.
  4. Click it again — all expand.
  5. Collapse everything, type in the search box — matching sections auto-expand.
  6. Clear the search — sections return to their collapsed state.
  7. Search, click collapse all, clear the search — everything stays collapsed.

  Impact & rollout

  - Backward compatibility: No breaking changes. Accordion controlled props are optional; existing uncontrolled usages continue to work.
  - Performance: Negligible — small additional per-namespace state.
  - Config/env changes: None.
  - Deployment notes: Safe to deploy.

  Checklist

  - Tests added/updated
  - Changelog entry added (changelog/+schema-selector-toolbar.added.md)
  - External docs updated (if user-facing or ops-facing change)
  - Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the schema selector easier to scan and control by adding a sticky search bar and a working collapse/expand-all toggle for namespaces with a tooltip.

- New Features
  - Search bar stays pinned while scrolling.
  - Collapse/expand all button in the toolbar with tooltip and correct icon/behavior (collapses if any section is open, otherwise expands all).
  - Searching auto-expands namespaces with matches; clearing search restores the previous open/closed state. If you toggle all during a search, that state persists after clearing.

- Refactors
  - `Accordion` now supports controlled props: `open` and `onOpenChange`. Existing uncontrolled usages continue to work.

<sup>Written for commit 224666382405959ac5872ee12b92adab23a23ec0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

