### PR TITLE
Fixed account login/logout events rendering in activities card

### DIFF
--- a/frontend/app/src/entities/events/ui/event-card.tsx
+++ b/frontend/app/src/entities/events/ui/event-card.tsx
@@ -5,6 +5,8 @@ import { DateDisplay } from "@/shared/components/display/date-display";
 import { TimelineBorder } from "@/shared/components/ui/timeline-border";
 
 import type { EventType } from "@/entities/events/types";
+import { AccountLoggedInEventTitle } from "@/entities/events/ui/account-events/account-logged-in-event-title";
+import { AccountLoggedOutEventTitle } from "@/entities/events/ui/account-events/account-logged-out-event-title";
 import { ArtifactEventTitle } from "@/entities/events/ui/artifact-events/artifact-event-title";
 import { BranchEventTitle } from "@/entities/events/ui/branch-events/branch-event-title";
 import { EventDetailsPopover } from "@/entities/events/ui/event-details-popover";
@@ -54,6 +56,14 @@ const EventContent = (props: EventType) => {
 
   if (props.__typename === "ArtifactEvent") {
     return <ArtifactEventTitle {...props} />;
+  }
+
+  if (props.__typename === "AccountLoggedInEventType") {
+    return <AccountLoggedInEventTitle {...props} />;
+  }
+
+  if (props.__typename === "AccountLoggedOutEventType") {
+    return <AccountLoggedOutEventTitle {...props} />;
   }
 
   return <span className="text-gray-600 text-sm">{props.event}</span>;


### PR DESCRIPTION
missing fallback in recent activites card:
<img width="974" height="1100" alt="image" src="https://github.com/user-attachments/assets/71d38def-b513-4c75-bf18-4d8e80b30dbc" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rendering of account login/logout events in the Recent Activities card by using dedicated titles. These events now show correct labels instead of the generic fallback.

- **Bug Fixes**
  - In `event-card.tsx`, add cases for `AccountLoggedInEventType` and `AccountLoggedOutEventType` to render `AccountLoggedInEventTitle` and `AccountLoggedOutEventTitle`.

<sup>Written for commit a262f2b93b9aebc270334f1e3b0a4d1932a72719. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

