### PR TITLE
add dynamic env var support for log forwarding destinations

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from infrahub_sdk.utils import generate_uuid
 from pydantic import (
@@ -22,7 +22,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from typing_extensions import Self
 
 from infrahub.constants.database import DatabaseType
@@ -932,16 +932,73 @@ class LogForwardingDestination(BaseModel):
         return self
 
 
+_DESTINATION_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _load_destination_from_env(name: str) -> LogForwardingDestination:
+    """Build a LogForwardingDestination by scanning os.environ for keys matching
+    INFRAHUB_LOG_FORWARDING_DESTINATION_{NAME_UPPER}_{FIELD_UPPER}.
+    """
+    prefix = f"INFRAHUB_LOG_FORWARDING_DESTINATION_{name.upper()}_"
+    valid_field_names = set(LogForwardingDestination.model_fields.keys()) - {"name"}
+    fields: dict[str, Any] = {"name": name}
+    for env_key, env_val in os.environ.items():
+        if env_key.upper().startswith(prefix):
+            suffix = env_key[len(prefix) :].lower()
+            if suffix in valid_field_names:
+                fields[suffix] = env_val
+    return LogForwardingDestination.model_validate(fields)
+
+
 class LogForwardingSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_LOG_FORWARDING_")
     hostname: str | None = Field(
         default=None,
         description="Hostname to use in syslog message headers. If not set, defaults to the system FQDN.",
     )
+    destination_names: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Comma-separated list of destination names to load from per-destination environment variables "
+            "(e.g. INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST). Names must match [a-z0-9_]+. "
+            "Mutually exclusive with `destinations`."
+        ),
+    )
     destinations: list[LogForwardingDestination] = Field(
         default_factory=list,
         description="List of log forwarding destinations. (Enterprise only: not available in the community version.)",
     )
+
+    @field_validator("destination_names", mode="before")
+    @classmethod
+    def _split_destination_names(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            return [n.strip() for n in v.split(",") if n.strip()]
+        return v
+
+    @model_validator(mode="after")
+    def _materialize_destinations_from_env(self) -> Self:
+        if not self.destination_names:
+            return self
+        # if destinations already exist, they must have been set in infrahub.toml or the DESTINATIONS env var
+        # neither of which is supported in combination with DESTINATION_NAMES
+        if self.destinations:
+            raise ValueError(
+                "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES cannot be combined with explicit `destinations` "
+                "(set via INFRAHUB_LOG_FORWARDING_DESTINATIONS or infrahub.toml). Use one mechanism, not both."
+            )
+        for name in self.destination_names:
+            if not _DESTINATION_NAME_RE.match(name):
+                raise ValueError(
+                    f"Invalid log forwarding destination name '{name}': names configured via "
+                    "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES must match [a-z0-9_]+ (lowercase letters, "
+                    "digits, and underscores only)."
+                )
+        loaded = [_load_destination_from_env(name) for name in self.destination_names]
+        # Re-run uniqueness check (covers duplicates within destination_names itself).
+        self.__class__.validate_unique_names(loaded)
+        self.destinations = loaded
+        return self
 
     @field_validator("destinations")
     @classmethod

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -960,8 +960,8 @@ class LogForwardingSettings(BaseSettings):
         default_factory=list,
         description=(
             "Comma-separated list of destination names to load from per-destination environment variables "
-            "(e.g. INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST). Names must match [a-z0-9_]+. "
-            "Mutually exclusive with `destinations`."
+            "(e.g. `INFRAHUB_LOG_FORWARDING_DESTINATION_PRIMARY_HOST` where `PRIMARY` is the destination name). "
+            "Names must match `[a-z0-9_]+`. Mutually exclusive with `destinations`."
         ),
     )
     destinations: list[LogForwardingDestination] = Field(

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -242,6 +242,109 @@ def test_log_forwarding_from_toml_file() -> None:
     assert backup.min_log_severity == ExtraLogLevel.WARNING
 
 
+def test_log_forwarding_destinations_from_per_destination_env_vars() -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem_primary,backup_collector",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST": "syslog.example.com",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PORT": "514",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PROTOCOL": "tcp",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_FORMAT": "rfc5424",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_TLS_ENABLED": "true",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_TLS_CA_BUNDLE": "/etc/ssl/certs/ca.crt",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_FORWARD_APPLICATION_LOGS": "true",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_MIN_LOG_SEVERITY": "INFO",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_HOST": "syslog-backup.example.com",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_PORT": "1514",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_PROTOCOL": "udp",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_FORMAT": "rfc3164",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        settings = LogForwardingSettings()
+
+    assert [d.name for d in settings.destinations] == ["siem_primary", "backup_collector"]
+
+    primary = settings.destinations[0]
+    assert primary.host == "syslog.example.com"
+    assert primary.port == 514
+    assert primary.protocol is SyslogProtocol.TCP
+    assert primary.format is SyslogFormat.RFC5424
+    assert primary.tls_enabled is True
+    assert primary.tls_ca_bundle == "/etc/ssl/certs/ca.crt"
+    assert primary.forward_application_logs is True
+    assert primary.min_log_severity is ExtraLogLevel.INFO
+
+    backup = settings.destinations[1]
+    assert backup.host == "syslog-backup.example.com"
+    assert backup.port == 1514
+    assert backup.protocol is SyslogProtocol.UDP
+    assert backup.format is SyslogFormat.RFC3164
+    assert backup.tls_enabled is False
+
+
+def test_log_forwarding_destination_names_mutually_exclusive_with_destinations_env() -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem_primary",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST": "h",
+        "INFRAHUB_LOG_FORWARDING_DESTINATIONS": json.dumps([{"name": "x", "host": "h"}]),
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        pytest.raises(ValidationError, match="cannot be combined with explicit `destinations`"),
+    ):
+        LogForwardingSettings()
+
+
+def test_log_forwarding_destination_names_mutually_exclusive_with_toml_destinations() -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem_primary",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST": "h",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        pytest.raises(ValueError, match="cannot be combined with explicit `destinations`"),
+    ):
+        load(
+            config_data={
+                "log_forwarding": {
+                    "destinations": [{"name": "x", "type": "syslog", "host": "h", "port": 514}],
+                }
+            }
+        )
+
+
+@pytest.mark.parametrize("invalid_name", ["SIEM-PRIMARY", "siem-primary", "Siem", "with space", "with.dot"])
+def test_log_forwarding_destination_names_rejects_invalid_charset(invalid_name: str) -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": invalid_name,
+        f"INFRAHUB_LOG_FORWARDING_DESTINATION_{invalid_name.upper()}_HOST": "h",
+    }
+    with patch.dict(os.environ, env, clear=False), pytest.raises(ValidationError, match="must match"):
+        LogForwardingSettings()
+
+
+def test_log_forwarding_destination_names_duplicate_names_rejected() -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem,siem",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_HOST": "h",
+    }
+    with patch.dict(os.environ, env, clear=False), pytest.raises(ValidationError, match="must be unique"):
+        LogForwardingSettings()
+
+
+def test_log_forwarding_destination_names_per_dest_env_validates_tls_udp() -> None:
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "broken",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BROKEN_HOST": "h",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BROKEN_PROTOCOL": "udp",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_BROKEN_TLS_ENABLED": "true",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        pytest.raises(ValidationError, match="TLS is only supported with TCP"),
+    ):
+        LogForwardingSettings()
+
+
 def test_settings_enterprise_features_aggregates_log_forwarding() -> None:
     config_data = {
         "log_forwarding": {"destinations": [{"name": "siem", "type": "syslog", "host": "localhost", "port": 514}]},

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -321,7 +321,7 @@ Configuration settings for the message bus.
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | `INFRAHUB_LOG_FORWARDING_HOSTNAME` | Hostname to use in syslog message headers. If not set, defaults to the system FQDN. | None | None |
-| `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` | Comma-separated list of destination names to load from per-destination environment variables (e.g. INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST). Names must match [a-z0-9_]+. Mutually exclusive with `destinations`. | array[string] | None |
+| `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` | Comma-separated list of destination names to load from per-destination environment variables (e.g. `INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST`). Names must match `[a-z0-9_]+`. Mutually exclusive with `destinations`. | array[string] | None |
 | `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
 
 ### INFRAHUB_LOG_FORWARDING_DESTINATIONS

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -321,7 +321,7 @@ Configuration settings for the message bus.
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | `INFRAHUB_LOG_FORWARDING_HOSTNAME` | Hostname to use in syslog message headers. If not set, defaults to the system FQDN. | None | None |
-| `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` | Comma-separated list of destination names to load from per-destination environment variables (e.g. `INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST`). Names must match `[a-z0-9_]+`. Mutually exclusive with `destinations`. | array[string] | None |
+| `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` | Comma-separated list of destination names to load from per-destination environment variables (e.g. `INFRAHUB_LOG_FORWARDING_DESTINATION_PRIMARY_HOST` where `PRIMARY` is the destination name). Names must match `[a-z0-9_]+`. Mutually exclusive with `destinations`. | array[string] | None |
 | `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
 
 ### INFRAHUB_LOG_FORWARDING_DESTINATIONS

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -321,6 +321,7 @@ Configuration settings for the message bus.
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
 | `INFRAHUB_LOG_FORWARDING_HOSTNAME` | Hostname to use in syslog message headers. If not set, defaults to the system FQDN. | None | None |
+| `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` | Comma-separated list of destination names to load from per-destination environment variables (e.g. INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_HOST). Names must match [a-z0-9_]+. Mutually exclusive with `destinations`. | array[string] | None |
 | `INFRAHUB_LOG_FORWARDING_DESTINATIONS` | List of log forwarding destinations. (Enterprise only: not available in the community version.) | array[object] | Check nested parameters |
 
 ### INFRAHUB_LOG_FORWARDING_DESTINATIONS


### PR DESCRIPTION
we currently support 2 methods for setting up log forwarding.
- JSON blob in the `INFRAHUB_LOG_FORWARDING_DESTINATIONS` env var
- configuration via `infrahub.toml`
```
[[log_forwarding.destinations]]
name = "siem-primary"
type = "syslog"
host = "syslog.example.com"
port = 514
protocol = "tcp"
format = "rfc5424"
tls_enabled = true
tls_ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
queue_size = 50000
forward_application_logs = true
min_log_severity = "INFO"

[[log_forwarding.destinations]]
name = "backup-collector"
type = "syslog"
host = "syslog-backup.example.com"
port = 1514
protocol = "udp"
format = "rfc3164"
queue_size = 5000
shutdown_drain_timeout = 5
```

it would be helpful to also support configuration via non-JSON environment variables, but we also need to support an arbitrary number of destinations. the solution is to add an `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` env var that is used to determine the names of other env vars used to configure log forwarding.
here's an example. the names in the `DESTINATION_NAMES` env var are used to determine the names of the env vars for each individual destination
```
INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES: "siem_primary,backup_collector"

# siem-primary destination
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST: "<syslog.example.com>"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PORT: "514"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PROTOCOL: "tcp"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_FORMAT: "rfc5424"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_TLS_ENABLED: "true"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_TLS_CA_BUNDLE: "/etc/ssl/certs/ca.crt"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_FORWARD_APPLICATION_LOGS: "true"
INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_MIN_LOG_SEVERITY: "INFO"

# backup-collector destination
INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_HOST: "<syslog-backup.example.com>"
INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_PORT: "1514"
INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_PROTOCOL: "udp"
INFRAHUB_LOG_FORWARDING_DESTINATION_BACKUP_COLLECTOR_FORMAT: "rfc3164"
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic env var support to configure multiple log forwarding destinations without JSON or `infrahub.toml`. Simplifies env-only deployments and documents the new variables.

- **New Features**
  - New `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` (comma-separated) to declare destinations.
  - Reads per-destination keys: `INFRAHUB_LOG_FORWARDING_DESTINATION_<NAME>_<FIELD>`.
  - Validates names `[a-z0-9_]+`, checks uniqueness, and enforces existing rules (e.g., TLS only with TCP).
  - Adds unit tests and updates config reference with the new variable.

- **Migration**
  - JSON (`INFRAHUB_LOG_FORWARDING_DESTINATIONS`) and `infrahub.toml` still supported.
  - Do not combine `INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` with `INFRAHUB_LOG_FORWARDING_DESTINATIONS` or TOML `destinations`.

<sup>Written for commit b1a5076a9642e102677290c47e029763a85fe09a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

