### PR TITLE
Prefer `max` over `sorted()` to compute the maximum value

### DIFF
--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -665,9 +665,7 @@ class Query:
             attrs_info[tuple(identifier)].append(info)
 
         for values in attrs_info.values():
-            attr_info = sorted(
-                values, key=lambda i: (i["branch_score"], i["time_score"], not i["deleted"]), reverse=True
-            )[0]
+            attr_info = max(values, key=lambda i: (i["branch_score"], i["time_score"], not i["deleted"]))
             if attr_info["deleted"]:
                 continue
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -617,14 +617,13 @@ class DiffTreeResolver:
             return None
         if len(enriched_diffs) > 0:
             # take the one with the longest duration that covers multiple branches
-            enriched_diff = sorted(
+            enriched_diff = max(
                 enriched_diffs,
                 key=lambda d: (
                     d.base_branch_name != d.diff_branch_name,
                     d.to_time.to_datetime() - d.from_time.to_datetime(),
                 ),
-                reverse=True,
-            )[0]
+            )
         else:
             enriched_diff = enriched_diffs[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,7 +574,6 @@ allow-dunder-method-names = [
     "INP001",   # File is part of an implicit namespace package
     "FURB118",  # Use `operator.itemgetter(1)` instead of defining a lambda
     "FURB140",  # Use `itertools.starmap` instead of the generator
-    "FURB192",  # Prefer `min` over `sorted()` to compute the minimum value
     "N801",     # Class name should use CapWords convention
     "N806",     # Variable in function should be lowercase
     "PERF401",  # Use a list comprehension to create a transformed list


### PR DESCRIPTION

# Why

Minor linting cleanup

## What changed

* Switch call to `sorted` and replace with simplified `max`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced sorted(...)[0] with max(...) to compute maximum values in query and diff logic for clearer intent and less work. Removed the `FURB192` ignore in `pyproject.toml` to enforce this lint rule.

<sup>Written for commit 42b040d09196bb34186d685783f1ad9eaf268965. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

