### PR TITLE
refactor: replace for-loop dict assignment with dict.update in NodeManager

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1169,8 +1169,7 @@ class NodeManager:
             # Attributes
             # --------------------------------------------------------
             if node_id in node_attributes:
-                for attr_name, attr in node_attributes[node_id].attrs.items():
-                    new_node_data[attr_name] = attr
+                new_node_data.update(node_attributes[node_id].attrs)
 
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1165,8 +1165,7 @@ class NodeManager:
             # Attributes
             # --------------------------------------------------------
             if node_id in node_attributes:
-                for attr_name, attr in node_attributes[node_id].attrs.items():
-                    new_node_data[attr_name] = attr
+                new_node_data.update(node_attributes[node_id].attrs)
 
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -589,7 +589,6 @@ allow-dunder-method-names = [
     "N801",     # Class name should use CapWords convention
     "N806",     # Variable in function should be lowercase
     "PERF401",  # Use a list comprehension to create a transformed list
-    "PERF403",  # Use a dictionary comprehension instead of a for-loop
     "PGH003",   # Use specific rule codes when ignoring type issues
     "PGH004",   # Use specific rule codes when using `noqa`
     "PLC0415",  # `import` should be at the top-level of a file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -578,7 +578,6 @@ allow-dunder-method-names = [
     "N801",     # Class name should use CapWords convention
     "N806",     # Variable in function should be lowercase
     "PERF401",  # Use a list comprehension to create a transformed list
-    "PERF403",  # Use a dictionary comprehension instead of a for-loop
     "PGH003",   # Use specific rule codes when ignoring type issues
     "PGH004",   # Use specific rule codes when using `noqa`
     "PLC0415",  # `import` should be at the top-level of a file


### PR DESCRIPTION
# Why

The loop manually assigned dict items one by one, which is what dict.update exists for. Ruff PERF403 flagged it. It's a very minor performance improvement.

## What changed

* Replaced the for-loop in NodeManager with a single dict.update call. No behavioral change.
* Remove ignore rule in pyproject.toml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the attribute copy loop in `NodeManager.get_many` with `dict.update` for cleaner, slightly faster code. Removed the `PERF403` ignore in `pyproject.toml`; no behavior change.

- **Refactors**
  - Use `new_node_data.update(node_attributes[node_id].attrs)` instead of per-item assignment.
  - Drop Ruff rule ignore for `PERF403` in `pyproject.toml`.

<sup>Written for commit 6b6a5664518b65c23edf2319ddb3f5a7ad6ffa64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/8902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

