### PR TITLE
Add permission decision support to filter picker

### DIFF
--- a/frontend/app/src/entities/nodes/object/domain/filter-definition.ts
+++ b/frontend/app/src/entities/nodes/object/domain/filter-definition.ts
@@ -1,3 +1,6 @@
+import { warnUnexpectedType } from "@/shared/utils/common";
+
+import type { DecisionOption } from "@/entities/role-manager/domain/get-decision-options";
 import type { AttributeKind, AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 import { ATTRIBUTE_ICONS } from "@/entities/schema/ui/field-schema-icon";
 
@@ -24,9 +27,16 @@ export type MetadataUserFilterDefinition = {
   peer: string;
 };
 
+export type PermissionDecisionFilterDefinition = {
+  type: "permission-decision";
+  schema: AttributeSchema;
+  options: DecisionOption[];
+};
+
 export type FilterDefinition =
   | AttributeFilterDefinition
   | RelationshipFilterDefinition
+  | PermissionDecisionFilterDefinition
   | MetadataDateFilterDefinition
   | MetadataUserFilterDefinition;
 
@@ -34,10 +44,14 @@ export function getFilterDefinitionName(def: FilterDefinition): string {
   switch (def.type) {
     case "attribute":
     case "relationship":
+    case "permission-decision":
       return def.schema.name;
     case "metadata-date":
     case "metadata-user":
       return def.name;
+    default:
+      warnUnexpectedType(def);
+      return def;
   }
 }
 
@@ -45,16 +59,21 @@ export function getFilterDefinitionLabel(def: FilterDefinition): string {
   switch (def.type) {
     case "attribute":
     case "relationship":
+    case "permission-decision":
       return def.schema.label ?? def.schema.name;
     case "metadata-date":
     case "metadata-user":
       return def.label;
+    default:
+      warnUnexpectedType(def);
+      return "???";
   }
 }
 
 export function getFilterDefinitionIcon(def: FilterDefinition): string {
   switch (def.type) {
     case "attribute":
+    case "permission-decision":
       return ATTRIBUTE_ICONS[def.schema.kind as AttributeKind] ?? "mdi:filter-variant";
     case "relationship":
       return "mdi:cube-outline";
@@ -62,5 +81,8 @@ export function getFilterDefinitionIcon(def: FilterDefinition): string {
       return "mdi:calendar-clock";
     case "metadata-user":
       return "mdi:account";
+    default:
+      warnUnexpectedType(def);
+      return "mdi:filter-variant";
   }
 }

--- a/frontend/app/src/entities/nodes/object/domain/filter-definition.ts
+++ b/frontend/app/src/entities/nodes/object/domain/filter-definition.ts
@@ -51,7 +51,7 @@ export function getFilterDefinitionName(def: FilterDefinition): string {
       return def.name;
     default:
       warnUnexpectedType(def);
-      return def;
+      return "???";
   }
 }
 

--- a/frontend/app/src/entities/nodes/object/ui/filters/active-object-filter-tags.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/active-object-filter-tags.tsx
@@ -18,6 +18,7 @@ import {
   InternalGroupsFilterTag,
 } from "@/entities/nodes/object/ui/filters/internal-groups-filter-tag";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
+import { getDecisionOptions } from "@/entities/role-manager/domain/get-decision-options";
 import type { ModelSchema } from "@/entities/schema/types";
 import { isOfKind } from "@/entities/schema/utils/is-of-kind";
 
@@ -29,7 +30,10 @@ function buildFilterDefinitions(schema: ModelSchema): Record<string, FilterDefin
   const definitions: Record<string, FilterDefinition> = {};
 
   for (const attr of schema?.attributes ?? []) {
-    definitions[attr.name] = { type: "attribute", schema: attr };
+    const decisionOptions = getDecisionOptions(schema.kind, attr.name);
+    definitions[attr.name] = decisionOptions
+      ? { type: "permission-decision", schema: attr, options: decisionOptions }
+      : { type: "attribute", schema: attr };
   }
   for (const rel of schema?.relationships ?? []) {
     definitions[rel.name] = { type: "relationship", schema: rel };

--- a/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+import { ListBoxItem } from "@/shared/components/aria/list-box";
+import { Select, SelectList, SelectTrigger } from "@/shared/components/aria/select";
+import { getCurrentFilterCondition } from "@/shared/components/filters/utils/get-current-filter-condition";
+import { FormField } from "@/shared/components/ui/form";
+import useFilters, { type Filter } from "@/shared/hooks/useFilters";
+
+import {
+  FILTER_CONDITION,
+  type FilterCondition,
+} from "@/entities/nodes/object/ui/filters/filter-condition-select";
+import { FilterFormLayout } from "@/entities/nodes/object/ui/filters/filter-form-layout";
+import type { DecisionOption } from "@/entities/role-manager/domain/get-decision-options";
+import type { AttributeSchema } from "@/entities/schema/types";
+
+export interface DecisionFilterFormProps {
+  attributeSchema: AttributeSchema;
+  options: DecisionOption[];
+  onSuccess?: () => void;
+}
+
+export function DecisionFilterForm({
+  attributeSchema,
+  options,
+  onSuccess,
+}: DecisionFilterFormProps) {
+  const [filters, setFilters] = useFilters();
+  const currentFilter = filters.find((f) => f.name.startsWith(attributeSchema.name));
+  const [condition, setCondition] = useState<FilterCondition>(
+    getCurrentFilterCondition(currentFilter) ?? FILTER_CONDITION.CONTAINS
+  );
+
+  const handleSubmit = (formData: Record<string, unknown>) => {
+    const cleanedFilters = filters.filter((f) => !f.name.startsWith(attributeSchema.name));
+
+    if (condition === FILTER_CONDITION.CONTAINS) {
+      const raw = formData.decision;
+      if (raw === undefined || raw === null || raw === "") {
+        setFilters(cleanedFilters);
+        return;
+      }
+      const numericValue = typeof raw === "number" ? raw : Number(raw);
+      const newFilter: Filter = {
+        name: `${attributeSchema.name}__value`,
+        value: numericValue,
+      };
+      setFilters([...cleanedFilters, newFilter]);
+      return;
+    }
+
+    if (condition === FILTER_CONDITION.IS_EMPTY) {
+      setFilters([...cleanedFilters, { name: `${attributeSchema.name}__isnull`, value: true }]);
+      return;
+    }
+
+    if (condition === FILTER_CONDITION.IS_NOT_EMPTY) {
+      setFilters([...cleanedFilters, { name: `${attributeSchema.name}__isnull`, value: false }]);
+      return;
+    }
+  };
+
+  const defaultValue =
+    currentFilter && getCurrentFilterCondition(currentFilter) === FILTER_CONDITION.CONTAINS
+      ? Number(currentFilter.value)
+      : undefined;
+
+  return (
+    <FilterFormLayout
+      filterType="permission-decision"
+      condition={condition}
+      onConditionChange={setCondition}
+      testId="decision-filter-form"
+      onSubmit={(formData) => {
+        handleSubmit(formData);
+        onSuccess?.();
+      }}
+    >
+      {condition === FILTER_CONDITION.CONTAINS && (
+        <FormField
+          name="decision"
+          defaultValue={defaultValue}
+          render={({ field }) => (
+            <Select
+              aria-label="select a decision"
+              placeholder="Select a decision"
+              selectedKey={field.value ?? null}
+              onSelectionChange={(key) => field.onChange(key)}
+            >
+              <SelectTrigger className="min-w-40" />
+              <SelectList items={options}>
+                {(item) => (
+                  <ListBoxItem id={item.value} textValue={item.label}>
+                    {item.label}
+                  </ListBoxItem>
+                )}
+              </SelectList>
+            </Select>
+          )}
+        />
+      )}
+    </FilterFormLayout>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/filters/field-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/field-filter-form.tsx
@@ -1,6 +1,9 @@
+import { warnUnexpectedType } from "@/shared/utils/common";
+
 import type { FilterDefinition } from "@/entities/nodes/object/domain/filter-definition";
 import { AttributeFilterForm } from "@/entities/nodes/object/ui/filters/attribute-filter-form";
 import { DateMetadataFilterForm } from "@/entities/nodes/object/ui/filters/date-metadata-filter-form";
+import { DecisionFilterForm } from "@/entities/nodes/object/ui/filters/decision-filter-form";
 import { RelationshipFilterForm } from "@/entities/nodes/object/ui/filters/relationship-filter-form";
 import { UserMetadataFilterForm } from "@/entities/nodes/object/ui/filters/user-metadata-filter-form";
 
@@ -13,6 +16,14 @@ export function FieldFilterForm({ definition, onSuccess }: FieldFilterFormProps)
   switch (definition.type) {
     case "attribute":
       return <AttributeFilterForm attributeSchema={definition.schema} onSuccess={onSuccess} />;
+    case "permission-decision":
+      return (
+        <DecisionFilterForm
+          attributeSchema={definition.schema}
+          options={definition.options}
+          onSuccess={onSuccess}
+        />
+      );
     case "relationship":
       return (
         <RelationshipFilterForm relationshipSchema={definition.schema} onSuccess={onSuccess} />
@@ -21,5 +32,8 @@ export function FieldFilterForm({ definition, onSuccess }: FieldFilterFormProps)
       return <DateMetadataFilterForm definition={definition} onSuccess={onSuccess} />;
     case "metadata-user":
       return <UserMetadataFilterForm definition={definition} onSuccess={onSuccess} />;
+    default:
+      warnUnexpectedType(definition);
+      return null;
   }
 }

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
@@ -33,6 +33,15 @@ export const ATTRIBUTE_FILTER_CONDITION_OPTIONS: Array<{ key: FilterCondition; l
   { key: FILTER_CONDITION.IS_NOT_EMPTY, label: "is not empty" },
 ];
 
+export const PERMISSION_DECISION_FILTER_CONDITION_OPTIONS: Array<{
+  key: FilterCondition;
+  label: string;
+}> = [
+  { key: FILTER_CONDITION.CONTAINS, label: "is" },
+  { key: FILTER_CONDITION.IS_EMPTY, label: "is empty" },
+  { key: FILTER_CONDITION.IS_NOT_EMPTY, label: "is not empty" },
+];
+
 export const DATETIME_FILTER_CONDITION_OPTIONS: Array<{ key: FilterCondition; label: string }> = [
   { key: FILTER_CONDITION.IS_EMPTY, label: "is empty" },
   { key: FILTER_CONDITION.IS_NOT_EMPTY, label: "is not empty" },
@@ -62,6 +71,8 @@ function getFilterConditionOptions(filterType: FilterConditionSelectProps["filte
   switch (filterType) {
     case "relationship":
       return RELATIONSHIP_FILTER_CONDITION_OPTIONS;
+    case "permission-decision":
+      return PERMISSION_DECISION_FILTER_CONDITION_OPTIONS;
     case "datetime":
       return DATETIME_FILTER_CONDITION_OPTIONS;
     case "metadata-date":

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
@@ -21,6 +21,7 @@ import {
 import { getFilterPickerCount } from "@/entities/nodes/object/domain/get-filter-picker-count";
 import { ALL_METADATA_FILTERS } from "@/entities/nodes/object/domain/metadata-filter-definitions";
 import { FieldFilterForm } from "@/entities/nodes/object/ui/filters/field-filter-form";
+import { getDecisionOptions } from "@/entities/role-manager/domain/get-decision-options";
 import type { ModelSchema } from "@/entities/schema/types";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 
@@ -45,10 +46,14 @@ export function FilterPicker({ schema, filters }: FilterPickerProps) {
 
   const fields: FilterDefinition[] = [
     ...sortByOrderWeight([...(schema.attributes ?? []), ...(schema.relationships ?? [])]).map(
-      (field): FilterDefinition =>
-        "peer" in field
-          ? { type: "relationship", schema: field }
-          : { type: "attribute", schema: field }
+      (field): FilterDefinition => {
+        if ("peer" in field) return { type: "relationship", schema: field };
+
+        const decisionOptions = getDecisionOptions(schema.kind, field.name);
+        return decisionOptions
+          ? { type: "permission-decision", schema: field, options: decisionOptions }
+          : { type: "attribute", schema: field };
+      }
     ),
     ...ALL_METADATA_FILTERS,
   ];

--- a/frontend/app/src/entities/role-manager/domain/get-decision-options.test.ts
+++ b/frontend/app/src/entities/role-manager/domain/get-decision-options.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { globalDecisionOptions, objectDecisionOptions } from "@/entities/role-manager/constants";
+import { getDecisionOptions } from "@/entities/role-manager/domain/get-decision-options";
+
+describe("getDecisionOptions", () => {
+  it("returns objectDecisionOptions for CoreObjectPermission decision", () => {
+    // GIVEN
+    const schemaKind = "CoreObjectPermission";
+    const attributeName = "decision";
+
+    // WHEN
+    const result = getDecisionOptions(schemaKind, attributeName);
+
+    // THEN
+    expect(result).toBe(objectDecisionOptions);
+  });
+
+  it("returns globalDecisionOptions for CoreGlobalPermission decision", () => {
+    // GIVEN
+    const schemaKind = "CoreGlobalPermission";
+    const attributeName = "decision";
+
+    // WHEN
+    const result = getDecisionOptions(schemaKind, attributeName);
+
+    // THEN
+    expect(result).toBe(globalDecisionOptions);
+  });
+
+  it("returns null when attributeName is not 'decision'", () => {
+    // GIVEN
+    const schemaKind = "CoreObjectPermission";
+    const attributeName = "action";
+
+    // WHEN
+    const result = getDecisionOptions(schemaKind, attributeName);
+
+    // THEN
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a non-permission schema kind", () => {
+    // GIVEN
+    const schemaKind = "CoreAccount";
+    const attributeName = "decision";
+
+    // WHEN
+    const result = getDecisionOptions(schemaKind, attributeName);
+
+    // THEN
+    expect(result).toBeNull();
+  });
+
+  it("returns null when schemaKind is undefined", () => {
+    // GIVEN / WHEN
+    const result = getDecisionOptions(undefined, "decision");
+
+    // THEN
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/app/src/entities/role-manager/domain/get-decision-options.ts
+++ b/frontend/app/src/entities/role-manager/domain/get-decision-options.ts
@@ -1,0 +1,15 @@
+import { GLOBAL_PERMISSION_OBJECT, OBJECT_PERMISSION_OBJECT } from "@/shared/config/constants";
+
+import { globalDecisionOptions, objectDecisionOptions } from "@/entities/role-manager/constants";
+
+export type DecisionOption = { value: number; label: string };
+
+export function getDecisionOptions(
+  schemaKind: string | null | undefined,
+  attributeName: string
+): DecisionOption[] | null {
+  if (attributeName !== "decision") return null;
+  if (schemaKind === OBJECT_PERMISSION_OBJECT) return objectDecisionOptions;
+  if (schemaKind === GLOBAL_PERMISSION_OBJECT) return globalDecisionOptions;
+  return null;
+}

--- a/frontend/app/src/entities/role-manager/ui/decision-column-header.tsx
+++ b/frontend/app/src/entities/role-manager/ui/decision-column-header.tsx
@@ -1,19 +1,13 @@
 import { Icon } from "@iconify-icon/react";
 import { useState } from "react";
 
-import { Select, SelectItem, SelectList, SelectTrigger } from "@/shared/components/aria/select";
-import { getCurrentFilterCondition } from "@/shared/components/filters/utils/get-current-filter-condition";
 import { cellHeaderStyle, cellsStyle } from "@/shared/components/table/style";
-import { Button } from "@/shared/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import useFilters from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";
 
-import {
-  FILTER_CONDITION,
-  type FilterCondition,
-  FilterConditionSelect,
-} from "@/entities/nodes/object/ui/filters/filter-condition-select";
+import { DecisionFilterForm } from "@/entities/nodes/object/ui/filters/decision-filter-form";
+import type { DecisionOption } from "@/entities/role-manager/domain/get-decision-options";
 import type { AttributeSchema } from "@/entities/schema/types";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 
@@ -22,39 +16,11 @@ export function DecisionColumnHeader({
   options,
 }: {
   attributeSchema: AttributeSchema;
-  options: Array<{ value: number; label: string }>;
+  options: DecisionOption[];
 }) {
-  const [filters, setFilters] = useFilters();
+  const [filters] = useFilters();
   const [showFilters, setShowFilters] = useState(false);
   const currentFilter = filters.find((f) => f.name.startsWith(attributeSchema.name));
-  const [condition, setCondition] = useState<FilterCondition>(
-    getCurrentFilterCondition(currentFilter) ?? FILTER_CONDITION.CONTAINS
-  );
-  const [selectedValue, setSelectedValue] = useState<string | null>(() => {
-    if (currentFilter && getCurrentFilterCondition(currentFilter) === FILTER_CONDITION.CONTAINS) {
-      return String(currentFilter.value);
-    }
-    return null;
-  });
-
-  const handleSubmit = () => {
-    const cleanedFilters = filters.filter((f) => !f.name.startsWith(attributeSchema.name));
-
-    if (condition === FILTER_CONDITION.CONTAINS && selectedValue) {
-      setFilters([
-        ...cleanedFilters,
-        { name: `${attributeSchema.name}__value`, value: selectedValue },
-      ]);
-    } else if (condition === FILTER_CONDITION.IS_EMPTY) {
-      setFilters([...cleanedFilters, { name: `${attributeSchema.name}__isnull`, value: true }]);
-    } else if (condition === FILTER_CONDITION.IS_NOT_EMPTY) {
-      setFilters([...cleanedFilters, { name: `${attributeSchema.name}__isnull`, value: false }]);
-    } else {
-      setFilters(cleanedFilters);
-    }
-
-    setShowFilters(false);
-  };
 
   return (
     <Popover open={showFilters} onOpenChange={setShowFilters}>
@@ -73,31 +39,11 @@ export function DecisionColumnHeader({
           Filter by {attributeSchema.label ?? attributeSchema.name}
         </div>
 
-        <div className="flex gap-2 p-2">
-          <div className="inline-flex h-10 items-center">Where</div>
-
-          <FilterConditionSelect
-            filterType="attribute"
-            value={condition}
-            onChange={(key) => setCondition(key as FilterCondition)}
-          />
-
-          {condition === FILTER_CONDITION.CONTAINS && (
-            <Select
-              aria-label="select a decision"
-              placeholder=""
-              value={selectedValue}
-              onChange={(key) => setSelectedValue(key as string)}
-            >
-              <SelectTrigger className="w-33" />
-              <SelectList items={options}>
-                {(item) => <SelectItem id={item.label}>{item.label}</SelectItem>}
-              </SelectList>
-            </Select>
-          )}
-
-          <Button onClick={handleSubmit}>Apply</Button>
-        </div>
+        <DecisionFilterForm
+          attributeSchema={attributeSchema}
+          options={options}
+          onSuccess={() => setShowFilters(false)}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/frontend/app/src/shared/components/filters/active-filter-tags.test.ts
+++ b/frontend/app/src/shared/components/filters/active-filter-tags.test.ts
@@ -5,6 +5,8 @@ import {
   getFilterTagDisplay,
 } from "@/shared/components/filters/active-filter-tags";
 
+import { objectDecisionOptions } from "@/entities/role-manager/constants";
+
 import { generateAttributeSchema, generateRelationshipSchema } from "../../../../tests/fake/schema";
 
 describe("formatAttributeFilterValue", () => {
@@ -210,6 +212,52 @@ describe("getFilterTagDisplay", () => {
 
     // THEN
     expect(result).toBeNull();
+  });
+
+  it("returns the decision label for a decision filter definition", () => {
+    // GIVEN
+    const filter = { name: "decision__value", value: 2 };
+
+    // WHEN
+    const result = getFilterTagDisplay({
+      filter,
+      fieldKey: "value",
+      filterDefinition: {
+        type: "permission-decision",
+        schema: generateAttributeSchema({ name: "decision", label: "Decision", kind: "Number" }),
+        options: objectDecisionOptions,
+      },
+    });
+
+    // THEN
+    expect(result).toEqual({
+      label: "Decision",
+      condition: "is",
+      value: "Allow on default branch",
+    });
+  });
+
+  it("falls back to the raw value when the decision value is not in the options", () => {
+    // GIVEN
+    const filter = { name: "decision__value", value: 99 };
+
+    // WHEN
+    const result = getFilterTagDisplay({
+      filter,
+      fieldKey: "value",
+      filterDefinition: {
+        type: "permission-decision",
+        schema: generateAttributeSchema({ name: "decision", label: "Decision", kind: "Number" }),
+        options: objectDecisionOptions,
+      },
+    });
+
+    // THEN
+    expect(result).toEqual({
+      label: "Decision",
+      condition: "is",
+      value: 99,
+    });
   });
 
   it("returns before/after display for metadata-date filters", () => {

--- a/frontend/app/src/shared/components/filters/active-filter-tags.tsx
+++ b/frontend/app/src/shared/components/filters/active-filter-tags.tsx
@@ -238,6 +238,15 @@ export function getFilterTagDisplay({
     filterDefinition.type === "relationship" || filterDefinition.type === "metadata-user";
 
   if (fieldKey === "value" || fieldKey === "values") {
+    if (filterDefinition.type === "permission-decision") {
+      const match = filterDefinition.options.find((option) => option.value === filter.value);
+      return {
+        label: name,
+        condition: "is",
+        value: match ? match.label : filter.value,
+      };
+    }
+
     if (filterDefinition.type !== "attribute") return null;
 
     return {


### PR DESCRIPTION
Why

The filter picker on permission tables (CoreObjectPermission, CoreGlobalPermission) displays a raw number input for the decision attribute. Users must know the internal bitmask values (1/2/4/6) to filter. The DecisionColumnHeader in the table already shows labeled options — the filter should match.

Goal: Show a labeled select ("Deny everywhere", "Allow on default branch", etc.) when filtering by decision, and display the label in the active filter tag.

What changed

  - New permission-decision filter definition type: Added PermissionDecisionFilterDefinition to the FilterDefinition union, carrying schema + options. Construction sites (FilterPicker, buildFilterDefinitions)
  resolve the options via getDecisionOptions(schemaKind, attrName) — downstream code just pattern-matches on type.
  - New DecisionFilterForm: Renders a labeled Select for the "is" condition, mirrors AttributeFilterForm for "is empty"/"is not empty". Wire format unchanged (decision__value: <number>, decision__isnull: <bool>).
  - New getDecisionOptions helper: Single source of truth — returns objectDecisionOptions (4 values) for CoreObjectPermission, globalDecisionOptions (2 values) for CoreGlobalPermission, null otherwise.
  - Active filter tag shows the label: getFilterTagDisplay maps the numeric value to its label for permission-decision definitions, with raw-value fallback for unknown values.
  - Condition wording: The decision filter uses "is" instead of "contains" in both the condition dropdown and the active filter tag.

  What stayed the same: DecisionColumnHeader untouched. No backend, URL state, or GraphQL wire format changes. Non-permission schemas with a decision attribute are unaffected.

  How to review

  1. Start with filter-definition.ts — the new union variant and helper updates
  2. Then get-decision-options.ts — the resolution logic + tests
  3. Then decision-filter-form.tsx and field-filter-form.tsx — the form and routing
  4. Then filter-picker.tsx and active-object-filter-tags.tsx — the two construction sites
  5. Then active-filter-tags.tsx + test — tag display with label lookup
  6. filter-condition-select.tsx — new condition option set for "is"

  Manual:
  1. Navigate to a role's Object Permissions table → open filter picker → select Decision → confirm labeled select with 4 options, condition shows "is"
  2. Apply a filter → confirm the active tag reads e.g. Decision | is | Allow in all branches
  3. Click the tag to edit → confirm the select reopens with the correct value preselected
  4. Repeat on Global Permissions → confirm 2-option set ("Deny", "Allow")
  5. On any non-permission table → confirm numeric attributes still show a plain number input

  Impact & rollout

  - Backward compatibility: None — URL filter format unchanged (decision__value=6)
  - Performance: No additional API calls; options are static frontend constants
  - Deployment notes: Safe to deploy independently

  Checklist

  - Tests added/updated
  - Changelog entry added (uv run towncrier create ...)
  - External docs updated (if user-facing or ops-facing change)
  - Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the numeric input with a labeled decision select in permission filters, shows labels in active filter tags, and reuses the same form in the Decision column header. Wire format stays the same; no backend changes.

- New Features
  - Added `permission-decision` filter type with options from `getDecisionOptions` for `CoreObjectPermission` and `CoreGlobalPermission`.
  - Introduced `DecisionFilterForm` with a labeled Select for "is"; preserves `decision__value` and `decision__isnull`.
  - `FilterPicker` and active filter tags display decision labels, with raw-value fallback.
  - Decision condition options: "is", "is empty", "is not empty".
  - Tests added for option resolution and tag display.

- Refactors
  - `DecisionColumnHeader` now uses `DecisionFilterForm` for consistent behavior.
  - Added default guards in filter-definition helpers via `warnUnexpectedType`.

<sup>Written for commit 14024a736a8fd50873bcb2b040a7e015d581e477. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

