### PR TITLE
Fix display_label backfill after schema change

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -218,15 +218,15 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         await self._human_friendly_id.compute(db=db, node=self)
 
     async def get_display_label(self, db: InfrahubDatabase) -> str:
-        if self._display_label and (value := self._display_label.get_value(node=self, at=self._at)):
-            return value
+        if self._display_label is not None:
+            if value := self._display_label.get_value(node=self, at=self._at):
+                return value
+            # Stored value is empty do not compute on the fly to avoid recomputation trigger issues
+            if self._schema.display_label:
+                return ""
 
         if not self._schema.display_label:
             return repr(self)
-
-        if self._display_label is not None:
-            # Stored value is empty do not compute on the fly to avoid recomputation trigger issues
-            return ""
 
         # This should only happens for "virtual" nodes (that never exist inside the db)
         display_label = DisplayLabel(node_schema=self._schema, template=self._schema.display_label)

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -224,6 +224,11 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         if not self._schema.display_label:
             return repr(self)
 
+        if self._display_label is not None:
+            # Stored value is empty do not compute on the fly to avoid recomputation trigger issues
+            return ""
+
+        # This should only happens for "virtual" nodes (that never exist inside the db)
         display_label = DisplayLabel(node_schema=self._schema, template=self._schema.display_label)
         await display_label.compute(db=db, node=self)
         return display_label.get_value(node=self, at=self._at) or ""

--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -4,7 +4,6 @@ from asyncio import sleep
 from typing import TYPE_CHECKING
 
 import pytest
-from infrahub_sdk import InfrahubClient
 from infrahub_sdk.task.models import TaskFilter, TaskState
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 

--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -51,39 +51,43 @@ class TestDisplayLabelBackfillOnSchemaChange(TestInfrahubDockerClient):
     def schema_with_display_label(self) -> dict:
         return {"version": "1.0", "nodes": [COLOR.model_dump()]}
 
+    @pytest.fixture(scope="class")
+    async def color_before(self, client: InfrahubClient, schema_without_display_label: dict) -> str:
+        """Load schema without display_label and create a node."""
+        response = await client.schema.load(schemas=[schema_without_display_label], wait_until_converged=True)
+        assert response.schema_updated
+
+        color = await client.create(kind="TestingColor", name="Red", description="A warm color")
+        await color.save()
+        return color.id
+
+    @pytest.fixture(scope="class")
+    async def color_after(self, client: InfrahubClient, color_before: str, schema_with_display_label: dict) -> str:
+        """Update schema to add display_label and create a second node."""
+        response = await client.schema.load(schemas=[schema_with_display_label], wait_until_converged=True)
+        assert response.schema_updated
+
+        color = await client.create(kind="TestingColor", name="Blue", description="A cool color")
+        await color.save()
+        return color.id
+
     async def _get_display_labels(self, client: InfrahubClient) -> dict[str, str]:
         result = await client.execute_graphql(query=QUERY_DISPLAY_LABELS)
         return {e["node"]["id"]: e["node"]["display_label"] for e in result["TestingColor"]["edges"]}
 
-    async def test_step01_load_schema_without_display_label(
-        self, client: InfrahubClient, schema_without_display_label: dict
-    ) -> None:
-        response = await client.schema.load(schemas=[schema_without_display_label], wait_until_converged=True)
-        assert response.schema_updated
-
-    async def test_step02_create_node_and_verify_no_display_label(self, client: InfrahubClient) -> None:
-        color = await client.create(kind="TestingColor", name="Red", description="A warm color")
-        await color.save()
-
+    async def test_node_created_before_display_label_has_repr(self, client: InfrahubClient, color_before: str) -> None:
+        """A node created without display_label in the schema should fall back to repr()."""
         await wait_for_all_tasks_to_be_completed(client=client)
         labels = await self._get_display_labels(client)
-        # Display label is null, so defaults to repr()
-        assert labels[color.id] == f"TestingColor(ID: {color.id})"
+        assert labels[color_before] == f"TestingColor(ID: {color_before})"
 
-    async def test_step03_load_schema_with_display_label(
-        self, client: InfrahubClient, schema_with_display_label: dict
-    ) -> None:
-        response = await client.schema.load(schemas=[schema_with_display_label], wait_until_converged=True)
-        assert response.schema_updated
-
-    async def test_step04_create_second_node(self, client: InfrahubClient) -> None:
-        color = await client.create(kind="TestingColor", name="Blue", description="A cool color")
-        await color.save()
-
+    async def test_node_created_after_display_label_has_value(self, client: InfrahubClient, color_after: str) -> None:
+        """A node created after display_label is added should have the correct value."""
         labels = await self._get_display_labels(client)
-        assert labels[color.id] == "Blue"
+        assert labels[color_after] == "Blue"
 
-    async def test_step05_display_labels_backfilled(self, client: InfrahubClient) -> None:
+    async def test_backfill_updates_preexisting_node(self, client: InfrahubClient, color_after: str) -> None:
+        """After the async backfill completes, all nodes should have correct display_labels."""
         await wait_for_all_tasks_to_be_completed(client=client)
         labels = await self._get_display_labels(client)
         assert set(labels.values()) == {"Red", "Blue"}

--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from asyncio import sleep
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.task.models import TaskFilter, TaskState
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+from tests.helpers.schema import COLOR
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+QUERY_DISPLAY_LABELS = """
+query {
+    TestingColor {
+        edges {
+            node {
+                id
+                display_label
+            }
+        }
+    }
+}
+"""
+
+
+async def wait_for_all_tasks_to_be_completed(client: InfrahubClient) -> None:
+    while (  # noqa: ASYNC110
+        await client.task.count(filters=TaskFilter(state=[TaskState.PENDING, TaskState.RUNNING, TaskState.SCHEDULED]))
+        > 0
+    ):
+        await sleep(1)
+
+
+class TestDisplayLabelBackfillOnSchemaChange(TestInfrahubDockerClient):
+    """IFC-2459: existing nodes should get their display_label backfilled
+    after the schema is updated to add one."""
+
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    @pytest.fixture(scope="class")
+    def schema_without_display_label(self) -> dict:
+        schema = COLOR.duplicate()
+        schema.display_label = None
+        return {"version": "1.0", "nodes": [schema.model_dump()]}
+
+    @pytest.fixture(scope="class")
+    def schema_with_display_label(self) -> dict:
+        return {"version": "1.0", "nodes": [COLOR.model_dump()]}
+
+    async def _get_display_labels(self, client: InfrahubClient) -> dict[str, str]:
+        result = await client.execute_graphql(query=QUERY_DISPLAY_LABELS)
+        return {e["node"]["id"]: e["node"]["display_label"] for e in result["TestingColor"]["edges"]}
+
+    async def test_step01_load_schema_without_display_label(
+        self, client: InfrahubClient, schema_without_display_label: dict
+    ) -> None:
+        response = await client.schema.load(schemas=[schema_without_display_label], wait_until_converged=True)
+        assert response.schema_updated
+
+    async def test_step02_create_node_and_verify_no_display_label(self, client: InfrahubClient) -> None:
+        color = await client.create(kind="TestingColor", name="Red", description="A warm color")
+        await color.save()
+
+        await wait_for_all_tasks_to_be_completed(client=client)
+        labels = await self._get_display_labels(client)
+        # Display label is null, so defaults to repr()
+        assert labels[color.id] == f"TestingColor(ID: {color.id})"
+
+    async def test_step03_load_schema_with_display_label(
+        self, client: InfrahubClient, schema_with_display_label: dict
+    ) -> None:
+        response = await client.schema.load(schemas=[schema_with_display_label], wait_until_converged=True)
+        assert response.schema_updated
+
+    async def test_step04_create_second_node(self, client: InfrahubClient) -> None:
+        color = await client.create(kind="TestingColor", name="Blue", description="A cool color")
+        await color.save()
+
+        labels = await self._get_display_labels(client)
+        assert labels[color.id] == "Blue"
+
+    async def test_step05_display_labels_backfilled(self, client: InfrahubClient) -> None:
+        await wait_for_all_tasks_to_be_completed(client=client)
+        labels = await self._get_display_labels(client)
+        assert set(labels.values()) == {"Red", "Blue"}

--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -36,8 +36,7 @@ async def wait_for_all_tasks_to_be_completed(client: InfrahubClient) -> None:
 
 
 class TestDisplayLabelBackfillOnSchemaChange(TestInfrahubDockerClient):
-    """IFC-2459: existing nodes should get their display_label backfilled
-    after the schema is updated to add one."""
+    """Existing nodes should get their display_label backfilled after the schema is updated to add one."""
 
     @pytest.fixture(scope="class")
     def infrahub_version(self) -> str:

--- a/dev/knowledge/backend/display-labels-and-hfid.md
+++ b/dev/knowledge/backend/display-labels-and-hfid.md
@@ -92,6 +92,29 @@ if self._existing:
 2. `Node.save()` -> `resolve_relationships()` (extra_filters gated by `self._human_friendly_id` / `self._display_label` for those sources, plus always-on computed attribute extra filters via `computed_attributes.get_registered_jinja2_node`)
 3. `_update()` checks `needs_update(fields)` for each property; recomputes and persists if needed
 
+### Query-Time Resolution (`get_display_label`)
+
+`Node.get_display_label(db)` returns the display label for a node during GraphQL queries. It distinguishes between saved and virtual nodes:
+
+1. **Stored value exists** (`_display_label` set with a non-empty value): return it directly.
+2. **Stored attribute is empty** (`_display_label` set but value is null): return `""`. The async backfill workflow is responsible for populating stored values after schema changes. Computing on the fly here would cause the backfill to detect no difference and skip the update (IFC-2459).
+3. **No `display_label` template** in schema: return `repr(self)`.
+4. **No stored attribute at all** (virtual nodes like IPAM available nodes that are never saved): compute on the fly using `DisplayLabel.compute()`.
+
+### Async Backfill After Schema Changes
+
+When a schema is updated to add or change a `display_label`, the async Prefect workflow chain updates existing nodes:
+
+```
+SchemaUpdatedEvent
+  -> display_labels_setup_jinja2 (gathers triggers, detects new/changed templates)
+  -> trigger_update_display_labels (iterates all nodes of the kind)
+  -> process_display_label (queries node via GraphQL, renders template)
+  -> display_label_jinja2_update_value (compares rendered vs stored, writes if different)
+```
+
+The trigger definitions and gathering logic live in `backend/infrahub/display_labels/`.
+
 ### Manual Override
 
 `set_display_label(value)` and `set_human_friendly_id(value)` set `manually_assigned=True`, which causes `compute()` to no-op on future calls.

--- a/dev/knowledge/backend/display-labels-and-hfid.md
+++ b/dev/knowledge/backend/display-labels-and-hfid.md
@@ -97,7 +97,7 @@ if self._existing:
 `Node.get_display_label(db)` returns the display label for a node during GraphQL queries. It distinguishes between saved and virtual nodes:
 
 1. **Stored value exists** (`_display_label` set with a non-empty value): return it directly.
-2. **Stored attribute is empty** (`_display_label` set but value is null): return `""`. The async backfill workflow is responsible for populating stored values after schema changes. Computing on the fly here would cause the backfill to detect no difference and skip the update (IFC-2459).
+2. **Stored attribute is empty** (`_display_label` set but value is null): return `""`. The async backfill workflow is responsible for populating stored values after schema changes. Computing on the fly here would cause the backfill to detect no difference and skip the update.
 3. **No `display_label` template** in schema: return `repr(self)`.
 4. **No stored attribute at all** (virtual nodes like IPAM available nodes that are never saved): compute on the fly using `DisplayLabel.compute()`.
 


### PR DESCRIPTION
## Why & What

When a schema was updated to add a display_label, the async Prefect backfill ran but skipped the update. The on-the-fly fallback in `get_display_label` computed the correct value during the backfill's own GraphQL query, making it appear no update was needed. The DB value stayed null, and regular queries returned empty strings.

Fix `get_display_label` to return `""` when the stored value is empty for saved nodes, so the backfill detects the difference and writes the correct value. On-the-fly computation is preserved only for virtual nodes (IPAM) that are never persisted.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes display_label backfill by stopping on-the-fly computation for persisted nodes so DB updates occur. Adds a Docker integration test and updates internal docs to clarify query-time behavior and backfill flow.

- **Bug Fixes**
  - Update `get_display_label`: if `_display_label` exists and has a value, return it; if it exists but is empty and the schema defines a display label, return "" instead of computing; compute only for virtual nodes.

- **Refactors**
  - Add Docker integration test for schema-update backfill using pytest fixtures; remove a duplicated import; expand internal knowledge docs on display labels and backfill.

<sup>Written for commit 017767fc092df5ebd3fc0fc5ee88a0330851a54e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

