### PR TITLE
Add "display" property in schema viewer

### DIFF
--- a/frontend/app/src/entities/schema/ui/attribute-display.tsx
+++ b/frontend/app/src/entities/schema/ui/attribute-display.tsx
@@ -61,6 +61,7 @@ export const AttributeDisplay = ({
 
       <div>
         <PropertyRow title="Branch" value={attribute.branch} />
+        <PropertyRow title="Display" value={attribute.display} />
         <PropertyRow title="Order weight" value={attribute.order_weight} />
       </div>
 

--- a/frontend/app/src/entities/schema/ui/relationship-display.tsx
+++ b/frontend/app/src/entities/schema/ui/relationship-display.tsx
@@ -72,6 +72,7 @@ export const RelationshipDisplay = ({
         <PropertyRow title="Branch" value={relationship.branch} />
         <PropertyRow title="Max count" value={relationship.max_count} />
         <PropertyRow title="Min count" value={relationship.min_count} />
+        <PropertyRow title="Display" value={relationship.display} />
         <PropertyRow title="Order weight" value={relationship.order_weight} />
       </div>
     </AccordionStyled>

--- a/frontend/app/src/entities/schema/ui/schema-viewer.test.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
 
 import { render } from "../../../../tests/components/render";
-import { generateAttributeSchema, generateNodeSchema } from "../../../../tests/fake/schema";
+import {
+  generateAttributeSchema,
+  generateNodeSchema,
+  generateRelationshipSchema,
+} from "../../../../tests/fake/schema";
 import { SchemaViewer } from "./schema-viewer";
 
 describe("SchemaViewer Component", () => {
@@ -60,6 +64,31 @@ describe("SchemaViewer Component", () => {
     await expect.element(component.getByText("test-regex")).toBeVisible();
     await expect.element(component.getByText("Min length1")).toBeVisible();
     await expect.element(component.getByText("Max length10")).toBeVisible();
+  });
+
+  test("displays attribute display value", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Node",
+      namespace: "Test",
+      attributes: [
+        generateAttributeSchema({
+          name: "attribute",
+          label: "Attribute",
+          display: "extra",
+        }),
+      ],
+    });
+
+    const component = await render(<SchemaViewer schema={schema} onClose={() => {}} />);
+
+    // WHEN
+    await component.getByText("Attributes").click();
+    await component.getByText("Attribute Text").click();
+
+    // THEN
+    await expect.element(component.getByText("Display", { exact: true })).toBeVisible();
+    await expect.element(component.getByText("extra", { exact: true }).first()).toBeVisible();
   });
 
   test("displays number pool attribute details", async () => {
@@ -196,5 +225,31 @@ describe("SchemaViewer Component", () => {
     // THEN
     await expect.element(component.getByText("CoreTransformPython")).toBeVisible();
     await expect.element(component.getByText("test-transform").first()).toBeVisible();
+  });
+
+  test("displays relationship display value", async () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      name: "Node",
+      namespace: "Test",
+      relationships: [
+        generateRelationshipSchema({
+          id: "relationship-id",
+          name: "relationship",
+          label: "Extra Relationship",
+          display: "extra",
+        }),
+      ],
+    });
+
+    const component = await render(<SchemaViewer schema={schema} onClose={() => {}} />);
+
+    // WHEN
+    await component.getByText("Relationships").click();
+    await component.getByText("Extra Relationship").click();
+
+    // THEN
+    await expect.element(component.getByText("Display", { exact: true })).toBeVisible();
+    await expect.element(component.getByText("extra", { exact: true }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
# Why

The schema viewer was not showing the new `display` property for attributes and relationships, even though the field is already present in the schema data. That made it harder to inspect whether a field is marked as `default` or `extra` from the UI.

This PR exposes that metadata in the schema viewer field details.

## What changed
- Added the `display` property to the expanded details view for schema attributes.
- Added the `display` property to the expanded details view for schema relationships.
- Grouped `display` with presentation/order metadata rather than identity fields.
- Added regression tests covering one attribute and one relationship with `display: "extra"`.

### Suggested review order
1. `frontend/app/src/entities/schema/ui/attribute-display.tsx`
2. `frontend/app/src/entities/schema/ui/relationship-display.tsx`
3. `frontend/app/src/entities/schema/ui/schema-viewer.test.tsx`

## How to review
Focus on the schema viewer field detail layout and whether `display` is grouped in the right section for both attributes and relationships.
Extra scrutiny:
- Whether `display` belongs in the lower metadata block next to branch/order metadata
- Whether the new tests are specific enough without being brittle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the display property in the schema viewer for attributes and relationships so you can see if a field is default or extra. It appears in the lower metadata block next to Branch and Order, with tests covering the "extra" value for one attribute and one relationship.

<sup>Written for commit d07c21136c37b305737b7372bf4126647aafed2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

