### PR TITLE
IFC-2463: Attach delete branch workflow to proposed change

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -299,6 +299,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                 log=log,
                 obj=obj,
                 context=context,
+                proposed_change_id=proposed_change_id,
             )
 
         events: list[InfrahubEvent] = [merge_event]
@@ -321,7 +322,11 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
 
 
 async def _do_merge_branch(
-    db: InfrahubDatabase, log: Logger | LoggerAdapter, obj: Branch, context: InfrahubContext
+    db: InfrahubDatabase,
+    log: Logger | LoggerAdapter,
+    obj: Branch,
+    context: InfrahubContext,
+    proposed_change_id: str | None = None,
 ) -> Sequence[tuple[DiffAction, NodeChangelog]]:
     component_registry = get_component_registry()
 
@@ -419,7 +424,7 @@ async def _do_merge_branch(
         await get_workflow().submit_workflow(
             workflow=BRANCH_DELETE,
             context=context,
-            parameters={"branch": obj.name},
+            parameters={"branch": obj.name, "proposed_change_id": proposed_change_id},
         )
 
     # -------------------------------------------------------------
@@ -437,9 +442,10 @@ async def _do_merge_branch(
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")
-async def delete_branch(branch: str, context: InfrahubContext, delete_from_git: bool = False) -> None:
-    await add_tags(branches=[branch])
-
+async def delete_branch(
+    branch: str, context: InfrahubContext, delete_from_git: bool = False, proposed_change_id: str | None = None
+) -> None:
+    await add_tags(branches=[branch], nodes=[proposed_change_id] if proposed_change_id else None)
     database = await get_database()
     async with database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=str(branch))

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -93,7 +93,6 @@ from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.validators.tasks import start_validator
 from infrahub.workers.dependencies import get_cache, get_client, get_database, get_event_service, get_workflow
 from infrahub.workflows.catalogue import (
-    BRANCH_DELETE,
     GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE,
     GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
     GIT_REPOSITORY_USER_CHECKS_TRIGGER,
@@ -245,13 +244,6 @@ async def merge_proposed_change(
             database=db,
             user_id=context.account.account_id,
         )
-
-        if config.SETTINGS.main.delete_branch_after_merge and not source_branch.is_default:
-            await get_workflow().submit_workflow(
-                workflow=BRANCH_DELETE,
-                context=context,
-                parameters={"branch": source_branch.name},
-            )
 
         current_user = await NodeManager.get_one_by_id_or_default_filter(
             id=context.account.account_id, kind=InfrahubKind.GENERICACCOUNT, db=db

--- a/backend/tests/component/core/diff/test_merge_task_lock.py
+++ b/backend/tests/component/core/diff/test_merge_task_lock.py
@@ -44,7 +44,13 @@ class TestMergeTaskLock:
         )
 
     @staticmethod
-    async def _mock_do_merge(db: InfrahubDatabase, log: Any, obj: Branch, context: Any) -> list:  # noqa: ARG004
+    async def _mock_do_merge(
+        db: InfrahubDatabase,
+        log: Any,  # noqa: ARG004
+        obj: Branch,
+        context: Any,  # noqa: ARG004
+        proposed_change_id: str | None = None,  # noqa: ARG004
+    ) -> list:
         obj.status = BranchStatus.MERGED
         await obj.save(db=db)
         registry.branch[obj.name] = obj
@@ -98,7 +104,9 @@ class TestMergeTaskLock:
         concurrent_count = 0
         max_concurrent = 0
 
-        async def tracking_mock_do_merge(db: InfrahubDatabase, log: Any, obj: Branch, context: Any):
+        async def tracking_mock_do_merge(
+            db: InfrahubDatabase, log: Any, obj: Branch, context: Any, proposed_change_id: str | None = None
+        ):
             nonlocal concurrent_count, max_concurrent
             concurrent_count += 1
             max_concurrent = max(max_concurrent, concurrent_count)

--- a/backend/tests/functional/branch/test_branch_delete_after_merge.py
+++ b/backend/tests/functional/branch/test_branch_delete_after_merge.py
@@ -57,7 +57,7 @@ class TestAutoDeleteBranchAfterMerge(TestInfrahubApp):
             mock_submit.assert_any_call(
                 workflow=BRANCH_DELETE,
                 context=ANY,
-                parameters={"branch": branch.name},
+                parameters={"branch": branch.name, "proposed_change_id": None},
             )
 
     async def test_branch_not_deleted_after_standard_merge_when_config_disabled(
@@ -113,5 +113,5 @@ class TestAutoDeleteBranchAfterMerge(TestInfrahubApp):
             mock_submit.assert_any_call(
                 workflow=BRANCH_DELETE,
                 context=ANY,
-                parameters={"branch": branch.name},
+                parameters={"branch": branch.name, "proposed_change_id": pc.id},
             )


### PR DESCRIPTION
Attach delete branch workflow to proposed change and also remove duplicate delete branch workflow trigger that leads to branch not found error as merge_branch workflow is also called in the course of merging a proposed change and that already calls delete branch workflow