### PR TITLE
Add integration tests for git operations

### DIFF
--- a/backend/tests/helpers/git.py
+++ b/backend/tests/helpers/git.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from testcontainers.core.container import DockerContainer
+
+
+@dataclass
+class GogsServer:
+    base_url: str
+    port: str
+    token: str
+    admin: str
+    password: str
+    container: DockerContainer

--- a/backend/tests/integration/git/conftest.py
+++ b/backend/tests/integration/git/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from testcontainers.core.container import DockerContainer
 
 from infrahub import config
+from tests.helpers.git import GogsServer
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -63,17 +64,35 @@ def gogs_clone_url(base_url: str, repo_name: str) -> str:
     return f"{auth_base}/{GOGS_ADMIN}/{repo_name}.git"
 
 
-def create_gogs_repo(base_url: str, token: str, repo_name: str, container: DockerContainer) -> str:
+def bad_credentials_clone_url(base_url: str, repo_name: str) -> str:
+    """Return an HTTP clone URL with a non-existent user and wrong password.
+
+    Using a username that does not exist in the system credential store prevents
+    any cached credentials from being substituted, so git always presents the
+    embedded (bad) credentials to the server.
+    """
+    parsed = urlparse(base_url)
+    netloc_with_auth = f"baduser:wrongpassword@{parsed.netloc}"
+    auth_base = urlunparse(parsed._replace(netloc=netloc_with_auth))
+    return f"{auth_base}/{GOGS_ADMIN}/{repo_name}.git"
+
+
+def create_gogs_repo(
+    base_url: str, token: str, repo_name: str, container: DockerContainer, private: bool = False
+) -> str:
     """Create a Gogs repository and return its clone URL.
 
     Gogs 0.13.0 initialises repos with 'master' as the default branch; Infrahub
     expects 'main'.  The branch-create API endpoint was added after 0.13.0, so we
     create the 'main' branch directly in the container's bare repository via git exec.
+
+    Pass private=True to create a private repository (required when testing auth failures,
+    since public repos allow anonymous clone access and never present credentials to the server).
     """
     resp = httpx.post(
         f"{base_url}/api/v1/user/repos",
         headers={"Authorization": f"token {token}"},
-        json={"name": repo_name, "auto_init": True, "readme": "Default"},
+        json={"name": repo_name, "auto_init": True, "readme": "Default", "private": private},
         timeout=5.0,
     )
     assert resp.status_code in (200, 201), f"Repo creation failed ({resp.status_code}): {resp.text}"
@@ -107,12 +126,9 @@ def create_gogs_repo(base_url: str, token: str, repo_name: str, container: Docke
     return gogs_clone_url(base_url, repo_name)
 
 
-@pytest.fixture(scope="module")
-def gogs_server() -> Generator[dict, None, None]:
-    """Start a Gogs container, initialize it, and yield connection info.
-
-    Yields a dict with keys: base_url, port, token, admin, password.
-    """
+@pytest.fixture(scope="session")
+def gogs_server() -> Generator[GogsServer, None, None]:
+    """Start a Gogs container, initialize it, and yield connection info."""
     os.environ.setdefault("GIT_TERMINAL_PROMPT", "0")
 
     container = DockerContainer(GOGS_IMAGE).with_exposed_ports(3000)
@@ -174,14 +190,14 @@ def gogs_server() -> Generator[dict, None, None]:
 
         token = _create_api_token(base_url)
 
-        yield {
-            "base_url": base_url,
-            "port": port,
-            "token": token,
-            "admin": GOGS_ADMIN,
-            "password": GOGS_PASSWORD,
-            "container": container,
-        }
+        yield GogsServer(
+            base_url=base_url,
+            port=port,
+            token=token,
+            admin=GOGS_ADMIN,
+            password=GOGS_PASSWORD,
+            container=container,
+        )
     finally:
         container.stop()
 

--- a/backend/tests/integration/git/test_delete_git_branch_gogs.py
+++ b/backend/tests/integration/git/test_delete_git_branch_gogs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
     from infrahub.database import InfrahubDatabase
+    from tests.helpers.git import GogsServer
 
 
 def _branch_exists_on_gogs(base_url: str, token: str, repo_name: str, branch_name: str) -> bool:
@@ -46,16 +47,12 @@ class TestDeleteGitBranchGogs(TestInfrahubApp):
         git_repos_source_dir_module_scope: Path,
         git_repos_dir_module_scope: Path,
         client: InfrahubClient,
-        gogs_server: dict,
+        gogs_server: GogsServer,
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        repo1_url = create_gogs_repo(
-            gogs_server["base_url"], gogs_server["token"], "gogs-repo-1", gogs_server["container"]
-        )
-        repo2_url = create_gogs_repo(
-            gogs_server["base_url"], gogs_server["token"], "gogs-repo-2", gogs_server["container"]
-        )
+        repo1_url = create_gogs_repo(gogs_server.base_url, gogs_server.token, "gogs-repo-1", gogs_server.container)
+        repo2_url = create_gogs_repo(gogs_server.base_url, gogs_server.token, "gogs-repo-2", gogs_server.container)
 
         for repo_url, repo_name in [(repo1_url, "gogs-repo-1"), (repo2_url, "gogs-repo-2")]:
             node = await client.create(
@@ -68,12 +65,12 @@ class TestDeleteGitBranchGogs(TestInfrahubApp):
         self,
         initial_dataset: None,
         client: InfrahubClient,
-        gogs_server: dict,
+        gogs_server: GogsServer,
         delete_branch_after_merge_reset_config: None,
         delete_git_branch_after_merge_reset_config: None,
     ) -> None:
-        base_url = gogs_server["base_url"]
-        token = gogs_server["token"]
+        base_url = gogs_server.base_url
+        token = gogs_server.token
         branch_name = "feature-alpha"
 
         config.SETTINGS.main.delete_branch_after_merge = True
@@ -106,12 +103,12 @@ class TestDeleteGitBranchGogs(TestInfrahubApp):
         self,
         initial_dataset: None,
         client: InfrahubClient,
-        gogs_server: dict,
+        gogs_server: GogsServer,
         delete_branch_after_merge_reset_config: None,
         delete_git_branch_after_merge_reset_config: None,
     ) -> None:
-        base_url = gogs_server["base_url"]
-        token = gogs_server["token"]
+        base_url = gogs_server.base_url
+        token = gogs_server.token
         branch_name = "feature-beta"
 
         config.SETTINGS.main.delete_branch_after_merge = True

--- a/backend/tests/integration/git/test_git_live_remote.py
+++ b/backend/tests/integration/git/test_git_live_remote.py
@@ -1,0 +1,326 @@
+"""Integration tests for InfrahubRepository and InfrahubReadOnlyRepository against a live remote."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core.constants import InfrahubKind, RepositoryOperationalStatus
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.exceptions import RepositoryCredentialsError, RepositoryError
+from infrahub.git.repository import InfrahubReadOnlyRepository, InfrahubRepository
+from tests.helpers.test_app import TestInfrahubApp
+from tests.integration.git.conftest import bad_credentials_clone_url, create_gogs_repo
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+    from testcontainers.core.container import DockerContainer
+
+    from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
+    from infrahub.database import InfrahubDatabase
+    from tests.helpers.git import GogsServer
+
+
+def _push_commit_to_remote(container: DockerContainer, repo_name: str, filename: str, branch: str = "main") -> None:
+    """Make a new commit directly in the remote server container and push it.
+
+    Reuses the working clone that create_gogs_repo() left in /tmp/{repo_name}.
+    """
+    script = (
+        f"set -e && "
+        f"cd /tmp/{repo_name} && "
+        f"git checkout {branch} && "
+        f"git pull origin {branch} && "
+        f"echo 'remote change' > {filename} && "
+        f"git add {filename} && "
+        f"git commit -m 'Remote-only commit [{filename}]' && "
+        f"git push origin {branch}"
+    )
+    result = container.get_wrapped_container().exec_run(["bash", "-c", script], user="git")
+    assert result.exit_code == 0, f"Remote commit failed (exit {result.exit_code}): {result.output.decode()}"
+
+
+class TestRepositoryRemoteOperations(TestInfrahubApp):
+    """Live-remote tests for InfrahubRepository and InfrahubReadOnlyRepository.
+
+    Each fixture sets up an isolated Gogs repository and Infrahub node for its
+    scenario.  Tests are isolated by repo name and node ID; they share the same
+    Infrahub stack instance to avoid paying per-class setup costs.
+    """
+
+    @pytest.fixture(scope="class")
+    async def auth_failure_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        gogs_server: GogsServer,
+    ) -> dict:
+        repo_name = "auth-failure-repo"
+        # Create the repo as *private* so the server requires authentication even
+        # for clone operations.  Public repos allow anonymous read access, which means
+        # the embedded bad credentials are never presented to the server and the clone
+        # succeeds — defeating the purpose of this test.
+        create_gogs_repo(
+            gogs_server.base_url,
+            gogs_server.token,
+            repo_name,
+            gogs_server.container,
+            private=True,
+        )
+        bad_url = bad_credentials_clone_url(gogs_server.base_url, repo_name)
+
+        # Pre-create the Infrahub node directly in the DB — not via the HTTP API — so
+        # that no automatic sync is triggered and _update_operational_status() has a
+        # node to write to when the clone fails.
+        obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)
+        await obj.new(db=db, name=repo_name, location=bad_url)
+        await obj.save(db=db)
+        return {"repo_name": repo_name, "node_id": obj.id, "bad_url": bad_url}
+
+    @pytest.fixture(scope="class")
+    async def push_rejection_dataset(
+        self,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        client: InfrahubClient,
+        gogs_server: GogsServer,
+    ) -> dict:
+        repo_name = "push-rejection-repo"
+        repo_url = create_gogs_repo(gogs_server.base_url, gogs_server.token, repo_name, gogs_server.container)
+        node = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={"name": repo_name, "location": repo_url},
+        )
+        await node.save()
+        return {"repo_name": repo_name, "node_id": node.id}
+
+    @pytest.fixture(scope="class")
+    async def merge_conflict_dataset(
+        self,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        client: InfrahubClient,
+        gogs_server: GogsServer,
+    ) -> dict:
+        repo_name = "merge-conflict-repo"
+        repo_url = create_gogs_repo(gogs_server.base_url, gogs_server.token, repo_name, gogs_server.container)
+        node = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={"name": repo_name, "location": repo_url},
+        )
+        await node.save()
+        return {"repo_name": repo_name, "node_id": node.id}
+
+    @pytest.fixture(scope="class")
+    async def readonly_sync_dataset(
+        self,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        client: InfrahubClient,
+        gogs_server: GogsServer,
+    ) -> dict:
+        repo_name = "readonly-sync-repo"
+        repo_url = create_gogs_repo(gogs_server.base_url, gogs_server.token, repo_name, gogs_server.container)
+        branch = await client.branch.create(branch_name="ro_sync_test", sync_with_git=False)
+        node = await client.create(
+            kind=InfrahubKind.READONLYREPOSITORY,
+            branch=branch.name,
+            name=repo_name,
+            location=repo_url,
+            ref="main",
+        )
+        await node.save()
+        return {"repo_name": repo_name, "node_id": node.id, "branch_name": branch.name}
+
+    async def test_clone_with_wrong_credentials_raises_credentials_error(
+        self,
+        auth_failure_dataset: dict,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+    ) -> None:
+        """Cloning with invalid credentials raises RepositoryCredentialsError and persists ERROR_CRED status.
+
+        Uses a fresh clone against a real server so the bad credentials are always
+        presented directly, bypassing any cached credential state.
+        """
+        with pytest.raises(RepositoryCredentialsError):
+            await InfrahubRepository.new(
+                id=auth_failure_dataset["node_id"],
+                name=auth_failure_dataset["repo_name"],
+                location=auth_failure_dataset["bad_url"],
+                client=client,
+            )
+
+        updated: CoreRepository = await NodeManager.get_one(
+            db=db,
+            id=auth_failure_dataset["node_id"],
+            kind=InfrahubKind.REPOSITORY,
+            raise_on_error=True,
+        )
+        assert updated.operational_status.value == RepositoryOperationalStatus.ERROR_CRED.value
+
+    async def test_push_rejected_non_fast_forward(
+        self,
+        push_rejection_dataset: dict,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        gogs_server: GogsServer,
+    ) -> None:
+        """push() returns True despite a non-fast-forward rejection — the failure is silent.
+
+        InfrahubRepository.push() has no exception handling.  GitPython's Remote.push()
+        does not raise on rejection — it logs a warning and returns a PushInfoList with
+        error flags.  The result is that push() returns True while the local commit was
+        never actually delivered to the remote.
+
+        This test is expected to fail once proper push-rejection handling is added.
+        """
+        repo_name = push_rejection_dataset["repo_name"]
+
+        repository: CoreRepository = await NodeManager.get_one(
+            db=db,
+            id=push_rejection_dataset["node_id"],
+            kind=InfrahubKind.REPOSITORY,
+            raise_on_error=True,
+        )
+        infrahub_repo = await InfrahubRepository.init(
+            id=repository.id,
+            name=repo_name,
+            client=client,
+        )
+
+        _push_commit_to_remote(gogs_server.container, repo_name, "remote_advance.txt")
+
+        # Without fetching first, our local history diverges from the remote.
+        git_repo = infrahub_repo.get_git_repo_main()
+        local_file = Path(str(git_repo.working_dir)) / "local_diverge.txt"
+        local_file.write_text("local only")
+        git_repo.index.add(["local_diverge.txt"])
+        local_commit = str(git_repo.index.commit("Local-only commit"))
+
+        # GitPython's Remote.push() does not raise on rejection; push() returns True.
+        result = await infrahub_repo.push("main")
+        assert result is True
+
+        git_repo.remotes.origin.fetch()
+        remote_main_commit = str(git_repo.commit("origin/main"))
+        assert remote_main_commit != local_commit
+
+    async def test_merge_conflict_raises_repository_error(
+        self,
+        merge_conflict_dataset: dict,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+    ) -> None:
+        """A real Git conflict between two local branches raises RepositoryError.
+
+        Verifies that merge() runs merge --abort on failure, leaving the repo in a
+        clean state rather than stuck mid-merge.
+        """
+        repo_name = merge_conflict_dataset["repo_name"]
+
+        repository: CoreRepository = await NodeManager.get_one(
+            db=db,
+            id=merge_conflict_dataset["node_id"],
+            kind=InfrahubKind.REPOSITORY,
+            raise_on_error=True,
+        )
+        infrahub_repo = await InfrahubRepository.init(
+            id=repository.id,
+            name=repo_name,
+            client=client,
+        )
+
+        # push_origin=False keeps the remote clean; the conflict is purely local.
+        await infrahub_repo.create_branch_in_git("conflict-branch-a", push_origin=False)
+        await infrahub_repo.create_branch_in_git("conflict-branch-b", push_origin=False)
+
+        branch_a_repo = infrahub_repo.get_git_repo_worktree(identifier="conflict-branch-a")
+        (Path(str(branch_a_repo.working_dir)) / "conflict.txt").write_text("branch-a content\n")
+        branch_a_repo.index.add(["conflict.txt"])
+        branch_a_repo.index.commit("conflict-branch-a: add conflict.txt")
+
+        branch_b_repo = infrahub_repo.get_git_repo_worktree(identifier="conflict-branch-b")
+        (Path(str(branch_b_repo.working_dir)) / "conflict.txt").write_text("branch-b content\n")
+        branch_b_repo.index.add(["conflict.txt"])
+        branch_b_repo.index.commit("conflict-branch-b: add conflict.txt")
+
+        with pytest.raises(RepositoryError):
+            await infrahub_repo.merge(
+                source_branch="conflict-branch-a",
+                dest_branch="conflict-branch-b",
+                push_remote=False,
+            )
+
+    async def test_sync_from_remote_detects_new_commit(
+        self,
+        readonly_sync_dataset: dict,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        gogs_server: GogsServer,
+    ) -> None:
+        """sync_from_remote() returns True and performs the sync when the remote has advanced."""
+        repo_name = readonly_sync_dataset["repo_name"]
+        branch_name = readonly_sync_dataset["branch_name"]
+
+        repository: CoreReadOnlyRepository = await NodeManager.get_one(
+            db=db,
+            id=readonly_sync_dataset["node_id"],
+            kind=InfrahubKind.READONLYREPOSITORY,
+            branch=branch_name,
+            raise_on_error=True,
+        )
+        infrahub_repo = await InfrahubReadOnlyRepository.init(
+            id=repository.id,
+            name=repo_name,
+            ref=repository.ref.value,
+            infrahub_branch_name=branch_name,
+            client=client,
+        )
+
+        commit_before = str(infrahub_repo.get_git_repo_main().head.commit)
+
+        _push_commit_to_remote(gogs_server.container, repo_name, "new_remote_file.txt")
+
+        git_repo = infrahub_repo.get_git_repo_main()
+        git_repo.remotes.origin.fetch()
+        commit_after_remote = str(git_repo.commit("origin/main"))
+        assert commit_after_remote != commit_before
+
+        synced = await infrahub_repo.sync_from_remote(commit=commit_after_remote)
+
+        assert synced is True
+
+    async def test_sync_from_remote_returns_false_when_up_to_date(
+        self,
+        readonly_sync_dataset: dict,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+    ) -> None:
+        """sync_from_remote() returns False when local already matches the given commit."""
+        repo_name = readonly_sync_dataset["repo_name"]
+        branch_name = readonly_sync_dataset["branch_name"]
+
+        repository: CoreReadOnlyRepository = await NodeManager.get_one(
+            db=db,
+            id=readonly_sync_dataset["node_id"],
+            kind=InfrahubKind.READONLYREPOSITORY,
+            branch=branch_name,
+            raise_on_error=True,
+        )
+        infrahub_repo = await InfrahubReadOnlyRepository.init(
+            id=repository.id,
+            name=repo_name,
+            ref=repository.ref.value,
+            infrahub_branch_name=branch_name,
+            client=client,
+        )
+
+        current_commit = str(infrahub_repo.get_git_repo_main().head.commit)
+        synced = await infrahub_repo.sync_from_remote(commit=current_commit)
+
+        assert synced is False


### PR DESCRIPTION
# Why

Add integration tests for git operations which are good to have in place for upcoming refactor work

## What changed

* Adds tests and slight refactoring of the gogs fixture
* Note that one of the added tests are expected to later fail once we've reworked how the code works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live-remote Git integration tests against a Gogs server and refactors the test fixture to a typed, session-scoped `GogsServer` for more reliable and faster test runs.

- **New Features**
  - Added `backend/tests/integration/git/test_git_live_remote.py` to cover:
    - Clone with wrong credentials → raises `RepositoryCredentialsError` and sets `ERROR_CRED`.
    - Push rejection (non-fast-forward) currently returns True; documents current behavior and is expected to fail after push-rejection handling is added.
    - Local merge conflict → raises `RepositoryError` and leaves a clean repo state.
    - Read-only repo sync detects remote changes and no-op when up to date.

- **Refactors**
  - Introduced `backend/tests/helpers/git.py` with a `GogsServer` dataclass.
  - Converted Gogs fixture to session scope and returned `GogsServer` instead of a dict.
  - Added `bad_credentials_clone_url()` and `create_gogs_repo(..., private=True)` for auth tests.
  - Updated existing Gogs branch deletion tests to use the new typed fixture.

<sup>Written for commit 8fcd8d3386aca9d81ddd985c33c45ae9871ab49d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

