### PR TITLE
hide the internal used CoreFileObject attributes

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/file_object.py
+++ b/backend/infrahub/core/schema/definitions/core/file_object.py
@@ -1,4 +1,4 @@
-from infrahub.core.constants import AllowOverrideType
+from infrahub.core.constants import AllowOverrideType, SchemaAttributeDisplay
 
 from ...attribute_schema import AttributeSchema as Attr
 from ...generic_schema import GenericSchema
@@ -18,6 +18,7 @@ core_file_object = GenericSchema(
             optional=False,
             order_weight=99990,
             allow_override=AllowOverrideType.NONE,
+            display=SchemaAttributeDisplay.EXTRA,
         ),
         Attr(
             name="checksum",
@@ -27,6 +28,7 @@ core_file_object = GenericSchema(
             optional=False,
             order_weight=99991,
             allow_override=AllowOverrideType.NONE,
+            display=SchemaAttributeDisplay.EXTRA,
         ),
         Attr(
             name="file_size",
@@ -36,6 +38,7 @@ core_file_object = GenericSchema(
             optional=False,
             order_weight=99992,
             allow_override=AllowOverrideType.NONE,
+            display=SchemaAttributeDisplay.EXTRA,
         ),
         Attr(
             name="file_type",
@@ -45,6 +48,7 @@ core_file_object = GenericSchema(
             optional=False,
             order_weight=99993,
             allow_override=AllowOverrideType.NONE,
+            display=SchemaAttributeDisplay.EXTRA,
         ),
         Attr(
             name="storage_id",
@@ -54,6 +58,7 @@ core_file_object = GenericSchema(
             optional=False,
             order_weight=99994,
             allow_override=AllowOverrideType.NONE,
+            display=SchemaAttributeDisplay.EXTRA,
         ),
     ],
 )

--- a/changelog/+02b13e00.changed.md
+++ b/changelog/+02b13e00.changed.md
@@ -1,0 +1,1 @@
+hides the `internal` attributes of CoreFileObject in the UI


### PR DESCRIPTION
# Why

Now that we have the ability to display attributes as `extra` fields in 1.9, I have reworked the attributes on the CoreFileObject generic to hide the attributes that are only relevant for internal Infrahub usage.

## What changed

The following attributes on the CoreFileObject generic have been changed to include the `display: "extra"` property.

## Validation
- Create a schemanode that inherits from the CoreFileObject generic
- Load schema into Inrahub
- Create a new object using the newly defined schemanode
- Note that only the userdefined attributes are shown by default in the UI. The internal attributes can be displayed using the `extra` toggle on the details section header

<img width="1092" height="1027" alt="image" src="https://github.com/user-attachments/assets/e07cfdf1-6b66-4658-a863-5adad498ace7" />
<img width="1101" height="1031" alt="image" src="https://github.com/user-attachments/assets/53ce9850-3171-4370-9d5b-390fd1a6121e" />


## Checklist

- [ ] Tests added/updated
- [X] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)