### PR TITLE
Github actions Bot -> Claude Bot as verified author of comments

### DIFF
--- a/.github/bug-agent-pipeline/test_pipeline_shell_logic.sh
+++ b/.github/bug-agent-pipeline/test_pipeline_shell_logic.sh
@@ -14,7 +14,7 @@
 #     Confirms a random-hex delimiter survives hostile content that contains
 #     the delimiter prefix, with exactly one open/close pair in the output.
 #  3. jq analyst-comment extraction
-#     Finds the last github-actions[bot] comment containing
+#     Finds the last claude[bot] comment containing
 #     AGENT_ANALYSIS_COMPLETE; returns empty when none match.
 #  4. PR marker validation (fixer workflow)
 #     Gates fixer execution: blocks without AGENT_TEST_COMPLETE, blocks if
@@ -203,11 +203,11 @@ echo "=== 3. jq analyst-comment extraction ==="
 
 COMMENTS_JSON='[
   {"user":{"login":"octocat"},"body":"random comment"},
-  {"user":{"login":"github-actions[bot]"},"body":"## Root cause analysis\n\n<!-- AGENT_ANALYSIS_COMPLETE -->"},
-  {"user":{"login":"github-actions[bot]"},"body":"Updated analysis\n\n<!-- AGENT_ANALYSIS_COMPLETE -->"}
+  {"user":{"login":"claude[bot]"},"body":"## Root cause analysis\n\n<!-- AGENT_ANALYSIS_COMPLETE -->"},
+  {"user":{"login":"claude[bot]"},"body":"Updated analysis\n\n<!-- AGENT_ANALYSIS_COMPLETE -->"}
 ]'
 
-ANALYST_COMMENT=$(echo "$COMMENTS_JSON" | jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AGENT_ANALYSIS_COMPLETE")))]' | jq -s '.[0] | last // empty')
+ANALYST_COMMENT=$(echo "$COMMENTS_JSON" | jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("AGENT_ANALYSIS_COMPLETE")))]' | jq -s '.[0] | last // empty')
 BODY=$(echo "$ANALYST_COMMENT" | jq -r '.body')
 
 assert_contains "finds last analyst comment" "$BODY" "Updated analysis"
@@ -215,7 +215,7 @@ assert_contains "has marker" "$BODY" "AGENT_ANALYSIS_COMPLETE"
 
 # Simulate no analyst comment found
 EMPTY_RESULT=$(echo '[{"user":{"login":"octocat"},"body":"no analysis here"}]' \
-  | jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AGENT_ANALYSIS_COMPLETE")))]' \
+  | jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("AGENT_ANALYSIS_COMPLETE")))]' \
   | jq -s '.[0] | last // empty')
 assert_eq "empty when no analyst comment" "" "$EMPTY_RESULT"
 
@@ -281,16 +281,16 @@ echo "=== 6. TEST_APPROVED count check ==="
 # Simulates the fixer's check for TEST_APPROVED in bot comments.
 
 COMMENTS_WITH_APPROVAL='[
-  {"user":{"login":"github-actions[bot]"},"body":"<!-- AGENT_REVIEW_VERDICT: TEST_APPROVED -->"},
+  {"user":{"login":"claude[bot]"},"body":"<!-- AGENT_REVIEW_VERDICT: TEST_APPROVED -->"},
   {"user":{"login":"octocat"},"body":"LGTM"},
-  {"user":{"login":"github-actions[bot]"},"body":"some other comment"}
+  {"user":{"login":"claude[bot]"},"body":"some other comment"}
 ]'
 
-APPROVED_COUNT=$(echo "$COMMENTS_WITH_APPROVAL" | jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
+APPROVED_COUNT=$(echo "$COMMENTS_WITH_APPROVAL" | jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
 assert_eq "finds approval" "1" "$APPROVED_COUNT"
 
 NO_APPROVAL='[{"user":{"login":"octocat"},"body":"not a bot"}]'
-ZERO_COUNT=$(echo "$NO_APPROVAL" | jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
+ZERO_COUNT=$(echo "$NO_APPROVAL" | jq '[.[] | select(.user.login == "claude[bot]" and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
 assert_eq "no approval found" "0" "$ZERO_COUNT"
 
 # ─────────────────────────────────────────────────────────────

--- a/.github/workflows/bug-agent-fix.yml
+++ b/.github/workflows/bug-agent-fix.yml
@@ -66,7 +66,7 @@ jobs:
           APPROVED_COUNT=$(gh api \
             "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --paginate \
-            --jq '[.[] | select(.user.login == "github-actions[bot]"
+            --jq '[.[] | select(.user.login == "claude[bot]"
               and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
 
           if [ "$APPROVED_COUNT" = "0" ]; then
@@ -256,7 +256,7 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, 'AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED') &&
       (
-        github.actor == 'github-actions[bot]' ||
+        github.actor == 'claude[bot]' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'

--- a/.github/workflows/bug-agent-review.yml
+++ b/.github/workflows/bug-agent-review.yml
@@ -19,7 +19,7 @@ jobs:
   review:
     if: |
       startsWith(github.event.pull_request.head.ref, 'ai-bug-pipeline-') &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      github.event.pull_request.user.login == 'claude[bot]' &&
       (
         contains(github.event.pull_request.body, 'AGENT_TEST_COMPLETE') ||
         contains(github.event.pull_request.body, 'AGENT_FIX_COMPLETE')

--- a/.github/workflows/bug-agent-test.yml
+++ b/.github/workflows/bug-agent-test.yml
@@ -48,7 +48,7 @@ jobs:
           ANALYST_COMMENT=$(gh api \
             "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
             --paginate \
-            --jq '.[] | select(.user.login == "github-actions[bot]"
+            --jq '.[] | select(.user.login == "claude[bot]"
               and (.body | contains("AGENT_ANALYSIS_COMPLETE")))' \
             | jq -s 'last // empty')
 
@@ -212,7 +212,7 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, 'AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED') &&
       (
-        github.actor == 'github-actions[bot]' ||
+        github.actor == 'claude[bot]' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'


### PR DESCRIPTION
## Why

Test-writing step is failing in the bug-fixing pipeline, due to the fact that the author of the comment if Claude bot and not Github Actions bot -> https://github.com/opsmill/infrahub/issues/8857.

## Solution

Change it.

## Side note

The analyst worked alone for the first time https://github.com/opsmill/infrahub/issues/8857#issuecomment-4246122642

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch bot author checks from `github-actions[bot]` to `claude[bot]` across bug-agent workflows and tests. This fixes the failing test-writing step by matching the actual author of pipeline comments.

- **Bug Fixes**
  - Updated `jq`/`gh` filters to select `claude[bot]` comments for `AGENT_ANALYSIS_COMPLETE` and `AGENT_REVIEW_VERDICT` markers.
  - Adjusted workflow conditions to allow events from `claude[bot]` (actor and PR author) in test, review, and fix jobs.
  - Updated test script fixtures and logic to use `claude[bot]`.

<sup>Written for commit 65d3fd8e623280f898933d4ca89d7453533f53e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

