### PR TITLE
Allow builtin Jinja2 filter to run on workers

### DIFF
--- a/backend/tests/component/git/test_artifact_composition.py
+++ b/backend/tests/component/git/test_artifact_composition.py
@@ -31,9 +31,9 @@ async def git_repo_filter_tests(git_upstream_repo_02: dict[str, str | Path], git
 
     templates = {
         # Untrusted filter
-        "template_safe.tpl.j2": '{% for item in data["items"] %}{{ item | safe }}\n{% endfor %}\n',
+        "template_untrusted.tpl.j2": '{% for item in data["items"] %}{{ item | fqdn_to_ip }}\n{% endfor %}\n',
         # Trusted filter
-        "template_upper.tpl.j2": '{% for item in data["items"] %}{{ item | upper }}\n{% endfor %}\n',
+        "template_trusted.tpl.j2": '{% for item in data["items"] %}{{ item | upper }}\n{% endfor %}\n',
     }
 
     for name, content in templates.items():
@@ -67,14 +67,16 @@ def _make_message(repo: InfrahubRepository, template: str) -> TransformJinjaTemp
 async def test_worker_rejects_local_only_filter(
     git_repo_filter_tests: InfrahubRepository, init_service: InfrahubServices, prefect_test_fixture: None
 ) -> None:
-    with pytest.raises(TransformError, match="'safe' filter isn't allowed to be used"):
-        await transform_render_jinja2_template(message=_make_message(git_repo_filter_tests, "template_safe.tpl.j2"))
+    with pytest.raises(TransformError, match="'fqdn_to_ip' filter isn't allowed to be used"):
+        await transform_render_jinja2_template(
+            message=_make_message(git_repo_filter_tests, "template_untrusted.tpl.j2")
+        )
 
 
 async def test_worker_allows_trusted_filters(
     git_repo_filter_tests: InfrahubRepository, init_service: InfrahubServices, prefect_test_fixture: None
 ) -> None:
     result = await transform_render_jinja2_template(
-        message=_make_message(git_repo_filter_tests, "template_upper.tpl.j2")
+        message=_make_message(git_repo_filter_tests, "template_trusted.tpl.j2")
     )
     assert result == "ONE\nTWO\n"


### PR DESCRIPTION
## Why & What

In a previous commit of the Python SDK we were preventing the use of builtin Jinja2 filters to run on worker. This was a side effect of a bug fix. These filters were previously marked as untrusted, though we were not properly validating their use before. Since they are part of Jinja2 itself, we dediced to allow them to be used in both the worker and the local context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled built-in `Jinja2` filters on workers and locally via `python_sdk` update; tests assert `upper` is allowed and `fqdn_to_ip` is blocked.

<sup>Written for commit 3f8a587c79ca47d7bfb1873445e06f9aa274ce8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

