### PR TITLE
show "Reimport current commit" action for all repository types

### DIFF
--- a/frontend/app/src/entities/repository/ui/repository-menu-section.test.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-menu-section.test.tsx
@@ -167,7 +167,7 @@ describe("RepositoryMenuSection", () => {
       .toBeVisible();
   });
 
-  test("does not show Reimport current commit for non-read-only repositories", async () => {
+  test("shows Reimport current commit for non-read-only repositories", async () => {
     // GIVEN
     const component = await render(
       <Menu aria-label="Repository actions">
@@ -181,7 +181,9 @@ describe("RepositoryMenuSection", () => {
     );
 
     // THEN
-    await expect.element(component.baseElement).not.toHaveTextContent("Reimport current commit");
+    await expect
+      .element(component.getByRole("menuitem", { name: /Reimport current commit/i }))
+      .toBeVisible();
   });
 
   test("calls importCurrentCommit mutation when clicking Reimport current commit", async () => {

--- a/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-menu-section.tsx
@@ -106,12 +106,10 @@ export function RepositoryMenuSection({
         </MenuItem>
       )}
 
-      {isReadOnlyRepository && (
-        <MenuItem onAction={() => importCurrentCommit({ repositoryId })}>
-          <Icon icon="mdi:reload" />
-          Reimport current commit
-        </MenuItem>
-      )}
+      <MenuItem onAction={() => importCurrentCommit({ repositoryId })}>
+        <Icon icon="mdi:reload" />
+        Reimport current commit
+      </MenuItem>
     </MenuSection>
   );
 }


### PR DESCRIPTION
## Summary

- Removed the guard so the action is available on both `CoreRepository` and `CoreReadOnlyRepository`
- The underlying mutation (`InfrahubRepositoryProcess`) is a generic repository operation, not read-only specific

## Expected actions

| Repository type | Actions |
|---|---|
| `CoreRepository` | Check connectivity, Reimport current commit |
| `CoreReadOnlyRepository` | Check connectivity, Import latest commit, Reimport current commit |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “Reimport current commit” in the repository actions menu for all repository types. Removed the read-only guard since `InfrahubRepositoryProcess` supports all repos and updated tests to assert visibility for non-read-only repositories.

<sup>Written for commit d123867c013ffbe355b29daa84e178bfd1a10bc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

