### PR TITLE
Fix git sync after pod restart/storage recovery on workers

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -62,10 +62,12 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         return response
 
-    async def sync(self, staging_branch: str | None = None) -> None:
+    async def sync(self, staging_branch: str | None = None, db_commits: dict[str, str] | None = None) -> None:
         """Synchronize the repository with its remote origin and with the database.
 
         By default the sync will focus only on the branches pulled from origin that have some differences with the local one.
+        If db_commits is provided, also detect branches where the local git HEAD differs from the DB commit value
+        and re-import objects for those branches (handles stale DB state after a re-clone).
         """
 
         log.info("Starting the synchronization.", repository=self.name)
@@ -74,7 +76,26 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         new_branches, updated_branches = await self.compare_local_remote()
 
-        if not new_branches and not updated_branches:
+        # Detect branches where the DB commit is stale compared to local git HEAD
+        stale_db_branches: list[str] = []
+        if db_commits and self.internal_status == RepositoryInternalStatus.ACTIVE.value:
+            already_handled = set(new_branches) | set(updated_branches)
+            local_branches = self.get_branches_from_local(include_worktree=False)
+            for branch_name, branch_data in local_branches.items():
+                if branch_name in already_handled:
+                    continue
+                db_commit = db_commits.get(self._get_mapped_target_branch(branch_name=branch_name))
+                if db_commit is not None and str(branch_data.commit) != db_commit:
+                    log.info(
+                        "Stale DB commit detected",
+                        repository=self.name,
+                        branch=branch_name,
+                        local_commit=str(branch_data.commit),
+                        db_commit=db_commit,
+                    )
+                    stale_db_branches.append(branch_name)
+
+        if not new_branches and not updated_branches and not stale_db_branches:
             return
 
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
@@ -119,6 +140,13 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                         repository=self.name,
                         branch=branch_name,
                     )
+
+            for branch_name in stale_db_branches:
+                infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+                commit = self.get_commit_value(branch_name=branch_name, remote=False)
+                self.create_commit_worktree(commit=commit)
+                await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+                await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit)
 
         await self._sync_staging(staging_branch=staging_branch, updated_branches=updated_branches)
 

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -260,6 +260,12 @@ async def sync_remote_repositories() -> None:
                     staging_branch=staging_branch,
                     infrahub_branch=infrahub_branch,
                 )
+
+                # After sync, check if DB commits are stale (e.g., after a fresh re-clone).
+                # The subflow sync only compares local git vs remote git — it doesn't
+                # detect drift between DB and local git HEAD.
+                if not init_failed:
+                    await repo.sync(db_commits=repository_data.branches)
                 # Tell workers to fetch to stay in sync
                 message = messages.RefreshGitFetch(
                     meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),

--- a/backend/tests/unit/git/test_sync_stale_db_commit.py
+++ b/backend/tests/unit/git/test_sync_stale_db_commit.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
+
+from infrahub import config
+from infrahub.core.constants import RepositoryInternalStatus
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from tests.helpers.file_repo import FileRepo
+from tests.helpers.test_client import dummy_async_request
+
+
+@pytest.fixture
+def git_sources_dir(tmp_path: Path) -> Path:
+    source_dir = tmp_path / "sources"
+    source_dir.mkdir()
+    return source_dir
+
+
+@pytest.fixture
+def git_repos_dir(tmp_path: Path) -> Path:
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    config.SETTINGS.git.repositories_directory = str(repos_dir)
+    return repos_dir
+
+
+@pytest.fixture
+def setup_registry() -> None:
+    registry._default_branch = "main"
+
+
+@pytest.fixture
+def upstream_repo(git_sources_dir: Path) -> FileRepo:
+    return FileRepo(name="car-dealership", sources_directory=git_sources_dir)
+
+
+@pytest.fixture
+async def infrahub_repo(
+    upstream_repo: FileRepo,
+    git_repos_dir: Path,
+    setup_registry: None,
+) -> InfrahubRepository:
+    repo = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name="car-dealership",
+        location=upstream_repo.path,
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+    return repo
+
+
+async def test_sync_detects_stale_db_commit(infrahub_repo: InfrahubRepository) -> None:
+    """When db_commits has a different commit than local HEAD, sync calls
+    update_commit_value and import_objects_from_files for the stale branch."""
+
+    # Get the real local commit for the default branch
+    local_commit = infrahub_repo.get_commit_value(branch_name="main", remote=False)
+    stale_db_commit = "0000000000000000000000000000000000000000"
+
+    assert local_commit != stale_db_commit
+
+    # Ensure the repo is ACTIVE so the processing block runs
+    infrahub_repo.internal_status = RepositoryInternalStatus.ACTIVE.value
+
+    mock_fetch = AsyncMock()
+    mock_compare = AsyncMock(return_value=([], []))
+    mock_update_commit = AsyncMock()
+    mock_import = AsyncMock()
+
+    with (
+        patch.object(InfrahubRepository, "fetch", mock_fetch),
+        patch.object(InfrahubRepository, "compare_local_remote", mock_compare),
+        patch.object(InfrahubRepository, "update_commit_value", mock_update_commit),
+        patch.object(InfrahubRepository, "import_objects_from_files", mock_import),
+    ):
+        await infrahub_repo.sync(db_commits={"main": stale_db_commit})
+
+        mock_fetch.assert_awaited_once()
+        mock_compare.assert_awaited_once()
+        mock_update_commit.assert_awaited_once_with(branch_name="main", commit=local_commit)
+        mock_import.assert_awaited_once_with(infrahub_branch_name="main", commit=local_commit)
+
+
+async def test_sync_skips_when_db_commit_matches(infrahub_repo: InfrahubRepository) -> None:
+    """When db_commits matches local HEAD, no import is triggered."""
+
+    local_commit = infrahub_repo.get_commit_value(branch_name="main", remote=False)
+
+    infrahub_repo.internal_status = RepositoryInternalStatus.ACTIVE.value
+
+    mock_fetch = AsyncMock()
+    mock_compare = AsyncMock(return_value=([], []))
+    mock_update_commit = AsyncMock()
+    mock_import = AsyncMock()
+
+    with (
+        patch.object(InfrahubRepository, "fetch", mock_fetch),
+        patch.object(InfrahubRepository, "compare_local_remote", mock_compare),
+        patch.object(InfrahubRepository, "update_commit_value", mock_update_commit),
+        patch.object(InfrahubRepository, "import_objects_from_files", mock_import),
+    ):
+        await infrahub_repo.sync(db_commits={"main": local_commit})
+
+        mock_fetch.assert_awaited_once()
+        mock_compare.assert_awaited_once()
+        mock_update_commit.assert_not_awaited()
+        mock_import.assert_not_awaited()
+
+
+async def test_sync_without_db_commits_preserves_existing_behavior(infrahub_repo: InfrahubRepository) -> None:
+    """When db_commits is None (not provided), no stale detection occurs and
+    the method returns early when compare_local_remote finds nothing."""
+
+    infrahub_repo.internal_status = RepositoryInternalStatus.ACTIVE.value
+
+    mock_fetch = AsyncMock()
+    mock_compare = AsyncMock(return_value=([], []))
+    mock_update_commit = AsyncMock()
+    mock_import = AsyncMock()
+
+    with (
+        patch.object(InfrahubRepository, "fetch", mock_fetch),
+        patch.object(InfrahubRepository, "compare_local_remote", mock_compare),
+        patch.object(InfrahubRepository, "update_commit_value", mock_update_commit),
+        patch.object(InfrahubRepository, "import_objects_from_files", mock_import),
+    ):
+        await infrahub_repo.sync()
+
+        mock_fetch.assert_awaited_once()
+        mock_compare.assert_awaited_once()
+        mock_update_commit.assert_not_awaited()
+        mock_import.assert_not_awaited()

--- a/backend/tests/unit/git/test_sync_stale_db_commit.py
+++ b/backend/tests/unit/git/test_sync_stale_db_commit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +13,9 @@ from infrahub.core.registry import registry
 from infrahub.git import InfrahubRepository
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_client import dummy_async_request
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

Closes #8930 

## What changed

- Pass through db commits to ensure when a repo is initially synced (in this case, the storage was lost on a pod on the task worker in a k8s deployment), it will re-sync, and also compare the local ref to the Db commit ref value and update accordingly.

<!-- If the diff is large, add a suggested review order:
### Suggested review order
1. Start with ...
2. Then ...
3. Tests are ...
-->

## How to review

This was vibe coded with Claude while I was working on customer issues so it may not be optimal or the proper fix, but it exists for a review.

## How to test

This one is somewhat difficult as it requires a repository and potentially a k8s deployment to restart pods with no persistence or override the volumes used for workers in the docker compose route.

## Impact & rollout

<!-- Delete items that don't apply -->

- **Backward compatibility:** <!-- any breaking changes or migration steps -->
- **Performance:** <!-- implications, measurements if relevant -->
- **Config/env changes:** <!-- new settings, feature flags, env vars -->
- **Deployment notes:** <!-- "safe to deploy" vs "requires coordinated release" -->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git sync after worker pod restart or storage recovery by detecting stale DB commit values and re-importing branches to align the DB with local git HEAD. Prevents repos from staying out of sync after a fresh re-clone.

- **Bug Fixes**
  - `InfrahubRepository.sync()` now accepts `db_commits` and detects branches where the DB commit differs from local HEAD (when local==remote). It updates the DB commit and re-imports objects for those branches.
  - `sync_remote_repositories()` now passes the per-branch commit map to `repo.sync()` after the normal sync to enable stale-DB detection.
  - Added unit tests for stale DB commit handling, match/no-op paths, and preserving behavior when `db_commits` is not provided.

<sup>Written for commit c1094a4f9138fc6bbb2d81d7c3cb31c49667b5b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

