### PR TITLE
Add testing guidelines related to schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,13 @@
 /backend/ @opsmill/backend
 /frontend/ @opsmill/frontend
-/frontend/app/src/shared/api/graphql/generated/**
-/frontend/app/src/shared/api/rest/types.generated.ts
+/dev/guidelines/backend @opsmill/backend
+/dev/knowledge/backend @opsmill/backend
 /docs/ @opsmill/sa @opsmill/product
 /docs/docs @opsmill/sa @opsmill/backend @opsmill/frontend
 /docs/docs/reference/ @opsmill/backend @opsmill/frontend
 /docker-compose.yml @opsmill/cloud
+/frontend/app/src/shared/api/graphql/generated/**
+/frontend/app/src/shared/api/rest/types.generated.ts
+/python_sdk/ @opsmill/backend
 uv.lock @opsmill/backend
 pyproject.toml @opsmill/backend
-/python_sdk/ @opsmill/backend

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -25,6 +25,38 @@ Tests are behavioral specifications. Write them to describe **what the system sh
 - **Do not reference issue numbers, GitHub URLs, or Jira tickets** in test code (names, comments, or docstrings). The git history links commits to issues.
 - **Do not describe which bug a test prevents.** Describe the expected behavior instead.
 
+## Test Schemas
+
+Many tests require schemas to be loaded before they can run. Over time this has led to duplicated schema definitions scattered across test files. To reduce duplication and ease maintenance, shared helper schemas are available in [`tests/helpers/schema/`](../../../backend/tests/helpers/schema/).
+
+### Available helpers
+
+The module provides individual node/generic schemas (`CAR`, `DEVICE`, `TAG`, `PERSON`, etc.) as well as pre-composed `SchemaRoot` bundles (`CAR_SCHEMA`, `DEVICE_SCHEMA`, `LOCATION_SCHEMA`, `SNOW_TICKET_SCHEMA`, etc.). A `load_schema` helper function handles registering a schema in the branch registry during tests.
+
+### Guidelines
+
+1. **Check existing helpers first.** Before defining a new schema in a test file, look at the schemas already available in `tests/helpers/schema/`. An existing schema may already cover your needs.
+
+2. **Derive from helpers with `deepcopy`.** When you need a schema that is close to an existing helper but requires small additions or modifications, deep-copy the helper and apply your changes instead of writing a new schema from scratch:
+
+   ```python
+   from copy import deepcopy
+
+   from infrahub.core.schema import AttributeSchema
+   from tests.helpers.schema import CAR
+
+   car_with_mileage = deepcopy(CAR)
+   car_with_mileage.attributes.append(
+       AttributeSchema(name="mileage", kind="Number")
+   )
+   ```
+
+   This avoids modifying the shared helper (which would risk breaking other tests) while keeping the test schema close to the canonical definition.
+
+3. **Only create new helpers for broadly useful schemas.** If a schema is only needed by a single test file, keep it local to that file. Promote a local schema to `tests/helpers/schema/` only when multiple test modules would benefit from sharing it.
+
+4. **Never modify an existing helper schema to satisfy a single test.** Changes to shared schemas affect every test that uses them. If an existing helper almost fits but not quite, use `deepcopy` as shown above.
+
 ## Dataclass Test Case Pattern
 
 For parametrized tests with multiple scenarios, use dataclasses to define test cases. This pattern provides type safety, readable test IDs, and clear separation between test data and test logic.
@@ -228,6 +260,28 @@ assert "no more addresses available" in exc_info.value.message
 ```
 
 The `match` parameter accepts a regular expression pattern and is more concise. Use `r"..."` raw strings to avoid escaping issues.
+
+## GraphQL Result Assertions
+
+When testing GraphQL mutations or queries that return errors, always assert on the **specific error message** using an equality check. Vague assertions hide regressions — if the error changes (e.g., a different validation fires first), the test keeps passing silently.
+
+```python
+# Bad - only checks that some error occurred
+assert result.errors
+
+# Bad - a substring check passes for any error that mentions the ID
+assert TEMPLATE_ID in str(result.errors[0])
+
+# Bad - slightly better but still a substring match, any error containing
+# this text passes even if the overall message changed
+assert f"The template requested {{'id': '{TEMPLATE_ID}'}} was not found." in str(result.errors[0])
+
+# Good - exact match on the error message
+assert result.errors
+assert str(result.errors[0].message) == f"The template requested {{'id': '{TEMPLATE_ID}'}} was not found."
+```
+
+Use `==` rather than `in` to compare error messages. An exact match ensures the test fails when the error wording changes, keeping assertions tightly coupled to the expected behavior.
 
 ## See Also
 


### PR DESCRIPTION
# Why

Test schema definitions are duplicated across many test files. We already have shared helpers in `tests/helpers/schema/`, but there's no documented guidance on when and how to use them. Similarly, GraphQL error assertions in tests are often too loose (substring checks or just `assert result.errors`), which lets regressions slip through undetected.

## What changed

- Added a **Test Schemas** section to `dev/guidelines/backend/testing.md` with guidelines for reusing shared schema helpers, deriving variants with `deepcopy`, and when to promote local schemas to shared helpers.
- Added a **GraphQL Result Assertions** section with examples showing why exact `==` checks on error messages are preferable to substring or existence checks.

## Checklist

- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds testing guidelines to `dev/guidelines/backend/testing.md` on reusing schemas from `tests/helpers/schema/` via `load_schema`, deriving variants with `deepcopy`, and using exact `==` checks for GraphQL errors. Updates `.github/CODEOWNERS` to tag the backend team for changes in `dev/guidelines/backend`, `dev/knowledge/backend`, and `python_sdk`.

<sup>Written for commit 17f0988ed76dead1377630c889a591883f6fd43d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

