### PR TITLE
install playwright browsers for bug-fixing pipeline

### DIFF
--- a/.github/workflows/bug-agent-fix.yml
+++ b/.github/workflows/bug-agent-fix.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Install frontend dependencies
         if: steps.resolve.outputs.skip != 'true'
         run: cd frontend/app && npm ci
+      - name: Install Playwright browsers
+        if: steps.resolve.outputs.skip != 'true'
+        run: cd frontend/app && npx playwright install chromium
 
       - name: Read prompt
         if: steps.resolve.outputs.skip != 'true'
@@ -337,6 +340,9 @@ jobs:
       - name: Install frontend dependencies
         if: steps.resolve.outputs.skip != 'true'
         run: cd frontend/app && npm ci
+      - name: Install Playwright browsers
+        if: steps.resolve.outputs.skip != 'true'
+        run: cd frontend/app && npx playwright install chromium
 
       - name: Read prompt
         if: steps.resolve.outputs.skip != 'true'

--- a/.github/workflows/bug-agent-test.yml
+++ b/.github/workflows/bug-agent-test.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Install frontend dependencies
         if: steps.analyst.outputs.skip != 'true'
         run: cd frontend/app && npm ci
+      - name: Install Playwright browsers
+        if: steps.analyst.outputs.skip != 'true'
+        run: cd frontend/app && npx playwright install chromium
 
       - name: Read prompt
         if: steps.analyst.outputs.skip != 'true'
@@ -298,6 +301,9 @@ jobs:
       - name: Install frontend dependencies
         if: steps.resolve.outputs.skip != 'true'
         run: cd frontend/app && npm ci
+      - name: Install Playwright browsers
+        if: steps.resolve.outputs.skip != 'true'
+        run: cd frontend/app && npx playwright install chromium
 
       - name: Read prompt
         if: steps.resolve.outputs.skip != 'true'


### PR DESCRIPTION
## Problem

The test-writer pipeline has failed for two reasons: 

- the branch was already existing
- because `vitest-browser-react` (used by all frontend tests) requires Playwright's headless Chromium binary, and it wasn't being installed in the bug-agent workflows. The regular CI already had it.

The pipeline posted a comment on the gh issue to explain this, I have copied/pasted it in this PR.

Related Github action run: https://github.com/opsmill/infrahub/actions/runs/24499569202.

## Solution

Add the same CI step about installing Playwright browsers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Playwright Chromium in bug-agent workflows so frontend tests can run headless in CI. This fixes test failures in the bug-fixing pipeline caused by missing browser binaries.

- **Bug Fixes**
  - Added `npx playwright install chromium` after `npm ci` in `bug-agent-fix.yml` and `bug-agent-test.yml`.
  - Steps respect existing `skip` conditions.
  - Aligns bug-agent pipelines with regular CI and unblocks `vitest-browser-react` tests.

<sup>Written for commit bf846ca5d2cd19571d348c5c881104e652d2fcf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

