### PR TITLE
IFC-2455: Use default branch as context branch when merging a proposed change

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Self
 from graphene import Boolean, Enum, Field, InputObjectType, List, Mutation, String
 
 from infrahub import lock
+from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
@@ -148,6 +149,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         node: Node | None = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
+        graphql_context.branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
 
         obj = await NodeManager.get_one_by_id_or_default_filter(
             db=graphql_context.db,
@@ -450,6 +452,7 @@ class ProposedChangeMerge(Mutation):
         wait_until_completion: bool = True,
     ) -> dict[str, bool]:
         graphql_context: GraphqlContext = info.context
+        graphql_context.branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
         task: dict | None = None
 
         identifier = data.get("id", "")

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -149,6 +149,8 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         node: Node | None = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
+        # The reason for doing so here is specifically that the proposed changes are of a branch agnostic kind
+        # so it would not be critical to know from which branch they are modified, however under normal circumstances we don't want to do this.
         graphql_context.branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
 
         obj = await NodeManager.get_one_by_id_or_default_filter(
@@ -452,6 +454,8 @@ class ProposedChangeMerge(Mutation):
         wait_until_completion: bool = True,
     ) -> dict[str, bool]:
         graphql_context: GraphqlContext = info.context
+        # The reason for doing so here is specifically that the proposed changes are of a branch agnostic kind
+        # so it would not be critical to know from which branch they are modified, however under normal circumstances we don't want to do this.
         graphql_context.branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
         task: dict | None = None
 


### PR DESCRIPTION
Use default branch as context branch when merging a proposed change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the default branch as the GraphQL context branch when updating or merging a proposed change so merges are evaluated against the correct baseline. Aligns with IFC-2455.

- **Bug Fixes**
  - Set `graphql_context.branch` to `registry.default_branch` in proposed change `mutate_update` and `mutate`; added inline comments explaining the branch-agnostic reasoning.
  - Prevents merges using non-default or stale branch context; no API/schema changes.

<sup>Written for commit 14673f22179c5a01257f2870e95178893f1d6d87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



