### PR TITLE
IFC-2463: Add open proposed change id to branch delete workflow parameters

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -10,12 +10,15 @@ from infrahub.branch.merge_mutation_checker import verify_branch_merge_mutation_
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreProposedChange
 from infrahub.database import retry_db_transaction
 from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_logger
+from infrahub.proposed_change.constants import ProposedChangeState
 from infrahub.workflows.catalogue import (
     BRANCH_CREATE,
     BRANCH_DELETE,
@@ -146,6 +149,16 @@ class BranchDelete(Mutation):
             "branch": obj.name,
             "delete_from_git": bool(data.delete_from_git),
         }
+        active_proposed_changes = await NodeManager.query(
+            db=graphql_context.db,
+            schema=CoreProposedChange,
+            filters={
+                "source_branch__value": obj.name,
+                "state__value": ProposedChangeState.OPEN.value,
+            },
+        )
+        if active_proposed_changes:
+            parameters["proposed_change_id"] = active_proposed_changes[0].id
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(

--- a/backend/tests/functional/branch/test_branch_delete.py
+++ b/backend/tests/functional/branch/test_branch_delete.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import ANY, AsyncMock, patch
+
+import pytest
+from infrahub_sdk.graphql import Mutation
+
+from infrahub.core import registry
+from infrahub.core.constants import InfrahubKind
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workflows.catalogue import BRANCH_DELETE
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+class TestBranchDelete(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+        prefect_test_fixture: None,
+    ) -> None: ...
+
+    async def test_branch_delete_workflow(
+        self,
+        initial_dataset: None,
+        client: InfrahubClient,
+    ) -> None:
+        branch = await client.branch.create(branch_name="branch-with-pc")
+
+        pc = await client.create(
+            kind=InfrahubKind.PROPOSEDCHANGE,
+            data={
+                "name": {"value": "test-pc"},
+                "source_branch": {"value": branch.name},
+                "destination_branch": {"value": registry.default_branch},
+                "is_draft": {"value": False},
+            },
+        )
+        await pc.save()
+
+        with patch.object(WorkflowLocalExecution, "execute_workflow", new_callable=AsyncMock) as mock_execute:
+            query = Mutation(
+                mutation="BranchDelete",
+                input_data={"data": {"name": branch.name}},
+                query={"ok": None},
+            )
+            await client.execute_graphql(query=query.render())
+
+            mock_execute.assert_any_call(
+                workflow=BRANCH_DELETE,
+                context=ANY,
+                parameters={"branch": branch.name, "proposed_change_id": pc.id, "delete_from_git": False},
+            )


### PR DESCRIPTION
 Add open proposed change id to branch delete workflow parameters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the ID of an open proposed change to the branch delete workflow when deleting a branch. This aligns with IFC-2463 so the workflow can reference and clean up the associated change.

- **New Features**
  - Look up an `OPEN` `CoreProposedChange` by `source_branch` via `NodeManager`; if found, include `proposed_change_id` in `BRANCH_DELETE` parameters (alongside `delete_from_git`).
  - Added a functional test that asserts `BRANCH_DELETE` receives `proposed_change_id` when deleting a branch with an open proposed change.

<sup>Written for commit e1f17b5ee9c3145135a95179b4c78ec6bff02de3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

