### PR TITLE
Fix git sync after storage recovery

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -169,6 +169,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
     is_read_only: bool = Field(False, description="If true, changes will not be synced to remote")
 
     internal_status: str = Field("active", description="Internal status: Active, Inactive, Staging")
+    reinitialized: bool = Field(False, description="Re-clone is needed because the local directory was missing")
     infrahub_branch_name: str | None = Field(None, description="Infrahub branch on which to sync the remote repository")
     model_config = ConfigDict(arbitrary_types_allowed=True, ignored_types=(Flow, Task))
 

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -154,6 +154,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         except RepositoryInvalidFileSystemError:
             await self.ensure_location_is_defined()
             await self.create_locally(infrahub_branch_name=self.infrahub_branch_name, update_commit_value=False)
+            self.reinitialized = True
             log.info(f"Initialized the local directory for {self.name} because it was missing.")
 
         if commit:

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -248,6 +248,15 @@ async def sync_remote_repositories() -> None:
                     log.info(exc.message)
                     continue
 
+            if repo.reinitialized:
+                try:
+                    await repo.import_objects_from_files(  # type: ignore[call-overload]
+                        git_branch_name=registry.default_branch, infrahub_branch_name=infrahub_branch
+                    )
+                except RepositoryError as exc:
+                    log.info(exc.message)
+                    continue
+
             try:
                 await sync_git_repo_with_origin_and_tag_on_failure(
                     client=client,

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -251,7 +251,7 @@ async def sync_remote_repositories() -> None:
             if repo.reinitialized:
                 try:
                     await repo.import_objects_from_files(  # type: ignore[call-overload]
-                        git_branch_name=registry.default_branch, infrahub_branch_name=infrahub_branch
+                        git_branch_name=repo.default_branch, infrahub_branch_name=infrahub_branch
                     )
                 except RepositoryError as exc:
                     log.info(exc.message)

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -1136,3 +1137,35 @@ async def test_repo_merge_use_explicit_merge_commit(
     response = await repo.merge(source_branch=branch02.name, dest_branch="main")
     commit = repo.get_git_repo_main().commit(response)
     assert commit.message.strip() == "Merged by Infrahub"
+
+
+async def test_init_reinitialized_after_missing_directory(
+    git_repo_02: InfrahubRepository, git_upstream_repo_02: dict[str, str | Path]
+) -> None:
+    """Verify that when the local clone directory is missing, re-clones from the upstream and sets the reinitialized flag."""
+    original_commit = git_repo_02.get_commit_value(branch_name="main", remote=False)
+    repo_id = git_repo_02.id
+
+    assert not git_repo_02.reinitialized
+
+    shutil.rmtree(git_repo_02.directory_root)
+    assert not git_repo_02.directory_root.exists()
+
+    recovered = await InfrahubRepository.init(
+        id=repo_id,
+        name=git_upstream_repo_02["name"],
+        location=str(git_upstream_repo_02["path"]),
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+
+    assert recovered.reinitialized
+    assert recovered.directory_root.is_dir()
+    assert recovered.directory_branches.is_dir()
+    assert recovered.directory_commits.is_dir()
+    assert recovered.has_origin
+
+    assert recovered.get_commit_value(branch_name="main", remote=False) == original_commit
+
+    new_branches, updated_branches = await recovered.compare_local_remote()
+    assert not new_branches
+    assert not updated_branches

--- a/changelog/8930.fixed.md
+++ b/changelog/8930.fixed.md
@@ -1,0 +1,1 @@
+Fixed git sync not importing objects after repository re-clone from a missing local directory


### PR DESCRIPTION
## Why & What

When a worker pod restarts with no local storage,
`init()` silently re-clones but never tells the caller. Since local HEAD matches remote after a fresh clone, `sync()` sees no diff and returns early. No objects imported, db commit not updated.

Add a reinitialized flag on the repo instance, set it during `init()` recovery, and use it in
`sync_remote_repositories` to trigger the import.

Closes #8930 

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git sync after worker storage loss by detecting re-cloned repos and importing before the next sync so objects and the DB commit are restored. Addresses #8930.

- **Bug Fixes**
  - Added a `reinitialized` flag on the repo model; set in `init()` when the local directory is recreated.
  - If `reinitialized`, `sync_remote_repositories` runs `import_objects_from_files` from the repo’s `default_branch` before the normal sync to avoid a no-diff early return.
  - Added a component test to verify the flag and keep local HEAD in sync.
  - Added a changelog entry for #8930.

<sup>Written for commit fe4f0d9eb66a6dc186e6192cddd69fd1e5a5a9b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



