### PR TITLE
fix: prevent deletion of admin/agent accounts and self-deletion (closes #8955)

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -28,6 +28,7 @@ from .constants import NODE_METADATA_TYPE, RELATIONSHIP_METADATA_TYPE
 from .directives import DIRECTIVES
 from .enums import generate_graphql_enum, get_enum_attribute_type_name
 from .metrics import SCHEMA_GENERATE_GRAPHQL_METRICS
+from .mutations.account import InfrahubAccountMutation
 from .mutations.action import InfrahubTriggerRuleMatchMutation, InfrahubTriggerRuleMutation
 from .mutations.artifact_definition import InfrahubArtifactDefinitionMutation
 from .mutations.ipam import (
@@ -523,6 +524,7 @@ class GraphQLSchemaManager:
                 continue
 
             mutation_map: dict[str, type[InfrahubMutation]] = {
+                InfrahubKind.ACCOUNT: InfrahubAccountMutation,
                 InfrahubKind.ARTIFACTDEFINITION: InfrahubArtifactDefinitionMutation,
                 InfrahubKind.REPOSITORY: InfrahubRepositoryMutation,
                 InfrahubKind.READONLYREPOSITORY: InfrahubRepositoryMutation,

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -5,18 +5,23 @@ from graphql import GraphQLResolveInfo
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
+from infrahub import config
 from infrahub.auth import AuthType
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.order import OrderModel
 from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
+from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, retry_db_transaction
-from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError
+from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
+from infrahub.graphql.mutations.main import InfrahubMutationMixin
 
 from ..types import InfrahubObjectType
+from .main import DeleteResult, InfrahubMutationOptions
 
 if TYPE_CHECKING:
     from ..initialization import GraphqlContext
@@ -169,3 +174,56 @@ class InfrahubAccountSelfUpdate(AccountMixin, Mutation):
         data = InfrahubAccountUpdateSelfInput(required=True)
 
     ok = Boolean()
+
+
+class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls, schema: NodeSchema, _meta: Any | None = None, **options: dict[str, Any]
+    ) -> None:
+        if not isinstance(schema, NodeSchema):
+            raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
+
+        if not _meta:
+            _meta = InfrahubMutationOptions(cls)
+        _meta.schema = schema
+
+        super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    async def mutate_delete(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+    ) -> DeleteResult:
+        graphql_context: GraphqlContext = info.context
+
+        obj = await NodeManager.find_object(
+            db=graphql_context.db,
+            kind=cls._meta.active_schema.kind,
+            id=data.get("id"),
+            hfid=data.get("hfid"),
+            branch=branch,
+        )
+
+        if graphql_context.account_session and graphql_context.account_session.account_id == obj.get_id():
+            raise ValidationError(input_value="You cannot delete your own account.")
+
+        initial_tokens = {
+            t for t in (config.SETTINGS.initial.admin_token, config.SETTINGS.initial.agent_token) if t is not None
+        }
+        if initial_tokens:
+            account_tokens = await NodeManager.query(
+                schema=InternalAccountToken,
+                filters={"account_ids": [obj.get_id()]},
+                db=graphql_context.db,
+                order=OrderModel(disable=True),
+            )
+            for account_token in account_tokens:
+                if account_token.token.value in initial_tokens:
+                    raise ValidationError(
+                        input_value="This account is associated with a system token and cannot be deleted."
+                    )
+
+        return await super().mutate_delete(info=info, data=data, branch=branch)

--- a/backend/tests/component/graphql/mutations/test_account.py
+++ b/backend/tests/component/graphql/mutations/test_account.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub import config
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.services import InfrahubServices
+from tests.helpers.graphql import graphql_mutation
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+DELETE_ACCOUNT = """
+mutation CoreAccountDelete($id: String!) {
+    CoreAccountDelete(data: { id: $id }) {
+        ok
+    }
+}
+"""
+
+
+async def test_delete_account_with_initial_admin_token_is_rejected(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+) -> None:
+    """Accounts associated with the initial admin token cannot be deleted."""
+    admin_token_value = "test-initial-admin-token"
+    original_token = config.SETTINGS.initial.admin_token
+    config.SETTINGS.initial.admin_token = admin_token_value
+    try:
+        admin_account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+        await admin_account.new(db=db, name="admin", account_type="User", password="admin-password")
+        await admin_account.save(db=db)
+
+        token = await Node.init(db=db, schema=InfrahubKind.ACCOUNTTOKEN)
+        await token.new(db=db, token=admin_token_value, name="admin-token", account=admin_account)
+        await token.save(db=db)
+
+        other_account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+        await other_account.new(db=db, name="other-user", account_type="User", password="other-password")
+        await other_account.save(db=db)
+
+        service = await InfrahubServices.new(database=db)
+        account_session = AccountSession(authenticated=True, account_id=other_account.id, auth_type=AuthType.API)
+
+        result = await graphql_mutation(
+            query=DELETE_ACCOUNT,
+            db=db,
+            variables={"id": admin_account.id},
+            service=service,
+            account_session=account_session,
+        )
+
+        assert result.errors
+    finally:
+        config.SETTINGS.initial.admin_token = original_token
+
+
+async def test_self_deletion_is_rejected(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+) -> None:
+    """Users cannot delete their own account."""
+    account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+    await account.new(db=db, name="self-delete-user", account_type="User", password="password123")
+    await account.save(db=db)
+
+    service = await InfrahubServices.new(database=db)
+    account_session = AccountSession(authenticated=True, account_id=account.id, auth_type=AuthType.API)
+
+    result = await graphql_mutation(
+        query=DELETE_ACCOUNT,
+        db=db,
+        variables={"id": account.id},
+        service=service,
+        account_session=account_session,
+    )
+
+    assert result.errors

--- a/changelog/8955.fixed.md
+++ b/changelog/8955.fixed.md
@@ -1,0 +1,1 @@
+Prevented deletion of the admin and agent accounts associated with system tokens, and prevented users from deleting their own account


### PR DESCRIPTION
# Why

Infrahub allows deletion of the built-in `admin` and `agent` accounts with no guard. Since `INFRAHUB_INITIAL_ADMIN_TOKEN` / `INFRAHUB_INITIAL_AGENT_TOKEN` are used by task workers to authenticate against the API server, deleting these accounts breaks all worker-to-server communication (401 errors on every periodic flow). Additionally, users can delete their own account via the GraphQL API.

**Goal:** Prevent deletion of accounts associated with system tokens and prevent self-deletion.

**Non-goals:** This PR does not add a "protected" schema attribute, does not change RBAC/permissions, and does not modify the generic mutation infrastructure.

Closes #8955

## What changed

- **`InfrahubAccountMutation`** added to `backend/infrahub/graphql/mutations/account.py`: a CoreAccount-specific mutation class (following the existing `InfrahubCoreMenuMutation` pattern) that overrides `mutate_delete` with two guards:
  1. Self-deletion prevention: rejects if the authenticated user is deleting their own account
  2. System token guard: queries the account's tokens and rejects if any match the configured `INFRAHUB_INITIAL_ADMIN_TOKEN` or `INFRAHUB_INITIAL_AGENT_TOKEN`
- **Registration** in `backend/infrahub/graphql/manager.py`: `InfrahubKind.ACCOUNT` mapped to `InfrahubAccountMutation` in `mutation_map`
- No schema changes, no migration, API contract unchanged for all other account operations (create, update, upsert)

## How to review

1. Start with `backend/infrahub/graphql/mutations/account.py` — the `InfrahubAccountMutation` class at the bottom
2. Then `backend/infrahub/graphql/manager.py` — one-line addition to `mutation_map`
3. Tests in `backend/tests/component/graphql/mutations/test_account.py`

## How to test

```bash
INFRAHUB_USE_TEST_CONTAINERS=true uv run pytest backend/tests/component/graphql/mutations/test_account.py -x -v
```

Expected: both tests pass (admin token deletion blocked, self-deletion blocked).

## Impact & rollout

- **Backward compatibility:** Users who intentionally delete admin/agent accounts will now get a validation error. This is the desired behavior per the issue.
- **Performance:** Negligible — one additional token query on account deletion only.
- **Config/env changes:** None. Uses existing `INFRAHUB_INITIAL_ADMIN_TOKEN` / `INFRAHUB_INITIAL_AGENT_TOKEN` settings.
- **Deployment notes:** Safe to deploy. No migration required.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- AGENT_FIX_COMPLETE -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deletion of accounts tied to initial admin/agent system tokens and blocks self-deletion. This protects worker authentication and avoids accidental lockouts.

- **Bug Fixes**
  - Added `InfrahubAccountMutation` for CoreAccount that overrides `mutate_delete` to block self-deletion and accounts with tokens matching `INFRAHUB_INITIAL_ADMIN_TOKEN` or `INFRAHUB_INITIAL_AGENT_TOKEN`.
  - Registered `InfrahubKind.ACCOUNT` to use this mutation in the GraphQL manager.
  - Added component tests covering both guards.
  - No schema or API changes; negligible overhead; uses existing settings.

<sup>Written for commit ce4cc9e9114d8a6ee0eca118884b6c0531946da6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

