### PR TITLE
Link branch merge/delete events to proposed change as primary node

### DIFF
--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -29,6 +29,8 @@ class BranchDeletedEvent(InfrahubEvent):
         }
         if self.proposed_change_id:
             resource["infrahub.branch.proposed_change_id"] = self.proposed_change_id
+            resource["infrahub.node.id"] = self.proposed_change_id
+            resource["infrahub.node.kind"] = InfrahubKind.PROPOSEDCHANGE
         return resource
 
     def get_messages(self) -> list[InfrahubMessage]:
@@ -42,18 +44,6 @@ class BranchDeletedEvent(InfrahubEvent):
             RefreshRegistryBranches(),
         ]
         return events
-
-    def get_related(self) -> list[dict[str, str]]:
-        related = super().get_related()
-        if self.proposed_change_id:
-            related.append(
-                {
-                    "prefect.resource.id": self.proposed_change_id,
-                    "prefect.resource.role": "infrahub.related.node",
-                    "infrahub.node.kind": InfrahubKind.PROPOSEDCHANGE,
-                }
-            )
-        return related
 
 
 class BranchCreatedEvent(InfrahubEvent):
@@ -97,24 +87,15 @@ class BranchMergedEvent(InfrahubEvent):
     )
 
     def get_resource(self) -> dict[str, str]:
-        return {
+        resource = {
             "prefect.resource.id": f"infrahub.branch.{self.branch_name}",
             "infrahub.branch.id": self.branch_id,
             "infrahub.branch.name": self.branch_name,
         }
-
-    def get_related(self) -> list[dict[str, str]]:
-        related = super().get_related()
         if self.proposed_change_id:
-            related.append(
-                {
-                    "prefect.resource.id": self.proposed_change_id,
-                    "prefect.resource.role": "infrahub.related.node",
-                    "infrahub.node.kind": InfrahubKind.PROPOSEDCHANGE,
-                }
-            )
-
-        return related
+            resource["infrahub.node.id"] = self.proposed_change_id
+            resource["infrahub.node.kind"] = InfrahubKind.PROPOSEDCHANGE
+        return resource
 
     def get_messages(self) -> list[InfrahubMessage]:
         return [RefreshRegistryBranches()]

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -312,8 +312,8 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         assert merge_event["InfrahubEvent"]["count"] == 1
         merge_event_id = merge_event["InfrahubEvent"]["edges"][0]["node"]["id"]
-        assert len(merge_event["InfrahubEvent"]["edges"][0]["node"]["related_nodes"]) == 1
-        assert merge_event["InfrahubEvent"]["edges"][0]["node"]["related_nodes"][0]["id"] == proposed_change.id
+        assert merge_event["InfrahubEvent"]["edges"][0]["node"]["primary_node"] is not None
+        assert merge_event["InfrahubEvent"]["edges"][0]["node"]["primary_node"]["id"] == proposed_change.id
 
         john = await NodeManager.get_one_by_id_or_default_filter(db=db, id="Johnny", kind=TestKind.PERSON)
         richard = await NodeManager.get_one_by_id_or_default_filter(db=db, id="Richard", kind=TestKind.PERSON)

--- a/backend/tests/unit/event/test_branch_action.py
+++ b/backend/tests/unit/event/test_branch_action.py
@@ -11,7 +11,7 @@ from infrahub.events.models import EventMeta
 
 
 def _make_meta() -> EventMeta:
-    branch = Branch(name="main", uuid=uuid.uuid4())
+    branch = Branch(name="test-branch-action-events", uuid=uuid.uuid4())
     return EventMeta(
         branch=branch,
         context=InfrahubContext.init(

--- a/backend/tests/unit/event/test_branch_action.py
+++ b/backend/tests/unit/event/test_branch_action.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.events.branch_action import BranchDeletedEvent, BranchMergedEvent
+from infrahub.events.models import EventMeta
+
+
+def _make_meta() -> EventMeta:
+    branch = MagicMock(spec=Branch)
+    branch.name = "main"
+    branch.uuid = uuid.uuid4()
+    branch.get_uuid.return_value = branch.uuid
+    return EventMeta(
+        branch=branch,
+        context=InfrahubContext.init(
+            branch=branch,
+            account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+        ),
+    )
+
+
+def test_branch_deleted_resource_without_proposed_change() -> None:
+    event = BranchDeletedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+        sync_with_git=True,
+    )
+
+    resource = event.get_resource()
+
+    assert resource["prefect.resource.id"] == "infrahub.branch.feature"
+    assert resource["infrahub.branch.id"] == "branch-123"
+    assert resource["infrahub.branch.name"] == "feature"
+    assert "infrahub.node.id" not in resource
+    assert "infrahub.node.kind" not in resource
+    assert "infrahub.branch.proposed_change_id" not in resource
+
+
+def test_branch_deleted_resource_with_proposed_change_sets_primary_node() -> None:
+    event = BranchDeletedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+        sync_with_git=True,
+        proposed_change_id="pc-456",
+    )
+
+    resource = event.get_resource()
+
+    assert resource["infrahub.node.id"] == "pc-456"
+    assert resource["infrahub.node.kind"] == InfrahubKind.PROPOSEDCHANGE
+    assert resource["infrahub.branch.proposed_change_id"] == "pc-456"
+
+
+def test_branch_deleted_related_excludes_proposed_change() -> None:
+    event = BranchDeletedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+        sync_with_git=True,
+        proposed_change_id="pc-456",
+    )
+
+    related = event.get_related()
+
+    pc_entries = [r for r in related if r.get("prefect.resource.id") == "pc-456"]
+    assert pc_entries == []
+
+
+def test_branch_merged_resource_without_proposed_change() -> None:
+    event = BranchMergedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+    )
+
+    resource = event.get_resource()
+
+    assert resource["prefect.resource.id"] == "infrahub.branch.feature"
+    assert "infrahub.node.id" not in resource
+    assert "infrahub.node.kind" not in resource
+
+
+def test_branch_merged_resource_with_proposed_change_sets_primary_node() -> None:
+    event = BranchMergedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+        proposed_change_id="pc-456",
+    )
+
+    resource = event.get_resource()
+
+    assert resource["infrahub.node.id"] == "pc-456"
+    assert resource["infrahub.node.kind"] == InfrahubKind.PROPOSEDCHANGE
+
+
+def test_branch_merged_related_excludes_proposed_change() -> None:
+    event = BranchMergedEvent(
+        meta=_make_meta(),
+        branch_name="feature",
+        branch_id="branch-123",
+        proposed_change_id="pc-456",
+    )
+
+    related = event.get_related()
+
+    pc_entries = [r for r in related if r.get("prefect.resource.id") == "pc-456"]
+    assert pc_entries == []

--- a/backend/tests/unit/event/test_branch_action.py
+++ b/backend/tests/unit/event/test_branch_action.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import MagicMock
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
@@ -12,10 +11,7 @@ from infrahub.events.models import EventMeta
 
 
 def _make_meta() -> EventMeta:
-    branch = MagicMock(spec=Branch)
-    branch.name = "main"
-    branch.uuid = uuid.uuid4()
-    branch.get_uuid.return_value = branch.uuid
+    branch = Branch(name="main", uuid=uuid.uuid4())
     return EventMeta(
         branch=branch,
         context=InfrahubContext.init(

--- a/changelog/+branch-event-primary-node.changed.md
+++ b/changelog/+branch-event-primary-node.changed.md
@@ -1,0 +1,1 @@
+`infrahub.branch.deleted` and `infrahub.branch.merged` events now expose the associated proposed change (when applicable) as the event's primary node instead of a related node. Consumers filtering on `primaryNodeIds` will match these events for a proposed change; filters relying on the proposed change appearing under `relatedNodes` must be updated.

--- a/frontend/app/src/entities/branches/constants.ts
+++ b/frontend/app/src/entities/branches/constants.ts
@@ -7,3 +7,6 @@ export const BRANCH_STATUS = {
 } as const;
 
 export type BranchStatus = (typeof BRANCH_STATUS)[keyof typeof BRANCH_STATUS];
+
+export const BRANCH_MERGED_EVENT = "infrahub.branch.merged";
+export const BRANCH_DELETED_EVENT = "infrahub.branch.deleted";

--- a/frontend/app/src/entities/proposed-changes/constants.ts
+++ b/frontend/app/src/entities/proposed-changes/constants.ts
@@ -1,3 +1,4 @@
+import { BRANCH_DELETED_EVENT, BRANCH_MERGED_EVENT } from "@/entities/branches/constants";
 import type { StateItem } from "@/entities/proposed-changes/ui/action-button/types";
 
 export const APPROVE_DECISION = "APPROVE";
@@ -39,6 +40,8 @@ export const PROPOSED_CHANGE_EVENTS = [
   PROPOSED_CHANGE_COMMENT,
   PROPOSED_CHANGE_THREAD,
   PROPOSED_CHANGE_APPROVALS_REVOKED,
+  BRANCH_MERGED_EVENT,
+  BRANCH_DELETED_EVENT,
 ];
 
 export const pcStatesList: Record<string, StateItem> = {


### PR DESCRIPTION
- `BranchDeletedEvent` and `BranchMergedEvent` now expose the associated proposed change (when present) as the event's **primary node** via `infrahub.node.id` / `infrahub.node.kind`, instead of attaching it through `get_related()`.
- Proposed change activity feed now subscribes to `infrahub.branch.merged` and `infrahub.branch.deleted`, so branch lifecycle events show up under the proposed change.
- Added `BRANCH_MERGED_EVENT` / `BRANCH_DELETED_EVENT` constants in the frontend branches entity and wired them into `PROPOSED_CHANGE_EVENTS`.
- Added unit tests covering the new resource payload for both events.
- Added changelog fragment documenting the breaking change for consumers filtering on `relatedNodes`.

<img width="1555" height="991" alt="image" src="https://github.com/user-attachments/assets/048940d1-6016-44c7-aefe-7d7e9f181023" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Branch merge/delete events now use the associated proposed change as the primary node (`infrahub.node.id` / `infrahub.node.kind`). This makes branch lifecycle events appear in the proposed change activity feed.

- **New Features**
  - Backend: Set the proposed change as the primary node for `infrahub.branch.merged` and `infrahub.branch.deleted` (removed from `get_related`).
  - Frontend: Added `BRANCH_MERGED_EVENT` and `BRANCH_DELETED_EVENT` and included them in `PROPOSED_CHANGE_EVENTS`.
  - Tests/Docs: Added unit tests for the new resource payload, updated integration tests to assert `primary_node`, and added a changelog entry.

- **Migration**
  - If you filter by proposed change using `relatedNodes`, switch to `primaryNodeIds`.
  - These branch events no longer include the proposed change under `relatedNodes`.

<sup>Written for commit 8f264ccf1db7d4f80b0a07e8a66f6e1ee2865a0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

