### PR TITLE
Last feedbacks from #8946

### DIFF
--- a/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
+++ b/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
@@ -131,11 +131,6 @@ def _extract_variables(template: str) -> list[str]:
     return InfrahubJinja2Template(template=template).get_variables()
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
 async def test_computed_attr_graphql_query_executes_successfully(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/backend/tests/unit/computed_attribute/test_models.py
+++ b/backend/tests/unit/computed_attribute/test_models.py
@@ -1,8 +1,6 @@
 import uuid
-from collections.abc import Callable
 from datetime import timedelta
 
-import pytest
 from prefect.events.schemas.automations import Automation, EventTrigger, Posture
 
 from infrahub.computed_attribute.constants import (
@@ -15,6 +13,30 @@ from infrahub.computed_attribute.models import ComputedAttributeAutomations, Com
 from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.schema import AttributeSchema, NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
+
+
+def _build_schema(
+    relationship_name: str = "parent",
+    peer: str = "TestingCountry",
+    hierarchical: str | None = "TestingLocation",
+) -> NodeSchema:
+    return NodeSchema(
+        name="Site",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="shortname", kind="Text"),
+            AttributeSchema(name="slug", kind="Text"),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name=relationship_name,
+                peer=peer,
+                hierarchical=hierarchical,
+                cardinality=RelationshipCardinality.ONE,
+                optional=False,
+            ),
+        ],
+    )
 
 
 def generate_automation(
@@ -72,36 +94,9 @@ async def test_load_from_prefect() -> None:
 
 
 class TestQueryFieldsInlineFragment:
-    @pytest.fixture(scope="class")
-    def build_schema(self) -> Callable[..., NodeSchema]:
-        def _build(
-            relationship_name: str = "parent",
-            peer: str = "TestingCountry",
-            hierarchical: str | None = "TestingLocation",
-        ) -> NodeSchema:
-            return NodeSchema(
-                name="Site",
-                namespace="Testing",
-                attributes=[
-                    AttributeSchema(name="shortname", kind="Text"),
-                    AttributeSchema(name="slug", kind="Text"),
-                ],
-                relationships=[
-                    RelationshipSchema(
-                        name=relationship_name,
-                        peer=peer,
-                        hierarchical=hierarchical,
-                        cardinality=RelationshipCardinality.ONE,
-                        optional=False,
-                    ),
-                ],
-            )
-
-        return _build
-
-    def test_uses_fragment_when_peer_differs_from_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_uses_fragment_when_peer_differs_from_hierarchical(self) -> None:
         """query_fields wraps attributes in an inline fragment when peer != hierarchical."""
-        schema = build_schema(peer="TestingCountry", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingCountry", hierarchical="TestingLocation")
         graphql_obj = ComputedAttrJinja2GraphQL(
             node_schema=schema,
             attribute_schema=schema.get_attribute(name="slug"),
@@ -120,9 +115,9 @@ class TestQueryFieldsInlineFragment:
         rendered = graphql_obj.render_graphql_query(query_filter="ids", filter_id="abc-123")
         assert "... on TestingCountry" in rendered
 
-    def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_for_non_hierarchical_relationship(self) -> None:
         """query_fields places attributes directly under node when relationship is not hierarchical."""
-        schema = build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
+        schema = _build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
         graphql_obj = ComputedAttrJinja2GraphQL(
             node_schema=schema,
             attribute_schema=schema.get_attribute(name="slug"),
@@ -138,9 +133,9 @@ class TestQueryFieldsInlineFragment:
         rendered = graphql_obj.render_graphql_query(query_filter="ids", filter_id="abc-123")
         assert "... on" not in rendered
 
-    def test_no_fragment_when_peer_equals_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_when_peer_equals_hierarchical(self) -> None:
         """query_fields places attributes directly under node when peer is the hierarchy generic itself."""
-        schema = build_schema(peer="TestingLocation", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingLocation", hierarchical="TestingLocation")
         graphql_obj = ComputedAttrJinja2GraphQL(
             node_schema=schema,
             attribute_schema=schema.get_attribute(name="slug"),

--- a/backend/tests/unit/display_labels/test_models.py
+++ b/backend/tests/unit/display_labels/test_models.py
@@ -1,44 +1,37 @@
-from collections.abc import Callable
-
-import pytest
-
 from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.schema import AttributeSchema, NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.display_labels.models import DisplayLabelJinja2GraphQL
 
 
+def _build_schema(
+    relationship_name: str = "parent",
+    peer: str = "TestingCountry",
+    hierarchical: str | None = "TestingLocation",
+) -> NodeSchema:
+    return NodeSchema(
+        name="Site",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="shortname", kind="Text"),
+            AttributeSchema(name="slug", kind="Text"),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name=relationship_name,
+                peer=peer,
+                hierarchical=hierarchical,
+                cardinality=RelationshipCardinality.ONE,
+                optional=False,
+            ),
+        ],
+    )
+
+
 class TestQueryFieldsInlineFragment:
-    @pytest.fixture(scope="class")
-    def build_schema(self) -> Callable[..., NodeSchema]:
-        def _build(
-            relationship_name: str = "parent",
-            peer: str = "TestingCountry",
-            hierarchical: str | None = "TestingLocation",
-        ) -> NodeSchema:
-            return NodeSchema(
-                name="Site",
-                namespace="Testing",
-                attributes=[
-                    AttributeSchema(name="shortname", kind="Text"),
-                    AttributeSchema(name="slug", kind="Text"),
-                ],
-                relationships=[
-                    RelationshipSchema(
-                        name=relationship_name,
-                        peer=peer,
-                        hierarchical=hierarchical,
-                        cardinality=RelationshipCardinality.ONE,
-                        optional=False,
-                    ),
-                ],
-            )
-
-        return _build
-
-    def test_uses_fragment_when_peer_differs_from_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_uses_fragment_when_peer_differs_from_hierarchical(self) -> None:
         """query_fields wraps attributes in an inline fragment when peer != hierarchical."""
-        schema = build_schema(peer="TestingCountry", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingCountry", hierarchical="TestingLocation")
         graphql_obj = DisplayLabelJinja2GraphQL(
             filter_key="ids",
             node_schema=schema,
@@ -57,9 +50,9 @@ class TestQueryFieldsInlineFragment:
         rendered = graphql_obj.render_graphql_query(filter_id="abc-123")
         assert "... on TestingCountry" in rendered
 
-    def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_for_non_hierarchical_relationship(self) -> None:
         """query_fields places attributes directly under node when relationship is not hierarchical."""
-        schema = build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
+        schema = _build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
         graphql_obj = DisplayLabelJinja2GraphQL(
             filter_key="ids",
             node_schema=schema,
@@ -72,9 +65,9 @@ class TestQueryFieldsInlineFragment:
         assert owner_node["name"] == {"value": None}
         assert not any(k.startswith("... on") for k in owner_node)
 
-    def test_no_fragment_when_peer_equals_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_when_peer_equals_hierarchical(self) -> None:
         """query_fields places attributes directly under node when peer is the hierarchy generic itself."""
-        schema = build_schema(peer="TestingLocation", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingLocation", hierarchical="TestingLocation")
         graphql_obj = DisplayLabelJinja2GraphQL(
             filter_key="ids",
             node_schema=schema,

--- a/backend/tests/unit/hfid/test_models.py
+++ b/backend/tests/unit/hfid/test_models.py
@@ -1,44 +1,37 @@
-from collections.abc import Callable
-
-import pytest
-
 from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.schema import AttributeSchema, NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.hfid.models import HFIDGraphQL
 
 
+def _build_schema(
+    relationship_name: str = "parent",
+    peer: str = "TestingCountry",
+    hierarchical: str | None = "TestingLocation",
+) -> NodeSchema:
+    return NodeSchema(
+        name="Site",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="shortname", kind="Text"),
+            AttributeSchema(name="slug", kind="Text"),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name=relationship_name,
+                peer=peer,
+                hierarchical=hierarchical,
+                cardinality=RelationshipCardinality.ONE,
+                optional=False,
+            ),
+        ],
+    )
+
+
 class TestQueryFieldsInlineFragment:
-    @pytest.fixture(scope="class")
-    def build_schema(self) -> Callable[..., NodeSchema]:
-        def _build(
-            relationship_name: str = "parent",
-            peer: str = "TestingCountry",
-            hierarchical: str | None = "TestingLocation",
-        ) -> NodeSchema:
-            return NodeSchema(
-                name="Site",
-                namespace="Testing",
-                attributes=[
-                    AttributeSchema(name="shortname", kind="Text"),
-                    AttributeSchema(name="slug", kind="Text"),
-                ],
-                relationships=[
-                    RelationshipSchema(
-                        name=relationship_name,
-                        peer=peer,
-                        hierarchical=hierarchical,
-                        cardinality=RelationshipCardinality.ONE,
-                        optional=False,
-                    ),
-                ],
-            )
-
-        return _build
-
-    def test_uses_fragment_when_peer_differs_from_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_uses_fragment_when_peer_differs_from_hierarchical(self) -> None:
         """query_fields wraps attributes in an inline fragment when peer != hierarchical."""
-        schema = build_schema(peer="TestingCountry", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingCountry", hierarchical="TestingLocation")
         graphql_obj = HFIDGraphQL(
             filter_key="ids",
             node_schema=schema,
@@ -57,9 +50,9 @@ class TestQueryFieldsInlineFragment:
         rendered = graphql_obj.render_graphql_query(filter_id="abc-123")
         assert "... on TestingCountry" in rendered
 
-    def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_for_non_hierarchical_relationship(self) -> None:
         """query_fields places attributes directly under node when relationship is not hierarchical."""
-        schema = build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
+        schema = _build_schema(relationship_name="owner", peer="TestingCountry", hierarchical=None)
         graphql_obj = HFIDGraphQL(
             filter_key="ids",
             node_schema=schema,
@@ -72,9 +65,9 @@ class TestQueryFieldsInlineFragment:
         assert owner_node["name"] == {"value": None}
         assert not any(k.startswith("... on") for k in owner_node)
 
-    def test_no_fragment_when_peer_equals_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
+    def test_no_fragment_when_peer_equals_hierarchical(self) -> None:
         """query_fields places attributes directly under node when peer is the hierarchy generic itself."""
-        schema = build_schema(peer="TestingLocation", hierarchical="TestingLocation")
+        schema = _build_schema(peer="TestingLocation", hierarchical="TestingLocation")
         graphql_obj = HFIDGraphQL(
             filter_key="ids",
             node_schema=schema,


### PR DESCRIPTION
Last feedbacks from https://github.com/opsmill/infrahub/pull/8946 which should not block the release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified unit tests by replacing class-scoped `pytest` fixtures with module-level helpers and removing unused imports/comments. No behavior changes or production code impact.

- **Refactors**
  - Replaced `build_schema` fixtures with `_build_schema` functions in computed_attribute, display_labels, and hfid tests.
  - Removed unused `pytest`/`Callable` imports and dropped a redundant comment block in the GraphQL component test.

<sup>Written for commit 79d29bb210ccc2c614067de13b3e0e78aa130631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

