### PR TITLE
Refactor Select and ListBoxItem into unified component API

### DIFF
--- a/frontend/app/biome.jsonc
+++ b/frontend/app/biome.jsonc
@@ -8,6 +8,7 @@
   "files": {
     "ignoreUnknown": false,
     "includes": [
+      "**",
       "!coverage",
       "!dist",
       "!playwright-report",

--- a/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
-import { ListBoxItem } from "@/shared/components/aria/list-box";
-import { Select, SelectList, SelectTrigger } from "@/shared/components/aria/select";
+import { Select, SelectItem, SelectList, SelectTrigger } from "@/shared/components/aria/select";
 import { getCurrentFilterCondition } from "@/shared/components/filters/utils/get-current-filter-condition";
 import { FormField } from "@/shared/components/ui/form";
 import useFilters, { type Filter } from "@/shared/hooks/useFilters";
@@ -84,16 +83,13 @@ export function DecisionFilterForm({
             <Select
               aria-label="select a decision"
               placeholder="Select a decision"
-              selectedKey={field.value ?? null}
-              onSelectionChange={(key) => field.onChange(key)}
+              value={field.value ?? null}
+              onChange={(key) => field.onChange(key)}
             >
-              <SelectTrigger className="min-w-40" />
+              <SelectTrigger className="min-w-40 rounded-xl" />
+
               <SelectList items={options}>
-                {(item) => (
-                  <ListBoxItem id={item.value} textValue={item.label}>
-                    {item.label}
-                  </ListBoxItem>
-                )}
+                {(item) => <SelectItem id={item.value}>{item.label}</SelectItem>}
               </SelectList>
             </Select>
           )}

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
@@ -148,21 +148,18 @@ function FilterPickerItem({ definition, hasActiveFilter, ref }: FilterPickerItem
     <ListBoxItem
       id={name}
       textValue={label}
+      selectionIndicator="none"
       className={({ isSelected }) => classNames(isSelected && "bg-stone-700/10 text-stone-800")}
       ref={ref}
     >
-      {({ isSelected }) => (
-        <>
-          {definition.type === "relationship" ? (
-            <FieldSchemaIcon fieldSchema={definition.schema} />
-          ) : (
-            <Icon icon={getFilterDefinitionIcon(definition)} />
-          )}
-          <span className="mr-auto">{label}</span>
-          {hasActiveFilter && <ActiveFilterIndicator />}
-          <ChevronRightIcon className={classNames("size-3.5", isSelected && "opacity-0")} />
-        </>
+      {definition.type === "relationship" ? (
+        <FieldSchemaIcon fieldSchema={definition.schema} />
+      ) : (
+        <Icon icon={getFilterDefinitionIcon(definition)} />
       )}
+      <span className="mr-auto">{label}</span>
+      {hasActiveFilter && <ActiveFilterIndicator />}
+      <ChevronRightIcon className={classNames("size-3.5")} />
     </ListBoxItem>
   );
 }

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -36,6 +36,7 @@ const listBoxItemBaseStyle =
   "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden";
 export interface ListBoxItemProps<T> extends AriaListBoxItemProps<T> {
   ref?: React.Ref<HTMLDivElement>;
+  selectionIndicator?: "checkmark" | "none";
 }
 
 export function ListBoxItem<T extends object>({
@@ -43,17 +44,19 @@ export function ListBoxItem<T extends object>({
   className,
   textValue,
   ref,
+  selectionIndicator = "checkmark",
   ...props
 }: ListBoxItemProps<T>) {
   return (
     <AriaListBoxItem
       ref={ref}
       textValue={textValue || (typeof children === "string" ? children : undefined)}
-      className={composeRenderProps(className, (className) =>
+      className={composeRenderProps(className, (className, { isSelected, isFocused }) =>
         classNames(
           disabledStyle,
           listBoxItemBaseStyle,
-          "data-focused:bg-stone-700/10 data-focused:text-stone-800",
+          isFocused && "bg-stone-700/10 text-stone-800",
+          isSelected && selectionIndicator === "none" && "bg-stone-700/10",
           className
         )
       )}
@@ -62,7 +65,9 @@ export function ListBoxItem<T extends object>({
       {(renderProps) => (
         <>
           {typeof children === "function" ? children(renderProps) : children}
-          {renderProps.isSelected && <CheckIcon className="absolute right-3 size-4" />}
+          {renderProps.isSelected && selectionIndicator === "checkmark" && (
+            <CheckIcon className={classNames("ml-auto size-4 shrink-0")} />
+          )}
         </>
       )}
     </AriaListBoxItem>

--- a/frontend/app/src/shared/components/aria/select.tsx
+++ b/frontend/app/src/shared/components/aria/select.tsx
@@ -2,14 +2,13 @@ import { ChevronDownIcon } from "lucide-react";
 import {
   Button as AriaButton,
   type ButtonProps as AriaButtonProps,
-  ListBox as AriaListBox,
   type ListBoxProps as AriaListBoxProps,
   Select as AriaSelect,
   SelectValue as AriaSelectValue,
   composeRenderProps,
 } from "react-aria-components";
 
-import { ListBoxItem, type ListBoxItemProps } from "@/shared/components/aria/list-box";
+import { ListBox, ListBoxItem, type ListBoxItemProps } from "@/shared/components/aria/list-box";
 import { Popover, type PopoverProps } from "@/shared/components/aria/popover";
 import { focusVisibleStyle } from "@/shared/components/aria/style-rac";
 import { inputStyle } from "@/shared/components/ui/style";
@@ -40,7 +39,7 @@ export const SelectPopover = ({ className, ...props }: PopoverProps) => (
 
 export const SelectList = <T extends object>({ ...props }: AriaListBoxProps<T>) => (
   <SelectPopover>
-    <AriaListBox selectionMode="single" className="p-1" {...props} />
+    <ListBox selectionMode="single" className="p-1" {...props} />
   </SelectPopover>
 );
 

--- a/frontend/app/src/shared/components/aria/select.tsx
+++ b/frontend/app/src/shared/components/aria/select.tsx
@@ -1,18 +1,17 @@
-import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import {
   Button as AriaButton,
   type ButtonProps as AriaButtonProps,
   ListBox as AriaListBox,
-  ListBoxItem as AriaListBoxItem,
-  type ListBoxItemProps as AriaListBoxItemProps,
   type ListBoxProps as AriaListBoxProps,
   Select as AriaSelect,
   SelectValue as AriaSelectValue,
   composeRenderProps,
 } from "react-aria-components";
 
+import { ListBoxItem, type ListBoxItemProps } from "@/shared/components/aria/list-box";
 import { Popover, type PopoverProps } from "@/shared/components/aria/popover";
-import { disabledStyle, focusVisibleStyle } from "@/shared/components/aria/style-rac";
+import { focusVisibleStyle } from "@/shared/components/aria/style-rac";
 import { inputStyle } from "@/shared/components/ui/style";
 import { classNames } from "@/shared/utils/common";
 
@@ -25,7 +24,7 @@ export const SelectTrigger = ({ className, children, ...props }: AriaButtonProps
     )}
     {...props}
   >
-    <AriaSelectValue className="grow truncate data-placeholder:text-gray-400" />
+    <AriaSelectValue className="truncate data-placeholder:text-gray-400" />
     <ChevronDownIcon className="ml-auto size-4" />
   </AriaButton>
 );
@@ -33,52 +32,25 @@ export const SelectTrigger = ({ className, children, ...props }: AriaButtonProps
 export const SelectPopover = ({ className, ...props }: PopoverProps) => (
   <Popover
     className={composeRenderProps(className, (className) =>
-      classNames("min-w-(--trigger-width) bg-white", className)
+      classNames("min-w-(--trigger-width)", className)
     )}
     {...props}
   />
 );
 
-export const SelectList = <T extends object>({ className, ...props }: AriaListBoxProps<T>) => (
+export const SelectList = <T extends object>({ ...props }: AriaListBoxProps<T>) => (
   <SelectPopover>
-    <AriaListBox
-      className={composeRenderProps(className, (className) =>
-        classNames(
-          "max-h-[inherit] overflow-auto p-1 outline-hidden [clip-path:inset(0_0_0_0_round_calc(var(--radius)-2px))]",
-          className
-        )
-      )}
-      {...props}
-    />
+    <AriaListBox selectionMode="single" className="p-1" {...props} />
   </SelectPopover>
 );
 
-export const SelectItem = <T extends object>({
-  children,
-  className,
-  textValue,
-  ...props
-}: AriaListBoxItemProps<T>) => {
+export const SelectItem = <T extends object>({ className, ...props }: ListBoxItemProps<T>) => {
   return (
-    <AriaListBoxItem
-      textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={composeRenderProps(className, (className) =>
-        classNames(
-          disabledStyle,
-          "relative flex w-full select-none items-center rounded-lg px-2 py-1.5 text-sm outline-hidden",
-          "data-focused:bg-stone-100",
-          "data-selection-mode:pl-8",
-          className
-        )
+    <ListBoxItem
+      className={composeRenderProps(className, (className, { isSelected }) =>
+        classNames(!isSelected && "pr-8", className)
       )}
       {...props}
-    >
-      {composeRenderProps(children, (children, { isSelected }) => (
-        <>
-          {isSelected && <CheckIcon className="absolute left-2 size-4" />}
-          {children}
-        </>
-      ))}
-    </AriaListBoxItem>
+    />
   );
 };

--- a/frontend/app/src/shared/components/form/fields/select.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/select.field.tsx
@@ -58,7 +58,7 @@ export function SelectField({
                 <Label>{label}</Label>
                 <SelectTrigger />
 
-                <SelectList selectionMode="single" items={items}>
+                <SelectList items={items}>
                   {(item) => (
                     <SelectItem key={item.key} textValue={item.label}>
                       {item.label}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies the Select and ListBoxItem APIs by integrating Select with the shared ListBox and moving checkmark logic into ListBoxItem. Switches Select to value/onChange and simplifies popover and item styling for consistency.

- **Refactors**
  - SelectItem now wraps ListBoxItem; selectionIndicator ("checkmark" | "none") controls checkmark visibility and spacing.
  - SelectList uses the shared ListBox, defaults to single, and uses a lighter popover; labels truncate consistently and non-selected items keep alignment.
  - Filter picker items set selectionIndicator="none" and always show the chevron.
  - Fix `biome.jsonc` includes to scan all files.

- **Migration**
  - Replace selectedKey/onSelectionChange with value/onChange on Select.
  - Use SelectItem inside SelectList instead of ListBoxItem.
  - Remove selectionMode="single" where passed to SelectList.
  - Pass selectionIndicator="none" when you don’t want a checkmark (e.g., items with a trailing chevron).

<sup>Written for commit dea9042ae28d519db94814e54439a98707a00659. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

