### PR TITLE
Linting cleanup for testcontainer package

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/__init__.py
+++ b/python_testcontainers/infrahub_testcontainers/__init__.py
@@ -1,6 +1,3 @@
-import importlib.metadata
+from ._version import __version__
 
-try:
-    __version__ = importlib.metadata.version("infrahub-testcontainers")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = importlib.metadata.version("infrahub-server")
+__all__ = ["__version__"]

--- a/python_testcontainers/infrahub_testcontainers/_version.py
+++ b/python_testcontainers/infrahub_testcontainers/_version.py
@@ -1,0 +1,6 @@
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("infrahub-testcontainers")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = importlib.metadata.version("infrahub-server")

--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -229,7 +229,6 @@ class InfrahubDockerCompose(DockerCompose):
             up_cmd.append(service_name)
         self._run_command(cmd=up_cmd)
 
-    # TODO would be good to the support for project_name upstream
     @cached_property
     def compose_command_property(self) -> list[str]:
         docker_compose_cmd = [self.docker_command_path or "docker", "compose"]

--- a/python_testcontainers/infrahub_testcontainers/helpers.py
+++ b/python_testcontainers/infrahub_testcontainers/helpers.py
@@ -4,11 +4,14 @@ import os
 import subprocess  # noqa: S404
 import uuid
 import warnings
-from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from prefect.client.orchestration import PrefectClient
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 from infrahub_testcontainers import __version__ as infrahub_version
 

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
-from types import TracebackType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
-import pytest
 from typing_extensions import Self
 
 from .constants import PERFORMANCE_TEST_KIND, PERFORMANCE_TEST_VERSION
-from .helpers import InfrahubDockerCompose
 from .host import get_system_stats
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    import pytest
+
+    from .helpers import InfrahubDockerCompose
 from .models import (
     ContextUnit,
     InfrahubActiveMeasurementItem,

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -71,33 +71,15 @@ ignore = [
     "E501",     # Line too long
     "EM101",    # Exception must not use a string literal, assign to variable first
     "EM102",    # Exception must not use an f-string literal, assign to variable first
-    "FBT001",   # Boolean-typed positional argument in function definition
-    "FBT002",   # Boolean default positional argument in function definition
-    "FIX002",   # Line contains TODO, consider resolving the issue
+    "FBT001",   # Boolean-typed positional argument in function definition — breaking change to fix
+    "FBT002",   # Boolean default positional argument in function definition — breaking change to fix
     "PERF203",  # `try`-`except` within a loop incurs performance overhead
     "PLR0912",  # Too many branches
     "PLR0914",  # Too many local variables
     "PLR6301",  # Method `infrahub_app` could be a function, class method, or static method
-    "RUF067",   # `__init__` module should only contain docstrings and re-exports
-    "SLF001",   # Private member accessed: `_session`
-    "TC001",    # Move application import `.helpers.InfrahubDockerCompose` into a type-checking block
-    "TC002",    # Move third-party import `pytest` into a type-checking block
-    "TC003",    # Move standard library import `types.TracebackType` into a type-checking block
-    "TD002",    # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`
-    "TD003",    # Missing issue link for this TODO
-    "TD004",    # Missing colon in TODO
+    "SLF001",   # Private member accessed: `_session` (pytest internal API, no public alternative)
     "TRY002",   # Create your own exception
     "TRY003",   # Avoid specifying long messages outside the exception class
-]
-
-"tests/**.py" = [
-    ##################################################################################################
-    # Rules below needs to be Investigated                                                           #
-    ##################################################################################################
-    "EM101",    # Exception must not use a string literal, assign to variable first
-    "PGH003",   # Use specific rule codes when ignoring type issues
-    "RUF067",   # `__init__` module should only contain docstrings and re-exports
-    "TC003",    # Move standard library import into a type-checking block
 ]
 
 

--- a/python_testcontainers/tests/__init__.py
+++ b/python_testcontainers/tests/__init__.py
@@ -1,7 +1,0 @@
-import builtins
-
-from rich import inspect as rinspect
-from rich import print as rprint
-
-builtins.rinspect = rinspect  # type: ignore
-builtins.rprint = rprint  # type: ignore

--- a/python_testcontainers/tests/conftest.py
+++ b/python_testcontainers/tests/conftest.py
@@ -1,0 +1,7 @@
+import builtins
+
+from rich import inspect as rinspect
+from rich import print as rprint
+
+builtins.rinspect = rinspect  # type: ignore[attr-defined]
+builtins.rprint = rprint  # type: ignore[attr-defined]

--- a/python_testcontainers/tests/test_container_postgres_backup.py
+++ b/python_testcontainers/tests/test_container_postgres_backup.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from testcontainers.core.exceptions import ContainerIsNotRunning
 
 from infrahub_testcontainers.container import InfrahubDockerCompose
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @pytest.fixture(name="compose_factory")
@@ -87,7 +90,8 @@ def test_task_manager_db_restore_backup_runs_expected_commands(
 
     def _raise(service_name: str) -> None:
         _ = service_name
-        raise ContainerIsNotRunning("task-manager-db")
+        msg = "task-manager-db"
+        raise ContainerIsNotRunning(msg)
 
     compose.get_container = _raise  # type: ignore[assignment]
     started_services: list[str] = []


### PR DESCRIPTION
# Why

Various small linting cleanups within the testcontainer package.

## What changed



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linting cleanup across the `infrahub_testcontainers` package to align with ruff and tidy test structure. Extracts version export, moves type-only imports behind `TYPE_CHECKING`, and simplifies ruff config.

- **Refactors**
  - Extract version lookup to `infrahub_testcontainers/_version.py`; `__init__` now re-exports `__version__`.
  - Gate type-only imports with `TYPE_CHECKING` in helpers, performance tests, and unit tests.
  - Move Rich test helpers from `tests/__init__.py` to `tests/conftest.py` with correct `type: ignore` hints.
  - Remove a stale TODO and adjust a test to avoid inline exception string literals.
  - Trim ruff ignores in `pyproject.toml` (drop unused rules and test-specific overrides).

<sup>Written for commit 7c7cccca77f5c39e79012b01b809224758981410. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

