### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/backend/infrahub/api/auth.py
+++ b/backend/infrahub/api/auth.py
@@ -25,10 +25,20 @@ async def login_user(
 ) -> models.UserToken:
     token = await authenticate_with_password(db=db, credentials=credentials)
     response.set_cookie(
-        "access_token", token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token",
+        token.access_token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=config.SETTINGS.security.access_token_lifetime,
     )
     response.set_cookie(
-        "refresh_token", token.refresh_token, httponly=True, max_age=config.SETTINGS.security.refresh_token_lifetime
+        "refresh_token",
+        token.refresh_token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=config.SETTINGS.security.refresh_token_lifetime,
     )
     return token
 
@@ -41,7 +51,12 @@ async def refresh_jwt_token(
 ) -> models.AccessTokenResponse:
     token = await create_fresh_access_token(db=db, refresh_data=refresh_token)
     response.set_cookie(
-        "access_token", token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token",
+        token.access_token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=config.SETTINGS.security.access_token_lifetime,
     )
 
     return token
@@ -54,5 +69,5 @@ async def logout(
     if user_session.session_id:
         await invalidate_refresh_token(db=db, token_id=user_session.session_id)
 
-    response.delete_cookie("access_token")
-    response.delete_cookie("refresh_token")
+    response.delete_cookie("access_token", secure=True, httponly=True, samesite="lax")
+    response.delete_cookie("refresh_token", secure=True, httponly=True, samesite="lax")

--- a/backend/infrahub/api/storage/storage.py
+++ b/backend/infrahub/api/storage/storage.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 router = APIRouter(prefix="/storage")
 router.include_router(file_object.router)
 
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024
+
 
 class UploadResponse(BaseModel):
     identifier: str
@@ -49,8 +51,10 @@ async def get_file(
 @router.post("/upload/content")
 def upload_content(item: UploadContentPayload, _: str = Depends(get_current_user)) -> UploadResponse:
     file_content = bytes(item.content, encoding="utf-8")
-    identifier = str(UUIDT())
+    if len(file_content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="Uploaded content exceeds maximum allowed size.")
 
+    identifier = str(UUIDT())
     checksum = hashlib.md5(file_content, usedforsecurity=False).hexdigest()
     registry.storage.store(identifier=identifier, content=io.BytesIO(file_content))
     return UploadResponse(identifier=identifier, checksum=checksum)
@@ -61,7 +65,11 @@ def upload_file(file: UploadFile = File(...), _: AccountSession = Depends(get_cu
     identifier = str(UUIDT())
 
     hasher = hashlib.md5(usedforsecurity=False)
+    file_size = 0
     while chunk := file.file.read(65536):
+        file_size += len(chunk)
+        if file_size > MAX_UPLOAD_SIZE:
+            raise HTTPException(status_code=413, detail="Uploaded file exceeds maximum allowed size.")
         hasher.update(chunk)
     checksum = hasher.hexdigest()
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `backend/infrahub/api/auth.py:L26`

Access and refresh tokens are set as HttpOnly cookies, but `secure` and `samesite` attributes are not explicitly set. Without `Secure`, cookies may be sent over non-HTTPS connections in some deployments. Without an appropriate `SameSite` policy, cross-site request forgery (CSRF) risk is increased for cookie-authenticated endpoints.

## Solution

Set cookie flags explicitly when issuing tokens, e.g. `secure=True` (in production), `samesite='Lax'` or `'Strict'`, and consider explicit `path`/`domain` scoping. Add CSRF defenses for state-changing cookie-authenticated endpoints.

## Changes

- `backend/infrahub/api/auth.py` (modified)
- `backend/infrahub/api/storage/storage.py` (modified)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure auth cookies by adding Secure and SameSite=Lax, and add 10 MB limits to upload endpoints to block CSRF/downgrade and DoS vectors.

- **Bug Fixes**
  - Auth cookies now set with `secure=True` and `samesite="lax"` on login/refresh; same attributes used when deleting cookies.
  - Enforced 10 MB max for `/storage/upload/content` and `/storage/upload/file`; returns 413 when exceeded and streams size checks during file uploads.

- **Migration**
  - Cookie-based auth now requires HTTPS in browsers. Ensure TLS termination in all environments (including local dev via https://localhost).

<sup>Written for commit a31aab1f4daa7bf9a9e250d7cc23f19f43ad1889. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

