### PR TITLE
Replace "Where" with field label in filter forms

### DIFF
--- a/frontend/app/src/entities/branches/ui/filters/branch-status-filter-form.tsx
+++ b/frontend/app/src/entities/branches/ui/filters/branch-status-filter-form.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { getCurrentFilterCondition } from "@/shared/components/filters/utils/get-current-filter-condition";
-import { Form, FormField, FormSubmit } from "@/shared/components/ui/form";
+import { FormField } from "@/shared/components/ui/form";
 import useFilters, { type Filter } from "@/shared/hooks/useFilters";
 
 import type { BranchStatus } from "@/entities/branches/constants";
@@ -10,8 +10,8 @@ import { BranchStatusEnum } from "@/entities/branches/ui/filters/branch-status-e
 import {
   FILTER_CONDITION,
   type FilterCondition,
-  FilterConditionSelect,
 } from "@/entities/nodes/object/ui/filters/filter-condition-select";
+import { FilterFormLayout } from "@/entities/nodes/object/ui/filters/filter-form-layout";
 
 export interface BranchStatusFilterFormProps {
   onSuccess?: () => void;
@@ -66,44 +66,35 @@ export function BranchStatusFilterForm({ onSuccess }: BranchStatusFilterFormProp
   };
 
   return (
-    <div className="flex gap-2 p-2">
-      <div className="inline-flex h-10 items-center">Where</div>
-
-      <FilterConditionSelect
-        filterType="attribute"
-        value={condition}
-        onChange={(key) => setCondition(key as FilterCondition)}
-      />
-
-      <Form
-        className="flex gap-2 space-y-0"
-        onSubmit={(formData) => {
-          handleSubmit(formData as Record<string, BranchStatus | null>);
-          onSuccess?.();
-        }}
-        data-testid="branch-status-filter-form"
-      >
-        {condition === FILTER_CONDITION.CONTAINS && (
-          <FormField
-            name="attribute"
-            defaultValue={
-              currentFilter &&
-              getCurrentFilterCondition(currentFilter) === FILTER_CONDITION.CONTAINS
-                ? currentFilter.value
-                : undefined
-            }
-            render={({ field }) => (
-              <BranchStatusEnum
-                value={field.value as BranchStatus | null}
-                onChange={field.onChange}
-                defaultOpen
-              />
-            )}
-          />
-        )}
-
-        <FormSubmit>Apply</FormSubmit>
-      </Form>
-    </div>
+    <FilterFormLayout
+      filterType="attribute"
+      label={fieldSchema.label}
+      condition={condition}
+      onConditionChange={setCondition}
+      testId="decision-filter-form"
+      onSubmit={(formData) => {
+        handleSubmit(formData as Record<string, BranchStatus | null>);
+        onSuccess?.();
+      }}
+      data-testid="branch-status-filter-form"
+    >
+      {condition === FILTER_CONDITION.CONTAINS && (
+        <FormField
+          name="attribute"
+          defaultValue={
+            currentFilter && getCurrentFilterCondition(currentFilter) === FILTER_CONDITION.CONTAINS
+              ? currentFilter.value
+              : undefined
+          }
+          render={({ field }) => (
+            <BranchStatusEnum
+              value={field.value as BranchStatus | null}
+              onChange={field.onChange}
+              defaultOpen
+            />
+          )}
+        />
+      )}
+    </FilterFormLayout>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
@@ -75,6 +75,7 @@ export function AttributeFilterForm({ attributeSchema, onSuccess }: AttributeFil
   return (
     <FilterFormLayout
       filterType={isDatetime ? "datetime" : "attribute"}
+      label={attributeSchema.label}
       condition={condition}
       onConditionChange={setCondition}
       testId="attribute-filter-form"

--- a/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.tsx
@@ -75,6 +75,7 @@ export function DateMetadataFilterForm({ definition, onSuccess }: DateMetadataFi
   return (
     <FilterFormLayout
       filterType="metadata-date"
+      label={definition.label}
       condition={condition}
       onConditionChange={setCondition}
       testId="metadata-date-filter-form"

--- a/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/decision-filter-form.tsx
@@ -67,6 +67,7 @@ export function DecisionFilterForm({
   return (
     <FilterFormLayout
       filterType="permission-decision"
+      label={attributeSchema.label}
       condition={condition}
       onConditionChange={setCondition}
       testId="decision-filter-form"

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-form-layout.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-form-layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type React from "react";
 
 import { Col, Row } from "@/shared/components/container";
 import { Form, FormSubmit } from "@/shared/components/ui/form";
@@ -15,7 +15,8 @@ interface FilterFormLayoutProps {
   onConditionChange: (condition: FilterCondition) => void;
   testId: string;
   onSubmit: (formData: Record<string, unknown>) => void;
-  children?: ReactNode;
+  children?: React.ReactNode;
+  label?: React.ReactNode;
 }
 
 export function FilterFormLayout({
@@ -25,11 +26,12 @@ export function FilterFormLayout({
   testId,
   onSubmit,
   children,
+  label,
 }: FilterFormLayoutProps) {
   return (
     <Col className="max-h-[inherit] overflow-hidden p-2">
       <Row className="shrink-0 gap-0">
-        <span className="font-semibold text-sm">Where</span>
+        <span className="font-semibold text-sm">{label}</span>
         <FilterConditionSelect
           filterType={filterType}
           value={condition}

--- a/frontend/app/src/entities/nodes/object/ui/filters/relationship-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/relationship-filter-form.tsx
@@ -78,6 +78,7 @@ export function RelationshipFilterForm({
   return (
     <FilterFormLayout
       filterType="relationship"
+      label={relationshipSchema.label}
       condition={condition}
       onConditionChange={setCondition}
       testId="relationship-filter-form"

--- a/frontend/app/src/entities/nodes/object/ui/filters/user-metadata-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/user-metadata-filter-form.tsx
@@ -41,6 +41,7 @@ export function UserMetadataFilterForm({ definition, onSuccess }: UserMetadataFi
   return (
     <FilterFormLayout
       filterType="metadata-user"
+      label={definition.label}
       condition={FILTER_CONDITION.IS_ANY_OF}
       onConditionChange={() => {}}
       testId="metadata-user-filter-form"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace the generic "Where" label in filter forms with the actual field label to make filters clearer and easier to scan. Also includes stability fixes in backend GraphQL/schema processing, better branch navigation after delete/merge, CI pipeline updates, and minor frontend dependency bumps.

- **Bug Fixes**
  - Use inline fragments for hierarchical relationship attributes in computed attributes, display labels, and HFIDs, fixing failures when referencing concrete peer fields.
  - Make schema loading idempotent by ordering HFID and uniqueness processing correctly; propagate generic uniqueness to nodes.
  - On git re-clone, mark repositories as reinitialized and re-import objects during sync to avoid missed imports.
  - Clean up the branch query param and navigate correctly after branch deletion or merge; merging proposed changes uses the default branch as context.

- **Dependencies**
  - Frontend: bump `@headlessui/react`, `@tanstack/react-query`, `@tanstack/react-query-devtools`, `@rolldown/plugin-babel`, `@uiw/react-color`.
  - Workflows/CI: rename `/bug-test` to `/bug-tdd`, add `bug-analyze`/`bug-tdd`/`bug-fix` command docs, tighten permissions, and add an `update-sdk-compatibility-docs` workflow.

<sup>Written for commit a59652c0599cf574a2a508752b840f732e969736. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

