### PR TITLE
fix(ci): missing npm install in sdk compat docs job

### DIFF
--- a/.github/workflows/update-sdk-compatibility-docs.yml
+++ b/.github/workflows/update-sdk-compatibility-docs.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
 
+      - name: Install NodeJS
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm install
+        working-directory: ./docs
+
       - name: Run compatibility update script
         env:
           GITHUB_TOKEN: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/pull/8813

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Node.js setup and `npm install` to the SDK compatibility docs CI job so the update script has required JS deps. Uses Node 24 and caches `npm` for faster runs.

- **Bug Fixes**
  - Configure Node with `actions/setup-node@v5` (Node 24) and cache based on `docs/package-lock.json`.
  - Run `npm install` in `./docs` before the compatibility update script.

<sup>Written for commit a3e7b494ef6c1afaf46042acb63cb66ce487c0fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

