### PR TITLE
refactor: replace lambda with operator.itemgetter in query result sorting

### DIFF
--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import starmap
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.constants import RelationshipStatus
@@ -89,10 +90,7 @@ class AttributeRemoveQuery(Query):
             subquery.append("RETURN peer_node as p2")
             return "\n".join(subquery)
 
-        sub_queries = [
-            render_sub_query_per_rel_type(rel_type, rel_def)
-            for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
-        ]
+        sub_queries = list(starmap(render_sub_query_per_rel_type, GraphAttributeRelationships.model_fields.items()))
         sub_query_all = "\nUNION\n".join(sub_queries)
 
         node_kinds_str = "|".join(self.node_kinds + profile_kinds_to_update + template_kinds_to_update)

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import starmap
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -118,16 +119,14 @@ class AttributeRenameQuery(Query):
         # Set metadata for vertex properties on default/global branch
         self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
 
-        sub_queries_create = [
-            self._render_sub_query_per_rel_type_create_new(rel_type, rel_def)
-            for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
-        ]
+        sub_queries_create = list(
+            starmap(self._render_sub_query_per_rel_type_create_new, GraphAttributeRelationships.model_fields.items())
+        )
         sub_query_create_all = "\nUNION\n".join(sub_queries_create)
 
-        sub_queries_update = [
-            self._render_sub_query_per_rel_type_update_active(rel_type, rel_def)
-            for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
-        ]
+        sub_queries_update = list(
+            starmap(self._render_sub_query_per_rel_type_update_active, GraphAttributeRelationships.model_fields.items())
+        )
         sub_query_update_all = "\nUNION\n".join(sub_queries_update)
 
         self.add_to_query(self.render_match())

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -634,7 +635,7 @@ class Query:
         for idx, result in enumerate(self.results):
             score_idx[idx] = result.branch_score
 
-        for idx, _ in sorted(score_idx.items(), key=lambda x: x[1], reverse=True):
+        for idx, _ in sorted(score_idx.items(), key=operator.itemgetter(1), reverse=True):
             yield self.results[idx]
 
     def get_results_group_by(self, *args: Any) -> Generator[QueryResult, None, None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -572,8 +572,6 @@ allow-dunder-method-names = [
     "FIX",      # flake8-fixme
     "FURB113",  # Use `extend(...)` instead of repeatedly calling `append()`
     "INP001",   # File is part of an implicit namespace package
-    "FURB118",  # Use `operator.itemgetter(1)` instead of defining a lambda
-    "FURB140",  # Use `itertools.starmap` instead of the generator
     "N801",     # Class name should use CapWords convention
     "N806",     # Variable in function should be lowercase
     "PERF401",  # Use a list comprehension to create a transformed list


### PR DESCRIPTION
# Why

These two ruff rules (FURB118, FURB140) were previously suppressed. The fixes are straightforward — operator.itemgetter and itertools.starmap are the idiomatic stdlib alternatives when a lambda or comprehension does nothing but unpack and forward arguments to a function. Enabling the rules and fixing the violations reduces the ignore list and keeps the codebase consistent with the rest of the ruff configuration.

## What changed

Removed FURB118 and FURB140 from the ruff ignore list in pyproject.toml and fixed all violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced lambda and manual unpacking with stdlib helpers for clearer code and `ruff` compliance. Removed `FURB118` and `FURB140` from the ignore list and fixed all violations.

- Refactors
  - Use `operator.itemgetter(1)` for result sorting in `backend/infrahub/core/query/__init__.py`.
  - Use `itertools.starmap` to build relationship subqueries in `attribute_remove.py` and `attribute_rename.py`.

<sup>Written for commit 52843a355d225b61c32be50116cd9a234319478b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

