### PR TITLE
Raise version to 1.9.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.0b0"
+version = "1.9.0b1"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.0b0"
+version = "1.9.0b1"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.0b0"
+version = "1.9.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.0b0"
+version = "1.9.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

Prepare for 1.9.0 beta 1

## What changed

* Version bump

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump versions to 1.9.0b1 for `infrahub-server` and `infrahub-testcontainers`. Update both `uv.lock` files to prepare the 1.9.0 beta 1 release.

<sup>Written for commit b3f15ce907f73335b0c879961c3e5323dcde79a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

