### PR TITLE
Transition to dynamic versions from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.0b0"
+dynamic = ["version"]
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"
@@ -1840,6 +1840,10 @@ include = [
 "python_sdk/infrahub_sdk" = "infrahub_sdk"
 "python_testcontainers/infrahub_testcontainers" = "infrahub_testcontainers"
 
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^infrahub-v(?P<version>[^+]+)$"
+
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.0b0"
+dynamic = ["version"]
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"
@@ -101,6 +101,13 @@ ignore = [
 ]
 
 
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^infrahub-v(?P<version>[^+]+)$"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+
 [tool.hatch.build.targets.sdist]
 include = [
     "infrahub_testcontainers",
@@ -118,5 +125,5 @@ include = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,6 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,15 +1,7 @@
-import sys
+from importlib.metadata import version
 from pathlib import Path
 
 from invoke import Context, UnexpectedExit
-
-try:
-    import tomllib
-except ModuleNotFoundError:
-    try:
-        import tomli as tomllib
-    except ModuleNotFoundError:
-        sys.exit("Please make sure to `pip install tomli` or enable the uv shell and run `uv sync`.")
 
 path = Path(__file__)
 TASKS_DIR = path.parent
@@ -44,13 +36,6 @@ def escape_path(path: Path) -> str:
 
 
 ESCAPED_REPO_PATH = escape_path(REPO_BASE)
-
-
-def project_ver() -> str:
-    """Find version from pyproject.toml to use for docker image tagging."""
-
-    with (REPO_BASE / "pyproject.toml").open("rb") as file:
-        return tomllib.load(file)["project"].get("version", "latest")
 
 
 def git_info(context: Context) -> tuple[str, str]:
@@ -105,10 +90,8 @@ def str_to_bool(value: str) -> bool:
 
 
 def get_version_from_pyproject() -> str:
-    """Retrieve the current version from the pyproject.toml file."""
-
-    with (REPO_BASE / "pyproject.toml").open("rb") as file:
-        return tomllib.load(file)["project"]["version"]
+    """Retrieve the current version from the installed package metadata."""
+    return version("infrahub-server")
 
 
 def get_yamllint_rules() -> dict:

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,6 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

Be able to build a release based on a git commit instead of hardcoding the version within our two pyproject.toml files. The main reason for this would be to avoid the constant merge conflicts we get for pyproject.toml / uv.lock between the `stable` and branches like `release-xyz` and `develop` (example 8965).

## Switch to dynamic versioning via `hatch-vcs`

Replaces the hardcoded `version` field in `pyproject.toml` (both `infrahub-server` and
`infrahub-testcontainers`) with dynamic versioning derived from git tags at build time.

### How it works

Both packages now use [`hatch-vcs`](https://github.com/ofek/hatch-vcs), which wraps
`setuptools-scm`, as a build-time dependency. The version is resolved from git tags matching
the pattern `infrahub-v<version>` (e.g. `infrahub-v1.8.5` → `1.8.5`).

`infrahub-testcontainers` lives in a subdirectory of the repo, so `search_parent_directories = true`
is set in its raw options to allow `setuptools-scm` to walk up to the repo root.

### Version resolution behaviour

| Build context | Resulting version |
|---|---|
| Exactly on tag `infrahub-v1.9.0` | `1.9.0` |
| 3 commits after `infrahub-v1.9.0` | `1.9.1.dev3+g<hash>` |
| Untagged commits after `infrahub-v1.9.0b0` | `1.9.0b1.dev2+g<hash>` |
| No reachable tags | Build error (see below) |

The dev suffix versions are valid [PEP 440](https://peps.python.org/pep-0440/) versions and
correctly express that the artifact was built from an untagged commit.

### Caveats

**Shallow clones:** `uv build` / `hatch build` will fail if no `infrahub-v*` tag is reachable
in the git history. All CI workflows already use `actions/checkout` with full history and
`submodules: true`, so this is not an issue in CI. Local builds require that at least one
`infrahub-v*` tag is fetched (`git fetch --tags`).

**No fallback version is configured.** A build without any reachable tag fails loudly rather
than silently producing a meaningless artifact. If a fallback is needed (e.g. for environments
where tags are unavailable), it can be added to both `pyproject.toml` files:

```toml
[tool.hatch.version]
source = "vcs"
tag-pattern = "^infrahub-v(?P<version>[^+]+)$"
fallback-version = "0.0.0"
```

### Additional changes

- `tasks/utils.py`: `get_version_from_pyproject()` previously read the version directly from
  the `[project]` table in `pyproject.toml`, which no longer contains a static `version` key.
  Updated to use `importlib.metadata.version("infrahub-server")` instead, which reads from the
  installed package. The unused `project_ver()` function (same issue) was removed along with
  the now-unnecessary `tomllib`/`tomli` import.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `infrahub-server` and `infrahub-testcontainers` to dynamic versions from git tags to remove manual bumps and reduce merge conflicts. Builds now resolve versions from tags like `infrahub-v1.9.0`.

- **New Features**
  - Use `hatch-vcs` to derive versions from tags matching `^infrahub-v(?P<version>[^+]+)$`.
  - Configure `infrahub-testcontainers` to search parent directories for the repo.
  - Update `tasks/utils.py` to read the version via `importlib.metadata.version("infrahub-server")`; remove old TOML parsing and unused helpers.

- **Migration**
  - Ensure `infrahub-v*` tags are fetched when building. In local clones, run `git fetch --tags`.
  - Builds without reachable tags will fail (no fallback version is set).

<sup>Written for commit f1aa23a3ed1dd365ae9cae14716b80a8e871d513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

