### PR TITLE
Type hint fixes for standard node

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Optional, Self, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Self, Union
 
 from pydantic import Field, field_validator
 
@@ -22,8 +22,6 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, InitializationError, ValidationError
 
 if TYPE_CHECKING:
-    from neo4j.graph import Node as Neo4jNode
-
     from infrahub.database import InfrahubDatabase
 
 
@@ -160,12 +158,12 @@ class Branch(StandardNode):
         ids: list[str] | None = None,
         name: str | None = None,
         node_ordering: StandardNodeOrdering | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> list[Self]:
         # Extract branch-specific params from kwargs, a future refactoring could update the parent signature for
         # standard nodes instead. Should be considered when additional StandardNode subclasses are introduced
-        branch_filters: BranchListFilters | None = kwargs.pop("branch_filters", None)  # type: ignore[assignment]
-        exclude_global: bool = kwargs.pop("exclude_global", False)  # type: ignore[assignment]
+        branch_filters: BranchListFilters | None = kwargs.pop("branch_filters", None)
+        exclude_global: bool = kwargs.pop("exclude_global", False)
 
         if branch_filters is None:
             branch_filters = BranchListFilters(name=name, ids=ids)
@@ -184,7 +182,7 @@ class Branch(StandardNode):
         )
         await query.execute(db=db)
 
-        return [cls.from_db(node=cast("Neo4jNode", result.get("n"))) for result in query.get_results()]
+        return [cls.from_db(node=result.get_node("n")) for result in query.get_results()]
 
     @classmethod
     async def get_list_count(

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -222,7 +222,7 @@ class StandardNode(BaseModel):
         return None
 
     @classmethod
-    async def _get_item_raw(cls, id: str, db: InfrahubDatabase) -> Neo4jNode:
+    async def _get_item_raw(cls, id: str, db: InfrahubDatabase) -> Neo4jNode | None:
         query: Query = await StandardNodeGetItemQuery.init(db=db, node_id=id, node_type=cls.get_type())
         await query.execute(db=db)
 
@@ -230,7 +230,7 @@ class StandardNode(BaseModel):
         if not result:
             return None
 
-        return result.get("n")
+        return result.get_node("n")
 
     @classmethod
     def from_db(cls, node: Neo4jNode, extras: Optional[dict[str, Any]] = None) -> Self:
@@ -243,7 +243,7 @@ class StandardNode(BaseModel):
             StandardNode: Proper StandardNode object
         """
 
-        attrs = {}
+        attrs: dict[str, Any] = {}
         node_data = dict(node)
         extras = extras or {}
         node_data.update(extras)
@@ -304,7 +304,7 @@ class StandardNode(BaseModel):
         ids: list[str] | None = None,
         name: str | None = None,
         node_ordering: StandardNodeOrdering | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> list[Self]:
         node_ordering = node_ordering or StandardNodeOrdering()
         query: Query = await StandardNodeGetListQuery.init(
@@ -312,4 +312,4 @@ class StandardNode(BaseModel):
         )
         await query.execute(db=db)
 
-        return [cls.from_db(result.get("n")) for result in query.get_results()]
+        return [cls.from_db(result.get_node("n")) for result in query.get_results()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,14 +251,6 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = "infrahub.core.node.standard"
-disable_error_code = [
-    "arg-type",
-    "assignment",
-    "return-value",
-]
-
-[[tool.mypy.overrides]]
 module = "infrahub.core.query"
 disable_error_code = [
     "arg-type",


### PR DESCRIPTION
# Why

Correct typehints for standard nodes and remove ignored violations from pyproject.toml

## What changed

Mainly small corrections and a switch from result.get("n") → result.get_node("n")

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type hints for standard node queries and branch models, and switches to typed result access via `get_node` to remove mypy ignores. This tightens Node handling and cleans up kwargs typing.

- **Refactors**
  - Use `result.get_node("n")` instead of `result.get("n")`; remove casts.
  - Update `_get_item_raw` to return `Neo4jNode | None` and handle missing results.
  - Change `**kwargs` from `dict[str, Any]` to `Any`; remove `type: ignore` pops.
  - Explicitly type `attrs: dict[str, Any]` in `from_db`; drop unused `Neo4jNode` import in branch model.
  - Remove mypy overrides for `infrahub.core.node.standard` in `pyproject.toml`.

<sup>Written for commit 5f6706e8db9ed9ff4f6fd7e7021447e3e3b98b29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

