### PR TITLE
Remove UP007/UP045 ignores and fix guess_field_type for UnionType

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Optional, Self, Union, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from pydantic import Field, field_validator
 
@@ -34,7 +34,7 @@ class Branch(StandardNode):
     status: BranchStatus = BranchStatus.OPEN
     description: str = ""
     origin_branch: str = "main"
-    branched_from: Optional[str] = Field(default=None, validate_default=True)
+    branched_from: str | None = Field(default=None, validate_default=True)
     hierarchy_level: int = 2
     is_default: bool = False
     is_global: bool = False
@@ -44,8 +44,8 @@ class Branch(StandardNode):
         description="Indicate if the branch should be extended to Git and if Infrahub should merge the branch in Git as part of a proposed change",
     )
     is_isolated: bool = True
-    schema_changed_at: Optional[str] = None
-    schema_hash: Optional[SchemaBranchHash] = None
+    schema_changed_at: str | None = None
+    schema_hash: SchemaBranchHash | None = None
     graph_version: int | None = None
 
     _exclude_attrs: list[str] = ["id", "uuid", "owner"]
@@ -220,7 +220,7 @@ class Branch(StandardNode):
     def isinstance(cls, obj: Any) -> bool:
         return isinstance(obj, cls)
 
-    def get_origin_branch(self) -> Optional[Branch]:
+    def get_origin_branch(self) -> Branch | None:
         """Return the branch Object of the origin_branch."""
         if not self.origin_branch or self.origin_branch == self.name:
             return None
@@ -239,7 +239,7 @@ class Branch(StandardNode):
 
         return [default_branch, self.name]
 
-    def get_branches_and_times_to_query(self, at: Optional[Timestamp] = None) -> dict[frozenset, str]:
+    def get_branches_and_times_to_query(self, at: Timestamp | None = None) -> dict[frozenset, str]:
         """Return all the names of the branches that are constituing this branch with the associated times excluding the global branch"""
 
         at = Timestamp(at)
@@ -260,7 +260,7 @@ class Branch(StandardNode):
 
     def get_branches_and_times_to_query_global(
         self,
-        at: Optional[Timestamp] = None,
+        at: Timestamp | None = None,
         is_isolated: bool = True,
     ) -> dict[frozenset, str]:
         """Return all the names of the branches that are constituting this branch with the associated times."""
@@ -330,7 +330,7 @@ class Branch(StandardNode):
         await super().delete(db=db)
 
     def get_query_filter_relationships(
-        self, rel_labels: list, at: Optional[Timestamp] = None, include_outside_parentheses: bool = False
+        self, rel_labels: list, at: Timestamp | None = None, include_outside_parentheses: bool = False
     ) -> tuple[list, dict]:
         """
         Generate a CYPHER Query filter based on a list of relationships to query a part of the graph at a specific time and on a specific branch.
@@ -368,7 +368,7 @@ class Branch(StandardNode):
 
     def get_query_filter_path(
         self,
-        at: Optional[Union[Timestamp, str]] = None,
+        at: Timestamp | str | None = None,
         is_isolated: bool = True,
         branch_agnostic: bool = False,
         variable_name: str = "r",

--- a/backend/infrahub/core/graph/constraints.py
+++ b/backend/infrahub/core/graph/constraints.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING, ForwardRef, Optional, Union, get_origin
+from typing import TYPE_CHECKING, ForwardRef, Union, get_origin
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -162,8 +162,8 @@ TYPE_MAPPING = {
 
 
 class ConstraintManagerBase:
-    constraint_node_class: Optional[type[ConstraintItem]] = ConstraintItem
-    constraint_rel_class: Optional[type[ConstraintItem]] = ConstraintItem
+    constraint_node_class: type[ConstraintItem] | None = ConstraintItem
+    constraint_rel_class: type[ConstraintItem] | None = ConstraintItem
 
     def __init__(self, db: InfrahubDatabase) -> None:
         self.db = db

--- a/backend/infrahub/core/graph/schema.py
+++ b/backend/infrahub/core/graph/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
@@ -215,7 +215,7 @@ class GraphBooleanNode(GraphVertex):
 
 class GraphRelationshipIsPartOf(BaseModel):
     from_: str = Field(..., description="Time from which the relationship is valid", alias="from")
-    to_: Optional[str] = Field(None, description="Time until which the relationship is valid", alias="to")
+    to_: str | None = Field(None, description="Time until which the relationship is valid", alias="to")
     status: RelationshipStatus = Field(..., description="status of the relationship")
 
 
@@ -229,9 +229,9 @@ class GraphRelationshipDefault(BaseModel):
         ge=1,
     )
     from_: str = Field(..., description="Time from which the relationship is valid", alias="from")
-    to_: Optional[str] = Field(None, description="Time until which the relationship is valid", alias="to")
+    to_: str | None = Field(None, description="Time until which the relationship is valid", alias="to")
     status: RelationshipStatus = Field(..., description="status of the relationship")
-    hierarchy: Optional[str] = Field(None, description="Name of the hierarchy this relationship is part of")
+    hierarchy: str | None = Field(None, description="Name of the hierarchy this relationship is part of")
 
 
 def get_graph_schema() -> dict[str, dict[str, type[Any]]]:

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union, get_args, get_origin
+from types import UnionType
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 from uuid import UUID
 
 import ujson
@@ -45,12 +46,12 @@ class StandardNodeQueryFields:
 
 
 class StandardNode(BaseModel):
-    id: Optional[str] = None
-    uuid: Optional[UUID] = None
-    created_at: Optional[str] = Field(default=None, validate_default=True)
+    id: str | None = None
+    uuid: UUID | None = None
+    created_at: str | None = Field(default=None, validate_default=True)
     created_by: str = Field(default=SYSTEM_USER_ID)
-    updated_by: Optional[str] = Field(default=None)
-    updated_at: Optional[str] = Field(default=None, validate_default=True)
+    updated_by: str | None = Field(default=None)
+    updated_at: str | None = Field(default=None, validate_default=True)
 
     _query: type[StandardNodeQuery] = StandardNodeCreateQuery
     _exclude_attrs: list[str] = ["id", "uuid", "_query"]
@@ -79,9 +80,9 @@ class StandardNode(BaseModel):
         annotation_origin = get_origin(field.annotation)
         annotation_args = get_args(field.annotation)
 
-        if (annotation_origin == Union and len(annotation_args) == 2 and type(None) in annotation_args) or (
-            annotation_origin is list and len(annotation_args)
-        ):
+        if (
+            annotation_origin in (Union, UnionType) and len(annotation_args) == 2 and type(None) in annotation_args
+        ) or (annotation_origin is list and len(annotation_args)):
             return get_origin(annotation_args[0]) or annotation_args[0]
 
         return annotation_origin or field.annotation
@@ -212,7 +213,7 @@ class StandardNode(BaseModel):
         return True
 
     @classmethod
-    async def get(cls, id: str, db: InfrahubDatabase) -> Optional[Self]:
+    async def get(cls, id: str, db: InfrahubDatabase) -> Self | None:
         """Get a node from the database identified by its ID."""
 
         node = await cls._get_item_raw(id=id, db=db)
@@ -233,7 +234,7 @@ class StandardNode(BaseModel):
         return result.get("n")
 
     @classmethod
-    def from_db(cls, node: Neo4jNode, extras: Optional[dict[str, Any]] = None) -> Self:
+    def from_db(cls, node: Neo4jNode, extras: dict[str, Any] | None = None) -> Self:
         """Convert a Neo4j Node to a Infrahub StandardNode
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -625,40 +625,11 @@ allow-dunder-method-names = [
     "PLR0915", # Too many statements
 ]
 
-"backend/infrahub/core/branch/models.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "UP007",  # Use X | Y for type annotations
-    "UP045",  # Use X | Y for type annotations
-]
-
-"backend/infrahub/core/graph/**.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "UP045",  # Use X | Y for type annotations
-]
-
 "backend/infrahub/core/node/__init__.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
     ##################################################################################################
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
-]
-
-"backend/infrahub/core/node/standard.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "UP045",  # Use X | Y for type annotations
-]
-
-"backend/infrahub/core/query/**.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "UP007",  # Use X | Y for type annotations
 ]
 
 "backend/infrahub/core/models.py" = [


### PR DESCRIPTION

# Why

Update to use modern version of optional types.

## What changed

* Fix Optional[X] -> X | None and Union[X,Y] -> X | Y across branch/models.py, graph/constraints.py, graph/schema.py, and node/standard.py; remove dead UP007 ignore for core/query/**.py.

* The guess_field_type method now checks for both typing.Union and types.UnionType so that X | None fields are handled correctly at runtime in to_db/from_db after the annotation syntax change.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate type hints to PEP 604 unions (`X | Y`) and fix runtime type detection so `X | None` fields serialize/deserialize correctly. Removes now-unneeded `UP007/UP045` ignores.

- **Bug Fixes**
  - Update `guess_field_type` to recognize both `typing.Union` and `types.UnionType`, ensuring `X | None` works in `to_db`/`from_db`.

- **Refactors**
  - Replace `Optional[X]` with `X | None` and `Union[X, Y]` with `X | Y` in `core/branch/models.py`, `core/graph/{constraints.py,schema.py}`, and `core/node/standard.py`.
  - Clean up linter config by removing `UP007/UP045` ignores in `pyproject.toml` (including the dead `core/query/**.py` rule).

<sup>Written for commit 2c1b450f0f19ce9780d1156fb0281081a566bf68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

