### PR TITLE
Fix button positioning on disabled state

### DIFF
--- a/frontend/app/src/shared/components/ui/button.tsx
+++ b/frontend/app/src/shared/components/ui/button.tsx
@@ -72,7 +72,10 @@ interface ButtonWithTooltipProps extends ButtonProps {
 }
 
 export const ButtonWithTooltip = forwardRef<HTMLButtonElement, ButtonWithTooltipProps>(
-  ({ tooltipContent, tooltipEnabled, side = "top", disabled, onClick, className, ...props }, ref) => {
+  (
+    { tooltipContent, tooltipEnabled, side = "top", disabled, onClick, className, ...props },
+    ref
+  ) => {
     // Native `disabled` kills pointer events, so the tooltip never fires on the
     // button itself. Use aria-disabled so the button stays hoverable and the
     // tooltip anchors directly to it (no extra wrapper that would shift side/align).
@@ -85,10 +88,7 @@ export const ButtonWithTooltip = forwardRef<HTMLButtonElement, ButtonWithTooltip
           {...props}
           aria-disabled={isDisabled || undefined}
           onClick={isDisabled ? undefined : onClick}
-          className={classNames(
-            isDisabled && "cursor-not-allowed opacity-60",
-            className
-          )}
+          className={classNames(isDisabled && "cursor-not-allowed opacity-60", className)}
         />
       </Tooltip>
     );

--- a/frontend/app/src/shared/components/ui/button.tsx
+++ b/frontend/app/src/shared/components/ui/button.tsx
@@ -72,22 +72,24 @@ interface ButtonWithTooltipProps extends ButtonProps {
 }
 
 export const ButtonWithTooltip = forwardRef<HTMLButtonElement, ButtonWithTooltipProps>(
-  ({ tooltipContent, tooltipEnabled, side = "top", disabled, className, ...props }, ref) => {
-    // When button is disabled, wrap in a span to allow tooltip to work
-    // (disabled buttons have pointer-events-none which prevents tooltips)
-    if (disabled && tooltipEnabled) {
-      return (
-        <Tooltip enabled={tooltipEnabled} content={tooltipContent} side={side}>
-          <span className="inline-flex">
-            <Button ref={ref} {...props} className={className} disabled={disabled} />
-          </span>
-        </Tooltip>
-      );
-    }
+  ({ tooltipContent, tooltipEnabled, side = "top", disabled, onClick, className, ...props }, ref) => {
+    // Native `disabled` kills pointer events, so the tooltip never fires on the
+    // button itself. Use aria-disabled so the button stays hoverable and the
+    // tooltip anchors directly to it (no extra wrapper that would shift side/align).
+    const isDisabled = !!disabled;
 
     return (
       <Tooltip enabled={tooltipEnabled} content={tooltipContent} side={side}>
-        <Button ref={ref} {...props} className={className} disabled={disabled} />
+        <Button
+          ref={ref}
+          {...props}
+          aria-disabled={isDisabled || undefined}
+          onClick={isDisabled ? undefined : onClick}
+          className={classNames(
+            isDisabled && "cursor-not-allowed opacity-60",
+            className
+          )}
+        />
       </Tooltip>
     );
   }


### PR DESCRIPTION
<img width="1547" height="983" alt="image" src="https://github.com/user-attachments/assets/94b40c65-9b14-4471-98b5-ca0d6ce9a4bd" />

## Summary

- `ButtonWithTooltip` wrapped disabled buttons in a `<span>` so the tooltip
  could still fire (native `disabled` applies `pointer-events: none`, which
  breaks Radix's hover detection). That span became the tooltip's positioning
  anchor, so the `side` prop was measured against the wrapper instead of the
  button itself — causing misaligned placement.
- Switched from native `disabled` to `aria-disabled`. The button keeps pointer
  events (so the tooltip fires directly on it), Radix anchors to the real
  button, and `side` is honored. `onClick` is suppressed and disabled styles
  are applied explicitly since CVA's `disabled:*` variants no longer match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tooltip misalignment on disabled buttons by anchoring the tooltip to the actual button and honoring the `side` prop. Keeps hover behavior while preventing clicks when disabled.

- **Bug Fixes**
  - Removed the wrapper `<span>` around disabled buttons so the tooltip positions relative to the button.
  - Switched from `disabled` to `aria-disabled`; kept pointer events for hover, suppressed `onClick`, and applied disabled styles via classes.

<sup>Written for commit 7b38c1c28a680bb939d4da368ca41d3f92e0ee72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

