### PR TITLE
Fix branch name display in event details for branch deletion events

### DIFF
--- a/changelog/+efd8a1d3.fixed.md
+++ b/changelog/+efd8a1d3.fixed.md
@@ -1,0 +1,1 @@
+Fix branch name display in event details popover for branch deletion events.

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -122,10 +122,10 @@ exports[`fix ts error`] = {
     "src/entities/events/ui/branch-events/branch-event-title.tsx:1629228177": [
       [7, 7, 40, "tsc: Cannot find module \'@/shared/api/graphql/generated/graphql\' or its corresponding type declarations.", "3357561780"]
     ],
-    "src/entities/events/ui/event-details.tsx:3472503684": [
-      [78, 34, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"],
-      [100, 30, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"],
-      [122, 28, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"]
+    "src/entities/events/ui/event-details.tsx:1445632781": [
+      [85, 34, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"],
+      [107, 30, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"],
+      [129, 28, 4, "tsc: Parameter \'node\' implicitly has an \'any\' type.", "2087865285"]
     ],
     "src/entities/events/ui/filters/global-branch-filter.tsx:4154549494": [
       [82, 14, 7, "tsc: Type \'{ label: string; name: string; }[]\' is not assignable to type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; }[] | { id?: string\'.\\n  Property \'state\' is missing in type \'{ label: string; name: string; }\' but required in type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; } | { id?: string\'.", "3821181085"]

--- a/frontend/app/src/entities/events/ui/event-details.tsx
+++ b/frontend/app/src/entities/events/ui/event-details.tsx
@@ -24,6 +24,13 @@ export const EventDetails = ({
   members,
   ...props
 }: EventType) => {
+  const displayedBranch =
+    branch ??
+    ("deleted_branch" in props ? props.deleted_branch : undefined) ??
+    ("created_branch" in props ? props.created_branch : undefined) ??
+    ("rebased_branch" in props ? props.rebased_branch : undefined) ??
+    ("source_branch" in props ? props.source_branch : undefined);
+
   return (
     <div className="divide-y divide-gray-200">
       <PropertyRow
@@ -37,7 +44,7 @@ export const EventDetails = ({
 
       <PropertyRow title="Event" value={event} />
 
-      <PropertyRow title="Branch" value={branch} />
+      <PropertyRow title="Branch" value={displayedBranch} />
 
       <PropertyRow title="Occured at" value={<DateDisplay date={occurred_at} />} />
 


### PR DESCRIPTION
<img width="1199" height="379" alt="image" src="https://github.com/user-attachments/assets/d3d2f1fc-e538-45f8-8760-da57016a7624" />

## Summary
- Event details popover showed an empty "Branch" row for `infrahub.branch.deleted` events because the interface-level `branch` field is null for deletions — the name lives on `deleted_branch`.
- Resolve the displayed branch from the event-specific fields (`deleted_branch`, `created_branch`, `rebased_branch`, `source_branch`) when `branch` is absent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty “Branch” field in the event details popover for branch deletion events by resolving the name from event-specific fields when the generic `branch` is null. Also improves branch display for creation, rebase, and other related events.

- **Bug Fixes**
  - When `branch` is missing, use `deleted_branch` → `created_branch` → `rebased_branch` → `source_branch` to populate the Branch row.

<sup>Written for commit 8438a3159266aa2b91df77ebd85b16a4b523bf8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

