### PR TITLE
Improved overflow handling in app header

### DIFF
--- a/frontend/app/src/entities/navigation/ui/app-header.tsx
+++ b/frontend/app/src/entities/navigation/ui/app-header.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/shared/components/ui/card";
+import { ScrollArea } from "@/shared/components/ui/scroll-area";
 
 import BranchSelector from "@/entities/branches/ui/branch-selector";
 import { BreadcrumbNavigation } from "@/entities/navigation/ui/breadcrumbs/breadcrumb-navigation";
@@ -7,14 +8,19 @@ import { TaskStatus } from "@/entities/tasks/ui/task-status";
 
 export function AppHeader() {
   return (
-    <Card className="flex h-12.5 items-center gap-2 p-2">
+    <Card className="flex h-12.5 shrink-0 items-center gap-2 overflow-hidden p-2">
       <TimeFrameSelector />
 
       <BranchSelector />
 
-      <div className="flex-1" data-testid="breadcrumb-navigation">
+      <ScrollArea
+        scrollX
+        scrollBarClassName="hidden"
+        className="flex-1"
+        data-testid="breadcrumb-navigation"
+      >
         <BreadcrumbNavigation />
-      </div>
+      </ScrollArea>
 
       <TaskStatus />
     </Card>

--- a/frontend/app/src/entities/navigation/ui/time-selector.tsx
+++ b/frontend/app/src/entities/navigation/ui/time-selector.tsx
@@ -35,7 +35,7 @@ export const TimeFrameSelector = () => {
   return (
     <div
       className={classNames(
-        "inline-flex h-8 items-center overflow-hidden rounded-lg border border-neutral-200",
+        "inline-flex h-8 shrink-0 items-center overflow-hidden rounded-lg border border-neutral-200",
         date && "bg-neutral-800"
       )}
     >


### PR DESCRIPTION
Why

The app header bar had no overflow handling, so long breadcrumb paths caused layout shifting. The header would grow or push sibling elements out of place, which was disruptive during testing and general use.

What changed

  - Breadcrumb area now scrolls horizontally instead of overflowing: Wrapped BreadcrumbNavigation in a ScrollArea with hidden scrollbars, so long paths are accessible without breaking the header layout.
  - Header card prevents shrinking and clips overflow: Added shrink-0 and overflow-hidden to the root Card so it stays at its fixed height regardless of content.
  - Time frame selector no longer shrinks: Added shrink-0 to TimeFrameSelector so it keeps its width when space is tight.

  No schema changes. No API changes. Only affects the app header layout.

  How to review

  Two small files:
  1. frontend/app/src/entities/navigation/ui/app-header.tsx — the core change (ScrollArea wrapper + overflow classes)
  2. frontend/app/src/entities/navigation/ui/time-selector.tsx — one-line shrink-0 addition

  How to test

  cd frontend/app && pnpm dev

  Navigate to a deeply nested object so the breadcrumb trail is long. The header should stay fixed height, breadcrumbs scroll horizontally, and the time selector / branch selector / task
  status should not get pushed or squished.

  Impact & rollout

  - Backward compatibility: None — purely visual/layout fix
  - Performance: No impact
  - Deployment notes: Safe to deploy

  Checklist

  - Tests added/updated
  - Changelog entry added (uv run towncrier create ...)
  - External docs updated (if user-facing or ops-facing change)
  - Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix header overflow by making breadcrumbs scroll horizontally and preventing controls from shrinking. Keeps the header height fixed and stops layout shifts. No API or schema changes.

- **Bug Fixes**
  - Wrapped breadcrumb navigation in a `ScrollArea` with horizontal scrolling and hidden scrollbars.
  - Added `shrink-0` and `overflow-hidden` to the header `Card` to keep a fixed height.
  - Added `shrink-0` to `TimeFrameSelector` so its width stays stable.

<sup>Written for commit cd598fc8e50fd13165ddcc98849c0c6cc23ec582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

