### PR TITLE
IFC-2342: Suppress irrelevant neo4j logs

### DIFF
--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -495,6 +495,8 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         trusted_certificates=trusted_certificates,
         notifications_disabled_classifications=[
             NotificationDisabledClassification.UNRECOGNIZED,
+            # Suppress spurious warnings for optional relationship types not yet in DB schema (HAS_OWNER, HAS_SOURCE, etc.)
+            NotificationDisabledClassification.SCHEMA,
         ],
         notifications_min_severity=NotificationMinimumSeverity.WARNING,
     )

--- a/changelog/+8620.fixed.md
+++ b/changelog/+8620.fixed.md
@@ -1,0 +1,1 @@
+Suppress spurious Neo4j SCHEMA notifications for optional relationship types that do not yet exist in the database schema, eliminating noisy log warnings about non-existent HAS_OWNER and HAS_SOURCE relationship types.


### PR DESCRIPTION
# Why

Fresh Infrahub deployments (or any deployment where no objects have been given owner/source metadata) flood Neo4j logs with repeated warnings: `The relationship type 'HAS_OWNER' does not exist` and `The relationship type 'HAS_SOURCE' does not exist`. These are false positives — the `OPTIONAL MATCH` queries are working correctly, but Neo4j generates a `SCHEMA` notification whenever a query references a relationship type that hasn't been created in the database yet. In clustered deployments the noise is multiplied across every node.

The goal is zero spurious warnings in Neo4j logs for optional relationship types, with no change to query results or performance.

Closes https://github.com/opsmill/infrahub/issues/8620

## What changed

**Driver notification config** (`backend/infrahub/database/__init__.py`): added `NotificationDisabledClassification.SCHEMA` to the `notifications_disabled_classifications` list in `get_db()`. The driver already had this infrastructure in place — only `UNRECOGNIZED` was previously disabled.

This is generic by design: it suppresses Neo4j `SCHEMA` category notifications for any optional relationship type, not just `HAS_OWNER`/`HAS_SOURCE`, so new optional types added in future won't cause the same noise.

**New unit test** (`backend/tests/unit/test_database_config.py`): asserts that the driver is initialised with `SCHEMA` in `notifications_disabled_classifications`, preventing accidental regression.

**Changelog** (`changelog/+8620.fixed.md`): towncrier fragment added.

## Behavioral changes

- Neo4j logs no longer contain `SCHEMA` category notifications (relationship type / label / property key does not exist). These were always non-blocking false positives.
- `PERFORMANCE`, `SECURITY`, `TOPOLOGY`, and all other notification categories are unchanged.
- Query results are identical — suppression is at the Bolt protocol level before results are transmitted; no query logic was modified.

## How to review

The key design question is whether suppressing the whole `SCHEMA` category is safe. It is: Infrahub validates schema at the application layer (Pydantic models, `RelationshipSchema.optional` flag, schema branch validation) before any query reaches Neo4j, so Neo4j `SCHEMA` notifications are always redundant here.

Alternatives considered: 
- Rewriting queries to use `WHERE type(r) = 'HAS_OWNER'` instead of `[r:HAS_OWNER]` — more targeted but changes execution plans and requires touching 10+ query files
- Pre-creating relationship type tokens at startup — cleanest long-term but adds migration complexity and doesn't cover dynamically-added optional types. Driver-level suppression is the simplest correct fix.


## Impact & rollout

- **Backward compatibility:** fully backward compatible — no schema changes, no API changes, no config changes required
- **Performance:** no measurable impact; filtering is server-side at the Bolt protocol level, zero per-query overhead in the Python application
- **Config/env changes:** none
- **Deployment notes:** safe to deploy; restart of the API server is sufficient for the new driver config to take effect

## Checklist

- [ ] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`changelog/+8620.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Neo4j SCHEMA notifications in the database driver to stop noisy “relationship type … does not exist” warnings for optional relationships (e.g., HAS_OWNER, HAS_SOURCE) on fresh deployments (IFC-2342). No changes to query results or other notification categories.

<sup>Written for commit bb14d1bdd0af991b2751f7fae7e8907deab2fdca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

