### PR TITLE
Split permission system into Loader, Resolver, and Manager

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -124,7 +124,9 @@ async def get_permission_manager(
     account_session: AccountSession = Depends(get_current_user),
 ) -> PermissionManager:
     """Return a `PermissionManager` for an account session based on a branch."""
-    return await PermissionManager.load_for_account(db=db, branch=branch_params.branch, account_session=account_session)
+    return await PermissionManager.load_for_account(
+        db=db, branch=branch_params.branch, default_branch_name=registry.default_branch, account_session=account_session
+    )
 
 
 async def get_context(

--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -124,10 +124,7 @@ async def get_permission_manager(
     account_session: AccountSession = Depends(get_current_user),
 ) -> PermissionManager:
     """Return a `PermissionManager` for an account session based on a branch."""
-    permission_manager = PermissionManager(account_session=account_session)
-    await permission_manager.load_permissions(db=db, branch=branch_params.branch)
-
-    return permission_manager
+    return await PermissionManager.load_for_account(db=db, branch=branch_params.branch, account_session=account_session)
 
 
 async def get_context(

--- a/backend/infrahub/graphql/auth/query_permission_checker/interface.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/interface.py
@@ -14,6 +14,22 @@ class CheckerResolution(Enum):
 
 
 class GraphQLQueryPermissionCheckerInterface(ABC):
+    """Base interface for all permission checkers in the pipeline.
+
+    Pipeline contract:
+    - Checkers are called in registration order
+    - supports() determines if a checker should run for this request
+    - check() performs the actual permission check
+    - TERMINATE stops the chain (request is authorized)
+    - NEXT_CHECKER continues to the next checker
+    - If no checker returns TERMINATE, the request is denied
+
+    Checker categories (by convention):
+    - Gate: May short-circuit (TERMINATE) or pass (NEXT_CHECKER). Never raises.
+    - Enforcement: Raises PermissionDeniedError if violated, returns NEXT_CHECKER.
+    - Terminal: Always returns TERMINATE. Must be last.
+    """
+
     @abstractmethod
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool: ...
 

--- a/backend/infrahub/graphql/auth/query_permission_checker/interface.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/interface.py
@@ -25,6 +25,7 @@ class GraphQLQueryPermissionCheckerInterface(ABC):
     - If no checker returns TERMINATE, the request is denied
 
     Checker categories (by convention):
+    - Pre-filter: Rejects unauthenticated requests with AuthorizationError. Runs first in the pipeline.
     - Gate: May short-circuit (TERMINATE) or pass (NEXT_CHECKER). Never raises.
     - Enforcement: Raises PermissionDeniedError if violated, returns NEXT_CHECKER.
     - Terminal: Always returns TERMINATE. Must be last.

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -113,7 +113,9 @@ async def prepare_graphql_params(
 
     permissions: PermissionManager | None = None
     if account_session:
-        permissions = await PermissionManager.load_for_account(db=db, branch=branch, account_session=account_session)
+        permissions = await PermissionManager.load_for_account(
+            db=db, branch=branch, default_branch_name=registry.default_branch, account_session=account_session
+        )
 
     return GraphqlParams(
         schema=gql_schema,

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -113,8 +113,7 @@ async def prepare_graphql_params(
 
     permissions: PermissionManager | None = None
     if account_session:
-        permissions = PermissionManager(account_session=account_session)
-        await permissions.load_permissions(db=db, branch=branch)
+        permissions = await PermissionManager.load_for_account(db=db, branch=branch, account_session=account_session)
 
     return GraphqlParams(
         schema=gql_schema,

--- a/backend/infrahub/graphql/permissions.py
+++ b/backend/infrahub/graphql/permissions.py
@@ -20,7 +20,9 @@ async def get_permissions(schema: MainSchemaTypes, graphql_context: GraphqlConte
     response: dict[str, Any] = {"count": len(schema_objects), "edges": []}
 
     nodes = await report_schema_permissions(
-        branch=graphql_context.branch, permission_manager=graphql_context.active_permissions.resolver, schemas=schema_objects
+        branch=graphql_context.branch,
+        permission_manager=graphql_context.active_permissions.resolver,
+        schemas=schema_objects,
     )
     response["edges"] = [{"node": node} for node in nodes]
 

--- a/backend/infrahub/graphql/permissions.py
+++ b/backend/infrahub/graphql/permissions.py
@@ -20,9 +20,7 @@ async def get_permissions(schema: MainSchemaTypes, graphql_context: GraphqlConte
     response: dict[str, Any] = {"count": len(schema_objects), "edges": []}
 
     nodes = await report_schema_permissions(
-        branch=graphql_context.branch,
-        permission_manager=graphql_context.active_permissions.resolver,
-        schemas=schema_objects,
+        branch=graphql_context.branch, resolver=graphql_context.active_permissions.resolver, schemas=schema_objects
     )
     response["edges"] = [{"node": node} for node in nodes]
 

--- a/backend/infrahub/graphql/permissions.py
+++ b/backend/infrahub/graphql/permissions.py
@@ -20,7 +20,7 @@ async def get_permissions(schema: MainSchemaTypes, graphql_context: GraphqlConte
     response: dict[str, Any] = {"count": len(schema_objects), "edges": []}
 
     nodes = await report_schema_permissions(
-        branch=graphql_context.branch, permission_manager=graphql_context.active_permissions, schemas=schema_objects
+        branch=graphql_context.branch, permission_manager=graphql_context.active_permissions.resolver, schemas=schema_objects
     )
     response["edges"] = [{"node": node} for node in nodes]
 

--- a/backend/infrahub/graphql/queries/account.py
+++ b/backend/infrahub/graphql/queries/account.py
@@ -127,7 +127,7 @@ async def resolve_account_permissions(
 
     response: dict[str, dict[str, Any]] = {}
     if "global_permissions" in fields:
-        global_list = graphql_context.active_permissions.permissions["global_permissions"]
+        global_list = graphql_context.active_permissions.resolver.permissions["global_permissions"]
         response["global_permissions"] = {"count": len(global_list)}
         response["global_permissions"]["edges"] = [
             {
@@ -143,7 +143,7 @@ async def resolve_account_permissions(
             for obj in global_list
         ]
     if "object_permissions" in fields:
-        object_list = graphql_context.active_permissions.permissions["object_permissions"]
+        object_list = graphql_context.active_permissions.resolver.permissions["object_permissions"]
         response["object_permissions"] = {"count": len(object_list)}
         response["object_permissions"]["edges"] = [
             {

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -1,5 +1,6 @@
 from infrahub.permissions.backend import PermissionBackend
 from infrahub.permissions.globals import define_global_permission_from_branch, get_or_create_global_permission
+from infrahub.permissions.loader import PermissionLoader
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.permissions.manager import PermissionManager
 from infrahub.permissions.report import report_schema_permissions
@@ -14,6 +15,7 @@ __all__ = [
     "AssignedPermissions",
     "LocalPermissionBackend",
     "PermissionBackend",
+    "PermissionLoader",
     "PermissionManager",
     "PermissionResolver",
     "define_global_permission_from_branch",

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -3,6 +3,7 @@ from infrahub.permissions.globals import define_global_permission_from_branch, g
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.permissions.manager import PermissionManager
 from infrahub.permissions.report import report_schema_permissions
+from infrahub.permissions.resolver import PermissionResolver
 from infrahub.permissions.types import (
     AssignedPermissions,
     define_object_permission_from_branch,
@@ -14,6 +15,7 @@ __all__ = [
     "LocalPermissionBackend",
     "PermissionBackend",
     "PermissionManager",
+    "PermissionResolver",
     "define_global_permission_from_branch",
     "define_object_permission_from_branch",
     "get_global_permission_for_kind",

--- a/backend/infrahub/permissions/loader.py
+++ b/backend/infrahub/permissions/loader.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core import registry
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+    from infrahub.permissions.types import AssignedPermissions
+
+__all__ = ["PermissionLoader"]
+
+
+class PermissionLoader:
+    """Loads permissions for an account session by orchestrating registered backends."""
+
+    def __init__(self, account_session: AccountSession) -> None:
+        self.account_session = account_session
+
+    async def load(self, db: InfrahubDatabase, branch: Branch) -> AssignedPermissions:
+        permissions: AssignedPermissions = {"global_permissions": [], "object_permissions": []}
+        for permission_backend in registry.permission_backends:
+            backend_permissions = await permission_backend.load_permissions(
+                db=db, branch=branch, account_session=self.account_session
+            )
+            permissions["global_permissions"].extend(backend_permissions["global_permissions"])
+            permissions["object_permissions"].extend(backend_permissions["object_permissions"])
+        return permissions

--- a/backend/infrahub/permissions/manager.py
+++ b/backend/infrahub/permissions/manager.py
@@ -26,7 +26,6 @@ class PermissionManager:
 
     @property
     def resolver(self) -> PermissionResolver:
-        """Lazily create a PermissionResolver from the current loaded permissions."""
         if self._resolver is None:
             self._resolver = PermissionResolver(permissions=self.permissions)
         return self._resolver

--- a/backend/infrahub/permissions/manager.py
+++ b/backend/infrahub/permissions/manager.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Self, Sequence
 
 from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.permissions.constants import GLOBAL_PERMISSION_DENIAL_MESSAGE, PermissionDecisionFlag
+from infrahub.permissions.loader import PermissionLoader
 from infrahub.permissions.resolver import PermissionResolver
 
 if TYPE_CHECKING:
@@ -13,36 +14,21 @@ if TYPE_CHECKING:
     from infrahub.core.account import ObjectPermission
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
-    from infrahub.permissions.types import AssignedPermissions
 
 __all__ = ["PermissionManager"]
 
 
 class PermissionManager:
-    def __init__(self, account_session: AccountSession) -> None:
+    def __init__(self, account_session: AccountSession, resolver: PermissionResolver) -> None:
         self.account_session = account_session
-        self.permissions: AssignedPermissions = {"global_permissions": [], "object_permissions": []}
-        self._resolver: PermissionResolver | None = None
+        self.resolver = resolver
 
-    @property
-    def resolver(self) -> PermissionResolver:
-        if self._resolver is None:
-            self._resolver = PermissionResolver(
-                permissions=self.permissions, default_branch_name=registry.default_branch
-            )
-        return self._resolver
-
-    async def load_permissions(self, db: InfrahubDatabase, branch: Branch) -> None:
-        """Load permissions from the configured backends into memory."""
-        for permission_backend in registry.permission_backends:
-            backend_permissions = await permission_backend.load_permissions(
-                db=db, branch=branch, account_session=self.account_session
-            )
-            self.permissions["global_permissions"].extend(backend_permissions["global_permissions"])
-            self.permissions["object_permissions"].extend(backend_permissions["object_permissions"])
-
-        # Invalidate the cached resolver so it picks up new permissions
-        self._resolver = None
+    @classmethod
+    async def load_for_account(cls, db: InfrahubDatabase, branch: Branch, account_session: AccountSession) -> Self:
+        loader = PermissionLoader(account_session=account_session)
+        permissions = await loader.load(db=db, branch=branch)
+        resolver = PermissionResolver(permissions=permissions, default_branch_name=registry.default_branch)
+        return cls(account_session=account_session, resolver=resolver)
 
     def is_super_admin(self) -> bool:
         return self.resolver.is_super_admin()

--- a/backend/infrahub/permissions/manager.py
+++ b/backend/infrahub/permissions/manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self, Sequence
 
-from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.permissions.constants import GLOBAL_PERMISSION_DENIAL_MESSAGE, PermissionDecisionFlag
@@ -24,10 +23,12 @@ class PermissionManager:
         self.resolver = resolver
 
     @classmethod
-    async def load_for_account(cls, db: InfrahubDatabase, branch: Branch, account_session: AccountSession) -> Self:
+    async def load_for_account(
+        cls, db: InfrahubDatabase, branch: Branch, default_branch_name: str, account_session: AccountSession
+    ) -> Self:
         loader = PermissionLoader(account_session=account_session)
         permissions = await loader.load(db=db, branch=branch)
-        resolver = PermissionResolver(permissions=permissions, default_branch_name=registry.default_branch)
+        resolver = PermissionResolver(permissions=permissions, default_branch_name=default_branch_name)
         return cls(account_session=account_session, resolver=resolver)
 
     def is_super_admin(self) -> bool:

--- a/backend/infrahub/permissions/manager.py
+++ b/backend/infrahub/permissions/manager.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Sequence
 
 from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
-from infrahub.core.constants import GlobalPermissions, PermissionDecision
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.permissions.constants import GLOBAL_PERMISSION_DENIAL_MESSAGE, PermissionDecisionFlag
+from infrahub.permissions.resolver import PermissionResolver
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
@@ -19,12 +19,17 @@ __all__ = ["PermissionManager"]
 
 
 class PermissionManager:
-    wildcard_values = ["*"]
-    wildcard_actions = ["any"]
-
     def __init__(self, account_session: AccountSession) -> None:
         self.account_session = account_session
         self.permissions: AssignedPermissions = {"global_permissions": [], "object_permissions": []}
+        self._resolver: PermissionResolver | None = None
+
+    @property
+    def resolver(self) -> PermissionResolver:
+        """Lazily create a PermissionResolver from the current loaded permissions."""
+        if self._resolver is None:
+            self._resolver = PermissionResolver(permissions=self.permissions)
+        return self._resolver
 
     async def load_permissions(self, db: InfrahubDatabase, branch: Branch) -> None:
         """Load permissions from the configured backends into memory."""
@@ -35,82 +40,31 @@ class PermissionManager:
             self.permissions["global_permissions"].extend(backend_permissions["global_permissions"])
             self.permissions["object_permissions"].extend(backend_permissions["object_permissions"])
 
-    def _compute_specificity(self, permission: ObjectPermission) -> int:
-        """Return how specific a permission is."""
-        specificity = 0
-        if permission.namespace not in self.wildcard_values:
-            specificity += 1
-        if permission.name not in self.wildcard_values:
-            specificity += 1
-        if permission.action not in self.wildcard_actions:
-            specificity += 1
-        if not permission.decision & PermissionDecisionFlag.ALLOW_ALL:
-            specificity += 1
-        return specificity
+        # Invalidate the cached resolver so it picks up new permissions
+        self._resolver = None
 
     def is_super_admin(self) -> bool:
-        return self.resolve_global_permission(
-            permission_to_check=GlobalPermission(
-                action=GlobalPermissions.SUPER_ADMIN, decision=PermissionDecision.ALLOW_ALL
-            ),
-        )
+        return self.resolver.is_super_admin()
 
     def report_object_permission(self, namespace: str, name: str, action: str) -> PermissionDecisionFlag:
         """Given a set of permissions, return the permission decision for a given kind and action."""
-        highest_specificity: int = -1
-        combined_decision = PermissionDecisionFlag.DENY
-
-        for permission in self.permissions["object_permissions"]:
-            if (
-                permission.namespace in [namespace, *self.wildcard_values]
-                and permission.name in [name, *self.wildcard_values]
-                and permission.action in [action, *self.wildcard_actions]
-            ):
-                permission_decision = PermissionDecisionFlag(value=permission.decision)
-                # Compute the specifity of a permission to keep the decision of the most specific if two or more permissions overlap
-                specificity = self._compute_specificity(permission=permission)
-                if specificity > highest_specificity:
-                    combined_decision = permission_decision
-                    highest_specificity = specificity
-                elif specificity == highest_specificity and permission_decision != PermissionDecisionFlag.DENY:
-                    combined_decision |= permission_decision
-
-        return combined_decision
+        return self.resolver.report_object_permission(namespace=namespace, name=name, action=action)
 
     def resolve_object_permission(self, permission_to_check: ObjectPermission) -> bool:
         """Compute the permissions and check if the one provided is granted."""
-        required_decision = PermissionDecisionFlag(value=permission_to_check.decision)
-        combined_decision = self.report_object_permission(
-            namespace=permission_to_check.namespace, name=permission_to_check.name, action=permission_to_check.action
-        )
-
-        return combined_decision & required_decision == required_decision
+        return self.resolver.resolve_object_permission(permission_to_check=permission_to_check)
 
     def resolve_global_permission(self, permission_to_check: GlobalPermission) -> bool:
         """Tell if a global permission is granted."""
-        grant_permission = False
-
-        for permission in self.permissions["global_permissions"]:
-            if permission.action == permission_to_check.action:
-                # Early exit on deny as deny preempt allow
-                if permission.decision == PermissionDecisionFlag.DENY:
-                    return False
-                grant_permission = True
-
-        return grant_permission
+        return self.resolver.resolve_global_permission(action=permission_to_check.action)
 
     def has_permission(self, permission: GlobalPermission | ObjectPermission) -> bool:
         """Tell if a permission is granted given the permissions loaded in memory."""
-        is_super_admin = self.is_super_admin()
-
-        if isinstance(permission, GlobalPermission):
-            return self.resolve_global_permission(permission_to_check=permission) or is_super_admin
-
-        return self.resolve_object_permission(permission_to_check=permission) or is_super_admin
+        return self.resolver.has_permission(permission=permission)
 
     def has_permissions(self, permissions: Sequence[GlobalPermission | ObjectPermission]) -> bool:
         """Same as `has_permission` but for multiple permissions, return `True` only if all permissions are granted."""
-        return all(self.has_permission(permission=permission) for permission in permissions)
+        return self.resolver.has_permissions(permissions=permissions)
 
     def raise_for_permission(self, permission: GlobalPermission | ObjectPermission, message: str = "") -> None:
         """Same as `has_permission` but raise a `PermissionDeniedError` if the permission is not granted."""

--- a/backend/infrahub/permissions/manager.py
+++ b/backend/infrahub/permissions/manager.py
@@ -27,7 +27,9 @@ class PermissionManager:
     @property
     def resolver(self) -> PermissionResolver:
         if self._resolver is None:
-            self._resolver = PermissionResolver(permissions=self.permissions)
+            self._resolver = PermissionResolver(
+                permissions=self.permissions, default_branch_name=registry.default_branch
+            )
         return self._resolver
 
     async def load_permissions(self, db: InfrahubDatabase, branch: Branch) -> None:

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -2,126 +2,41 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub.core import registry
-from infrahub.core.account import GlobalPermission
-from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions, InfrahubKind, PermissionDecision
-from infrahub.core.schema.node_schema import NodeSchema
-from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
-
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema import MainSchemaTypes
-    from infrahub.permissions.manager import PermissionManager
+    from infrahub.permissions.resolver import PermissionResolver
     from infrahub.permissions.types import KindPermissions
 
 
 __all__ = ["report_schema_permissions"]
 
 
-def get_permission_report(  # noqa: PLR0911
-    permission_manager: PermissionManager,
-    branch: Branch,
-    node: MainSchemaTypes,
-    action: str,
-    global_permission_report: dict[GlobalPermissions, bool],
-) -> BranchRelativePermissionDecision:
-    # Block mutations on merged branches
-    # Note: Branch delete is allowed via middleware, this covers node permissions
-    # We want this check about the super admin permission as not even an admin account
-    # should be able to modify merged branches or those that need a rebase
-    if branch.status in (BranchStatus.MERGED, BranchStatus.NEED_REBASE) and action != "view":
-        return BranchRelativePermissionDecision.DENY
-
-    if global_permission_report[GlobalPermissions.SUPER_ADMIN]:
-        return BranchRelativePermissionDecision.ALLOW
-
-    if action != "view":
-        if node.kind in (InfrahubKind.ACCOUNTGROUP, InfrahubKind.ACCOUNTROLE, InfrahubKind.GENERICACCOUNT) or (
-            isinstance(node, NodeSchema) and InfrahubKind.GENERICACCOUNT in node.inherit_from
-        ):
-            return (
-                BranchRelativePermissionDecision.ALLOW
-                if global_permission_report[GlobalPermissions.MANAGE_ACCOUNTS]
-                else BranchRelativePermissionDecision.DENY
-            )
-        if node.kind in (InfrahubKind.BASEPERMISSION, InfrahubKind.GLOBALPERMISSION, InfrahubKind.OBJECTPERMISSION) or (
-            isinstance(node, NodeSchema) and InfrahubKind.BASEPERMISSION in node.inherit_from
-        ):
-            return (
-                BranchRelativePermissionDecision.ALLOW
-                if global_permission_report[GlobalPermissions.MANAGE_PERMISSIONS]
-                else BranchRelativePermissionDecision.DENY
-            )
-        if node.kind in (InfrahubKind.GENERICREPOSITORY, InfrahubKind.REPOSITORY, InfrahubKind.READONLYREPOSITORY) or (
-            isinstance(node, NodeSchema) and InfrahubKind.GENERICREPOSITORY in node.inherit_from
-        ):
-            return (
-                BranchRelativePermissionDecision.ALLOW
-                if global_permission_report[GlobalPermissions.MANAGE_REPOSITORIES]
-                else BranchRelativePermissionDecision.DENY
-            )
-
-    is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
-    decision = permission_manager.report_object_permission(namespace=node.namespace, name=node.name, action=action)
-
-    if (
-        decision == PermissionDecisionFlag.ALLOW_ALL
-        or (decision & PermissionDecisionFlag.ALLOW_DEFAULT and is_default_branch)
-        or (decision & PermissionDecisionFlag.ALLOW_OTHER and not is_default_branch)
-    ):
-        return BranchRelativePermissionDecision.ALLOW
-    if decision & PermissionDecisionFlag.ALLOW_DEFAULT:
-        return BranchRelativePermissionDecision.ALLOW_DEFAULT
-    if decision & PermissionDecisionFlag.ALLOW_OTHER:
-        return BranchRelativePermissionDecision.ALLOW_OTHER
-
-    return BranchRelativePermissionDecision.DENY
-
-
 async def report_schema_permissions(
-    branch: Branch, permission_manager: PermissionManager, schemas: list[MainSchemaTypes]
+    branch: Branch, permission_manager: PermissionResolver, schemas: list[MainSchemaTypes]
 ) -> list[KindPermissions]:
-    global_permission_report: dict[GlobalPermissions, bool] = {}
-    for perm in GlobalPermissions:
-        global_permission_report[perm] = permission_manager.resolve_global_permission(
-            permission_to_check=GlobalPermission(action=perm.value, decision=PermissionDecision.ALLOW_ALL.value)
-        )
+    """Build a permission report for a list of schema types.
 
-    permission_objects: list[KindPermissions] = []
-    for node in schemas:
-        permission_objects.append(
-            {
-                "kind": node.kind,
-                "create": get_permission_report(
-                    permission_manager=permission_manager,
-                    branch=branch,
-                    node=node,
-                    action="create",
-                    global_permission_report=global_permission_report,
-                ),
-                "delete": get_permission_report(
-                    permission_manager=permission_manager,
-                    branch=branch,
-                    node=node,
-                    action="delete",
-                    global_permission_report=global_permission_report,
-                ),
-                "update": get_permission_report(
-                    permission_manager=permission_manager,
-                    branch=branch,
-                    node=node,
-                    action="update",
-                    global_permission_report=global_permission_report,
-                ),
-                "view": get_permission_report(
-                    permission_manager=permission_manager,
-                    branch=branch,
-                    node=node,
-                    action="view",
-                    global_permission_report=global_permission_report,
-                ),
-            }
-        )
+    Uses PermissionResolver.get_branch_decision() as the single source of truth,
+    ensuring the report always matches what the pipeline enforces.
+    """
+    global_report = permission_manager.build_global_report()
 
-    return permission_objects
+    return [
+        {
+            "kind": node.kind,
+            "create": permission_manager.get_branch_decision(
+                branch=branch, node=node, action="create", global_report=global_report
+            ),
+            "delete": permission_manager.get_branch_decision(
+                branch=branch, node=node, action="delete", global_report=global_report
+            ),
+            "update": permission_manager.get_branch_decision(
+                branch=branch, node=node, action="update", global_report=global_report
+            ),
+            "view": permission_manager.get_branch_decision(
+                branch=branch, node=node, action="view", global_report=global_report
+            ),
+        }
+        for node in schemas
+    ]

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -20,21 +20,13 @@ async def report_schema_permissions(
     Uses PermissionResolver.get_branch_decision() as the single source of truth,
     ensuring the report always matches what the pipeline enforces.
     """
-    global_report = resolver.build_global_report()
-
     return [
         {
-            "kind": node.kind,
-            "create": resolver.get_branch_decision(
-                branch=branch, node=node, action="create", global_report=global_report
-            ),
-            "delete": resolver.get_branch_decision(
-                branch=branch, node=node, action="delete", global_report=global_report
-            ),
-            "update": resolver.get_branch_decision(
-                branch=branch, node=node, action="update", global_report=global_report
-            ),
-            "view": resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report),
+            "kind": node_schema.kind,
+            "create": resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create"),
+            "delete": resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="delete"),
+            "update": resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="update"),
+            "view": resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view"),
         }
-        for node in schemas
+        for node_schema in schemas
     ]

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -13,30 +13,28 @@ __all__ = ["report_schema_permissions"]
 
 
 async def report_schema_permissions(
-    branch: Branch, permission_manager: PermissionResolver, schemas: list[MainSchemaTypes]
+    branch: Branch, resolver: PermissionResolver, schemas: list[MainSchemaTypes]
 ) -> list[KindPermissions]:
     """Build a permission report for a list of schema types.
 
     Uses PermissionResolver.get_branch_decision() as the single source of truth,
     ensuring the report always matches what the pipeline enforces.
     """
-    global_report = permission_manager.build_global_report()
+    global_report = resolver.build_global_report()
 
     return [
         {
             "kind": node.kind,
-            "create": permission_manager.get_branch_decision(
+            "create": resolver.get_branch_decision(
                 branch=branch, node=node, action="create", global_report=global_report
             ),
-            "delete": permission_manager.get_branch_decision(
+            "delete": resolver.get_branch_decision(
                 branch=branch, node=node, action="delete", global_report=global_report
             ),
-            "update": permission_manager.get_branch_decision(
+            "update": resolver.get_branch_decision(
                 branch=branch, node=node, action="update", global_report=global_report
             ),
-            "view": permission_manager.get_branch_decision(
-                branch=branch, node=node, action="view", global_report=global_report
-            ),
+            "view": resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report),
         }
         for node in schemas
     ]

--- a/backend/infrahub/permissions/resolver.py
+++ b/backend/infrahub/permissions/resolver.py
@@ -117,14 +117,7 @@ class PermissionResolver:
         action: str,
         global_report: dict[GlobalPermissions, bool] | None = None,
     ) -> BranchRelativePermissionDecision:
-        """Unified branch-relative permission decision.
-
-        This method encodes the full priority chain:
-        1. Merged / need-rebase branches deny ALL mutations (even super admin).
-        2. Super admin allows everything else.
-        3. Kind-specific global permissions for mutations.
-        4. Object permissions converted to branch-relative decisions.
-        """
+        """Compute the branch-relative permission decision for a kind/action."""
         if global_report is None:
             global_report = self.build_global_report()
 

--- a/backend/infrahub/permissions/resolver.py
+++ b/backend/infrahub/permissions/resolver.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from infrahub.core import registry
+from infrahub.core.account import GlobalPermission
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions
+from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
+from infrahub.permissions.types import AssignedPermissions, get_global_permission_for_kind
+
+if TYPE_CHECKING:
+    from infrahub.core.account import ObjectPermission
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema import MainSchemaTypes
+
+__all__ = ["PermissionResolver"]
+
+
+class PermissionResolver:
+    """Stateless permission decision engine.
+
+    Given loaded permissions, resolves any permission query without
+    touching the database or requiring an account session.
+    """
+
+    wildcard_values = ["*"]
+    wildcard_actions = ["any"]
+
+    def __init__(self, permissions: AssignedPermissions) -> None:
+        self.permissions = permissions
+
+    def _compute_specificity(self, permission: ObjectPermission) -> int:
+        """Return how specific a permission is.
+
+        More-specific permissions take priority when multiple rules match.
+        """
+        specificity = 0
+        if permission.namespace not in self.wildcard_values:
+            specificity += 1
+        if permission.name not in self.wildcard_values:
+            specificity += 1
+        if permission.action not in self.wildcard_actions:
+            specificity += 1
+        if not permission.decision & PermissionDecisionFlag.ALLOW_ALL:
+            specificity += 1
+        return specificity
+
+    def is_super_admin(self) -> bool:
+        return self.resolve_global_permission(action=GlobalPermissions.SUPER_ADMIN.value)
+
+    def resolve_global_permission(self, action: str) -> bool:
+        """Tell if a global permission is granted, given the action string."""
+        grant_permission = False
+
+        for permission in self.permissions["global_permissions"]:
+            if permission.action == action:
+                # Deny preempts allow
+                if permission.decision == PermissionDecisionFlag.DENY:
+                    return False
+                grant_permission = True
+
+        return grant_permission
+
+    def build_global_report(self) -> dict[GlobalPermissions, bool]:
+        """Precompute the result of every global permission check."""
+        return {perm: self.resolve_global_permission(action=perm.value) for perm in GlobalPermissions}
+
+    def report_object_permission(self, namespace: str, name: str, action: str) -> PermissionDecisionFlag:
+        """Given loaded permissions, return the permission decision for a kind + action."""
+        highest_specificity: int = -1
+        combined_decision = PermissionDecisionFlag.DENY
+
+        for permission in self.permissions["object_permissions"]:
+            if (
+                permission.namespace in [namespace, *self.wildcard_values]
+                and permission.name in [name, *self.wildcard_values]
+                and permission.action in [action, *self.wildcard_actions]
+            ):
+                permission_decision = PermissionDecisionFlag(value=permission.decision)
+                specificity = self._compute_specificity(permission=permission)
+                if specificity > highest_specificity:
+                    combined_decision = permission_decision
+                    highest_specificity = specificity
+                elif specificity == highest_specificity and permission_decision != PermissionDecisionFlag.DENY:
+                    combined_decision |= permission_decision
+
+        return combined_decision
+
+    def resolve_object_permission(self, permission_to_check: ObjectPermission) -> bool:
+        """Compute the permissions and check if the one provided is granted."""
+        required_decision = PermissionDecisionFlag(value=permission_to_check.decision)
+        combined_decision = self.report_object_permission(
+            namespace=permission_to_check.namespace,
+            name=permission_to_check.name,
+            action=permission_to_check.action,
+        )
+        return combined_decision & required_decision == required_decision
+
+    def has_permission(self, permission: GlobalPermission | ObjectPermission) -> bool:
+        """Tell if a permission is granted; super admin bypasses all checks."""
+        is_super = self.is_super_admin()
+
+        if isinstance(permission, GlobalPermission):
+            return self.resolve_global_permission(action=permission.action) or is_super
+
+        return self.resolve_object_permission(permission_to_check=permission) or is_super
+
+    def has_permissions(self, permissions: Sequence[GlobalPermission | ObjectPermission]) -> bool:
+        """Return ``True`` only if *all* permissions are granted."""
+        return all(self.has_permission(permission=permission) for permission in permissions)
+
+    def get_branch_decision(  # noqa: PLR0911
+        self,
+        branch: Branch,
+        node: MainSchemaTypes,
+        action: str,
+        global_report: dict[GlobalPermissions, bool] | None = None,
+    ) -> BranchRelativePermissionDecision:
+        """Unified branch-relative permission decision.
+
+        This method encodes the full priority chain:
+        1. Merged / need-rebase branches deny ALL mutations (even super admin).
+        2. Super admin allows everything else.
+        3. Kind-specific global permissions for mutations.
+        4. Object permissions converted to branch-relative decisions.
+        """
+        if global_report is None:
+            global_report = self.build_global_report()
+
+        if branch.status in (BranchStatus.MERGED, BranchStatus.NEED_REBASE) and action != "view":
+            return BranchRelativePermissionDecision.DENY
+
+        if global_report[GlobalPermissions.SUPER_ADMIN]:
+            return BranchRelativePermissionDecision.ALLOW
+
+        # Kind-specific global permissions for mutations
+        if action != "view":
+            required_global = get_global_permission_for_kind(schema=node)
+            if required_global is not None:
+                return (
+                    BranchRelativePermissionDecision.ALLOW
+                    if global_report[required_global]
+                    else BranchRelativePermissionDecision.DENY
+                )
+
+        # Object permissions with branch-relative logic
+        is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
+        decision = self.report_object_permission(namespace=node.namespace, name=node.name, action=action)
+
+        if (
+            decision == PermissionDecisionFlag.ALLOW_ALL
+            or (decision & PermissionDecisionFlag.ALLOW_DEFAULT and is_default_branch)
+            or (decision & PermissionDecisionFlag.ALLOW_OTHER and not is_default_branch)
+        ):
+            return BranchRelativePermissionDecision.ALLOW
+        if decision & PermissionDecisionFlag.ALLOW_DEFAULT:
+            return BranchRelativePermissionDecision.ALLOW_DEFAULT
+        if decision & PermissionDecisionFlag.ALLOW_OTHER:
+            return BranchRelativePermissionDecision.ALLOW_OTHER
+
+        return BranchRelativePermissionDecision.DENY

--- a/backend/infrahub/permissions/resolver.py
+++ b/backend/infrahub/permissions/resolver.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
-from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions
@@ -27,8 +26,9 @@ class PermissionResolver:
     wildcard_values = ["*"]
     wildcard_actions = ["any"]
 
-    def __init__(self, permissions: AssignedPermissions) -> None:
+    def __init__(self, permissions: AssignedPermissions, default_branch_name: str) -> None:
         self.permissions = permissions
+        self.default_branch_name = default_branch_name
         self._global_report: dict[GlobalPermissions, bool] | None = None
 
     def _compute_specificity(self, permission: ObjectPermission) -> int:
@@ -138,7 +138,7 @@ class PermissionResolver:
                 )
 
         # Object permissions with branch-relative logic
-        is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
+        is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, self.default_branch_name)
         decision = self.report_object_permission(namespace=node_schema.namespace, name=node_schema.name, action=action)
 
         if (

--- a/backend/infrahub/permissions/resolver.py
+++ b/backend/infrahub/permissions/resolver.py
@@ -29,6 +29,7 @@ class PermissionResolver:
 
     def __init__(self, permissions: AssignedPermissions) -> None:
         self.permissions = permissions
+        self._global_report: dict[GlobalPermissions, bool] | None = None
 
     def _compute_specificity(self, permission: ObjectPermission) -> int:
         """Return how specific a permission is.
@@ -63,8 +64,12 @@ class PermissionResolver:
         return grant_permission
 
     def build_global_report(self) -> dict[GlobalPermissions, bool]:
-        """Precompute the result of every global permission check."""
-        return {perm: self.resolve_global_permission(action=perm.value) for perm in GlobalPermissions}
+        """Precompute (and cache) the result of every global permission check."""
+        if self._global_report is None:
+            self._global_report = {
+                perm: self.resolve_global_permission(action=perm.value) for perm in GlobalPermissions
+            }
+        return self._global_report
 
     def report_object_permission(self, namespace: str, name: str, action: str) -> PermissionDecisionFlag:
         """Given loaded permissions, return the permission decision for a kind + action."""
@@ -111,15 +116,10 @@ class PermissionResolver:
         return all(self.has_permission(permission=permission) for permission in permissions)
 
     def get_branch_decision(  # noqa: PLR0911
-        self,
-        branch: Branch,
-        node: MainSchemaTypes,
-        action: str,
-        global_report: dict[GlobalPermissions, bool] | None = None,
+        self, branch: Branch, node_schema: MainSchemaTypes, action: str
     ) -> BranchRelativePermissionDecision:
         """Compute the branch-relative permission decision for a kind/action."""
-        if global_report is None:
-            global_report = self.build_global_report()
+        global_report = self.build_global_report()
 
         if branch.status in (BranchStatus.MERGED, BranchStatus.NEED_REBASE) and action != "view":
             return BranchRelativePermissionDecision.DENY
@@ -129,7 +129,7 @@ class PermissionResolver:
 
         # Kind-specific global permissions for mutations
         if action != "view":
-            required_global = get_global_permission_for_kind(schema=node)
+            required_global = get_global_permission_for_kind(schema=node_schema)
             if required_global is not None:
                 return (
                     BranchRelativePermissionDecision.ALLOW
@@ -139,7 +139,7 @@ class PermissionResolver:
 
         # Object permissions with branch-relative logic
         is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
-        decision = self.report_object_permission(namespace=node.namespace, name=node.name, action=action)
+        decision = self.report_object_permission(namespace=node_schema.namespace, name=node_schema.name, action=action)
 
         if (
             decision == PermissionDecisionFlag.ALLOW_ALL

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -89,7 +89,10 @@ class TestDefaultBranchPermission:
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
@@ -136,7 +139,10 @@ class TestDefaultBranchPermission:
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
@@ -189,7 +195,10 @@ class TestDefaultBranchPermission:
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_query = create_autospec(spec=InfrahubGraphQLQueryAnalyzer)

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -88,8 +88,9 @@ class TestDefaultBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.branch = MagicMock()
@@ -134,8 +135,9 @@ class TestDefaultBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_query = MagicMock(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.branch = MagicMock()
@@ -186,8 +188,9 @@ class TestDefaultBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_query = create_autospec(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.branch = None

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -89,7 +89,10 @@ class TestMergeBranchPermission:
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
@@ -127,7 +130,10 @@ class TestMergeBranchPermission:
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -88,8 +88,9 @@ class TestMergeBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.operation_name = "Foo"
@@ -125,8 +126,9 @@ class TestMergeBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.operation_name = "Foo"

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -79,7 +79,10 @@ class TestSuperAdminPermission:
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_context = MagicMock(spec=GraphqlContext)
@@ -104,7 +107,10 @@ class TestSuperAdminPermission:
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
         permission_manager = await PermissionManager.load_for_account(
-            db=db, branch=permissions_helper.default_branch, account_session=session
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
         )
 
         graphql_context = GraphqlContext(

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -78,8 +78,9 @@ class TestSuperAdminPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_context = MagicMock(spec=GraphqlContext)
         graphql_context.permissions = permission_manager
@@ -102,8 +103,9 @@ class TestSuperAdminPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
 
         graphql_context = GraphqlContext(
             db=MagicMock(),

--- a/backend/tests/component/permissions/test_loader.py
+++ b/backend/tests/component/permissions/test_loader.py
@@ -1,0 +1,73 @@
+from infrahub.auth import AccountSession
+from infrahub.core import registry
+from infrahub.core.account import ObjectPermission
+from infrahub.core.branch import Branch
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
+from infrahub.database import InfrahubDatabase
+from infrahub.permissions import AssignedPermissions, PermissionBackend, PermissionLoader
+from infrahub.permissions.constants import PermissionDecisionFlag
+
+
+class DummyBackendAllow(PermissionBackend):
+    async def load_permissions(
+        self, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
+    ) -> AssignedPermissions:
+        return {
+            "global_permissions": [],
+            "object_permissions": [ObjectPermission("*", "*", "*", PermissionDecisionFlag.ALLOW_ALL.value)],
+        }
+
+
+class DummyBackendDeny(PermissionBackend):
+    async def load_permissions(
+        self, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
+    ) -> AssignedPermissions:
+        return {
+            "global_permissions": [],
+            "object_permissions": [ObjectPermission("Ipam", "*", "*", PermissionDecisionFlag.DENY.value)],
+        }
+
+
+async def test_load_permissions(
+    db: InfrahubDatabase,
+    default_permission_backend: None,
+    default_branch: Branch,
+    session_admin: AccountSession,
+    session_first_account: AccountSession,
+) -> None:
+    loader = PermissionLoader(account_session=session_admin)
+    permissions = await loader.load(db=db, branch=default_branch)
+
+    assert "global_permissions" in permissions
+    assert permissions["global_permissions"][0].action == GlobalPermissions.SUPER_ADMIN.value
+
+    assert "object_permissions" in permissions
+    assert str(permissions["object_permissions"][0]) == str(
+        ObjectPermission(
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
+        )
+    )
+
+    loader = PermissionLoader(account_session=session_first_account)
+    permissions = await loader.load(db=db, branch=default_branch)
+
+    assert "global_permissions" in permissions
+    assert not permissions["global_permissions"]
+
+    assert "object_permissions" in permissions
+    assert not permissions["object_permissions"]
+
+
+async def test_load_permissions_multiple_backends(
+    db: InfrahubDatabase, default_branch: Branch, session_first_account: AccountSession
+) -> None:
+    registry.permission_backends = [DummyBackendAllow(), DummyBackendDeny()]
+
+    loader = PermissionLoader(account_session=session_first_account)
+    permissions = await loader.load(db=db, branch=default_branch)
+
+    assert "global_permissions" in permissions
+    assert not permissions["global_permissions"]
+
+    assert "object_permissions" in permissions
+    assert len(permissions["object_permissions"]) == 2

--- a/backend/tests/component/permissions/test_manager.py
+++ b/backend/tests/component/permissions/test_manager.py
@@ -63,7 +63,7 @@ async def test_has_permission_global(
     await group2.members.save(db=db)
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_first_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_first_account
     )
     assert permission_manager.has_permission(permission=allow_default_branch_edition)
     try:
@@ -72,7 +72,7 @@ async def test_has_permission_global(
         pytest.fail("PermissionDeniedError raised unexpectedly")
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_second_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_second_account
     )
     assert not permission_manager.has_permission(permission=allow_default_branch_edition)
     with pytest.raises(PermissionDeniedError):
@@ -149,14 +149,14 @@ async def test_has_permission_object(
     )
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_first_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_first_account
     )
     assert not permission_manager.has_permission(permission=permission)
     with pytest.raises(PermissionDeniedError, match=r"You do not have the following permission"):
         permission_manager.raise_for_permission(permission=permission)
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_second_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_second_account
     )
     assert permission_manager.has_permission(permission=permission)
     try:
@@ -255,14 +255,14 @@ async def test_has_permissions_object(
     ]
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_first_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_first_account
     )
     assert not permission_manager.has_permissions(permissions=permissions)
     with pytest.raises(PermissionDeniedError, match=r"You do not have one of the following permissions"):
         permission_manager.raise_for_permissions(permissions=permissions)
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_second_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_second_account
     )
     assert permission_manager.has_permissions(permissions=permissions)
     try:
@@ -334,7 +334,7 @@ async def test_report_permission_object(
     await group2.members.save(db=db)
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_first_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_first_account
     )
     assert (
         permission_manager.report_object_permission(namespace="Builtin", name="Tag", action="create")
@@ -346,7 +346,7 @@ async def test_report_permission_object(
     )
 
     permission_manager = await PermissionManager.load_for_account(
-        db=db, branch=default_branch, account_session=session_second_account
+        db=db, branch=default_branch, default_branch_name=default_branch.name, account_session=session_second_account
     )
     assert (
         permission_manager.report_object_permission(namespace="Builtin", name="Tag", action="create")

--- a/backend/tests/component/permissions/test_manager.py
+++ b/backend/tests/component/permissions/test_manager.py
@@ -1,80 +1,14 @@
 import pytest
 
 from infrahub.auth import AccountSession
-from infrahub.core import registry
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionAction, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import PermissionDeniedError
-from infrahub.permissions import AssignedPermissions, PermissionBackend, PermissionManager
+from infrahub.permissions import PermissionManager
 from infrahub.permissions.constants import PermissionDecisionFlag
-
-
-class DummyBackendAllow(PermissionBackend):
-    async def load_permissions(
-        self, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
-    ) -> AssignedPermissions:
-        return {
-            "global_permissions": [],
-            "object_permissions": [ObjectPermission("*", "*", "*", PermissionDecisionFlag.ALLOW_ALL.value)],
-        }
-
-
-class DummyBackendDeny(PermissionBackend):
-    async def load_permissions(
-        self, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
-    ) -> AssignedPermissions:
-        return {
-            "global_permissions": [],
-            "object_permissions": [ObjectPermission("Ipam", "*", "*", PermissionDecisionFlag.DENY.value)],
-        }
-
-
-async def test_load_permissions(
-    db: InfrahubDatabase,
-    default_permission_backend: None,
-    default_branch: Branch,
-    session_admin: AccountSession,
-    session_first_account: AccountSession,
-) -> None:
-    permission_manager = PermissionManager(account_session=session_admin)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
-
-    assert "global_permissions" in permission_manager.permissions
-    assert permission_manager.permissions["global_permissions"][0].action == GlobalPermissions.SUPER_ADMIN.value
-
-    assert "object_permissions" in permission_manager.permissions
-    assert str(permission_manager.permissions["object_permissions"][0]) == str(
-        ObjectPermission(
-            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
-        )
-    )
-
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
-
-    assert "global_permissions" in permission_manager.permissions
-    assert not permission_manager.permissions["global_permissions"]
-
-    assert "object_permissions" in permission_manager.permissions
-    assert not permission_manager.permissions["object_permissions"]
-
-
-async def test_load_permissions_multiple_backends(
-    db: InfrahubDatabase, default_branch: Branch, session_first_account: AccountSession
-) -> None:
-    registry.permission_backends = [DummyBackendAllow(), DummyBackendDeny()]
-
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
-
-    assert "global_permissions" in permission_manager.permissions
-    assert not permission_manager.permissions["global_permissions"]
-
-    assert "object_permissions" in permission_manager.permissions
-    assert len(permission_manager.permissions["object_permissions"]) == 2
 
 
 async def test_has_permission_global(
@@ -128,16 +62,18 @@ async def test_has_permission_global(
     await group2.members.add(db=db, data={"id": session_second_account.account_id})
     await group2.members.save(db=db)
 
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_first_account
+    )
     assert permission_manager.has_permission(permission=allow_default_branch_edition)
     try:
         permission_manager.raise_for_permission(permission=allow_default_branch_edition)
     except PermissionDeniedError:
         pytest.fail("PermissionDeniedError raised unexpectedly")
 
-    permission_manager = PermissionManager(account_session=session_second_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_second_account
+    )
     assert not permission_manager.has_permission(permission=allow_default_branch_edition)
     with pytest.raises(PermissionDeniedError):
         permission_manager.raise_for_permission(permission=allow_default_branch_edition)
@@ -212,14 +148,16 @@ async def test_has_permission_object(
         decision=PermissionDecision.ALLOW_ALL.value,
     )
 
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_first_account
+    )
     assert not permission_manager.has_permission(permission=permission)
     with pytest.raises(PermissionDeniedError, match=r"You do not have the following permission"):
         permission_manager.raise_for_permission(permission=permission)
 
-    permission_manager = PermissionManager(account_session=session_second_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_second_account
+    )
     assert permission_manager.has_permission(permission=permission)
     try:
         permission_manager.raise_for_permission(permission=permission)
@@ -316,14 +254,16 @@ async def test_has_permissions_object(
         ),
     ]
 
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_first_account
+    )
     assert not permission_manager.has_permissions(permissions=permissions)
     with pytest.raises(PermissionDeniedError, match=r"You do not have one of the following permissions"):
         permission_manager.raise_for_permissions(permissions=permissions)
 
-    permission_manager = PermissionManager(account_session=session_second_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_second_account
+    )
     assert permission_manager.has_permissions(permissions=permissions)
     try:
         permission_manager.raise_for_permissions(permissions=permissions)
@@ -393,8 +333,9 @@ async def test_report_permission_object(
     await group2.members.add(db=db, data={"id": session_second_account.account_id})
     await group2.members.save(db=db)
 
-    permission_manager = PermissionManager(account_session=session_first_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_first_account
+    )
     assert (
         permission_manager.report_object_permission(namespace="Builtin", name="Tag", action="create")
         == PermissionDecisionFlag.DENY
@@ -404,8 +345,9 @@ async def test_report_permission_object(
         == PermissionDecisionFlag.ALLOW_ALL
     )
 
-    permission_manager = PermissionManager(account_session=session_second_account)
-    await permission_manager.load_permissions(db=db, branch=default_branch)
+    permission_manager = await PermissionManager.load_for_account(
+        db=db, branch=default_branch, account_session=session_second_account
+    )
     assert (
         permission_manager.report_object_permission(namespace="Builtin", name="Tag", action="create")
         == PermissionDecisionFlag.ALLOW_ALL

--- a/backend/tests/component/permissions/test_resolver.py
+++ b/backend/tests/component/permissions/test_resolver.py
@@ -34,7 +34,7 @@ def empty_resolver() -> PermissionResolver:
 
 
 @pytest.fixture
-def node(register_core_models_schema: None) -> MainSchemaTypes:
+def node_schema(register_core_models_schema: None) -> MainSchemaTypes:
     return registry.schema.get(name=InfrahubKind.TAG)
 
 
@@ -378,7 +378,7 @@ class TestBuildGlobalReport:
 
 
 class TestGetBranchDecision:
-    def test_merged_branch_denies_mutations_even_super_admin(self, node: MainSchemaTypes) -> None:
+    def test_merged_branch_denies_mutations_even_super_admin(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -388,11 +388,11 @@ class TestGetBranchDecision:
         )
         branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
         assert (
-            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_merged_branch_allows_view(self, node: MainSchemaTypes) -> None:
+    def test_merged_branch_allows_view(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -402,18 +402,20 @@ class TestGetBranchDecision:
         )
         branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
         assert (
-            resolver.get_branch_decision(branch=branch, node=node, action="view")
+            resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view")
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_need_rebase_denies_mutations(self, empty_resolver: PermissionResolver, node: MainSchemaTypes) -> None:
+    def test_need_rebase_denies_mutations(
+        self, empty_resolver: PermissionResolver, node_schema: MainSchemaTypes
+    ) -> None:
         branch = Branch(name="rebase-branch", status=BranchStatus.NEED_REBASE)
         assert (
-            empty_resolver.get_branch_decision(branch=branch, node=node, action="update")
+            empty_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="update")
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_super_admin_allows_on_open_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
+    def test_super_admin_allows_on_open_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -422,7 +424,7 @@ class TestGetBranchDecision:
             ]
         )
         assert (
-            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            resolver.get_branch_decision(branch=default_branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW
         )
 
@@ -436,15 +438,17 @@ class TestGetBranchDecision:
                 )
             ]
         )
-        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
-        result = resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = resolver.get_branch_decision(branch=default_branch, node_schema=account_group_schema, action="create")
         assert result == BranchRelativePermissionDecision.ALLOW
 
     def test_manage_accounts_required_but_denied(
         self, register_core_models_schema: None, empty_resolver: PermissionResolver, default_branch: Branch
     ) -> None:
-        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
-        result = empty_resolver.get_branch_decision(branch=default_branch, node=node, action="update")
+        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = empty_resolver.get_branch_decision(
+            branch=default_branch, node_schema=account_group_schema, action="update"
+        )
         assert result == BranchRelativePermissionDecision.DENY
 
     def test_manage_accounts_not_required_for_view(
@@ -456,22 +460,22 @@ class TestGetBranchDecision:
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
             ]
         )
-        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
-        result = resolver.get_branch_decision(branch=default_branch, node=node, action="view")
+        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = resolver.get_branch_decision(branch=default_branch, node_schema=account_group_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW
 
-    def test_allow_default_on_default_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
+    def test_allow_default_on_default_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
             ]
         )
         assert (
-            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            resolver.get_branch_decision(branch=default_branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_allow_default_on_other_branch(self, node: MainSchemaTypes) -> None:
+    def test_allow_default_on_other_branch(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
@@ -479,11 +483,11 @@ class TestGetBranchDecision:
         )
         branch = Branch(name="feature-123", status=BranchStatus.OPEN)
         assert (
-            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW_DEFAULT
         )
 
-    def test_allow_other_on_other_branch(self, node: MainSchemaTypes) -> None:
+    def test_allow_other_on_other_branch(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
@@ -491,30 +495,30 @@ class TestGetBranchDecision:
         )
         branch = Branch(name="feature-123", status=BranchStatus.OPEN)
         assert (
-            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_allow_other_on_default_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
+    def test_allow_other_on_default_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
             ]
         )
         assert (
-            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            resolver.get_branch_decision(branch=default_branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW_OTHER
         )
 
     def test_no_permissions_deny(
-        self, empty_resolver: PermissionResolver, default_branch: Branch, node: MainSchemaTypes
+        self, empty_resolver: PermissionResolver, default_branch: Branch, node_schema: MainSchemaTypes
     ) -> None:
         assert (
-            empty_resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            empty_resolver.get_branch_decision(branch=default_branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_allow_all_on_any_branch(self, node: MainSchemaTypes) -> None:
+    def test_allow_all_on_any_branch(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
@@ -523,21 +527,11 @@ class TestGetBranchDecision:
         for branch_name in ("main", "feature-123"):
             branch = Branch(name=branch_name, status=BranchStatus.OPEN)
             assert (
-                resolver.get_branch_decision(branch=branch, node=node, action="create")
+                resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create")
                 == BranchRelativePermissionDecision.ALLOW
             )
 
-    def test_precomputed_global_report(
-        self, empty_resolver: PermissionResolver, default_branch: Branch, node: MainSchemaTypes
-    ) -> None:
-        report: dict[GlobalPermissions, bool] = dict.fromkeys(GlobalPermissions, False)
-        report[GlobalPermissions.SUPER_ADMIN] = True
-        assert (
-            empty_resolver.get_branch_decision(branch=default_branch, node=node, action="create", global_report=report)
-            == BranchRelativePermissionDecision.ALLOW
-        )
-
-    def test_global_branch_name_treated_as_default(self, node: MainSchemaTypes) -> None:
+    def test_global_branch_name_treated_as_default(self, node_schema: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
@@ -545,6 +539,6 @@ class TestGetBranchDecision:
         )
         branch = Branch(name="-global-", status=BranchStatus.OPEN)
         assert (
-            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.ALLOW
         )

--- a/backend/tests/component/permissions/test_resolver.py
+++ b/backend/tests/component/permissions/test_resolver.py
@@ -89,8 +89,7 @@ class TestResolveGlobalPermission:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -100,12 +99,10 @@ class TestResolveGlobalPermission:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
                 ),
                 GlobalPermission(
-                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                    decision=PermissionDecision.DENY.value,
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.DENY.value
                 ),
             ]
         )
@@ -115,8 +112,7 @@ class TestResolveGlobalPermission:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.MANAGE_SCHEMA.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -126,8 +122,7 @@ class TestResolveGlobalPermission:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -139,7 +134,23 @@ class TestResolveGlobalPermission:
 
 class TestReportObjectPermission:
     def test_no_permissions_returns_deny(self, empty_resolver: PermissionResolver) -> None:
-        assert empty_resolver.report_object_permission("Infra", "Device", "create") == PermissionDecisionFlag.DENY
+        assert (
+            empty_resolver.report_object_permission(namespace="Infra", name="Device", action="create")
+            == PermissionDecisionFlag.DENY
+        )
+
+    def test_unrelated_kind_does_not_grant(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(
+                    namespace="Infra", name="Device", action="any", decision=PermissionDecision.ALLOW_ALL.value
+                )
+            ]
+        )
+        assert (
+            resolver.report_object_permission(namespace="Builtin", name="Tag", action="create")
+            == PermissionDecisionFlag.DENY
+        )
 
     def test_wildcard_allow(self) -> None:
         resolver = _make_resolver(
@@ -147,7 +158,10 @@ class TestReportObjectPermission:
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
             ]
         )
-        assert resolver.report_object_permission("Infra", "Device", "create") == PermissionDecisionFlag.ALLOW_ALL
+        assert (
+            resolver.report_object_permission(namespace="Infra", name="Device", action="create")
+            == PermissionDecisionFlag.ALLOW_ALL
+        )
 
     def test_specific_deny_overrides_wildcard_allow(self) -> None:
         resolver = _make_resolver(
@@ -156,7 +170,10 @@ class TestReportObjectPermission:
                 ObjectPermission(namespace="Builtin", name="Tag", action="any", decision=PermissionDecision.DENY.value),
             ]
         )
-        assert resolver.report_object_permission("Builtin", "Tag", "create") == PermissionDecisionFlag.DENY
+        assert (
+            resolver.report_object_permission(namespace="Builtin", name="Tag", action="create")
+            == PermissionDecisionFlag.DENY
+        )
 
     def test_specific_allow_overrides_wildcard_deny(self) -> None:
         resolver = _make_resolver(
@@ -167,7 +184,10 @@ class TestReportObjectPermission:
                 ),
             ]
         )
-        assert resolver.report_object_permission("Builtin", "Tag", "create") == PermissionDecisionFlag.ALLOW_ALL
+        assert (
+            resolver.report_object_permission(namespace="Builtin", name="Tag", action="create")
+            == PermissionDecisionFlag.ALLOW_ALL
+        )
 
     def test_allow_default_only(self) -> None:
         resolver = _make_resolver(
@@ -175,7 +195,7 @@ class TestReportObjectPermission:
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
             ]
         )
-        result = resolver.report_object_permission("Infra", "Device", "create")
+        result = resolver.report_object_permission(namespace="Infra", name="Device", action="create")
         assert result == PermissionDecisionFlag.ALLOW_DEFAULT
         assert result & PermissionDecisionFlag.ALLOW_DEFAULT
         assert not (result & PermissionDecisionFlag.ALLOW_OTHER)
@@ -186,7 +206,7 @@ class TestReportObjectPermission:
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
             ]
         )
-        result = resolver.report_object_permission("Infra", "Device", "create")
+        result = resolver.report_object_permission(namespace="Infra", name="Device", action="create")
         assert result == PermissionDecisionFlag.ALLOW_OTHER
         assert result & PermissionDecisionFlag.ALLOW_OTHER
         assert not (result & PermissionDecisionFlag.ALLOW_DEFAULT)
@@ -200,7 +220,7 @@ class TestReportObjectPermission:
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value),
             ]
         )
-        result = resolver.report_object_permission("Infra", "Device", "create")
+        result = resolver.report_object_permission(namespace="Infra", name="Device", action="create")
         assert result == PermissionDecisionFlag.ALLOW_ALL
 
 
@@ -214,7 +234,7 @@ class TestResolveObjectPermission:
         check = ObjectPermission(
             namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
         )
-        assert resolver.resolve_object_permission(check) is True
+        assert resolver.resolve_object_permission(permission_to_check=check) is True
 
     def test_allow_default_denied_when_only_allow_other(self) -> None:
         resolver = _make_resolver(
@@ -225,7 +245,7 @@ class TestResolveObjectPermission:
         check = ObjectPermission(
             namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_DEFAULT.value
         )
-        assert resolver.resolve_object_permission(check) is False
+        assert resolver.resolve_object_permission(permission_to_check=check) is False
 
     def test_allow_other_denied_when_only_allow_default(self) -> None:
         resolver = _make_resolver(
@@ -236,90 +256,106 @@ class TestResolveObjectPermission:
         check = ObjectPermission(
             namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_OTHER.value
         )
-        assert resolver.resolve_object_permission(check) is False
+        assert resolver.resolve_object_permission(permission_to_check=check) is False
 
     def test_deny_is_denied(self, empty_resolver: PermissionResolver) -> None:
         check = ObjectPermission(
             namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
         )
-        assert empty_resolver.resolve_object_permission(check) is False
+        assert empty_resolver.resolve_object_permission(permission_to_check=check) is False
 
 
 class TestHasPermission:
+    def test_object_permission_granted(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+            ]
+        )
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert resolver.has_permission(permission=check) is True
+
+    def test_object_permission_denied(self, empty_resolver: PermissionResolver) -> None:
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert empty_resolver.has_permission(permission=check) is False
+
+    def test_global_permission_granted(self) -> None:
+        check = GlobalPermission(
+            action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
+        )
+        resolver = _make_resolver(global_permissions=[check])
+        assert resolver.has_permission(permission=check) is True
+
+    def test_global_permission_denied(self, empty_resolver: PermissionResolver) -> None:
+        check = GlobalPermission(
+            action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert empty_resolver.has_permission(permission=check) is False
+
     def test_super_admin_bypass_for_object(self) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
         check = ObjectPermission(
             namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
         )
-        assert resolver.has_permission(check) is True
+        assert resolver.has_permission(permission=check) is True
 
     def test_super_admin_bypass_for_global(self) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
         check = GlobalPermission(
-            action=GlobalPermissions.MANAGE_SCHEMA.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
+            action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
         )
-        assert resolver.has_permission(check) is True
+        assert resolver.has_permission(permission=check) is True
 
     def test_has_permissions_all_required(self) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
                 ),
                 GlobalPermission(
-                    action=GlobalPermissions.MANAGE_SCHEMA.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
                 ),
             ]
         )
         checks = [
             GlobalPermission(
-                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
+                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
             ),
-            GlobalPermission(
-                action=GlobalPermissions.MANAGE_SCHEMA.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
-            ),
+            GlobalPermission(action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value),
         ]
-        assert resolver.has_permissions(checks) is True
+        assert resolver.has_permissions(permissions=checks) is True
 
     def test_has_permissions_fails_if_one_missing(self) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
                 ),
             ]
         )
         checks = [
             GlobalPermission(
-                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
+                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
             ),
-            GlobalPermission(
-                action=GlobalPermissions.MANAGE_SCHEMA.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
-            ),
+            GlobalPermission(action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value),
         ]
-        assert resolver.has_permissions(checks) is False
+        assert resolver.has_permissions(permissions=checks) is False
 
 
 class TestBuildGlobalReport:
@@ -332,8 +368,7 @@ class TestBuildGlobalReport:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.MANAGE_SCHEMA.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.MANAGE_SCHEMA.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -347,8 +382,7 @@ class TestGetBranchDecision:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -362,8 +396,7 @@ class TestGetBranchDecision:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -384,8 +417,7 @@ class TestGetBranchDecision:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.SUPER_ADMIN.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )
@@ -400,8 +432,7 @@ class TestGetBranchDecision:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
-                    action=GlobalPermissions.MANAGE_ACCOUNTS.value,
-                    decision=PermissionDecision.ALLOW_ALL.value,
+                    action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
                 )
             ]
         )

--- a/backend/tests/component/permissions/test_resolver.py
+++ b/backend/tests/component/permissions/test_resolver.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from infrahub.core.account import GlobalPermission, ObjectPermission
+from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
+from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
+from infrahub.permissions.resolver import PermissionResolver
+
+if TYPE_CHECKING:
+    from infrahub.permissions.types import AssignedPermissions
+
+
+def _make_resolver(
+    global_permissions: list[GlobalPermission] | None = None,
+    object_permissions: list[ObjectPermission] | None = None,
+) -> PermissionResolver:
+    permissions: AssignedPermissions = {
+        "global_permissions": global_permissions or [],
+        "object_permissions": object_permissions or [],
+    }
+    return PermissionResolver(permissions=permissions)
+
+
+@pytest.fixture
+def empty_resolver() -> PermissionResolver:
+    return _make_resolver()
+
+
+@pytest.fixture
+def branch() -> Branch:
+    return Branch(name="main", status=BranchStatus.OPEN)
+
+
+@pytest.fixture
+def node() -> GenericSchema:
+    return GenericSchema(namespace="Infra", name="Device")
+
+
+class TestComputeSpecificity:
+    def test_all_wildcards(self, empty_resolver: PermissionResolver) -> None:
+        perm = ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+        assert empty_resolver._compute_specificity(perm) == 0
+
+    def test_specific_namespace(self, empty_resolver: PermissionResolver) -> None:
+        perm = ObjectPermission(namespace="Infra", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+        assert empty_resolver._compute_specificity(perm) == 1
+
+    def test_specific_namespace_and_name(self, empty_resolver: PermissionResolver) -> None:
+        perm = ObjectPermission(
+            namespace="Infra", name="Device", action="any", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert empty_resolver._compute_specificity(perm) == 2
+
+    def test_all_specific(self, empty_resolver: PermissionResolver) -> None:
+        perm = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert empty_resolver._compute_specificity(perm) == 3
+
+    def test_deny_adds_bonus(self, empty_resolver: PermissionResolver) -> None:
+        perm = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.DENY.value
+        )
+        assert empty_resolver._compute_specificity(perm) == 4
+
+    def test_allow_default_no_bonus(self, empty_resolver: PermissionResolver) -> None:
+        """ALLOW_DEFAULT (2) shares bits with ALLOW_ALL (6), so no bonus."""
+        perm = ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+        assert empty_resolver._compute_specificity(perm) == 0
+
+    def test_allow_other_no_bonus(self, empty_resolver: PermissionResolver) -> None:
+        """ALLOW_OTHER (4) shares bits with ALLOW_ALL (6), so no bonus."""
+        perm = ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
+        assert empty_resolver._compute_specificity(perm) == 0
+
+    def test_deny_with_specific_fields(self, empty_resolver: PermissionResolver) -> None:
+        """DENY (1) does NOT share bits with ALLOW_ALL (6), so bonus applies."""
+        perm = ObjectPermission(namespace="Infra", name="*", action="any", decision=PermissionDecision.DENY.value)
+        assert empty_resolver._compute_specificity(perm) == 2
+
+
+class TestResolveGlobalPermission:
+    def test_no_permissions(self, empty_resolver: PermissionResolver) -> None:
+        assert empty_resolver.resolve_global_permission(action=GlobalPermissions.SUPER_ADMIN.value) is False
+
+    def test_allow(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        assert resolver.resolve_global_permission(action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value) is True
+
+    def test_deny_preempts_allow(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                ),
+                GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.DENY.value,
+                ),
+            ]
+        )
+        assert resolver.resolve_global_permission(action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value) is False
+
+    def test_unrelated_action_ignored(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.MANAGE_SCHEMA.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        assert resolver.resolve_global_permission(action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value) is False
+
+    def test_is_super_admin(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        assert resolver.is_super_admin() is True
+
+    def test_not_super_admin(self, empty_resolver: PermissionResolver) -> None:
+        assert empty_resolver.is_super_admin() is False
+
+
+class TestReportObjectPermission:
+    def test_no_permissions_returns_deny(self, empty_resolver: PermissionResolver) -> None:
+        assert empty_resolver.report_object_permission("Infra", "Device", "create") == PermissionDecisionFlag.DENY
+
+    def test_wildcard_allow(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+            ]
+        )
+        assert resolver.report_object_permission("Infra", "Device", "create") == PermissionDecisionFlag.ALLOW_ALL
+
+    def test_specific_deny_overrides_wildcard_allow(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value),
+                ObjectPermission(namespace="Builtin", name="Tag", action="any", decision=PermissionDecision.DENY.value),
+            ]
+        )
+        assert resolver.report_object_permission("Builtin", "Tag", "create") == PermissionDecisionFlag.DENY
+
+    def test_specific_allow_overrides_wildcard_deny(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.DENY.value),
+                ObjectPermission(
+                    namespace="Builtin", name="Tag", action="any", decision=PermissionDecision.ALLOW_ALL.value
+                ),
+            ]
+        )
+        assert resolver.report_object_permission("Builtin", "Tag", "create") == PermissionDecisionFlag.ALLOW_ALL
+
+    def test_allow_default_only(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+            ]
+        )
+        result = resolver.report_object_permission("Infra", "Device", "create")
+        assert result == PermissionDecisionFlag.ALLOW_DEFAULT
+        assert result & PermissionDecisionFlag.ALLOW_DEFAULT
+        assert not (result & PermissionDecisionFlag.ALLOW_OTHER)
+
+    def test_allow_other_only(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
+            ]
+        )
+        result = resolver.report_object_permission("Infra", "Device", "create")
+        assert result == PermissionDecisionFlag.ALLOW_OTHER
+        assert result & PermissionDecisionFlag.ALLOW_OTHER
+        assert not (result & PermissionDecisionFlag.ALLOW_DEFAULT)
+
+    def test_same_specificity_combines_allow(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(
+                    namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value
+                ),
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value),
+            ]
+        )
+        result = resolver.report_object_permission("Infra", "Device", "create")
+        assert result == PermissionDecisionFlag.ALLOW_ALL
+
+
+class TestResolveObjectPermission:
+    def test_allow_all_granted(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+            ]
+        )
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert resolver.resolve_object_permission(check) is True
+
+    def test_allow_default_denied_when_only_allow_other(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
+            ]
+        )
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_DEFAULT.value
+        )
+        assert resolver.resolve_object_permission(check) is False
+
+    def test_allow_other_denied_when_only_allow_default(self) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+            ]
+        )
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_OTHER.value
+        )
+        assert resolver.resolve_object_permission(check) is False
+
+    def test_deny_is_denied(self, empty_resolver: PermissionResolver) -> None:
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert empty_resolver.resolve_object_permission(check) is False
+
+
+class TestHasPermission:
+    def test_super_admin_bypass_for_object(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        check = ObjectPermission(
+            namespace="Infra", name="Device", action="create", decision=PermissionDecision.ALLOW_ALL.value
+        )
+        assert resolver.has_permission(check) is True
+
+    def test_super_admin_bypass_for_global(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        check = GlobalPermission(
+            action=GlobalPermissions.MANAGE_SCHEMA.value,
+            decision=PermissionDecision.ALLOW_ALL.value,
+        )
+        assert resolver.has_permission(check) is True
+
+    def test_has_permissions_all_required(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                ),
+                GlobalPermission(
+                    action=GlobalPermissions.MANAGE_SCHEMA.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                ),
+            ]
+        )
+        checks = [
+            GlobalPermission(
+                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+            GlobalPermission(
+                action=GlobalPermissions.MANAGE_SCHEMA.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ]
+        assert resolver.has_permissions(checks) is True
+
+    def test_has_permissions_fails_if_one_missing(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                ),
+            ]
+        )
+        checks = [
+            GlobalPermission(
+                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+            GlobalPermission(
+                action=GlobalPermissions.MANAGE_SCHEMA.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ]
+        assert resolver.has_permissions(checks) is False
+
+
+class TestBuildGlobalReport:
+    def test_empty_permissions(self, empty_resolver: PermissionResolver) -> None:
+        report = empty_resolver.build_global_report()
+        assert all(v is False for v in report.values())
+        assert GlobalPermissions.SUPER_ADMIN in report
+
+    def test_reflects_granted_permissions(self) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.MANAGE_SCHEMA.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        report = resolver.build_global_report()
+        assert report[GlobalPermissions.MANAGE_SCHEMA] is True
+        assert report[GlobalPermissions.SUPER_ADMIN] is False
+
+
+class TestGetBranchDecision:
+    @pytest.fixture(autouse=True)
+    def _set_default_branch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from infrahub.core.registry import registry as _registry
+
+        monkeypatch.setattr(_registry, "_default_branch", "main")
+
+    def test_merged_branch_denies_mutations_even_super_admin(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.DENY
+
+    def test_merged_branch_allows_view(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
+        assert resolver.get_branch_decision(branch, node, "view") == BranchRelativePermissionDecision.ALLOW
+
+    def test_need_rebase_denies_mutations(self, empty_resolver: PermissionResolver, node: GenericSchema) -> None:
+        branch = Branch(name="rebase-branch", status=BranchStatus.NEED_REBASE)
+        assert empty_resolver.get_branch_decision(branch, node, "update") == BranchRelativePermissionDecision.DENY
+
+    def test_super_admin_allows_on_open_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        branch = Branch(name="main", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+
+    def test_manage_accounts_required_and_granted(self, branch: Branch) -> None:
+        resolver = _make_resolver(
+            global_permissions=[
+                GlobalPermission(
+                    action=GlobalPermissions.MANAGE_ACCOUNTS.value,
+                    decision=PermissionDecision.ALLOW_ALL.value,
+                )
+            ]
+        )
+        node = GenericSchema(namespace="Core", name="AccountGroup")
+        with patch(
+            "infrahub.permissions.resolver.get_global_permission_for_kind",
+            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
+        ):
+            result = resolver.get_branch_decision(branch, node, "create")
+        assert result == BranchRelativePermissionDecision.ALLOW
+
+    def test_manage_accounts_required_but_denied(self, empty_resolver: PermissionResolver, branch: Branch) -> None:
+        node = GenericSchema(namespace="Core", name="AccountGroup")
+        with patch(
+            "infrahub.permissions.resolver.get_global_permission_for_kind",
+            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
+        ):
+            result = empty_resolver.get_branch_decision(branch, node, "update")
+        assert result == BranchRelativePermissionDecision.DENY
+
+    def test_manage_accounts_not_required_for_view(self, branch: Branch) -> None:
+        """View action should skip the kind-specific global check entirely."""
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+            ]
+        )
+        node = GenericSchema(namespace="Core", name="AccountGroup")
+        with patch(
+            "infrahub.permissions.resolver.get_global_permission_for_kind",
+            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
+        ):
+            result = resolver.get_branch_decision(branch, node, "view")
+        assert result == BranchRelativePermissionDecision.ALLOW
+
+    def test_allow_default_on_default_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+            ]
+        )
+        branch = Branch(name="main", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+
+    def test_allow_default_on_other_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+            ]
+        )
+        branch = Branch(name="feature-123", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW_DEFAULT
+
+    def test_allow_other_on_other_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
+            ]
+        )
+        branch = Branch(name="feature-123", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+
+    def test_allow_other_on_default_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
+            ]
+        )
+        branch = Branch(name="main", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW_OTHER
+
+    def test_no_permissions_deny(self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema) -> None:
+        assert empty_resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.DENY
+
+    def test_allow_all_on_any_branch(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
+            ]
+        )
+        for branch_name in ("main", "feature-123"):
+            branch = Branch(name=branch_name, status=BranchStatus.OPEN)
+            assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+
+    def test_precomputed_global_report(
+        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema
+    ) -> None:
+        report: dict[GlobalPermissions, bool] = dict.fromkeys(GlobalPermissions, False)
+        report[GlobalPermissions.SUPER_ADMIN] = True
+        assert (
+            empty_resolver.get_branch_decision(branch, node, "create", global_report=report)
+            == BranchRelativePermissionDecision.ALLOW
+        )
+
+    def test_global_branch_name_treated_as_default(self, node: GenericSchema) -> None:
+        resolver = _make_resolver(
+            object_permissions=[
+                ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
+            ]
+        )
+        branch = Branch(name="-global-", status=BranchStatus.OPEN)
+        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW

--- a/backend/tests/component/permissions/test_resolver.py
+++ b/backend/tests/component/permissions/test_resolver.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import GlobalPermissions, PermissionDecision
-from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
+from infrahub.core.registry import registry
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.resolver import PermissionResolver
 
 if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.permissions.types import AssignedPermissions
 
 
@@ -34,13 +34,8 @@ def empty_resolver() -> PermissionResolver:
 
 
 @pytest.fixture
-def branch() -> Branch:
-    return Branch(name="main", status=BranchStatus.OPEN)
-
-
-@pytest.fixture
-def node() -> GenericSchema:
-    return GenericSchema(namespace="Infra", name="Device")
+def node(register_core_models_schema: None) -> MainSchemaTypes:
+    return registry.schema.get(name=InfrahubKind.TAG)
 
 
 class TestComputeSpecificity:
@@ -348,13 +343,7 @@ class TestBuildGlobalReport:
 
 
 class TestGetBranchDecision:
-    @pytest.fixture(autouse=True)
-    def _set_default_branch(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from infrahub.core.registry import registry as _registry
-
-        monkeypatch.setattr(_registry, "_default_branch", "main")
-
-    def test_merged_branch_denies_mutations_even_super_admin(self, node: GenericSchema) -> None:
+    def test_merged_branch_denies_mutations_even_super_admin(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -364,9 +353,12 @@ class TestGetBranchDecision:
             ]
         )
         branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.DENY
+        assert (
+            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            == BranchRelativePermissionDecision.DENY
+        )
 
-    def test_merged_branch_allows_view(self, node: GenericSchema) -> None:
+    def test_merged_branch_allows_view(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -376,13 +368,19 @@ class TestGetBranchDecision:
             ]
         )
         branch = Branch(name="merged-branch", status=BranchStatus.MERGED)
-        assert resolver.get_branch_decision(branch, node, "view") == BranchRelativePermissionDecision.ALLOW
+        assert (
+            resolver.get_branch_decision(branch=branch, node=node, action="view")
+            == BranchRelativePermissionDecision.ALLOW
+        )
 
-    def test_need_rebase_denies_mutations(self, empty_resolver: PermissionResolver, node: GenericSchema) -> None:
+    def test_need_rebase_denies_mutations(self, empty_resolver: PermissionResolver, node: MainSchemaTypes) -> None:
         branch = Branch(name="rebase-branch", status=BranchStatus.NEED_REBASE)
-        assert empty_resolver.get_branch_decision(branch, node, "update") == BranchRelativePermissionDecision.DENY
+        assert (
+            empty_resolver.get_branch_decision(branch=branch, node=node, action="update")
+            == BranchRelativePermissionDecision.DENY
+        )
 
-    def test_super_admin_allows_on_open_branch(self, node: GenericSchema) -> None:
+    def test_super_admin_allows_on_open_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -391,10 +389,14 @@ class TestGetBranchDecision:
                 )
             ]
         )
-        branch = Branch(name="main", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+        assert (
+            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW
+        )
 
-    def test_manage_accounts_required_and_granted(self, branch: Branch) -> None:
+    def test_manage_accounts_required_and_granted(
+        self, register_core_models_schema: None, default_branch: Branch
+    ) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -403,78 +405,85 @@ class TestGetBranchDecision:
                 )
             ]
         )
-        node = GenericSchema(namespace="Core", name="AccountGroup")
-        with patch(
-            "infrahub.permissions.resolver.get_global_permission_for_kind",
-            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
-        ):
-            result = resolver.get_branch_decision(branch, node, "create")
+        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = resolver.get_branch_decision(branch=default_branch, node=node, action="create")
         assert result == BranchRelativePermissionDecision.ALLOW
 
-    def test_manage_accounts_required_but_denied(self, empty_resolver: PermissionResolver, branch: Branch) -> None:
-        node = GenericSchema(namespace="Core", name="AccountGroup")
-        with patch(
-            "infrahub.permissions.resolver.get_global_permission_for_kind",
-            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
-        ):
-            result = empty_resolver.get_branch_decision(branch, node, "update")
+    def test_manage_accounts_required_but_denied(
+        self, register_core_models_schema: None, empty_resolver: PermissionResolver, default_branch: Branch
+    ) -> None:
+        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = empty_resolver.get_branch_decision(branch=default_branch, node=node, action="update")
         assert result == BranchRelativePermissionDecision.DENY
 
-    def test_manage_accounts_not_required_for_view(self, branch: Branch) -> None:
+    def test_manage_accounts_not_required_for_view(
+        self, register_core_models_schema: None, default_branch: Branch
+    ) -> None:
         """View action should skip the kind-specific global check entirely."""
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
             ]
         )
-        node = GenericSchema(namespace="Core", name="AccountGroup")
-        with patch(
-            "infrahub.permissions.resolver.get_global_permission_for_kind",
-            return_value=GlobalPermissions.MANAGE_ACCOUNTS,
-        ):
-            result = resolver.get_branch_decision(branch, node, "view")
+        node = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        result = resolver.get_branch_decision(branch=default_branch, node=node, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW
 
-    def test_allow_default_on_default_branch(self, node: GenericSchema) -> None:
+    def test_allow_default_on_default_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
             ]
         )
-        branch = Branch(name="main", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+        assert (
+            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW
+        )
 
-    def test_allow_default_on_other_branch(self, node: GenericSchema) -> None:
+    def test_allow_default_on_other_branch(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
             ]
         )
         branch = Branch(name="feature-123", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW_DEFAULT
+        assert (
+            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW_DEFAULT
+        )
 
-    def test_allow_other_on_other_branch(self, node: GenericSchema) -> None:
+    def test_allow_other_on_other_branch(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
             ]
         )
         branch = Branch(name="feature-123", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+        assert (
+            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW
+        )
 
-    def test_allow_other_on_default_branch(self, node: GenericSchema) -> None:
+    def test_allow_other_on_default_branch(self, default_branch: Branch, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
             ]
         )
-        branch = Branch(name="main", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW_OTHER
+        assert (
+            resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW_OTHER
+        )
 
-    def test_no_permissions_deny(self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema) -> None:
-        assert empty_resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.DENY
+    def test_no_permissions_deny(
+        self, empty_resolver: PermissionResolver, default_branch: Branch, node: MainSchemaTypes
+    ) -> None:
+        assert (
+            empty_resolver.get_branch_decision(branch=default_branch, node=node, action="create")
+            == BranchRelativePermissionDecision.DENY
+        )
 
-    def test_allow_all_on_any_branch(self, node: GenericSchema) -> None:
+    def test_allow_all_on_any_branch(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
@@ -482,23 +491,29 @@ class TestGetBranchDecision:
         )
         for branch_name in ("main", "feature-123"):
             branch = Branch(name=branch_name, status=BranchStatus.OPEN)
-            assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+            assert (
+                resolver.get_branch_decision(branch=branch, node=node, action="create")
+                == BranchRelativePermissionDecision.ALLOW
+            )
 
     def test_precomputed_global_report(
-        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema
+        self, empty_resolver: PermissionResolver, default_branch: Branch, node: MainSchemaTypes
     ) -> None:
         report: dict[GlobalPermissions, bool] = dict.fromkeys(GlobalPermissions, False)
         report[GlobalPermissions.SUPER_ADMIN] = True
         assert (
-            empty_resolver.get_branch_decision(branch, node, "create", global_report=report)
+            empty_resolver.get_branch_decision(branch=default_branch, node=node, action="create", global_report=report)
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_global_branch_name_treated_as_default(self, node: GenericSchema) -> None:
+    def test_global_branch_name_treated_as_default(self, node: MainSchemaTypes) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
             ]
         )
         branch = Branch(name="-global-", status=BranchStatus.OPEN)
-        assert resolver.get_branch_decision(branch, node, "create") == BranchRelativePermissionDecision.ALLOW
+        assert (
+            resolver.get_branch_decision(branch=branch, node=node, action="create")
+            == BranchRelativePermissionDecision.ALLOW
+        )

--- a/backend/tests/unit/permissions/test_merged_branch_permissions.py
+++ b/backend/tests/unit/permissions/test_merged_branch_permissions.py
@@ -2,10 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from infrahub.core.account import ObjectPermission
+from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import GlobalPermissions
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.resolver import PermissionResolver
@@ -17,18 +17,22 @@ def empty_resolver() -> PermissionResolver:
 
 
 @pytest.fixture
-def node() -> GenericSchema:
+def super_admin_resolver() -> PermissionResolver:
+    return PermissionResolver(
+        permissions={
+            "global_permissions": [
+                GlobalPermission(
+                    action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
+                )
+            ],
+            "object_permissions": [],
+        }
+    )
+
+
+@pytest.fixture
+def node_schema() -> GenericSchema:
     return GenericSchema(namespace="Testing", name="TestNode")
-
-
-@pytest.fixture
-def global_report() -> dict[GlobalPermissions, bool]:
-    return dict.fromkeys(GlobalPermissions, False)
-
-
-@pytest.fixture
-def super_admin_report() -> dict[GlobalPermissions, bool]:
-    return {perm: perm == GlobalPermissions.SUPER_ADMIN for perm in GlobalPermissions}
 
 
 class TestMergedBranchPermissions:
@@ -38,31 +42,20 @@ class TestMergedBranchPermissions:
 
     @pytest.mark.parametrize("action", ["create", "update", "delete"])
     def test_mutations_denied(
-        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema, global_report: dict, action: str
+        self, empty_resolver: PermissionResolver, branch: Branch, node_schema: GenericSchema, action: str
     ) -> None:
-        result = empty_resolver.get_branch_decision(
-            branch=branch, node=node, action=action, global_report=global_report
-        )
+        result = empty_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
     @pytest.mark.parametrize("action", ["create", "update", "delete"])
     def test_super_admin_doesnt_bypass(
-        self,
-        empty_resolver: PermissionResolver,
-        branch: Branch,
-        node: GenericSchema,
-        super_admin_report: dict,
-        action: str,
+        self, super_admin_resolver: PermissionResolver, branch: Branch, node_schema: GenericSchema, action: str
     ) -> None:
-        result = empty_resolver.get_branch_decision(
-            branch=branch, node=node, action=action, global_report=super_admin_report
-        )
+        result = super_admin_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
     @patch("infrahub.permissions.resolver.registry")
-    def test_view_allowed(
-        self, mock_registry: MagicMock, branch: Branch, node: GenericSchema, global_report: dict
-    ) -> None:
+    def test_view_allowed(self, mock_registry: MagicMock, branch: Branch, node_schema: GenericSchema) -> None:
         mock_registry.default_branch = "main"
         resolver = PermissionResolver(
             permissions={
@@ -77,7 +70,7 @@ class TestMergedBranchPermissions:
                 ],
             }
         )
-        result = resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report)
+        result = resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW
 
 
@@ -88,31 +81,20 @@ class TestNeedRebaseBranchPermissions:
 
     @pytest.mark.parametrize("action", ["create", "update", "delete"])
     def test_mutations_denied(
-        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema, global_report: dict, action: str
+        self, empty_resolver: PermissionResolver, branch: Branch, node_schema: GenericSchema, action: str
     ) -> None:
-        result = empty_resolver.get_branch_decision(
-            branch=branch, node=node, action=action, global_report=global_report
-        )
+        result = empty_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
     @pytest.mark.parametrize("action", ["create", "update", "delete"])
     def test_super_admin_doesnt_bypass(
-        self,
-        empty_resolver: PermissionResolver,
-        branch: Branch,
-        node: GenericSchema,
-        super_admin_report: dict,
-        action: str,
+        self, super_admin_resolver: PermissionResolver, branch: Branch, node_schema: GenericSchema, action: str
     ) -> None:
-        result = empty_resolver.get_branch_decision(
-            branch=branch, node=node, action=action, global_report=super_admin_report
-        )
+        result = super_admin_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
     @patch("infrahub.permissions.resolver.registry")
-    def test_view_allowed(
-        self, mock_registry: MagicMock, branch: Branch, node: GenericSchema, global_report: dict
-    ) -> None:
+    def test_view_allowed(self, mock_registry: MagicMock, branch: Branch, node_schema: GenericSchema) -> None:
         mock_registry.default_branch = "main"
         resolver = PermissionResolver(
             permissions={
@@ -127,5 +109,5 @@ class TestNeedRebaseBranchPermissions:
                 ],
             }
         )
-        result = resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report)
+        result = resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW

--- a/backend/tests/unit/permissions/test_merged_branch_permissions.py
+++ b/backend/tests/unit/permissions/test_merged_branch_permissions.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from infrahub.core.account import GlobalPermission, ObjectPermission
@@ -13,7 +11,9 @@ from infrahub.permissions.resolver import PermissionResolver
 
 @pytest.fixture
 def empty_resolver() -> PermissionResolver:
-    return PermissionResolver(permissions={"global_permissions": [], "object_permissions": []})
+    return PermissionResolver(
+        permissions={"global_permissions": [], "object_permissions": []}, default_branch_name="main"
+    )
 
 
 @pytest.fixture
@@ -26,7 +26,8 @@ def super_admin_resolver() -> PermissionResolver:
                 )
             ],
             "object_permissions": [],
-        }
+        },
+        default_branch_name="main",
     )
 
 
@@ -54,9 +55,7 @@ class TestMergedBranchPermissions:
         result = super_admin_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
-    @patch("infrahub.permissions.resolver.registry")
-    def test_view_allowed(self, mock_registry: MagicMock, branch: Branch, node_schema: GenericSchema) -> None:
-        mock_registry.default_branch = "main"
+    def test_view_allowed(self, branch: Branch, node_schema: GenericSchema) -> None:
         resolver = PermissionResolver(
             permissions={
                 "global_permissions": [],
@@ -68,7 +67,8 @@ class TestMergedBranchPermissions:
                         decision=PermissionDecisionFlag.ALLOW_ALL.value,
                     )
                 ],
-            }
+            },
+            default_branch_name="main",
         )
         result = resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW
@@ -93,9 +93,7 @@ class TestNeedRebaseBranchPermissions:
         result = super_admin_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action=action)
         assert result == BranchRelativePermissionDecision.DENY
 
-    @patch("infrahub.permissions.resolver.registry")
-    def test_view_allowed(self, mock_registry: MagicMock, branch: Branch, node_schema: GenericSchema) -> None:
-        mock_registry.default_branch = "main"
+    def test_view_allowed(self, branch: Branch, node_schema: GenericSchema) -> None:
         resolver = PermissionResolver(
             permissions={
                 "global_permissions": [],
@@ -107,7 +105,8 @@ class TestNeedRebaseBranchPermissions:
                         decision=PermissionDecisionFlag.ALLOW_ALL.value,
                     )
                 ],
-            }
+            },
+            default_branch_name="main",
         )
         result = resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW

--- a/backend/tests/unit/permissions/test_merged_branch_permissions.py
+++ b/backend/tests/unit/permissions/test_merged_branch_permissions.py
@@ -1,175 +1,131 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from infrahub.core.account import ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import GlobalPermissions
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
-from infrahub.permissions.report import get_permission_report
+from infrahub.permissions.resolver import PermissionResolver
 
 
-def _create_branch(status: BranchStatus, name: str = "test-branch") -> Branch:
-    return Branch(name=name, status=status)
+@pytest.fixture
+def empty_resolver() -> PermissionResolver:
+    return PermissionResolver(permissions={"global_permissions": [], "object_permissions": []})
 
 
-def _create_node() -> GenericSchema:
+@pytest.fixture
+def node() -> GenericSchema:
     return GenericSchema(namespace="Testing", name="TestNode")
 
 
-def _create_global_permission_report(super_admin: bool = False) -> dict[GlobalPermissions, bool]:
-    return {perm: super_admin if perm == GlobalPermissions.SUPER_ADMIN else False for perm in GlobalPermissions}
+@pytest.fixture
+def global_report() -> dict[GlobalPermissions, bool]:
+    return dict.fromkeys(GlobalPermissions, False)
+
+
+@pytest.fixture
+def super_admin_report() -> dict[GlobalPermissions, bool]:
+    return {perm: perm == GlobalPermissions.SUPER_ADMIN for perm in GlobalPermissions}
 
 
 class TestMergedBranchPermissions:
-    def test_permission_denies_create_on_merged_branch(self) -> None:
-        """Test that create permission is DENY on merged branch."""
-        mock_manager = MagicMock()
+    @pytest.fixture
+    def branch(self) -> Branch:
+        return Branch(name="test-branch", status=BranchStatus.MERGED)
 
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.MERGED),
-            node=_create_node(),
-            action="create",
-            global_permission_report=_create_global_permission_report(),
+    @pytest.mark.parametrize("action", ["create", "update", "delete"])
+    def test_mutations_denied(
+        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema, global_report: dict, action: str
+    ) -> None:
+        result = empty_resolver.get_branch_decision(
+            branch=branch, node=node, action=action, global_report=global_report
         )
         assert result == BranchRelativePermissionDecision.DENY
-        # Should not have called the permission manager since it returns early
-        mock_manager.report_object_permission.assert_not_called()
 
-    def test_permission_denies_update_on_merged_branch(self) -> None:
-        """Test that update permission is DENY on merged branch."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.MERGED),
-            node=_create_node(),
-            action="update",
-            global_permission_report=_create_global_permission_report(),
+    @pytest.mark.parametrize("action", ["create", "update", "delete"])
+    def test_super_admin_doesnt_bypass(
+        self,
+        empty_resolver: PermissionResolver,
+        branch: Branch,
+        node: GenericSchema,
+        super_admin_report: dict,
+        action: str,
+    ) -> None:
+        result = empty_resolver.get_branch_decision(
+            branch=branch, node=node, action=action, global_report=super_admin_report
         )
         assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
 
-    def test_permission_denies_delete_on_merged_branch(self) -> None:
-        """Test that delete permission is DENY on merged branch."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.MERGED),
-            node=_create_node(),
-            action="delete",
-            global_permission_report=_create_global_permission_report(),
-        )
-        assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
-
-    def test_super_admin_doesnt_bypass_merged_check(self) -> None:
-        """Test that super admin can't perform actions on merged branches."""
-        mock_branch = _create_branch(BranchStatus.MERGED)
-        mock_node = _create_node()
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=mock_branch,
-            node=mock_node,
-            action="create",
-            global_permission_report=_create_global_permission_report(super_admin=True),
-        )
-        assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
-
-    @patch("infrahub.permissions.report.registry")
-    def test_permission_allows_view_on_merged_branch(self, mock_registry: MagicMock) -> None:
-        """Test that view permission proceeds to normal logic on merged branch."""
+    @patch("infrahub.permissions.resolver.registry")
+    def test_view_allowed(
+        self, mock_registry: MagicMock, branch: Branch, node: GenericSchema, global_report: dict
+    ) -> None:
         mock_registry.default_branch = "main"
-        mock_manager = MagicMock()
-        mock_manager.report_object_permission.return_value = PermissionDecisionFlag.ALLOW_ALL
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.MERGED),
-            node=_create_node(),
-            action="view",
-            global_permission_report=_create_global_permission_report(),
+        resolver = PermissionResolver(
+            permissions={
+                "global_permissions": [],
+                "object_permissions": [
+                    ObjectPermission(
+                        namespace="Testing",
+                        name="TestNode",
+                        action="view",
+                        decision=PermissionDecisionFlag.ALLOW_ALL.value,
+                    )
+                ],
+            }
         )
+        result = resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report)
         assert result == BranchRelativePermissionDecision.ALLOW
-        mock_manager.report_object_permission.assert_called_once()
 
 
 class TestNeedRebaseBranchPermissions:
-    """Tests for permission blocking on branches needing rebase."""
+    @pytest.fixture
+    def branch(self) -> Branch:
+        return Branch(name="test-branch", status=BranchStatus.NEED_REBASE)
 
-    def test_permission_denies_create_on_need_rebase_branch(self) -> None:
-        """Test that create permission is DENY on branch needing rebase."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.NEED_REBASE),
-            node=_create_node(),
-            action="create",
-            global_permission_report=_create_global_permission_report(),
+    @pytest.mark.parametrize("action", ["create", "update", "delete"])
+    def test_mutations_denied(
+        self, empty_resolver: PermissionResolver, branch: Branch, node: GenericSchema, global_report: dict, action: str
+    ) -> None:
+        result = empty_resolver.get_branch_decision(
+            branch=branch, node=node, action=action, global_report=global_report
         )
         assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
 
-    def test_permission_denies_update_on_need_rebase_branch(self) -> None:
-        """Test that update permission is DENY on branch needing rebase."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.NEED_REBASE),
-            node=_create_node(),
-            action="update",
-            global_permission_report=_create_global_permission_report(),
+    @pytest.mark.parametrize("action", ["create", "update", "delete"])
+    def test_super_admin_doesnt_bypass(
+        self,
+        empty_resolver: PermissionResolver,
+        branch: Branch,
+        node: GenericSchema,
+        super_admin_report: dict,
+        action: str,
+    ) -> None:
+        result = empty_resolver.get_branch_decision(
+            branch=branch, node=node, action=action, global_report=super_admin_report
         )
         assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
 
-    def test_permission_denies_delete_on_need_rebase_branch(self) -> None:
-        """Test that delete permission is DENY on branch needing rebase."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.NEED_REBASE),
-            node=_create_node(),
-            action="delete",
-            global_permission_report=_create_global_permission_report(),
-        )
-        assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
-
-    def test_super_admin_doesnt_bypass_need_rebase_check(self) -> None:
-        """Test that super admin can't perform actions on branches needing rebase."""
-        mock_manager = MagicMock()
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.NEED_REBASE),
-            node=_create_node(),
-            action="create",
-            global_permission_report=_create_global_permission_report(super_admin=True),
-        )
-        assert result == BranchRelativePermissionDecision.DENY
-        mock_manager.report_object_permission.assert_not_called()
-
-    @patch("infrahub.permissions.report.registry")
-    def test_permission_allows_view_on_need_rebase_branch(self, mock_registry: MagicMock) -> None:
-        """Test that view permission proceeds to normal logic on branch needing rebase."""
+    @patch("infrahub.permissions.resolver.registry")
+    def test_view_allowed(
+        self, mock_registry: MagicMock, branch: Branch, node: GenericSchema, global_report: dict
+    ) -> None:
         mock_registry.default_branch = "main"
-        mock_manager = MagicMock()
-        mock_manager.report_object_permission.return_value = PermissionDecisionFlag.ALLOW_ALL
-
-        result = get_permission_report(
-            permission_manager=mock_manager,
-            branch=_create_branch(BranchStatus.NEED_REBASE),
-            node=_create_node(),
-            action="view",
-            global_permission_report=_create_global_permission_report(),
+        resolver = PermissionResolver(
+            permissions={
+                "global_permissions": [],
+                "object_permissions": [
+                    ObjectPermission(
+                        namespace="Testing",
+                        name="TestNode",
+                        action="view",
+                        decision=PermissionDecisionFlag.ALLOW_ALL.value,
+                    )
+                ],
+            }
         )
+        result = resolver.get_branch_decision(branch=branch, node=node, action="view", global_report=global_report)
         assert result == BranchRelativePermissionDecision.ALLOW
-        mock_manager.report_object_permission.assert_called_once()

--- a/backend/tests/unit/permissions/test_resolver.py
+++ b/backend/tests/unit/permissions/test_resolver.py
@@ -7,25 +7,25 @@ import pytest
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
-from infrahub.core.registry import registry
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
+from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.resolver import PermissionResolver
 
 if TYPE_CHECKING:
-    from infrahub.core.schema import MainSchemaTypes
     from infrahub.permissions.types import AssignedPermissions
 
 
 def _make_resolver(
     global_permissions: list[GlobalPermission] | None = None,
     object_permissions: list[ObjectPermission] | None = None,
+    default_branch_name: str = "main",
 ) -> PermissionResolver:
     permissions: AssignedPermissions = {
         "global_permissions": global_permissions or [],
         "object_permissions": object_permissions or [],
     }
-    return PermissionResolver(permissions=permissions)
+    return PermissionResolver(permissions=permissions, default_branch_name=default_branch_name)
 
 
 @pytest.fixture
@@ -34,8 +34,13 @@ def empty_resolver() -> PermissionResolver:
 
 
 @pytest.fixture
-def node_schema(register_core_models_schema: None) -> MainSchemaTypes:
-    return registry.schema.get(name=InfrahubKind.TAG)
+def node_schema() -> GenericSchema:
+    return GenericSchema(namespace="Builtin", name="Tag")
+
+
+@pytest.fixture
+def default_branch() -> Branch:
+    return Branch(name="main", status=BranchStatus.OPEN)
 
 
 class TestComputeSpecificity:
@@ -378,7 +383,7 @@ class TestBuildGlobalReport:
 
 
 class TestGetBranchDecision:
-    def test_merged_branch_denies_mutations_even_super_admin(self, node_schema: MainSchemaTypes) -> None:
+    def test_merged_branch_denies_mutations_even_super_admin(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -392,7 +397,7 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_merged_branch_allows_view(self, node_schema: MainSchemaTypes) -> None:
+    def test_merged_branch_allows_view(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -406,16 +411,14 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_need_rebase_denies_mutations(
-        self, empty_resolver: PermissionResolver, node_schema: MainSchemaTypes
-    ) -> None:
+    def test_need_rebase_denies_mutations(self, empty_resolver: PermissionResolver, node_schema: GenericSchema) -> None:
         branch = Branch(name="rebase-branch", status=BranchStatus.NEED_REBASE)
         assert (
             empty_resolver.get_branch_decision(branch=branch, node_schema=node_schema, action="update")
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_super_admin_allows_on_open_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
+    def test_super_admin_allows_on_open_branch(self, default_branch: Branch, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -428,9 +431,7 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_manage_accounts_required_and_granted(
-        self, register_core_models_schema: None, default_branch: Branch
-    ) -> None:
+    def test_manage_accounts_required_and_granted(self, default_branch: Branch) -> None:
         resolver = _make_resolver(
             global_permissions=[
                 GlobalPermission(
@@ -438,33 +439,31 @@ class TestGetBranchDecision:
                 )
             ]
         )
-        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        account_group_schema = GenericSchema(namespace="Core", name="AccountGroup")
         result = resolver.get_branch_decision(branch=default_branch, node_schema=account_group_schema, action="create")
         assert result == BranchRelativePermissionDecision.ALLOW
 
     def test_manage_accounts_required_but_denied(
-        self, register_core_models_schema: None, empty_resolver: PermissionResolver, default_branch: Branch
+        self, empty_resolver: PermissionResolver, default_branch: Branch
     ) -> None:
-        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        account_group_schema = GenericSchema(namespace="Core", name="AccountGroup")
         result = empty_resolver.get_branch_decision(
             branch=default_branch, node_schema=account_group_schema, action="update"
         )
         assert result == BranchRelativePermissionDecision.DENY
 
-    def test_manage_accounts_not_required_for_view(
-        self, register_core_models_schema: None, default_branch: Branch
-    ) -> None:
+    def test_manage_accounts_not_required_for_view(self, default_branch: Branch) -> None:
         """View action should skip the kind-specific global check entirely."""
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
             ]
         )
-        account_group_schema = registry.schema.get(name=InfrahubKind.ACCOUNTGROUP)
+        account_group_schema = GenericSchema(namespace="Core", name="AccountGroup")
         result = resolver.get_branch_decision(branch=default_branch, node_schema=account_group_schema, action="view")
         assert result == BranchRelativePermissionDecision.ALLOW
 
-    def test_allow_default_on_default_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
+    def test_allow_default_on_default_branch(self, default_branch: Branch, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
@@ -475,7 +474,7 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_allow_default_on_other_branch(self, node_schema: MainSchemaTypes) -> None:
+    def test_allow_default_on_other_branch(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)
@@ -487,7 +486,7 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.ALLOW_DEFAULT
         )
 
-    def test_allow_other_on_other_branch(self, node_schema: MainSchemaTypes) -> None:
+    def test_allow_other_on_other_branch(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
@@ -499,7 +498,7 @@ class TestGetBranchDecision:
             == BranchRelativePermissionDecision.ALLOW
         )
 
-    def test_allow_other_on_default_branch(self, default_branch: Branch, node_schema: MainSchemaTypes) -> None:
+    def test_allow_other_on_default_branch(self, default_branch: Branch, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_OTHER.value)
@@ -511,14 +510,14 @@ class TestGetBranchDecision:
         )
 
     def test_no_permissions_deny(
-        self, empty_resolver: PermissionResolver, default_branch: Branch, node_schema: MainSchemaTypes
+        self, empty_resolver: PermissionResolver, default_branch: Branch, node_schema: GenericSchema
     ) -> None:
         assert (
             empty_resolver.get_branch_decision(branch=default_branch, node_schema=node_schema, action="create")
             == BranchRelativePermissionDecision.DENY
         )
 
-    def test_allow_all_on_any_branch(self, node_schema: MainSchemaTypes) -> None:
+    def test_allow_all_on_any_branch(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_ALL.value)
@@ -531,7 +530,7 @@ class TestGetBranchDecision:
                 == BranchRelativePermissionDecision.ALLOW
             )
 
-    def test_global_branch_name_treated_as_default(self, node_schema: MainSchemaTypes) -> None:
+    def test_global_branch_name_treated_as_default(self, node_schema: GenericSchema) -> None:
         resolver = _make_resolver(
             object_permissions=[
                 ObjectPermission(namespace="*", name="*", action="any", decision=PermissionDecision.ALLOW_DEFAULT.value)

--- a/changelog/+permission-resolver.housekeeping.md
+++ b/changelog/+permission-resolver.housekeeping.md
@@ -1,0 +1,1 @@
+Refactored permission system to extract decision logic into a single `PermissionResolver` class. `PermissionManager` now delegates resolution to the resolver and the permission report uses the same resolver, ensuring the GraphQL pipeline and UI report always agree.

--- a/dev/guides/backend/creating-permission-checkers.md
+++ b/dev/guides/backend/creating-permission-checkers.md
@@ -1,0 +1,238 @@
+# Creating Permission Checkers
+
+> Part of: `dev/guides/backend/` | Related: [Permissions Knowledge](../../knowledge/backend/permissions.md)
+
+Step-by-step guide for adding a new permission checker to the GraphQL pipeline.
+
+## When to Create a Checker
+
+Create a new checker when you need to enforce a permission constraint that:
+
+- Applies to GraphQL operations (queries or mutations)
+- Cannot be expressed through existing object permissions alone
+- Requires a global permission or custom logic before the `ObjectPermissionChecker` runs
+
+If you only need to gate CRUD on a specific kind, object permissions already handle that via `ObjectPermissionChecker`. You do NOT need a new checker.
+
+## Prerequisites
+
+- Understanding of the permission system (see [Permissions Knowledge](../../knowledge/backend/permissions.md))
+- Familiarity with the GraphQL query analyzer (`graphql/analyzer.py`)
+
+## Checker Categories
+
+Before writing a checker, decide which category it falls into:
+
+| Category | When to use | Returns | Raises? |
+|---|---|---|---|
+| **Gate** | Short-circuit the entire pipeline for a class of users (e.g., super admin bypass) | `TERMINATE` or `NEXT_CHECKER` | Never |
+| **Enforcement** | Validate a specific constraint and block if violated | `NEXT_CHECKER` always | `PermissionDeniedError` on violation |
+| **Terminal** | Final authority — runs last, handles the general case | `TERMINATE` always | `PermissionDeniedError` on violation |
+
+Most new checkers will be **enforcement** checkers. There should only be one terminal checker (`ObjectPermissionChecker`).
+
+## Steps
+
+### Step 1: Create the Checker Class
+
+Create a new file in `backend/infrahub/graphql/auth/query_permission_checker/` or add to an existing file if closely related to an existing checker.
+
+```python
+# backend/infrahub/graphql/auth/query_permission_checker/my_checker.py
+from infrahub import config
+from infrahub.auth import AccountSession
+from infrahub.core.account import GlobalPermission
+from infrahub.core.branch import Branch
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.initialization import GraphqlParams
+
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
+
+
+class MyPermissionChecker(GraphQLQueryPermissionCheckerInterface):
+    """Describe what this checker enforces."""
+
+    permission_required = GlobalPermission(
+        action=GlobalPermissions.MY_PERMISSION.value,
+        decision=PermissionDecision.ALLOW_ALL.value,
+    )
+
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch
+    ) -> bool:
+        # Return True if this checker should run for this request.
+        # Most checkers use this pattern:
+        return config.SETTINGS.main.allow_anonymous_access or account_session.authenticated
+
+    async def check(
+        self,
+        db: InfrahubDatabase,
+        account_session: AccountSession,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch,
+    ) -> CheckerResolution:
+        # 1. Determine if this request is relevant to your checker
+        if not self._is_relevant(analyzed_query, db, branch):
+            return CheckerResolution.NEXT_CHECKER
+
+        # 2. If relevant and it's a mutation, enforce the permission
+        if analyzed_query.contains_mutation:
+            query_parameters.context.active_permissions.raise_for_permission(
+                permission=self.permission_required
+            )
+
+        # 3. Enforcement checkers always return NEXT_CHECKER
+        return CheckerResolution.NEXT_CHECKER
+```
+
+### Step 2: Implement the Relevance Check
+
+The checker needs to determine whether the current query touches objects it cares about. Common patterns:
+
+**Check by kind:**
+```python
+from infrahub.core.manager import get_schema
+from infrahub.core.schema.node_schema import NodeSchema
+
+# Check if any impacted model matches your target kinds
+for kind in analyzed_query.query_report.impacted_models:
+    schema = get_schema(db=db, branch=branch, node_schema=kind)
+    if kind == InfrahubKind.MY_KIND or (
+        isinstance(schema, NodeSchema) and InfrahubKind.MY_GENERIC in schema.inherit_from
+    ):
+        return True  # This query is relevant
+```
+
+**Check by operation name:**
+```python
+if "MyOperationName" in analyzed_query.operation_names:
+    return True
+```
+
+**Check by relationship access:**
+```python
+if (
+    kind in analyzed_query.query_report.requested_read
+    and "my_relationship" in analyzed_query.query_report.requested_read[kind].relationships
+):
+    return True
+```
+
+### Step 3: Register the Checker
+
+Add your checker to the pipeline in `backend/infrahub/graphql/api/dependencies.py`:
+
+```python
+from ..auth.query_permission_checker.my_checker import MyPermissionChecker
+
+def build_graphql_query_permission_checker() -> GraphQLQueryPermissionChecker:
+    return GraphQLQueryPermissionChecker(
+        [
+            AnonymousGraphQLPermissionChecker(get_anonymous_access_setting),
+            SuperAdminPermissionChecker(),
+            DefaultBranchPermissionChecker(),
+            MergeBranchPermissionChecker(),
+            AccountManagerPermissionChecker(),
+            RepositoryManagerPermissionChecker(),
+            PermissionManagerPermissionChecker(),
+            MyPermissionChecker(),              # <-- Add here
+            ObjectPermissionChecker(),          # Must remain last
+        ]
+    )
+```
+
+**Ordering rules:**
+- Gate checkers go at the top (Anonymous, SuperAdmin)
+- Enforcement checkers go in the middle, before `ObjectPermissionChecker`
+- `ObjectPermissionChecker` must always be last (it's the terminal checker)
+
+### Step 4: Update the Permission Report
+
+If your checker enforces a global permission for specific kinds, update `get_global_permission_for_kind()` in `backend/infrahub/permissions/types.py` so the permission report stays in sync:
+
+```python
+def get_global_permission_for_kind(schema: MainSchemaTypes) -> GlobalPermissions | None:
+    kind_permission_map = {
+        InfrahubKind.GENERICACCOUNT: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.ACCOUNTGROUP: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.ACCOUNTROLE: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.BASEPERMISSION: GlobalPermissions.MANAGE_PERMISSIONS,
+        InfrahubKind.GENERICREPOSITORY: GlobalPermissions.MANAGE_REPOSITORIES,
+        InfrahubKind.MY_KIND: GlobalPermissions.MY_PERMISSION,  # <-- Add here
+    }
+    # ...
+```
+
+This ensures `PermissionResolver.get_branch_decision()` — which powers both the pipeline and the UI permission report — reflects your checker's constraint.
+
+### Step 5: Add a Denial Message
+
+If your checker uses a new global permission, add a human-readable denial message in `backend/infrahub/permissions/constants.py`:
+
+```python
+GLOBAL_PERMISSION_DENIAL_MESSAGE = {
+    # ... existing entries ...
+    GlobalPermissions.MY_PERMISSION.value: "You are not allowed to perform this action",
+}
+
+GLOBAL_PERMISSION_DESCRIPTION = {
+    # ... existing entries ...
+    GlobalPermissions.MY_PERMISSION: "Allow a user to perform this action",
+}
+```
+
+### Step 6: Write Tests
+
+Create tests in `backend/tests/component/graphql/auth/query_permission_checker/`. Follow the pattern in existing test files (e.g., `test_object_permission_checker.py`).
+
+Test at minimum:
+- `supports()` returns correct values for authenticated/unauthenticated users
+- `check()` returns `NEXT_CHECKER` when the query is not relevant
+- `check()` raises `PermissionDeniedError` when the permission is missing
+- `check()` passes when the permission is present
+- `check()` only enforces on mutations (if that's the intent)
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql.auth.query_permission_checker.my_checker import MyPermissionChecker
+
+
+class TestMyPermissionChecker:
+    async def test_irrelevant_query_passes(self, db, branch):
+        checker = MyPermissionChecker()
+        # Set up analyzed_query that doesn't touch your kinds
+        # ...
+        result = await checker.check(db=db, ...)
+        assert result == CheckerResolution.NEXT_CHECKER
+
+    async def test_mutation_without_permission_raises(self, db, branch):
+        checker = MyPermissionChecker()
+        # Set up analyzed_query with mutation on your kind
+        # Set up permission manager without the required permission
+        # ...
+        with pytest.raises(PermissionDeniedError):
+            await checker.check(db=db, ...)
+
+    async def test_mutation_with_permission_passes(self, db, branch):
+        checker = MyPermissionChecker()
+        # Set up analyzed_query with mutation on your kind
+        # Set up permission manager WITH the required permission
+        # ...
+        result = await checker.check(db=db, ...)
+        assert result == CheckerResolution.NEXT_CHECKER
+```
+
+## Checklist
+
+- [ ] Checker class created with `supports()` and `check()` methods
+- [ ] Registered in `dependencies.py` (before `ObjectPermissionChecker`)
+- [ ] `get_global_permission_for_kind()` updated in `types.py` (if applicable)
+- [ ] Denial message added to `constants.py` (if new global permission)
+- [ ] Tests written and passing
+- [ ] Existing tests still pass: `uv run pytest backend/tests/component/graphql/auth/ -v`

--- a/dev/guides/backend/creating-permission-checkers.md
+++ b/dev/guides/backend/creating-permission-checkers.md
@@ -25,6 +25,7 @@ Before writing a checker, decide which category it falls into:
 
 | Category | When to use | Returns | Raises? |
 |---|---|---|---|
+| **Pre-filter** | Reject unauthenticated requests before the pipeline runs | `NEXT_CHECKER` | `AuthorizationError` |
 | **Gate** | Short-circuit the entire pipeline for a class of users (e.g., super admin bypass) | `TERMINATE` or `NEXT_CHECKER` | Never |
 | **Enforcement** | Validate a specific constraint and block if violated | `NEXT_CHECKER` always | `PermissionDeniedError` on violation |
 | **Terminal** | Final authority — runs last, handles the general case | `TERMINATE` always | `PermissionDeniedError` on violation |

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -70,7 +70,7 @@ Key methods:
 - `resolve_global_permission(action: str) -> bool` — Checks if a global permission is granted
 - `report_object_permission(namespace, name, action) -> PermissionDecisionFlag` — Returns the combined decision flag for a kind/action
 - `has_permission(permission) -> bool` — Unified check with super admin bypass
-- `get_branch_decision(branch, node, action) -> BranchRelativePermissionDecision` — Computes the full branch-relative decision for a kind/action, used by both the checker pipeline and permission reports
+- `get_branch_decision(branch, node_schema, action) -> BranchRelativePermissionDecision` — Computes the full branch-relative decision for a kind/action, used by both the checker pipeline and permission reports
 - `build_global_report() -> dict[GlobalPermissions, bool]` — Precomputes all global permission checks for batch operations
 
 ### PermissionManager (`permissions/manager.py`)

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -122,8 +122,9 @@ Each checker returns `TERMINATE` (stop chain, authorized) or `NEXT_CHECKER` (con
 
 | Category | Behavior | Examples |
 |---|---|---|
-| Gate | May short-circuit or pass. Never raises. | Anonymous, SuperAdmin |
-| Enforcement | Raises if violated, returns NEXT_CHECKER. | DefaultBranch, MergeBranch, AccountManager, RepositoryManager, PermissionManager |
+| Gate | May short-circuit (TERMINATE) or pass (NEXT_CHECKER). Never raises. | SuperAdmin |
+| Pre-filter | Rejects unauthenticated requests with `AuthorizationError`. Runs first in the pipeline. | Anonymous |
+| Enforcement | Raises `PermissionDeniedError` if violated, returns NEXT_CHECKER. | DefaultBranch, MergeBranch, AccountManager, RepositoryManager, PermissionManager |
 | Terminal | Always returns TERMINATE. Must be last. | ObjectPermission |
 
 ## REST API Enforcement

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -62,23 +62,39 @@ Account --[group_member]--> AccountGroup --[role__accountgroups]--> AccountRole 
 
 ## Key Classes
 
+The permission stack has three components, each with one responsibility:
+
+```
+PermissionLoader  →  PermissionResolver  →  PermissionManager
+   (I/O)              (decisions)            (enforcement)
+```
+
+A factory wires them together: `PermissionManager.load_for_account(db, branch, account_session)`.
+
+### PermissionLoader (`permissions/loader.py`)
+
+Loads permissions for an account session by orchestrating registered backends. Owns the `registry.permission_backends` dependency.
+
+Key methods:
+- `load(db, branch) -> AssignedPermissions` — Iterates registered backends and accumulates their permissions
+
 ### PermissionResolver (`permissions/resolver.py`)
 
-Stateless decision engine. Takes loaded permissions as input, computes decisions. No I/O, no exceptions, no side effects. This is the **single source of truth** for all permission decisions.
+Stateless decision engine. Takes loaded permissions and a default branch name as input, computes decisions. No I/O, no exceptions, no side effects. This is the **single source of truth** for all permission decisions.
 
 Key methods:
 - `resolve_global_permission(action: str) -> bool` — Checks if a global permission is granted
 - `report_object_permission(namespace, name, action) -> PermissionDecisionFlag` — Returns the combined decision flag for a kind/action
 - `has_permission(permission) -> bool` — Unified check with super admin bypass
 - `get_branch_decision(branch, node_schema, action) -> BranchRelativePermissionDecision` — Computes the full branch-relative decision for a kind/action, used by both the checker pipeline and permission reports
-- `build_global_report() -> dict[GlobalPermissions, bool]` — Precomputes all global permission checks for batch operations
+- `build_global_report() -> dict[GlobalPermissions, bool]` — Precomputes (and caches) all global permission checks for batch operations
 
 ### PermissionManager (`permissions/manager.py`)
 
-Per-request container. Handles permission loading from backends and enforcement (raising `PermissionDeniedError`). Delegates all resolution to `PermissionResolver` via the `resolver` property.
+Per-request facade. Holds the resolver and provides enforcement methods that raise `PermissionDeniedError` on denial. All resolution methods delegate to the injected resolver.
 
 Key methods:
-- `load_permissions(db, branch)` — Loads permissions from all configured backends
+- `load_for_account(db, branch, account_session)` (classmethod) — Factory that wires loader → resolver → manager
 - `raise_for_permission(permission, message)` — Raises if permission is denied
 - `raise_for_permissions(permissions, message)` — Raises if any permission is denied
 

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -1,0 +1,147 @@
+# Permissions and Authorization
+
+> Part of: `dev/knowledge/backend/` | Related: [Backend Architecture](architecture.md)
+
+How the Infrahub permission system works — data model, resolution logic, and enforcement.
+
+## Overview
+
+The permission system has three layers:
+
+1. **Data layer** — Permission nodes stored in Neo4j, assigned through Account -> Group -> Role -> Permission chains
+2. **Resolution layer** — `PermissionResolver` computes decisions from loaded permissions
+3. **Enforcement layer** — GraphQL checker pipeline + ad-hoc `raise_for_permission()` calls in REST endpoints
+
+## Permission Types
+
+### Global Permissions
+
+Gate workflow actions and operational scope. Defined in `GlobalPermissions` enum (`core/constants/__init__.py`):
+
+| Permission | Purpose |
+|---|---|
+| `SUPER_ADMIN` | Bypasses all permission checks |
+| `EDIT_DEFAULT_BRANCH` | Allows mutations on the default branch |
+| `MERGE_BRANCH` | Allows merging branches directly (without proposed change) |
+| `MERGE_PROPOSED_CHANGE` | Allows merging proposed changes |
+| `REVIEW_PROPOSED_CHANGE` | Allows approving/rejecting proposed changes |
+| `MANAGE_SCHEMA` | Allows schema modifications |
+| `MANAGE_ACCOUNTS` | Allows mutations on Account, AccountGroup, AccountRole |
+| `MANAGE_PERMISSIONS` | Allows mutations on permission objects and reading role-permission relationships |
+| `MANAGE_REPOSITORIES` | Allows mutations on Repository and ReadOnlyRepository |
+| `OVERRIDE_CONTEXT` | Allows overriding the execution context |
+| `READ_TELEMETRY` | Allows reading telemetry data |
+| `UPDATE_OBJECT_HFID_DISPLAY_LABEL` | Allows ad-hoc updates to HFIDs and display labels |
+
+Global permission resolution: deny preempts allow. If any loaded permission for an action has decision=DENY, the permission is denied regardless of other ALLOW entries.
+
+### Object Permissions
+
+Gate CRUD operations on specific kinds. Defined by four fields:
+
+- **namespace** — Schema namespace (e.g., `Infra`, `Core`, `*` for wildcard)
+- **name** — Schema name (e.g., `Device`, `*` for wildcard)
+- **action** — `view`, `create`, `update`, `delete`, or `any` (wildcard)
+- **decision** — Bitflag: `DENY` (1), `ALLOW_DEFAULT` (2), `ALLOW_OTHER` (4), `ALLOW_ALL` (6)
+
+The decision values are branch-relative:
+- `ALLOW_DEFAULT` — Permission applies on the default branch only
+- `ALLOW_OTHER` — Permission applies on non-default branches only
+- `ALLOW_ALL` — Permission applies on all branches (`ALLOW_DEFAULT | ALLOW_OTHER`)
+
+## Data Model
+
+```
+Account --[group_member]--> AccountGroup --[role__accountgroups]--> AccountRole --[role__permissions]--> Permission
+```
+
+- `CoreGlobalPermission` — Node with `action` (dropdown) and `decision` (number) attributes
+- `CoreObjectPermission` — Node with `namespace`, `name`, `action`, `decision` attributes
+- `CoreAccountRole` — Has a `permissions` relationship to `CoreBasePermission` (parent of both permission types)
+- `CoreAccountGroup` — Has a `roles` relationship to `CoreAccountRole`
+
+## Key Classes
+
+### PermissionResolver (`permissions/resolver.py`)
+
+Stateless decision engine. Takes loaded permissions as input, computes decisions. No I/O, no exceptions, no side effects. This is the **single source of truth** for all permission decisions.
+
+Key methods:
+- `resolve_global_permission(action: str) -> bool` — Checks if a global permission is granted
+- `report_object_permission(namespace, name, action) -> PermissionDecisionFlag` — Returns the combined decision flag for a kind/action
+- `has_permission(permission) -> bool` — Unified check with super admin bypass
+- `get_branch_decision(branch, node, action) -> BranchRelativePermissionDecision` — Computes the full branch-relative decision for a kind/action, used by both the checker pipeline and permission reports
+- `build_global_report() -> dict[GlobalPermissions, bool]` — Precomputes all global permission checks for batch operations
+
+### PermissionManager (`permissions/manager.py`)
+
+Per-request container. Handles permission loading from backends and enforcement (raising `PermissionDeniedError`). Delegates all resolution to `PermissionResolver` via the `resolver` property.
+
+Key methods:
+- `load_permissions(db, branch)` — Loads permissions from all configured backends
+- `raise_for_permission(permission, message)` — Raises if permission is denied
+- `raise_for_permissions(permissions, message)` — Raises if any permission is denied
+
+### PermissionBackend (`permissions/backend.py`)
+
+Abstract base class for permission loading. The only implementation is `LocalPermissionBackend` which loads from Neo4j. Multiple backends can be chained — each contributes permissions additively. Configured via `config.SETTINGS.main.permission_backends`.
+
+## Specificity Algorithm
+
+When multiple object permissions match a request, the most specific one wins. Specificity is scored 0-4:
+
+- +1 if namespace is not `*`
+- +1 if name is not `*`
+- +1 if action is not `any`
+- +1 if decision is `DENY` (deny bonus — DENY always wins at equal granularity)
+
+At equal specificity, non-DENY permissions are OR'd together.
+
+## Decision Priority Chain
+
+`PermissionResolver.get_branch_decision()` encodes the full priority chain:
+
+1. **Merged/need-rebase branches** — Deny ALL mutations, even for super admins
+2. **Super admin** — Allow everything else
+3. **Kind-specific global permissions** — For mutations on protected kinds (accounts, permissions, repositories), require the corresponding `MANAGE_*` permission
+4. **Object permissions** — Apply specificity algorithm, convert to branch-relative decision
+
+This chain is used by both the GraphQL permission report (UI display) and the checker pipeline (enforcement), ensuring they always agree.
+
+## GraphQL Checker Pipeline
+
+Registered in `graphql/api/dependencies.py`. Checkers run in order:
+
+```
+Anonymous -> SuperAdmin -> DefaultBranch -> MergeBranch -> AccountManager -> RepositoryManager -> PermissionManager -> ObjectPermission
+```
+
+Each checker returns `TERMINATE` (stop chain, authorized) or `NEXT_CHECKER` (continue). If no checker terminates, the request is denied.
+
+**Checker categories** (by convention):
+
+| Category | Behavior | Examples |
+|---|---|---|
+| Gate | May short-circuit or pass. Never raises. | Anonymous, SuperAdmin |
+| Enforcement | Raises if violated, returns NEXT_CHECKER. | DefaultBranch, MergeBranch, AccountManager, RepositoryManager, PermissionManager |
+| Terminal | Always returns TERMINATE. Must be last. | ObjectPermission |
+
+## REST API Enforcement
+
+REST endpoints have no pipeline. Each must manually call `raise_for_permission()`. Some endpoints (schema load, file object download, telemetry) do this correctly. Others only check authentication without authorization.
+
+## Permission Loading (Neo4j Queries)
+
+Four query classes in `core/account.py`:
+- `AccountGlobalPermissionQuery` — Account -> Group -> Role -> GlobalPermission (4 hops)
+- `AccountObjectPermissionQuery` — Account -> Group -> Role -> ObjectPermission (4 hops + 4 attribute subqueries)
+- `AccountRoleGlobalPermissionQuery` — Role -> GlobalPermission (for anonymous access)
+- `AccountRoleObjectPermissionQuery` — Role -> ObjectPermission (for anonymous access)
+
+Permissions are loaded per-request with no caching.
+
+## Helper Functions
+
+- `get_global_permission_for_kind(schema)` — Maps a schema kind to its required global permission (e.g., `AccountGroup` -> `MANAGE_ACCOUNTS`). Returns `None` for unprotected kinds. Located in `permissions/types.py`.
+- `define_object_permission_from_branch(schema, action, branch_name)` — Creates an `ObjectPermission` with the correct branch-relative decision for the given branch. Located in `permissions/types.py`.
+- `define_global_permission_from_branch(permission, branch_name)` — Creates a `GlobalPermission` with the correct branch-relative decision. Located in `permissions/globals.py`.


### PR DESCRIPTION
# Why

The permission system mixed three concerns inside `PermissionManager`: loading permissions from backends, resolving decisions, and enforcing them. On top of that, `report.py` had its own copy of the decision priority chain that sometimes disagreed with what the GraphQL pipeline enforced (super admins could mutate objects on merged branches even though the UI report said "denied.")

This PR splits the permission system into three components and makes the resolver the single source of truth so the report and the pipeline always agree.

## What

The permission stack is now `PermissionLoader` → `PermissionResolver` → `PermissionManager`. The loader owns the `registry.permission_backends` dependency. The resolver is a stateless decision engine that takes loaded permissions and a default branch name and computes everything. The manager is a thin facade that holds the resolver and provides the enforcement methods (`raise_for_*`).

A `PermissionManager.load_for_account(db, branch, account_session)` factory wires the three together for callers that want the all-in-one behaviour.

```python
# 3 components, each with one job
loader = PermissionLoader(account_session=account_session)
permissions = await loader.load(db=db, branch=branch)
resolver = PermissionResolver(permissions=permissions, default_branch_name=registry.default_branch)
manager = PermissionManager(account_session=account_session, resolver=resolver)

# Or, the factory wires everything:
manager = await PermissionManager.load_for_account(
  db=db, branch=branch, account_session=account_session
)
```

`report.py` now calls the resolver directly instead of reimplementing the priority chain. The pipeline and the report compute identical decisions because they go through the same code path.

## What stayed the same

- All `PermissionManager` enforcement methods keep their signatures (`has_permission`, `raise_for_permission`, `raise_for_permissions`, etc.)
- The pipeline registration order in `dependencies.py` is unchanged
- The `MANAGE_*` global permissions are still enforcement gates (Layer 2 from the analysis is intentionally out of scope)
- No database, GraphQL schema, or REST API changes
- No frontend changes required

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies permission decisions behind a stateless `PermissionResolver` used by both the GraphQL checker pipeline and the permission report, eliminating mismatches and keeping `PermissionManager` focused on loading and enforcement.

- **Refactors**
  - Added `PermissionResolver` as the single source of truth for global/object and branch-relative decisions; exported from `infrahub.permissions`; added resolver tests.
  - `PermissionManager` now delegates via a lazy `resolver` property and invalidates it on load; public APIs unchanged.
  - Replaced the report’s logic: `report_schema_permissions()` now takes a `resolver`, precomputes globals with `resolver.build_global_report()`, and calls `resolver.get_branch_decision()`; removed `get_permission_report()`.
  - GraphQL permissions query now passes `active_permissions.resolver`.
  - Documented the checker pipeline contract in the interface; added a checker guide and permissions knowledge doc.

- **Bug Fixes**
  - Fixed pipeline vs report inconsistencies (mutations on merged/need-rebase branches, `manage-*` global checks, super admin precedence); rewrote merged-branch tests.

<sup>Written for commit 512f8aef12b7d3ca067d2b01c084b0cb2c043d3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

