### PR TITLE
Prefer the use of variables instead of hard coded values

### DIFF
--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -125,11 +125,14 @@ async def add_node_to_group(
 
     mutation = Mutation(
         mutation="RelationshipAdd",
-        input_data={"data": {"id": group_id, "name": "members", "nodes": [{"id": node_id}]}},
+        input_data={"data": {"id": "$group_id", "name": "members", "nodes": [{"id": "$node_id"}]}},
         query={"ok": None},
+        variables={"group_id": str, "node_id": str},
     )
 
-    await service.client.execute_graphql(query=mutation.render(), branch_name=branch_name)
+    await service.client.execute_graphql(
+        query=mutation.render(), variables={"group_id": group_id, "node_id": node_id}, branch_name=branch_name
+    )
 
 
 @flow(
@@ -147,11 +150,14 @@ async def remove_node_from_group(
 
     mutation = Mutation(
         mutation="RelationshipRemove",
-        input_data={"data": {"id": group_id, "name": "members", "nodes": [{"id": node_id}]}},
+        input_data={"data": {"id": "$group_id", "name": "members", "nodes": [{"id": "$node_id"}]}},
         query={"ok": None},
+        variables={"group_id": str, "node_id": str},
     )
 
-    await service.client.execute_graphql(query=mutation.render(), branch_name=branch_name)
+    await service.client.execute_graphql(
+        query=mutation.render(), variables={"group_id": group_id, "node_id": node_id}, branch_name=branch_name
+    )
 
 
 @flow(

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -345,7 +345,7 @@ class ComputedAttrJinja2GraphQL(BaseModel):
     attribute_schema: AttributeSchema = Field(..., description="The computed attribute")
     variables: list[str] = Field(..., description="The list of variable names used within the computed attribute")
 
-    def render_graphql_query(self, query_filter: str, filter_id: str) -> str:
+    def render_graphql_query(self, query_filter: str) -> str:
         query_fields = self.query_fields
         query_fields["id"] = None
         query_fields[self.attribute_schema.name] = {"value": None}
@@ -353,10 +353,11 @@ class ComputedAttrJinja2GraphQL(BaseModel):
             name="ComputedAttributeFilter",
             query={
                 self.node_schema.kind: {
-                    "@filters": {query_filter: filter_id},
+                    "@filters": {query_filter: "$filter_id"},
                     "edges": {"node": query_fields},
                 }
             },
+            variables={"filter_id": str},
         )
 
         return query.render()

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -266,9 +266,11 @@ async def process_jinja2(
         )
 
         for id_filter in resolved.node_filters:
-            query = attribute_graphql.render_graphql_query(query_filter=id_filter, filter_id=object_id)
+            query = attribute_graphql.render_graphql_query(query_filter=id_filter)
             try:
-                response = await client.execute_graphql(query=query, branch_name=branch_name)
+                response = await client.execute_graphql(
+                    query=query, variables={"filter_id": object_id}, branch_name=branch_name
+                )
             except URLNotFoundError:
                 log.warning(
                     f"Process computed attributes for {computed_attribute_kind}.{computed_attribute_name} failed for branch {branch_name} (not found)"

--- a/backend/infrahub/display_labels/models.py
+++ b/backend/infrahub/display_labels/models.py
@@ -174,7 +174,7 @@ class DisplayLabelJinja2GraphQL(BaseModel):
     node_schema: NodeSchema = Field(..., description="The node kind where the computed attribute is defined")
     variables: list[str] = Field(..., description="The list of variable names used within the computed attribute")
 
-    def render_graphql_query(self, filter_id: str) -> str:
+    def render_graphql_query(self) -> str:
         query_fields = self.query_fields
         query_fields["id"] = None
         query_fields["display_label"] = None
@@ -182,10 +182,11 @@ class DisplayLabelJinja2GraphQL(BaseModel):
             name="DisplayLabelFilter",
             query={
                 self.node_schema.kind: {
-                    "@filters": {self.filter_key: filter_id},
+                    "@filters": {self.filter_key: "$filter_id"},
                     "edges": {"node": query_fields},
                 }
             },
+            variables={"filter_id": str},
         )
 
         return query.render()

--- a/backend/infrahub/display_labels/tasks.py
+++ b/backend/infrahub/display_labels/tasks.py
@@ -106,8 +106,8 @@ async def process_display_label(
         node_schema=node_schema, variables=variables, filter_key=display_label_template.filter_key
     )
 
-    query = display_label_graphql.render_graphql_query(filter_id=object_id)
-    response = await client.execute_graphql(query=query, branch_name=branch_name)
+    query = display_label_graphql.render_graphql_query()
+    response = await client.execute_graphql(query=query, variables={"filter_id": object_id}, branch_name=branch_name)
     update_candidates = display_label_graphql.parse_response(response=response)
 
     if not update_candidates:

--- a/backend/infrahub/hfid/models.py
+++ b/backend/infrahub/hfid/models.py
@@ -174,7 +174,7 @@ class HFIDGraphQL(BaseModel):
     node_schema: NodeSchema = Field(..., description="The node kind where the computed attribute is defined")
     variables: list[str] = Field(..., description="The list of variable names used within the computed attribute")
 
-    def render_graphql_query(self, filter_id: str) -> str:
+    def render_graphql_query(self) -> str:
         query_fields = self.query_fields
         query_fields["id"] = None
         query_fields["hfid"] = None
@@ -182,10 +182,11 @@ class HFIDGraphQL(BaseModel):
             name="HFIDFilter",
             query={
                 self.node_schema.kind: {
-                    "@filters": {self.filter_key: filter_id},
+                    "@filters": {self.filter_key: "$filter_id"},
                     "edges": {"node": query_fields},
                 }
             },
+            variables={"filter_id": str},
         )
 
         return query.render()

--- a/backend/infrahub/hfid/tasks.py
+++ b/backend/infrahub/hfid/tasks.py
@@ -105,8 +105,8 @@ async def process_hfid(
         node_schema=node_schema, variables=hfid_definition.hfid, filter_key=hfid_definition.filter_key
     )
 
-    query = hfid_graphql.render_graphql_query(filter_id=object_id)
-    response = await client.execute_graphql(query=query, branch_name=branch_name)
+    query = hfid_graphql.render_graphql_query()
+    response = await client.execute_graphql(query=query, variables={"filter_id": object_id}, branch_name=branch_name)
     update_candidates = hfid_graphql.parse_response(response=response)
 
     if not update_candidates:

--- a/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
+++ b/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -100,11 +100,15 @@ CITY = NodeSchema(
 
 
 async def assert_correct_graphql_structure(
-    db: InfrahubDatabase, default_branch: Branch, rendered_query: str, expected_value: str
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    rendered_query: str,
+    expected_value: str,
+    variables: dict[str, Any] | None = None,
 ) -> None:
     assert "... on TestingCountry" in rendered_query
 
-    result = await graphql_query(query=rendered_query, db=db, branch=default_branch)
+    result = await graphql_query(query=rendered_query, db=db, branch=default_branch, variables=variables)
 
     assert result.errors is None
     edges = result.data["TestingCity"]["edges"]
@@ -167,8 +171,10 @@ async def test_computed_attr_graphql_query_executes_successfully(
         variables=variables,
     )
 
-    rendered_query = graphql_obj.render_graphql_query(query_filter="parent__ids", filter_id=country.id)
-    await assert_correct_graphql_structure(db, default_branch, rendered_query, expected_country_code)
+    rendered_query = graphql_obj.render_graphql_query(query_filter="parent__ids")
+    await assert_correct_graphql_structure(
+        db, default_branch, rendered_query, expected_country_code, variables={"filter_id": country.id}
+    )
 
 
 async def test_display_label_graphql_query_executes_successfully(
@@ -199,8 +205,10 @@ async def test_display_label_graphql_query_executes_successfully(
         variables=["parent__country_code__value", "shortname__value"],
     )
 
-    rendered_query = graphql_obj.render_graphql_query(filter_id=city.id)
-    await assert_correct_graphql_structure(db, default_branch, rendered_query, expected_country_code)
+    rendered_query = graphql_obj.render_graphql_query()
+    await assert_correct_graphql_structure(
+        db, default_branch, rendered_query, expected_country_code, variables={"filter_id": city.id}
+    )
 
 
 async def test_hfid_graphql_query_executes_successfully(
@@ -232,5 +240,7 @@ async def test_hfid_graphql_query_executes_successfully(
         variables=["parent__country_code__value", "shortname__value"],
     )
 
-    rendered_query = graphql_obj.render_graphql_query(filter_id=city.id)
-    await assert_correct_graphql_structure(db, default_branch, rendered_query, expected_country_code)
+    rendered_query = graphql_obj.render_graphql_query()
+    await assert_correct_graphql_structure(
+        db, default_branch, rendered_query, expected_country_code, variables={"filter_id": city.id}
+    )

--- a/backend/tests/unit/computed_attribute/test_models.py
+++ b/backend/tests/unit/computed_attribute/test_models.py
@@ -117,7 +117,7 @@ class TestQueryFieldsInlineFragment:
         )
         assert parent_node["... on TestingCountry"]["slug"] == {"value": None}
 
-        rendered = graphql_obj.render_graphql_query(query_filter="ids", filter_id="abc-123")
+        rendered = graphql_obj.render_graphql_query(query_filter="ids")
         assert "... on TestingCountry" in rendered
 
     def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:
@@ -135,7 +135,7 @@ class TestQueryFieldsInlineFragment:
         assert owner_node["name"] == {"value": None}
         assert not any(k.startswith("... on") for k in owner_node)
 
-        rendered = graphql_obj.render_graphql_query(query_filter="ids", filter_id="abc-123")
+        rendered = graphql_obj.render_graphql_query(query_filter="ids")
         assert "... on" not in rendered
 
     def test_no_fragment_when_peer_equals_hierarchical(self, build_schema: Callable[..., NodeSchema]) -> None:
@@ -153,5 +153,5 @@ class TestQueryFieldsInlineFragment:
         assert parent_node["name"] == {"value": None}
         assert not any(k.startswith("... on") for k in parent_node)
 
-        rendered = graphql_obj.render_graphql_query(query_filter="ids", filter_id="abc-123")
+        rendered = graphql_obj.render_graphql_query(query_filter="ids")
         assert "... on" not in rendered

--- a/backend/tests/unit/display_labels/test_models.py
+++ b/backend/tests/unit/display_labels/test_models.py
@@ -54,7 +54,7 @@ class TestQueryFieldsInlineFragment:
         )
         assert parent_node["... on TestingCountry"]["slug"] == {"value": None}
 
-        rendered = graphql_obj.render_graphql_query(filter_id="abc-123")
+        rendered = graphql_obj.render_graphql_query()
         assert "... on TestingCountry" in rendered
 
     def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:

--- a/backend/tests/unit/hfid/test_models.py
+++ b/backend/tests/unit/hfid/test_models.py
@@ -54,7 +54,7 @@ class TestQueryFieldsInlineFragment:
         )
         assert parent_node["... on TestingCountry"]["slug"] == {"value": None}
 
-        rendered = graphql_obj.render_graphql_query(filter_id="abc-123")
+        rendered = graphql_obj.render_graphql_query()
         assert "... on TestingCountry" in rendered
 
     def test_no_fragment_for_non_hierarchical_relationship(self, build_schema: Callable[..., NodeSchema]) -> None:


### PR DESCRIPTION
# Why

Avoid rendering GraphQL queries with values directly in the query and use variables instead. The reason is that we cache GraphQL queries in the backend but can only do so if the variables are sent in as actual variables.

Relates to #8945

## What changed



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GraphQL queries and mutations to use variables instead of hard-coded values to enable backend query caching and reduce cache misses. Aligns with Linear 8945.

- **Refactors**
  - Use variables in `RelationshipAdd`/`RelationshipRemove` mutations; declare types and pass `variables` to `execute_graphql`.
  - Computed attributes, display labels, and HFID builders now reference `$filter_id`, declare it in `Query.variables`, remove the `filter_id` arg from `render_graphql_query`, and pass `variables={"filter_id": object_id}` in tasks.
  - Tests updated to pass variables and match new method signatures.

<sup>Written for commit 0f544741b4776bf42e28304780368a9573c78d73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

