### PR TITLE
Fix SVG artifact preview scroll and download 

### DIFF
--- a/changelog/+4f7e9565.fixed.md
+++ b/changelog/+4f7e9565.fixed.md
@@ -1,0 +1,1 @@
+Allow scrolling in the artifact preview for SVG images so oversized content is no longer clipped.

--- a/changelog/+4f7e9565.fixed.md
+++ b/changelog/+4f7e9565.fixed.md
@@ -1,1 +1,1 @@
-Allow scrolling in the artifact preview for SVG images so oversized content is no longer clipped.
+Improve SVG artifact handling: allow scrolling in the preview so oversized content is no longer clipped, and fix the download action so the saved file contains the raw SVG content.

--- a/frontend/app/src/app/providers/react-aria-router-provider.tsx
+++ b/frontend/app/src/app/providers/react-aria-router-provider.tsx
@@ -12,7 +12,10 @@ const EXTERNAL_HREF_PREFIXES = ["https://", "http://", "mailto:", "blob:", "data
 
 function useAbsoluteHref(path: To) {
   const relative = useHref(path);
-  if (typeof path === "string" && EXTERNAL_HREF_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+  if (
+    typeof path === "string" &&
+    EXTERNAL_HREF_PREFIXES.some((prefix) => path.startsWith(prefix))
+  ) {
     return path;
   }
   return relative;

--- a/frontend/app/src/app/providers/react-aria-router-provider.tsx
+++ b/frontend/app/src/app/providers/react-aria-router-provider.tsx
@@ -8,12 +8,11 @@ declare module "react-aria-components" {
   }
 }
 
+const EXTERNAL_HREF_PREFIXES = ["https://", "http://", "mailto:", "blob:", "data:"];
+
 function useAbsoluteHref(path: To) {
   const relative = useHref(path);
-  if (
-    typeof path === "string" &&
-    (path.startsWith("https://") || path.startsWith("http://") || path.startsWith("mailto:"))
-  ) {
+  if (typeof path === "string" && EXTERNAL_HREF_PREFIXES.some((prefix) => path.startsWith(prefix))) {
     return path;
   }
   return relative;

--- a/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
@@ -5,7 +5,7 @@ import { DataViewerDownloadButton } from "@/shared/components/data-viewer/data-v
 import type { DataViewerContentType } from "@/shared/components/data-viewer/types";
 import NoDataFound from "@/shared/components/errors/no-data-found";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
-import { isCopyableContentType } from "@/shared/utils/file";
+import { isBinaryContentType, isCopyableContentType } from "@/shared/utils/file";
 
 import { getArtifactFileDownloadUrl } from "@/entities/artifacts/domain/get-artifact-file";
 import { useGetArtifactFile } from "@/entities/artifacts/domain/get-artifact-file.query";
@@ -44,7 +44,12 @@ export function ArtifactFile({ storageId, fileName, contentType, className }: Ar
           <DataViewerLinkButton href={downloadUrl} target="_blank" rel="noopener noreferrer">
             Raw
           </DataViewerLinkButton>
-          <DataViewerDownloadButton data={data} fileName={fileName} contentType={contentType} />
+          <DataViewerDownloadButton
+            data={data}
+            fileName={fileName}
+            contentType={contentType}
+            downloadUrl={isBinaryContentType(contentType) ? downloadUrl : undefined}
+          />
           {isCopyableContentType(contentType) && <DataViewerCopyButton data={data} />}
         </>
       }

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -51,7 +51,7 @@ function DataViewerContent({
 
     case "image/svg+xml": {
       return (
-        <ScrollArea scrollX className="bg-white" scrollBarClassName="bg-transparent">
+        <ScrollArea scrollX className="bg-white rounded-lg" scrollBarClassName="bg-transparent">
           <Svg value={content} className="mx-auto" />
         </ScrollArea>
       );

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -51,11 +51,7 @@ function DataViewerContent({
 
     case "image/svg+xml": {
       return (
-        <ScrollArea
-          scrollX
-          className="grow rounded-lg border border-neutral-700 bg-white shadow-sm"
-          scrollBarClassName="bg-transparent"
-        >
+        <ScrollArea scrollX className="rounded-lg bg-white" scrollBarClassName="bg-transparent">
           <div className="p-4">
             <Svg value={content} />
           </div>

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -51,7 +51,7 @@ function DataViewerContent({
 
     case "image/svg+xml": {
       return (
-        <ScrollArea scrollX className="bg-white rounded-lg" scrollBarClassName="bg-transparent">
+        <ScrollArea scrollX className="rounded-lg bg-white" scrollBarClassName="bg-transparent">
           <Svg value={content} className="mx-auto" />
         </ScrollArea>
       );

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -51,7 +51,15 @@ function DataViewerContent({
 
     case "image/svg+xml": {
       return (
-        <Svg value={content} className="grow rounded-lg border border-neutral-700 shadow-sm" />
+        <ScrollArea
+          scrollX
+          className="grow rounded-lg border border-neutral-700 bg-white shadow-sm"
+          scrollBarClassName="bg-transparent"
+        >
+          <div className="p-4">
+            <Svg value={content} />
+          </div>
+        </ScrollArea>
       );
     }
 

--- a/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
+++ b/frontend/app/src/shared/components/data-viewer/data-viewer.tsx
@@ -51,10 +51,8 @@ function DataViewerContent({
 
     case "image/svg+xml": {
       return (
-        <ScrollArea scrollX className="rounded-lg bg-white" scrollBarClassName="bg-transparent">
-          <div className="p-4">
-            <Svg value={content} />
-          </div>
+        <ScrollArea scrollX className="bg-white" scrollBarClassName="bg-transparent">
+          <Svg value={content} className="mx-auto" />
         </ScrollArea>
       );
     }


### PR DESCRIPTION
issue: https://github.com/opsmill/infrahub/issues/8984

<img width="1555" height="991" alt="image" src="https://github.com/user-attachments/assets/b09250d8-9395-472f-bc18-91ec6262dd2f" />

## Summary
- Wrap oversized SVG artifact previews in a scroll area so content is no longer clipped
- Fix SVG/text artifact downloads that produced the Vite index.html instead of the raw content
- Allow blob: / data: URLs to pass through ReactAriaRouterProvider so native download works
- Use client-side blob URLs for text artifacts (SVG, JSON, YAML, etc.) so `download` triggers a save across dev and prod




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SVG artifact previews horizontally scrollable so oversized SVGs aren’t clipped and can be viewed at full size. Fix artifact downloads by allowing `blob:`/`data:` URLs in `ReactAriaRouterProvider` and using client-side Blob URLs for text files while keeping direct links for binaries; addresses IFC-2483.

<sup>Written for commit 815aa806dbfd579ac0b78d458dd33c25de872b40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





