### PR TITLE
docs: Add documentation for GraphQL fragments support

### DIFF
--- a/docs/docs/guides/graphql-fragment.mdx
+++ b/docs/docs/guides/graphql-fragment.mdx
@@ -92,7 +92,7 @@ query DeviceInterfaces($device_name: String!) {
 }
 ```
 
-When Infrahub imports this query from the repository, it detects the `...interfaceFields` spread, resolves it against the declared fragment files, and stores the complete query with the fragment definition inlined.
+When Infrahub imports this query from the repository, it detects the `...interfaceFields` spread, resolves it against the declared fragment files, and stores the complete query with the fragment definition included inline.
 
 ## 4. Sync the repository
 
@@ -106,7 +106,7 @@ infrahubctl render device_config_transform device_name=router01
 
 ## 5. Verify the result
 
-Open the GraphQL query in the Infrahub web interface or query it via the API. The stored query contains the fragment definition inlined alongside the operation, so it executes without any additional resolution at runtime.
+Open the GraphQL query in the Infrahub web interface or query it via the API. The stored query contains the fragment definition included inline alongside the operation, so it executes without any additional resolution at runtime.
 
 ```shell
 curl -s "https://<host>/api/query/device_interfaces_query?device_name=router01" | python -m json.tool

--- a/docs/docs/guides/graphql-fragment.mdx
+++ b/docs/docs/guides/graphql-fragment.mdx
@@ -1,0 +1,192 @@
+---
+title: Using GraphQL fragments
+---
+
+# Using GraphQL fragments
+
+[GraphQL fragments](../topics/graphql.mdx#graphql-fragments) allow you to define reusable field selections that can be shared across multiple queries. Instead of duplicating the same field selections in every query, define them once as a fragment and reference them with standard GraphQL spread syntax (`...fragmentName`).
+
+This is particularly useful when multiple [Transformations](../topics/transformation.mdx) or [Generators](../topics/generator.mdx) need to query the same fields from a model. Update the fragment once, and all queries that reference it pick up the change on their next execution.
+
+## Prerequisites
+
+- A running Infrahub instance
+- An [external Git repository](../guides/repository.mdx) connected to Infrahub (or a local repository for testing with `infrahubctl`)
+- Familiarity with [GraphQL queries](../topics/graphql.mdx) in Infrahub
+
+## 1. Define a fragment file
+
+Create a `.gql` file containing one or more fragment definitions. Each fragment targets a specific GraphQL type and selects the fields you want to reuse.
+
+Create a file named `fragments/interface_fields.gql`:
+
+```graphql
+fragment interfaceFields on InfraInterfaceL3 {
+  name {
+    value
+  }
+  description {
+    value
+  }
+  speed {
+    value
+  }
+  ip_addresses {
+    edges {
+      node {
+        address {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+:::info
+
+The type after `on` must match a valid model in your Infrahub schema. In this example, `InfraInterfaceL3` refers to the model kind as it appears in GraphQL queries.
+
+:::
+
+## 2. Declare the fragment in `.infrahub.yml`
+
+Add a `graphql_fragments` section to your `.infrahub.yml` file. Each entry requires a `name` and a `file_path` relative to the repository root.
+
+```yaml
+graphql_fragments:
+  - name: interface_fields
+    file_path: "fragments/interface_fields.gql"
+
+queries:
+  - name: device_interfaces_query
+    file_path: "queries/device_interfaces.gql"
+```
+
+The `file_path` field accepts either a single `.gql` file or a directory. When pointing to a directory, Infrahub loads all `.gql` files within it.
+
+## 3. Reference fragments in a query
+
+Use the standard GraphQL spread syntax (`...fragmentName`) to reference a fragment in any query file declared in the same repository.
+
+Create a file named `queries/device_interfaces.gql`:
+
+```graphql
+query DeviceInterfaces($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        name {
+          value
+        }
+        interfaces {
+          edges {
+            node {
+              ...interfaceFields
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+When Infrahub imports this query from the repository, it detects the `...interfaceFields` spread, resolves it against the declared fragment files, and stores the complete query with the fragment definition inlined.
+
+## 4. Sync the repository
+
+After committing the fragment file, the `.infrahub.yml` update, and the query file, sync the repository with Infrahub. Fragments are processed during the same repository sync that imports GraphQL queries.
+
+If you are testing locally with `infrahubctl`, the fragment resolution happens automatically when rendering Transformations:
+
+```shell
+infrahubctl render device_config_transform device_name=router01
+```
+
+## 5. Verify the result
+
+Open the GraphQL query in the Infrahub web interface or query it via the API. The stored query contains the fragment definition inlined alongside the operation, so it executes without any additional resolution at runtime.
+
+```shell
+curl -s "https://<host>/api/query/device_interfaces_query?device_name=router01" | python -m json.tool
+```
+
+## Advanced usage
+
+### Multiple fragments per file
+
+A single `.gql` file can contain multiple fragment definitions:
+
+```graphql
+fragment interfaceFields on InfraInterfaceL3 {
+  name {
+    value
+  }
+  speed {
+    value
+  }
+}
+
+fragment addressFields on InfraIPAddress {
+  address {
+    value
+  }
+  prefix_length {
+    value
+  }
+}
+```
+
+Both fragments become available to any query in the repository.
+
+### Directory-based declarations
+
+Point `file_path` to a directory to load all `.gql` files within it:
+
+```yaml
+graphql_fragments:
+  - name: all_fragments
+    file_path: "fragments/"
+```
+
+Infrahub loads all `.gql` files in the `fragments/` directory in alphabetical order.
+
+### Transitive fragments
+
+Fragments can reference other fragments. Infrahub resolves dependencies transitively and detects circular references.
+
+```graphql
+fragment deviceDetails on InfraDevice {
+  name {
+    value
+  }
+  interfaces {
+    edges {
+      node {
+        ...interfaceFields
+      }
+    }
+  }
+}
+```
+
+When a query uses `...deviceDetails`, Infrahub automatically includes both `deviceDetails` and `interfaceFields` in the resolved query.
+
+## Error handling
+
+Infrahub validates fragments during repository sync and raises specific errors:
+
+| Error | Cause |
+|-------|-------|
+| `FragmentFileNotFoundError` | The `file_path` in `.infrahub.yml` does not exist in the repository |
+| `FragmentNotFoundError` | A query references a fragment name that is not defined in any declared fragment file |
+| `DuplicateFragmentError` | The same fragment name is defined in multiple files |
+| `CircularFragmentError` | Two or more fragments reference each other, creating a dependency cycle |
+
+## Related resources
+
+- [GraphQL queries in Infrahub](../topics/graphql.mdx) — query format, stored queries, and fragment concepts
+- [`.infrahub.yml` configuration](../topics/infrahub-yml.mdx) — repository manifest structure and resource types
+- [Creating a Jinja Transformation](../guides/jinja2-transform.mdx) — using queries with Jinja2 templates
+- [Creating a Python Transformation](../guides/python-transform.mdx) — using queries with Python code

--- a/docs/docs/topics/graphql.mdx
+++ b/docs/docs/topics/graphql.mdx
@@ -267,7 +267,7 @@ graphql_fragments:
     file_path: "fragments/interface_fields.gql"
 ```
 
-When Infrahub imports a query from a Git repository, it checks for fragment spread references (`...fragmentName`). If any are found, the corresponding fragment definitions are resolved from the declared fragment files and inlined into the query before it is stored in the database.
+When Infrahub imports a query from a Git repository, it checks for fragment spread references (`...fragmentName`). If any are found, the corresponding fragment definitions are resolved from the declared fragment files and included inline in the query before it is stored in the database.
 
 ### Fragment resolution behavior
 

--- a/docs/docs/topics/graphql.mdx
+++ b/docs/docs/topics/graphql.mdx
@@ -253,6 +253,53 @@ More details on the `.infrahub.yml` file format can be found in [.infrahub.yml t
 
 Stored GraphQL queries can be executed by using the `/api/query/{query_id}` REST API endpoint. The `{query_id}` can be the name or the id of the `GraphQLQuery` node in the database. More information can be found in the [Swagger documentation](http://localhost:8000/api/docs).
 
+## GraphQL fragments
+
+GraphQL fragments are reusable field selections that can be shared across multiple stored queries. Instead of duplicating the same nested field selections in every query, you define them once as a fragment and reference them using the standard GraphQL spread syntax (`...fragmentName`).
+
+### How fragments work in Infrahub
+
+Fragment files are `.gql` files containing one or more `fragment ... on Type { }` definitions. They are declared in the [`.infrahub.yml`](../topics/infrahub-yml.mdx) configuration file under `graphql_fragments`:
+
+```yaml
+graphql_fragments:
+  - name: interface_fields
+    file_path: "fragments/interface_fields.gql"
+```
+
+When Infrahub imports a query from a Git repository, it checks for fragment spread references (`...fragmentName`). If any are found, the corresponding fragment definitions are resolved from the declared fragment files and inlined into the query before it is stored in the database.
+
+### Fragment resolution behavior
+
+- **Transitive resolution**: If fragment A references fragment B, both are included automatically
+- **Duplicate detection**: A fragment name defined in multiple files raises an error
+- **Circular dependency detection**: Fragments that reference each other in a cycle are rejected
+- **Directory support**: The `file_path` in `.infrahub.yml` can point to a directory, loading all `.gql` files within it
+
+### Using fragments in queries
+
+Reference a fragment in any query file declared in the same repository:
+
+```graphql
+query DeviceInterfaces($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        interfaces {
+          edges {
+            node {
+              ...interfaceFields
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For step-by-step instructions on setting up and using fragments, see [Using GraphQL fragments](../guides/graphql-fragment.mdx).
+
 ## Single-target query pattern
 
 When writing GraphQL queries for [transformations](./transformation.mdx), [generators](./generator.mdx), [artifacts](./artifact.mdx), and [computed attributes](./computed-attributes.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.

--- a/docs/docs/topics/infrahub-yml.mdx
+++ b/docs/docs/topics/infrahub-yml.mdx
@@ -35,6 +35,7 @@ The configuration organizes resources into distinct categories based on their pu
 - **Schema definitions**: Data models for infrastructure representation
 - **Data definitions**: Object files for storing infrastructure data
 - **Query definitions**: GraphQL queries for data retrieval
+- **Fragment definitions**: Reusable [GraphQL fragments](../topics/graphql.mdx#graphql-fragments) for composing queries
 - **Menu definitions**: UI navigation structure definitions
 
 Each category has its own processing pipeline and validation requirements, reflecting the different ways Infrahub handles these resource types.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -108,6 +108,7 @@ const sidebars: SidebarsConfig = {
             'guides/jinja2-transform',
             'guides/python-transform',
             'guides/artifact',
+            'guides/graphql-fragment',
             'guides/object-storage',
           ],
         },


### PR DESCRIPTION
New how-to guide and topic updates covering fragment definition, .infrahub.yml declaration, query usage, and resolution behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for GraphQL fragments: a new how-to guide and updates explaining fragment files, `graphql_fragments` in `.infrahub.yml`, query usage, and resolution behavior. Also adds a sidebar link and fixes a Vale spelling issue.

- **New Features**
  - Added guide with steps, examples, and error cases for defining and using fragments.
  - Expanded `topics/graphql.mdx` to cover transitive resolution, duplicate/circular detection, and directory support.
  - Updated `topics/infrahub-yml.mdx` to document `graphql_fragments`, and added the guide to `docs/sidebars.ts`.

- **Bug Fixes**
  - Fixed Vale spelling for “inlined” in fragment docs.

<sup>Written for commit 81fcca2ce03cfbf0ad3fba54f92071c438af4a57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

