### PR TITLE
feat(cli): add reset-deployment-id command

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
+from uuid import UUID
 
 import typer
 import ujson
@@ -35,7 +36,7 @@ from infrahub.core.graph.schema import (
     GraphRelationshipIsPartOf,
     GraphRelationshipProperties,
 )
-from infrahub.core.initialization import get_root_node, initialize_registry
+from infrahub.core.initialization import get_root_node, initialize_registry, reset_deployment_id
 from infrahub.core.migrations.exceptions import MigrationFailureError
 from infrahub.core.migrations.graph import get_graph_migrations, get_migration_by_number
 from infrahub.core.migrations.shared import MigrationInput, get_migration_console
@@ -167,6 +168,62 @@ async def check_inheritance_cmd(
         raise typer.Exit(code=1)
 
     await dbdriver.close()
+
+
+@app.command(name="reset-deployment-id")
+async def reset_deployment_id_cmd(
+    ctx: typer.Context,
+    deployment_id: str | None = typer.Option(
+        None, "--deployment-id", help="Set an explicit UUID instead of generating a random one."
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+    config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
+) -> None:
+    """Reset the internal deployment_id on the Root node.
+
+    Running Infrahub server and worker processes cache this value at startup and
+    must be restarted after this command to pick up the new value.
+    """
+    logging.getLogger("infrahub").setLevel(logging.WARNING)
+    logging.getLogger("neo4j").setLevel(logging.ERROR)
+    logging.getLogger("prefect").setLevel(logging.ERROR)
+
+    console = Console()
+
+    if deployment_id is not None:
+        try:
+            UUID(deployment_id)
+        except ValueError:
+            console.print(f"[red]{deployment_id!r} is not a valid UUID.[/red]")
+            raise typer.Exit(code=1) from None
+
+    config.load_and_exit(config_file_name=config_file)
+
+    context: CliContext = ctx.obj
+    dbdriver = await context.init_db(retry=1)
+
+    try:
+        root = await get_root_node(db=dbdriver)
+        current = str(root.get_uuid())
+        console.print(f"Current deployment_id: [bold]{current}[/bold]")
+
+        if not yes and not typer.confirm("Reset the deployment_id?"):
+            console.print("Aborted.")
+            raise typer.Exit(code=1)
+
+        try:
+            old_uuid, new_uuid = await reset_deployment_id(db=dbdriver, new_uuid=deployment_id)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from exc
+
+        console.print(f"New deployment_id:     [bold green]{new_uuid}[/bold green]")
+        console.print(f"(was {old_uuid})")
+        console.print(
+            "[yellow]Restart all running Infrahub server and worker processes to pick up the new value.[/yellow]"
+        )
+    finally:
+        await dbdriver.close()
 
 
 @app.command(name="check-duplicate-schema-fields")

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -1,7 +1,9 @@
 import importlib
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
+
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config, lock
 from infrahub.constants.database import DatabaseType
@@ -30,7 +32,7 @@ from infrahub.core.protocols import CoreAccount, CoreAccountGroup, CoreAccountRo
 from infrahub.core.root import Root
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.manager import SchemaManager
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.timestamp import Timestamp, current_timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
@@ -225,6 +227,32 @@ async def create_root_node(db: InfrahubDatabase) -> Root:
     registry.default_branch = root.default_branch
 
     return root
+
+
+async def reset_deployment_id(db: InfrahubDatabase, new_uuid: str | None = None) -> tuple[str, str]:
+    """Rewrite the uuid of the singleton Root node.
+
+    The normal StandardNode update path matches on uuid and cannot change it, so
+    this helper issues a direct write keyed on the :Root label.
+    """
+    root = await get_root_node(db=db)
+    old_uuid = str(root.get_uuid())
+
+    if new_uuid is None:
+        new_uuid = str(UUIDT())
+    else:
+        UUID(new_uuid)
+
+    if new_uuid == old_uuid:
+        raise ValueError("The new deployment_id must be different from the current one.")
+
+    await db.execute_query(
+        query=("MATCH (n:Root {uuid: $old_uuid}) SET n.uuid = $new_uuid, n.updated_at = $updated_at RETURN n"),
+        params={"old_uuid": old_uuid, "new_uuid": new_uuid, "updated_at": current_timestamp()},
+        name="root_reset_deployment_id",
+    )
+
+    return old_uuid, new_uuid
 
 
 async def create_default_branch(db: InfrahubDatabase) -> Branch:

--- a/backend/tests/component/core/test_initialization.py
+++ b/backend/tests/component/core/test_initialization.py
@@ -1,8 +1,44 @@
+from uuid import UUID
+
+import pytest
+
 from infrahub.core.branch import Branch
-from infrahub.core.initialization import first_time_initialization
+from infrahub.core.initialization import first_time_initialization, get_root_node, reset_deployment_id
 from infrahub.database import InfrahubDatabase
 
 
 async def test_first_time_initialization(db: InfrahubDatabase, default_branch: Branch) -> None:
     await first_time_initialization(db=db)
     assert True
+
+
+async def test_reset_deployment_id_generates_new_uuid(db: InfrahubDatabase, default_branch: Branch) -> None:
+    root_before = await get_root_node(db=db)
+    original = str(root_before.get_uuid())
+
+    old_uuid, new_uuid = await reset_deployment_id(db=db)
+
+    assert old_uuid == original
+    assert new_uuid != original
+    UUID(new_uuid)
+
+    root_after = await get_root_node(db=db)
+    assert str(root_after.get_uuid()) == new_uuid
+
+
+async def test_reset_deployment_id_with_explicit_value(db: InfrahubDatabase, default_branch: Branch) -> None:
+    explicit = "11111111-2222-3333-4444-555555555555"
+
+    _, new_uuid = await reset_deployment_id(db=db, new_uuid=explicit)
+
+    assert new_uuid == explicit
+    root_after = await get_root_node(db=db)
+    assert str(root_after.get_uuid()) == explicit
+
+
+async def test_reset_deployment_id_rejects_unchanged_value(db: InfrahubDatabase, default_branch: Branch) -> None:
+    root = await get_root_node(db=db)
+    current = str(root.get_uuid())
+
+    with pytest.raises(ValueError, match="must be different"):
+        await reset_deployment_id(db=db, new_uuid=current)

--- a/changelog/+reset-deployment-id.added.md
+++ b/changelog/+reset-deployment-id.added.md
@@ -1,0 +1,1 @@
+Added `infrahub db reset-deployment-id` CLI command to regenerate the internal `deployment_id` without rebuilding the database.

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -18,6 +18,7 @@ $ infrahub db [OPTIONS] COMMAND [ARGS]...
 
 * `migrate`: Check the current format of the internal...
 * `check-inheritance`: Check the database for any vertices with...
+* `reset-deployment-id`: Reset the internal deployment_id on the...
 * `check-duplicate-schema-fields`: Check for any duplicate schema attributes...
 * `update-core-schema`: Check the current format of the internal...
 * `constraint`: Manage Database Constraints
@@ -64,6 +65,29 @@ $ infrahub db check-inheritance [OPTIONS] [CONFIG_FILE]
 **Options**:
 
 * `--fix / --no-fix`: Fix the inheritance of any invalid nodes.  [default: no-fix]
+* `--help`: Show this message and exit.
+
+## `infrahub db reset-deployment-id`
+
+Reset the internal deployment_id on the Root node.
+
+Running Infrahub server and worker processes cache this value at startup and
+must be restarted after this command to pick up the new value.
+
+**Usage**:
+
+```console
+$ infrahub db reset-deployment-id [OPTIONS] [CONFIG_FILE]
+```
+
+**Arguments**:
+
+* `[CONFIG_FILE]`: [env var: INFRAHUB_CONFIG; default: infrahub.toml]
+
+**Options**:
+
+* `--deployment-id TEXT`: Set an explicit UUID instead of generating a random one.
+* `-y, --yes`: Skip the confirmation prompt.
 * `--help`: Show this message and exit.
 
 ## `infrahub db check-duplicate-schema-fields`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new CLI command to reset the internal deployment_id (Root node UUID) without rebuilding the database. Use this to rotate the ID after environment clones or restores; restart server and workers to apply.

- **New Features**
  - New command: infrahub db reset-deployment-id
    - Options: --deployment-id <UUID> (explicit), -y/--yes (skip confirm), config file via INFRAHUB_CONFIG.
  - Validates the provided UUID and rejects unchanged values; shows current and new IDs.
  - Auto-generates a new UUID using `infrahub_sdk.uuidt` (UUIDT) when not provided.
  - Backend helper updates the Root node directly and sets updated_at.
  - Added tests covering generation, explicit value, and unchanged-value rejection.

<sup>Written for commit 83bac05fe8bfafb11c25c86ca2fc842e26a30dac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

