### PR TITLE
Update SDK commit to latest in infrahub-develop

### DIFF
--- a/docs/docs/reference/dotinfrahub.mdx
+++ b/docs/docs/reference/dotinfrahub.mdx
@@ -96,6 +96,7 @@ To help with the development process of a repository configuration file, you can
 | file_path | string | The file within the repository with the transform code. | True |
 | class_name | string | The name of the transform class to run. | False |
 | convert_query_response | boolean | Decide if the transform should convert the result of the GraphQL query to SDK InfrahubNode objects. | False |
+| description | string | Description for this transform | False |
 
 <!-- vale off -->
 ## Generator Definitions


### PR DESCRIPTION

# Why

Bring in the latest commit from `infrahub-develop`, so that the pipeline of #8678 will work.

## What changed

* Python SDK commit to latest `infrahub-develop`.
* Documentation update for the change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `python_sdk` submodule to the latest `infrahub-develop` to align with SDK changes and unblock #8678. Also updates the `.infrahub` reference docs to document the optional `description` field for transforms.

<sup>Written for commit a47c82c0657859fdadad77ef8360993a1f34f4a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



