### PR TITLE
fix schema kind click in schema viewer modal + Added stacked modal

### DIFF
--- a/changelog/+schema-kind-click.fixed.md
+++ b/changelog/+schema-kind-click.fixed.md
@@ -1,0 +1,1 @@
+Fix clicking on kinds in the schema viewer modal to navigate to the related schema.

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -261,8 +261,8 @@ exports[`fix ts error`] = {
     "src/entities/role-manager/ui/permission-combobox.tsx:231819180": [
       [93, 64, 9, "tsc: Type \'(relationship: PermissionNode) => void\' is not assignable to type \'(newObject: NodeCore) => void\'.\\n  Types of parameters \'relationship\' and \'newObject\' are incompatible.\\n    Type \'NodeCore\' is not assignable to type \'PermissionNode\'.\\n      Property \'identifier\' is missing in type \'NodeCore\' but required in type \'{ identifier: { value: string; }; }\'.", "3172999"]
     ],
-    "src/entities/schema/ui/computed-attribute-display.tsx:2447319862": [
-      [38, 14, 8, "tsc: Type \'{ title: string; fileName: string; data: string; }\' is not assignable to type \'IntrinsicAttributes & DataViewerProps\'.\\n  Property \'fileName\' does not exist on type \'IntrinsicAttributes & DataViewerProps\'.", "3193632964"]
+    "src/entities/schema/ui/computed-attribute-display.tsx:126058563": [
+      [40, 14, 8, "tsc: Type \'{ title: string; fileName: string; data: string; }\' is not assignable to type \'IntrinsicAttributes & DataViewerProps\'.\\n  Property \'fileName\' does not exist on type \'IntrinsicAttributes & DataViewerProps\'.", "3193632964"]
     ],
     "src/entities/tasks/domain/is-task-running-on-branch/is-task-running-on-branch.test.ts:298753925": [
       [60, 8, 24, "tsc: Type \'null\' is not assignable to type \'{ count: number; }\'.", "1753184293"]

--- a/frontend/app/src/entities/schema/ui/attribute-display.tsx
+++ b/frontend/app/src/entities/schema/ui/attribute-display.tsx
@@ -13,9 +13,11 @@ import { AccordionStyled, NullDisplay, PropertyRow, PropertyTitle } from "./styl
 
 export const AttributeDisplay = ({
   attribute,
+  onKindClick,
   defaultOpen = false,
 }: {
   attribute: components["schemas"]["AttributeSchema-Output"];
+  onKindClick?: (kind: string) => void;
   defaultOpen?: boolean;
 }) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -43,7 +45,12 @@ export const AttributeDisplay = ({
         <PropertyRow title="Kind" value={attribute.kind} />
         <PropertyRow
           title="Computed attribute"
-          value={<ComputedAttributeDisplay computedAttribute={attribute.computed_attribute} />}
+          value={
+            <ComputedAttributeDisplay
+              computedAttribute={attribute.computed_attribute}
+              onKindClick={onKindClick}
+            />
+          }
         />
         <PropertyRow title="Name" value={attribute.name} />
         <PropertyRow title="Label" value={attribute.label} />

--- a/frontend/app/src/entities/schema/ui/computed-attribute-display.tsx
+++ b/frontend/app/src/entities/schema/ui/computed-attribute-display.tsx
@@ -8,12 +8,14 @@ import { DataViewer } from "@/shared/components/data-viewer/data-viewer";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 
-import { ModelDisplay } from "./styled";
+import { SchemaKindDisplay } from "./styled";
 
 export const ComputedAttributeDisplay = ({
   computedAttribute,
+  onKindClick,
 }: {
   computedAttribute?: components["schemas"]["ComputedAttribute-Output"] | null;
+  onKindClick?: (kind: string) => void;
 }) => {
   if (!computedAttribute) {
     return "-";
@@ -24,7 +26,7 @@ export const ComputedAttributeDisplay = ({
 
     return (
       <Row>
-        <ModelDisplay kinds={["CoreTransformJinja2"]} />
+        <SchemaKindDisplay kinds={["CoreTransformJinja2"]} onKindClick={onKindClick} />
 
         <DialogTrigger>
           <Pressable>
@@ -48,7 +50,7 @@ export const ComputedAttributeDisplay = ({
   if (computedAttribute.kind === "TransformPython") {
     return (
       <Row>
-        <ModelDisplay kinds={["CoreTransformPython"]} />
+        <SchemaKindDisplay kinds={["CoreTransformPython"]} onKindClick={onKindClick} />
 
         <Badge variant="gray-outline">{computedAttribute.transform as string}</Badge>
       </Row>

--- a/frontend/app/src/entities/schema/ui/relationship-display.tsx
+++ b/frontend/app/src/entities/schema/ui/relationship-display.tsx
@@ -7,13 +7,15 @@ import { warnUnexpectedType } from "@/shared/utils/common";
 
 import type { RelationshipSchema } from "@/entities/schema/types";
 
-import { AccordionStyled, ModelDisplay, PropertyRow } from "./styled";
+import { AccordionStyled, PropertyRow, SchemaKindDisplay } from "./styled";
 
 export const RelationshipDisplay = ({
   relationship,
+  onKindClick,
   defaultOpen = false,
 }: {
   relationship: RelationshipSchema;
+  onKindClick?: (kind: string) => void;
   defaultOpen?: boolean;
 }) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -57,7 +59,10 @@ export const RelationshipDisplay = ({
       </div>
 
       <div>
-        <PropertyRow title="Peer" value={<ModelDisplay kinds={[relationship.peer]} />} />
+        <PropertyRow
+          title="Peer"
+          value={<SchemaKindDisplay kinds={[relationship.peer]} onKindClick={onKindClick} />}
+        />
         <PropertyRow title="Peer identifier" value={relationship.identifier} />
         <PropertyRow title="Common parent" value={relationship.common_parent} />
         <PropertyRow title="Cardinality" value={relationship.cardinality} />

--- a/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer-modal.tsx
@@ -1,7 +1,10 @@
+import { useState } from "react";
+
 import { Modal, type ModalProps } from "@/shared/components/aria/modal";
 import { classNames } from "@/shared/utils/common";
 
 import type { ModelSchema } from "@/entities/schema/types";
+import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 import { SchemaViewer } from "@/entities/schema/ui/schema-viewer";
 
 interface SchemaViewerModalProps extends Omit<ModalProps, "children"> {
@@ -17,17 +20,45 @@ export function SchemaViewerModal({
   className,
   ...props
 }: SchemaViewerModalProps) {
+  const [nestedKind, setNestedKind] = useState<string | null>(null);
+
   return (
     <Modal aria-label="Schema viewer" className={classNames("w-150 p-0", className)} {...props}>
       {({ close }) => (
-        <SchemaViewer
-          schema={schema}
-          defaultTab={defaultTab}
-          targetField={targetField}
-          onClose={close}
-          className="rounded-[inherit] border-0 p-3"
-        />
+        <>
+          <SchemaViewer
+            schema={schema}
+            defaultTab={defaultTab}
+            targetField={targetField}
+            onKindClick={setNestedKind}
+            onClose={close}
+            className="rounded-[inherit] border-0 p-3"
+          />
+
+          {nestedKind && (
+            <NestedSchemaViewerModal
+              kind={nestedKind}
+              onOpenChange={(isOpen) => {
+                if (!isOpen) setNestedKind(null);
+              }}
+            />
+          )}
+        </>
       )}
     </Modal>
   );
+}
+
+function NestedSchemaViewerModal({
+  kind,
+  onOpenChange,
+}: {
+  kind: string;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const { schema } = useSchema(kind);
+
+  if (!schema) return null;
+
+  return <SchemaViewerModal schema={schema} isOpen onOpenChange={onOpenChange} />;
 }

--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -24,7 +24,7 @@ import { isProfileSchema } from "@/entities/schema/utils/is-profile-schema";
 import { AttributeDisplay } from "./attribute-display";
 import { RelationshipDisplay } from "./relationship-display";
 import { SchemaHelpMenu } from "./schema-help-menu";
-import { ModelDisplay, PropertyRow, TabPanelStyled, TabStyled } from "./styled";
+import { PropertyRow, SchemaKindDisplay, TabPanelStyled, TabStyled } from "./styled";
 
 export const SchemaViewerStack = ({ className = "" }: { className: string }) => {
   const [selectedKind, setKinds] = useQueryState(QSP.KIND, parseAsNativeArrayOf(parseAsString));
@@ -49,6 +49,9 @@ export const SchemaViewerStack = ({ className = "" }: { className: string }) => 
             key={kind + index}
             className="absolute top-0 max-h-full w-full"
             schema={schema}
+            onKindClick={(clickedKind) => {
+              setKinds(selectedKind.length > 0 ? [...selectedKind, clickedKind] : [clickedKind]);
+            }}
             onClose={() => {
               const nextKinds = selectedKind.filter((_, i) => i !== index);
               setKinds(nextKinds);
@@ -68,6 +71,7 @@ export const SchemaViewerStack = ({ className = "" }: { className: string }) => 
 export const SchemaViewer = ({
   className = "",
   schema,
+  onKindClick,
   onClose,
   style,
   defaultTab = "properties",
@@ -75,6 +79,7 @@ export const SchemaViewer = ({
 }: {
   className?: string;
   schema: ModelSchema;
+  onKindClick?: (kind: string) => void;
   onClose: () => void;
   style?: CSSProperties;
   defaultTab?: "properties" | "attributes" | "relationships";
@@ -120,7 +125,12 @@ export const SchemaViewer = ({
 
       <SchemaViewerTitle schema={schema} />
 
-      <SchemaViewerDetails schema={schema} defaultTab={defaultTab} targetField={targetField} />
+      <SchemaViewerDetails
+        schema={schema}
+        onKindClick={onKindClick}
+        defaultTab={defaultTab}
+        targetField={targetField}
+      />
     </section>
   );
 };
@@ -145,10 +155,12 @@ const SchemaViewerTitle = ({ schema }: { schema: ModelSchema }) => {
 
 const SchemaViewerDetails = ({
   schema,
+  onKindClick,
   defaultTab,
   targetField,
 }: {
   schema: ModelSchema;
+  onKindClick?: (kind: string) => void;
   defaultTab: "properties" | "attributes" | "relationships";
   targetField?: string;
 }) => {
@@ -161,15 +173,16 @@ const SchemaViewerDetails = ({
       </TabList>
 
       <TabPanelStyled id="properties">
-        <Properties schema={schema} />
+        <Properties schema={schema} onKindClick={onKindClick} />
       </TabPanelStyled>
 
       <TabPanelStyled id="attributes">
         {schema.attributes && schema.attributes.length > 0 ? (
           schema.attributes?.map((attribute) => (
             <AttributeDisplay
-              key={attribute.id}
+              key={attribute.name}
               attribute={attribute}
+              onKindClick={onKindClick}
               defaultOpen={attribute.name === targetField}
             />
           ))
@@ -182,8 +195,9 @@ const SchemaViewerDetails = ({
         {schema.relationships && schema.relationships.length > 0
           ? schema.relationships?.map((relationship) => (
               <RelationshipDisplay
-                key={relationship.id}
+                key={relationship.name}
                 relationship={relationship}
+                onKindClick={onKindClick}
                 defaultOpen={relationship.name === targetField}
               />
             ))
@@ -193,7 +207,13 @@ const SchemaViewerDetails = ({
   );
 };
 
-const Properties = ({ schema }: { schema: ModelSchema }) => {
+const Properties = ({
+  schema,
+  onKindClick,
+}: {
+  schema: ModelSchema;
+  onKindClick?: (kind: string) => void;
+}) => {
   return (
     <div className="divide-y divide-gray-200 p-2">
       <div>
@@ -210,7 +230,10 @@ const Properties = ({ schema }: { schema: ModelSchema }) => {
 
       {isGenericSchema(schema) && (
         <div>
-          <PropertyRow title="Used by" value={<ModelDisplay kinds={schema.used_by} />} />
+          <PropertyRow
+            title="Used by"
+            value={<SchemaKindDisplay kinds={schema.used_by} onKindClick={onKindClick} />}
+          />
           <PropertyRow title="Hierarchical" value={schema.hierarchical} />
           <PropertyRow title="Restricted namespaces" value={schema.restricted_namespaces} />
         </div>
@@ -218,20 +241,39 @@ const Properties = ({ schema }: { schema: ModelSchema }) => {
 
       {isNodeSchema(schema) && (
         <div>
-          <PropertyRow title="Inherit from" value={<ModelDisplay kinds={schema.inherit_from} />} />
+          <PropertyRow
+            title="Inherit from"
+            value={<SchemaKindDisplay kinds={schema.inherit_from} onKindClick={onKindClick} />}
+          />
           <PropertyRow
             title="Hierarchy"
             value={
-              schema.hierarchy ? <ModelDisplay kinds={[schema.hierarchy]} /> : schema.hierarchy
+              schema.hierarchy ? (
+                <SchemaKindDisplay kinds={[schema.hierarchy]} onKindClick={onKindClick} />
+              ) : (
+                schema.hierarchy
+              )
             }
           />
           <PropertyRow
             title="Parent"
-            value={schema.parent ? <ModelDisplay kinds={[schema.parent]} /> : schema.parent}
+            value={
+              schema.parent ? (
+                <SchemaKindDisplay kinds={[schema.parent]} onKindClick={onKindClick} />
+              ) : (
+                schema.parent
+              )
+            }
           />
           <PropertyRow
             title="Children"
-            value={schema.children ? <ModelDisplay kinds={[schema.children]} /> : schema.children}
+            value={
+              schema.children ? (
+                <SchemaKindDisplay kinds={[schema.children]} onKindClick={onKindClick} />
+              ) : (
+                schema.children
+              )
+            }
           />
         </div>
       )}

--- a/frontend/app/src/entities/schema/ui/styled.tsx
+++ b/frontend/app/src/entities/schema/ui/styled.tsx
@@ -1,11 +1,9 @@
-import { parseAsNativeArrayOf, parseAsString, useQueryState } from "nuqs";
 import type { ReactElement } from "react";
 import { Tab, TabPanel, type TabPanelProps, type TabProps } from "react-aria-components";
 
 import { focusVisibleStyle } from "@/shared/components/aria/style-rac";
 import Accordion, { type AccordionProps } from "@/shared/components/display/accordion";
 import { Badge } from "@/shared/components/ui/badge";
-import { QSP } from "@/shared/config/qsp";
 import { classNames, warnUnexpectedType } from "@/shared/utils/common";
 
 interface AccordionStyleProps extends AccordionProps {
@@ -144,8 +142,13 @@ export const TabPanelStyled = ({ className, ...props }: TabPanelProps) => {
 
 export const NullDisplay = () => <div className="text-gray-500 text-xs">null</div>;
 
-export const ModelDisplay = ({ kinds }: { kinds?: string[] }) => {
-  const [selectedKinds, setKinds] = useQueryState(QSP.KIND, parseAsNativeArrayOf(parseAsString));
+export const SchemaKindDisplay = ({
+  kinds,
+  onKindClick,
+}: {
+  kinds?: string[];
+  onKindClick?: (kind: string) => void;
+}) => {
   if (!kinds) return null;
   if (kinds.length === 0) return <span>empty</span>;
 
@@ -154,10 +157,11 @@ export const ModelDisplay = ({ kinds }: { kinds?: string[] }) => {
       {kinds.map((kind) => (
         <Badge
           key={kind}
-          className="cursor-pointer border-sky-200 bg-sky-50 text-sky-800 hover:bg-sky-100"
-          onClick={() =>
-            setKinds(selectedKinds && selectedKinds?.length > 0 ? [...selectedKinds, kind] : [kind])
-          }
+          className={classNames(
+            "border-sky-200 bg-sky-50 text-sky-800",
+            onKindClick && "cursor-pointer hover:bg-sky-100"
+          )}
+          onClick={onKindClick ? () => onKindClick(kind) : undefined}
         >
           {kind}
         </Badge>

--- a/frontend/app/src/shared/components/aria/modal.tsx
+++ b/frontend/app/src/shared/components/aria/modal.tsx
@@ -6,6 +6,7 @@ import {
   type DialogProps,
 } from "react-aria-components";
 
+import { Stacked } from "@/shared/components/aria/utils/stacked";
 import { classNames } from "@/shared/utils/common";
 
 export function ModalOverlay({ className, ...props }: AriaModalOverlayProps) {
@@ -24,10 +25,12 @@ export function ModalOverlay({ className, ...props }: AriaModalOverlayProps) {
 }
 
 export interface ModalProps
-  extends Pick<AriaModalOverlayProps, "isOpen" | "onOpenChange" | "isDismissable">,
-    DialogProps {}
+  extends Omit<AriaModalOverlayProps, "children">,
+    Pick<DialogProps, "aria-label" | "children"> {}
 
 export function Modal({
+  "aria-label": ariaLabel,
+  children,
   isOpen,
   onOpenChange,
   className,
@@ -36,20 +39,33 @@ export function Modal({
 }: ModalProps) {
   return (
     <ModalOverlay isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={isDismissable}>
-      <AriaModal
-        className={classNames(
-          "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
-          "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white p-2 shadow-lg",
-          "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
-          "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
-          className
-        )}
-      >
-        <AriaDialog
-          className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-auto outline-hidden"
-          {...props}
-        />
-      </AriaModal>
+      {({ state: { isOpen } }) => (
+        <Stacked isStacked={isOpen}>
+          {(depth) => (
+            <AriaModal
+              className={classNames(
+                "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transition-all duration-200",
+                "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white p-2 shadow-lg",
+                "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
+                "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
+                className
+              )}
+              style={{
+                top: `${50 - depth * 4}%`,
+                scale: 1 - depth * 0.05,
+              }}
+              {...props}
+            >
+              <AriaDialog
+                aria-label={ariaLabel}
+                className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-auto outline-hidden"
+              >
+                {children}
+              </AriaDialog>
+            </AriaModal>
+          )}
+        </Stacked>
+      )}
     </ModalOverlay>
   );
 }

--- a/frontend/app/src/shared/components/aria/utils/stacked.tsx
+++ b/frontend/app/src/shared/components/aria/utils/stacked.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface StackContextValue {
+  onChildOpen: () => void;
+  onChildClose: () => void;
+}
+
+const StackContext = React.createContext<StackContextValue>({
+  onChildOpen: () => {},
+  onChildClose: () => {},
+});
+
+interface StackedProps {
+  isStacked?: boolean;
+  children: (stackOffset: number) => React.ReactNode;
+}
+
+export function Stacked({ isStacked, children }: StackedProps) {
+  const parent = React.use(StackContext);
+  const [layersAbove, setLayersAbove] = React.useState(0);
+
+  React.useLayoutEffect(() => {
+    if (!isStacked) return;
+    parent.onChildOpen();
+    return () => parent.onChildClose();
+  }, [isStacked]);
+
+  const onChildOpen = () => {
+    setLayersAbove((c) => c + 1);
+    parent.onChildOpen();
+  };
+  const onChildClose = () => {
+    setLayersAbove((c) => c - 1);
+    parent.onChildClose();
+  };
+
+  return <StackContext value={{ onChildOpen, onChildClose }}>{children(layersAbove)}</StackContext>;
+}


### PR DESCRIPTION
Why

In the schema viewer modal, clicking on kind badges (e.g., inherit_from, peer, used_by) did nothing. The ModalDisplay component was coupled to query string state (QSP.KIND), which only works in the sidebar stack view, not inside a modal context. Users couldn't browse related schemas from within the modal.

What changed

  - Kind badges are now clickable in the modal: Clicking a kind badge opens a nested schema viewer modal for that schema. Nested modals stack visually — the parent scales down and shifts up, so the user sees the navigation context.
  - Decoupled ModelDisplay from query state: Renamed to SchemaKindDisplay and replaced the direct QSP.KIND mutation with an onKindClick callback. The sidebar stack view and the modal view each provide their own handler. Badges only show hover/pointer styles when a click handler is provided.
  - Added Stacked context for nested modals: A new utility tracks modal depth through React context so parent modals visually recede when children open (scale and top offset per layer).

  How to review

  1. Start with styled.tsx — the ModelDisplay → SchemaKindDisplay rename and decoupling from QSP.
  2. Then schema-viewer.tsx — threading onKindClick through the component tree.
  3. Then schema-viewer-modal.tsx — the nested modal recursion pattern.
  4. Then modal.tsx + stacked.tsx — the stacking infrastructure.

  How to test

  1. Open a schema from the sidebar schema viewer — kind badges should still navigate within the stack as before.
  2. Open a schema viewer modal (e.g., from an object detail page).
  3. Click on a kind badge (e.g., a peer type or inherit_from value).
  4. A nested modal should open showing that schema, with the parent modal visually receded.
  5. Close the nested modal — parent should restore to normal position.
  Checklist

  - Tests added/updated
  - Changelog entry added (uv run towncrier create ...)
  - External docs updated (if user-facing or ops-facing change)
  - Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unresponsive kind badges in the schema viewer modal. Clicking a kind now opens the related schema in a nested modal, with parent modals visually stacked for clear navigation context.

- New Features
  - Added stacked modals via a new Stacked context; parent modals scale and shift when a child opens.
  - Updated Modal to render children with depth-based transform for stacking.
  - Decoupled kind badge behavior from query state: renamed ModelDisplay to SchemaKindDisplay with an onKindClick callback.
  - Threaded onKindClick through SchemaViewer, attributes, relationships, and computed attributes; modal spawns nested viewers using useSchema.

<sup>Written for commit 6f6b3c3a3a9b72c323e3f9f5af5cd546bce6103f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

