### PR TITLE
Prepare for release 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ### Fixed
 
-- Schema deletions are now rejected when a generic is still referenced by another node's inherit_from, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
+- Schema deletions are now rejected when a generic is still referenced by another node's `inherit_from`, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
 - Fix branch name display in event details popover for branch deletion events.
 - Fix check messages overflowing outside their container in proposed changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.8.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.6) - 2026-04-21
+
+### Changed
+
+- SSO authentication now anchors account identity on the provider-issued `sub` claim rather than the user display name. Existing accounts are linked transparently on first login after upgrade. If a display name collision occurs with another SSO user's account, the email address is used as the account name instead.
+
+### Fixed
+
+- Schema deletions are now rejected when a generic is still referenced by another node's inherit_from, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
+- Fix branch name display in event details popover for branch deletion events.
+- Fix check messages overflowing outside their container in proposed changes.
+
 ## [Infrahub - v1.8.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.8.5) - 2026-04-17
 
 ### Fixed

--- a/changelog/+152ca1f.changed.md
+++ b/changelog/+152ca1f.changed.md
@@ -1,1 +1,0 @@
-SSO authentication now anchors account identity on the provider-issued `sub` claim rather than the user display name. Existing accounts are linked transparently on first login after upgrade. If a display name collision occurs with another SSO user's account, the email address is used as the account name instead.

--- a/changelog/+a3f1c720.fixed.md
+++ b/changelog/+a3f1c720.fixed.md
@@ -1,1 +1,0 @@
-Fix check messages overflowing outside their container in proposed changes.

--- a/changelog/+efd8a1d3.fixed.md
+++ b/changelog/+efd8a1d3.fixed.md
@@ -1,1 +1,0 @@
-Fix branch name display in event details popover for branch deletion events.

--- a/changelog/8988.fixed.md
+++ b/changelog/8988.fixed.md
@@ -1,1 +1,0 @@
-Schema deletions are now rejected when a generic is still referenced by another node's inherit_from, and partial schema writes are rolled back if loading the updated schema fails.

--- a/docs/docs/release-notes/infrahub/release-1_8_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_6.mdx
@@ -1,0 +1,29 @@
+---
+title: Release 1.8.6
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.8.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 21st, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.8.6](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.8.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Changed
+
+- SSO authentication now anchors account identity on the provider-issued `sub` claim rather than the user display name. Existing accounts are linked transparently on first login after upgrade. If a display name collision occurs with another SSO user's account, the email address is used as the account name instead.
+
+### Fixed
+
+- Schema deletions are now rejected when a generic is still referenced by another node's inherit_from, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
+- Fix branch name display in event details popover for branch deletion events.
+- Fix check messages overflowing outside their container in proposed changes.

--- a/docs/docs/release-notes/infrahub/release-1_8_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_6.mdx
@@ -24,6 +24,6 @@ title: Release 1.8.6
 
 ### Fixed
 
-- Schema deletions are now rejected when a generic is still referenced by another node's inherit_from, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
+- Schema deletions are now rejected when a generic is still referenced by another node's `inherit_from`, and partial schema writes are rolled back if loading the updated schema fails. ([#8988](https://github.com/opsmill/infrahub/issues/8988))
 - Fix branch name display in event details popover for branch deletion events.
 - Fix check messages overflowing outside their container in proposed changes.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -431,6 +431,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_8_6',
             'release-notes/infrahub/release-1_8_5',
             'release-notes/infrahub/release-1_8_4',
             'release-notes/infrahub/release-1_8_3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.8.5"
+version = "1.8.6"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.8.5"
+version = "1.8.6"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.5"
+version = "1.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.8.5"
+version = "1.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
Preparation PR for release 1.8.6


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the 1.8.6 release by bumping versions, updating the changelog, and adding release notes. Switch SSO identity to the `sub` claim; includes stability and UI fixes.

- **Bug Fixes**
  - Block schema deletion when a generic is still referenced and roll back partial writes if schema loading fails (#8988).
  - Fix branch name display in event details for branch deletion events.
  - Prevent check message overflow in proposed changes.

- **Dependencies**
  - Bump `infrahub-server` and `infrahub-testcontainers` to 1.8.6 and update lockfiles.
  - Add the 1.8.6 release notes page and sidebar entry.

<sup>Written for commit 0aa281ffb9b2b1441bca5a6ae4de8053d9f8471b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



