### PR TITLE
fixed offset parameter when querying InfrahubBranch

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -157,6 +157,7 @@ class Branch(StandardNode):
         cls,
         db: InfrahubDatabase,
         limit: int = 1000,
+        offset: int | None = None,
         ids: list[str] | None = None,
         name: str | None = None,
         node_ordering: StandardNodeOrdering | None = None,
@@ -180,6 +181,7 @@ class Branch(StandardNode):
             branch_filters=branch_filters,
             exclude_global=exclude_global,
             limit=limit,
+            offset=offset,
             node_ordering=node_ordering,
         )
         await query.execute(db=db)

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -301,6 +301,7 @@ class StandardNode(BaseModel):
         cls,
         db: InfrahubDatabase,
         limit: int = 1000,
+        offset: int | None = None,
         ids: list[str] | None = None,
         name: str | None = None,
         node_ordering: StandardNodeOrdering | None = None,
@@ -308,7 +309,14 @@ class StandardNode(BaseModel):
     ) -> list[Self]:
         node_ordering = node_ordering or StandardNodeOrdering()
         query: Query = await StandardNodeGetListQuery.init(
-            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, node_ordering=node_ordering, **kwargs
+            db=db,
+            node_class=cls,
+            ids=ids,
+            node_name=name,
+            limit=limit,
+            offset=offset,
+            node_ordering=node_ordering,
+            **kwargs,
         )
         await query.execute(db=db)
 

--- a/backend/tests/component/core/test_branch.py
+++ b/backend/tests/component/core/test_branch.py
@@ -452,3 +452,19 @@ async def test_create_branch(db: InfrahubDatabase, empty_database: None) -> None
     branch = await Branch.get_by_name(name=branch_name, db=db)
     assert branch.name == branch_name
     assert branch.description == description
+
+
+async def test_get_list_with_offset(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """Test that Branch.get_list offset skips the expected number of records."""
+    for i in range(5):
+        await create_branch(branch_name=f"offset-test-{i}", db=db)
+
+    all_branches = await Branch.get_list(db=db)
+    total = len(all_branches)
+    assert total >= 6  # main + global + 5 created
+
+    offset_branches = await Branch.get_list(db=db, offset=3)
+
+    assert len(offset_branches) == total - 3, (
+        f"offset=3 should skip 3 branches, expected {total - 3} but got {len(offset_branches)}"
+    )

--- a/backend/tests/component/graphql/queries/test_branch.py
+++ b/backend/tests/component/graphql/queries/test_branch.py
@@ -251,12 +251,14 @@ class TestBranchQuery(TestInfrahubApp):
             }
         """
         gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+
+        # Query all branches without pagination
         all_branches = await graphql(
             schema=gql_params.schema,
             source=query,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={"offset": 2, "limit": 5},
+            variable_values={},
         )
         assert all_branches.errors is None
         assert all_branches.data
@@ -285,6 +287,19 @@ class TestBranchQuery(TestInfrahubApp):
         )
 
         assert all_branches.data["InfrahubBranch"]["default_branch"]["name"]["value"] == "main"
+
+        # Query with offset and limit to verify pagination works
+        paginated_branches = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values={"offset": 2, "limit": 5},
+        )
+        assert paginated_branches.errors is None
+        assert paginated_branches.data
+        assert paginated_branches.data["InfrahubBranch"]["count"] == 12  # count reflects total, not paginated
+        assert len(paginated_branches.data["InfrahubBranch"]["edges"]) == 5
 
         name_branches = await graphql(
             schema=gql_params.schema,

--- a/changelog/+branch-offset.fixed.md
+++ b/changelog/+branch-offset.fixed.md
@@ -1,0 +1,1 @@
+Fixed pagination offset being ignored when querying branches

--- a/changelog/+branch-offset.fixed.md
+++ b/changelog/+branch-offset.fixed.md
@@ -1,1 +1,1 @@
-Fixed pagination offset being ignored when querying branches
+Fixed pagination offset being ignored when querying InfrahubBranch


### PR DESCRIPTION
Why

The offset parameter in InfrahubBranch GraphQL queries was silently ignored. Branch.get_list() accepted offset via `**kwargs` but never forwarded it to the query layer, so pagination with offset always returned the full result set.

What changed

- Fix: Added offset as an explicit parameter to Branch.get_list() and passed it through to BranchNodeGetListQuery.init(). The base Query class already supports offset (generates SKIP in Cypher) — the value just never reached it.
- Existing test fix: test_paginated_branch_query was querying with offset=2, limit=5 but asserting against all branches via .sort() which returns None, making the assertion vacuously true. Split into an unpaginated query for full results and a separate paginated query with proper assertions.
- New test: Added test_get_list_with_offset component test that directly validates Branch.get_list() at the model layer.
- What stayed the same: No schema changes. No query/Cypher changes. get_list_count unchanged (count queries should not use offset). API contract unchanged — offset was already accepted by the GraphQL resolver, it just wasn't working.

How to review

Focus on backend/infrahub/core/branch/models.py — the fix is 2 lines. The rest is tests.

  Impact & rollout

  - Backward compatibility: None — offset was already accepted but ignored, now it works as documented.
  - Deployment notes: Safe to deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ignored offset parameter in InfrahubBranch queries so pagination works correctly. Also makes `StandardNode.get_list` explicitly accept `offset` for consistency.

- **Bug Fixes**
  - Pass `offset` through `Branch.get_list()` and `StandardNode.get_list()` to `BranchNodeGetListQuery.init()` / `StandardNodeGetListQuery.init()` so SKIP is applied and signatures align.
  - Fix `test_paginated_branch_query` by separating unpaginated and paginated checks and removing a no-op `.sort()`.
  - Add `test_get_list_with_offset` to validate model-level pagination.
  - No schema/Cypher changes; `get_list_count` unchanged.

<sup>Written for commit bfca59609e2675a0f2442285cc21302e8207c700. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

