### PR TITLE
docs: restricted namespace topic

### DIFF
--- a/docs/docs/topics/schema.mdx
+++ b/docs/docs/topics/schema.mdx
@@ -800,6 +800,52 @@ nodes:
       - "InfraAsset"
 ```
 
+#### Restricting inheritance by namespace
+
+The `restricted_namespaces` property on a generic limits which namespaces are allowed to define nodes that inherit from it. When set, any node with `inherit_from` referencing that generic must belong to one of the listed namespaces — schema validation fails otherwise.
+
+This is useful when a generic is designed to be implemented only by a specific, known set of nodes. Without the restriction, the generic appears available to anyone, which can mislead schema authors into creating node types that look valid but behave incorrectly at runtime.
+
+```yaml
+generics:
+  - name: GenericService
+    namespace: Customer
+    restricted_namespaces:
+      - Customer
+    attributes:
+      - name: service_name
+        kind: Text
+        unique: true
+      - name: customer_account
+        kind: Text
+
+nodes:
+  - name: SingleSiteService
+    namespace: Customer     # Allowed — Customer is in restricted_namespaces
+    inherit_from:
+      - CustomerGenericService
+    attributes:
+      - name: site_name
+        kind: Text
+
+  - name: CloudService
+    namespace: Customer     # Allowed — Customer is in restricted_namespaces
+    inherit_from:
+      - CustomerGenericService
+
+  - name: HttpService
+    namespace: Dcim         # Error — Dcim is not in restricted_namespaces
+    inherit_from:
+      - CustomerGenericService
+
+```
+
+:::info
+`restricted_namespaces` is optional. When not set on a generic, nodes from any namespace can inherit from it.
+:::
+
+Infrahub uses this same mechanism on several of its own built-in generics — for example `CoreGenericRepository`, `CoreValidator`, `CoreCheck`, `CoreWebhook`, `CoreComment`, and `CoreThread` — to prevent accidental extension of types that rely on specific internal code. Nodes inheriting from these generics must belong to the `Core` namespace.
+
 ### Inherited properties
 
 #### List of inheritable properties

--- a/docs/docs/topics/schema.mdx
+++ b/docs/docs/topics/schema.mdx
@@ -844,7 +844,7 @@ nodes:
 `restricted_namespaces` is optional. When not set on a generic, nodes from any namespace can inherit from it.
 :::
 
-Infrahub uses this same mechanism on several of its own built-in generics — for example `CoreGenericRepository`, `CoreValidator`, `CoreCheck`, `CoreWebhook`, `CoreComment`, and `CoreThread` — to prevent accidental extension of types that rely on specific internal code. Nodes inheriting from these generics must belong to the `Core` namespace.
+Infrahub uses this same mechanism on several of its own built-in generics — for example `CoreGenericRepository` and `CoreWebhook` — to prevent accidental extension of types that rely on specific internal code. Nodes inheriting from these generics must belong to the `Core` namespace.
 
 ### Inherited properties
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a "Restricting inheritance by namespace" section to schema docs explaining the `restricted_namespaces` property on generics and how it enforces allowed namespaces during validation. Includes a YAML example, notes that the field is optional, and clarifies built-in generics (`CoreGenericRepository`, `CoreValidator`, `CoreCheck`, `CoreWebhook`, `CoreComment`, `CoreThread`) that require the `Core` namespace.

<sup>Written for commit 9d7bcdf6f6c296591ebfef75b50c114926f9f243. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

