### PR TITLE
Add rules section for Claude and instructions for Python testing

### DIFF
--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../dev/rules

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "backend/tests/unit/**/*.py"
+  - "backend/tests/component/**/*.py"
+  - "backend/tests/functional/**/*.py"
+  - "backend/tests/integration/**/*.py"
+  - "backend/tests/integration_docker/**/*.py"
+---
+
+# Python Testing Rules
+
+Full reference: `dev/guidelines/backend/testing.md`
+
+## No mocking
+
+Do NOT use `unittest.mock`, `pytest-mock`, `MagicMock`, `patch`, or `Mock`.
+
+Use adapter/protocol patterns instead. The message bus demonstrates this:
+
+- Production: `backend/infrahub/services/adapters/message_bus/rabbitmq.py`
+- Testing: `backend/tests/adapters/message_bus.py` (`BusRecorder` / `BusSimulator`)
+
+Both implement `InfrahubMessageBus`. Tests inject the test adapter — no patching.
+
+Acceptable exceptions only:
+
+- External HTTP APIs with no test mode: use `httpx_mock` or `responses`
+- Time-dependent behavior: `freezegun`
+
+## Parametrized tests
+
+Use the dataclass pattern, not tuples. First field must be `name` — it becomes the pytest ID. Always use keyword arguments when constructing test cases.
+
+## Exception testing
+
+Always use the `match` parameter of `pytest.raises`:
+
+```python
+with pytest.raises(SomeError, match=r"expected message"):
+    call_function()
+```
+
+## GraphQL error assertions
+
+Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes.
+
+## Test file placement
+
+Test files mirror source structure: `infrahub/core/node.py` → `tests/unit/core/test_node.py`
+
+Do not reference issue numbers, GitHub URLs, or Jira tickets in test names, docstrings, or comments.
+
+## Schema fixtures
+
+Check `backend/tests/helpers/schema/` before defining test schemas inline. Use `deepcopy` to derive variants from existing helpers rather than writing new schemas from scratch.


### PR DESCRIPTION
# Why

Start to use the rules section in Claude (https://code.claude.com/docs/en/memory#organize-rules-with-claude/rules/) which loads rules based on file paths.

This should help the AI agents to follow instructions that we've written. This first PR highlights the instructions we have elsewhere specifically for Python tests. We will need to consider the placement of other future rules.

## What changed

* Added symlink from `.claude/rules` -> `dev/rules`
* Added initial rule file for python-testing.md

## How to review

There should hopefully not be a lot to review just good to note the structure of the rules files with the paths.