### PR TITLE
Fix git worktree breaking check_connectivity

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import shutil
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
@@ -1006,7 +1007,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     @classmethod
     def check_connectivity(cls, name: str, url: str) -> None:
-        cmd = git.cmd.Git()
+        # Use a neutral working directory so git doesn't discover a .git pointer
+        # from the process CWD (e.g. worktree builds where /source/.git is a
+        # pointer file referencing a host path absent from a container).
+        cmd = git.cmd.Git(working_dir=tempfile.gettempdir())
         try:
             cmd.ls_remote("--tags", url)
         except GitCommandError as exc:

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from git import Repo
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 
@@ -40,3 +41,18 @@ async def test_has_conflicting_changes_no_false_positive(
 
     # The branch adds a file containing ======= but has no actual conflicts with main
     assert not repository.has_conflicting_changes(target_branch="main", source_branch="change1")
+
+
+def test_check_connectivity_ignores_cwd_git_pointer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Git operations must not be affected by a broken .git worktree pointer in the process current working directory."""
+    source_dir = tmp_path / "source-repo"
+    source_dir.mkdir()
+    Repo.init(source_dir, initial_branch="main")
+
+    # Simulate a worktree environment: current working directory has a .git file pointing to a path that doesn't exist
+    cwd = tmp_path / "broken-worktree"
+    cwd.mkdir()
+    (cwd / ".git").write_text("gitdir: /nonexistent/.git/worktrees/fake\n")
+    monkeypatch.chdir(cwd)
+
+    InfrahubRepository.check_connectivity(name="test", url=f"file://{source_dir}")

--- a/changelog/9008.fixed.md
+++ b/changelog/9008.fixed.md
@@ -1,0 +1,1 @@
+Fixed git repository registration failing when the working directory contains a `.git` reference pointing to a path that is inaccessible to the process (for example, in containerized setups).


### PR DESCRIPTION
Use a neutral working directory for the bare `Git()` call in `check_connectivity` so git doesn't discover a `.git` worktree pointer from the process current working directory. Fixes local-build containers failing `ls_remote` when the host source is a git worktree.

Fixes #9008

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
