### PR TITLE
docs: add log forwarding documentation

### DIFF
--- a/.vale/styles/Infrahub/sentence-case.yml
+++ b/.vale/styles/Infrahub/sentence-case.yml
@@ -50,6 +50,12 @@ exceptions:
   - VLAN
   - WebUI
   - IDE
+  - TCP
+  - TLS
+  - UDP
+  - RFC
+  - SIEM
+  - PRI
 
   # Technical terms that should keep their case
   - Python

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -250,3 +250,16 @@ YAML
 yamllint
 YouTube
 AIOps
+backoff
+codec
+connectionless
+Datadog
+enqueues
+Filebeat
+Logstash
+QRadar
+rsyslog
+sourcetype
+Splunk
+syslog
+Syslog

--- a/docs/docs/guides/log-forwarding.mdx
+++ b/docs/docs/guides/log-forwarding.mdx
@@ -1,0 +1,254 @@
+---
+title: Setting up log forwarding
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import EnterpriseBadge from "../../src/components/EnterpriseBadge";
+
+# Setting up log forwarding <EnterpriseBadge />
+
+This guide walks through configuring Infrahub to forward audit events and application logs to external SIEM or syslog systems. For conceptual background on how log forwarding works, see the [log forwarding topic](../topics/log-forwarding.mdx).
+
+:::info Enterprise Edition
+
+Log forwarding requires the Enterprise Edition of Infrahub. The Community Edition includes the configuration surface but does not transmit messages.
+
+:::
+
+## Prerequisites
+
+- Infrahub Enterprise Edition running
+- A syslog-compatible receiver (rsyslog, syslog-ng, Splunk, Datadog Agent, Logstash, or similar)
+- Network connectivity from Infrahub to the receiver on the chosen port
+- For TLS: a CA certificate or bundle trusted by the syslog server
+
+## Configuring a single destination
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="toml" label="Via the configuration file" default>
+
+Add a `[[log_forwarding.destinations]]` section to your Infrahub TOML configuration file:
+
+```toml
+[[log_forwarding.destinations]]
+name = "siem_primary"
+type = "syslog"
+host = "syslog.example.com"
+port = 514
+```
+
+This minimal configuration sends audit events over UDP using RFC 5424 format to port 514.
+
+The defaults are:
+
+| Setting | Default |
+|---------|---------|
+| Protocol | UDP |
+| Format | RFC 5424 |
+| Port | 514 (or 6514 when TLS is enabled) |
+
+</TabItem>
+<TabItem value="env" label="Via environment variables">
+
+Environment variables are useful for Docker Compose and Kubernetes deployments where configuration files may not be practical.
+
+Define destination names as a comma-separated list, then set per-destination fields using the pattern `INFRAHUB_LOG_FORWARDING_DESTINATION_{NAME}_{FIELD}`:
+
+```bash
+export INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES="siem_primary"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST="syslog.example.com"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PORT="514"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PROTOCOL="udp"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_FORMAT="rfc5424"
+```
+
+Alternatively, pass the full destination configuration as JSON:
+
+```bash
+export INFRAHUB_LOG_FORWARDING_DESTINATIONS='[{"name":"siem_primary","type":"syslog","host":"syslog.example.com","port":514}]'
+```
+
+:::note
+
+Destination names must match `[a-z0-9_]+` (lowercase letters, digits, and underscores only).
+
+:::
+
+:::warning
+
+`INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` and `INFRAHUB_LOG_FORWARDING_DESTINATIONS` are mutually exclusive. Use one or the other, not both. If both are set, Infrahub will raise a validation error on startup.
+
+:::
+
+</TabItem>
+</Tabs>
+
+:::note
+
+When `INFRAHUB_LOG_FORWARDING_HOSTNAME` is not set, Infrahub uses `socket.getfqdn()` to determine the hostname in syslog headers. In Docker environments, this resolves to the container ID rather than a meaningful hostname. Set `hostname` explicitly in your configuration or via the `INFRAHUB_LOG_FORWARDING_HOSTNAME` environment variable when running in containers.
+
+:::
+
+Restart Infrahub to apply the configuration.
+
+For the complete list of destination parameters, see the [configuration reference](../reference/configuration.mdx#log-forwarding).
+
+## Enabling TLS encryption
+
+TLS requires the TCP protocol. Configuring TLS with UDP raises a validation error.
+
+```toml
+[[log_forwarding.destinations]]
+name = "siem_secure"
+type = "syslog"
+host = "syslog.example.com"
+protocol = "tcp"
+tls_enabled = true
+tls_ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
+```
+
+When TLS is enabled and no explicit port is set, the port defaults to 6514.
+
+The `tls_ca_bundle` field accepts either a file path or an inline PEM string.
+
+Environment variable equivalent:
+
+```bash
+export INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES="siem_secure"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_SECURE_HOST="syslog.example.com"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_SECURE_PROTOCOL="tcp"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_SECURE_TLS_ENABLED="true"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_SECURE_TLS_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
+```
+
+## Configuring multiple destinations
+
+Use multiple `[[log_forwarding.destinations]]` blocks to send events to more than one receiver. Each destination operates independently with its own queue and connection.
+
+```toml
+[log_forwarding]
+hostname = "infrahub-prod-01"
+
+[[log_forwarding.destinations]]
+name = "siem_primary"
+type = "syslog"
+host = "syslog-primary.example.com"
+protocol = "tcp"
+tls_enabled = true
+tls_ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
+
+[[log_forwarding.destinations]]
+name = "siem_backup"
+type = "syslog"
+host = "syslog-backup.example.com"
+port = 514
+protocol = "udp"
+format = "rfc3164"
+```
+
+The optional `hostname` field at the top level overrides the syslog header hostname for all destinations. If not set, it defaults to the system FQDN.
+
+With environment variables, use comma-separated destination names:
+
+```bash
+export INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES="siem_primary,siem_backup"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST="syslog-primary.example.com"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_PROTOCOL="tcp"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_TLS_ENABLED="true"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_BACKUP_HOST="syslog-backup.example.com"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_BACKUP_PORT="514"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_BACKUP_PROTOCOL="udp"
+export INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_BACKUP_FORMAT="rfc3164"
+```
+
+:::note
+
+Destination names must be unique. Duplicate names are rejected during configuration validation.
+
+:::
+
+## Enabling application log forwarding
+
+By default, only audit events are forwarded. Application log forwarding adds exception events such as permission denied (`infrahub.permission.denied`) to the forwarded stream. These are sent as `APPLICATION_LOG` messages through the `forward_exception()` path and require explicit opt-in per destination:
+
+```toml
+[[log_forwarding.destinations]]
+name = "siem_all_logs"
+type = "syslog"
+host = "syslog.example.com"
+protocol = "tcp"
+forward_application_logs = true
+min_log_severity = "WARNING"
+```
+
+The `min_log_severity` field filters which messages are forwarded. Options are: `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, `CRITICAL`.
+
+Application log messages use syslog facility `LOG_LOCAL0` (16), while audit events use `LOG_AUTH` (4). This distinction helps receivers separate and route the two categories independently.
+
+:::warning
+
+Permission denied events are only forwarded when `forward_application_logs` is enabled. If you need these events for security monitoring, ensure this setting is active on the relevant destinations.
+
+:::
+
+## Verifying logs are arriving
+
+After configuring log forwarding and restarting Infrahub:
+
+1. **Check Infrahub startup logs** for messages confirming that log forwarding destinations have been initialized.
+
+2. **Trigger an event** by performing an action that generates an audit event, such as logging in, creating a node, or updating an object.
+
+3. **Check your syslog receiver** for incoming messages. An RFC 5424 audit event looks like:
+
+```text
+<38>1 2025-01-15T10:30:00.000000Z infrahub.example.com infrahub worker-01 - - {"event":"infrahub.node.created","meta":{"branch":"main","account_id":"01234567-abcd-0000-0000-000000000001"},"kind":"InfraDevice","node_id":"01234567-abcd-0000-0000-000000000002","action":"created"}
+```
+
+The same event in RFC 3164 format:
+
+```text
+<38>Jan 15 10:30:00 infrahub.example.com infrahub[worker-01]: {"event":"infrahub.node.created","meta":{"branch":"main","account_id":"01234567-abcd-0000-0000-000000000001"},"kind":"InfraDevice","node_id":"01234567-abcd-0000-0000-000000000002","action":"created"}
+```
+
+The PRI value `38` comes from `facility * 8 + severity`: LOG_AUTH (4) * 8 + INFORMATIONAL (6) = 38.
+
+## Tuning and troubleshooting
+
+### Queue sizing
+
+The `queue_size` parameter (default 10,000) controls how many messages can be buffered per destination. If the queue fills because the receiver is slow or unreachable, new messages are dropped. Increase this value for high-volume environments.
+
+### Reconnection behavior
+
+For TCP connections, `max_reconnect_interval` (default 60 seconds) caps the exponential backoff between reconnection attempts. Lower this value if faster recovery is needed.
+
+### Graceful shutdown
+
+`shutdown_drain_timeout` (default 10 seconds) controls how long Infrahub waits for queued messages to be transmitted during shutdown. Increase this value if you need to ensure all buffered messages are delivered before the process exits.
+
+### TCP framing
+
+The `tcp_framing` option controls how TCP messages are delimited:
+
+- `newline` (default): messages are separated by newline characters
+- `octet-counting`: messages are length-prefixed per RFC 6587; required by some rsyslog and syslog-ng configurations
+
+### Common issues
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| Validation error on startup | TLS enabled with UDP protocol | Change protocol to `tcp` — TLS is only supported with TCP |
+| Validation error on startup | Duplicate destination names | Ensure each destination has a unique `name` |
+| No messages received | Firewall blocking syslog port | Verify network connectivity from Infrahub to the receiver on the configured port |
+| No messages received | Community Edition | Log forwarding requires Enterprise Edition |
+| Truncated messages | Receiver does not support octet-counting | Switch `tcp_framing` to `newline`, or configure the receiver for octet-counting |
+
+## Related resources
+
+- [Log forwarding concepts](../topics/log-forwarding.mdx)
+- [Configuration reference](../reference/configuration.mdx#log-forwarding)
+- [Infrahub events reference](../reference/infrahub-events.mdx)
+- [Activity log](../topics/activity-log.mdx)
+- [Webhooks](./webhooks.mdx)

--- a/docs/docs/guides/log-forwarding.mdx
+++ b/docs/docs/guides/log-forwarding.mdx
@@ -77,7 +77,7 @@ Destination names must match `[a-z0-9_]+` (lowercase letters, digits, and unders
 
 :::warning
 
-`INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` and `INFRAHUB_LOG_FORWARDING_DESTINATIONS` are mutually exclusive. Use one or the other, not both. If both are set, Infrahub will raise a validation error on startup.
+`INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES` and `INFRAHUB_LOG_FORWARDING_DESTINATIONS` should not both be set unless they define the exact same destinations. Mixing the two approaches is not recommended — pick one method and use it consistently.
 
 :::
 
@@ -170,7 +170,7 @@ Destination names must be unique. Duplicate names are rejected during configurat
 
 ## Enabling application log forwarding
 
-By default, only audit events are forwarded. Application log forwarding adds exception events such as permission denied (`infrahub.permission.denied`) to the forwarded stream. These are sent as `APPLICATION_LOG` messages through the `forward_exception()` path and require explicit opt-in per destination:
+By default, only audit events are forwarded. Enabling application log forwarding adds permission denied events (`infrahub.permission.denied`) to the forwarded stream. These are the only events currently sent through this channel. They require explicit opt-in per destination:
 
 ```toml
 [[log_forwarding.destinations]]
@@ -179,12 +179,9 @@ type = "syslog"
 host = "syslog.example.com"
 protocol = "tcp"
 forward_application_logs = true
-min_log_severity = "WARNING"
 ```
 
-The `min_log_severity` field filters which messages are forwarded. Options are: `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, `CRITICAL`.
-
-Application log messages use syslog facility `LOG_LOCAL0` (16), while audit events use `LOG_AUTH` (4). This distinction helps receivers separate and route the two categories independently.
+Permission denied events use syslog facility `LOG_LOCAL0` (16), while audit events use `LOG_AUTH` (4). This distinction helps receivers separate and route the two categories independently.
 
 :::warning
 

--- a/docs/docs/topics/activity-log.mdx
+++ b/docs/docs/topics/activity-log.mdx
@@ -6,6 +6,8 @@ title: Activity log
 
 Changes (events) in Infrahub are documented in the **Activity log**. It helps you see which objects were impacted, when a change was made, and who made it. It can be used to troubleshoot unforeseen changes, audit previous operations, and comprehend the order of updates across various branches.
 
+To export these events to an external SIEM or centralized logging system, see [log forwarding](./log-forwarding.mdx).
+
 :::warning Permissions
 Because figuring out who may view which changes requires complicated query requirements, we have currently set aside the permission framework for this functionality.
 

--- a/docs/docs/topics/community-vs-enterprise.mdx
+++ b/docs/docs/topics/community-vs-enterprise.mdx
@@ -194,6 +194,7 @@ Community Edition provides all the essential security features needed for most o
 
 - **Advanced authorization**: Sophisticated workflow-based approval processes
 - **Change management**: Capability to require approvals for changes
+- **Log forwarding**: Export audit events and application logs to external SIEM systems via syslog
 
 ### Support and services
 

--- a/docs/docs/topics/events.mdx
+++ b/docs/docs/topics/events.mdx
@@ -28,3 +28,4 @@ These events serve multiple purposes:
 
 * They feed the [activity log](./activity-log.mdx), providing a detailed, chronological timeline of system changes.
 * They enable event-driven automation, such as triggering [webhooks](./webhooks.mdx) and [event rules and actions](./event-actions.mdx).
+* They can be forwarded to external SIEM systems via [log forwarding](./log-forwarding.mdx) (Enterprise Edition).

--- a/docs/docs/topics/log-forwarding.mdx
+++ b/docs/docs/topics/log-forwarding.mdx
@@ -190,7 +190,7 @@ TLS adds encryption on top of TCP. It is only valid with TCP — configuring TLS
 
 Log forwarding works with any syslog-compatible receiver. Brief guidance for common platforms:
 
-- **Splunk**: Configure a TCP or UDP syslog input on a Heavy Forwarder or Universal Forwarder. Set the sourcetype to `syslog` or a custom type.
+- **Splunk**: Configure a TCP or UDP syslog input on a Heavy Forwarder or Universal Forwarder. Set the sourcetype to `syslog` or a custom type. RFC 5424 enables structured field extraction.
 - **Datadog**: Use the Datadog Agent's syslog input or configure a syslog-to-Datadog pipeline. Point Infrahub at the agent's syslog listening port.
 - **Elastic (ELK)**: Configure Logstash with a `syslog` input plugin or use the Filebeat syslog input for a lighter footprint. RFC 5424 works well with the Logstash syslog codec.
 - **IBM QRadar / ArcSight**: Use standard syslog ingestion. RFC 5424 is recommended. Configure a log source pointing to Infrahub's hostname.

--- a/docs/docs/topics/log-forwarding.mdx
+++ b/docs/docs/topics/log-forwarding.mdx
@@ -1,0 +1,205 @@
+---
+title: Log forwarding
+---
+
+import EnterpriseBadge from "../../src/components/EnterpriseBadge";
+
+# Log forwarding <EnterpriseBadge />
+
+Log forwarding enables Infrahub to stream audit events and application logs to external systems via the syslog protocol. This supports compliance, security monitoring, and operational visibility by integrating with SIEM platforms and centralized log management.
+
+:::info Enterprise Edition
+
+Log forwarding is available exclusively in the Enterprise Edition. The Community Edition includes the configuration model but uses a no-op implementation that does not transmit messages. See [Community vs Enterprise](./community-vs-enterprise.mdx) for details.
+
+:::
+
+## Why log forwarding matters
+
+Many organizations face regulatory and operational requirements that demand centralized, tamper-evident logging across all infrastructure tools:
+
+- **Compliance**: Standards such as SOC 2, PCI-DSS, and ISO 27001 require historical tracing of user actions across all systems in a central location
+- **Security monitoring**: Real-time detection of suspicious activity such as permission denied events, unexpected schema changes, or mass deletions
+- **Operational visibility**: Correlate infrastructure data changes in Infrahub with network incidents tracked in external monitoring systems
+- **Production deployment approval**: Security teams often require centralized log export before approving tools for production use
+
+Infrahub provides two complementary mechanisms for event visibility:
+
+- The [activity log](./activity-log.mdx) provides in-app visibility for browsing and filtering events through the web interface
+- Log forwarding exports those same events to purpose-built external tools for long-term retention, alerting, and cross-system correlation
+
+Log forwarding is distinct from [webhooks](./webhooks.mdx). Webhooks are HTTP callbacks designed for real-time integrations with custom payloads. Log forwarding uses the syslog protocol for compliance and SIEM use cases where standardized log ingestion is required.
+
+## Architecture overview
+
+Log forwarding uses a queue-based, non-blocking architecture to ensure event processing is never delayed by slow or unreachable syslog receivers.
+
+The data flow is:
+
+1. An action in Infrahub generates an `InfrahubEvent` (or a `ForwardableError` for permission denials)
+2. The `LogForwardingService` converts it to a `SyslogMessage` and enqueues it
+3. Each configured destination has its own independent async queue (bounded by `queue_size`, default 10,000)
+4. A per-destination consumer task reads from the queue and transmits over the configured protocol
+5. TCP connections use exponential backoff reconnection (capped at `max_reconnect_interval`)
+6. On graceful shutdown, queues are drained up to `shutdown_drain_timeout` seconds before connections close
+
+In the Community Edition, the `LogForwardingServiceCommunity` stub replaces the enterprise implementation. All methods return immediately with zero overhead.
+
+:::note
+
+The syslog header hostname defaults to `socket.getfqdn()`. In Docker environments, this resolves to the container ID. Set `hostname` explicitly in the log forwarding configuration when running in containers.
+
+:::
+
+## Message categories
+
+Log forwarding handles two categories of messages, each mapped to a different syslog facility:
+
+- **Audit events** (`AUDIT_EVENT`): Generated from Infrahub events representing user and system actions. Uses syslog facility `LOG_AUTH` (4). Always forwarded when a destination is configured.
+- **Application logs** (`APPLICATION_LOG`): Used for forwarding exception events such as permission denials. Uses syslog facility `LOG_LOCAL0` (16). Opt-in per destination via `forward_application_logs` with severity filtering via `min_log_severity`.
+
+The facility distinction allows receivers to separate and route audit events independently from application-level messages.
+
+### Forwarded audit event types
+
+The following event types are forwarded as audit events:
+
+- **Account**: `infrahub.account.logged_in`, `infrahub.account.logged_out`
+- **Node**: `infrahub.node.created`, `infrahub.node.updated`, `infrahub.node.deleted`
+- **Branch**: `infrahub.branch.created`, `infrahub.branch.deleted`, `infrahub.branch.merged`, `infrahub.branch.rebased`
+- **Proposed change**: `infrahub.proposed_change.approved`, `infrahub.proposed_change.rejected`, `infrahub.proposed_change.merged`, and others
+- **Schema**: `infrahub.schema.updated`
+
+For the complete list of event types and their payload fields, see the [Infrahub events reference](../reference/infrahub-events.mdx).
+
+### Permission denied events
+
+Permission denied events (`infrahub.permission.denied`) are categorized as `APPLICATION_LOG`, not `AUDIT_EVENT`. They are forwarded through the `forward_exception()` path and require `forward_application_logs = true` on the destination to be received.
+
+These events carry security context useful for detecting unauthorized access attempts:
+
+- `account_id`: ID of the account that made the request
+- `auth_type`: Authentication method used
+- `ip_address`: Source IP address of the request
+- `request_path`: API endpoint or path targeted
+- `operation`: GraphQL operation name (if applicable)
+- `query_type`: Whether it was a query or mutation (if applicable)
+- `graphql_operations`: List of GraphQL operations requested (if applicable)
+
+:::warning
+
+If `forward_application_logs` is not enabled on a destination, permission denied events are silently dropped for that destination.
+
+:::
+
+## Syslog format standards
+
+Infrahub supports two syslog format standards. The format is configured per destination.
+
+### RFC 5424 (default)
+
+RFC 5424 is the modern syslog standard with structured headers and ISO 8601 timestamps. This is the recommended format for new deployments.
+
+Message structure:
+
+```text
+<PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA MSG
+```
+
+Example:
+
+```text
+<38>1 2025-01-15T10:30:00.000000Z infrahub.example.com infrahub worker-01 - - {"event":"infrahub.node.created","meta":{"branch":"main","account_id":"01234567-abcd-0000-0000-000000000001"},"kind":"InfraDevice","node_id":"01234567-abcd-0000-0000-000000000002","action":"created"}
+```
+
+### RFC 3164 (legacy)
+
+RFC 3164 is the older BSD syslog format with shorter timestamps and a simpler header. Use this when the receiving system does not support RFC 5424.
+
+Message structure:
+
+```text
+<PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
+```
+
+Example:
+
+```text
+<38>Jan 15 10:30:00 infrahub.example.com infrahub[worker-01]: {"event":"infrahub.node.created","meta":{"branch":"main","account_id":"01234567-abcd-0000-0000-000000000001"},"kind":"InfraDevice","node_id":"01234567-abcd-0000-0000-000000000002","action":"created"}
+```
+
+### PRI value calculation
+
+The PRI (priority) value encodes both facility and severity: `PRI = facility * 8 + severity`.
+
+For audit events using LOG_AUTH (facility 4) at INFORMATIONAL severity (6): `4 * 8 + 6 = 38`.
+
+The severity codes follow RFC 5424:
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| 0 | Emergency | System is unusable |
+| 1 | Alert | Action must be taken immediately |
+| 2 | Critical | Critical conditions |
+| 3 | Error | Error conditions |
+| 4 | Warning | Warning conditions |
+| 5 | Notice | Normal but significant condition |
+| 6 | Informational | Informational messages |
+| 7 | Debug | Debug-level messages |
+
+### Message payload
+
+The MSG field always contains a JSON representation of the event. For audit events, this includes the full event payload with metadata (branch, account, timestamps, affected objects). For application log messages such as permission denials, this includes the exception details and request context.
+
+## Transport protocols
+
+### UDP (default)
+
+UDP is connectionless and fire-and-forget. It offers lower overhead but provides no delivery guarantee. Messages may be lost if the receiver is unavailable or the network drops packets.
+
+- Default port: 514
+- No connection state or reconnection logic
+- Suitable for high-volume, loss-tolerant scenarios
+
+### TCP
+
+TCP provides connection-oriented, reliable delivery with acknowledgment. The sender maintains a persistent connection to the receiver and automatically reconnects with exponential backoff if the connection drops.
+
+- Default port: 514 (or 6514 with TLS)
+- Recommended for compliance use cases where message loss is unacceptable
+- Two framing options:
+  - `newline` (default): messages are delimited by a newline character
+  - `octet-counting`: messages are length-prefixed per RFC 6587; required by some receivers (notably certain rsyslog configurations)
+
+### TLS
+
+TLS adds encryption on top of TCP. It is only valid with TCP — configuring TLS with UDP raises a validation error.
+
+- Default port changes to 6514 when TLS is enabled without an explicit port
+- `tls_ca_bundle` accepts a file path to a CA certificate bundle or an inline PEM string
+- The server certificate is validated against the provided CA bundle
+
+## Security considerations
+
+- **Use TLS** for any deployment transmitting logs over untrusted networks. Syslog payloads contain sensitive data including account IDs, IP addresses, node details, and permission denial reasons.
+- **Queue overflow**: When a destination queue fills (default 10,000 messages), new messages are dropped rather than blocking event processing. Size the queue appropriately for your event volume and receiver throughput.
+- **Receiver authentication**: The syslog protocol itself does not authenticate the sender. Use network-level controls (firewall rules, VPN, network segmentation) in addition to TLS.
+- **Certificate management**: The `tls_ca_bundle` should point to a properly managed certificate store that is rotated according to your organization's security policies.
+
+## SIEM platform integration
+
+Log forwarding works with any syslog-compatible receiver. Brief guidance for common platforms:
+
+- **Splunk**: Configure a TCP or UDP syslog input on a Heavy Forwarder or Universal Forwarder. Set the sourcetype to `syslog` or a custom type. RFC 5424 enables structured field extraction.
+- **Datadog**: Use the Datadog Agent's syslog input or configure a syslog-to-Datadog pipeline. Point Infrahub at the agent's syslog listening port.
+- **Elastic (ELK)**: Configure Logstash with a `syslog` input plugin or use the Filebeat syslog input for a lighter footprint. RFC 5424 works well with the Logstash syslog codec.
+- **IBM QRadar / ArcSight**: Use standard syslog ingestion. RFC 5424 is recommended. Configure a log source pointing to Infrahub's hostname.
+
+In all cases, configure the receiver to parse JSON from the MSG field to extract structured event data for indexing and alerting.
+
+## Relationship to other features
+
+- **Activity log**: The in-app UI for browsing and filtering events. Log forwarding exports the same events to external systems. See [Activity log](./activity-log.mdx).
+- **Webhooks**: HTTP callbacks for real-time integrations with custom payloads. Log forwarding uses syslog for compliance and SIEM use cases. See [Webhooks](./webhooks.mdx).
+- **Event framework**: Log forwarding consumes the same events that power the activity log, webhooks, and event rules. See [Events](./events.mdx) and the [Infrahub events reference](../reference/infrahub-events.mdx).
+- **Configuration reference**: All log forwarding parameters are documented in the [configuration reference](../reference/configuration.mdx#log-forwarding).

--- a/docs/docs/topics/log-forwarding.mdx
+++ b/docs/docs/topics/log-forwarding.mdx
@@ -36,14 +36,14 @@ Log forwarding uses a queue-based, non-blocking architecture to ensure event pro
 
 The data flow is:
 
-1. An action in Infrahub generates an `InfrahubEvent` (or a `ForwardableError` for permission denials)
-2. The `LogForwardingService` converts it to a `SyslogMessage` and enqueues it
+1. An action in Infrahub generates an event (or a permission denied exception)
+2. The log forwarding service converts it to a syslog message and enqueues it
 3. Each configured destination has its own independent async queue (bounded by `queue_size`, default 10,000)
 4. A per-destination consumer task reads from the queue and transmits over the configured protocol
 5. TCP connections use exponential backoff reconnection (capped at `max_reconnect_interval`)
 6. On graceful shutdown, queues are drained up to `shutdown_drain_timeout` seconds before connections close
 
-In the Community Edition, the `LogForwardingServiceCommunity` stub replaces the enterprise implementation. All methods return immediately with zero overhead.
+In the Community Edition, a no-op stub replaces the enterprise implementation. All methods return immediately with zero overhead.
 
 :::note
 
@@ -56,7 +56,7 @@ The syslog header hostname defaults to `socket.getfqdn()`. In Docker environment
 Log forwarding handles two categories of messages, each mapped to a different syslog facility:
 
 - **Audit events** (`AUDIT_EVENT`): Generated from Infrahub events representing user and system actions. Uses syslog facility `LOG_AUTH` (4). Always forwarded when a destination is configured.
-- **Application logs** (`APPLICATION_LOG`): Used for forwarding exception events such as permission denials. Uses syslog facility `LOG_LOCAL0` (16). Opt-in per destination via `forward_application_logs` with severity filtering via `min_log_severity`.
+- **Application logs** (`APPLICATION_LOG`): Currently used exclusively for forwarding permission denied exceptions. Uses syslog facility `LOG_LOCAL0` (16). Opt-in per destination via `forward_application_logs`.
 
 The facility distinction allows receivers to separate and route audit events independently from application-level messages.
 
@@ -190,7 +190,7 @@ TLS adds encryption on top of TCP. It is only valid with TCP — configuring TLS
 
 Log forwarding works with any syslog-compatible receiver. Brief guidance for common platforms:
 
-- **Splunk**: Configure a TCP or UDP syslog input on a Heavy Forwarder or Universal Forwarder. Set the sourcetype to `syslog` or a custom type. RFC 5424 enables structured field extraction.
+- **Splunk**: Configure a TCP or UDP syslog input on a Heavy Forwarder or Universal Forwarder. Set the sourcetype to `syslog` or a custom type.
 - **Datadog**: Use the Datadog Agent's syslog input or configure a syslog-to-Datadog pipeline. Point Infrahub at the agent's syslog listening port.
 - **Elastic (ELK)**: Configure Logstash with a `syslog` input plugin or use the Filebeat syslog input for a lighter footprint. RFC 5424 works well with the Logstash syslog codec.
 - **IBM QRadar / ArcSight**: Use standard syslog ingestion. RFC 5424 is recommended. Configure a log source pointing to Infrahub's hostname.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -132,6 +132,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'guides/events-rules-actions',
             'guides/webhooks',
+            'guides/log-forwarding',
           ],
         },
         {
@@ -308,6 +309,7 @@ const sidebars: SidebarsConfig = {
                 'topics/event-actions',
                 'topics/tasks',
                 'topics/webhooks',
+                'topics/log-forwarding',
               ],
             },
             {


### PR DESCRIPTION
## Summary

- Add guide page (`docs/docs/guides/log-forwarding.mdx`) with step-by-step configuration for TOML and environment variables, TLS, multiple destinations, application log forwarding, verification, and troubleshooting
- Add topic page (`docs/docs/topics/log-forwarding.mdx`) covering architecture, message categories, syslog formats (RFC 5424/3164), transport protocols, security considerations, and SIEM platform integration
- Add backlinks from activity log, events, and community-vs-enterprise pages; update sidebar and vale spelling/heading exceptions

## Test plan

- [x] `npm run build` passes with no errors or broken links
- [x] `vale` passes with 0 errors, 0 warnings
- [x] `rumdl check` passes with no issues
- [ ] Visual review of rendered pages on the docs site