### PR TITLE
docs(faq): add production-readiness Q&A (HA, DR, upgrades, monitoring…

### DIFF
--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -89,11 +89,11 @@ Capacity depends heavily on the schema you define, so we publish sizing tiers ra
 
 If you want to evaluate Infrahub against your own schema and dataset size, reach out on [Discord](https://discord.gg/opsmill) or at [contact@opsmill.com](mailto:contact@opsmill.com), and we happy to help.
 
-### How is Infrahub architected for high availability?
+### How is Infrahub architectured for high availability?
 
 A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. This is the default topology we recommend for most organisations, and it is what the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page describes under the HA tiers.
 
-Keeping a single logical instance keeps operations simple — one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one upgrade target.
+Running a single logical instance means one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one target for monitoring and upgrades.
 
 ### Can I run Infrahub across multiple regions or multiple instances?
 
@@ -105,9 +105,9 @@ This pattern adds regional failure isolation: an issue in one instance has no im
 
 Database backup is a routine, automated operation, with native support for S3-compatible object storage. Compressed backups for large production deployments typically fall in the single-digit to tens of gigabytes range. See the [database backup and restore topic](../topics/database-backup.mdx) for step-by-step guidance and scheduling recommendations.
 
-### What are realistic RPO and RTO targets for Infrahub?
+### What are realistic recovery targets for Infrahub?
 
-With hourly backups, RPO is one hour. RTO for restoring a large instance is also about one hour, mainly driven by restoring the task manager database.
+With hourly backups, the recovery point objective (RPO) is one hour. The recovery time objective (RTO) for restoring a large instance is also about one hour, mainly driven by restoring the task manager database.
 
 In deployment patterns where data-plane agents enforce their last-known desired state rather than querying Infrahub directly, the effective data-plane RTO during an Infrahub outage is zero — running infrastructure keeps operating, and only the build pipeline pauses until Infrahub is available again.
 
@@ -119,9 +119,9 @@ We recommend a full database backup before every upgrade and validation in a sta
 
 ### What monitoring and observability does Infrahub provide?
 
-Infrahub ships with built-in observability. OpenTelemetry distributed tracing is supported natively, with configurable push-based metrics export to any OTLP-compatible backend (Jaeger, Zipkin, Datadog, and others). A pull-based Prometheus `/metrics` endpoint is also available. See the [configuration reference](../reference/configuration.mdx) for the relevant environment variables.
+Infrahub exposes a metrics endpoint by default, and the Infrahub Exporter provides Prometheus-format scraping and OTLP push to monitoring systems such as Prometheus and OpenTelemetry collectors. Workflow orchestration runs on Prefect, which provides task-level observability. 
 
-In production, the signals most commonly watched are API request latency, task manager queue depth, database connection pool usage, and disk utilisation.
+In production, the most commonly monitored signals are API request latency, task manager queue depth, database connection pool usage, and disk utilisation.
 
 ### How does Infrahub handle authentication and access control?
 
@@ -139,7 +139,7 @@ See the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) compari
 
 Across production deployments, we have found that Generator execution is more often the build-pipeline bottleneck than GraphQL query latency. The two highest-impact tuning levers are using targeted field selection in your queries rather than eager relationship loading, and increasing pagination size where appropriate. These are the same query patterns any downstream build system should use.
 
-Core engine performance is an ongoing investment rather than a fixed milestone — recent work moving branch-merge logic into the database layer, for example, produced about a 4x improvement in merge times on datasets ranging from tens of thousands to hundreds of thousands of objects.
+Core engine performance is an ongoing investment, not a fixed milestone — recent work in v1.8 moved branch-merge logic into the database layer, delivering about a 4x improvement in merge times on datasets ranging from tens to hundreds of thousands of objects.
 
 ### How can I get involved?
 

--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -89,7 +89,7 @@ Capacity depends heavily on the schema you define, so we publish sizing tiers ra
 
 If you want to evaluate Infrahub against your own schema and dataset size, reach out on [Discord](https://discord.gg/opsmill) or at [contact@opsmill.com](mailto:contact@opsmill.com), and we happy to help.
 
-### How is Infrahub architectured for high availability?
+### What does a high-availability Infrahub deployment look like?
 
 A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. This is the default topology we recommend for most organisations, and it is what the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page describes under the HA tiers.
 

--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -61,6 +61,8 @@ Each deployment option comes with trade-offs. It's important to also consider yo
 
 :::
 
+For production deployments that require high availability, Kubernetes with the official Helm chart is the recommended topology because it provides the cleanest upgrade path and native handling of component failover.
+
 We're also working on a managed cloud SaaS version of Infrahub. Please [subscribe to our mailing list](https://opsmill.com) to stay updated.
 
 ### How can I install Infrahub?
@@ -79,11 +81,65 @@ Infrahub is production-ready and has been deployed in a number of organizations 
 
 If you are planning to deploy Infrahub in a critical environment we recommend reaching out to our customer success team via [Discord](https://discord.gg/opsmill), [contact@opsmill.com](mailto:contact@opsmill.com) or [Online Meeting](https://cal.com/team/opsmill/meet).
 
+For teams preparing a production rollout, the [production deployment guide](../guides/production-deployment.mdx) collects the hardening recommendations we apply in customer environments.
+
 ### How much data can Infrahub handle right now?
 
-We've built a framework to test and evaluate performance, but exact numbers are hard to provide as it depends heavily on the schema you use in Infrahub.
+Capacity depends heavily on the schema you define, so we publish sizing tiers rather than a single number. The [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page documents recommended resource allocations across deployment profiles, from moderate environments up to tens of thousands of device-class objects. Production deployments today manage datasets well into the hundreds of thousands of managed objects on a single instance.
 
-If you have specific needs or want to evaluate Infrahub's performance in your environment, feel free to contact us at [contact@opsmill.com](mailto:contact@opsmill.com) or through our [Discord](https://discord.gg/opsmill) server.
+If you want to evaluate Infrahub against your own schema and dataset size, reach out on [Discord](https://discord.gg/opsmill) or at [contact@opsmill.com](mailto:contact@opsmill.com) and we can help you set up a benchmark.
+
+### How is Infrahub architected for high availability?
+
+A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. That is the default topology we recommend for most organizations, and it is what the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page describes under the HA tiers.
+
+Keeping a single logical instance keeps operations simple — one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one upgrade target.
+
+### Can I run Infrahub across multiple regions or multiple instances?
+
+Yes. Some organizations have operational or regulatory reasons to run regionally independent infrastructure, and Infrahub supports a multi-instance model where each region runs its own HA topology and no state is shared between them.
+
+This pattern adds regional failure isolation: an issue in one instance has no impact on the others, and upgrades can follow a canary pattern region-by-region. The trade-off is that each instance manages its own resource allocation. It is a good fit when the organization already has regional operational boundaries.
+
+### How do I back up and restore Infrahub?
+
+Database backup is a routine, automated operation, with native support for S3-compatible object storage. Compressed backups for large production deployments typically fall in the single-digit to tens of gigabytes range. See the [database backup and restore topic](../topics/database-backup.mdx) for step-by-step guidance and scheduling recommendations.
+
+### What are realistic RPO and RTO targets for Infrahub?
+
+With hourly backups, RPO is one hour. RTO for restoring a large instance is also approximately one hour, dominated by restoring the task manager database.
+
+In deployment patterns where data-plane agents enforce their last-known desired state rather than querying Infrahub directly, the effective data-plane RTO during an Infrahub outage is zero — running infrastructure keeps operating, and only the build pipeline pauses until Infrahub is available again.
+
+### How do I upgrade Infrahub?
+
+The `infrahub upgrade` command handles schema and database migrations. On Kubernetes, Helm runs the upgrade as a job during the release update and manages rolling pod updates for you. For VM-based deployments, documented procedures codify the stop/upgrade/restart sequence with safety checks.
+
+We recommend a full database backup before every upgrade and validation in a staging environment that mirrors production topology. The [upgrade guide](../guides/upgrade.mdx) has the detailed steps.
+
+### What monitoring and observability does Infrahub provide?
+
+Infrahub ships with built-in observability. OpenTelemetry distributed tracing is supported natively, with configurable push-based metrics export to any OTLP-compatible backend (Jaeger, Zipkin, Datadog, and others). A pull-based Prometheus `/metrics` endpoint is also available. See the [configuration reference](../reference/configuration.mdx) for the relevant environment variables.
+
+In production, the signals most commonly watched are API request latency, task manager queue depth, database connection pool usage, and disk utilization.
+
+### How does Infrahub handle authentication and access control?
+
+Infrahub supports OAuth2 / OIDC single sign-on (see the [SSO guide](../guides/sso.mdx)) and token-based API authentication (see [managing API tokens](../guides/managing-api-tokens.mdx)).
+
+The RBAC model provides pre-configured roles (Admin, Standard User, Anonymous User), custom role creation, global permissions, and namespace-scoped object-level permissions with configurable decision types. Enterprise adds workflow-based approval processes with configurable approval thresholds and enforced approval gates. All changes are tracked immutably with actor attribution. Full details are in the [permissions reference](../reference/permissions.mdx) and the [change approval workflow guide](../guides/change-approval-workflow.mdx).
+
+### If I start with Community, can I move to Enterprise later?
+
+Yes. Community and Enterprise share the same core engine, the same data model, and the same APIs, so moving from one to the other does not require a data migration or re-architecture — your schema, data, integrations, and Generators carry over. Enterprise capabilities are enabled on top of the same platform.
+
+See the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) comparison for the full breakdown of what each edition includes.
+
+### What drives Infrahub performance at scale, and what can I tune?
+
+Across production deployments we've found that Generator execution is more often the build-pipeline bottleneck than GraphQL query latency. The two highest-impact tuning levers are using targeted field selection in your queries rather than eager relationship loading, and increasing pagination size where appropriate. These are the same query patterns any downstream build system should use.
+
+Core engine performance is an ongoing investment rather than a fixed milestone — recent work moving branch-merge logic into the database layer, for example, produced roughly a 4x improvement in merge times on datasets ranging from tens of thousands to hundreds of thousands of objects.
 
 ### How can I get involved?
 

--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -85,21 +85,21 @@ For teams preparing a production rollout, the [production deployment guide](../g
 
 ### How much data can Infrahub handle right now?
 
-Capacity depends heavily on the schema you define, so we publish sizing tiers rather than a single number. The [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page documents recommended resource allocations across deployment profiles, from moderate environments up to tens of thousands of device-class objects. Production deployments today manage datasets well into the hundreds of thousands of managed objects on a single instance.
+Capacity depends heavily on the schema you define, so we publish sizing tiers rather than one number. The [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page documents recommended resource allocations across deployment profiles, from moderate environments up to tens of thousands of device-class objects. Production deployments today manage datasets well into the hundreds of thousands of managed objects on a single instance.
 
-If you want to evaluate Infrahub against your own schema and dataset size, reach out on [Discord](https://discord.gg/opsmill) or at [contact@opsmill.com](mailto:contact@opsmill.com) and we can help you set up a benchmark.
+If you want to evaluate Infrahub against your own schema and dataset size, reach out on [Discord](https://discord.gg/opsmill) or at [contact@opsmill.com](mailto:contact@opsmill.com), and we happy to help.
 
 ### How is Infrahub architected for high availability?
 
-A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. That is the default topology we recommend for most organizations, and it is what the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page describes under the HA tiers.
+A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. This is the default topology we recommend for most organisations, and it is what the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) page describes under the HA tiers.
 
 Keeping a single logical instance keeps operations simple — one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one upgrade target.
 
 ### Can I run Infrahub across multiple regions or multiple instances?
 
-Yes. Some organizations have operational or regulatory reasons to run regionally independent infrastructure, and Infrahub supports a multi-instance model where each region runs its own HA topology and no state is shared between them.
+Yes. Some organisations have operational or regulatory reasons to run regionally independent infrastructure, and Infrahub supports a multi-instance model where each region runs its own HA topology and no state is shared between them.
 
-This pattern adds regional failure isolation: an issue in one instance has no impact on the others, and upgrades can follow a canary pattern region-by-region. The trade-off is that each instance manages its own resource allocation. It is a good fit when the organization already has regional operational boundaries.
+This pattern adds regional failure isolation: an issue in one instance has no impact on the others, and upgrades can follow a canary pattern region by region. The trade-off is that each instance manages its own resource allocation. It is a good fit when the organisation already has regional operational boundaries.
 
 ### How do I back up and restore Infrahub?
 
@@ -107,13 +107,13 @@ Database backup is a routine, automated operation, with native support for S3-co
 
 ### What are realistic RPO and RTO targets for Infrahub?
 
-With hourly backups, RPO is one hour. RTO for restoring a large instance is also approximately one hour, dominated by restoring the task manager database.
+With hourly backups, RPO is one hour. RTO for restoring a large instance is also about one hour, mainly driven by restoring the task manager database.
 
 In deployment patterns where data-plane agents enforce their last-known desired state rather than querying Infrahub directly, the effective data-plane RTO during an Infrahub outage is zero — running infrastructure keeps operating, and only the build pipeline pauses until Infrahub is available again.
 
 ### How do I upgrade Infrahub?
 
-The `infrahub upgrade` command handles schema and database migrations. On Kubernetes, Helm runs the upgrade as a job during the release update and manages rolling pod updates for you. For VM-based deployments, documented procedures codify the stop/upgrade/restart sequence with safety checks.
+The `infrahub upgrade` command handles schema and database migrations. On Kubernetes, Helm runs the upgrade as a job during the release update and manages rolling pod updates. For VM-based deployments, documented procedures define the stop/upgrade/restart sequence with safety checks.
 
 We recommend a full database backup before every upgrade and validation in a staging environment that mirrors production topology. The [upgrade guide](../guides/upgrade.mdx) has the detailed steps.
 
@@ -121,7 +121,7 @@ We recommend a full database backup before every upgrade and validation in a sta
 
 Infrahub ships with built-in observability. OpenTelemetry distributed tracing is supported natively, with configurable push-based metrics export to any OTLP-compatible backend (Jaeger, Zipkin, Datadog, and others). A pull-based Prometheus `/metrics` endpoint is also available. See the [configuration reference](../reference/configuration.mdx) for the relevant environment variables.
 
-In production, the signals most commonly watched are API request latency, task manager queue depth, database connection pool usage, and disk utilization.
+In production, the signals most commonly watched are API request latency, task manager queue depth, database connection pool usage, and disk utilisation.
 
 ### How does Infrahub handle authentication and access control?
 
@@ -131,15 +131,15 @@ The RBAC model provides pre-configured roles (Admin, Standard User, Anonymous Us
 
 ### If I start with Community, can I move to Enterprise later?
 
-Yes. Community and Enterprise share the same core engine, the same data model, and the same APIs, so moving from one to the other does not require a data migration or re-architecture — your schema, data, integrations, and Generators carry over. Enterprise capabilities are enabled on top of the same platform.
+Yes. Community and Enterprise share the same core engine, data model, and APIs, so moving from one to the other does not require a data migration or re-architecture — your schema, data, integrations, and Generators carry over. Enterprise capabilities are enabled on top of the same platform.
 
 See the [Community vs Enterprise](../topics/community-vs-enterprise.mdx) comparison for the full breakdown of what each edition includes.
 
 ### What drives Infrahub performance at scale, and what can I tune?
 
-Across production deployments we've found that Generator execution is more often the build-pipeline bottleneck than GraphQL query latency. The two highest-impact tuning levers are using targeted field selection in your queries rather than eager relationship loading, and increasing pagination size where appropriate. These are the same query patterns any downstream build system should use.
+Across production deployments, we have found that Generator execution is more often the build-pipeline bottleneck than GraphQL query latency. The two highest-impact tuning levers are using targeted field selection in your queries rather than eager relationship loading, and increasing pagination size where appropriate. These are the same query patterns any downstream build system should use.
 
-Core engine performance is an ongoing investment rather than a fixed milestone — recent work moving branch-merge logic into the database layer, for example, produced roughly a 4x improvement in merge times on datasets ranging from tens of thousands to hundreds of thousands of objects.
+Core engine performance is an ongoing investment rather than a fixed milestone — recent work moving branch-merge logic into the database layer, for example, produced about a 4x improvement in merge times on datasets ranging from tens of thousands to hundreds of thousands of objects.
 
 ### How can I get involved?
 


### PR DESCRIPTION
# Why

Production-readiness questions — high availability, DR, backups, upgrades, monitoring, access control, and the Community→Enterprise path — are the most common follow-ups from teams evaluating Infrahub at scale, but the public FAQ only touches them at a high level. This PR expands the FAQ so those questions have first-class, link-to-docs answers.

**Non-goals:** this is not a rewrite of the FAQ's voice or structure, and it does not introduce any new docs pages — every new entry links to an existing guide, topic, or reference that already lives in the repo.

## What changed

All edits are in a single file: `docs/docs/faq/faq.mdx`.

**Updated existing entries:**

- "What are the deployment options for Infrahub?" — one-line addition noting Kubernetes + Helm as the recommended topology for HA deployments.
- "What is the status of the project? Can I deploy Infrahub in production?" — pointer appended to the production deployment guide.
- "How much data can Infrahub handle right now?" — rewritten to reference the published sizing tiers in Community vs. Enterprise and note that production deployments today run well into the hundreds of thousands of managed objects on a single instance.

**New entries, inserted under About Infrahub immediately after "How much data…":**

- How is Infrahub architected for high availability?
- Can I run Infrahub across multiple regions or multiple instances?
- How do I back up and restore Infrahub?
- What are realistic RPO and RTO targets for Infrahub?
- How do I upgrade Infrahub?
- What monitoring and observability does Infrahub provide?
- How does Infrahub handle authentication and access control?
- If I start with Community, can I move to Enterprise later?
- What drives Infrahub performance at scale, and what can I tune?

**What stayed the same:** no schema changes, no code changes, no navigation/sidebar changes, no existing FAQ entries removed or reordered. The About OpsMill section is untouched.

## How to review

The only file to look at is `docs/docs/faq/faq.mdx`. The review lens that matters most is tone consistency — each new entry is intentionally 2–5 sentences, neutral, and linked to existing docs rather than to marketing pages, to match the voice of the surrounding FAQ. Source material came from https://opsmill.com/blog/from-why-infrahub-to-will-it-run-in-production-answering-the-questions-that-matter/, but the blog's customer anecdotes, superlatives, and services pitches were deliberately omitted.

Worth a second pair of eyes on:

- The RPO/RTO numbers ("hourly backups → 1h RPO, ~1h RTO") — lifted from the blog, please confirm they match what the field team is telling customers.
- The 4x branch-merge improvement number — same origin; happy to soften or remove if we don't want a specific figure in the FAQ.
- The Community vs. Enterprise migration claim ("no data migration or re-architecture needed") — please sanity-check against what engineering would commit to.

## How to test

```bash
# Lint
cd docs
npm install
npm run build   # Docusaurus build — catches broken links and MDX syntax

# Local preview
npm start       # opens http://localhost:3000; navigate to /faq
```

Expected: build succeeds, all nine new anchors render under the About Infrahub TOC, and every internal link resolves. Link targets referenced by the new content all exist in this repo: `../topics/community-vs-enterprise.mdx`, `../topics/database-backup.mdx`, `../guides/production-deployment.mdx`, `../guides/upgrade.mdx`, `../guides/sso.mdx`, `../guides/managing-api-tokens.mdx`, `../guides/change-approval-workflow.mdx`, `../reference/permissions.mdx`, `../reference/configuration.mdx`.

CI's `lychee` link check will cover this automatically.

## Impact & rollout

- **Backward compatibility:** none at risk. Docs-only change; no URL changes to existing FAQ anchors.
- **Performance:** n/a.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy. Changes reach `docs.infrahub.app` via the normal `sync-docs.yml` workflow on the next push to `stable`.

## Checklist

- [ ] Tests added/updated — n/a, docs-only
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`) — not added; happy to add a `housekeeping` fragment if the team wants docs-only changes in the release notes (e.g. `uv run towncrier create +faq-production-readiness.housekeeping.md --content "Expanded FAQ with production-readiness questions (HA, DR, upgrades, monitoring, access control)."`)
- [x] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) — n/a