### PR TITLE
fix individual env var parsing for log forwarding

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -980,13 +980,6 @@ class LogForwardingSettings(BaseSettings):
     def _materialize_destinations_from_env(self) -> Self:
         if not self.destination_names:
             return self
-        # if destinations already exist, they must have been set in infrahub.toml or the DESTINATIONS env var
-        # neither of which is supported in combination with DESTINATION_NAMES
-        if self.destinations:
-            raise ValueError(
-                "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES cannot be combined with explicit `destinations` "
-                "(set via INFRAHUB_LOG_FORWARDING_DESTINATIONS or infrahub.toml). Use one mechanism, not both."
-            )
         for name in self.destination_names:
             if not _DESTINATION_NAME_RE.match(name):
                 raise ValueError(
@@ -997,6 +990,16 @@ class LogForwardingSettings(BaseSettings):
         loaded = [_load_destination_from_env(name) for name in self.destination_names]
         # Re-run uniqueness check (covers duplicates within destination_names itself).
         self.__class__.validate_unique_names(loaded)
+        # in case destinations have already been loaded
+        if self.destinations == loaded:
+            return self
+        # if destinations already exist and != loaded, they must have be set in different places
+        # with different values
+        if self.destinations:
+            raise ValueError(
+                "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES cannot be combined with explicit `destinations` "
+                "(set via INFRAHUB_LOG_FORWARDING_DESTINATIONS or infrahub.toml). Use one mechanism, not both."
+            )
         self.destinations = loaded
         return self
 

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -345,6 +345,66 @@ def test_log_forwarding_destination_names_per_dest_env_validates_tls_udp() -> No
         LogForwardingSettings()
 
 
+def test_log_forwarding_destination_names_rejects_matching_names_from_destinations_env() -> None:
+    """Defining different destinations with the same name using DESTINATIONS and DESTINATION_NAMES raises an error"""
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem_primary",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST": "host-from-env.example.com",
+        "INFRAHUB_LOG_FORWARDING_DESTINATIONS": json.dumps(
+            [{"name": "siem_primary", "host": "host-from-blob.example.com"}]
+        ),
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        pytest.raises(ValidationError, match="cannot be combined with explicit `destinations`"),
+    ):
+        LogForwardingSettings()
+
+
+def test_log_forwarding_destination_names_rejects_matching_names_from_toml_destinations() -> None:
+    """Defining different destinations with the same name using DESTINATION_NAMES (per-dest env) and TOML destinations raises an error"""
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "siem_primary",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_SIEM_PRIMARY_HOST": "host-from-env.example.com",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        pytest.raises(ValueError, match="cannot be combined with explicit `destinations`"),
+    ):
+        load(
+            config_data={
+                "log_forwarding": {
+                    "destinations": [
+                        {"name": "siem_primary", "type": "syslog", "host": "host-from-toml.example.com", "port": 514}
+                    ],
+                }
+            }
+        )
+
+
+def test_log_forwarding_destination_names_survives_revalidation() -> None:
+    """Validating the same destinations multiple times succeeds
+
+    This can happen when starting Infrahub"""
+    env = {
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "my_syslog",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_MY_SYSLOG_HOST": "syslog.example.com",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_MY_SYSLOG_PORT": "514",
+        "INFRAHUB_LOG_FORWARDING_DESTINATION_MY_SYSLOG_PROTOCOL": "udp",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        first_pass = LogForwardingSettings()
+        assert [d.name for d in first_pass.destinations] == ["my_syslog"]
+
+        revalidated = LogForwardingSettings.model_validate(first_pass.model_dump())
+
+    assert [d.name for d in revalidated.destinations] == ["my_syslog"]
+    dest = revalidated.destinations[0]
+    assert dest.host == "syslog.example.com"
+    assert dest.port == 514
+    assert dest.protocol is SyslogProtocol.UDP
+
+
 def test_settings_enterprise_features_aggregates_log_forwarding() -> None:
     config_data = {
         "log_forwarding": {"destinations": [{"name": "siem", "type": "syslog", "host": "localhost", "port": 514}]},


### PR DESCRIPTION
IFC-2495

`LogForwardingSettings()` was being evaluated twice during startup which broke using individual env vars. the pydantic validation assumed that if `LogForwardingSettings.destinations` was already set, then it came from the JSON blob env var (`INFRAHUB_LOG_FORWARDING_DESTINATIONS`) or `infrahub.toml` and I was trying to prevent users from setting conflicting logging destinations in multiple places.

New solution is just to compare the logging settings loaded from the individual env vars with anything already set in `destinations` and raise an error if they conflict. technically, this allows users to set identical forwarding destinations using `INFRAHUB_LOG_FORWARDING_DESTINATIONS`, `infrahub.toml`, and individual env vars, which is not best practice, but as long as all the settings are identical, it won't prevent Infrahub from starting