### PR TITLE
Flaky tests: "Event loop is closed" in test_client -> additional logs to find out

### DIFF
--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -1,0 +1,43 @@
+from sys import stderr
+from traceback import format_exception
+
+from infrahub.server import app
+
+
+def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
+    """Print a Redis pool state summary when a "Event loop is closed" RuntimeError is fired"""
+
+    lines: list[str] = [
+        "Event loop closed during test_client teardown — diagnostic dump",
+        f"  node: {nodeid}",
+        "  traceback:",
+    ]
+    for line in format_exception(type(exc), exc, exc.__traceback__):
+        lines.extend(f"    {sub}" for sub in line.rstrip().splitlines())
+    try:
+        service = getattr(app.state, "service", None)
+        cache = getattr(service, "_cache", None)
+        connection = getattr(cache, "connection", None)
+        pool = getattr(connection, "connection_pool", None)
+        if pool is not None:
+            lines.append(f"  redis pool: {pool!r}")
+            for attr in ("_available_connections", "_in_use_connections"):
+                conns = list(getattr(pool, attr) or [])
+                lines.append(f"    {attr} (n={len(conns)}):")
+                for conn in conns:
+                    try:
+                        writer = conn._writer
+                        transport = writer._transport
+                        loop = transport._loop
+                    except AttributeError:
+                        writer = transport = loop = None
+                    writer_id = id(writer) if writer else None
+                    loop_id = id(loop) if loop else None
+                    loop_closed = loop.is_closed() if loop is not None else "n/a"
+                    lines.append(f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}")
+        else:
+            lines.append("  redis pool: <none>")
+    except Exception as diag_exc:
+        lines.append(f"  (diagnostic dump failed: {diag_exc!r})")
+
+    print("\n".join(lines), file=stderr, flush=True)

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -34,6 +34,7 @@ from infrahub.workers.dependencies import build_cache, build_client, build_datab
 from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
+from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic
 from tests.helpers.events import query_events_by_name
 
 from .test_client import InfrahubTestClient
@@ -123,6 +124,7 @@ class TestInfrahubAppBase(TestInfrahub):
     @pytest.fixture(scope="class")
     async def test_client(
         self,
+        request: pytest.FixtureRequest,
         dependency_provider: Provider,
         db: InfrahubDatabase,
         db_class: InfrahubDatabase,
@@ -139,8 +141,15 @@ class TestInfrahubAppBase(TestInfrahub):
             return db_class
 
         with dependency_provider.scope(build_database, _db):
-            async with lifespan(app):
-                yield InfrahubTestClient(app=app, base_url="http://testserver")
+            try:
+                async with lifespan(app):
+                    yield InfrahubTestClient(app=app, base_url="http://testserver")
+            except RuntimeError as exc:
+                # If the fixture teardown hits the "Event loop is closed"
+                # race dump the pool state so CI logs have something to correlate with.
+                if "Event loop is closed" in str(exc):
+                    dump_event_loop_closed_diagnostic(getattr(request.node, "nodeid", "<unknown>"), exc)
+                raise
 
     @pytest.fixture(scope="class")
     async def client(

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -1,0 +1,193 @@
+"""Tests for the diagnostic helper in tests.helpers.diagnostics."""
+
+import asyncio
+import contextlib
+import io
+import socket
+from types import SimpleNamespace
+from typing import Callable, Generator
+
+import pytest
+import redis.asyncio as redis
+from redis.asyncio.connection import Connection, ConnectionPool
+
+from tests.helpers import diagnostics
+from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic
+
+
+@pytest.fixture
+def captured_stderr(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    buffer = io.StringIO()
+    monkeypatch.setattr(diagnostics, "stderr", buffer)
+    return buffer
+
+
+@pytest.fixture
+def install_service_pool(monkeypatch: pytest.MonkeyPatch) -> Callable[[ConnectionPool | None], None]:
+    """Install a service on app.state whose ._cache.connection.connection_pool resolves
+    to the given pool. Uses a real redis.Redis for the .connection layer
+    so only the outer service/cache pair is a SimpleNamespace."""
+
+    def _install(pool: ConnectionPool | None) -> None:
+        if pool is None:
+            monkeypatch.setattr(diagnostics.app.state, "service", None, raising=False)
+            return
+        service = SimpleNamespace(_cache=SimpleNamespace(connection=redis.Redis(connection_pool=pool)))
+        monkeypatch.setattr(diagnostics.app.state, "service", service, raising=False)
+
+    return _install
+
+
+_WriterWithLoop = tuple[asyncio.StreamWriter, asyncio.AbstractEventLoop]
+
+
+@pytest.fixture
+def closed_loop_writer() -> Generator[_WriterWithLoop, None, None]:
+    """Real StreamWriter whose event loop has been closed — mirrors the production
+    failure mode. GC of the orphaned writer emits ResourceWarning; callers should
+    use @pytest.mark.filterwarnings("ignore::ResourceWarning")."""
+    loop = asyncio.new_event_loop()
+    sock_a, sock_b = socket.socketpair()
+    try:
+        _reader, writer = loop.run_until_complete(asyncio.open_connection(sock=sock_a))
+        loop.close()
+        yield writer, loop
+    finally:
+        sock_b.close()
+
+
+@pytest.fixture
+def open_loop_writer() -> Generator[_WriterWithLoop, None, None]:
+    """Real StreamWriter on a running event loop; cleanly closed in teardown."""
+    loop = asyncio.new_event_loop()
+    sock_a, sock_b = socket.socketpair()
+    writer = None
+    try:
+        _reader, writer = loop.run_until_complete(asyncio.open_connection(sock=sock_a))
+        yield writer, loop
+    finally:
+        if writer:
+            writer.close()
+            with contextlib.suppress(Exception):
+                loop.run_until_complete(writer.wait_closed())
+        loop.close()
+        sock_b.close()
+
+
+def _caught_runtime_error(message: str = "Event loop is closed") -> RuntimeError:
+    try:
+        raise RuntimeError(message)
+    except RuntimeError as exc:
+        return exc
+
+
+def test_dump_header_node_and_traceback_with_no_service(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    install_service_pool(None)
+
+    dump_event_loop_closed_diagnostic("tests/foo.py::test_bar", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert "Event loop closed during test_client teardown" in output
+    assert "  node: tests/foo.py::test_bar" in output
+    assert "  traceback:" in output
+    assert "RuntimeError: Event loop is closed" in output
+    assert "  redis pool: <none>" in output
+
+
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+def test_dump_redis_pool_details(
+    install_service_pool: Callable[[ConnectionPool | None], None],
+    captured_stderr: io.StringIO,
+    closed_loop_writer: _WriterWithLoop,
+    open_loop_writer: _WriterWithLoop,
+) -> None:
+    closed_writer, closed_loop = closed_loop_writer
+    open_writer, open_loop = open_loop_writer
+    conn_available = Connection()
+    conn_available._writer = closed_writer
+    conn_in_use = Connection()
+    conn_in_use._writer = open_writer
+
+    pool = ConnectionPool()
+    pool._available_connections.append(conn_available)
+    pool._in_use_connections.add(conn_in_use)
+
+    install_service_pool(pool)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert f"  redis pool: {pool!r}" in output
+    assert "    _available_connections (n=1):" in output
+    assert "    _in_use_connections (n=1):" in output
+    assert (
+        f"      conn={id(conn_available)} writer={id(closed_writer)} loop={id(closed_loop)} loop_closed=True"
+    ) in output
+    assert (f"      conn={id(conn_in_use)} writer={id(open_writer)} loop={id(open_loop)} loop_closed=False") in output
+
+
+def test_dump_redis_pool_with_empty_connection_buckets(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    install_service_pool(ConnectionPool())
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert "    _available_connections (n=0):" in output
+    assert "    _in_use_connections (n=0):" in output
+
+
+def test_dump_handles_connection_without_writer(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    pool = ConnectionPool()
+    conn = Connection()
+    pool._available_connections.append(conn)
+    install_service_pool(pool)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    assert f"      conn={id(conn)} writer=None loop=None loop_closed=n/a" in captured_stderr.getvalue()
+
+
+def test_dump_catches_exception_in_diagnostic_section(
+    monkeypatch: pytest.MonkeyPatch, captured_stderr: io.StringIO
+) -> None:
+    class BoomService:
+        @property
+        def _cache(self) -> object:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(diagnostics.app.state, "service", BoomService(), raising=False)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert "Event loop closed during test_client teardown" in output
+    assert "  (diagnostic dump failed: RuntimeError('boom')" in output
+
+
+def test_dump_surfaces_attribute_error_when_pool_internals_change(
+    monkeypatch: pytest.MonkeyPatch, captured_stderr: io.StringIO
+) -> None:
+    class RenamedPool:
+        @property
+        def _available_connections(self) -> list:
+            raise AttributeError("'ConnectionPool' object has no attribute '_available_connections'")
+
+        def __repr__(self) -> str:
+            return "<redis.asyncio.connection.ConnectionPool(...)>"
+
+    pool = RenamedPool()
+    service = SimpleNamespace(_cache=SimpleNamespace(connection=SimpleNamespace(connection_pool=pool)))
+    monkeypatch.setattr(diagnostics.app.state, "service", service, raising=False)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert "  redis pool: <redis.asyncio.connection.ConnectionPool(...)>" in output
+    assert "  (diagnostic dump failed: AttributeError(" in output
+    assert "_available_connections (n=0):" not in output


### PR DESCRIPTION
## Why

An existing test exhibits a flaky behavior `backend/tests/component/proposed_change/test_validate_artifacts_generation.py::TestValidateArtifactsGeneration::test_unique_query_selective_field_change`
Evidence: https://github.com/opsmill/infrahub/actions/runs/23923336916/job/69774700376?pr=8799

Closes [IFC-2442](https://opsmill.atlassian.net/browse/IFC-2442)

## What's the issue

### Stack analysis

The issue may **not** be directly related to this specific component test `test_unique_query_selective_field_change`.
The logs are showing the following error "_RuntimeError: Event loop is closed_".

Following the logs which you can find in the final section

- `backend/infrahub/server.py:118:` in lifespan `await shutdown(application)`
- `backend/infrahub/services/__init__.py:180`  is the call await `self._cache.close_connection()`
- `backend/infrahub/services/adapters/cache/redis.py:66 ` is the one-line implementation `await self.connection.aclose()`
- The four frames inside `.venv/.../redis/asyncio/ `pin the self.connection to `redis.asyncio.Redis`, and `self.connection_pool.disconnect()` to the `redis-py` pool implementation. The `asyncio.StreamWriter._writer.close()` belongs to the `Connection` object inside that pool.

#### Conclusion 

This means that the Redis client object is trying to close an event loop which is already closed. This happens in the `teardown` of the test, not specifically in the `TestValidateArtifactsGeneration::test_unique_query_selective_field_change`.

### Which loop is already closed? 

#### How the current loop is transmitted to Redis

The first Redis command is what opens the socket
Any Redis operation goes through `Redis.execute_command` → `ConnectionPool.get_connection()` → returns a pooled `Connection`. If that `Connection.is_connected` is `false`, the pool calls `await connection.connect()` → `connection._connect()`:
```
  # redis/asyncio/connection.py  (SocketConnection._connect, abridged)
  async def _connect(self):
      reader, writer = await asyncio.open_connection(
          host=self.host,
          port=self.port,
          ssl=self.ssl_context,
          ...
      )
      self._reader = reader
      self._writer = writer
```
  That await `asyncio.open_connection(...)` is the line that links the connection to a specific loop.

#### Asyncio `open_connection` method

`asyncio.open_connection` permanently binds the transport to the running loop:
```
  async def open_connection(host=None, port=None, *, limit=_DEFAULT_LIMIT, **kwds):
      loop = events.get_running_loop()                                # (A)
      reader = StreamReader(limit=limit, loop=loop)
      protocol = StreamReaderProtocol(reader, loop=loop)
      transport, _ = await loop.create_connection(                    # (B)
          lambda: protocol, host, port, **kwds)
      writer = StreamWriter(transport, protocol, reader, loop)        # (C)
      return reader, writer
```

-  (A) `events.get_running_loop()` reads the loop currently driving the await.
- (B) `loop.create_connection(...)` returns an `_SelectorSocketTransport`. Inside the transport's `__init__`, it stores `self._loop = loop`. That reference is never updated for the life of the transport.
- (C) `StreamWriter(transport, protocol, reader, loop)` wraps that transport. `StreamWriter.close()` is a one-liner: return `self._transport.close()`. So the close path depends on the transport's stored `_loop`, not on the writer's own.

#### Transport `close()` method

  ```
The transport's close() method (asyncio/selector_events.py):
  def close(self):
      if self._closing:
          return
      self._closing = True
      self._loop._remove_reader(self._sock_fd)
      if not self._buffer:
          self._conn_lost += 1
          self._loop.call_soon(self._call_connection_lost, None)   # (D)
```
Line (D) uses `self._loop`. If that loop's `_closed` flag is true, `BaseEventLoop.call_soon` → `_check_closed` raises `RuntimeError('Event loop is closed')`. This is the exact last frame of the CI traceback.

#### Where does this transport loop initially comes from?

  | Role                                                                              | Resolved loop scope |
  |-----------------------------------------------------------------------------------|---------------------|
  | Async fixtures (including `test_client`) / from `asyncio_default_fixture_loop_scope="session"` | session             |
  | Async tests / forced by `backend/tests/conftest.py::pytest_collection_modifyitems`             | session             |

Given the pyproject + conftest setup, the running loop during any of these moments should be the session-level loop.

## So what could be the issue?

Hard to tell as of now.

## Solution proposed

Test logs giving additional information when this Error is raised.
I asked Claude to create possible scenarios where this message could help:

### 1) Classic race: one bad writer in a pool of one 
#### Message
```
RuntimeError: Event loop is closed
    redis pool: <redis.asyncio.connection.ConnectionPool(Connection<host=localhost,port=32768,db=0>)>
      _available_connections (n=1):
        conn=4734790224 writer=4734806912 loop=4716166544 loop_closed=True
      _in_use_connections (n=0):
```
#### What we get 
Confirms the dead writer is in the cache pool + gives the loop id


### 2) Multiple bad writers in the same pool
#### Message
```
RuntimeError: Event loop is closed
    redis pool: <redis.asyncio.connection.ConnectionPool(...)>
      _available_connections (n=3):
        conn=4734790224 writer=4734806912 loop=4716166544 loop_closed=True
        conn=4734790512 writer=4734807200 loop=4716166544 loop_closed=True
        conn=4734790800 writer=4734807488 loop=4716166544 loop_closed=True
      _in_use_connections (n=0):
```
#### What we get
Whole-loop death (all writers on the same dead loop), not a per-connection race


### 3) Mixed pool: some writers alive, some dead
#### Message
```
RuntimeError: Event loop is closed
    redis pool: <redis.asyncio.connection.ConnectionPool(...)>
      _available_connections (n=2):
        conn=4734790224 writer=4734806912 loop=4716166544 loop_closed=True
        conn=4750123456 writer=4750789012 loop=4750333333 loop_closed=False
      _in_use_connections (n=0):
```
#### What we get
Cross-class singleton leak (two distinct loop ids in one pool)

### 4) Banner fires in more than one class teardown per run
#### Message
```
 Event loop closed during test_client teardown — diagnostic dump
    node: .../TestValidateArtifactsGeneration::test_unique_query_selective_field_change
    ...
      _available_connections (n=1):
        conn=4734790224 writer=4734806912 loop=4716166544 loop_closed=True

  Event loop closed during test_client teardown — diagnostic dump
    node: .../TestArtifact::test_create_artifact
    ...
      _available_connections (n=2):
        conn=4800111222 writer=4800333444 loop=4800555666 loop_closed=True
        conn=4800777888 writer=4800999000 loop=4800555666 loop_closed=True
```
#### What we get 
Systemic vs isolated (grep banner count; >1 = every lifespan-using class leaks)

### 5) Empty/cleared pool; trace still names the cache
#### Message
```
RuntimeError: Event loop is closed
    redis pool: <redis.asyncio.connection.ConnectionPool(...)>
      _available_connections (n=1):
        conn=4734790224 writer=None loop=None loop_closed=n/a
      ...
      RuntimeError: Event loop is closed
    redis pool: <redis.asyncio.connection.ConnectionPool(...)>
      _available_connections (n=1):
        conn=4734790224 writer=None loop=None loop_closed=n/a
      _in_use_connections (n=0):
```
#### What we get
Look upstream of `pool.disconnect()`, the pool is already clean.

### 6) app.state.service not initialised (unlikely to happen in the case we are analyzing)
#### Message
```
RuntimeError: Event loop is closed
    redis pool: <none>
```
#### What we get
Failure is in app_initialization, not in Redis shutdown

[IFC-2442]: https://opsmill.atlassian.net/browse/IFC-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ