### PR TITLE
Flaky tests: additional wait methods 

### DIFF
--- a/backend/tests/integration_docker/test_profiles.py
+++ b/backend/tests/integration_docker/test_profiles.py
@@ -50,13 +50,7 @@ class TestProfiles(TestInfrahubDockerClient):
         expected_source_id: str | None,
         max_retries: int = 20,
     ) -> None:
-        """Poll until the attribute's source.id matches the expected value.
-
-        Profile refreshes update `.value` and `.source` separately, so tests that
-        assert on `.source.id` (or `.is_from_profile`) right after waiting on
-        `.value` can race. Use this helper after `wait_for_attribute_value` when
-        the assertion depends on source metadata.
-        """
+        """Poll until the attribute's source.id matches the expected value."""
 
         def _source_id(node: InfrahubNode) -> str | None:
             attr_value = getattr(node, attribute)

--- a/backend/tests/integration_docker/test_profiles.py
+++ b/backend/tests/integration_docker/test_profiles.py
@@ -133,12 +133,7 @@ class TestProfiles(TestInfrahubDockerClient):
         expected_is_from_profile: bool,
         max_retries: int = 20,
     ) -> None:
-        """Poll until the relationship's `is_from_profile` flag matches.
-
-        Profile refreshes set peer and source/`is_from_profile` in separate steps,
-        mirroring the attribute race. Use this after `wait_for_relationship_peer`
-        when the assertion depends on profile provenance.
-        """
+        """Poll until the relationship's `is_from_profile` flag matches."""
         for _ in range(max_retries):
             node = await client.get(kind=kind, id=node_id, property=True, include=[relationship])
             rel: RelatedNode = getattr(node, relationship)
@@ -151,6 +146,34 @@ class TestProfiles(TestInfrahubDockerClient):
         pytest.fail(
             f"Expected {relationship}.is_from_profile={expected_is_from_profile} "
             f"but got {rel.is_from_profile} after {max_retries} seconds"
+        )
+
+    async def wait_for_relationship(
+        self,
+        client: InfrahubClient,
+        kind: str,
+        node_id: str,
+        relationship: str,
+        expected_peer_id: str | None,
+        expected_is_from_profile: bool,
+        max_retries: int = 20,
+    ) -> None:
+        """Poll for both the relationship peer and its profile provenance."""
+        await self.wait_for_relationship_peer(
+            client=client,
+            kind=kind,
+            node_id=node_id,
+            relationship=relationship,
+            expected_peer_id=expected_peer_id,
+            max_retries=max_retries,
+        )
+        await self.wait_for_relationship_from_profile(
+            client=client,
+            kind=kind,
+            node_id=node_id,
+            relationship=relationship,
+            expected_is_from_profile=expected_is_from_profile,
+            max_retries=max_retries,
         )
 
     async def wait_for_relationship_peers(
@@ -609,18 +632,12 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await device.save()
 
-        await self.wait_for_relationship_peer(
+        await self.wait_for_relationship(
             client=client,
             kind="TestingDevice",
             node_id=device.id,
             relationship="manufacturer",
             expected_peer_id=manufacturer.id,
-        )
-        await self.wait_for_relationship_from_profile(
-            client=client,
-            kind="TestingDevice",
-            node_id=device.id,
-            relationship="manufacturer",
             expected_is_from_profile=True,
         )
 
@@ -712,12 +729,13 @@ class TestProfiles(TestInfrahubDockerClient):
         device_to_update.manufacturer = manufacturer_from_user
         await device_to_update.save()
 
-        await self.wait_for_relationship_peer(
+        await self.wait_for_relationship(
             client=client,
             kind="TestingDevice",
             node_id=device.id,
             relationship="manufacturer",
             expected_peer_id=manufacturer_from_user.id,
+            expected_is_from_profile=False,
         )
 
         device_after_update = await client.get(

--- a/backend/tests/integration_docker/test_profiles.py
+++ b/backend/tests/integration_docker/test_profiles.py
@@ -41,6 +41,39 @@ class TestProfiles(TestInfrahubDockerClient):
         current_value = getattr(node, attribute).value
         pytest.fail(f"Expected {attribute}={expected_value} but got {current_value} after {max_retries} seconds")
 
+    async def wait_for_attribute_source(
+        self,
+        client: InfrahubClient,
+        kind: str,
+        node_id: str,
+        attribute: str,
+        expected_source_id: str | None,
+        max_retries: int = 20,
+    ) -> None:
+        """Poll until the attribute's source.id matches the expected value.
+
+        Profile refreshes update `.value` and `.source` separately, so tests that
+        assert on `.source.id` (or `.is_from_profile`) right after waiting on
+        `.value` can race. Use this helper after `wait_for_attribute_value` when
+        the assertion depends on source metadata.
+        """
+
+        def _source_id(node: InfrahubNode) -> str | None:
+            attr_value = getattr(node, attribute)
+            source = getattr(attr_value, "source", None)
+            return source.id if source is not None else None
+
+        for _ in range(max_retries):
+            node = await client.get(kind=kind, id=node_id, property=True)
+            if _source_id(node) == expected_source_id:
+                return
+            await sleep(1)
+
+        node = await client.get(kind=kind, id=node_id, property=True)
+        pytest.fail(
+            f"Expected {attribute}.source.id={expected_source_id} but got {_source_id(node)} after {max_retries} seconds"
+        )
+
     async def wait_for_relationship_peer(
         self,
         client: InfrahubClient,
@@ -180,6 +213,13 @@ class TestProfiles(TestInfrahubDockerClient):
         await self.wait_for_attribute_value(
             client=client, kind="TestingDevice", node_id=device.id, attribute="weight", expected_value=50
         )
+        await self.wait_for_attribute_source(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="weight",
+            expected_source_id=profile_low.id,
+        )
 
         device_updated = await client.get(kind="TestingDevice", id=device.id, property=True)
         assert device_updated.weight.value == 50
@@ -214,6 +254,13 @@ class TestProfiles(TestInfrahubDockerClient):
 
         await self.wait_for_attribute_value(
             client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=None
+        )
+        await self.wait_for_attribute_source(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="height",
+            expected_source_id=None,
         )
         device_after_delete = await client.get(kind="TestingDevice", id=device.id, property=True)
         assert device_after_delete.height.value is None

--- a/backend/tests/integration_docker/test_profiles.py
+++ b/backend/tests/integration_docker/test_profiles.py
@@ -74,6 +74,34 @@ class TestProfiles(TestInfrahubDockerClient):
             f"Expected {attribute}.source.id={expected_source_id} but got {_source_id(node)} after {max_retries} seconds"
         )
 
+    async def wait_for_attribute(
+        self,
+        client: InfrahubClient,
+        kind: str,
+        node_id: str,
+        attribute: str,
+        expected_value: str | int | None,
+        expected_source_id: str | None,
+        max_retries: int = 20,
+    ) -> None:
+        """Poll for both the attribute value and its profile source to match."""
+        await self.wait_for_attribute_value(
+            client=client,
+            kind=kind,
+            node_id=node_id,
+            attribute=attribute,
+            expected_value=expected_value,
+            max_retries=max_retries,
+        )
+        await self.wait_for_attribute_source(
+            client=client,
+            kind=kind,
+            node_id=node_id,
+            attribute=attribute,
+            expected_source_id=expected_source_id,
+            max_retries=max_retries,
+        )
+
     async def wait_for_relationship_peer(
         self,
         client: InfrahubClient,
@@ -95,6 +123,35 @@ class TestProfiles(TestInfrahubDockerClient):
         node = await client.get(kind=kind, id=node_id, property=True, include=[relationship])
         rel = getattr(node, relationship)
         pytest.fail(f"Expected {relationship} peer_id={expected_peer_id} but got {rel.id} after {max_retries} seconds")
+
+    async def wait_for_relationship_from_profile(
+        self,
+        client: InfrahubClient,
+        kind: str,
+        node_id: str,
+        relationship: str,
+        expected_is_from_profile: bool,
+        max_retries: int = 20,
+    ) -> None:
+        """Poll until the relationship's `is_from_profile` flag matches.
+
+        Profile refreshes set peer and source/`is_from_profile` in separate steps,
+        mirroring the attribute race. Use this after `wait_for_relationship_peer`
+        when the assertion depends on profile provenance.
+        """
+        for _ in range(max_retries):
+            node = await client.get(kind=kind, id=node_id, property=True, include=[relationship])
+            rel: RelatedNode = getattr(node, relationship)
+            if rel.is_from_profile == expected_is_from_profile:
+                return
+            await sleep(1)
+
+        node = await client.get(kind=kind, id=node_id, property=True, include=[relationship])
+        rel = getattr(node, relationship)
+        pytest.fail(
+            f"Expected {relationship}.is_from_profile={expected_is_from_profile} "
+            f"but got {rel.is_from_profile} after {max_retries} seconds"
+        )
 
     async def wait_for_relationship_peers(
         self,
@@ -151,8 +208,13 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await profile.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=42
+        await self.wait_for_attribute(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="height",
+            expected_value=42,
+            expected_source_id=profile.id,
         )
 
         device_with_profile = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -198,8 +260,13 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await profile_high.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="weight", expected_value=100
+        await self.wait_for_attribute(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="weight",
+            expected_value=100,
+            expected_source_id=profile_high.id,
         )
 
         device_with_profiles = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -210,14 +277,12 @@ class TestProfiles(TestInfrahubDockerClient):
         profile_low_update.profile_priority.value = 500
         await profile_low_update.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="weight", expected_value=50
-        )
-        await self.wait_for_attribute_source(
+        await self.wait_for_attribute(
             client=client,
             kind="TestingDevice",
             node_id=device.id,
             attribute="weight",
+            expected_value=50,
             expected_source_id=profile_low.id,
         )
 
@@ -241,8 +306,13 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await profile.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=200
+        await self.wait_for_attribute(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="height",
+            expected_value=200,
+            expected_source_id=profile.id,
         )
 
         device_with_profile = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -252,14 +322,12 @@ class TestProfiles(TestInfrahubDockerClient):
         profile_to_delete = await client.get(kind="ProfileTestingDevice", id=profile.id)
         await profile_to_delete.delete()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=None
-        )
-        await self.wait_for_attribute_source(
+        await self.wait_for_attribute(
             client=client,
             kind="TestingDevice",
             node_id=device.id,
             attribute="height",
+            expected_value=None,
             expected_source_id=None,
         )
         device_after_delete = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -282,8 +350,13 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await profile.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=300
+        await self.wait_for_attribute(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="height",
+            expected_value=300,
+            expected_source_id=profile.id,
         )
 
         device_with_profile = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -295,8 +368,13 @@ class TestProfiles(TestInfrahubDockerClient):
         profile_to_update.related_nodes.remove(device.id)
         await profile_to_update.save()
 
-        await self.wait_for_attribute_value(
-            client=client, kind="TestingDevice", node_id=device.id, attribute="height", expected_value=None
+        await self.wait_for_attribute(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            attribute="height",
+            expected_value=None,
+            expected_source_id=None,
         )
 
         device_after_removal = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -494,12 +572,13 @@ class TestProfiles(TestInfrahubDockerClient):
         )
         await device.save()
 
-        await self.wait_for_attribute_value(
+        await self.wait_for_attribute(
             client=client,
             kind="TestingDevice",
             node_id=device.id,
             attribute="part_number",
             expected_value="PROFILE-PN-001",
+            expected_source_id=profile.id,
         )
 
         device_with_profile = await client.get(kind="TestingDevice", id=device.id, property=True)
@@ -536,6 +615,13 @@ class TestProfiles(TestInfrahubDockerClient):
             node_id=device.id,
             relationship="manufacturer",
             expected_peer_id=manufacturer.id,
+        )
+        await self.wait_for_relationship_from_profile(
+            client=client,
+            kind="TestingDevice",
+            node_id=device.id,
+            relationship="manufacturer",
+            expected_is_from_profile=True,
         )
 
         device_with_profile = await client.get(


### PR DESCRIPTION
## Why 
Following tests have a flaky behavior:
- `backend/tests/integration_docker/test_profiles.py::TestProfiles::test_profile_priority_change_triggers_refresh` -> https://github.com/opsmill/infrahub/actions/runs/23923735833/job/69775929481?pr=8800
- `backend/tests/integration_docker/test_profiles.py::TestProfiles::test_profile_delete_triggers_refresh` -> https://github.com/opsmill/infrahub/actions/runs/23494377664/job/68371295373?pr=8672

### Analysis

In this test class, a waiter already exists: `wait_for_attribute_value`. However this method waits for the `infrahub.core.query.attribute.AttributeUpdateValueQuery` to complete inside the `infrahub.core.attribute.BaseAttribute._update` method.

However, in this method, two additional queries can be done, and there is no transaction grouping them all:
- `infrahub.core.query.attribute.AttributeUpdateFlagQuery`
- `infrahub.core.query.attribute.AttributeUpdateNodePropertyQuery`

Therefore, there is a race window during which the attribute value has been updated and the user can query it, but the other two requests have not yet been completed. This is why a transaction should be on top of these queries. Based on the logs, the transaction was not applied, or servers are not refreshed for an unknown reason.

However, `test_profile_priority_change_triggers_refresh` asserts against the source id, and so is `test_profile_delete_triggers_refresh` as it checks `is_from_profile` attribute which is derived from a `OPTIONAL MATCH (a)-[r:HAS_SOURCE]->(:CoreProfile)` query (`infrahub.core.query.node.NodeListGetAttributeQuery.query_init`). If the source is not updated yet, these tests will fail.

#### Summary of all the tests that could be impcated
- `test_profile_attribute_update_triggers_refresh `-> needs to wait for the **source** to be updated
- `test_profile_priority_change_triggers_refresh` -> needs to wait for the **source** to be updated
- `test_profile_delete_triggers_refresh`-> needs to wait for the **source** to be updated
- `test_cannot_delete_profile_when_device_inherits_required_attribute`-> needs to wait for the **source** to be updated
- `test_cannot_delete_profile_when_device_inherits_required_relationship` -> same logic but for relationship peers update in `infrahub.core.relationship.model.RelationshipManager.save`(`RelationshipCreateQuery`/`RelationshipDeleteQuery` and then `AttributeUpdateNodePropertyQuery`).

### Solution 

#### Short-term (this PR)
- Add another utility method which awaits the source to be updated, or other similar properties.
- Refactor the utility method in order to group these awaiting logics.

#### Mid-term (another PR)
- Transactions should be used at an upper-level, no sync problem should exist. Awaiting for some internal additional informations. 

Closes [IFC-2443]

[IFC-2443]: https://opsmill.atlassian.net/browse/IFC-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ