### PR TITLE
fix(git): fetch from remote when worktree commit is missing locally

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -705,30 +705,18 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 raise RepositoryError(identifier=self.name, message=exc.stderr) from exc
 
             if not self.has_origin:
-                raise CommitNotFoundError(
+                raise RepositoryError(
                     identifier=self.name,
-                    commit=commit,
+                    message=f"Commit {commit} not found and no remote origin configured to fetch from.",
                 ) from exc
 
             # Commit may exist on the remote but hasn't been fetched to this worker yet
             log.info(f"Commit {commit} not found locally, fetching from remote.", repository=self.name)
-            try:
-                repo.remotes.origin.fetch()
-            except GitCommandError:
-                raise CommitNotFoundError(
-                    identifier=self.name,
-                    commit=commit,
-                ) from exc
+            repo.remotes.origin.fetch()
 
-            try:
-                repo.git.worktree("add", directory, commit)
-                log.debug(f"Commit worktree created {commit} after fetch", repository=self.name)
-                return worktree
-            except GitCommandError:
-                raise CommitNotFoundError(
-                    identifier=self.name,
-                    commit=commit,
-                ) from exc
+            repo.git.worktree("add", directory, commit)
+            log.debug(f"Commit worktree created {commit} after fetch", repository=self.name)
+            return worktree
 
     def create_branch_worktree(self, branch_name: str, branch_id: str) -> bool:
         """Create a new worktree for a given branch."""

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -701,12 +701,34 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             log.debug(f"Commit worktree created {commit}", repository=self.name)
             return worktree
         except GitCommandError as exc:
-            if "invalid reference" in exc.stderr:
+            if "invalid reference" not in exc.stderr:
+                raise RepositoryError(identifier=self.name, message=exc.stderr) from exc
+
+            if not self.has_origin:
                 raise CommitNotFoundError(
                     identifier=self.name,
                     commit=commit,
                 ) from exc
-            raise RepositoryError(identifier=self.name, message=exc.stderr) from exc
+
+            # Commit may exist on the remote but hasn't been fetched to this worker yet
+            log.info(f"Commit {commit} not found locally, fetching from remote.", repository=self.name)
+            try:
+                repo.remotes.origin.fetch()
+            except GitCommandError:
+                raise CommitNotFoundError(
+                    identifier=self.name,
+                    commit=commit,
+                ) from exc
+
+            try:
+                repo.git.worktree("add", directory, commit)
+                log.debug(f"Commit worktree created {commit} after fetch", repository=self.name)
+                return worktree
+            except GitCommandError:
+                raise CommitNotFoundError(
+                    identifier=self.name,
+                    commit=commit,
+                ) from exc
 
     def create_branch_worktree(self, branch_name: str, branch_id: str) -> bool:
         """Create a new worktree for a given branch."""

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -18,7 +18,6 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.registry import registry
 from infrahub.exceptions import (
     CheckError,
-    CommitNotFoundError,
     RepositoryError,
     RepositoryFileNotFoundError,
     RepositoryInvalidBranchError,
@@ -210,7 +209,17 @@ async def test_create_commit_worktree_wrong_commit(git_repo_01: InfrahubReposito
 
     commit = "ffff1c0c64122bb2a7b208f7a9452146685bc7dd"
 
-    with pytest.raises(CommitNotFoundError):
+    with pytest.raises(GitCommandError, match="invalid reference"):
+        repo.create_commit_worktree(commit=commit)
+
+
+async def test_create_commit_worktree_wrong_commit_no_origin(git_repo_01: InfrahubRepository) -> None:
+    repo = git_repo_01
+    repo.has_origin = False
+
+    commit = "ffff1c0c64122bb2a7b208f7a9452146685bc7dd"
+
+    with pytest.raises(RepositoryError, match="no remote origin configured"):
         repo.create_commit_worktree(commit=commit)
 
 

--- a/changelog/9036.fixed.md
+++ b/changelog/9036.fixed.md
@@ -1,0 +1,1 @@
+Fixed task failures (artifact generation, transforms) that could occur when a recently pushed commit had not yet been fetched locally.


### PR DESCRIPTION
## Why

Task runs (artifact generation, transforms, ...) fail with `CommitNotFoundError` whenever the commit SHA recorded in the database hasn't been fetched yet to the local git clone on the worker picking up the task. Other paths like `get_commit_value` and `update_latest_commit` already fetch before they touch a commit; `create_commit_worktree` did not. In multi-worker deployments where fetch timing varies per worker this can cause issues for recently pushed commits.

## What

`InfrahubRepositoryBase.create_commit_worktree` now treats a `fatal: invalid reference` from git worktree add as a cue to fetch from origin and try again, mirroring the pattern used elsewhere. If the repo has no origin configured we don't bother fetching and surface a `RepositoryError` that explains the configuration problem.