### PR TITLE
add support for all metadata to get_many(prefetch_relationships=True)

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1332,6 +1332,9 @@ class NodeManager:
                 peer_with_metadata.created_by = metadata_map.get(MetadataOptions.CREATED_BY)
                 peer_with_metadata.updated_at = metadata_map.get(MetadataOptions.UPDATED_AT)
                 peer_with_metadata.updated_by = metadata_map.get(MetadataOptions.UPDATED_BY)
+                peer_with_metadata.source_id = metadata_map.get(MetadataOptions.SOURCE)
+                peer_with_metadata.owner_id = metadata_map.get(MetadataOptions.OWNER)
+                peer_with_metadata.is_protected = metadata_map.get(MetadataOptions.IS_PROTECTED)
                 rel_peers_with_metadata.append(peer_with_metadata)
 
             rel_manager.has_fetched_relationships = True

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -975,7 +975,7 @@ class GroupedPeerNodes:
         self._rel_directions_map: dict[tuple[str, str], dict[RelationshipDirection, set[str]]] = defaultdict(dict)
         # {(node_id, rel_name, direction, peer_Id): {MetadataOptions: value}}
         self._metadata_map: dict[
-            tuple[str, str, RelationshipDirection, str], dict[MetadataOptions, Timestamp | str | None]
+            tuple[str, str, RelationshipDirection, str], dict[MetadataOptions, Timestamp | str | bool | None]
         ] = {}
 
     def add_peer(
@@ -988,13 +988,17 @@ class GroupedPeerNodes:
         created_by: str | None = None,
         updated_at: Timestamp | None = None,
         updated_by: str | None = None,
+        source_id: str | None = None,
+        owner_id: str | None = None,
+        is_protected: bool | None = None,
     ) -> None:
         self._rel_names_by_node_id[node_id].add(rel_name)
         if direction not in self._rel_directions_map[node_id, rel_name]:
             self._rel_directions_map[node_id, rel_name][direction] = set()
         self._rel_directions_map[node_id, rel_name][direction].add(peer_id)
         key = (node_id, rel_name, direction, peer_id)
-        if created_at is not None or created_by is not None or updated_at is not None or updated_by is not None:
+        provided = (created_at, created_by, updated_at, updated_by, source_id, owner_id, is_protected)
+        if any(v is not None for v in provided):
             self._metadata_map[key] = {}
         if created_at is not None:
             self._metadata_map[key][MetadataOptions.CREATED_AT] = created_at
@@ -1004,6 +1008,12 @@ class GroupedPeerNodes:
             self._metadata_map[key][MetadataOptions.UPDATED_AT] = updated_at
         if updated_by is not None:
             self._metadata_map[key][MetadataOptions.UPDATED_BY] = updated_by
+        if source_id is not None:
+            self._metadata_map[key][MetadataOptions.SOURCE] = source_id
+        if owner_id is not None:
+            self._metadata_map[key][MetadataOptions.OWNER] = owner_id
+        if is_protected is not None:
+            self._metadata_map[key][MetadataOptions.IS_PROTECTED] = is_protected
 
     def get_peer_ids(self, node_id: str, rel_name: str, direction: RelationshipDirection) -> set[str]:
         if (node_id, rel_name) not in self._rel_directions_map:
@@ -1022,7 +1032,7 @@ class GroupedPeerNodes:
 
     def get_metadata_map(
         self, node_id: str, rel_name: str, direction: RelationshipDirection, peer_id: str
-    ) -> dict[MetadataOptions, Timestamp | str | None]:
+    ) -> dict[MetadataOptions, Timestamp | str | bool | None]:
         return self._metadata_map.get((node_id, rel_name, direction, peer_id), {})
 
 
@@ -1109,6 +1119,52 @@ CALL (rel) {
             """ % {"branch_filter": branch_filter_str, "time_details": time_details}
         self.add_to_query(last_updated_query)
         self.return_labels.extend(["updated_at", "updated_by"])
+
+    def _add_is_protected_query(self, branch_filter: str) -> None:
+        if not (self.include_metadata & MetadataOptions.IS_PROTECTED):
+            return
+        query = """
+CALL (rel) {
+    MATCH (rel)-[r:IS_PROTECTED]->(is_protected)
+    WHERE %(branch_filter)s
+    RETURN is_protected.value AS is_protected_value
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+        """ % {"branch_filter": branch_filter}
+        self.add_to_query(query)
+        self.return_labels.append("is_protected_value")
+
+    def _add_node_property_query(self, node_prop: str, branch_filter: str) -> None:
+        query = """
+CALL (rel) {
+    OPTIONAL MATCH (rel)-[r:HAS_%(node_prop_type)s]->(prop_node:Node)
+    WHERE %(branch_filter)s
+    WITH r, prop_node
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    RETURN CASE
+        WHEN r.status = "active" THEN prop_node.uuid
+        ELSE NULL
+    END AS %(node_prop)s_uuid
+}
+        """ % {
+            "node_prop": node_prop,
+            "node_prop_type": node_prop.upper(),
+            "branch_filter": branch_filter,
+        }
+        self.add_to_query(query)
+        self.return_labels.append(f"{node_prop}_uuid")
+
+    def _add_has_owner_query(self, branch_filter: str) -> None:
+        if not (self.include_metadata & MetadataOptions.OWNER):
+            return
+        self._add_node_property_query(node_prop="owner", branch_filter=branch_filter)
+
+    def _add_has_source_query(self, branch_filter: str) -> None:
+        if not (self.include_metadata & MetadataOptions.SOURCE):
+            return
+        self._add_node_property_query(node_prop="source", branch_filter=branch_filter)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         self.params["ids"] = self.ids
@@ -1201,6 +1257,9 @@ CALL (rel) {
 
         self._add_created_metadata_to_query()
         self._add_updated_metadata_to_query(branch_filter_str=rels_filter)
+        self._add_is_protected_query(branch_filter=rels_filter)
+        self._add_has_owner_query(branch_filter=rels_filter)
+        self._add_has_source_query(branch_filter=rels_filter)
         return_labels_str = ", ".join(sorted(self.return_labels))
         self.add_to_query(f"WITH DISTINCT {return_labels_str}, rel.name AS rel_name")
         self.return_labels.append("rel_name")
@@ -1231,6 +1290,18 @@ CALL (rel) {
             if self.include_metadata & MetadataOptions.UPDATED_BY:
                 updated_by_str = result.get("updated_by")
 
+            is_protected: bool | None = None
+            if self.include_metadata & MetadataOptions.IS_PROTECTED:
+                is_protected = result.get_as_type("is_protected_value", return_type=bool)
+
+            source_id: str | None = None
+            if self.include_metadata & MetadataOptions.SOURCE:
+                source_id = result.get_as_type("source_uuid", return_type=str)
+
+            owner_id: str | None = None
+            if self.include_metadata & MetadataOptions.OWNER:
+                owner_id = result.get_as_type("owner_uuid", return_type=str)
+
             direction_enum = {
                 "inbound": RelationshipDirection.INBOUND,
                 "outbound": RelationshipDirection.OUTBOUND,
@@ -1245,6 +1316,9 @@ CALL (rel) {
                 created_by=created_by_str,
                 updated_at=updated_at,
                 updated_by=updated_by_str,
+                source_id=source_id,
+                owner_id=owner_id,
+                is_protected=is_protected,
             )
 
         return gpn

--- a/backend/tests/component/core/test_node_manager_prefetch_metadata.py
+++ b/backend/tests/component/core/test_node_manager_prefetch_metadata.py
@@ -1,0 +1,179 @@
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import MetadataOptions
+from infrahub.core.manager import NodeManager
+from infrahub.core.metadata.model import MetadataQueryOptions
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.core.relationship.model import Relationship
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from tests.conftest import do_car_person_schema_unregistered
+
+
+@dataclass
+class _RelMetadataCase:
+    name: str
+    flags: MetadataOptions
+    expect_is_protected_populated: bool
+    expect_source_populated: bool
+    expect_owner_populated: bool
+    expect_timestamps_populated: bool
+
+
+_REL_METADATA_CASES = [
+    _RelMetadataCase(
+        name="none",
+        flags=MetadataOptions.NONE,
+        expect_is_protected_populated=False,
+        expect_source_populated=False,
+        expect_owner_populated=False,
+        expect_timestamps_populated=False,
+    ),
+    _RelMetadataCase(
+        name="is-protected-only",
+        flags=MetadataOptions.IS_PROTECTED,
+        expect_is_protected_populated=True,
+        expect_source_populated=False,
+        expect_owner_populated=False,
+        expect_timestamps_populated=False,
+    ),
+    _RelMetadataCase(
+        name="source-only",
+        flags=MetadataOptions.SOURCE,
+        expect_is_protected_populated=False,
+        expect_source_populated=True,
+        expect_owner_populated=False,
+        expect_timestamps_populated=False,
+    ),
+    _RelMetadataCase(
+        name="owner-only",
+        flags=MetadataOptions.OWNER,
+        expect_is_protected_populated=False,
+        expect_source_populated=False,
+        expect_owner_populated=True,
+        expect_timestamps_populated=False,
+    ),
+    _RelMetadataCase(
+        name="linked-nodes",
+        flags=MetadataOptions.LINKED_NODES,
+        expect_is_protected_populated=False,
+        expect_source_populated=True,
+        expect_owner_populated=True,
+        expect_timestamps_populated=False,
+    ),
+    _RelMetadataCase(
+        name="user-timestamps",
+        flags=MetadataOptions.USER_TIMESTAMPS,
+        expect_is_protected_populated=False,
+        expect_source_populated=False,
+        expect_owner_populated=False,
+        expect_timestamps_populated=True,
+    ),
+    _RelMetadataCase(
+        name="all",
+        flags=MetadataOptions.IS_PROTECTED | MetadataOptions.LINKED_NODES | MetadataOptions.USER_TIMESTAMPS,
+        expect_is_protected_populated=True,
+        expect_source_populated=True,
+        expect_owner_populated=True,
+        expect_timestamps_populated=True,
+    ),
+]
+
+
+class TestGetManyPrefetchRelationshipMetadataFiltering:
+    """`include_metadata` selectively populates relationship metadata under prefetch"""
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def _schema(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> SchemaBranch:
+        return registry.schema.register_schema(
+            schema=do_car_person_schema_unregistered(), branch=default_branch_scope_class.name
+        )
+
+    @pytest.fixture(scope="class")
+    async def fixture_data(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, _schema: SchemaBranch
+    ) -> dict[str, Node]:
+        owner_node = await Node.init(db=db, schema="TestPerson")
+        await owner_node.new(db=db, name="Owner", height=180)
+        await owner_node.save(db=db)
+
+        source_node = await Node.init(db=db, schema="TestPerson")
+        await source_node.new(db=db, name="Source", height=170)
+        await source_node.save(db=db)
+
+        driver = await Node.init(db=db, schema="TestPerson")
+        await driver.new(db=db, name="Driver", height=190)
+        await driver.save(db=db)
+
+        car = await Node.init(db=db, schema="TestCar")
+        await car.new(
+            db=db,
+            name="volt",
+            nbr_seats=4,
+            is_electric=True,
+            owner={
+                "id": driver.id,
+                "_relation__is_protected": True,
+                "_relation__source": source_node.id,
+                "_relation__owner": owner_node.id,
+            },
+        )
+        await car.save(db=db)
+        return {"car": car, "driver": driver, "source": source_node, "owner": owner_node}
+
+    @pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in _REL_METADATA_CASES])
+    async def test_get_many_prefetch_metadata_filtering(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        fixture_data: dict[str, Node],
+        case: _RelMetadataCase,
+    ) -> None:
+        car = fixture_data["car"]
+        driver = fixture_data["driver"]
+        source_node = fixture_data["source"]
+        owner_node = fixture_data["owner"]
+
+        nodes = await NodeManager.get_many(
+            db=db,
+            ids=[car.id],
+            prefetch_relationships=True,
+            include_metadata=MetadataQueryOptions(relationship_level=case.flags),
+        )
+
+        assert car.id in nodes
+        rel = await nodes[car.id].get_relationship("owner").get(db=db)
+        assert rel is not None
+        assert isinstance(rel, Relationship)
+        assert rel.peer_id == driver.id
+
+        # is_protected: defaults to False on FlagPropertyMixin; we set it to True
+        if case.expect_is_protected_populated:
+            assert rel.is_protected is True
+        else:
+            assert rel.is_protected is False
+
+        if case.expect_source_populated:
+            assert rel.source_id == source_node.id
+        else:
+            assert rel.source_id is None
+
+        if case.expect_owner_populated:
+            assert rel.owner_id == owner_node.id
+        else:
+            assert rel.owner_id is None
+
+        if case.expect_timestamps_populated:
+            assert rel._get_updated_at() is not None
+            assert rel._get_updated_by() is not None
+            assert rel._get_created_at() is not None
+            assert rel._get_created_by() is not None
+        else:
+            assert rel._get_updated_at() is None
+            assert rel._get_updated_by() is None
+            assert rel._get_created_at() is None
+            assert rel._get_created_by() is None


### PR DESCRIPTION
`NodeManager.get_many()` with `prefetch_relationships=True` did not support all the types of metadata we have on our Node objects. Specifically, it did not support timestamps (updated/created_at/by) or is_protected.

should not affect performance b/c the new metadata types have to be affirmatively requested

this PR adds support for those metadata options to the method.