### PR TITLE
Fix typing errors for protocols

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -15,6 +15,7 @@ from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.node import Node
 from infrahub.core.node.delete_validator import NodeDeleteValidator
 from infrahub.core.order import OrderModel
+from infrahub.core.protocols_base import CoreNode
 from infrahub.core.query.node import (
     AttributeFromDB,
     GroupedPeerNodes,
@@ -75,7 +76,7 @@ def get_schema[SchemaProtocol](
 ) -> MainSchemaTypes:
     if isinstance(node_schema, str):
         return db.schema.get(name=node_schema, branch=branch.name, duplicate=duplicate)
-    if hasattr(node_schema, "_is_runtime_protocol") and node_schema._is_runtime_protocol:
+    if isinstance(node_schema, type) and issubclass(node_schema, CoreNode):
         return db.schema.get(name=node_schema.__name__, branch=branch.name, duplicate=duplicate)
     if not isinstance(node_schema, (MainSchemaTypes)):
         raise ValueError(f"Invalid schema provided {node_schema}")

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -23,6 +23,7 @@ from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX, SchemaEleme
 from infrahub.core.metadata.interface import MetadataInterface
 from infrahub.core.metadata.model import MetadataInfo
 from infrahub.core.protocols import CoreNumberPool, CoreObjectTemplate
+from infrahub.core.protocols_base import CoreNode
 from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery, NodeUpdateMetadataQuery
 from infrahub.core.schema import (
     AttributeSchema,
@@ -352,7 +353,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         elif isinstance(schema, str):
             # TODO need to raise a proper exception for this, right now it will raise a generic ValueError
             attrs["schema"] = db.schema.get(name=schema, branch=branch)
-        elif hasattr(schema, "_is_runtime_protocol") and schema._is_runtime_protocol:
+        elif isinstance(schema, type) and issubclass(schema, CoreNode):
             attrs["schema"] = db.schema.get(name=schema.__name__, branch=branch)
         else:
             raise ValueError(

--- a/backend/infrahub/core/protocols_base.py
+++ b/backend/infrahub/core/protocols_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
@@ -69,15 +69,24 @@ class InfrahubDatabase(Protocol):
     def to_database_id(self, db_id: str | int) -> str | int: ...
 
 
-@runtime_checkable
-class CoreNode(Protocol):
+class CoreNode:
+    _is_runtime_protocol: ClassVar[bool] = True
     id: str
 
-    def get_id(self) -> str: ...
-    def get_kind(self) -> str: ...
-    def get_schema(self) -> NonGenericSchemaTypes: ...
-    def get_attribute(self, name: str) -> BaseAttribute: ...
-    def get_relationship(self, name: str) -> RelationshipManager: ...
+    def get_id(self) -> str:
+        raise NotImplementedError()
+
+    def get_kind(self) -> str:
+        raise NotImplementedError()
+
+    def get_schema(self) -> NonGenericSchemaTypes:
+        raise NotImplementedError()
+
+    def get_attribute(self, name: str) -> BaseAttribute:
+        raise NotImplementedError()
+
+    def get_relationship(self, name: str) -> RelationshipManager:
+        raise NotImplementedError()
 
     @classmethod
     async def init(
@@ -86,12 +95,18 @@ class CoreNode(Protocol):
         db: InfrahubDatabase,
         branch: Branch | str | None = None,
         at: Timestamp | str | None = None,
-    ) -> Self: ...
-    async def new(self, db: InfrahubDatabase, id: str | None = None, **kwargs: Any) -> Self: ...
-    async def save(self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID) -> Self: ...
-    async def delete(
-        self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID
-    ) -> None: ...
+    ) -> Self:
+        raise NotImplementedError()
+
+    async def new(self, db: InfrahubDatabase, id: str | None = None, **kwargs: Any) -> Self:
+        raise NotImplementedError()
+
+    async def save(self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID) -> Self:
+        raise NotImplementedError()
+
+    async def delete(self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID) -> None:
+        raise NotImplementedError()
+
     async def load(
         self,
         db: InfrahubDatabase,
@@ -99,7 +114,9 @@ class CoreNode(Protocol):
         db_id: str | None = None,
         updated_at: Timestamp | str | None = None,
         **kwargs: Any,
-    ) -> Self: ...
+    ) -> Self:
+        raise NotImplementedError()
+
     async def to_graphql(
         self,
         db: InfrahubDatabase,
@@ -107,10 +124,23 @@ class CoreNode(Protocol):
         related_node_ids: set | None = None,
         filter_sensitive: bool = False,
         permissions: dict | None = None,
-    ) -> dict: ...
-    async def get_display_label(self, db: InfrahubDatabase) -> str: ...
-    async def from_graphql(self, data: dict, db: InfrahubDatabase) -> bool: ...
-    def _get_created_at(self) -> Timestamp | None: ...
-    def _get_created_by(self) -> str | None: ...
-    def _get_updated_at(self) -> Timestamp | None: ...
-    def _get_updated_by(self) -> str | None: ...
+    ) -> dict:
+        raise NotImplementedError()
+
+    async def get_display_label(self, db: InfrahubDatabase) -> str:
+        raise NotImplementedError()
+
+    async def from_graphql(self, data: dict, db: InfrahubDatabase) -> bool:
+        raise NotImplementedError()
+
+    def _get_created_at(self) -> Timestamp | None:
+        raise NotImplementedError()
+
+    def _get_created_by(self) -> str | None:
+        raise NotImplementedError()
+
+    def _get_updated_at(self) -> Timestamp | None:
+        raise NotImplementedError()
+
+    def _get_updated_by(self) -> str | None:
+        raise NotImplementedError()

--- a/backend/infrahub/core/protocols_base.py
+++ b/backend/infrahub/core/protocols_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
@@ -70,7 +70,6 @@ class InfrahubDatabase(Protocol):
 
 
 class CoreNode:
-    _is_runtime_protocol: ClassVar[bool] = True
     id: str
 
     def get_id(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ INFRAHUB_PRODUCTION = false
 pretty = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
-disable_error_code = ["type-abstract"]
 exclude = [
     "^backend/tests/fixtures/repos/*", # To avoid 'Duplicate module named "transforms"'
     "^backend/tests/scale",


### PR DESCRIPTION
# Why

`CoreNode` in `protocols_base.py` was defined as a `@runtime_checkable Protocol`. Every generated class in `protocols.py` inherits from it, making them Protocol subclasses too. mypy's `type-abstract` rule rejects Protocol classes as `type[X]` arguments — the pattern used throughout the codebase (`kind=CoreNumberPool`, `schema=CoreAccountGroup`, etc.)

The prior workaround was a blanket `disable_error_code = ["type-abstract"]` in `pyproject.toml`. This PR removes the suppression and fixes the root cause.


## How to test

```bash
uv run invoke backend.mypy        # must pass with 0 errors, no type-abstract suppression
uv run invoke backend.test-unit
```

## Checklist
- [x] I have reviewed AI generated content
