### PR TITLE
IFC-2296: Fix crashing when inheriting generic schema on generate_profile mismatch

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2743,7 +2743,12 @@ class SchemaBranch:
             if attr_pool_relationship:
                 template_schema.relationships.append(attr_pool_relationship)
 
-        if getattr(node, "generate_profile", False):
+        parent_generates_profile = isinstance(node, NodeSchema) and any(
+            getattr(self.get(name=kind, duplicate=False), "generate_profile", False)
+            for kind in node.inherit_from
+            if self.has(name=kind)
+        )
+        if getattr(node, "generate_profile", False) or parent_generates_profile:
             if PROFILES_RELATIONSHIP_NAME not in [r.name for r in template_schema.relationships]:
                 settings = dict(profiles_rel_settings)
                 settings["identifier"] = PROFILE_TEMPLATE_RELATIONSHIP_IDENTIFIER

--- a/backend/tests/component/graphql/profiles/test_template_profile_mismatch.py
+++ b/backend/tests/component/graphql/profiles/test_template_profile_mismatch.py
@@ -1,0 +1,75 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import BranchSupportType
+from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+
+
+@pytest.fixture
+def interface_schema(default_branch: Branch, register_core_models_schema: SchemaBranch) -> None:
+    generic = GenericSchema(
+        name="Interface",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        generate_profile=True,
+        attributes=[
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "speed", "kind": "Number", "optional": True},
+        ],
+    )
+    registry.schema.set(name=generic.kind, schema=generic)
+
+    # This node inherits from a profile-enabled generic but opts out of profiles.
+    # Its template must still satisfy the 'profiles' field from the generic template interface.
+    node = NodeSchema(
+        name="InterfaceL3",
+        namespace="Test",
+        branch=BranchSupportType.AWARE.value,
+        generate_profile=False,
+        generate_template=True,
+        inherit_from=[generic.kind],
+        attributes=[
+            {"name": "vrf", "kind": "Text", "optional": True},
+        ],
+    )
+    registry.schema.set(name=node.kind, schema=node)
+
+    registry.schema.process_schema_branch(name=default_branch.name)
+
+
+async def test_template_node_has_profiles_relationship_when_parent_generic_does(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    interface_schema: None,
+) -> None:
+    template_node = registry.schema.get(name="TemplateTestInterfaceL3", branch=default_branch, duplicate=False)
+    relationship_names = [r.name for r in template_node.relationships]
+    assert "profiles" in relationship_names, (
+        "TemplateTestInterfaceL3 is missing 'profiles' — it would fail the TemplateTestInterface GraphQL interface"
+    )
+
+
+async def test_graphql_schema_has_no_validation_errors_when_node_disables_profiles(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    interface_schema: None,
+) -> None:
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+
+    # Any query will trigger validate_schema() in the execution path;
+    # a schema that violates interface contracts returns errors before the query even runs.
+    result = await graphql(
+        schema=gql_params.schema,
+        source="{ __typename }",
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors is None, f"GraphQL schema has validation errors: {[str(e) for e in result.errors]}"


### PR DESCRIPTION
# Why

When a node schema sets `generate_profile=False` but inherits from a generic with `generate_profile=True`, schema processing generates templates for both. The generic's template gains a `profiles` relationship (because the generic has `generate_profile=True`), but the node's template does not (because the node has `generate_profile=False`). This violates the GraphQL interface contract — the generic template acts as an interface, and every implementing type must provide all its fields.

The result was a hard crash on any query with the error:
> `Interface field TemplateXxx.profiles expected but TemplateXxxL3 does not provide it.`

Closes https://github.com/opsmill/infrahub/issues/8445

## What changed

- **`add_relationships_to_template()` in `schema_branch.py`**: before deciding whether to add the `profiles` relationship to a node's template, the method now also checks if any of the node's parent generics have `generate_profile=True`. If a parent generic generates profiles, the node's template must also carry `profiles` to satisfy the generic's template interface.

- **Two regression tests** in `tests/component/graphql/profiles/test_template_profile_mismatch.py`:
  - Schema-level check: verifies `TemplateTestInterfaceL3` has the `profiles` relationship after processing.
  - GraphQL-level check: executes a query and asserts no schema validation errors — this reproduces the exact crash from the issue.


## How to test

```bash
uv run pytest backend/tests/component/graphql/profiles/test_template_profile_mismatch.py -v
uv run pytest backend/tests/component/core/schema/schema_branch/ -v
```

## Checklist

- [x] Tests added/updated
