### PR TITLE
Add DateTime attribute range filtering (__after / __before / between)

### DIFF
--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.constants import AttributeDBNodeType
@@ -401,7 +402,7 @@ async def default_attribute_query_filter(
     query_params: dict[str, Any] = {}
     query_where: list[str] = []
 
-    if filter_value and not isinstance(filter_value, str | bool | int | list):
+    if filter_value and not isinstance(filter_value, str | bool | int | list | datetime):
         raise TypeError(f"filter {filter_name}: {filter_value} ({type(filter_value)}) is not supported.")
 
     if isinstance(filter_value, list) and not all(isinstance(value, str | bool | int) for value in filter_value):
@@ -472,6 +473,20 @@ async def default_attribute_query_filter(
                 )
             )
             query_params[f"{param_prefix}_{filter_name}"] = filter_value
+
+    elif filter_name in ("before", "after") and filter_value is not None:
+        query_filter.extend(
+            (QueryRel(labels=[RELATIONSHIP_TO_VALUE_LABEL]), QueryNode(name="av", labels=[attribute_value_label]))
+        )
+        operator = ">" if filter_name == "after" else "<"
+        # Normalize datetime input to a canonical UTC ISO string. Stored DateTime
+        # attribute values are strings, so lexicographic Cypher comparison is only
+        # correct when both sides share canonical form. Mirrors the metadata path
+        # in _build_metadata_filter_requirement for node_metadata__*__before/after.
+        if isinstance(filter_value, datetime):
+            filter_value = Timestamp(filter_value.isoformat()).to_string()
+        query_where.append(f"av.value {operator} ${param_prefix}_{filter_name}")
+        query_params[f"{param_prefix}_{filter_name}"] = filter_value
 
     elif filter_name in [v.value for v in FlagProperty] and filter_value is not None:
         query_filter.append(QueryRel(labels=[filter_name.upper()]))

--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -382,6 +382,29 @@ LIMIT 1
         return None
 
 
+def _datetime_range_filter_clause(
+    filter_name: str,
+    filter_value: Any,
+    attribute_value_label: str,
+    param_prefix: str,
+) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
+    """Build subquery clauses for a DateTime attribute __after / __before filter.
+
+    Filter values arriving as datetime objects are normalized to canonical UTC
+    ISO strings: lexicographic Cypher comparison of stored values is only correct
+    when both sides share canonical form. Mirrors the metadata path in
+    _build_metadata_filter_requirement for node_metadata__*__before/after.
+    """
+    operator = ">" if filter_name == "after" else "<"
+    if isinstance(filter_value, datetime):
+        filter_value = Timestamp(filter_value.isoformat()).to_string()
+    return (
+        [QueryRel(labels=[RELATIONSHIP_TO_VALUE_LABEL]), QueryNode(name="av", labels=[attribute_value_label])],
+        {f"{param_prefix}_{filter_name}": filter_value},
+        [f"av.value {operator} ${param_prefix}_{filter_name}"],
+    )
+
+
 async def default_attribute_query_filter(
     name: str,
     filter_name: str,
@@ -475,18 +498,15 @@ async def default_attribute_query_filter(
             query_params[f"{param_prefix}_{filter_name}"] = filter_value
 
     elif filter_name in ("before", "after") and filter_value is not None:
-        query_filter.extend(
-            (QueryRel(labels=[RELATIONSHIP_TO_VALUE_LABEL]), QueryNode(name="av", labels=[attribute_value_label]))
+        new_filter, new_params, new_where = _datetime_range_filter_clause(
+            filter_name=filter_name,
+            filter_value=filter_value,
+            attribute_value_label=attribute_value_label,
+            param_prefix=param_prefix,
         )
-        operator = ">" if filter_name == "after" else "<"
-        # Normalize datetime input to a canonical UTC ISO string. Stored DateTime
-        # attribute values are strings, so lexicographic Cypher comparison is only
-        # correct when both sides share canonical form. Mirrors the metadata path
-        # in _build_metadata_filter_requirement for node_metadata__*__before/after.
-        if isinstance(filter_value, datetime):
-            filter_value = Timestamp(filter_value.isoformat()).to_string()
-        query_where.append(f"av.value {operator} ${param_prefix}_{filter_name}")
-        query_params[f"{param_prefix}_{filter_name}"] = filter_value
+        query_filter.extend(new_filter)
+        query_params.update(new_params)
+        query_where.extend(new_where)
 
     elif filter_name in [v.value for v in FlagProperty] and filter_value is not None:
         query_filter.append(QueryRel(labels=[filter_name.upper()]))

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -143,6 +143,21 @@ class DateTime(InfrahubDataType):
     graphql_filter = graphene.DateTime
     infrahub = "DateTime"
 
+    @classmethod
+    def get_graphql_filters(
+        cls, name: str, include_properties: bool = True, include_isnull: bool = False
+    ) -> dict[str, typing.Any]:
+        filters = super().get_graphql_filters(
+            name=name, include_properties=include_properties, include_isnull=include_isnull
+        )
+        filters[f"{name}__after"] = graphene.DateTime(
+            description=f"Filter where {name} is strictly after this timestamp"
+        )
+        filters[f"{name}__before"] = graphene.DateTime(
+            description=f"Filter where {name} is strictly before this timestamp"
+        )
+        return filters
+
 
 class Email(InfrahubDataType):
     label: str = "Email"

--- a/backend/tests/component/graphql/test_graphql_query_metadata.py
+++ b/backend/tests/component/graphql/test_graphql_query_metadata.py
@@ -1280,3 +1280,142 @@ async def test_graphql_metadata_filter_with_non_utc_timezone_offset(
     assert result.data["TestCriticality"]["count"] == 1
     names = {e["node"]["name"]["value"] for e in result.data["TestCriticality"]["edges"]}
     assert names == {"tz-second"}
+
+
+# ============================================================================
+# DateTime Attribute Filter Tests
+# ============================================================================
+
+
+class TestDateTimeAttributeFilter:
+    """Test class for DateTime attribute filtering (time__after / time__before, used independently and combined).
+
+    These tests target the GraphQL filter inputs `<attr>__after` and `<attr>__before`
+    for node attributes of kind `DateTime`, mirroring the existing
+    `node_metadata__created_at__after` / `node_metadata__updated_at__after` filters.
+    """
+
+    async def _run_query(
+        self, db: InfrahubDatabase, query_str: str, branch: Branch, variables: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Execute a GraphQL query and return the data."""
+        gql_params = await prepare_graphql_params(db=db, branch=branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query_str,
+            context_value=gql_params.context,
+            root_value=None,
+            variable_values=variables or {},
+        )
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+        assert result.data
+        return result.data
+
+    def _get_names(self, data: dict[str, Any], query_name: str = "TestCriticality") -> set[str]:
+        """Extract node names from query result."""
+        return {e["node"]["name"]["value"] for e in data[query_name]["edges"]}
+
+    async def test_attribute_time_after(
+        self, db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+    ) -> None:
+        """Test that <attr>__after filters DateTime attribute values strictly greater than the cutoff."""
+        early = await Node.init(db=db, schema=criticality_schema)
+        await early.new(db=db, name="early", level=1, time="2026-01-01T00:00:00Z")
+        await early.save(db=db)
+
+        late = await Node.init(db=db, schema=criticality_schema)
+        await late.new(db=db, name="late", level=2, time="2026-06-01T00:00:00Z")
+        await late.save(db=db)
+
+        query = """
+        query($cutoff: DateTime!) {
+            TestCriticality(time__after: $cutoff) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        data = await self._run_query(db, query, default_branch, {"cutoff": "2026-03-01T00:00:00Z"})
+        assert data["TestCriticality"]["count"] == 1
+        assert self._get_names(data) == {"late"}
+
+    async def test_attribute_time_before(
+        self, db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+    ) -> None:
+        """Test that <attr>__before filters DateTime attribute values strictly less than the cutoff."""
+        early = await Node.init(db=db, schema=criticality_schema)
+        await early.new(db=db, name="early", level=1, time="2026-01-01T00:00:00Z")
+        await early.save(db=db)
+
+        late = await Node.init(db=db, schema=criticality_schema)
+        await late.new(db=db, name="late", level=2, time="2026-06-01T00:00:00Z")
+        await late.save(db=db)
+
+        query = """
+        query($cutoff: DateTime!) {
+            TestCriticality(time__before: $cutoff) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        data = await self._run_query(db, query, default_branch, {"cutoff": "2026-03-01T00:00:00Z"})
+        assert data["TestCriticality"]["count"] == 1
+        assert self._get_names(data) == {"early"}
+
+    async def test_attribute_time_range(
+        self, db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+    ) -> None:
+        """Test that combining <attr>__after and <attr>__before bounds the result set on both sides."""
+        feb = await Node.init(db=db, schema=criticality_schema)
+        await feb.new(db=db, name="february", level=1, time="2026-02-01T00:00:00Z")
+        await feb.save(db=db)
+
+        apr = await Node.init(db=db, schema=criticality_schema)
+        await apr.new(db=db, name="april", level=2, time="2026-04-01T00:00:00Z")
+        await apr.save(db=db)
+
+        aug = await Node.init(db=db, schema=criticality_schema)
+        await aug.new(db=db, name="august", level=3, time="2026-08-01T00:00:00Z")
+        await aug.save(db=db)
+
+        query = """
+        query($after: DateTime!, $before: DateTime!) {
+            TestCriticality(time__after: $after, time__before: $before) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        data = await self._run_query(
+            db,
+            query,
+            default_branch,
+            {"after": "2026-03-01T00:00:00Z", "before": "2026-06-01T00:00:00Z"},
+        )
+        assert data["TestCriticality"]["count"] == 1
+        assert self._get_names(data) == {"april"}
+
+    async def test_attribute_time_isnull_unaffected(
+        self, db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+    ) -> None:
+        """Regression baseline: existing time__isnull filter must keep working."""
+        with_time = await Node.init(db=db, schema=criticality_schema)
+        await with_time.new(db=db, name="has_time", level=1, time="2026-01-01T00:00:00Z")
+        await with_time.save(db=db)
+
+        without_time = await Node.init(db=db, schema=criticality_schema)
+        await without_time.new(db=db, name="no_time", level=2)
+        await without_time.save(db=db)
+
+        query = """
+        query($isnull: Boolean!) {
+            TestCriticality(time__isnull: $isnull) {
+                count
+                edges { node { name { value } } }
+            }
+        }
+        """
+        data = await self._run_query(db, query, default_branch, {"isnull": True})
+        assert data["TestCriticality"]["count"] == 1
+        assert self._get_names(data) == {"no_time"}

--- a/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
@@ -5,6 +5,7 @@ import type { FormAttributeValue } from "@/shared/components/form/type";
 import { FormField } from "@/shared/components/ui/form";
 import useFilters, { type Filter } from "@/shared/hooks/useFilters";
 
+import { DateRangePickerFields } from "@/entities/nodes/object/ui/filters/date-range-picker-fields";
 import { DynamicFilterInput } from "@/entities/nodes/object/ui/filters/dynamic-filter-input";
 import {
   FILTER_CONDITION,
@@ -23,12 +24,50 @@ export function AttributeFilterForm({ attributeSchema, onSuccess }: AttributeFil
   const [filters, setFilters] = useFilters();
   const currentFilter = filters.find((filter) => filter.name.startsWith(attributeSchema.name));
   const isDatetime = attributeSchema.kind === ATTRIBUTE_KIND.DATETIME;
-  const defaultCondition = isDatetime ? FILTER_CONDITION.IS_EMPTY : FILTER_CONDITION.CONTAINS;
+
+  const afterFilterName = `${attributeSchema.name}__after`;
+  const beforeFilterName = `${attributeSchema.name}__before`;
+  const afterFilter = filters.find((f) => f.name === afterFilterName);
+  const beforeFilter = filters.find((f) => f.name === beforeFilterName);
+
+  const toISOString = (value: unknown): string =>
+    value instanceof Date ? value.toISOString() : String(value);
+
+  const defaultCondition = isDatetime ? FILTER_CONDITION.AFTER : FILTER_CONDITION.CONTAINS;
   const [condition, setCondition] = useState<FilterCondition>(
     getCurrentFilterCondition(currentFilter) ?? defaultCondition
   );
 
   const handleSubmit = (formData: Record<string, FormAttributeValue["value"]>) => {
+    if (
+      isDatetime &&
+      (condition === FILTER_CONDITION.AFTER ||
+        condition === FILTER_CONDITION.BEFORE ||
+        condition === FILTER_CONDITION.BETWEEN)
+    ) {
+      const { afterDate, beforeDate } = formData as {
+        afterDate?: unknown;
+        beforeDate?: unknown;
+      };
+      let newFilters = filters.filter(
+        (f) => f.name !== afterFilterName && f.name !== beforeFilterName
+      );
+
+      if (
+        (condition === FILTER_CONDITION.AFTER || condition === FILTER_CONDITION.BETWEEN) &&
+        afterDate
+      ) {
+        newFilters = [...newFilters, { name: afterFilterName, value: toISOString(afterDate) }];
+      }
+      if (
+        (condition === FILTER_CONDITION.BEFORE || condition === FILTER_CONDITION.BETWEEN) &&
+        beforeDate
+      ) {
+        newFilters = [...newFilters, { name: beforeFilterName, value: toISOString(beforeDate) }];
+      }
+      return setFilters(newFilters);
+    }
+
     if (condition === FILTER_CONDITION.CONTAINS) {
       const { attribute } = formData;
 
@@ -84,7 +123,16 @@ export function AttributeFilterForm({ attributeSchema, onSuccess }: AttributeFil
         onSuccess?.();
       }}
     >
-      {condition === FILTER_CONDITION.CONTAINS && (
+      {isDatetime &&
+      (condition === FILTER_CONDITION.AFTER ||
+        condition === FILTER_CONDITION.BEFORE ||
+        condition === FILTER_CONDITION.BETWEEN) ? (
+        <DateRangePickerFields
+          condition={condition}
+          afterDefault={afterFilter?.value as string | undefined}
+          beforeDefault={beforeFilter?.value as string | undefined}
+        />
+      ) : condition === FILTER_CONDITION.CONTAINS ? (
         <FormField
           name="attribute"
           defaultValue={
@@ -96,7 +144,7 @@ export function AttributeFilterForm({ attributeSchema, onSuccess }: AttributeFil
             return <DynamicFilterInput {...field} fieldSchema={attributeSchema} />;
           }}
         />
-      )}
+      ) : null}
     </FilterFormLayout>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
-import DateTimePicker from "react-datepicker";
 
-import { FormField } from "@/shared/components/ui/form";
 import useFilters, { type Filter } from "@/shared/hooks/useFilters";
-import { DATE_TIME_FORMAT } from "@/shared/utils/date";
 
 import type { MetadataDateFilterDefinition } from "@/entities/nodes/object/domain/filter-definition";
+import { DateRangePickerFields } from "@/entities/nodes/object/ui/filters/date-range-picker-fields";
 import {
   FILTER_CONDITION,
   type FilterCondition,
@@ -68,10 +66,6 @@ export function DateMetadataFilterForm({ definition, onSuccess }: DateMetadataFi
     onSuccess?.();
   };
 
-  const isBetween = condition === FILTER_CONDITION.BETWEEN;
-  const showAfter = condition === FILTER_CONDITION.AFTER || isBetween;
-  const showBefore = condition === FILTER_CONDITION.BEFORE || isBetween;
-
   return (
     <FilterFormLayout
       filterType="metadata-date"
@@ -81,51 +75,11 @@ export function DateMetadataFilterForm({ definition, onSuccess }: DateMetadataFi
       testId="metadata-date-filter-form"
       onSubmit={handleSubmit}
     >
-      <div className={isBetween ? "flex flex-row gap-4" : "flex flex-col gap-0"}>
-        {showAfter && (
-          <FormField
-            name="afterDate"
-            defaultValue={afterFilter?.value ?? undefined}
-            render={({ field }) => (
-              <div className="flex flex-col gap-1">
-                {isBetween && <span className="text-gray-600 text-xs">After</span>}
-                <DateTimePicker
-                  selected={field.value ? new Date(field.value as string) : null}
-                  onChange={field.onChange}
-                  inline
-                  showTimeSelect
-                  timeIntervals={1}
-                  calendarStartDay={1}
-                  dateFormat={DATE_TIME_FORMAT}
-                  calendarClassName="flex!"
-                />
-              </div>
-            )}
-          />
-        )}
-
-        {showBefore && (
-          <FormField
-            name="beforeDate"
-            defaultValue={beforeFilter?.value ?? undefined}
-            render={({ field }) => (
-              <div className="flex flex-col gap-1">
-                {isBetween && <span className="text-gray-600 text-xs">Before</span>}
-                <DateTimePicker
-                  selected={field.value ? new Date(field.value as string) : null}
-                  onChange={field.onChange}
-                  inline
-                  showTimeSelect
-                  timeIntervals={1}
-                  calendarStartDay={1}
-                  dateFormat={DATE_TIME_FORMAT}
-                  calendarClassName="flex!"
-                />
-              </div>
-            )}
-          />
-        )}
-      </div>
+      <DateRangePickerFields
+        condition={condition}
+        afterDefault={afterFilter?.value as string | undefined}
+        beforeDefault={beforeFilter?.value as string | undefined}
+      />
     </FilterFormLayout>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/filters/date-range-picker-fields.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/date-range-picker-fields.tsx
@@ -1,0 +1,72 @@
+import DateTimePicker from "react-datepicker";
+
+import { FormField } from "@/shared/components/ui/form";
+import { DATE_TIME_FORMAT } from "@/shared/utils/date";
+
+import {
+  FILTER_CONDITION,
+  type FilterCondition,
+} from "@/entities/nodes/object/ui/filters/filter-condition-select";
+
+export interface DateRangePickerFieldsProps {
+  condition: FilterCondition;
+  afterDefault?: string;
+  beforeDefault?: string;
+}
+
+export function DateRangePickerFields({
+  condition,
+  afterDefault,
+  beforeDefault,
+}: DateRangePickerFieldsProps) {
+  const isBetween = condition === FILTER_CONDITION.BETWEEN;
+  const showAfter = condition === FILTER_CONDITION.AFTER || isBetween;
+  const showBefore = condition === FILTER_CONDITION.BEFORE || isBetween;
+
+  return (
+    <div className={isBetween ? "flex flex-row gap-4" : "flex flex-col gap-0"}>
+      {showAfter && (
+        <FormField
+          name="afterDate"
+          defaultValue={afterDefault ?? undefined}
+          render={({ field }) => (
+            <div className="flex flex-col gap-1">
+              {isBetween && <span className="text-gray-600 text-xs">After</span>}
+              <DateTimePicker
+                selected={field.value ? new Date(field.value as string) : null}
+                onChange={field.onChange}
+                inline
+                showTimeSelect
+                timeIntervals={1}
+                calendarStartDay={1}
+                dateFormat={DATE_TIME_FORMAT}
+                calendarClassName="flex!"
+              />
+            </div>
+          )}
+        />
+      )}
+      {showBefore && (
+        <FormField
+          name="beforeDate"
+          defaultValue={beforeDefault ?? undefined}
+          render={({ field }) => (
+            <div className="flex flex-col gap-1">
+              {isBetween && <span className="text-gray-600 text-xs">Before</span>}
+              <DateTimePicker
+                selected={field.value ? new Date(field.value as string) : null}
+                onChange={field.onChange}
+                inline
+                showTimeSelect
+                timeIntervals={1}
+                calendarStartDay={1}
+                dateFormat={DATE_TIME_FORMAT}
+                calendarClassName="flex!"
+              />
+            </div>
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
@@ -43,6 +43,9 @@ export const PERMISSION_DECISION_FILTER_CONDITION_OPTIONS: Array<{
 ];
 
 export const DATETIME_FILTER_CONDITION_OPTIONS: Array<{ key: FilterCondition; label: string }> = [
+  { key: FILTER_CONDITION.BEFORE, label: "before" },
+  { key: FILTER_CONDITION.AFTER, label: "after" },
+  { key: FILTER_CONDITION.BETWEEN, label: "between" },
   { key: FILTER_CONDITION.IS_EMPTY, label: "is empty" },
   { key: FILTER_CONDITION.IS_NOT_EMPTY, label: "is not empty" },
 ];

--- a/frontend/app/src/shared/api/graphql/generated/types.ts
+++ b/frontend/app/src/shared/api/graphql/generated/types.ts
@@ -3095,6 +3095,8 @@ export type CoreArtifactValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -4696,6 +4698,8 @@ export type CoreDataValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -6708,6 +6712,8 @@ export type CoreGeneratorValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -11722,6 +11728,8 @@ export type CoreProposedChangeThreadsArgs = {
 
 /** Metadata related to a proposed change */
 export type CoreProposedChangeValidationsArgs = {
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -11745,6 +11753,8 @@ export type CoreProposedChangeValidationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<OrderInput>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -13020,6 +13030,8 @@ export type CoreRepositoryValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -13541,6 +13553,8 @@ export type CoreSchemaValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -15525,6 +15539,8 @@ export type CoreUserValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -15752,6 +15768,8 @@ export type CoreValidatorChecksArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -25843,6 +25861,8 @@ export type QueryCoreArtifactCheckArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -25941,6 +25961,8 @@ export type QueryCoreArtifactCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -25961,6 +25983,8 @@ export type QueryCoreArtifactCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26334,6 +26358,8 @@ export type QueryCoreArtifactValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26374,6 +26400,8 @@ export type QueryCoreArtifactValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26493,6 +26521,8 @@ export type QueryCoreArtifactValidatorArgs = {
   proposed_change__total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   proposed_change__total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   proposed_change__total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26816,6 +26846,8 @@ export type QueryCoreCheckArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26902,6 +26934,8 @@ export type QueryCoreCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26922,6 +26956,8 @@ export type QueryCoreCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27467,6 +27503,8 @@ export type QueryCoreDataCheckArgs = {
   conflicts__source__id?: InputMaybe<Scalars['ID']['input']>;
   conflicts__value?: InputMaybe<Scalars['GenericScalar']['input']>;
   conflicts__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27565,6 +27603,8 @@ export type QueryCoreDataCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27585,6 +27625,8 @@ export type QueryCoreDataCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27609,6 +27651,8 @@ export type QueryCoreDataValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27649,6 +27693,8 @@ export type QueryCoreDataValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27738,6 +27784,8 @@ export type QueryCoreDataValidatorArgs = {
   proposed_change__total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   proposed_change__total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   proposed_change__total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27862,6 +27910,8 @@ export type QueryCoreFileCheckArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27954,6 +28004,8 @@ export type QueryCoreFileCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -27974,6 +28026,8 @@ export type QueryCoreFileCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -28496,6 +28550,8 @@ export type QueryCoreGeneratorCheckArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -28588,6 +28644,8 @@ export type QueryCoreGeneratorCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -28608,6 +28666,8 @@ export type QueryCoreGeneratorCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -29057,6 +29117,8 @@ export type QueryCoreGeneratorValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -29097,6 +29159,8 @@ export type QueryCoreGeneratorValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -29231,6 +29295,8 @@ export type QueryCoreGeneratorValidatorArgs = {
   proposed_change__total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   proposed_change__total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   proposed_change__total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -32527,6 +32593,8 @@ export type QueryCoreProposedChangeArgs = {
   total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  validations__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validations__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validations__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validations__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validations__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -32547,6 +32615,8 @@ export type QueryCoreProposedChangeArgs = {
   validations__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validations__label__value?: InputMaybe<Scalars['String']['input']>;
   validations__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validations__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validations__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validations__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validations__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validations__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33357,6 +33427,8 @@ export type QueryCoreRepositoryValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33397,6 +33469,8 @@ export type QueryCoreRepositoryValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33521,6 +33595,8 @@ export type QueryCoreRepositoryValidatorArgs = {
   repository__sync_status__source__id?: InputMaybe<Scalars['ID']['input']>;
   repository__sync_status__value?: InputMaybe<Scalars['String']['input']>;
   repository__sync_status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33633,6 +33709,8 @@ export type QueryCoreSchemaCheckArgs = {
   conflicts__source__id?: InputMaybe<Scalars['ID']['input']>;
   conflicts__value?: InputMaybe<Scalars['GenericScalar']['input']>;
   conflicts__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33725,6 +33803,8 @@ export type QueryCoreSchemaCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33745,6 +33825,8 @@ export type QueryCoreSchemaCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33769,6 +33851,8 @@ export type QueryCoreSchemaValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33809,6 +33893,8 @@ export type QueryCoreSchemaValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33898,6 +33984,8 @@ export type QueryCoreSchemaValidatorArgs = {
   proposed_change__total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   proposed_change__total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   proposed_change__total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -33938,6 +34026,8 @@ export type QueryCoreStandardCheckArgs = {
   conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   conclusion__value?: InputMaybe<Scalars['String']['input']>;
   conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -34024,6 +34114,8 @@ export type QueryCoreStandardCheckArgs = {
   subscriber_of_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subscriber_of_groups__name__value?: InputMaybe<Scalars['String']['input']>;
   subscriber_of_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -34044,6 +34136,8 @@ export type QueryCoreStandardCheckArgs = {
   validator__label__source__id?: InputMaybe<Scalars['ID']['input']>;
   validator__label__value?: InputMaybe<Scalars['String']['input']>;
   validator__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validator__started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  validator__started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   validator__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   validator__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   validator__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35289,6 +35383,8 @@ export type QueryCoreUserValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35329,6 +35425,8 @@ export type QueryCoreUserValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35453,6 +35551,8 @@ export type QueryCoreUserValidatorArgs = {
   repository__sync_status__source__id?: InputMaybe<Scalars['ID']['input']>;
   repository__sync_status__value?: InputMaybe<Scalars['String']['input']>;
   repository__sync_status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35492,6 +35592,8 @@ export type QueryCoreValidatorArgs = {
   checks__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__conclusion__value?: InputMaybe<Scalars['String']['input']>;
   checks__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  checks__created_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  checks__created_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   checks__created_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   checks__created_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
   checks__created_at__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35532,6 +35634,8 @@ export type QueryCoreValidatorArgs = {
   checks__severity__source__id?: InputMaybe<Scalars['ID']['input']>;
   checks__severity__value?: InputMaybe<Scalars['String']['input']>;
   checks__severity__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  completed_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35621,6 +35725,8 @@ export type QueryCoreValidatorArgs = {
   proposed_change__total_comments__source__id?: InputMaybe<Scalars['ID']['input']>;
   proposed_change__total_comments__value?: InputMaybe<Scalars['BigInt']['input']>;
   proposed_change__total_comments__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  started_at__after?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__before?: InputMaybe<Scalars['DateTime']['input']>;
   started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1512,7 +1512,60 @@ input CoreArtifactUpsertInput {
 
 """A validator related to the artifacts"""
 type CoreArtifactValidator implements CoreNode & CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -2279,7 +2332,60 @@ input CoreDataCheckUpsertInput {
 
 """A check to validate the data integrity between two branches"""
 type CoreDataValidator implements CoreNode & CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -3325,7 +3431,60 @@ input CoreGeneratorInstanceUpsertInput {
 
 """A validator related to generators"""
 type CoreGeneratorValidator implements CoreNode & CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -5399,7 +5558,49 @@ type CoreProposedChange implements CoreNode & CoreTaskTarget {
   threads(ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, offset: Int, order: OrderInput, resolved__is_protected: Boolean, resolved__owner__id: ID, resolved__source__id: ID, resolved__value: Boolean, resolved__values: [Boolean]): NestedPaginatedCoreThread!
   """Total number of comments on this proposed change"""
   total_comments: NumberAttribute
-  validations(completed_at__is_protected: Boolean, completed_at__owner__id: ID, completed_at__source__id: ID, completed_at__value: DateTime, completed_at__values: [DateTime], conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, offset: Int, order: OrderInput, started_at__is_protected: Boolean, started_at__owner__id: ID, started_at__source__id: ID, started_at__value: DateTime, started_at__values: [DateTime], state__is_protected: Boolean, state__owner__id: ID, state__source__id: ID, state__value: String, state__values: [String]): NestedPaginatedCoreValidator!
+  validations(
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
+    completed_at__is_protected: Boolean
+    completed_at__owner__id: ID
+    completed_at__source__id: ID
+    completed_at__value: DateTime
+    completed_at__values: [DateTime]
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    offset: Int
+    order: OrderInput
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
+    started_at__is_protected: Boolean
+    started_at__owner__id: ID
+    started_at__source__id: ID
+    started_at__value: DateTime
+    started_at__values: [DateTime]
+    state__is_protected: Boolean
+    state__owner__id: ID
+    state__source__id: ID
+    state__value: String
+    state__values: [String]
+  ): NestedPaginatedCoreValidator!
 }
 
 """Metadata related to a proposed change"""
@@ -5887,7 +6088,60 @@ input CoreRepositoryUpsertInput {
 
 """A Validator related to a specific repository"""
 type CoreRepositoryValidator implements CoreNode & CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -6151,7 +6405,60 @@ input CoreSchemaCheckUpsertInput {
 
 """A validator related to the schema"""
 type CoreSchemaValidator implements CoreNode & CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -7082,7 +7389,60 @@ input CoreTriggerRuleUpdateInput {
 """A Validator related to a user defined checks in a repository"""
 type CoreUserValidator implements CoreNode & CoreValidator {
   check_definition: NestedEdgedCoreCheckDefinition!
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -7187,7 +7547,60 @@ input CoreUserValidatorUpsertInput {
 
 """A validator that runs checks against a proposed change"""
 interface CoreValidator {
-  checks(conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], created_at__is_protected: Boolean, created_at__owner__id: ID, created_at__source__id: ID, created_at__value: DateTime, created_at__values: [DateTime], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, kind__is_protected: Boolean, kind__owner__id: ID, kind__source__id: ID, kind__value: String, kind__values: [String], label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, message__is_protected: Boolean, message__owner__id: ID, message__source__id: ID, message__value: String, message__values: [String], name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, origin__is_protected: Boolean, origin__owner__id: ID, origin__source__id: ID, origin__value: String, origin__values: [String], severity__is_protected: Boolean, severity__owner__id: ID, severity__source__id: ID, severity__value: String, severity__values: [String]): NestedPaginatedCoreCheck!
+  checks(
+    conclusion__is_protected: Boolean
+    conclusion__owner__id: ID
+    conclusion__source__id: ID
+    conclusion__value: String
+    conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
+    created_at__is_protected: Boolean
+    created_at__owner__id: ID
+    created_at__source__id: ID
+    created_at__value: DateTime
+    created_at__values: [DateTime]
+    display_label__isnull: Boolean
+    display_label__value: String
+    display_label__values: [String]
+    ids: [ID]
+    isnull: Boolean
+    kind__is_protected: Boolean
+    kind__owner__id: ID
+    kind__source__id: ID
+    kind__value: String
+    kind__values: [String]
+    label__is_protected: Boolean
+    label__owner__id: ID
+    label__source__id: ID
+    label__value: String
+    label__values: [String]
+    limit: Int
+    message__is_protected: Boolean
+    message__owner__id: ID
+    message__source__id: ID
+    message__value: String
+    message__values: [String]
+    name__is_protected: Boolean
+    name__owner__id: ID
+    name__source__id: ID
+    name__value: String
+    name__values: [String]
+    offset: Int
+    order: OrderInput
+    origin__is_protected: Boolean
+    origin__owner__id: ID
+    origin__source__id: ID
+    origin__value: String
+    origin__values: [String]
+    severity__is_protected: Boolean
+    severity__owner__id: ID
+    severity__source__id: ID
+    severity__value: String
+    severity__values: [String]
+  ): NestedPaginatedCoreCheck!
   """Timestamp when the validator finished"""
   completed_at: TextAttribute
   """Final outcome of the validation"""
@@ -13713,6 +14126,10 @@ type Query {
     conclusion__source__id: ID
     conclusion__value: String
     conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -13821,6 +14238,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -13841,6 +14262,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -14236,6 +14661,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -14276,6 +14705,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -14405,6 +14838,10 @@ type Query {
     proposed_change__total_comments__source__id: ID
     proposed_change__total_comments__value: BigInt
     proposed_change__total_comments__values: [BigInt]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -14750,6 +15187,10 @@ type Query {
     conclusion__source__id: ID
     conclusion__value: String
     conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -14846,6 +15287,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -14866,6 +15311,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -15441,6 +15890,10 @@ type Query {
     conflicts__source__id: ID
     conflicts__value: GenericScalar
     conflicts__values: [GenericScalar]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -15549,6 +16002,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -15569,6 +16026,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -15591,6 +16052,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -15631,6 +16096,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -15730,6 +16199,10 @@ type Query {
     proposed_change__total_comments__source__id: ID
     proposed_change__total_comments__value: BigInt
     proposed_change__total_comments__values: [BigInt]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -15860,6 +16333,10 @@ type Query {
     conclusion__source__id: ID
     conclusion__value: String
     conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -15962,6 +16439,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -15982,6 +16463,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -16534,6 +17019,10 @@ type Query {
     conclusion__source__id: ID
     conclusion__value: String
     conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -16636,6 +17125,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -16656,6 +17149,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -17127,6 +17624,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -17167,6 +17668,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -17311,6 +17816,10 @@ type Query {
     proposed_change__total_comments__source__id: ID
     proposed_change__total_comments__value: BigInt
     proposed_change__total_comments__values: [BigInt]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -20815,6 +21324,10 @@ type Query {
     total_comments__source__id: ID
     total_comments__value: BigInt
     total_comments__values: [BigInt]
+    """Filter where completed_at is strictly after this timestamp"""
+    validations__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validations__completed_at__before: DateTime
     validations__completed_at__is_protected: Boolean
     validations__completed_at__owner__id: ID
     validations__completed_at__source__id: ID
@@ -20835,6 +21348,10 @@ type Query {
     validations__label__source__id: ID
     validations__label__value: String
     validations__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validations__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validations__started_at__before: DateTime
     validations__started_at__is_protected: Boolean
     validations__started_at__owner__id: ID
     validations__started_at__source__id: ID
@@ -21663,6 +22180,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -21703,6 +22224,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -21837,6 +22362,10 @@ type Query {
     repository__sync_status__source__id: ID
     repository__sync_status__value: String
     repository__sync_status__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -21955,6 +22484,10 @@ type Query {
     conflicts__source__id: ID
     conflicts__value: GenericScalar
     conflicts__values: [GenericScalar]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -22057,6 +22590,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -22077,6 +22614,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -22099,6 +22640,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -22139,6 +22684,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -22238,6 +22787,10 @@ type Query {
     proposed_change__total_comments__source__id: ID
     proposed_change__total_comments__value: BigInt
     proposed_change__total_comments__values: [BigInt]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -22276,6 +22829,10 @@ type Query {
     conclusion__source__id: ID
     conclusion__value: String
     conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    created_at__before: DateTime
     created_at__is_protected: Boolean
     created_at__isnull: Boolean
     created_at__owner__id: ID
@@ -22372,6 +22929,10 @@ type Query {
     subscriber_of_groups__label__values: [String]
     subscriber_of_groups__name__value: String
     subscriber_of_groups__name__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    validator__completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    validator__completed_at__before: DateTime
     validator__completed_at__is_protected: Boolean
     validator__completed_at__owner__id: ID
     validator__completed_at__source__id: ID
@@ -22392,6 +22953,10 @@ type Query {
     validator__label__source__id: ID
     validator__label__value: String
     validator__label__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    validator__started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    validator__started_at__before: DateTime
     validator__started_at__is_protected: Boolean
     validator__started_at__owner__id: ID
     validator__started_at__source__id: ID
@@ -23715,6 +24280,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -23755,6 +24324,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -23889,6 +24462,10 @@ type Query {
     repository__sync_status__source__id: ID
     repository__sync_status__value: String
     repository__sync_status__values: [String]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID
@@ -23926,6 +24503,10 @@ type Query {
     checks__conclusion__source__id: ID
     checks__conclusion__value: String
     checks__conclusion__values: [String]
+    """Filter where created_at is strictly after this timestamp"""
+    checks__created_at__after: DateTime
+    """Filter where created_at is strictly before this timestamp"""
+    checks__created_at__before: DateTime
     checks__created_at__is_protected: Boolean
     checks__created_at__owner__id: ID
     checks__created_at__source__id: ID
@@ -23966,6 +24547,10 @@ type Query {
     checks__severity__source__id: ID
     checks__severity__value: String
     checks__severity__values: [String]
+    """Filter where completed_at is strictly after this timestamp"""
+    completed_at__after: DateTime
+    """Filter where completed_at is strictly before this timestamp"""
+    completed_at__before: DateTime
     completed_at__is_protected: Boolean
     completed_at__isnull: Boolean
     completed_at__owner__id: ID
@@ -24065,6 +24650,10 @@ type Query {
     proposed_change__total_comments__source__id: ID
     proposed_change__total_comments__value: BigInt
     proposed_change__total_comments__values: [BigInt]
+    """Filter where started_at is strictly after this timestamp"""
+    started_at__after: DateTime
+    """Filter where started_at is strictly before this timestamp"""
+    started_at__before: DateTime
     started_at__is_protected: Boolean
     started_at__isnull: Boolean
     started_at__owner__id: ID


### PR DESCRIPTION
Closes #9073.

## Summary

Adds `before` / `after` / `between` filtering on node attributes of kind `DateTime`, mirroring the picker UX 1.9 already provides for `node_metadata__created_at` / `node_metadata__updated_at`. Six commits, three layers — none large.

| Commit | Layer | Change |
|---|---|---|
| `291f14b` | backend tests | Failing TDD tests for `time__after` / `time__before` / range / `__isnull` regression baseline (4 tests) |
| `efa6cf9` | backend GraphQL | Override `get_graphql_filters` on `DateTime` data type to expose `<name>__after` / `<name>__before` |
| `0cda9e6` | backend Cypher | `default_attribute_query_filter` accepts `datetime` and routes `before`/`after` to `>` / `<` against `av.value`; filter values normalized to canonical UTC via `Timestamp(value.isoformat()).to_string()` (mirrors `_build_metadata_filter_requirement`) |
| `83d9d8b` | frontend conds | Extend `DATETIME_FILTER_CONDITION_OPTIONS` with `BEFORE` / `AFTER` / `BETWEEN` |
| `3c080f9` | frontend refactor | Extract `DateMetadataFilterForm`'s picker block into shared `DateRangePickerFields` component |
| `8eb6c8d` | frontend form | `AttributeFilterForm` routes DateTime kind + range condition to the new picker; default condition for DateTime flips from `IS_EMPTY` to `AFTER` |

## Test plan

- [x] **TDD red phase** — 3 new tests fail with `Unknown argument 'time__after'` GraphQL errors before `efa6cf9`.
- [x] **TDD green phase** — All 4 `TestDateTimeAttributeFilter` tests pass after `0cda9e6`.
- [x] `backend/tests/component/graphql/test_graphql_query_metadata.py` — 37/37 pass.
- [x] `backend/tests/component/core/test_node_get_list_query.py` — 57/57 pass.
- [x] Backend unit suite (`uv run invoke backend.test-unit`) — 608/608 pass.
- [x] Backend component (full `graphql/` + `core/`) — 1446 passed, 13 skipped, 3 xfailed; pytest exit 0. Local run hit `--session-timeout=1800` at ~53% of files; CI has a longer budget.
- [x] Frontend vitest — 653/653 pass across 88 files.
- [x] Biome — clean.
- [ ] **Manual UI smoke test pending.** Built-in `CoreAccountToken.expiration` is the easiest path (generate a few API tokens with varied expirations, filter by `expiration__after` / `__before` / `between`). Other built-in DateTime fields exist on `CoreValidator` and `CoreCheck`. None of the default-loaded demo nodes (`models/base/`, `models/infrastructure_edge.py`) currently have a custom DateTime attribute — separate optional follow-up could add e.g. `InfraDevice.last_seen` for richer demo coverage.

## Implementation notes

- **No regression on existing UX.** `__isnull` / `__value` filters on DateTime attributes still work identically. The `__isnull` regression test confirms it.
- **No frontend type regeneration in this PR.** `frontend/app/src/shared/api/graphql/generated/types.ts` is regenerated by `pnpm codegen` from `schema/schema.graphql`, which itself is exported from a live backend via `infrahub dev export-graphql-schema`. Codegen against the current `schema.graphql` is a no-op — the file pre-dates the new filter args. Since the frontend builds list-page queries dynamically via `jsonToGraphQLQuery` (no `gql`-tagged static queries reference these new args), runtime behavior works regardless. Schema/types regeneration should happen as part of the normal release workflow.
- **Two existing helpers already handle the new keys** — no change needed:
  - `getCurrentFilterCondition` already maps `<attr>__after` → `AFTER` / `<attr>__before` → `BEFORE`.
  - `active-filter-tags.tsx` already renders chips for `before` / `after` suffixes on non-relationship definitions.

## Caveat: stored value timezone canonicalization

DateTime *attribute* values are stored as user-supplied strings (`BaseAttribute.serialize_value` is identity). Lexicographic Cypher `<` / `>` is correct only when stored values are also in canonical form. In practice values written via the standard graphene `DateTime` ingestion path are canonical, but values inserted via direct DB writes or non-standard paths could produce off-by-tz results. Same limitation applies to the existing metadata path; flagged in #9073 for a separate hardening effort (either write-time normalization or `datetime()` casts in Cypher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)