### PR TITLE
Flaky test: drop fragile wait_until_converged=True from test_schema_load_and_delete

### DIFF
--- a/backend/tests/integration_docker/test_schema_migration.py
+++ b/backend/tests/integration_docker/test_schema_migration.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import time
 from pathlib import Path
 
@@ -80,16 +79,12 @@ class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
 
         device_branch = await client.branch.create(branch_name="device_branch")
 
-        device_interface = await client.schema.load(
-            schemas=[device_and_interface_schema], branch=device_branch.name, wait_until_converged=True
-        )
+        device_interface = await client.schema.load(schemas=[device_and_interface_schema], branch=device_branch.name)
         assert device_interface.schema_updated
         # Validate that the schema is in sync after loading the device and interface schema
         assert await self.schema_in_sync(client=client, branch=device_branch.name)
 
-        delete_interface = await client.schema.load(
-            schemas=[delete_interface_schema], branch=device_branch.name, wait_until_converged=True
-        )
+        delete_interface = await client.schema.load(schemas=[delete_interface_schema], branch=device_branch.name)
         assert delete_interface.schema_updated
         # Validate that the schema is in sync after removing the interface
         assert await self.schema_in_sync(client=client, branch=device_branch.name)
@@ -106,13 +101,18 @@ class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
         }
         """
         deadline = time.monotonic() + wait_for_seconds
+        last_error: GraphQLError | None = None
         while True:
-            with contextlib.suppress(GraphQLError):
+            try:
                 response = await client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
                 if response["InfrahubStatus"]["summary"]["schema_hash_synced"]:
                     return True
+            except GraphQLError as exc:
+                last_error = exc
 
             if time.monotonic() >= deadline:
+                if last_error is not None:
+                    client.log.warning(f"schema_in_sync timed out; last suppressed GraphQLError: {last_error.errors}")
                 return False
 
             await asyncio.sleep(1)


### PR DESCRIPTION
## Why

CI job `backend-docker-integration` ([run 24860740980 / job 72785427002](https://github.com/opsmill/infrahub/actions/runs/24860740980/job/72785427002)) failed with `GraphQLError: "Unable to find the schema 'NetworkInterface' in the registry"` at `test_schema_load_and_delete` line 90.

## Goal
Stop the test from flaking by routing it through the already-hardened local convergence helper instead of the SDK's `wait_until_converged=True`, which could poll the server during the racy post-delete window and propagates transient errors.

Closes [IFC-2487]

## What changed

- `test_schema_load_and_delete` no longer passes `wait_until_converged=True`. Each load is followed by an explicit `await self.schema_in_sync(...)` which polls for up to 30 s with `GraphQLError` suppressed. This is the pattern PR #8811 added for exactly this race.
- `schema_in_sync` now uses an explicit `try/except GraphQLError` instead of `contextlib.suppress`, records the last suppressed error, and logs it via `client.log.warning(...)` on timeout.

## How to test

```bash
uv run pytest -q backend/tests/integration_docker/test_schema_migration.py::TestSchemaMigrations
```

### Another solution?

If `infrahub_sdk.schema.InfrahubSchema.wait_until_converged` can raise error through a call to `infrahub_sdk.schema.InfrahubSchema.in_sync` method, maybe should we catch errors raised as this is a wait method?

## Checklist

- [x] Tests added/updated (test-only fix)

[IFC-2487]: https://opsmill.atlassian.net/browse/IFC-2487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ