### PR TITLE
IFC-2408: Fix attribute migration for sub-template schemas

### DIFF
--- a/backend/infrahub/core/migrations/schema/attribute_supports_generated_schema.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_generated_schema.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
+from infrahub.core import registry
 from infrahub.core.migrations.query.attribute_remove import AttributeRemoveQuery
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
@@ -141,9 +142,15 @@ class AttributeSupportsGeneratedSchemaMigration(AttributeSchemaMigration):
                 all_queries.append(ProfilesAttributeRemoveMigrationQuery)
 
         # Check template support changes
+        schema_branch = (
+            registry.schema.get_schema_branch(name=branch.name)
+            if registry.schema.has_schema_branch(name=branch.name)
+            else None
+        )
+        is_sub_template = schema_branch is not None and schema_branch.has(name=f"Template{self.new_schema.kind}")
         if (
             isinstance(self.new_schema, NodeSchema)
-            and self.new_schema.generate_template
+            and (self.new_schema.generate_template or is_sub_template)
             and self.previous_attribute_schema.support_templates != self.new_attribute_schema.support_templates
         ):
             if self.new_attribute_schema.support_templates:

--- a/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
@@ -4,14 +4,14 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SchemaPathType
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind, SchemaPathType
 from infrahub.core.migrations.schema.attribute_supports_generated_schema import (
     AttributeSupportsGeneratedSchemaMigration,
 )
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.definitions.core.template import core_object_component_template, core_object_template
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
@@ -282,32 +282,30 @@ async def test_migration_edge_timestamps(
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
-# ---------------------------------------------------------------------------
-# Sub-template fixtures & tests (generate_template=False COMPONENT nodes)
-# ---------------------------------------------------------------------------
+_PART = NodeSchema(
+    name="Part",
+    namespace="Test",
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="serial_number", kind="Text", optional=True),
+    ],
+)
 
-_DEVICE_PART_NODES = [
-    {
-        "name": "Device",
-        "namespace": "Test",
-        "branch": "aware",
-        "generate_template": True,
-        "attributes": [{"name": "hostname", "kind": "Text", "unique": True}],
-        "relationships": [
-            {"name": "parts", "peer": "TestPart", "kind": "Component", "cardinality": "many", "optional": True}
-        ],
-    },
-    {
-        "name": "Part",
-        "namespace": "Test",
-        "branch": "aware",
-        "generate_template": False,
-        "attributes": [
-            {"name": "name", "kind": "Text", "unique": True},
-            {"name": "serial_number", "kind": "Text", "optional": True, "read_only": True},
-        ],
-    },
-]
+_DEVICE = NodeSchema(
+    name="Device",
+    namespace="Test",
+    generate_template=True,
+    attributes=[AttributeSchema(name="hostname", kind="Text", unique=True)],
+    relationships=[
+        RelationshipSchema(
+            name="parts",
+            peer="TestPart",
+            kind=RelationshipKind.COMPONENT,
+            cardinality=RelationshipCardinality.MANY,
+            optional=True,
+        )
+    ],
+)
 
 
 @pytest.fixture
@@ -316,11 +314,13 @@ async def device_part_schema_read_only_serial(
 ) -> SchemaBranch:
     """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
     serial_number starts read_only=True so it is NOT on template instances."""
+    part = _PART.model_copy(deep=True)
+    part.get_attribute("serial_number").read_only = True
     registry.schema.register_schema(
         schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
         branch=default_branch.name,
     )
-    return registry.schema.register_schema(schema=SchemaRoot(nodes=_DEVICE_PART_NODES), branch=default_branch.name)
+    return registry.schema.register_schema(schema=SchemaRoot(nodes=[_DEVICE, part]), branch=default_branch.name)
 
 
 @pytest.fixture
@@ -329,21 +329,11 @@ async def device_part_schema(
 ) -> SchemaBranch:
     """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
     serial_number starts read_only=False so it IS on template instances."""
-    nodes = [
-        {**_DEVICE_PART_NODES[0]},
-        {
-            **_DEVICE_PART_NODES[1],
-            "attributes": [
-                {"name": "name", "kind": "Text", "unique": True},
-                {"name": "serial_number", "kind": "Text", "optional": True, "read_only": False},
-            ],
-        },
-    ]
     registry.schema.register_schema(
         schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
         branch=default_branch.name,
     )
-    return registry.schema.register_schema(schema=SchemaRoot(nodes=nodes), branch=default_branch.name)
+    return registry.schema.register_schema(schema=SchemaRoot(nodes=[_DEVICE, _PART]), branch=default_branch.name)
 
 
 async def test_migration_enable_support_sub_template(

--- a/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
@@ -12,7 +12,7 @@ from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import SchemaRoot
-from infrahub.core.schema.definitions.core.template import core_object_template
+from infrahub.core.schema.definitions.core.template import core_object_component_template, core_object_template
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -280,3 +280,158 @@ async def test_migration_edge_timestamps(
 
     after_snapshot = await snapshotter.snapshot()
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
+
+
+# ---------------------------------------------------------------------------
+# Sub-template fixtures & tests (generate_template=False COMPONENT nodes)
+# ---------------------------------------------------------------------------
+
+_DEVICE_PART_NODES = [
+    {
+        "name": "Device",
+        "namespace": "Test",
+        "branch": "aware",
+        "generate_template": True,
+        "attributes": [{"name": "hostname", "kind": "Text", "unique": True}],
+        "relationships": [
+            {"name": "parts", "peer": "TestPart", "kind": "Component", "cardinality": "many", "optional": True}
+        ],
+    },
+    {
+        "name": "Part",
+        "namespace": "Test",
+        "branch": "aware",
+        "generate_template": False,
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "serial_number", "kind": "Text", "optional": True, "read_only": True},
+        ],
+    },
+]
+
+
+@pytest.fixture
+async def device_part_schema_read_only_serial(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+) -> SchemaBranch:
+    """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
+    serial_number starts read_only=True so it is NOT on template instances."""
+    registry.schema.register_schema(
+        schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
+        branch=default_branch.name,
+    )
+    return registry.schema.register_schema(schema=SchemaRoot(nodes=_DEVICE_PART_NODES), branch=default_branch.name)
+
+
+@pytest.fixture
+async def device_part_schema(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+) -> SchemaBranch:
+    """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
+    serial_number starts read_only=False so it IS on template instances."""
+    nodes = [
+        {**_DEVICE_PART_NODES[0]},
+        {
+            **_DEVICE_PART_NODES[1],
+            "attributes": [
+                {"name": "name", "kind": "Text", "unique": True},
+                {"name": "serial_number", "kind": "Text", "optional": True, "read_only": False},
+            ],
+        },
+    ]
+    registry.schema.register_schema(
+        schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
+        branch=default_branch.name,
+    )
+    return registry.schema.register_schema(schema=SchemaRoot(nodes=nodes), branch=default_branch.name)
+
+
+async def test_migration_enable_support_sub_template(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    device_part_schema_read_only_serial: SchemaBranch,
+) -> None:
+    """Enabling read_only→False on a sub-template schema adds the attribute to existing TemplateTestPart instances."""
+    template_part = await Node.init(db=db, schema="TemplateTestPart", branch=default_branch)
+    await template_part.new(db=db, template_name="Template Part 1")
+    await template_part.save(db=db)
+
+    with pytest.raises(ValueError):
+        template_part.get_attribute(name="serial_number")
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_part_schema = schema.get(name="TestPart")
+    prev_attr = prev_part_schema.get_attribute(name="serial_number")
+    prev_attr.id = str(uuid.uuid4())
+
+    candidate_schema = schema.duplicate()
+    new_part_schema = candidate_schema.get(name="TestPart")
+    new_attr = new_part_schema.get_attribute(name="serial_number")
+    new_attr.id = prev_attr.id
+    new_attr.read_only = False
+    candidate_schema.set(name="TestPart", schema=new_part_schema)
+
+    migration = AttributeSupportsGeneratedSchemaMigration(
+        previous_node_schema=prev_part_schema,
+        new_node_schema=new_part_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPart", field_name="serial_number"),
+    )
+
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    await assert_attribute_path_status(
+        db=db,
+        node_label="TemplateTestPart",
+        attr_name="serial_number",
+        branch_name=default_branch.name,
+        expected_status="active",
+    )
+
+
+async def test_migration_disable_support_sub_template(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    device_part_schema: SchemaBranch,
+) -> None:
+    """Disabling read_only→True on a sub-template schema removes the attribute from existing TemplateTestPart instances."""
+    template_part = await Node.init(db=db, schema="TemplateTestPart", branch=default_branch)
+    await template_part.new(db=db, template_name="Template Part 1", serial_number="SN-12345")
+    await template_part.save(db=db)
+
+    await assert_attribute_path_status(
+        db=db,
+        node_label="TemplateTestPart",
+        attr_name="serial_number",
+        branch_name=default_branch.name,
+        expected_status="active",
+    )
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_part_schema = schema.get(name="TestPart")
+    prev_attr = prev_part_schema.get_attribute(name="serial_number")
+    prev_attr.id = str(uuid.uuid4())
+
+    candidate_schema = schema.duplicate()
+    new_part_schema = candidate_schema.get(name="TestPart")
+    new_attr = new_part_schema.get_attribute(name="serial_number")
+    new_attr.id = prev_attr.id
+    new_attr.read_only = True
+    candidate_schema.set(name="TestPart", schema=new_part_schema)
+
+    migration = AttributeSupportsGeneratedSchemaMigration(
+        previous_node_schema=prev_part_schema,
+        new_node_schema=new_part_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPart", field_name="serial_number"),
+    )
+
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    await assert_attribute_path_status(
+        db=db,
+        node_label="TemplateTestPart",
+        attr_name="serial_number",
+        branch_name=default_branch.name,
+        expected_status="deleted",
+    )

--- a/changelog/8722.fixed.md
+++ b/changelog/8722.fixed.md
@@ -1,0 +1,1 @@
+Fixed attribute migration for sub-template schemas: changing `read_only` or `optional` on a node with `generate_template=False` that is a COMPONENT or PARENT peer of a `generate_template=True` node now correctly updates existing template instances.


### PR DESCRIPTION
# Why

When a node has `generate_template=False` but is a COMPONENT or PARENT peer of a `generate_template=True` node, Infrahub auto-generates a `TemplateXxx` schema for it ("sub-template"). When an attribute on that node later changed `read_only` or `optional`, the `AttributeSupportsGeneratedSchemaMigration` skipped the migration because it only checked `self.new_schema.generate_template` — which is `False` for sub-template nodes. Existing `TemplateXxx` instances were left with stale attribute paths, silently out of sync with the schema.

Closes https://github.com/opsmill/infrahub/issues/8722


## How to test

```bash
uv run pytest backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py -v
```

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`changelog/8722.fixed.md`)
- [x] I have reviewed AI generated content
