### PR TITLE
IFC-1663: Refresh schema after files are imported

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -199,6 +199,8 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         try:
             config_file = await self.get_repository_config(branch_name=infrahub_branch_name, commit=commit)  # type: ignore[call-overload]
             await self.import_schema_files(branch_name=infrahub_branch_name, commit=commit, config_file=config_file)  # type: ignore[call-overload]
+            if config_file.schemas:
+                await self.sdk.schema.all(branch=infrahub_branch_name, refresh=True)
             await self.import_all_graphql_query(
                 branch_name=infrahub_branch_name, commit=commit, config_file=config_file
             )  # type: ignore[call-overload]

--- a/changelog/6814.fixed.md
+++ b/changelog/6814.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where object files in a git commit were imported using a stale schema cache when the same commit also contained schema changes. The schema cache is now refreshed after schema files are imported, ensuring object files are validated against the updated schema.


### PR DESCRIPTION
This PR fixes a bug where object files in a git commit were imported using a stale schema cache when the same commit also contained schema changes. 

The schema cache is now refreshed after schema files are imported, ensuring object files are validated against the updated schema.

Closes https://github.com/opsmill/infrahub/issues/6814