### PR TITLE
Show 20 slowest component tests

### DIFF
--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -94,7 +94,7 @@ def lint(context: Context) -> None:
 def test_component(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run backend component tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/component"
+        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub --durations=20 {MAIN_DIRECTORY}/tests/component"
         if database == "neo4j":
             exec_cmd += " --neo4j"
         print(f"{exec_cmd}")


### PR DESCRIPTION
# Why

Add a `--durations=20` param when running component tests to identify the 20 slowest tests

## What changed

* Add parameter to command within the invoke tasks.