### PR TITLE
docs: add Infrahub Marketplace documentation

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -266,5 +266,8 @@ QRadar
 rsyslog
 sourcetype
 Splunk
+stderr
+stdin
+stdout
 syslog
 Syslog

--- a/changelog/infp-528.added.md
+++ b/changelog/infp-528.added.md
@@ -1,0 +1,1 @@
+Added documentation for the Infrahub Marketplace, including a topic page explaining what the Marketplace is, a guide for fetching and loading schemas using `infrahubctl marketplace get`, and a guide for publishing schemas. Updated the quick-start guide, installation guide, and existing schema references to point to the Marketplace instead of the deprecated GitHub schema library.

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -916,8 +916,22 @@ server {
 
 </details>
 
+## Load a schema
+
+Infrahub ships with a minimal built-in schema. After installation, load a domain schema to model your infrastructure.
+
+:::tip Use the Marketplace for pre-built schemas
+
+The [Infrahub Marketplace](https://marketplace.infrahub.app) hosts ready-to-use schemas for common domains such as DCIM, IPAM, locations, and routing.
+Fetch a schema with `infrahubctl marketplace get opsmill/dcim`, then load it with `infrahubctl schema load schemas/dcim.yml`.
+See [Use a schema from the Marketplace](./marketplace-install-schema.mdx) for the complete workflow.
+
+:::
+
 ## Related resources
 
+- [Use a schema from the Marketplace](./marketplace-install-schema.mdx) - Fetch and load pre-built schemas
+- [Infrahub Marketplace](../topics/marketplace.mdx) - Overview of available schemas and collections
 - [Database backup and restore](./database-backup.mdx) - Learn how to backup and restore your Infrahub database
 - [High availability architecture](../topics/architecture.mdx#scalability-and-high-availability) - Understand resilient deployment architectures
 - [Local demo environment](../topics/local-demo-environment.mdx) - Explore the demo environment configuration

--- a/docs/docs/guides/marketplace-install-schema.mdx
+++ b/docs/docs/guides/marketplace-install-schema.mdx
@@ -1,0 +1,118 @@
+---
+title: Use a schema from the Marketplace
+---
+
+# Use a schema from the Marketplace
+
+The [Infrahub Marketplace](https://marketplace.infrahub.app) hosts pre-built schemas for common infrastructure domains.
+This guide walks you through fetching a schema from the Marketplace and loading it into a running Infrahub instance.
+
+## Prerequisites
+
+- A running Infrahub instance
+- `infrahubctl` installed and configured with your instance URL (see [installation guide](./installation.mdx))
+
+## Step 1: Find the schema
+
+Browse [marketplace.infrahub.app](https://marketplace.infrahub.app) and identify the schema or collection you want.
+Each item has an identifier in `namespace/name` format — for example, `opsmill/dcim`.
+Note this identifier; you will use it in the next step.
+
+## Step 2: Fetch the schema
+
+Run `infrahubctl marketplace get` with the identifier:
+
+```shell
+infrahubctl marketplace get opsmill/dcim
+```
+
+The command downloads the schema YAML to `./schemas/` by default:
+
+```text
+Downloaded schema opsmill/dcim (version 1.4.2) → schemas/dcim.yml
+```
+
+### Fetch a specific version
+
+Pin to a published version with `--version`:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --version 1.2.0
+```
+
+### Save to a custom directory
+
+Use `--output-dir` to change where files are saved:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --output-dir ./infra/schemas
+```
+
+### Inspect before loading
+
+Use `--stdout` to print the schema YAML to stdout without writing to disk:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --stdout
+```
+
+This is useful for reviewing the schema or piping it into another tool before committing to disk.
+
+### Collections
+
+The Marketplace also hosts collections — bundles of related schemas published together.
+The `get` command detects whether an identifier is a schema or a collection automatically.
+To force collection download when a name exists as both, add `--collection`:
+
+```shell
+infrahubctl marketplace get opsmill/starter-pack --collection
+```
+
+A collection download writes one file per schema in the bundle.
+
+## Step 3: Load the schema into Infrahub
+
+Use `infrahubctl schema load` to apply the downloaded file to your instance:
+
+```shell
+infrahubctl schema load schemas/dcim.yml
+```
+
+For a collection, load all files at once:
+
+```shell
+infrahubctl schema load schemas/
+```
+
+Infrahub validates the schema, applies the changes, and restarts the relevant services.
+
+:::tip Verify the schema loaded
+
+After loading, browse to the [schema page](http://localhost:8000/schema) in the Infrahub UI.
+The new nodes should appear in the node list.
+
+:::
+
+## Version compatibility
+
+Marketplace schemas are versioned independently from Infrahub itself.
+If a schema uses features from a newer version of Infrahub than you are running, `infrahubctl schema load` reports a validation error.
+Check the schema's Marketplace page for the minimum supported Infrahub version before loading.
+
+## Offline and air-gapped environments
+
+If your Infrahub instance cannot reach the internet, download the schema YAML from a machine that can, transfer the file, and then run `infrahubctl schema load` from the air-gapped environment.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `No schema or collection named '…' found` | Identifier not found on Marketplace | Check spelling; browse the Marketplace for the correct `namespace/name` |
+| `Could not reach marketplace` | Network error | Check `--marketplace-url`; verify connectivity to `marketplace.infrahub.app` |
+| Schema validation errors on load | Incompatible Infrahub version or conflicting nodes | Check version compatibility; review error details for conflicting node names |
+
+## Related resources
+
+- [Infrahub Marketplace](../topics/marketplace.mdx) — concept overview
+- [Import schema file](./import-schema.mdx) — load a schema from a local file
+- [Schema](../topics/schema.mdx) — schema concepts and YAML format reference

--- a/docs/docs/overview/concepts.mdx
+++ b/docs/docs/overview/concepts.mdx
@@ -14,7 +14,7 @@ The schema provides an abstraction layer to the graph database, and as such no k
 
 The schema is described in YAML format, and consists of nodes, attributes, relationships, and other descriptors. A new deployment of Infrahub will have no schema by default — it is up to the administrator to define and load the initial schema.
 
-Example schemas can be found in the [Schema Library](https://github.com/opsmill/schema-library), the most comprehensive collection currently maintained by the community and OpsMill.
+Example schemas can be found in the [Infrahub Marketplace](https://marketplace.infrahub.app), the catalog of schemas maintained by the community and OpsMill.
 
 The schema can be loaded using the [`infrahubctl schema load`]($(base_url)infrahubctl/infrahubctl-load) command for development, or via Infrahub Git integration for production deployments. Once loaded, it's stored and version controlled in the graph database. Changes to the schema can be made at any time, and it's best practice to make schema changes in a branch to allow for testing before implementation.
 

--- a/docs/docs/overview/next-steps.mdx
+++ b/docs/docs/overview/next-steps.mdx
@@ -10,7 +10,7 @@ If you completed the [Quick Start](./quickstart.mdx), you have a local Infrahub 
 
 The Quick Start used pre-built schemas from the Schema Library. For a POC, model a slice of your actual infrastructure — the devices, services, or resources that matter most to your team.
 
-Start with a focused scope. Pick one domain (for example: data center fabric, WAN sites, or firewall policies) and model it. You can always expand later. The [Schema Library](https://github.com/opsmill/schema-library) remains a good starting point to extend from.
+Start with a focused scope. Pick one domain (for example: data center fabric, WAN sites, or firewall policies) and model it. You can always expand later. The [Infrahub Marketplace](https://marketplace.infrahub.app) is a good starting point — browse it for schemas that match your domain and extend from there.
 
 <ReferenceLink title="Create a schema" url="../guides/create-schema"/>
 

--- a/docs/docs/overview/quickstart.mdx
+++ b/docs/docs/overview/quickstart.mdx
@@ -80,31 +80,30 @@ You should see the Infrahub web interface with a navigation menu on the left sid
 
 A schema defines the structure of your infrastructure data in Infrahub — the types of objects, their attributes, and how they relate to each other. [Learn more about schemas](../topics/schema.mdx).
 
-Rather than writing a schema from scratch, use the [Schema Library](https://github.com/opsmill/schema-library), a community-maintained collection of reusable data models.
+Rather than writing a schema from scratch, use the [Infrahub Marketplace](https://marketplace.infrahub.app), a catalog of reusable schemas for common infrastructure domains maintained by the community and OpsMill.
 
-1. Download the schema library:
+1. Browse [marketplace.infrahub.app](https://marketplace.infrahub.app) and identify the schema you need (for example, `opsmill/dcim`).
+
+2. Fetch the schema to your project:
 
 ```bash
-uv run invoke schema-library-get
+infrahubctl marketplace get opsmill/dcim
 ```
 
-2. Explore the downloaded schema files in the `schema-library/` folder in your IDE.
+This downloads the schema YAML to `./schemas/`.
 
 :::info
 
-- The schema library is divided into a `base/` with core definitions and `extensions/` that build on top of the base. You need to load the base to add extensions.
-- Since you have access to the full schema code, you can explore and modify the schemas to fit your organization's needs.
+The Marketplace organizes schemas into base schemas (core definitions) and extensions that build on top of a base.
+You need to load the base before loading extensions.
+Browse the Marketplace to discover what is available and check each schema's dependencies.
 
 :::
 
 3. Load the schema into your project:
 
-:::info
-To keep things organized, put all schema files in a `schemas/` folder in your project and load them from there. Copy the files you need from the `schema-library/` folder into your project's `schemas/` folder.
-:::
-
 ```bash
-uv run infrahubctl schema load schemas/
+infrahubctl schema load schemas/
 ```
 
 :::success Verification

--- a/docs/docs/topics/marketplace.mdx
+++ b/docs/docs/topics/marketplace.mdx
@@ -1,0 +1,40 @@
+---
+title: Infrahub Marketplace
+---
+
+# Infrahub Marketplace
+
+The Infrahub Marketplace is a public catalog of pre-built schemas and schema collections that you can fetch and load into any Infrahub instance.
+It provides a curated starting point for common infrastructure domains — from physical device modeling to IP address management — so you can get a working data model without building one from scratch.
+
+## What the Marketplace contains
+
+The Marketplace hosts two types of content:
+
+- **Schemas** — versioned YAML files that define nodes, attributes, and relationships for a specific domain. A DCIM schema might define `Device`, `Interface`, and `Platform` nodes; an IPAM schema might define `IPAddress`, `Prefix`, and `VLAN`.
+- **Collections** — curated bundles of related schemas published together. A "network automation starter" collection might include DCIM, IPAM, location, and organization schemas in a single download.
+
+## How identifiers work
+
+Every item in the Marketplace is identified by a `namespace/name` reference, similar to Docker Hub image names or npm package scopes.
+
+- `opsmill/dcim` — the `dcim` schema published by the `opsmill` namespace
+- `opsmill/starter-pack` — the `starter-pack` collection published by `opsmill`
+
+Namespaces are tied to the account of the schema's author on the Marketplace.
+
+## Schemas and schema versions
+
+Marketplace schemas follow [semantic versioning](https://semver.org/). Each published schema has a version number (`MAJOR.MINOR.PATCH`). When you fetch a schema you can pin to a specific version or use the latest published release.
+
+Breaking changes — such as removing a node or changing a relationship cardinality — require a major version bump. Additive changes (new nodes, new optional attributes) use a minor or patch bump.
+
+## Relationship to an Infrahub instance
+
+The Marketplace is an external catalog — it stores schema definitions, not your infrastructure data. Fetching a schema from the Marketplace downloads its YAML to your local filesystem. You then load that YAML into your Infrahub instance using `infrahubctl schema load`. The Marketplace and your instance remain independent; updates to a schema on the Marketplace do not automatically change your loaded schema.
+
+## Related resources
+
+- [Schema](./schema.mdx) — core schema concepts and how schemas govern data in Infrahub
+- [Import schema file](../guides/import-schema.mdx) — loading a local schema YAML into Infrahub
+- [Use a schema from the Marketplace](../guides/marketplace-install-schema.mdx) — step-by-step guide for fetching and loading a Marketplace schema

--- a/docs/docs/topics/schema-extensions.mdx
+++ b/docs/docs/topics/schema-extensions.mdx
@@ -61,7 +61,7 @@ If multiple extensions target the same node, all extensions are merged. Conflict
 
 The extension mechanism was designed to support modular schema composition. In large organizations, different teams often own different parts of the infrastructure model. Extensions allow teams to add their specific requirements to shared base schemas without coordinating changes to common files.
 
-This pattern is used extensively in the [OpsMill Schema Library](https://github.com/opsmill/schema-library), where the `extensions/` directory contains feature modules that augment base schemas:
+This pattern is used extensively in schemas published on the [Infrahub Marketplace](https://marketplace.infrahub.app), where extensions are feature modules that augment base schemas:
 
 - `extensions/lag/` adds LAG support to interface models
 - `extensions/contracts/` adds procurement tracking to organization models
@@ -155,4 +155,4 @@ Schema extensions interact with several other Infrahub concepts:
 
 - [Reference: Node extension](../reference/schema/node-extension.mdx) - Complete reference for extension properties
 - [Guide: Import schema file](../guides/import-schema.mdx) - How to load schema files including extensions
-- [OpsMill Schema Library](https://github.com/opsmill/schema-library/tree/main/extensions) - Production examples of schema extensions
+- [Infrahub Marketplace](https://marketplace.infrahub.app) - Community and OpsMill schema catalog, including production examples of schema extensions

--- a/docs/docs/tutorials/getting-started/schema.mdx
+++ b/docs/docs/tutorials/getting-started/schema.mdx
@@ -54,6 +54,14 @@ Use the following command to load these new models into Infrahub
 invoke demo.load-infra-schema
 ```
 
+:::tip Find these schemas on the Marketplace
+
+The schemas loaded above (`dcim`, `ipam`, `location`, `organization`, `routing`) are also available on the [Infrahub Marketplace](https://marketplace.infrahub.app) as `opsmill/dcim`, `opsmill/ipam`, and so on.
+When starting a new Infrahub project outside of this demo, you can fetch them directly with `infrahubctl marketplace get opsmill/dcim` instead of using the demo command.
+See [Use a schema from the Marketplace](../../guides/marketplace-install-schema.mdx) for the full workflow.
+
+:::
+
 <details>
   <summary>Expected Results</summary>
   ```shell

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -70,6 +70,16 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Marketplace',
+          link: {
+            type: 'generated-index',
+          },
+          items: [
+            'guides/marketplace-install-schema',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Schema & Data Modeling',
           link: {
             type: 'generated-index',
@@ -171,6 +181,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'topics/architecture',
             'topics/community-vs-enterprise',
+            'topics/marketplace',
           ],
         },
         {


### PR DESCRIPTION
## Summary

- Adds a new topic page explaining what the Infrahub Marketplace is, how `namespace/name` identifiers work, and the relationship between the Marketplace and a local Infrahub instance
- Adds a how-to guide for fetching a schema with `infrahubctl marketplace get` and loading it with `infrahubctl schema load`
- Updates the getting-started tutorial and installation guide with Marketplace callouts
- Replaces all references to the deprecated GitHub schema library (`github.com/opsmill/schema-library`) in active docs with links to `marketplace.infrahub.app`

Relates to: infp-528 | Depends on SDK PR: opsmill/infrahub-sdk-python#952

## Test plan

- [ ] Browse to `/topics/marketplace` and confirm the topic page renders correctly
- [ ] Browse to `/guides/marketplace-install-schema` and confirm all steps and commands are accurate
- [ ] Verify the getting-started tutorial and installation guide show the Marketplace callout
- [ ] Confirm no active docs link to `github.com/opsmill/schema-library`
- [ ] `uv run invoke docs.lint` passes with no new errors
- [ ] `uv run invoke docs.build` completes with no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)