### PR TITLE
IFC-2168 create standard nodes to replace trigger placeholder automations

### DIFF
--- a/backend/infrahub/computed_attribute/signature.py
+++ b/backend/infrahub/computed_attribute/signature.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from infrahub.trigger.signature import TriggerSignatureBase, TriggerSignatureGetListQueryBase
+
+
+class ComputedAttrJinja2SignatureGetListQuery(TriggerSignatureGetListQueryBase):
+    def __init__(
+        self,
+        attribute_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._attribute_name = attribute_name
+        super().__init__(**kwargs)
+
+    def _collect_conditions(self) -> list[str]:
+        conditions = super()._collect_conditions()
+        if self._attribute_name is not None:
+            self._signature_filter_params["filter_attribute_name"] = self._attribute_name
+            conditions.append("n.attribute_name = $filter_attribute_name")
+        return conditions
+
+
+class ComputedAttrJinja2Signature(TriggerSignatureBase):
+    """Stores the hash of a self-targeting Jinja2 computed-attribute definition per
+    (branch, target_kind, attribute_name), used to detect definition changes during
+    schema-setup runs."""
+
+    attribute_name: str
+
+    list_query_cls: ClassVar[type[TriggerSignatureGetListQueryBase]] = ComputedAttrJinja2SignatureGetListQuery

--- a/backend/infrahub/display_labels/signature.py
+++ b/backend/infrahub/display_labels/signature.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from infrahub.trigger.signature import TriggerSignatureBase, TriggerSignatureGetListQueryBase
+
+
+class DisplayLabelSignatureGetListQuery(TriggerSignatureGetListQueryBase):
+    pass
+
+
+class DisplayLabelSignature(TriggerSignatureBase):
+    """Stores the hash of a Jinja2 display-label definition per (branch, target_kind), used to
+    detect definition changes during schema-setup runs."""
+
+    list_query_cls: ClassVar[type[TriggerSignatureGetListQueryBase]] = DisplayLabelSignatureGetListQuery

--- a/backend/infrahub/hfid/models.py
+++ b/backend/infrahub/hfid/models.py
@@ -45,7 +45,7 @@ class HFIDTriggerDefinition(TriggerBranchDefinition):
         branches_out_of_scope: list[str] | None = None,
     ) -> list[HFIDTriggerDefinition]:
         """
-        This function is used to create a trigger definition for a display labels of type Jinja2.
+        This function is used to create a trigger definition for a HFID of type Jinja2.
         """
 
         definitions: list[HFIDTriggerDefinition] = []

--- a/backend/infrahub/hfid/signature.py
+++ b/backend/infrahub/hfid/signature.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from infrahub.trigger.signature import TriggerSignatureBase, TriggerSignatureGetListQueryBase
+
+
+class HFIDSignatureGetListQuery(TriggerSignatureGetListQueryBase):
+    pass
+
+
+class HFIDSignature(TriggerSignatureBase):
+    """Stores the hash of a human-friendly-id definition per (branch, target_kind), used to
+    detect definition changes during schema-setup runs."""
+
+    list_query_cls: ClassVar[type[TriggerSignatureGetListQueryBase]] = HFIDSignatureGetListQuery

--- a/backend/infrahub/trigger/signature.py
+++ b/backend/infrahub/trigger/signature.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Self
+
+from infrahub.core.node.standard import StandardNode, StandardNodeOrdering
+from infrahub.core.query.standard_node import StandardNodeGetListQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.query import Query
+    from infrahub.database import InfrahubDatabase
+
+
+class TriggerSignatureGetListQueryBase(StandardNodeGetListQuery):
+    def __init__(
+        self,
+        branch_name: str | None = None,
+        target_kind: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._branch_name = branch_name
+        self._target_kind = target_kind
+        self._signature_filter_params: dict[str, Any] = {}
+
+        self.raw_filter = " AND ".join(self._collect_conditions())
+
+        super().__init__(**kwargs)
+
+        self.params.update(self._signature_filter_params)
+
+    def _collect_conditions(self) -> list[str]:
+        conditions: list[str] = []
+
+        if self._branch_name is not None:
+            self._signature_filter_params["filter_branch"] = self._branch_name
+            conditions.append("n.branch = $filter_branch")
+
+        if self._target_kind is not None:
+            self._signature_filter_params["filter_target_kind"] = self._target_kind
+            conditions.append("n.target_kind = $filter_target_kind")
+
+        return conditions
+
+
+class TriggerSignatureBase(StandardNode):
+    """Common shape for trigger-signature StandardNodes: a hash of a schema-derived definition
+    scoped to (branch, target_kind), used by setup flows to detect when downstream values
+    must be recomputed."""
+
+    branch: str
+    target_kind: str
+    definition_hash: str
+
+    list_query_cls: ClassVar[type[TriggerSignatureGetListQueryBase]] = TriggerSignatureGetListQueryBase
+
+    @classmethod
+    async def get_list(
+        cls,
+        db: InfrahubDatabase,
+        limit: int = 1000,
+        offset: int | None = None,
+        ids: list[str] | None = None,
+        name: str | None = None,
+        node_ordering: StandardNodeOrdering | None = None,
+        **kwargs: Any,
+    ) -> list[Self]:
+        branch: str | None = kwargs.pop("branch", None)
+        target_kind: str | None = kwargs.pop("target_kind", None)
+
+        node_ordering = node_ordering or StandardNodeOrdering()
+        query: Query = await cls.list_query_cls.init(
+            db=db,
+            node_class=cls,
+            ids=ids,
+            node_name=name,
+            limit=limit,
+            offset=offset,
+            node_ordering=node_ordering,
+            branch_name=branch,
+            target_kind=target_kind,
+            **kwargs,
+        )
+        await query.execute(db=db)
+        return [cls.from_db(node=result.get_node("n")) for result in query.get_results()]

--- a/backend/tests/component/computed_attribute/test_signature.py
+++ b/backend/tests/component/computed_attribute/test_signature.py
@@ -1,0 +1,111 @@
+from infrahub.computed_attribute.signature import ComputedAttrJinja2Signature
+from infrahub.database import InfrahubDatabase
+
+
+async def test_create(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="abc123"
+    )
+    await sig.save(db=db)
+
+    assert sig.id is not None
+    assert sig.uuid is not None
+
+
+async def test_get(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="abc123"
+    )
+    await sig.save(db=db)
+
+    fetched = await ComputedAttrJinja2Signature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.branch == "main"
+    assert fetched.target_kind == "TestCar"
+    assert fetched.attribute_name == "full_name"
+    assert fetched.definition_hash == "abc123"
+
+
+async def test_update(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="abc123"
+    )
+    await sig.save(db=db)
+
+    sig.definition_hash = "def456"
+    await sig.save(db=db)
+
+    fetched = await ComputedAttrJinja2Signature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.definition_hash == "def456"
+
+
+async def test_delete(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="abc123"
+    )
+    await sig.save(db=db)
+    other = ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="display", definition_hash="xyz789"
+    )
+    await other.save(db=db)
+
+    await sig.delete(db=db)
+
+    remaining = await ComputedAttrJinja2Signature.get_list(db=db)
+    assert len(remaining) == 1
+    assert remaining[0].attribute_name == "display"
+
+
+async def test_list_unfiltered(db: InfrahubDatabase, empty_database: None) -> None:
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="h1"
+    ).save(db=db)
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="display", definition_hash="h2"
+    ).save(db=db)
+    await ComputedAttrJinja2Signature(
+        branch="dev", target_kind="TestCar", attribute_name="full_name", definition_hash="h3"
+    ).save(db=db)
+
+    sigs = await ComputedAttrJinja2Signature.get_list(db=db)
+    assert len(sigs) == 3
+
+
+async def test_list_filter_by_branch(db: InfrahubDatabase, empty_database: None) -> None:
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="h1"
+    ).save(db=db)
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="display", definition_hash="h2"
+    ).save(db=db)
+    await ComputedAttrJinja2Signature(
+        branch="dev", target_kind="TestCar", attribute_name="full_name", definition_hash="h3"
+    ).save(db=db)
+
+    main_sigs = await ComputedAttrJinja2Signature.get_list(db=db, branch="main")
+    assert len(main_sigs) == 2
+
+    dev_sigs = await ComputedAttrJinja2Signature.get_list(db=db, branch="dev")
+    assert len(dev_sigs) == 1
+
+
+async def test_list_filter_disambiguates_attribute_name(db: InfrahubDatabase, empty_database: None) -> None:
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="full_name", definition_hash="h_full"
+    ).save(db=db)
+    await ComputedAttrJinja2Signature(
+        branch="main", target_kind="TestCar", attribute_name="display", definition_hash="h_disp"
+    ).save(db=db)
+
+    matched = await ComputedAttrJinja2Signature.get_list(
+        db=db, branch="main", target_kind="TestCar", attribute_name="full_name"
+    )
+    assert len(matched) == 1
+    assert matched[0].definition_hash == "h_full"
+
+    matched_other = await ComputedAttrJinja2Signature.get_list(
+        db=db, branch="main", target_kind="TestCar", attribute_name="display"
+    )
+    assert len(matched_other) == 1
+    assert matched_other[0].definition_hash == "h_disp"

--- a/backend/tests/component/display_labels/test_signature.py
+++ b/backend/tests/component/display_labels/test_signature.py
@@ -1,0 +1,96 @@
+from infrahub.database import InfrahubDatabase
+from infrahub.display_labels.signature import DisplayLabelSignature
+from infrahub.hfid.signature import HFIDSignature
+
+
+async def test_create(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    assert sig.id is not None
+    assert sig.uuid is not None
+
+
+async def test_get(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    fetched = await DisplayLabelSignature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.branch == "main"
+    assert fetched.target_kind == "TestCar"
+    assert fetched.definition_hash == "abc123"
+
+
+async def test_update(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    sig.definition_hash = "def456"
+    await sig.save(db=db)
+
+    fetched = await DisplayLabelSignature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.definition_hash == "def456"
+
+
+async def test_delete(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+    other = DisplayLabelSignature(branch="main", target_kind="TestPerson", definition_hash="xyz789")
+    await other.save(db=db)
+
+    await sig.delete(db=db)
+
+    remaining = await DisplayLabelSignature.get_list(db=db)
+    assert len(remaining) == 1
+    assert remaining[0].target_kind == "TestPerson"
+
+
+async def test_list_unfiltered(db: InfrahubDatabase, empty_database: None) -> None:
+    await DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await DisplayLabelSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await DisplayLabelSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    sigs = await DisplayLabelSignature.get_list(db=db)
+    assert len(sigs) == 3
+
+
+async def test_list_filter_by_branch(db: InfrahubDatabase, empty_database: None) -> None:
+    await DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await DisplayLabelSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await DisplayLabelSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    main_sigs = await DisplayLabelSignature.get_list(db=db, branch="main")
+    assert len(main_sigs) == 2
+    assert {sig.target_kind for sig in main_sigs} == {"TestCar", "TestPerson"}
+
+    dev_sigs = await DisplayLabelSignature.get_list(db=db, branch="dev")
+    assert len(dev_sigs) == 1
+    assert dev_sigs[0].target_kind == "TestCar"
+
+
+async def test_list_filter_by_branch_and_target_kind(db: InfrahubDatabase, empty_database: None) -> None:
+    await DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await DisplayLabelSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await DisplayLabelSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    matched = await DisplayLabelSignature.get_list(db=db, branch="main", target_kind="TestCar")
+    assert len(matched) == 1
+    assert matched[0].definition_hash == "h1"
+
+    no_match = await DisplayLabelSignature.get_list(db=db, branch="main", target_kind="Unknown")
+    assert no_match == []
+
+
+async def test_label_isolation_from_other_signature_kinds(db: InfrahubDatabase, empty_database: None) -> None:
+    await DisplayLabelSignature(branch="main", target_kind="TestCar", definition_hash="display_hash").save(db=db)
+    await HFIDSignature(branch="main", target_kind="TestCar", definition_hash="hfid_hash_value").save(db=db)
+
+    display_sigs = await DisplayLabelSignature.get_list(db=db)
+    hfid_sigs = await HFIDSignature.get_list(db=db)
+
+    assert len(display_sigs) == 1
+    assert len(hfid_sigs) == 1
+    assert display_sigs[0].definition_hash == "display_hash"
+    assert hfid_sigs[0].definition_hash == "hfid_hash_value"

--- a/backend/tests/component/hfid/test_signature.py
+++ b/backend/tests/component/hfid/test_signature.py
@@ -1,0 +1,81 @@
+from infrahub.database import InfrahubDatabase
+from infrahub.hfid.signature import HFIDSignature
+
+
+async def test_create(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = HFIDSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    assert sig.id is not None
+    assert sig.uuid is not None
+
+
+async def test_get(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = HFIDSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    fetched = await HFIDSignature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.branch == "main"
+    assert fetched.target_kind == "TestCar"
+    assert fetched.definition_hash == "abc123"
+
+
+async def test_update(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = HFIDSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+
+    sig.definition_hash = "def456"
+    await sig.save(db=db)
+
+    fetched = await HFIDSignature.get(id=str(sig.uuid), db=db)
+    assert fetched is not None
+    assert fetched.definition_hash == "def456"
+
+
+async def test_delete(db: InfrahubDatabase, empty_database: None) -> None:
+    sig = HFIDSignature(branch="main", target_kind="TestCar", definition_hash="abc123")
+    await sig.save(db=db)
+    other = HFIDSignature(branch="main", target_kind="TestPerson", definition_hash="xyz789")
+    await other.save(db=db)
+
+    await sig.delete(db=db)
+
+    remaining = await HFIDSignature.get_list(db=db)
+    assert len(remaining) == 1
+    assert remaining[0].target_kind == "TestPerson"
+
+
+async def test_list_unfiltered(db: InfrahubDatabase, empty_database: None) -> None:
+    await HFIDSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await HFIDSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await HFIDSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    sigs = await HFIDSignature.get_list(db=db)
+    assert len(sigs) == 3
+
+
+async def test_list_filter_by_branch(db: InfrahubDatabase, empty_database: None) -> None:
+    await HFIDSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await HFIDSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await HFIDSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    main_sigs = await HFIDSignature.get_list(db=db, branch="main")
+    assert len(main_sigs) == 2
+
+    dev_sigs = await HFIDSignature.get_list(db=db, branch="dev")
+    assert len(dev_sigs) == 1
+    assert dev_sigs[0].target_kind == "TestCar"
+
+
+async def test_list_filter_by_branch_and_target_kind(db: InfrahubDatabase, empty_database: None) -> None:
+    await HFIDSignature(branch="main", target_kind="TestCar", definition_hash="h1").save(db=db)
+    await HFIDSignature(branch="main", target_kind="TestPerson", definition_hash="h2").save(db=db)
+    await HFIDSignature(branch="dev", target_kind="TestCar", definition_hash="h3").save(db=db)
+
+    matched = await HFIDSignature.get_list(db=db, branch="main", target_kind="TestCar")
+    assert len(matched) == 1
+    assert matched[0].definition_hash == "h1"
+
+    no_match = await HFIDSignature.get_list(db=db, branch="main", target_kind="Unknown")
+    assert no_match == []


### PR DESCRIPTION
## Why

This is the data model that will replace the trigger placeholder used for HFID, Display Labels and Computed attributes computation.

The current data model uses `backend/infrahub/trigger/constants.py:TRIGGER_PLACEHOLDER_FIELD` constant string to reference a fake field that will allow these objects to be recomputed when their definition/signature changes.

From now on, the goal will be to use these standard nodes to allow to recompute these nodes when required.

Closes [IFC-2168]

### What's not included in this PR

This PR is just about creating the new data model, not using it in production code. Replacement will be done later in another PR.

[IFC-2168]: https://opsmill.atlassian.net/browse/IFC-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ