### PR TITLE
event loop flaky test suite: second fix tentative

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import logging
 import os
@@ -74,7 +75,7 @@ from tests.helpers.constants import (
     PORT_PREFECT,
     PORT_REDIS,
 )
-from tests.helpers.diagnostics import install_redis_loop_diagnostics
+from tests.helpers.diagnostics import install_redis_loop_diagnostics, register_known_loop
 from tests.helpers.utils import get_exposed_port, start_neo4j_container, start_prefect_server_container
 
 ResponseClass = TypeVar("ResponseClass")
@@ -119,6 +120,12 @@ def add_tracker() -> None:
 def _install_redis_loop_diagnostics() -> None:
     # This fixture should be deleted once the flakiness is gone
     install_redis_loop_diagnostics()
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True, loop_scope="session")
+async def _register_pytest_session_loop() -> None:
+    # This fixture should be deleted once the flakiness is gone
+    register_known_loop("pytest-session", asyncio.get_running_loop())
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -74,6 +74,7 @@ from tests.helpers.constants import (
     PORT_PREFECT,
     PORT_REDIS,
 )
+from tests.helpers.diagnostics import install_redis_loop_diagnostics
 from tests.helpers.utils import get_exposed_port, start_neo4j_container, start_prefect_server_container
 
 ResponseClass = TypeVar("ResponseClass")
@@ -112,6 +113,11 @@ def pytest_configure(config: pytest.Config) -> None:
 @pytest.fixture(scope="session", autouse=True)
 def add_tracker() -> None:
     os.environ["PYTEST_RUNNING"] = "true"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _install_redis_loop_diagnostics() -> None:
+    install_redis_loop_diagnostics()
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -117,6 +117,7 @@ def add_tracker() -> None:
 
 @pytest.fixture(scope="session", autouse=True)
 def _install_redis_loop_diagnostics() -> None:
+    # This fixture should be deleted once the flakiness is gone
     install_redis_loop_diagnostics()
 
 

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -2,6 +2,7 @@
 import asyncio
 from sys import stderr
 from traceback import format_exception
+from typing import Any, cast
 
 from redis.asyncio.connection import Connection, ConnectionPool
 
@@ -114,8 +115,8 @@ def install_redis_loop_diagnostics() -> None:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
-        self._creation_loop_id = id(loop)
-        self._creation_loop_repr = repr(loop)
+        cast("Any", self)._creation_loop_id = id(loop)
+        cast("Any", self)._creation_loop_repr = repr(loop)
 
     original_disconnect = ConnectionPool.disconnect
 
@@ -128,5 +129,5 @@ def install_redis_loop_diagnostics() -> None:
 
     setattr(_instrumented_connect, _INSTALLED_MARKER, True)
     setattr(_instrumented_disconnect, _INSTALLED_MARKER, True)
-    Connection._connect = _instrumented_connect
-    ConnectionPool.disconnect = _instrumented_disconnect
+    cast("Any", Connection)._connect = _instrumented_connect
+    cast("Any", ConnectionPool).disconnect = _instrumented_disconnect

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -1,5 +1,6 @@
 # This file should be deleted once the flakiness is gone
 import asyncio
+import threading
 from sys import stderr
 from traceback import format_exception
 from typing import Any, cast
@@ -19,8 +20,12 @@ def _current_loop_info() -> tuple[int | None, bool | None]:
     return id(loop), loop.is_closed()
 
 
-def _conn_creation_info(conn: object) -> tuple[int | None, str | None]:
-    return getattr(conn, "_creation_loop_id", None), getattr(conn, "_creation_loop_repr", None)
+def _conn_creation_info(conn: object) -> tuple[int | None, str | None, str | None]:
+    return (
+        getattr(conn, "_creation_loop_id", None),
+        getattr(conn, "_creation_loop_repr", None),
+        getattr(conn, "_creation_thread_name", None),
+    )
 
 
 def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
@@ -55,10 +60,11 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
                     writer_id = id(writer) if writer else None
                     loop_id = id(loop) if loop else None
                     loop_closed = loop.is_closed() if loop is not None else "n/a"
-                    creation_loop_id, creation_loop_repr = _conn_creation_info(conn)
+                    creation_loop_id, creation_loop_repr, creation_thread_name = _conn_creation_info(conn)
                     lines.append(
                         f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}"
                         f" creation_loop={creation_loop_id} creation_loop_repr={creation_loop_repr!r}"
+                        f" creation_thread={creation_thread_name!r}"
                     )
         else:
             lines.append("  redis pool: <none>")
@@ -76,12 +82,13 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
     diverged: list[str] = []
     for attr in ("_available_connections", "_in_use_connections"):
         for conn in list(getattr(pool, attr, None) or []):
-            creation_loop_id, creation_loop_repr = _conn_creation_info(conn)
+            creation_loop_id, creation_loop_repr, creation_thread_name = _conn_creation_info(conn)
             if creation_loop_id is None or creation_loop_id == current_loop_id:
                 continue
             diverged.append(
                 f"  {attr}: conn={id(conn)} creation_loop={creation_loop_id}"
-                f" creation_loop_repr={creation_loop_repr!r} current_loop={current_loop_id}"
+                f" creation_loop_repr={creation_loop_repr!r} creation_thread={creation_thread_name!r}"
+                f" current_loop={current_loop_id}"
             )
     if diverged:
         print(
@@ -94,11 +101,11 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
 def install_redis_loop_diagnostics() -> None:
     """Monkey-patch redis.asyncio Connection / ConnectionPool to record event-loop identity.
 
-    Stamps `_creation_loop_id` and `_creation_loop_repr` on each Connection right after
-    `_connect` succeeds. The fields survive `Connection.disconnect()`'s `finally:`, so the post-mortem dump can
-    identify which loop the writer was bound to. Also wraps `ConnectionPool.disconnect` to log per-connection
-    loop divergence to stderr *before* the disconnect runs — gives a proactive signal even when the underlying
-    disconnect doesn't raise.
+    Stamps `_creation_loop_id`, `_creation_loop_repr`, and `_creation_thread_name` on each Connection
+    right after `_connect` succeeds. The fields survive `Connection.disconnect()`'s `finally:`, so the
+    post-mortem dump can identify which loop and thread the writer was bound to. Also wraps
+    `ConnectionPool.disconnect` to log per-connection loop divergence to stderr *before* the disconnect
+    runs — gives a proactive signal even when the underlying disconnect doesn't raise.
 
     Idempotent: calling it again is a no-op once the marker is set on both patched targets.
     """
@@ -117,6 +124,7 @@ def install_redis_loop_diagnostics() -> None:
             return
         cast("Any", self)._creation_loop_id = id(loop)
         cast("Any", self)._creation_loop_repr = repr(loop)
+        cast("Any", self)._creation_thread_name = threading.current_thread().name
 
     original_disconnect = ConnectionPool.disconnect
 

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -1,4 +1,4 @@
-# This file should be deleted once the flakiness reason
+# This file should be deleted once the flakiness is gone
 import asyncio
 from sys import stderr
 from traceback import format_exception

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -1,7 +1,25 @@
+# This file should be deleted once the flakiness reason
+import asyncio
 from sys import stderr
 from traceback import format_exception
 
+from redis.asyncio.connection import Connection, ConnectionPool
+
 from infrahub.server import app
+
+_INSTALLED_MARKER = "__diag_installed__"
+
+
+def _current_loop_info() -> tuple[int | None, bool | None]:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None, None
+    return id(loop), loop.is_closed()
+
+
+def _conn_creation_info(conn: object) -> tuple[int | None, str | None]:
+    return getattr(conn, "_creation_loop_id", None), getattr(conn, "_creation_loop_repr", None)
 
 
 def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
@@ -15,6 +33,8 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
     for line in format_exception(type(exc), exc, exc.__traceback__):
         lines.extend(f"    {sub}" for sub in line.rstrip().splitlines())
     try:
+        current_loop_id, current_loop_closed = _current_loop_info()
+        lines.append(f"  current loop: id={current_loop_id} closed={current_loop_closed}")
         service = getattr(app.state, "service", None)
         cache = getattr(service, "_cache", None)
         connection = getattr(cache, "connection", None)
@@ -34,10 +54,79 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
                     writer_id = id(writer) if writer else None
                     loop_id = id(loop) if loop else None
                     loop_closed = loop.is_closed() if loop is not None else "n/a"
-                    lines.append(f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}")
+                    creation_loop_id, creation_loop_repr = _conn_creation_info(conn)
+                    lines.append(
+                        f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}"
+                        f" creation_loop={creation_loop_id} creation_loop_repr={creation_loop_repr!r}"
+                    )
         else:
             lines.append("  redis pool: <none>")
     except Exception as diag_exc:
         lines.append(f"  (diagnostic dump failed: {diag_exc!r})")
 
     print("\n".join(lines), file=stderr, flush=True)
+
+
+def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
+    """Print a stderr line for every pooled connection whose creation loop differs from the running loop."""
+    current_loop_id, _ = _current_loop_info()
+    if current_loop_id is None:
+        return
+    diverged: list[str] = []
+    for attr in ("_available_connections", "_in_use_connections"):
+        for conn in list(getattr(pool, attr, None) or []):
+            creation_loop_id, creation_loop_repr = _conn_creation_info(conn)
+            if creation_loop_id is None or creation_loop_id == current_loop_id:
+                continue
+            diverged.append(
+                f"  {attr}: conn={id(conn)} creation_loop={creation_loop_id}"
+                f" creation_loop_repr={creation_loop_repr!r} current_loop={current_loop_id}"
+            )
+    if diverged:
+        print(
+            "\n".join(["Redis pool disconnect loop divergence detected:", *diverged]),
+            file=stderr,
+            flush=True,
+        )
+
+
+def install_redis_loop_diagnostics() -> None:
+    """Monkey-patch redis.asyncio Connection / ConnectionPool to record event-loop identity.
+
+    Stamps `_creation_loop_id` and `_creation_loop_repr` on each Connection right after
+    `_connect` succeeds. The fields survive `Connection.disconnect()`'s `finally:`, so the post-mortem dump can
+    identify which loop the writer was bound to. Also wraps `ConnectionPool.disconnect` to log per-connection
+    loop divergence to stderr *before* the disconnect runs — gives a proactive signal even when the underlying
+    disconnect doesn't raise.
+
+    Idempotent: calling it again is a no-op once the marker is set on both patched targets.
+    """
+    if getattr(Connection._connect, _INSTALLED_MARKER, False) and getattr(
+        ConnectionPool.disconnect, _INSTALLED_MARKER, False
+    ):
+        return
+
+    original_connect = Connection._connect
+
+    async def _instrumented_connect(self: Connection) -> None:
+        await original_connect(self)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._creation_loop_id = id(loop)
+        self._creation_loop_repr = repr(loop)
+
+    original_disconnect = ConnectionPool.disconnect
+
+    async def _instrumented_disconnect(self: ConnectionPool, inuse_connections: bool = True) -> None:
+        try:
+            _dump_pool_loop_divergence(self)
+        except Exception as diag_exc:
+            print(f"(redis loop divergence dump failed: {diag_exc!r})", file=stderr, flush=True)
+        await original_disconnect(self, inuse_connections=inuse_connections)
+
+    setattr(_instrumented_connect, _INSTALLED_MARKER, True)
+    setattr(_instrumented_disconnect, _INSTALLED_MARKER, True)
+    Connection._connect = _instrumented_connect
+    ConnectionPool.disconnect = _instrumented_disconnect

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -12,6 +12,24 @@ from infrahub.server import app
 _INSTALLED_MARKER = "__diag_installed__"
 _CREATION_STACK_DEPTH = 12
 
+# Maps `id(loop)` to a human-readable label of the subsystem that owns the loop.
+# Populated by `register_known_loop` (e.g. `register_known_loop("pytest-session", loop)` from
+# the autouse pytest fixture). Looked up by `_loop_label` to annotate dumps; without an entry,
+# the dump falls back to `None` for that field. Best-effort: a loop with no registration is
+# still reported by id/repr/thread/stack — the label just won't be human-readable.
+_KNOWN_LOOPS: dict[int, str] = {}
+
+
+def register_known_loop(label: str, loop: asyncio.AbstractEventLoop) -> None:
+    """Tag `loop` with `label` so divergence and post-mortem dumps can name its owner."""
+    _KNOWN_LOOPS[id(loop)] = label
+
+
+def _loop_label(loop_id: int | None) -> str | None:
+    if loop_id is None:
+        return None
+    return _KNOWN_LOOPS.get(loop_id)
+
 
 def _current_loop_info() -> tuple[int | None, bool | None]:
     try:
@@ -50,7 +68,8 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
         lines.extend(f"    {sub}" for sub in line.rstrip().splitlines())
     try:
         current_loop_id, current_loop_closed = _current_loop_info()
-        lines.append(f"  current loop: id={current_loop_id} closed={current_loop_closed}")
+        current_loop_label = _loop_label(current_loop_id)
+        lines.append(f"  current loop: id={current_loop_id} label={current_loop_label!r} closed={current_loop_closed}")
         service = getattr(app.state, "service", None)
         cache = getattr(service, "_cache", None)
         connection = getattr(cache, "connection", None)
@@ -76,9 +95,11 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
                         creation_thread_name,
                         creation_stack,
                     ) = _conn_creation_info(conn)
+                    creation_loop_label = _loop_label(creation_loop_id)
                     lines.append(
                         f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}"
-                        f" creation_loop={creation_loop_id} creation_loop_repr={creation_loop_repr!r}"
+                        f" creation_loop={creation_loop_id} creation_loop_label={creation_loop_label!r}"
+                        f" creation_loop_repr={creation_loop_repr!r}"
                         f" creation_thread={creation_thread_name!r}"
                     )
                     lines.extend(_format_stack_block(creation_stack, indent="        "))
@@ -95,6 +116,7 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
     current_loop_id, _ = _current_loop_info()
     if current_loop_id is None:
         return
+    current_loop_label = _loop_label(current_loop_id)
     diverged: list[str] = []
     for attr in ("_available_connections", "_in_use_connections"):
         for conn in list(getattr(pool, attr, None) or []):
@@ -106,10 +128,12 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
             ) = _conn_creation_info(conn)
             if creation_loop_id is None or creation_loop_id == current_loop_id:
                 continue
+            creation_loop_label = _loop_label(creation_loop_id)
             diverged.append(
                 f"  {attr}: conn={id(conn)} creation_loop={creation_loop_id}"
+                f" creation_loop_label={creation_loop_label!r}"
                 f" creation_loop_repr={creation_loop_repr!r} creation_thread={creation_thread_name!r}"
-                f" current_loop={current_loop_id}"
+                f" current_loop={current_loop_id} current_loop_label={current_loop_label!r}"
             )
             diverged.extend(_format_stack_block(creation_stack, indent="    "))
     if diverged:

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -13,10 +13,6 @@ _INSTALLED_MARKER = "__diag_installed__"
 _CREATION_STACK_DEPTH = 12
 
 # Maps `id(loop)` to a human-readable label of the subsystem that owns the loop.
-# Populated by `register_known_loop` (e.g. `register_known_loop("pytest-session", loop)` from
-# the autouse pytest fixture). Looked up by `_loop_label` to annotate dumps; without an entry,
-# the dump falls back to `None` for that field. Best-effort: a loop with no registration is
-# still reported by id/repr/thread/stack — the label just won't be human-readable.
 _KNOWN_LOOPS: dict[int, str] = {}
 
 

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -2,7 +2,7 @@
 import asyncio
 import threading
 from sys import stderr
-from traceback import format_exception
+from traceback import format_exception, format_stack
 from typing import Any, cast
 
 from redis.asyncio.connection import Connection, ConnectionPool
@@ -10,6 +10,7 @@ from redis.asyncio.connection import Connection, ConnectionPool
 from infrahub.server import app
 
 _INSTALLED_MARKER = "__diag_installed__"
+_CREATION_STACK_DEPTH = 12
 
 
 def _current_loop_info() -> tuple[int | None, bool | None]:
@@ -20,12 +21,21 @@ def _current_loop_info() -> tuple[int | None, bool | None]:
     return id(loop), loop.is_closed()
 
 
-def _conn_creation_info(conn: object) -> tuple[int | None, str | None, str | None]:
+def _conn_creation_info(conn: object) -> tuple[int | None, str | None, str | None, str | None]:
     return (
         getattr(conn, "_creation_loop_id", None),
         getattr(conn, "_creation_loop_repr", None),
         getattr(conn, "_creation_thread_name", None),
+        getattr(conn, "_creation_stack", None),
     )
+
+
+def _format_stack_block(creation_stack: str | None, indent: str) -> list[str]:
+    if not creation_stack:
+        return []
+    block = [f"{indent}creation_stack:"]
+    block.extend(f"{indent}  {line}" for line in creation_stack.rstrip().splitlines())
+    return block
 
 
 def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
@@ -60,12 +70,18 @@ def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
                     writer_id = id(writer) if writer else None
                     loop_id = id(loop) if loop else None
                     loop_closed = loop.is_closed() if loop is not None else "n/a"
-                    creation_loop_id, creation_loop_repr, creation_thread_name = _conn_creation_info(conn)
+                    (
+                        creation_loop_id,
+                        creation_loop_repr,
+                        creation_thread_name,
+                        creation_stack,
+                    ) = _conn_creation_info(conn)
                     lines.append(
                         f"      conn={id(conn)} writer={writer_id} loop={loop_id} loop_closed={loop_closed}"
                         f" creation_loop={creation_loop_id} creation_loop_repr={creation_loop_repr!r}"
                         f" creation_thread={creation_thread_name!r}"
                     )
+                    lines.extend(_format_stack_block(creation_stack, indent="        "))
         else:
             lines.append("  redis pool: <none>")
     except Exception as diag_exc:
@@ -82,7 +98,12 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
     diverged: list[str] = []
     for attr in ("_available_connections", "_in_use_connections"):
         for conn in list(getattr(pool, attr, None) or []):
-            creation_loop_id, creation_loop_repr, creation_thread_name = _conn_creation_info(conn)
+            (
+                creation_loop_id,
+                creation_loop_repr,
+                creation_thread_name,
+                creation_stack,
+            ) = _conn_creation_info(conn)
             if creation_loop_id is None or creation_loop_id == current_loop_id:
                 continue
             diverged.append(
@@ -90,6 +111,7 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
                 f" creation_loop_repr={creation_loop_repr!r} creation_thread={creation_thread_name!r}"
                 f" current_loop={current_loop_id}"
             )
+            diverged.extend(_format_stack_block(creation_stack, indent="    "))
     if diverged:
         print(
             "\n".join(["Redis pool disconnect loop divergence detected:", *diverged]),
@@ -101,11 +123,12 @@ def _dump_pool_loop_divergence(pool: ConnectionPool) -> None:
 def install_redis_loop_diagnostics() -> None:
     """Monkey-patch redis.asyncio Connection / ConnectionPool to record event-loop identity.
 
-    Stamps `_creation_loop_id`, `_creation_loop_repr`, and `_creation_thread_name` on each Connection
-    right after `_connect` succeeds. The fields survive `Connection.disconnect()`'s `finally:`, so the
-    post-mortem dump can identify which loop and thread the writer was bound to. Also wraps
-    `ConnectionPool.disconnect` to log per-connection loop divergence to stderr *before* the disconnect
-    runs — gives a proactive signal even when the underlying disconnect doesn't raise.
+    Stamps `_creation_loop_id`, `_creation_loop_repr`, `_creation_thread_name`, and `_creation_stack`
+    on each Connection right after `_connect` succeeds. The fields survive `Connection.disconnect()`'s
+    `finally:`, so the post-mortem dump can identify which loop and thread the writer was bound to and
+    which call site triggered the connect. Also wraps `ConnectionPool.disconnect` to log per-connection
+    loop divergence to stderr *before* the disconnect runs — gives a proactive signal even when the
+    underlying disconnect doesn't raise.
 
     Idempotent: calling it again is a no-op once the marker is set on both patched targets.
     """
@@ -125,6 +148,9 @@ def install_redis_loop_diagnostics() -> None:
         cast("Any", self)._creation_loop_id = id(loop)
         cast("Any", self)._creation_loop_repr = repr(loop)
         cast("Any", self)._creation_thread_name = threading.current_thread().name
+        # format_stack returns frames oldest-first; drop the topmost (this wrapper) so the
+        # innermost shown frame is the awaiter of `_connect`.
+        cast("Any", self)._creation_stack = "".join(format_stack(limit=_CREATION_STACK_DEPTH)[:-1])
 
     original_disconnect = ConnectionPool.disconnect
 

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -12,7 +12,7 @@ import redis.asyncio as redis
 from redis.asyncio.connection import Connection, ConnectionPool
 
 from tests.helpers import diagnostics
-from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic
+from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic, install_redis_loop_diagnostics
 
 
 @pytest.fixture
@@ -126,6 +126,7 @@ def test_dump_redis_pool_details(
         f"      conn={id(conn_available)} writer={id(closed_writer)} loop={id(closed_loop)} loop_closed=True"
     ) in output
     assert (f"      conn={id(conn_in_use)} writer={id(open_writer)} loop={id(open_loop)} loop_closed=False") in output
+    assert "creation_loop=None creation_loop_repr=None" in output
 
 
 def test_dump_redis_pool_with_empty_connection_buckets(
@@ -191,3 +192,122 @@ def test_dump_surfaces_attribute_error_when_pool_internals_change(
     assert "  redis pool: <redis.asyncio.connection.ConnectionPool(...)>" in output
     assert "  (diagnostic dump failed: AttributeError(" in output
     assert "_available_connections (n=0):" not in output
+
+
+@pytest.fixture
+def reset_diagnostics_install() -> Generator[None, None, None]:
+    """Snapshot and restore the patched redis methods so a test can reinstall
+    from a clean slate without leaking state into other tests."""
+    original_connect = Connection._connect
+    original_disconnect = ConnectionPool.disconnect
+    try:
+        yield
+    finally:
+        Connection._connect = original_connect
+        ConnectionPool.disconnect = original_disconnect
+
+
+async def test_install_stamps_creation_loop_id_on_connection(
+    reset_diagnostics_install: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def stub_connect(self: Connection) -> None:
+        return None
+
+    monkeypatch.setattr(Connection, "_connect", stub_connect)
+
+    install_redis_loop_diagnostics()
+
+    conn = Connection()
+    await conn._connect()
+
+    assert conn._creation_loop_id == id(asyncio.get_running_loop())
+    assert conn._creation_loop_repr == repr(asyncio.get_running_loop())
+
+
+async def test_install_pre_disconnect_logs_loop_divergence(
+    reset_diagnostics_install: None, monkeypatch: pytest.MonkeyPatch, captured_stderr: io.StringIO
+) -> None:
+    disconnected: list[ConnectionPool] = []
+
+    async def stub_disconnect(self: ConnectionPool, inuse_connections: bool = True) -> None:
+        disconnected.append(self)
+
+    monkeypatch.setattr(ConnectionPool, "disconnect", stub_disconnect)
+
+    install_redis_loop_diagnostics()
+
+    pool = ConnectionPool()
+    foreign_loop_id = id(asyncio.get_running_loop()) + 1  # guaranteed to differ
+    conn = Connection()
+    conn._creation_loop_id = foreign_loop_id
+    conn._creation_loop_repr = "<FakeLoop running=False>"
+    pool._available_connections.append(conn)
+
+    await pool.disconnect()
+
+    output = captured_stderr.getvalue()
+    assert "Redis pool disconnect loop divergence detected:" in output
+    assert f"creation_loop={foreign_loop_id}" in output
+    assert "creation_loop_repr='<FakeLoop running=False>'" in output
+    assert disconnected == [pool]  # original disconnect still runs
+
+
+async def test_install_pre_disconnect_silent_when_no_divergence(
+    reset_diagnostics_install: None, monkeypatch: pytest.MonkeyPatch, captured_stderr: io.StringIO
+) -> None:
+    async def stub_disconnect(self: ConnectionPool, inuse_connections: bool = True) -> None:
+        return None
+
+    monkeypatch.setattr(ConnectionPool, "disconnect", stub_disconnect)
+
+    install_redis_loop_diagnostics()
+
+    pool = ConnectionPool()
+    conn = Connection()
+    conn._creation_loop_id = id(asyncio.get_running_loop())
+    conn._creation_loop_repr = repr(asyncio.get_running_loop())
+    pool._available_connections.append(conn)
+
+    await pool.disconnect()
+
+    assert "loop divergence" not in captured_stderr.getvalue()
+
+
+def test_install_is_idempotent(reset_diagnostics_install: None) -> None:
+    install_redis_loop_diagnostics()
+    first_connect = Connection._connect
+    first_disconnect = ConnectionPool.disconnect
+
+    install_redis_loop_diagnostics()
+
+    assert Connection._connect is first_connect
+    assert ConnectionPool.disconnect is first_disconnect
+    assert getattr(Connection._connect, diagnostics._INSTALLED_MARKER, False) is True
+    assert getattr(ConnectionPool.disconnect, diagnostics._INSTALLED_MARKER, False) is True
+
+
+def test_dump_includes_creation_loop_when_stamped(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    pool = ConnectionPool()
+    conn = Connection()
+    conn._creation_loop_id = 424242
+    conn._creation_loop_repr = "<StampedLoop>"
+    pool._available_connections.append(conn)
+    install_service_pool(pool)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert "creation_loop=424242 creation_loop_repr='<StampedLoop>'" in output
+
+
+async def test_dump_prints_current_loop(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    install_service_pool(None)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert f"  current loop: id={id(asyncio.get_running_loop())} closed=False" in output

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -14,7 +14,25 @@ import redis.asyncio as redis
 from redis.asyncio.connection import Connection, ConnectionPool
 
 from tests.helpers import diagnostics
-from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic, install_redis_loop_diagnostics
+from tests.helpers.diagnostics import (
+    dump_event_loop_closed_diagnostic,
+    install_redis_loop_diagnostics,
+    register_known_loop,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_known_loops() -> Generator[None, None, None]:
+    """Snapshot and clear the loop-label registry around each test so the session-scope
+    `_register_pytest_session_loop` fixture (and any registrations from other tests) do
+    not leak into substring assertions here."""
+    snapshot = diagnostics._KNOWN_LOOPS.copy()
+    diagnostics._KNOWN_LOOPS.clear()
+    try:
+        yield
+    finally:
+        diagnostics._KNOWN_LOOPS.clear()
+        diagnostics._KNOWN_LOOPS.update(snapshot)
 
 
 @pytest.fixture
@@ -128,7 +146,7 @@ def test_dump_redis_pool_details(
         f"      conn={id(conn_available)} writer={id(closed_writer)} loop={id(closed_loop)} loop_closed=True"
     ) in output
     assert (f"      conn={id(conn_in_use)} writer={id(open_writer)} loop={id(open_loop)} loop_closed=False") in output
-    assert "creation_loop=None creation_loop_repr=None creation_thread=None" in output
+    assert "creation_loop=None creation_loop_label=None creation_loop_repr=None creation_thread=None" in output
 
 
 def test_dump_redis_pool_with_empty_connection_buckets(
@@ -315,7 +333,10 @@ def test_dump_includes_creation_loop_when_stamped(
     dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
 
     output = captured_stderr.getvalue()
-    assert "creation_loop=424242 creation_loop_repr='<StampedLoop>' creation_thread='StampedThread'" in output
+    assert (
+        "creation_loop=424242 creation_loop_label=None creation_loop_repr='<StampedLoop>'"
+        " creation_thread='StampedThread'"
+    ) in output
     assert "        creation_stack:" in output
     assert '          File "stamped.py", line 9, in stamped_call' in output
 
@@ -328,4 +349,61 @@ async def test_dump_prints_current_loop(
     dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
 
     output = captured_stderr.getvalue()
-    assert f"  current loop: id={id(asyncio.get_running_loop())} closed=False" in output
+    assert f"  current loop: id={id(asyncio.get_running_loop())} label=None closed=False" in output
+
+
+async def test_register_known_loop_labels_current_loop_in_dump(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    register_known_loop("pytest-session", asyncio.get_running_loop())
+    install_service_pool(None)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    output = captured_stderr.getvalue()
+    assert f"  current loop: id={id(asyncio.get_running_loop())} label='pytest-session' closed=False" in output
+
+
+def test_dump_uses_label_for_known_creation_loop(
+    install_service_pool: Callable[[ConnectionPool | None], None], captured_stderr: io.StringIO
+) -> None:
+    diagnostics._KNOWN_LOOPS[424242] = "prefect-worker"
+    pool = ConnectionPool()
+    conn = Connection()
+    cast("Any", conn)._creation_loop_id = 424242
+    cast("Any", conn)._creation_loop_repr = "<StampedLoop>"
+    cast("Any", conn)._creation_thread_name = "StampedThread"
+    pool._available_connections.append(conn)
+    install_service_pool(pool)
+
+    dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
+
+    assert "creation_loop=424242 creation_loop_label='prefect-worker'" in captured_stderr.getvalue()
+
+
+async def test_pre_disconnect_dump_includes_known_loop_labels(
+    reset_diagnostics_install: None, monkeypatch: pytest.MonkeyPatch, captured_stderr: io.StringIO
+) -> None:
+    async def stub_disconnect(self: ConnectionPool, inuse_connections: bool = True) -> None:
+        return None
+
+    monkeypatch.setattr(ConnectionPool, "disconnect", stub_disconnect)
+
+    register_known_loop("pytest-session", asyncio.get_running_loop())
+    foreign_loop_id = id(asyncio.get_running_loop()) + 1
+    diagnostics._KNOWN_LOOPS[foreign_loop_id] = "prefect-worker"
+
+    install_redis_loop_diagnostics()
+
+    pool = ConnectionPool()
+    conn = Connection()
+    cast("Any", conn)._creation_loop_id = foreign_loop_id
+    cast("Any", conn)._creation_loop_repr = "<ForeignLoop>"
+    cast("Any", conn)._creation_thread_name = "ForeignThread"
+    pool._available_connections.append(conn)
+
+    await pool.disconnect()
+
+    output = captured_stderr.getvalue()
+    assert "creation_loop_label='prefect-worker'" in output
+    assert "current_loop_label='pytest-session'" in output

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -5,7 +5,7 @@ import contextlib
 import io
 import socket
 from types import SimpleNamespace
-from typing import Callable, Generator
+from typing import Any, Callable, Generator, cast
 
 import pytest
 import redis.asyncio as redis
@@ -203,8 +203,8 @@ def reset_diagnostics_install() -> Generator[None, None, None]:
     try:
         yield
     finally:
-        Connection._connect = original_connect
-        ConnectionPool.disconnect = original_disconnect
+        cast("Any", Connection)._connect = original_connect
+        cast("Any", ConnectionPool).disconnect = original_disconnect
 
 
 async def test_install_stamps_creation_loop_id_on_connection(
@@ -220,8 +220,8 @@ async def test_install_stamps_creation_loop_id_on_connection(
     conn = Connection()
     await conn._connect()
 
-    assert conn._creation_loop_id == id(asyncio.get_running_loop())
-    assert conn._creation_loop_repr == repr(asyncio.get_running_loop())
+    assert cast("Any", conn)._creation_loop_id == id(asyncio.get_running_loop())
+    assert cast("Any", conn)._creation_loop_repr == repr(asyncio.get_running_loop())
 
 
 async def test_install_pre_disconnect_logs_loop_divergence(
@@ -239,8 +239,8 @@ async def test_install_pre_disconnect_logs_loop_divergence(
     pool = ConnectionPool()
     foreign_loop_id = id(asyncio.get_running_loop()) + 1  # guaranteed to differ
     conn = Connection()
-    conn._creation_loop_id = foreign_loop_id
-    conn._creation_loop_repr = "<FakeLoop running=False>"
+    cast("Any", conn)._creation_loop_id = foreign_loop_id
+    cast("Any", conn)._creation_loop_repr = "<FakeLoop running=False>"
     pool._available_connections.append(conn)
 
     await pool.disconnect()
@@ -264,8 +264,8 @@ async def test_install_pre_disconnect_silent_when_no_divergence(
 
     pool = ConnectionPool()
     conn = Connection()
-    conn._creation_loop_id = id(asyncio.get_running_loop())
-    conn._creation_loop_repr = repr(asyncio.get_running_loop())
+    cast("Any", conn)._creation_loop_id = id(asyncio.get_running_loop())
+    cast("Any", conn)._creation_loop_repr = repr(asyncio.get_running_loop())
     pool._available_connections.append(conn)
 
     await pool.disconnect()
@@ -291,8 +291,8 @@ def test_dump_includes_creation_loop_when_stamped(
 ) -> None:
     pool = ConnectionPool()
     conn = Connection()
-    conn._creation_loop_id = 424242
-    conn._creation_loop_repr = "<StampedLoop>"
+    cast("Any", conn)._creation_loop_id = 424242
+    cast("Any", conn)._creation_loop_repr = "<StampedLoop>"
     pool._available_connections.append(conn)
     install_service_pool(pool)
 

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -1,5 +1,6 @@
 """Tests for the diagnostic helper in tests.helpers.diagnostics."""
 
+# This file should be deleted once the flakiness is gone
 import asyncio
 import contextlib
 import io

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import io
 import socket
+import threading
 from types import SimpleNamespace
 from typing import Any, Callable, Generator, cast
 
@@ -127,7 +128,7 @@ def test_dump_redis_pool_details(
         f"      conn={id(conn_available)} writer={id(closed_writer)} loop={id(closed_loop)} loop_closed=True"
     ) in output
     assert (f"      conn={id(conn_in_use)} writer={id(open_writer)} loop={id(open_loop)} loop_closed=False") in output
-    assert "creation_loop=None creation_loop_repr=None" in output
+    assert "creation_loop=None creation_loop_repr=None creation_thread=None" in output
 
 
 def test_dump_redis_pool_with_empty_connection_buckets(
@@ -223,6 +224,7 @@ async def test_install_stamps_creation_loop_id_on_connection(
 
     assert cast("Any", conn)._creation_loop_id == id(asyncio.get_running_loop())
     assert cast("Any", conn)._creation_loop_repr == repr(asyncio.get_running_loop())
+    assert cast("Any", conn)._creation_thread_name == threading.current_thread().name
 
 
 async def test_install_pre_disconnect_logs_loop_divergence(
@@ -242,6 +244,7 @@ async def test_install_pre_disconnect_logs_loop_divergence(
     conn = Connection()
     cast("Any", conn)._creation_loop_id = foreign_loop_id
     cast("Any", conn)._creation_loop_repr = "<FakeLoop running=False>"
+    cast("Any", conn)._creation_thread_name = "ForeignThread-7"
     pool._available_connections.append(conn)
 
     await pool.disconnect()
@@ -250,6 +253,7 @@ async def test_install_pre_disconnect_logs_loop_divergence(
     assert "Redis pool disconnect loop divergence detected:" in output
     assert f"creation_loop={foreign_loop_id}" in output
     assert "creation_loop_repr='<FakeLoop running=False>'" in output
+    assert "creation_thread='ForeignThread-7'" in output
     assert disconnected == [pool]  # original disconnect still runs
 
 
@@ -294,13 +298,14 @@ def test_dump_includes_creation_loop_when_stamped(
     conn = Connection()
     cast("Any", conn)._creation_loop_id = 424242
     cast("Any", conn)._creation_loop_repr = "<StampedLoop>"
+    cast("Any", conn)._creation_thread_name = "StampedThread"
     pool._available_connections.append(conn)
     install_service_pool(pool)
 
     dump_event_loop_closed_diagnostic("nid", _caught_runtime_error())
 
     output = captured_stderr.getvalue()
-    assert "creation_loop=424242 creation_loop_repr='<StampedLoop>'" in output
+    assert "creation_loop=424242 creation_loop_repr='<StampedLoop>' creation_thread='StampedThread'" in output
 
 
 async def test_dump_prints_current_loop(

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -225,6 +225,12 @@ async def test_install_stamps_creation_loop_id_on_connection(
     assert cast("Any", conn)._creation_loop_id == id(asyncio.get_running_loop())
     assert cast("Any", conn)._creation_loop_repr == repr(asyncio.get_running_loop())
     assert cast("Any", conn)._creation_thread_name == threading.current_thread().name
+    creation_stack = cast("Any", conn)._creation_stack
+    assert isinstance(creation_stack, str)
+    assert creation_stack
+    # Topmost frame (the wrapper itself) is dropped — innermost should be the awaiter.
+    assert "_instrumented_connect" not in creation_stack
+    assert "test_install_stamps_creation_loop_id_on_connection" in creation_stack
 
 
 async def test_install_pre_disconnect_logs_loop_divergence(
@@ -245,6 +251,7 @@ async def test_install_pre_disconnect_logs_loop_divergence(
     cast("Any", conn)._creation_loop_id = foreign_loop_id
     cast("Any", conn)._creation_loop_repr = "<FakeLoop running=False>"
     cast("Any", conn)._creation_thread_name = "ForeignThread-7"
+    cast("Any", conn)._creation_stack = '  File "fake.py", line 1, in fake_call\n    await connect()\n'
     pool._available_connections.append(conn)
 
     await pool.disconnect()
@@ -254,6 +261,8 @@ async def test_install_pre_disconnect_logs_loop_divergence(
     assert f"creation_loop={foreign_loop_id}" in output
     assert "creation_loop_repr='<FakeLoop running=False>'" in output
     assert "creation_thread='ForeignThread-7'" in output
+    assert "    creation_stack:" in output
+    assert '      File "fake.py", line 1, in fake_call' in output
     assert disconnected == [pool]  # original disconnect still runs
 
 
@@ -299,6 +308,7 @@ def test_dump_includes_creation_loop_when_stamped(
     cast("Any", conn)._creation_loop_id = 424242
     cast("Any", conn)._creation_loop_repr = "<StampedLoop>"
     cast("Any", conn)._creation_thread_name = "StampedThread"
+    cast("Any", conn)._creation_stack = '  File "stamped.py", line 9, in stamped_call\n    await x()\n'
     pool._available_connections.append(conn)
     install_service_pool(pool)
 
@@ -306,6 +316,8 @@ def test_dump_includes_creation_loop_when_stamped(
 
     output = captured_stderr.getvalue()
     assert "creation_loop=424242 creation_loop_repr='<StampedLoop>' creation_thread='StampedThread'" in output
+    assert "        creation_stack:" in output
+    assert '          File "stamped.py", line 9, in stamped_call' in output
 
 
 async def test_dump_prints_current_loop(


### PR DESCRIPTION
### Why

CI occasionally fails with `RuntimeError: Event loop is closed` during `test_client` teardown ([example](https://github.com/opsmill/infrahub/actions/runs/25103323984/job/73558143027?pr=9084)).

#9022 added a stderr dump, but it runs *after* redis-py's `Connection.disconnect()` `finally:` clause nulls `_writer`/`_reader`. The dump shows `writer=None loop=None`. Therefore, the loop the writer was actually bound to is hidden. This is the one fact we need to identify the offender (Prefect worker loop? executor loop? `asyncio.run` site?).

### What

Test-only additions on top of #9022 and no production code changes.

#### Additional information
When redis-py creates a new connection, we now record a snapshot of context against the connection itself: an identifier and a short textual description of the event loop the writer was bound to, the name of the thread the connect ran on, and a small call stack pointing at whatever code triggered the connect.

#### Loop mismatch detection
When a pool is disconnected we also intercept the call. If any pooled connection was created on a different loop than the one currently running, we log a divergence line per connection.

#### Loop human friendly label registry
Finally, a small registry maps loop identifiers to human-readable labels, with the pytest-asyncio session loop tagged once at startup. Both dump paths consult the registry so a divergence between two loops shows up as named subsystems rather than two opaque integers.

Installation runs once per test session via an autouse fixture and is safe to call repeatedly.

## What the next CI hit will show

Two stderr blocks instead of one:

- **Pre-disconnect** — a divergence block listing every connection whose creation loop is not the current loop, with the loop id, the registry label if known, the loop's textual description, the thread the connect ran on, and an indented call-stack sub-block.
- **Post-mortem** — the existing dump, now annotated per connection with the same set of creation-time fields, plus a top-level line naming the current loop's id, label, and closed state.

What actually identifies the owner of an orphaned writer:

- The registry label, when the foreign loop matches a known subsystem.
- The thread name, which usually distinguishes a Prefect worker, an executor pool worker, and the main thread.
- The captured call stack, which points at the synchronous awaiter of the connect.
- The loop id and textual description

## Example pre-disconnect output (loop divergence case)

```
Redis pool disconnect loop divergence detected:
  _available_connections: conn=4391928112 creation_loop=4391851520 creation_loop_label=None creation_loop_repr='<_UnixSelectorEventLoop running=False closed=True debug=False>' creation_thread='ThreadPoolExecutor-0_0' current_loop=4399238400 current_loop_label='pytest-session'
    creation_stack:
      File ".../prefect/utilities/asyncutils.py", line 213, in run_coro_as_sync
        return call.result()
      File ".../prefect/_internal/concurrency/calls.py", line 312, in result
        return self.future.result(timeout=timeout)
      File ".../infrahub/services/adapters/cache/redis.py", line 41, in get
        result = await self._client.get(key)
      File ".../redis/asyncio/client.py", line 612, in execute_command
        conn = await self.connection_pool.get_connection(...)
```

If every pooled connection's creation loop matches the current loop, nothing is printed.

To delete once the flakiness is identified and fixed.