### PR TITLE
improve frontend knowledge

### DIFF
--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -33,6 +33,31 @@
 
 [Gates determined based on constitution file]
 
+### Frontend principles (apply when feature includes UI)
+
+| Principle | Status | Notes |
+|---|---|---|
+| Reuse Before Reinvent | | New UI primitives require justification in Complexity Tracking. List shared components consumed (see "Shared Components Inventory" below). |
+| Single State Owner | | URL params owned by page, form state owned by `useForm`, server data owned by TanStack Query. No mirrored `useState` between page and selectors. |
+| Backend Authoritative | | No client-side duplication of server-side defaults, filters, or hidden lists. |
+| Component Contracts Designed for All Callers | | Visualizations / panels reused across modes have prop APIs that support every caller from day one (no synthetic-prop hacks). |
+| E2E Happy Path | | New pages ship with at least one full-flow Playwright test, not just static-text checks. |
+
+### Shared Components Inventory (frontend features only)
+
+*REQUIRED before writing tasks for any frontend feature. Forces discovery of existing primitives.*
+
+List the shared components, hooks, and entity exports this feature will consume. Cross-reference `dev/knowledge/frontend/shared-components.md` and `dev/knowledge/frontend/design-system.md`.
+
+| Need | Reusing | Source |
+|---|---|---|
+| [e.g., pick a peer object] | `PeerInput` | `shared/components/inputs/peer.tsx` |
+| [e.g., resolve UUID] | `useGetObject` | re-exported via `peer.field.tsx` |
+| [e.g., card surface] | `Card` / `CardHeader` / `CardContent` | `@infrahub/ui` |
+| [e.g., kind selector] | `NodeKindField` | `shared/components/form/fields/node-kind.field.tsx` |
+
+If a row reads "(building new)", add a Complexity Tracking entry justifying it.
+
 ## Project Structure
 
 ### Documentation (this feature)

--- a/dev/guidelines/frontend/component-patterns.md
+++ b/dev/guidelines/frontend/component-patterns.md
@@ -2,6 +2,37 @@
 
 > Part of: `dev/guidelines/frontend/`
 
+## Reuse Before Reinvent
+
+Before creating a new picker, combobox, kind selector, card, modal, button, form input, or any component that "feels generic", consult the inventories:
+
+1. `dev/knowledge/frontend/shared-components.md` — full primitive map
+2. `dev/knowledge/frontend/design-system.md` — `@infrahub/ui` package
+3. `rg -i "<name>" frontend/app/src/shared/components/`
+4. `rg -i "<name>" frontend/packages/ui/src/components/`
+
+If a primitive matches 80%+ of what you need, **wrap or extend it** instead of writing a new one. Examples:
+
+- Need a peer picker with a paste-UUID toggle? Wrap `PeerInput` and add the toggle.
+- Need a card with a custom header slot? Extend `Card`/`CardHeader` in `@infrahub/ui`, not in feature code.
+- Need a single-object lookup by UUID? Use `useGetObject` — never hand-roll a `gql` string.
+
+If you genuinely need a new primitive:
+
+- Justify it in the PR description ("evaluated `PeerInput`, `Combobox`, `RelationshipComboboxList` — none cover X because Y").
+- Add an entry to `shared-components.md` so the next person finds it.
+- Place it in `shared/components/` (not in an entity) if it's reusable. Place it in `frontend/packages/ui/` if it's generic enough for any surface.
+
+### Anti-patterns
+
+| Anti-pattern | Replacement |
+|---|---|
+| `<section className="rounded-md border bg-white p-4 shadow-lg">…</section>` | `Card` from `@infrahub/ui` |
+| Hand-rolled `gql` + `graphqlClient.query(...)` for a single node | `useGetObject({ objectId, objectSchema: { kind: "CoreNode" } })` |
+| Reinvented kind combobox + object combobox | Wrap `PeerInput` (`shared/components/inputs/peer.tsx`) |
+| Custom dialog with focus trap | `Modal` from `@infrahub/ui` |
+| `<button className="bg-custom-blue-700 …">` | `Button` from `@infrahub/ui` |
+
 ## Early Return Style
 
 Use early returns instead of nested ternaries for components with multiple states.

--- a/dev/guidelines/frontend/naming-conventions.md
+++ b/dev/guidelines/frontend/naming-conventions.md
@@ -42,3 +42,22 @@
 - Tests: colocate with source, never in `__tests__/`
 - Types: `{noun}.types.ts` in entity `domain/`, or inline in component
 - Avoid `index.ts` barrel exports; prefer direct imports
+
+## Query Keys
+
+Build query keys from a single object, not positional spreads. Object-shaped keys are easier to read in devtools, easier to invalidate by partial match, and easier to diff.
+
+```ts
+// ✅ Good
+export const pathTraversalKeys = {
+  all: ["path-traversal"] as const,
+  traverse: (params: { sourceId: string; destinationId: string; maxDepth: number }) =>
+    [...pathTraversalKeys.all, "traverse", params] as const,
+};
+
+// ❌ Bad: positional spread
+traverse: (sourceId, destinationId, maxDepth) =>
+  [...pathTraversalKeys.all, "traverse", sourceId, destinationId, maxDepth] as const,
+```
+
+Partial invalidation works naturally with the object form: `queryClient.invalidateQueries({ queryKey: pathTraversalKeys.all })`.

--- a/dev/guidelines/frontend/page-architecture.md
+++ b/dev/guidelines/frontend/page-architecture.md
@@ -1,0 +1,114 @@
+# Page Architecture
+
+> Part of: `dev/guidelines/frontend/`
+
+Rules for structuring page components and the forms / panels they contain. These exist because a recent feature (see PR #9099, path-traversal) shipped a 500+ line page that owned URL sync, clipboard helpers, formatters, mode routing, and rendering simultaneously, and duplicated `useState` between the page and its selector subcomponents.
+
+## State ownership
+
+Every piece of state has exactly one owner. When in doubt, push it up; never duplicate.
+
+| State | Owner | Mechanism |
+|---|---|---|
+| URL-shareable parameters (filters, current selection, mode) | Page | `useFilters` or `nuqs` |
+| Form fields (in-flight edits before submit) | Form | `react-hook-form` `useForm` |
+| Server data | TanStack Query cache | `ui/queries/*.query.ts` |
+| Cross-page global state | Jotai atoms | `shared/stores/` or `entities/*/stores.ts` |
+| Local UI state (open/closed, hover) | Component | `useState` |
+
+### Forbidden patterns
+
+- **Page `useState` shadowed by selector `useState` for the same field.** Lift to a single owner. If the selector is a form, expose `onSubmit(values)` and let the page commit the values to the URL.
+- **`useEffect` to copy props into local state.** Derive during render or use `defaultValues` on the form.
+- **Reading `searchParams` in two places.** One hook call per param, at the page level. Pass values down.
+
+## Pages own URL sync
+
+The page component is the binding layer between the URL and the rest of the tree. It:
+
+1. Reads URL params via `useFilters` / `nuqs`.
+2. Decides which mode/sub-tree to render.
+3. Passes values to forms as `defaultValues` and to data hooks as query inputs.
+4. Receives form submissions and writes back to the URL.
+
+Children should not call `useSearchParams` for state the page already owns.
+
+## Forms own form state
+
+A form component:
+
+1. Calls `useForm({ defaultValues })` once.
+2. Renders fields with `FormField` / `.field.tsx` primitives.
+3. Calls `onSubmit(values)` on submit; does not write to the URL itself.
+4. Does not mirror its own values into a `useState` — the form is the source of truth.
+
+If the form is also a query builder (e.g. path traversal), the page receives submitted values and either updates the URL or directly enables a query.
+
+## Component size budget
+
+Soft budgets, not hard limits. If you cross them, ask whether you have multiple concerns mashed into one file.
+
+| File type | Soft budget | Action when exceeded |
+|---|---|---|
+| Page component | ~250 lines | Split into mode subtrees or extract panels. |
+| Form component | ~300 lines | Extract field groups or move pure helpers to `utils.ts`. |
+| Selector / picker | ~200 lines | Check if a shared primitive exists (`PeerInput`, `Combobox`). Reuse first. |
+| Generic primitive | ~150 lines | Refactor into composition, not configuration. |
+
+## Pure helpers belong in `utils.ts` and have unit tests
+
+If a function is pure (no React, no fetch), it does not belong in a `.tsx` component file. Move it to the entity's `utils.ts` (or `domain/`) and write a Vitest test.
+
+Examples of helpers that should live in `utils.ts`:
+
+- Formatters (`format*`, `*Preview`)
+- Clipboard helpers (`copyAllAsText`, `formatAsText`)
+- Mappers between API and UI shapes
+- Aggregations (`getKindCounts`, `groupByX`)
+- Color/icon resolvers (`getKindColor`, `getKindIcon`)
+
+`dev/guides/frontend/writing-unit-tests.md` covers the test setup.
+
+## Concern separation: the "split when you see it" list
+
+Move these out of the page component the moment you write them:
+
+- Pure formatters → `utils.ts`
+- Clipboard / `navigator.*` helpers → `utils.ts` (or a small hook if stateful)
+- API mappers → `domain/`
+- React Query hooks → `ui/queries/`
+- Subtree-specific UI when modes diverge → separate component (`<PathMode />`, `<ImpactMode />`)
+
+## Component contracts: design for both callers from the start
+
+When two modes/features will share a visualization or panel, design the contract for both *before* shipping the first one. Example from PR #9099: a graph component shipped with `destination` as a required prop; when a second mode arrived without a single destination, the only fix was fabricating a synthetic value — a smell that traces back to the original prop design.
+
+Rule: if a second caller is in the spec at all, the prop API must support it on the first iteration. Make optional what is genuinely optional.
+
+## Backend is authoritative
+
+If the backend already filters, transforms, or defaults something, do not duplicate it on the client. Examples:
+
+- Default namespace exclusions for traversal (Core/Internal/Builtin/Lineage/Profile/Template) are server-side. The client must not maintain a parallel `HIDDEN_NAMESPACES` list.
+- Schema kinds and their hidden flags come from `useGetSchema`. Do not hardcode them.
+- Sort order, pagination defaults, and access checks belong to the server.
+
+If the client needs to *display* a server-side default, surface it via the API (extend a query or response field) rather than mirroring the constant.
+
+## Anti-patterns observed in past PRs
+
+| Anti-pattern | Replacement |
+|---|---|
+| 500+ line page mixing URL sync, formatters, clipboard, modes, rendering (PR #9099) | Split into mode components + `utils.ts` + dedicated form |
+| Two selectors each owning a copy of the same `sourceId/maxDepth/...` via `useState` (PR #9099) | Single form (or controlled inputs from page); no `useState` mirror |
+| Mapper fabricating a synthetic destination to satisfy a required prop (PR #9099) | Make the prop optional on the visualization API |
+| Two selectors with ~50% duplicated UI | Extract a `KindMultiSelect` / shared block once both exist |
+| Hand-rolling `gql` + `graphqlClient.query` in a `ui/` file | Use the entity layer (`useGetObject`, `ui/queries/`) |
+| Hardcoding `HIDDEN_NAMESPACES` on the client | Backend-authoritative; surface via schema if needed |
+
+## See also
+
+- `dev/knowledge/frontend/entities-structure.md` — three-layer api/domain/ui architecture
+- `dev/knowledge/frontend/shared-components.md` — reuse-first inventory
+- `dev/guidelines/frontend/component-patterns.md` — early returns and layout extraction
+- `dev/guidelines/frontend/object-forms.md` — form field patterns and `react-hook-form` usage

--- a/dev/guides/frontend/writing-e2e-tests.md
+++ b/dev/guides/frontend/writing-e2e-tests.md
@@ -16,6 +16,18 @@ Write E2E tests when you need to:
 
 **Note**: For testing isolated components, see [Writing Component Tests](writing-component-tests.md). E2E tests should cover integration flows, not individual component behavior.
 
+## Minimum bar for new pages
+
+Every new page added under `frontend/app/src/pages/` ships with **at least one happy-path E2E test** that exercises the full flow:
+
+1. Navigate to the page.
+2. Perform the primary user action (select inputs, submit, etc.).
+3. Assert the resulting rendered output (rows, nodes, charts, count, etc.).
+
+A test that only checks static text visibility ("page heading is visible") does not satisfy this bar. Without an end-to-end assertion on rendered data, regressions in fetch logic, query key invalidation, or visualization wiring can ship undetected.
+
+For features with multiple modes (e.g. a `mode=path` vs `mode=impact` toggle), the happy path for each mode counts as one test.
+
 ## Prerequisites
 
 - Understanding of [Playwright](https://playwright.dev/) test framework

--- a/dev/knowledge/frontend/design-system.md
+++ b/dev/knowledge/frontend/design-system.md
@@ -1,0 +1,77 @@
+# Design System (`@infrahub/ui`)
+
+> Part of: `dev/knowledge/frontend/`
+
+Location: `frontend/packages/ui/`
+
+`@infrahub/ui` is the in-repo design-system package. Components live there once they are stable, accessible, themeable, and shared across the app, Storybook, and any future surfaces (admin UI, embedded views, docs site).
+
+The package is published locally via the workspace and consumed in `frontend/app` as `@infrahub/ui`.
+
+## What's in the package today
+
+| Component | Exports | Notes |
+|---|---|---|
+| `Button` | `Button`, `LinkButton`, `buttonVariants`, `ButtonProps`, `LinkButtonProps` | Migrated in #9065. Replaces ad-hoc `<button>` with Tailwind classes. |
+| `Card` | `Card`, `CardHeader`, `CardContent`, `CardProps`, `CardHeaderProps`, `CardContentProps` | Migrated in #9048. Replaces hand-rolled `<section className="rounded-md border bg-white p-4 shadow-lg">` patterns. |
+| `Modal` | `Modal`, `ModalOverlay`, `ModalProps`, `ModalOverlayProps` | Migrated in #9088. Use instead of HeadlessUI Dialog for new modals. |
+| `Spinner` | `Spinner`, `SpinnerProps` | Loading indicator. |
+| `Meter` | `Meter`, `MeterProps` | Migrated in #9100. Replaces ad-hoc progress-bar charts. |
+| `ScrollArea` | `ScrollArea`, `ScrollAreaProps` | Migrated in #9101. Replaces `shared/components/ui/scroll-area`. |
+
+Source of truth: `frontend/packages/ui/src/index.ts`.
+
+## When to consume from `@infrahub/ui`
+
+Always, for the components above. Do not reimplement them inline in feature code, even if it "feels lighter":
+
+- Card visual: bordered + rounded + shadow + padded surface.
+- Button visual: any clickable styled button.
+- Modal: any dialog/overlay.
+- Spinner: any loading indicator.
+
+If a component needs a slot the package doesn't expose yet, **extend the package** rather than forking the markup in feature code. Open a PR against `frontend/packages/ui/`.
+
+## When to consume from `shared/components/ui/`
+
+`frontend/app/src/shared/components/ui/` contains primitives that have not yet been migrated. They are still the canonical implementation for now. Examples: `combobox`, `popover`, `tooltip`, `dropdown-menu`, `badge`, `alert`, `accordion`, `pagination`, `resizable`, `command`.
+
+When you touch one of these and notice it could be a generic primitive, consider migrating it to `@infrahub/ui` as part of the change.
+
+## Migration policy
+
+- Net-new generic primitives (no Infrahub-specific data dependencies) should land in `@infrahub/ui` from day one.
+- Existing primitives in `shared/components/ui/` are migrated incrementally — see PRs #9048 (Card), #9065 (Button), #9088 (Modal) as references.
+- Migration PRs include: the component, its Storybook story, focus-visible styles, and call-site updates across the app.
+
+## Storybook
+
+Each migrated component ships with a `*.stories.tsx`. Run Storybook from `frontend/packages/ui/` to preview variants before consuming. Stories double as the contract documentation: if a variant isn't in the story, treat it as not-yet-supported.
+
+## Anti-patterns
+
+| Anti-pattern | Why it's wrong |
+|---|---|
+| Re-implementing the card shell inline (`<section className="rounded-md border …">`) | Drift between callers, no shared theming, no a11y review. Use `Card` from `@infrahub/ui`. |
+| Wrapping `Button` from `@infrahub/ui` to add a single class | Use `className` prop or extend variants in the package. |
+| Importing `Button` / `Card` / `Modal` / `Spinner` from anywhere except `@infrahub/ui` | The shared packages are deduplicated for a reason — bundle size and styling consistency. |
+| Adding a one-off `<dialog>` because Modal feels heavy | Use `Modal` — it handles focus trap, escape, and overlay. |
+
+## Discovery commands
+
+```bash
+# What's exported from @infrahub/ui?
+cat frontend/packages/ui/src/index.ts
+
+# What components have Storybook stories?
+ls frontend/packages/ui/src/components/*/
+
+# Where in the app is a primitive consumed?
+rg "from \"@infrahub/ui\"" frontend/app/src
+```
+
+## See also
+
+- `dev/knowledge/frontend/shared-components.md` — full primitive inventory
+- `dev/guidelines/frontend/styling.md` — Tailwind, CVA, layout primitives
+- `dev/guidelines/frontend/component-patterns.md` — early-return + extraction patterns

--- a/dev/knowledge/frontend/entities-structure.md
+++ b/dev/knowledge/frontend/entities-structure.md
@@ -99,6 +99,29 @@ import { getSchemaFromApi } from "@/entities/schema/api/get-schema-from-api"; //
 
 Mappers are optional. Use them only when transformation is non-trivial (more than 5-6 lines of field access). For simple entities, inline the transformation in the domain async function.
 
+## GraphQL fetching: go through the entity layer
+
+The `ui/` layer **never** builds `gql` strings inline or calls `graphqlClient.query` directly. Either:
+
+1. Use a hook from another entity's `ui/queries/` (e.g. `useGetObject` from `entities/nodes/object`).
+2. Add a new fetcher: `api/get-{noun}-from-api.ts` → `domain/get-{noun}.ts` → `ui/queries/get-{noun}.query.ts`.
+
+Inline `gql` in `ui/` bypasses caching, branch context, schema typing, and the layered architecture. It is a pattern bug, not a shortcut.
+
+### Single-object reads
+
+For "I have a UUID, give me the node", always use `useGetObject({ objectId, objectSchema: { kind: "CoreNode" } })` from `entities/nodes/object/ui/queries/get-object.query.ts`. Do not write a one-off `resolveUuid` function.
+
+## Backend is authoritative
+
+If the server defaults, filters, sorts, or hides something, the client must not maintain a parallel constant. Examples:
+
+- Default namespace exclusions (Core, Internal, Builtin, Lineage, Profile, Template) are applied server-side. Do not duplicate them in a client `HIDDEN_NAMESPACES` constant.
+- Schema kinds and their hidden flags come from `useGetSchema`.
+- Pagination defaults, sort order, and ACL checks live on the server.
+
+If the client genuinely needs to display a server-side default, surface it via the API response — do not mirror the constant.
+
 ## Reference Example: branches
 
 ```text

--- a/dev/knowledge/frontend/react.md
+++ b/dev/knowledge/frontend/react.md
@@ -47,3 +47,9 @@ const filtered = items.filter(item => item.active);
 const [filtered, setFiltered] = useState([]);
 useEffect(() => setFiltered(items.filter(i => i.active)), [items]);
 ```
+
+## URL is the source of truth for shareable state
+
+Anything a user might bookmark, share, or refresh-and-resume (filters, current selection, mode toggle) lives in the URL — not in `useState`. Use `nuqs` for typed URL params, or `useFilters` for the standard filter pattern.
+
+The page component reads URL params and passes them down. Children should not read `searchParams` for state the page already owns. See `dev/guidelines/frontend/page-architecture.md` for the full state-ownership rules.

--- a/dev/knowledge/frontend/shared-components.md
+++ b/dev/knowledge/frontend/shared-components.md
@@ -1,0 +1,138 @@
+# Shared Components Inventory
+
+> Part of: `dev/knowledge/frontend/`
+
+A discovery map of reusable building blocks. **Look here before building a new picker, combobox, kind selector, or form input.** Most "new" UI in this codebase already has a shared primitive — see PR #9099 for an example where a 200+ line custom object picker and a hand-rolled `gql` UUID resolver were written because this map didn't exist.
+
+The dependency rule still applies: `app → pages → entities → shared`. Cross-entity reuse goes through another entity's `domain/` or `ui/` — never `api/`.
+
+## When to use what
+
+### Picking an existing object (single)
+
+| Need | Use | Location |
+|------|-----|----------|
+| Pick a peer in a form (with `react-hook-form`) | `PeerField` | `shared/components/form/fields/peer.field.tsx` |
+| Pick a peer outside a form | `PeerInput` | `shared/components/inputs/peer.tsx` |
+| Resolve a single object by UUID | `useGetObject({ objectId, objectSchema })` | `entities/nodes/object/ui/queries/get-object.query.ts` |
+| Searchable + paginated list of one peer kind | `RelationshipComboboxList` | `entities/nodes/relationships/ui/relationship-combobox-list.tsx` |
+| Hierarchical (parent/child) peer list | `RelationshipHierarchicalComboboxList` | `entities/nodes/relationships/ui/relationship-hierarchical-combobox-list.tsx` |
+| Add-relationship action button | `AddRelationshipAction` | `entities/nodes/relationships/ui/add-relationship-action.tsx` |
+
+**Never** hand-build a `gql` query string + `graphqlClient.query` to resolve a single node. That bypasses caching, branch context, and the entity layer. Use `useGetObject`.
+
+### Picking a node kind
+
+| Need | Use | Location |
+|------|-----|----------|
+| Select a single schema kind | `NodeKindField` | `shared/components/form/fields/node-kind.field.tsx` |
+| Multi-select kinds (chips) | None yet — extract one if you need this | Candidate: `shared/components/form/fields/node-kind-multi.field.tsx` |
+| Filter system namespaces from a kind list | Use the schema metadata — **do not** hardcode `["Core", "Internal", ...]` on the client; the backend already filters |
+
+### Picking primitive values
+
+| Need | Use | Location |
+|------|-----|----------|
+| Combobox (single value) | `Combobox` | `shared/components/ui/combobox.tsx` |
+| Command palette pattern | `Command` | `shared/components/ui/command.tsx` |
+| Dropdown menu | `DropdownMenu` | `shared/components/ui/dropdown-menu.tsx` |
+| Date picker | `DatePicker` | `shared/components/inputs/date-picker.tsx` |
+| Color picker | `ColorPicker` | `shared/components/inputs/color-picker.tsx` |
+| Search input | `SearchInput` | `shared/components/inputs/search-input.tsx` |
+| Pool select | `PoolSelect` | `shared/components/inputs/pool-select.tsx` |
+| Enum select | `EnumInput` | `shared/components/inputs/enum.tsx` |
+
+### Form fields (`react-hook-form` integration)
+
+All `.field.tsx` files in `shared/components/form/fields/` wrap a primitive in the `{ source, value }` form-value structure documented in `dev/guidelines/frontend/object-forms.md`.
+
+| Field | Purpose |
+|-------|---------|
+| `input.field.tsx` | Text input |
+| `number.field.tsx` | Numeric input |
+| `textarea.field.tsx` | Multi-line text |
+| `password-input.field.tsx` | Password with show/hide |
+| `checkbox.field.tsx` | Boolean |
+| `select.field.tsx` | Single-value dropdown |
+| `enum.field.tsx` | Enum value |
+| `dropdown.field.tsx` | Custom dropdown |
+| `datetime.field.tsx` | Date/time picker |
+| `color.field.tsx` | Color picker |
+| `file.field.tsx` | File upload (uses `FileDropzone`) |
+| `json.field.tsx` | JSON editor |
+| `list.field.tsx` | List of values |
+| `peer.field.tsx` | Single relationship |
+| `node-kind.field.tsx` | Schema kind selector |
+| `relationships/relationship.field.tsx` | Generic relationship dispatcher |
+| `relationships/relationship-many.field.tsx` | Many-cardinality relationship |
+| `relationships/relationship-hierarchical.field.tsx` | Hierarchical relationship |
+
+**Use `.field.tsx` only inside a `<Form>` from `shared/components/ui/form.tsx`.** Outside a form, use the underlying input from `shared/components/inputs/` or the primitive from `shared/components/ui/`.
+
+### Layout
+
+| Need | Use | Location |
+|------|-----|----------|
+| Horizontal flex layout | `Row` | `shared/components/container/` |
+| Vertical flex layout | `Col` | `shared/components/container/` |
+| Resizable panels | `ResizablePanelGroup` | `shared/components/ui/resizable.tsx` |
+| Scrollable area | `ScrollArea` | `@infrahub/ui` |
+| Tooltip | `Tooltip` | `shared/components/ui/tooltip.tsx` |
+| Popover | `Popover` | `shared/components/ui/popover.tsx` |
+| Accordion | `Accordion` | `shared/components/ui/accordion.tsx` |
+| Badge | `Badge` | `shared/components/ui/badge.tsx` |
+| Alert | `Alert` | `shared/components/ui/alert.tsx` |
+| Pagination | `Pagination` | `shared/components/ui/pagination.tsx` |
+| Keyboard shortcut display | `Kbd` | `shared/components/ui/kbd.tsx` |
+| Card surface | `Card`, `CardHeader`, `CardContent` | `@infrahub/ui` (see `design-system.md`) |
+| Modal/dialog | `Modal`, `ModalOverlay` | `@infrahub/ui` |
+| Button | `Button`, `LinkButton` | `@infrahub/ui` |
+| Spinner | `Spinner` | `@infrahub/ui` |
+
+### Hooks
+
+| Need | Use | Location |
+|------|-----|----------|
+| URL query-param sync | `useFilters` (or `nuqs` directly for typed params) | `shared/hooks/useFilters.ts` |
+| Debounced value | `useDebounce` | `shared/hooks/useDebounce.ts` |
+| Pagination state | `usePagination` | `shared/hooks/usePagination.ts` |
+| Local-storage state | `useLocalStorage` | `shared/hooks/useLocalStorage.ts` |
+| Copy to clipboard | `useCopyToClipboard` | `shared/hooks/useCopyToClipboard.ts` |
+| Detect truncation | `useIsTruncated` | `shared/hooks/useIsTruncated.ts` |
+| Previous value | `usePrevious` | `shared/hooks/usePrevious.ts` |
+| Search input state | `useSearch` | `shared/hooks/useSearch.ts` |
+| Page title | `useTitle` | `shared/hooks/useTitle.ts` |
+| Branch context | `useCurrentBranch` | (entity hook) |
+| Date context | `useAtomValue(datetimeAtom)` | `shared/stores/` |
+
+### Domain helpers (cross-entity reuse)
+
+Import another entity's `domain/` types and async functions, or its `ui/` hooks/components. Never import `api/`.
+
+| Source entity | Useful exports |
+|---|---|
+| `entities/schema` | `useGetSchema`, `SchemaNode` types |
+| `entities/branches` | `useGetBranches`, `BranchListItem` |
+| `entities/nodes/object` | `useGetObject` from `ui/queries/get-object.query.ts` |
+| `entities/nodes/relationships` | `RelationshipComboboxList`, `AddRelationshipAction` |
+
+## Discovery checklist before writing new code
+
+Before adding a new component, run this:
+
+1. `rg -i "<name>" frontend/app/src/shared/components/`
+2. `rg -i "<name>" frontend/packages/ui/src/components/`
+3. Check the table above for the closest match.
+4. If nothing fits, ask: can I extend an existing component, or am I duplicating it with a different name?
+5. If you really need something new, justify it in the PR description and update this file.
+
+## Anti-patterns observed in past PRs
+
+| Anti-pattern | Replacement |
+|---|---|
+| Hand-rolled `gql` string + `graphqlClient.query(...)` for a single node read | `useGetObject({ objectId, objectSchema: { kind: "CoreNode" } })` |
+| Reimplementing kind combobox + object combobox + UUID input | Wrap `PeerInput` and add a UUID-mode toggle |
+| `<section className="rounded-md border bg-white p-4 shadow-lg">…</section>` | `Card` from `@infrahub/ui` |
+| `<div className="flex items-center gap-2">` | `<Row>` from `shared/components/container` |
+| Hardcoding system namespace lists on the client | Backend is authoritative; surface via schema if needed |
+| Duplicating `useState` between page and selector | Single source of truth — see `dev/guidelines/frontend/page-architecture.md` |

--- a/frontend/app/AGENTS.md
+++ b/frontend/app/AGENTS.md
@@ -23,7 +23,9 @@ cd frontend/app && pnpm codegen    # Generate GraphQL types
 
 ### Guidelines (How to write code)
 
-- `dev/guidelines/frontend/naming-conventions.md` - File naming patterns
+- `dev/guidelines/frontend/component-patterns.md` - Reuse-first checklist, early returns, layout extraction
+- `dev/guidelines/frontend/page-architecture.md` - State ownership, URL sync, size budgets, backend-authoritative rule
+- `dev/guidelines/frontend/naming-conventions.md` - File naming patterns and query-key shape
 - `dev/guidelines/frontend/typescript.md` - TypeScript and React patterns
 - `dev/guidelines/frontend/styling.md` - Tailwind CSS and CVA
 - `dev/guidelines/frontend/object-forms.md` - react-hook-form patterns and focus management
@@ -33,7 +35,9 @@ cd frontend/app && pnpm codegen    # Generate GraphQL types
 
 - `dev/knowledge/frontend/react.md` - React 19 and React Compiler patterns
 - `dev/knowledge/frontend/architecture.md` - Project organization
-- `dev/knowledge/frontend/entities-structure.md` - Entity layer pattern (api/domain/ui)
+- `dev/knowledge/frontend/entities-structure.md` - Entity layer pattern (api/domain/ui), GraphQL fetching, backend authority
+- `dev/knowledge/frontend/shared-components.md` - **Reuse-first inventory** — look here before building anything generic
+- `dev/knowledge/frontend/design-system.md` - `@infrahub/ui` package (Button, Card, Modal, Spinner)
 - `dev/knowledge/frontend/file-components.md` - DataViewer and file handling components
 
 ### Guides (How to do X)


### PR DESCRIPTION
- Adds three new knowledge/guideline docs: a `shared-components.md` reuse-first inventory, a `design-system.md` reference for `@infrahub/ui` (Button, Card, Modal,
  Spinner, Meter, ScrollArea), and a `page-architecture.md` guideline covering state ownership, URL sync, size budgets, and the backend-authoritative rule.
  - Extends existing docs with the lessons surfaced by PR #9099: query-keys-as-objects (`naming-conventions.md`), GraphQL-through-the-entity-layer +
  backend-authoritative (`entities-structure.md`), URL-as-source-of-truth (`react.md`), reuse-before-reinvent checklist + anti-patterns (`component-patterns.md`),
  and a minimum E2E happy-path bar for new pages (`writing-e2e-tests.md`).
  - Wires the new docs into `frontend/app/AGENTS.md` and `.specify/templates/plan-template.md` (adds Frontend principles gate + Shared Components Inventory required
  before tasks).