### PR TITLE
docs: migrate generators

### DIFF
--- a/docs/docs/generator/best-practices.mdx
+++ b/docs/docs/generator/best-practices.mdx
@@ -4,7 +4,7 @@ title: Best practices for modular Generators
 
 This page collects practical guidance for building and operating modular Generator cascades in Infrahub. These patterns come from real-world experience — they address problems that are not obvious until you have built a multi-layer cascade and run it in production.
 
-For foundational concepts, see [modular Generators](../topics/modular-generators). For the chaining mechanism, see [how to chain Generators](chaining-generators).
+For foundational concepts, see [Modular Generators](./modular-generators). For the chaining mechanism, see [How to chain Generators](./chaining-generators).
 
 ## 1. One Generator, one layer
 
@@ -118,7 +118,7 @@ A cascade has no single log showing the full chain. Each Generator runs independ
 
 | Symptom                            | Where to look first                                                                                                              |
 |------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| Expected objects were not created  | Check whether the Generator for that layer ran at all ([Generator instances](../topics/generator#generator-instances) in the UI) |
+| Expected objects were not created  | Check whether the Generator for that layer ran at all ([Generator instances](./#generator-instances) in the UI) |
 | Generator ran but created nothing  | Check the Generator's task log — likely an upstream validation failure                                                           |
 | Cascade stopped after layer N      | Check whether layer N wrote checksums to layer N+1 targets                                                                       |
 | Objects were created but are wrong | Check the query results — the query may be returning unexpected data                                                             |
@@ -126,7 +126,7 @@ A cascade has no single log showing the full chain. Each Generator runs independ
 
 ### Check Generator instances
 
-The Infrahub UI shows [Generator instances](../topics/generator#generator-instances) per definition. Each instance corresponds to one target and shows its status:
+The Infrahub UI shows [Generator instances](./#generator-instances) per definition. Each instance corresponds to one target and shows its status:
 
 - `ready` — the Generator ran successfully for this target
 - `error` — the Generator failed for this target (check the task log for details)
@@ -192,7 +192,7 @@ Generators work best when the schema supports the generation pattern. A few sche
 
 ### Add `GeneratorTarget` to all downstream target nodes
 
-Any node kind that participates in a cascade as a downstream target should inherit from the `GeneratorTarget` generic (see [how to chain Generators](chaining-generators)). This gives it the `checksum` attribute needed for trigger-based chaining.
+Any node kind that participates in a cascade as a downstream target should inherit from the `GeneratorTarget` generic (see [How to chain Generators](./chaining-generators)). This gives it the `checksum` attribute needed for trigger-based chaining.
 
 ```yaml
 nodes:
@@ -255,12 +255,11 @@ Always test cascades in a branch, not on the default branch. This lets you:
 - Delete the branch and start over if something goes wrong
 - Review the cascade output in a proposed change before merging
 
-The `branch_scope: "other_branches"` trigger configuration (from the [chaining guide](chaining-generators)) ensures triggers only fire in branches, giving you a controlled testing environment.
+The `branch_scope: "other_branches"` trigger configuration (from the [chaining guide](./chaining-generators)) ensures triggers only fire in branches, giving you a controlled testing environment.
 
 ### Monitor Generator instances after changes
 
 After modifying a Generator or its schema, run the cascade in a test branch and check:
-
 
 1. All Generator instances show `ready` status
 2. Object counts match expectations at each layer
@@ -299,3 +298,9 @@ Use this checklist when building a new modular Generator cascade:
 - [ ] **Trigger rules use** `branch_scope: "other_branches"` — test in branches before production
 - [ ] **Each layer tested independently** — before running the full cascade
 - [ ] **Generator instances checked after runs** — verify `ready` status across all targets
+
+## Related
+
+- [Modular Generators](./modular-generators) — concepts, mental model, and when to use multiple Generators
+- [How to chain Generators](./chaining-generators) — checksum+trigger pattern step by step
+- [Generator overview](./) — single-Generator fundamentals, instances, and execution lifecycle

--- a/docs/docs/generator/chaining-generators.mdx
+++ b/docs/docs/generator/chaining-generators.mdx
@@ -1,15 +1,15 @@
 ---
-title: How to connect modular Generators with checksums and triggers
+title: How to chain Generators with checksums and triggers
 ---
 
-[Modular Generators](../topics/modular-generators) split automation into focused layers, each handled by its own Generator. But each Generator runs independently — there's no built-in way to say "run Generator B after Generator A finishes."
+[Modular Generators](./modular-generators) split automation into focused layers, each handled by its own Generator. But each Generator runs independently — there's no built-in way to say "run Generator B after Generator A finishes."
 
 This guide shows how to connect modular Generators using Infrahub's [event framework](../topics/event-actions): when a Generator finishes, it computes a checksum of what it created, writes it to the downstream target objects, and a trigger rule detects the change and runs the next Generator automatically.
 
 **Prerequisites:**
 
-- Familiarity with [Generators](../topics/generator) and [how to create one](generator)
-- Understanding of the [modular Generators concept](../topics/modular-generators)
+- Familiarity with [Generators](./) and [how to create one](./create)
+- Understanding of the [modular Generators concept](./modular-generators)
 - Basic understanding of [event rules and actions](../topics/event-actions)
 
 ## How the pattern works
@@ -29,7 +29,7 @@ Generator A finishes
         → CoreGeneratorAction runs Generator B for the updated target
 ```
 
-## Step 1: Add a checksum attribute to target objects
+## Add a checksum attribute to target objects
 
 To signal downstream Generators, the target objects need an attribute that the upstream Generator can write to. The recommended approach is to define a schema generic with a `checksum` attribute and have target nodes inherit from it.
 
@@ -63,9 +63,9 @@ nodes:
     # ... rest of the node definition
 ```
 
-**Why a generic?** It keeps the pattern reusable. Any node kind that participates in a modular Generator setup just inherits from `GeneratorTarget` — no need to manually add checksum attributes to each schema.
+**Why a generic?** It keeps the pattern reusable. Any node kind that participates in a modular Generator setup inherits from `GeneratorTarget` — no need to manually add checksum attributes to each schema.
 
-## Step 2: Calculate and write the checksum in your Generator
+## Calculate and write the checksum in your Generator
 
 After the Generator creates or modifies its objects, it needs to compute a checksum and write it to the downstream targets. This should be the **last step** in your `generate()` method — only signal completion after all work is done.
 
@@ -124,7 +124,7 @@ class FabricGenerator(InfrahubGenerator, GeneratorMixin):
 - `update_checksum()` must be the **last step** in `generate()`. Only signal downstream after all work is complete.
 - The checksum naturally reflects everything the Generator touched, because it's derived from the SDK tracking context.
 
-## Step 3: Validate upstream dependencies before generating
+## Validate upstream dependencies before generating
 
 In a modular Generator setup there is no central orchestrator sequencing execution. A checksum change fires a trigger per target — which means a downstream Generator could start before the upstream Generator has finished creating all its objects. Each Generator must therefore protect itself by validating that upstream work is complete before proceeding.
 
@@ -221,7 +221,7 @@ class RackGenerator(InfrahubGenerator):
 
 Both checks should happen at the top of `generate()`, before any objects are created.
 
-## Step 4: Create trigger rules and actions
+## Create trigger rules and actions
 
 With the checksum being written to downstream targets, you need trigger rules to detect the change and fire the next Generator. You can define these as object files in your repository (recommended) or create them via the UI.
 
@@ -333,7 +333,7 @@ For each pair of (upstream Generator, downstream Generator), define one `CoreGen
 
 ### Using the UI (alternative)
 
-If you prefer to create trigger rules via the Infrahub UI, follow the [creating event trigger rules and actions](events-rules-actions) guide. The configuration is the same:
+If you prefer to create trigger rules via the Infrahub UI, follow the [creating event trigger rules and actions](../guides/events-rules-actions) guide. The configuration is the same:
 
 1. Create a **Generator Action** (Actions > Create > Generator Action) pointing to the downstream Generator
 2. Create a **Node Trigger Rule** (Trigger Rules > Create > Node Trigger) for the downstream target kind, with mutation action `updated`
@@ -342,7 +342,7 @@ If you prefer to create trigger rules via the Infrahub UI, follow the [creating 
 
 UI-created triggers work identically but aren't version-controlled.
 
-## Step 5: Disable CI-based execution (optional)
+## Disable CI-based execution (optional)
 
 Generators that are entirely event-driven should have their CI execution disabled to avoid double-runs:
 
@@ -367,7 +367,7 @@ Set both `execute_in_proposed_change` and `execute_after_merge` to `false` for a
 This is a design choice. Some teams keep CI execution enabled for the first Generator (the entry point) and only use event triggers for downstream Generators.
 :::
 
-## Step 6: Test the modular setup
+## Test the modular setup
 
 ### Run the first Generator manually
 
@@ -412,8 +412,10 @@ You should see a checksum value on each pod.
 | Generator runs in a loop                     | The downstream Generator modifies an attribute that triggers the upstream Generator                 | Ensure Generators only write checksums to *downstream* targets, never upstream. The checksum guard (`if checksum != old`) should also prevent repeated triggers for the same output.                            |
 | Checksum unchanged after re-run            | Generator produced the same output as before                                                       | This is **expected behavior** — execution correctly stops when nothing changed.                                                                                                                              |
 | Trigger fires but Generator errors         | Generator definition name doesn't match the action's Generator reference                           | Verify that the `generator` field in `CoreGeneratorAction` matches the `name` field in your Generator definition in `.infrahub.yml`.                                                                           |
-| Generator fails with "not fully generated" | Upstream validation caught incomplete data — the upstream Generator hasn't finished yet             | This is the validation from Step 3 working as intended. The Generator will succeed on the next trigger once the upstream layer is complete.                                                                     |
+| Generator fails with "not fully generated" | Upstream validation caught incomplete data — the upstream Generator hasn't finished yet             | This is the validation from the upstream validation section working as intended. The Generator will succeed on the next trigger once the upstream layer is complete.                                                                     |
 
-:::info Next steps
-For additional debugging techniques, pool scoping strategies, and operational guidance for running cascades in production, see [best practices for modular Generators](modular-generator-best-practices).
-:::
+## Related
+
+- [Modular Generators](./modular-generators) — concepts, mental model, and trade-offs
+- [Best practices for modular Generators](./best-practices) — idempotency, debugging cascades, and operational guidance
+- [Generator overview](./) — single-Generator fundamentals and execution lifecycle

--- a/docs/docs/generator/create.mdx
+++ b/docs/docs/generator/create.mdx
@@ -1,16 +1,13 @@
 ---
-title: How to Create a Generator
+title: Create a Generator
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# How to create a Generator in Infrahub
+Generators in Infrahub allow you to automatically create or modify data based on existing information in your database. They are defined in [external repositories](../topics/repository) and can be developed and tested locally using [infrahubctl generator]($(base_url)infrahubctl/infrahubctl-generator).
 
-Generators in Infrahub allow you to automatically create or modify data based on existing information in your database. They are defined in [external repositories](../topics/repository.mdx) and can be developed and tested locally using [infrahubctl generator]($(base_url)infrahubctl/infrahubctl-generator).
-
-In this guide, you'll learn how to develop a Generator and integrate it into Infrahub.
-
-For conceptual information about Generators and their architecture, see [Generators](../topics/generator.mdx).
+For conceptual information about Generators and their architecture, see [Generators](./).
 
 ## What you'll build
 
@@ -20,30 +17,18 @@ You'll build a basic Generator that:
 2. Creates a number of Resource objects based on each Widget's count property
 3. Automatically runs when changes to Widget objects are proposed
 
-## Steps overview
-
-1. Prepare the data model by creating a schema and objects
-2. Create a GraphQL query to fetch data from Infrahub
-3. Implement a Python Generator that creates the data
-4. Tie everything together in an `.infrahub.yml` file
-5. Test the Generator locally with infrahubctl
-6. Deploy the Generator to Infrahub
-7. Validate that the Generator works in Infrahub's CI pipeline
-
 ## Prerequisites
 
-Before you begin, you'll need:
-
 - Basic knowledge of Infrahub, Python, GraphQL, YAML, and Git
-- Familiarity with Generators and how they work in Infrahub (see [Generators topic](../topics/generator.mdx))
+- Familiarity with Generators and how they work in Infrahub (see [Generators](./) )
 - An Infrahub instance running locally or remotely
-- A Git repository connected to Infrahub (see [Adding an External Repository guide](./repository.mdx))
+- A Git repository connected to Infrahub (see [Adding an External Repository guide](../guides/repository))
 - [infrahubctl]($(base_url)infrahubctl/infrahubctl) installed and configured locally
 - The repository cloned locally where you'll develop the Generator
 
-## Step 1: Setting up the data model
+## Prepare the data model
 
-In this step, you'll create the data structures needed for your Generator, including a schema, group, and sample objects that the Generator will process.
+In this section, you'll create the data structures needed for your Generator, including a schema, group, and sample objects that the Generator will process.
 
 ### Create a new branch
 
@@ -220,7 +205,7 @@ You can also use an object file to create the widgets, though it's less relevant
     - Count: `2`
     - Member of groups: `widgets`
 
-## Step 2: Create the GraphQL query
+## Create the GraphQL query
 
 Next, create a GraphQL query that fetches the data your Generator needs to process.
 
@@ -298,7 +283,7 @@ You now have a working GraphQL query that retrieves the necessary data from Infr
 
 :::
 
-## Step 3: Implement the Generator
+## Implement the Generator class
 
 Now create a Python class that implements your Generator logic. The Generator creates `TestResource` objects equal to the widget's count value.
 
@@ -336,9 +321,9 @@ class WidgetGenerator(InfrahubGenerator):
 
 ```
 
-## Step 4: Tie everything together in the .infrahub.yml file
+## Configure .infrahub.yml
 
-Now that you have your GraphQL query and Python Generator, edit your [.infrahub.yml](../topics/infrahub-yml.mdx) file to tie everything together.
+Now that you have your GraphQL query and Python Generator, edit your [.infrahub.yml](../topics/infrahub-yml) file to tie everything together.
 
 1. Add the following configuration to the file `.infrahub.yml`:
 
@@ -359,7 +344,7 @@ queries:
     file_path: "queries/widget_query.gql"
 ```
 
-For a complete explanation of the `.infrahub.yml` file format, see the [infrahub.yml topic](../topics/infrahub-yml.mdx).
+For a complete explanation of the `.infrahub.yml` file format, see the [infrahub.yml topic](../topics/infrahub-yml).
 
 2. Verify the configuration
 
@@ -380,7 +365,7 @@ widget_generator (generators/widget_generator.py::WidgetGenerator) Target: widge
 
 :::
 
-## Step 5: Test the Generator locally
+## Test locally
 
 Before deploying your Generator to Infrahub, test it locally using the `infrahubctl` command-line tool.
 
@@ -415,7 +400,7 @@ Your Generator worked as expected, it's now time to deploy it to Infrahub.
 
 :::
 
-## Step 6: Deploy to Infrahub
+## Deploy to Infrahub
 
 Now that you've tested your Generator, deploy it to Infrahub.
 
@@ -482,7 +467,7 @@ Your Generator is now deployed to Infrahub in the `main` branch and ready to be 
 
 :::
 
-## Step 7: Run the Generator in Infrahub's CI pipeline
+## Validate in the CI pipeline
 
 Now let's verify that your Generator automatically runs when new widgets are created:
 
@@ -526,3 +511,9 @@ Now that you've created a basic Generator, you can:
 Want to see how Generators can be used in production? Read our blog post on [How to Turn Your Source of Truth into a Service Factory](https://www.opsmill.com/how-to-turn-your-source-of-truth-into-a-service-factory/).
 
 :::
+
+## Related
+
+- [Generator overview](./) — concepts, execution model, and lifecycle flags
+- [Modular Generators](./modular-generators) — split generation across multiple focused layers
+- [How to chain Generators](./chaining-generators) — connect modular Generators with the checksum+trigger pattern

--- a/docs/docs/generator/index.mdx
+++ b/docs/docs/generator/index.mdx
@@ -8,15 +8,15 @@ A `Generator` is a generic plugin that queries data and creates new nodes and re
 
 :::success Examples
 
-- Within your [schema](schema) you could create an abstract service object that through a Generator creates other nodes.
+- Within your [schema](../topics/schema) you could create an abstract service object that through a Generator creates other nodes.
 - Want to read how Generators can be used to create a service catalog? See our blog post on [How to Turn Your Source of Truth into a Service Factory](https://www.opsmill.com/how-to-turn-your-source-of-truth-into-a-service-factory/).
 :::
 
 ## High level design
 
-Generators are defined as a **Generator definition** within an [.infrahub.yml](infrahub-yml) file. A Generator definition consists of a number of related objects.
+Generators are defined as a **Generator definition** within an [.infrahub.yml](../topics/infrahub-yml) file. A Generator definition consists of a number of related objects.
 
-- [Group](./groups.mdx) of targets - Objects that the Generator will act upon
+- [Group](../groups/) of targets - Objects that the Generator will act upon
 - Generator class - Python code that defines the generation logic
 - GraphQL Query - Data collection specification
 
@@ -24,11 +24,11 @@ Generators are defined as a **Generator definition** within an [.infrahub.yml](i
 
 Running a Generator definition will create new nodes as defined by the Generator, or remove old ones that are no longer required. The removal of obsolete objects is handled using the [SDK tracking feature]($(base_url)python-sdk/topics/tracking)
 
-The targets point to a [group](./groups.mdx) that will consist of objects that are impacted by the Generator. The members of this group can be any type of object within your schema, service objects, devices, contracts or anything you want the Generator to act upon. Generator groups (`CoreGeneratorGroup`) serve as target collections that define which objects trigger Generator execution, while the actual tracking of generated objects is handled by individual Generator instances.
+The targets point to a [group](../groups/) that will consist of objects that are impacted by the Generator. The members of this group can be any type of object within your schema, service objects, devices, contracts or anything you want the Generator to act upon. Generator groups (`CoreGeneratorGroup`) serve as target collections that define which objects trigger Generator execution, while the actual tracking of generated objects is handled by individual Generator instances.
 
-The [GraphQL query](graphql) defines the data that will be collected when running the Generator. Any object identified in this step is added as a member to a GraphQL query [group](./groups.mdx) (`CoreGraphQLQueryGroup`). The membership in these groups are then used to determine which Generators need to be executed as part of a proposed change during the pipeline run.
+The [GraphQL query](../topics/graphql) defines the data that will be collected when running the Generator. Any object identified in this step is added as a member to a GraphQL query [group](../groups/) (`CoreGraphQLQueryGroup`). The membership in these groups are then used to determine which Generators need to be executed as part of a proposed change during the pipeline run.
 
-The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Just like [Transformations](transformation) and [checks](check), the Generators are user defined.
+The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Like [Transformations](../topics/transformation) and [Checks](../topics/check), Generators are user defined.
 
 Generators can be executed in several ways, depending on your workflow and where you are in the lifecycle (local development vs. in Infrahub):
 
@@ -147,7 +147,7 @@ Because runs are concurrent:
 
 - Your Generator code should not depend on side effects from other runs of the same Generator.
 - Each run should be self-contained — it reads its scoped data, creates its objects, and finishes.
-- If you need ordering (layer A must complete before layer B starts), use separate Generator definitions with a trigger mechanism rather than relying on execution order within a single definition. See [modular Generators](modular-generators) for this pattern.
+- If you need ordering (layer A must complete before layer B starts), use separate Generator definitions with a trigger mechanism rather than relying on execution order within a single definition. See [modular Generators](./modular-generators) for this pattern.
 
 ## Generator instances
 
@@ -177,7 +177,7 @@ More members in the target group means more parallel runs and better utilization
 
 ### Example: modular parallelism
 
-In a modular Generator setup (see [modular Generators](modular-generators)), parallelism increases at each layer:
+In a modular Generator setup (see [modular Generators](./modular-generators)), parallelism increases at each layer:
 
 | Layer  | Target group | Members      | Parallel runs |
 |--------|--------------|--------------|---------------|
@@ -199,7 +199,7 @@ Objects become Generator targets by being members of the group specified in the 
 
 You add objects to a target group through the `member_of_groups` relationship, which can be set:
 
-- **In the UI**: when creating or editing an object (see [organizing objects with groups](../guides/groups.mdx))
+- **In the UI**: when creating or editing an object (see [organizing objects with groups](../groups/add-members))
 - **In object files**: define group membership in your YAML object definitions
 - **Programmatically**: via the SDK or GraphQL mutations
 
@@ -280,7 +280,7 @@ When `false`, the Generator will not run after the branch has been merged.
 
 ## Video guides
 
-In this video series we're diving into the concept of Generators and services, exploring their significance, structure, and how they can streamline processes for teams. Whether you're a developer or just curious about automation in IT, this guide will provide you with a comprehensive understanding of Generators and their applications.
+In this video series we're diving into the concept of Generators and services, exploring their significance, structure, and how they can streamline processes for teams. This guide provides a comprehensive understanding of Generators and their applications.
 
 The first video will highlight what Generators are and how they can be used to deliver services.
 

--- a/docs/docs/generator/modular-generators.mdx
+++ b/docs/docs/generator/modular-generators.mdx
@@ -2,14 +2,14 @@
 title: Modular Generators
 ---
 
-A [Generator](generator) reads data from Infrahub and creates new objects based on the result. A single Generator works well when the scope is contained: one input kind, one set of outputs, no intermediate dependencies.
+A [Generator](./) reads data from Infrahub and creates new objects based on the result. A single Generator works well when the scope is contained: one input kind, one set of outputs, no intermediate dependencies.
 
 Real-world automation is rarely that contained. A data center fabric has layers: the fabric itself, then pods, then racks, then devices. An enterprise network has sites, buildings, floors, and closets. Each layer depends on objects created by the previous one. Trying to handle all of this in a single Generator leads to a monolithic Python class that is hard to test, impossible to run partially, and painful to maintain. It can also become slow for large datasets.
 
 **Modular Generators** solve this by splitting generation across multiple focused Generators, each responsible for one layer or domain. Later Generators depend on objects created by earlier ones, connected through an event-driven signaling mechanism.
 
 :::info
-For single-Generator fundamentals, see [Generators](generator). For a step-by-step guide on building your first Generator, see [how to create a Generator](../guides/generator).
+For single-Generator fundamentals, see [Generators](./). For a step-by-step guide on building your first Generator, see [Create a Generator](./create).
 :::
 
 ## Why split into multiple Generators
@@ -62,7 +62,7 @@ Since there is no central orchestrator, each Generator must be self-protecting. 
 When a Generator finishes, it needs a way to tell Infrahub that the next layer should run. This is done through a signaling mechanism, typically by updating an attribute on the downstream target objects. Infrahub's event framework detects the change and triggers the next Generator. The Generators never call each other directly. They communicate exclusively through the data they create and modify in Infrahub.
 
 :::info
-The specific mechanism for connecting Generators (the checksum and trigger pattern) is covered in a separate how-to document.
+The specific mechanism for connecting Generators (the checksum and trigger pattern) is covered in [How to chain Generators](./chaining-generators).
 :::
 
 ### Modular Generators in practice
@@ -115,12 +115,12 @@ The DC-AI solution uses modular Generators to build a 5-stage Clos data center f
 
 A fabric with 4 pods and 32 racks per pod runs 4 pod Generators concurrently, then 128 rack Generators concurrently. Each Generator is independently testable with `infrahubctl generator` and can be re-run for day-two changes without affecting other layers.
 
-## Connection to other concepts
+## Related
 
-- [Generators](generator): single-Generator fundamentals, high-level design, and execution methods
-- [How to create a Generator](../guides/generator): step-by-step guide for building a Generator
-- [How to connect modular Generators](../guides/chaining-generators): checksum-based trigger pattern
-- [Best practices for modular Generators](../guides/modular-generator-best-practices): idempotency, pool scoping, debugging, and operational guidance
-- [Groups](groups): Generators use groups to define their targets and track generated objects
-- [GraphQL queries](graphql): each Generator definition includes a query that collects input data
-- [.infrahub.yml](infrahub-yml): configuration file where Generator definitions are declared
+- [Generator overview](./) — single-Generator fundamentals, high-level design, and execution methods
+- [Create a Generator](./create) — step-by-step guide for building a Generator
+- [How to chain Generators](./chaining-generators) — checksum-based trigger pattern
+- [Best practices for modular Generators](./best-practices) — idempotency, pool scoping, debugging, and operational guidance
+- [Groups](../groups/) — Generators use groups to define their targets and track generated objects
+- [GraphQL queries](../topics/graphql) — each Generator definition includes a query that collects input data
+- [.infrahub.yml](../topics/infrahub-yml) — configuration file where Generator definitions are declared

--- a/docs/docs/groups/use-in-automation.mdx
+++ b/docs/docs/groups/use-in-automation.mdx
@@ -62,7 +62,7 @@ As the Generator runs, Infrahub automatically tracks the objects it produces in 
 
 Downstream automation (artifact definitions, Checks) can target either group, depending on whether you want to operate on the inputs or the produced objects.
 
-See [Generator overview](../topics/generator.mdx) for full details, including the difference between Standard and Generator groups.
+See [Generator overview](../generator/) for full details, including the difference between Standard and Generator groups.
 
 ## Pattern: chain groups through the pipeline
 
@@ -80,4 +80,4 @@ Groups are the glue between each stage — replace any stage without rewiring th
 ## Next
 
 - [Query group membership](./query-members.mdx) to inspect what each group contains at each stage.
-- [Artifacts](../topics/artifact.mdx), [Transformations](../topics/transformation.mdx), [Checks](../topics/check.mdx), [Generators](../topics/generator.mdx) for feature-specific details.
+- [Artifacts](../topics/artifact.mdx), [Transformations](../topics/transformation.mdx), [Checks](../topics/check.mdx), [Generators](../generator/) for feature-specific details.

--- a/docs/docs/guides/graphql-fragment.mdx
+++ b/docs/docs/guides/graphql-fragment.mdx
@@ -6,7 +6,7 @@ title: Using GraphQL fragments
 
 [GraphQL fragments](../topics/graphql.mdx#graphql-fragments) allow you to define reusable field selections that can be shared across multiple queries. Instead of duplicating the same field selections in every query, define them once as a fragment and reference them with standard GraphQL spread syntax (`...fragmentName`).
 
-This is particularly useful when multiple [Transformations](../topics/transformation.mdx) or [Generators](../topics/generator.mdx) need to query the same fields from a model. Update the fragment once, and all queries that reference it pick up the change on their next execution.
+This is particularly useful when multiple [Transformations](../topics/transformation.mdx) or [Generators](../generator/) need to query the same fields from a model. Update the fragment once, and all queries that reference it pick up the change on their next execution.
 
 ## Prerequisites
 

--- a/docs/docs/guides/resource-manager.mdx
+++ b/docs/docs/guides/resource-manager.mdx
@@ -273,7 +273,7 @@ In the mutation we passed additional data to the allocated resource, in this cas
 
 :::success Idempotent allocation of an IP address
 
-You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../topics/generator.mdx).
+You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../generator/).
 
 Execute this mutation twice, note the identifier. The resulting IP address should be the same, as well as the id. Replace the id with the id of the `CoreIPAddressPool` we created previously.
 
@@ -451,7 +451,7 @@ Allocate an IP address directly from the pool:
   }
   ```
 
-  This is essential for [Generators](../topics/generator.mdx) and automated workflows.
+  This is essential for [Generators](../generator/) and automated workflows.
 
   :::
 
@@ -793,7 +793,7 @@ This feature is not yet available directly via the Web Interface.
   }
   ```
 
-  This is essential for [Generators](../topics/generator.mdx) and automated workflows.
+  This is essential for [Generators](../generator/) and automated workflows.
 
   :::
 
@@ -802,7 +802,7 @@ This feature is not yet available directly via the Web Interface.
 
 :::success
 
-You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../topics/generator.mdx).
+You can allocate resources in an idempotent way by specifying an identifier in the GraphQL mutation. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [Generators](../generator/).
 
 Execute this mutation twice, note the identifier. The resulting IP prefix should be the same, as well as the id. Replace the id with the id of the `CoreIPPrefixPool` we created previously.
 
@@ -1145,6 +1145,6 @@ The query shows the IP address is allocated in the test branch, preventing dupli
 
 - [Resource Manager topic](../topics/resource-manager.mdx) - Deep dive into Resource Manager concepts and architecture
 - [Resource Manager blog post](https://opsmill.com/blog/infrahub-resource-manager-automate-allocation/) - Alternative learning resource with additional examples
-- [Generators topic](../topics/generator.mdx) - Learn how to automate resource allocation workflows
+- [Generators topic](../generator/) - Learn how to automate resource allocation workflows
 - [IPAM topic](../topics/ipam.mdx) - Additional information about IP address management
 - [Schema topic](./import-schema.mdx) - Learn more about creating and managing schemas in Infrahub

--- a/docs/docs/home.mdx
+++ b/docs/docs/home.mdx
@@ -71,7 +71,7 @@ import HomePageCard from "../src/components/HomePage/card.tsx";
     <HomePageCard title="Generators"
         svgPath="/img/infrahub-logo.svg"
         description="Create consistent infrastructure objects using Generators."
-        link="topics/generator"
+        link="generator/"
     />
 </div>
 

--- a/docs/docs/overview/concepts.mdx
+++ b/docs/docs/overview/concepts.mdx
@@ -38,7 +38,7 @@ Generators use templates as a starting point and prompt users for specific infor
 
 Advanced users can create custom Generators to suit their organization's specific needs and integrate them into workflows and CI/CD pipelines for automated infrastructure provisioning.
 
-<ReferenceLink title="Learn more about Generators" url="../topics/generator" />
+<ReferenceLink title="Learn more about Generators" url="../generator/" />
 
 ## Version control
 

--- a/docs/docs/overview/next-steps.mdx
+++ b/docs/docs/overview/next-steps.mdx
@@ -52,7 +52,7 @@ A local Docker setup works for development, but for a POC that involves your tea
 
 At this point, you have a running Infrahub instance with your own schema, real data, a connected Git repository, and generated artifacts. From here you can:
 
-- [Build Generators](../guides/generator.mdx) to automate the creation of infrastructure objects from templates and business logic.
+- [Build Generators](../generator/create.mdx) to automate the creation of infrastructure objects from templates and business logic.
 - [Set up events and webhooks](../guides/events-rules-actions.mdx) to trigger external systems when data changes.
 - [Deploy artifacts with Ansible]($(base_url)ansible) or [Nornir]($(base_url)nornir) to push configurations to your infrastructure.
 

--- a/docs/docs/release-notes/infrahub/release-0_13.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_13.mdx
@@ -95,7 +95,7 @@ Similar to the Transformations & artifacts, Generator will be automatically exec
 
 The Generator itself is a Python class that is based on the `InfrahubGenerator` class from the SDK. Just like Transformations and checks, the Generators are user defined.
 
-More information about Generators is available in the [Documentation](../../topics/generator.mdx).
+More information about Generators is available in the [Documentation](../../generator/).
 
 #### Redesigned proposed change creation form
 

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -10,7 +10,7 @@ This guide provides best practices to help you develop robust, efficient, and ma
 The following features in Infrahub are based on user provided code :
 
 - [**Transformations** (Python and Jinja2)](./transformation.mdx): Used to generate [artifacts](./artifact.mdx) and define [Computed Attributes](../computed-attributes/index.mdx).
-- [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
+- [**Generators**](../generator/): Automate complex tasks by generating outputs dynamically.
 - [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
 
 ## Development lifecycle

--- a/docs/docs/topics/graphql.mdx
+++ b/docs/docs/topics/graphql.mdx
@@ -302,7 +302,7 @@ For step-by-step instructions on setting up and using fragments, see [Using Grap
 
 ## Single-target query pattern
 
-When writing GraphQL queries for [transformations](./transformation.mdx), [generators](./generator.mdx), [artifacts](./artifact.mdx), and [computed attributes](../computed-attributes/index.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.
+When writing GraphQL queries for [transformations](./transformation.mdx), [generators](../generator/), [artifacts](./artifact.mdx), and [computed attributes](../computed-attributes/index.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.
 
 ### What is a single-target query?
 
@@ -468,7 +468,7 @@ Single-target queries are **required** for:
 
 - **Python transformations** - See [Creating a Python transformation](../guides/python-transform.mdx)
 - **Jinja2 transformations** - See [Creating a Jinja transformation](../guides/jinja2-transform.mdx)
-- **Generators** - See [Generators](./generator.mdx)
+- **Generators** - See [Generators](../generator/)
 - **Artifact definitions** - See [Artifacts](./artifact.mdx)
 - **Computed attributes** - See [Computed attributes](../computed-attributes/index.mdx)
 

--- a/docs/docs/topics/infrahub-yml.mdx
+++ b/docs/docs/topics/infrahub-yml.mdx
@@ -157,5 +157,5 @@ The `.infrahub.yml` configuration file is a crucial bridge between Git repositor
 - [How to organize objects with groups](../guides/groups.mdx) - Creating and managing groups
 - [Schema development](../topics/schema.mdx) - Designing infrastructure data models
 - [Transformations](../topics/transformation.mdx) - Data processing and template concepts
-- [Generators](../topics/generator.mdx) - Infrastructure provisioning automation
+- [Generators](../generator/) - Infrastructure provisioning automation
 - [Artifacts](../topics/artifact.mdx) - Output generation and delivery

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -76,7 +76,7 @@ Learn more about [Transformations](transformation) and [artifacts](artifact).
 
 Infrahub will automatically run Generators as part of the proposed change workflow.
 
-Learn more about [Generators](generator).
+Learn more about [Generators](../generator/).
 
 ## Conflict management and resolution
 
@@ -197,6 +197,6 @@ The proposed change functionality interconnects with several other key concepts 
 - [Artifacts](artifact): Explore how proposed changes affect the generated outputs from your infrastructure data
 - [Checks](check): Discover how validation checks ensure the quality and compliance of proposed changes
 - [Transformations](transformation): Understand how Transformations are managed and reviewed within proposed changes
-- [Generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
+- [Generators](../generator/): Learn about the code generation process that can be triggered by changes in proposed changes
 - [Permissions and roles](permissions-roles): Understand the access controls that govern who can create, review, and merge proposed changes
 - [Change Management Workflow Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)

--- a/docs/docs/topics/resource-manager.mdx
+++ b/docs/docs/topics/resource-manager.mdx
@@ -56,7 +56,7 @@ mutation {
 This feature is essential for:
 
 - Automated workflows that may run multiple times
-- [Generators](./generator.mdx) that need consistent results
+- [Generators](../generator/) that need consistent results
 
 ## Pool types and use cases
 
@@ -199,7 +199,7 @@ Infrahub provides comprehensive visibility into resource utilization:
 
 ### With Generators
 
-Resource Manager integrates seamlessly with [Generators](./generator.mdx) to create fully automated provisioning workflows:
+Resource Manager integrates seamlessly with [Generators](../generator/) to create fully automated provisioning workflows:
 
 - Template configurations with dynamically allocated IPs
 - Generate DNS records based on allocations
@@ -249,5 +249,5 @@ Resource Manager exposes full functionality through GraphQL APIs:
 ## Related resources
 
 - [Resource Manager Guide](../guides/resource-manager.mdx) - Step-by-step instructions for creating and using pools
-- [Generator Documentation](./generator.mdx) - Automate configurations with allocated resources
+- [Generator Documentation](../generator/) - Automate configurations with allocated resources
 - [GraphQL Documentation](./graphql.mdx) - Learn about Infrahub's GraphQL interface

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -96,7 +96,7 @@ A TransformPython can be rendered with 2 different methods:
 
 ## Using Transformations with groups
 
-Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](./generator.mdx), which combine a Transformation with a [group](./groups.mdx) of targets.
+Transformations themselves are generic pieces of logic that process data and produce output. They become targeted to specific objects through [artifact definitions](./artifact.mdx) and [Generators](../generator/), which combine a Transformation with a [group](./groups.mdx) of targets.
 
 This design enables powerful patterns:
 

--- a/docs/docs/tutorials/getting-started/resource-manager.mdx
+++ b/docs/docs/tutorials/getting-started/resource-manager.mdx
@@ -142,4 +142,4 @@ Ready to dive deeper into resource management?
 
 - [Resource Manager Guide](../../guides/resource-manager.mdx) - Learn to create and configure all types of resource pools
 - [Resource Manager Concepts](../../topics/resource-manager.mdx) - Understand advanced features like weighted allocation and pool composition
-- [Generators Concepts](../../topics/generator.mdx) - Combine Resource Manager with automated configuration generation
+- [Generators Concepts](../../generator/) - Combine Resource Manager with automated configuration generation

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -47,3 +47,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 |---|---|---|
 | `profiles.yml` | Profiles | TBD |
 | `computed-attributes.yml` | Computed Attributes | TBD |
+| `generator.yml` | Generator | TBD |

--- a/docs/redirects-pending/generator.yml
+++ b/docs/redirects-pending/generator.yml
@@ -1,0 +1,18 @@
+---
+feature: Generator
+pr: TBD
+description: |
+  Migrated Generator documentation from a topic+guide pair (plus three supplementary guides)
+  to a hub+spokes structure under docs/generator/. All five legacy files were removed as part
+  of this migration (user requested immediate cleanup rather than the standard iteration-phase approach).
+redirects:
+  - from: /docs/topics/generator
+    to: /docs/generator/
+  - from: /docs/guides/generator
+    to: /docs/generator/create
+  - from: /docs/topics/modular-generators
+    to: /docs/generator/modular-generators
+  - from: /docs/guides/chaining-generators
+    to: /docs/generator/chaining-generators
+  - from: /docs/guides/modular-generator-best-practices
+    to: /docs/generator/best-practices

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -185,17 +185,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Generators',
-          collapsible: true,
-          collapsed: true,
+          link: { type: 'doc', id: 'generator/index' }, // hub
           items: [
-            { type: 'doc', id: 'topics/generator', label: 'Generator Overview (Topic)' },
-            { type: 'doc', id: 'guides/generator', label: 'Generator Overview (Guide)' },
-            { type: 'doc', id: 'guides/chaining-generators', label: 'Chaining Generators' },
-            { type: 'doc', id: 'topics/modular-generators', label: 'Modular Generators (Topic)' },
-            { type: 'doc', id: 'guides/modular-generator-best-practices', label: 'Modular Generator Best Practices' },
-            // Cross-links to Development Resources
-            { type: 'ref', id: 'topics/developer-guide', label: 'Developer Guide' },
-            { type: 'ref', id: 'topics/resources-testing-framework', label: 'Testing Framework' },
+            'generator/create',
+            'generator/modular-generators',
+            'generator/chaining-generators',
+            'generator/best-practices',
           ],
         },
         {


### PR DESCRIPTION
  ## Summary

  Migrate the **Generator** feature documentation per the Infrahub docs revamp.
  Pattern: hub + spokes (5 source files → 5 new files under `docs/generator/`).

  ## Content changes

  - **`generator/index.mdx`** (hub): all conceptual content from `topics/generator.mdx` — per-target execution
  model, query parameter mapping, parallel execution, generator instances, group targeting, query response
  modes, execution lifecycle, video guides, and known limitations.
  - **`generator/create.mdx`**: how-to guide from `guides/generator.mdx`, rewritten without Step N headings.
  Running Widget/Resource example preserved in full.
  - **`generator/modular-generators.mdx`**: concept page from `topics/modular-generators.mdx` — why split,
  mental model, trade-offs, real-world DC fabric example.
  - **`generator/chaining-generators.mdx`**: how-to from `guides/chaining-generators.mdx` — checksum+trigger
  pattern for connecting modular Generators.
  - **`generator/best-practices.mdx`**: from `guides/modular-generator-best-practices.mdx` — idempotency, re-run
   safety, cascade debugging, schema design, operational guidance, and quick-reference checklist.

  ## What didn't change

  - All factual content preserved; no new claims invented.
  - Legacy files removed per user request (standard iteration approach keeps them; cleanup is handled here
  instead).
  - All cross-section inbound links updated to new paths (`topics/`, `guides/`, `overview/`, `home.mdx`,
  `groups/`).

  ## Redirects

  `docs/redirects-pending/generator.yml` added with 5 redirect entries covering all legacy URLs.

  ## Out of scope (tracked in Open Questions)

  - Cross-section content to add elsewhere (e.g. generator references in other feature pages not yet migrated)

  ## Verification

  - `npm run build` succeeds (no broken links, no MDX errors)
  - `uv run invoke docs.lint` passes (one pre-existing error in `faq.mdx` unrelated to this PR)
  - Forbidden words (`simple`, `easy`, `just`) scan: clean

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
