### PR TITLE
feat(permissions): add rebase_branch permission

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -104,6 +104,7 @@ class GlobalPermissions(InfrahubStringEnum):
     EDIT_DEFAULT_BRANCH = "edit_default_branch"
     SUPER_ADMIN = "super_admin"
     MERGE_BRANCH = "merge_branch"
+    REBASE_BRANCH = "rebase_branch"
     DELETE_BRANCH = "delete_branch"
     MERGE_PROPOSED_CHANGE = "merge_proposed_change"
     REVIEW_PROPOSED_CHANGE = "review_proposed_change"

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -408,6 +408,7 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
         GlobalPermissions.MANAGE_ACCOUNTS,
         GlobalPermissions.MANAGE_PERMISSIONS,
         GlobalPermissions.MERGE_BRANCH,
+        GlobalPermissions.REBASE_BRANCH,
     ):
         await get_or_create_global_permission(db=db, permission=permission_action)
 

--- a/backend/infrahub/graphql/api/dependencies.py
+++ b/backend/infrahub/graphql/api/dependencies.py
@@ -11,6 +11,7 @@ from ..auth.query_permission_checker.object_permission_checker import (
     PermissionManagerPermissionChecker,
     RepositoryManagerPermissionChecker,
 )
+from ..auth.query_permission_checker.rebase_operation_checker import RebaseBranchPermissionChecker
 from ..auth.query_permission_checker.super_admin_checker import SuperAdminPermissionChecker
 
 
@@ -26,6 +27,7 @@ def build_graphql_query_permission_checker() -> GraphQLQueryPermissionChecker:
             SuperAdminPermissionChecker(),
             DefaultBranchPermissionChecker(),
             MergeBranchPermissionChecker(),
+            RebaseBranchPermissionChecker(),
             AccountManagerPermissionChecker(),
             RepositoryManagerPermissionChecker(),
             PermissionManagerPermissionChecker(),

--- a/backend/infrahub/graphql/auth/query_permission_checker/rebase_operation_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/rebase_operation_checker.py
@@ -1,0 +1,35 @@
+from infrahub import config
+from infrahub.auth import AccountSession
+from infrahub.core.account import GlobalPermission
+from infrahub.core.branch import Branch
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.initialization import GraphqlParams
+
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
+
+
+class RebaseBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
+    """Checker that makes sure a user account can rebase a branch."""
+
+    permission_required = GlobalPermission(
+        action=GlobalPermissions.REBASE_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
+    )
+
+    async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:  # noqa: ARG002
+        return config.SETTINGS.main.allow_anonymous_access or account_session.authenticated
+
+    async def check(
+        self,
+        db: InfrahubDatabase,  # noqa: ARG002
+        account_session: AccountSession,  # noqa: ARG002
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch,  # noqa: ARG002
+    ) -> CheckerResolution:
+        if "BranchRebase" in [operation.name for operation in analyzed_query.operations]:
+            query_parameters.context.active_permissions.raise_for_permission(permission=self.permission_required)
+            return CheckerResolution.TERMINATE
+
+        return CheckerResolution.NEXT_CHECKER

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -24,6 +24,7 @@ class BranchRelativePermissionDecision(StrEnum):
 GLOBAL_PERMISSION_DENIAL_MESSAGE = {
     GlobalPermissions.EDIT_DEFAULT_BRANCH.value: "You are not allowed to change data in the default branch",
     GlobalPermissions.MERGE_BRANCH.value: "You are not allowed to merge a branch",
+    GlobalPermissions.REBASE_BRANCH.value: "You are not allowed to rebase a branch",
     GlobalPermissions.DELETE_BRANCH.value: "You are not allowed to delete a branch you did not create",
     GlobalPermissions.MERGE_PROPOSED_CHANGE.value: "You are not allowed to merge proposed changes",
     GlobalPermissions.REVIEW_PROPOSED_CHANGE.value: "You are not allowed to review proposed changes",
@@ -38,6 +39,7 @@ GLOBAL_PERMISSION_DENIAL_MESSAGE = {
 GLOBAL_PERMISSION_DESCRIPTION = {
     GlobalPermissions.EDIT_DEFAULT_BRANCH: "Allow a user to change data in the default branch",
     GlobalPermissions.MERGE_BRANCH: "Allow a user to merge branches",
+    GlobalPermissions.REBASE_BRANCH: "Allow a user to rebase branches",
     GlobalPermissions.DELETE_BRANCH: "Allow a user to delete branches",
     GlobalPermissions.MERGE_PROPOSED_CHANGE: "Allow a user to merge proposed changes",
     GlobalPermissions.REVIEW_PROPOSED_CHANGE: "Allow a user to approve or reject proposed changes",

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_rebase_operation_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_rebase_operation_checker.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core import registry
+from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
+from infrahub.core.node import Node
+from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
+from infrahub.graphql.auth.query_permission_checker.rebase_operation_checker import RebaseBranchPermissionChecker
+from infrahub.graphql.initialization import prepare_graphql_params
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from tests.component.graphql.conftest import PermissionsHelper
+
+
+REBASE_QUERY = """
+mutation {
+    BranchRebase(data: { name: "branch1" }) {
+        ok
+    }
+}
+"""
+
+UNRELATED_QUERY = """
+mutation {
+    BuiltinTagCreate(data: { name: { value: "tag1" } }) {
+        ok
+    }
+}
+"""
+
+
+class TestRebaseBranchPermission:
+    async def test_setup(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        register_core_models_schema: None,
+        default_branch: Branch,
+        permissions_helper: PermissionsHelper,
+        first_account: CoreAccount,
+        second_account: CoreAccount,
+    ) -> None:
+        permissions_helper._default_branch = default_branch
+
+        permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
+        await permission.new(
+            db=db, action=GlobalPermissions.REBASE_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
+        )
+        await permission.save(db=db)
+
+        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+        await role.new(db=db, name="rebaser", permissions=[permission])
+        await role.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+        await group.new(db=db, name="rebaser", roles=[role])
+        await group.save(db=db)
+
+        await group.members.add(db=db, data={"id": first_account.id})
+        await group.members.save(db=db)
+
+        permissions_helper._first = first_account
+        permissions_helper._second = second_account
+
+    async def test_supports_authenticated_account(
+        self,
+        db: InfrahubDatabase,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = RebaseBranchPermissionChecker()
+        user = AccountSession(authenticated=True, account_id="abc", auth_type=AuthType.JWT)
+        is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
+        assert is_supported is True
+
+    async def test_account_with_permission_can_rebase(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = RebaseBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        gql_params = await prepare_graphql_params(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=REBASE_QUERY,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
+        )
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=analyzed_query,
+            query_parameters=gql_params,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.TERMINATE
+
+    async def test_account_with_permission_skips_unrelated_operation(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = RebaseBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        gql_params = await prepare_graphql_params(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=UNRELATED_QUERY,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
+        )
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=analyzed_query,
+            query_parameters=gql_params,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER
+
+    async def test_account_without_permission_is_denied(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = RebaseBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        gql_params = await prepare_graphql_params(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=REBASE_QUERY,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
+        )
+
+        with pytest.raises(PermissionDeniedError, match=r"You are not allowed to rebase a branch"):
+            await checker.check(
+                db=db,
+                account_session=session,
+                analyzed_query=analyzed_query,
+                query_parameters=gql_params,
+                branch=permissions_helper.default_branch,
+            )
+
+    async def test_account_without_permission_skips_unrelated_operation(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = RebaseBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        gql_params = await prepare_graphql_params(
+            db=db, branch=permissions_helper.default_branch, account_session=session
+        )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=UNRELATED_QUERY,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
+        )
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=analyzed_query,
+            query_parameters=gql_params,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER

--- a/changelog/8050.added.md
+++ b/changelog/8050.added.md
@@ -1,0 +1,1 @@
+Add a `rebase_branch` global permission so administrators can grant non-admin users the ability to rebase branches without requiring `super_admin`.


### PR DESCRIPTION
## Why & What

Until now rebasing a branch required super_admin, even when the user already had merge_branch and merge_proposed_change. That left admins with no way to delegate rebase to a regular user.

Add a rebase_branch global permission alongside the existing merge permissions, register it during first time initialization, and add a checker that gates the BranchRebase mutation.

Closes #8050

In a follow-up PR, that will target `develop`, I will probably try to get rid of checkers for branch merge and branch rebase. Having `raise_for_permission` call in the mutation code should suffice. This PR targets `stable` that why I went with another checker, to be consistent with what already exists.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content
