### PR TITLE
Database sessions reused through Prefect flows signature and through get_database()

### DIFF
--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -163,7 +163,6 @@ async def run_generator(
     node_ids: list[str],
     generator_definition_id: str,
     context: InfrahubContext,
-    service: InfrahubServices,  # noqa: ARG001
 ) -> None:
     await add_tags(branches=[branch_name], nodes=node_ids + [generator_definition_id])
 

--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -208,11 +208,12 @@ async def run_generator_group_event(
 async def configure_action_rules(
     service: InfrahubServices,
 ) -> None:
-    await setup_triggers_specific(
-        gatherer=gather_trigger_action_rules,  # type: ignore[arg-type]
-        trigger_type=TriggerType.ACTION_TRIGGER_RULE,
-        db=service.database,
-    )
+    async with service.database.start_session(read_only=True) as db:
+        await setup_triggers_specific(
+            gatherer=gather_trigger_action_rules,  # type: ignore[arg-type]
+            trigger_type=TriggerType.ACTION_TRIGGER_RULE,
+            db=db,
+        )
 
 
 async def _get_targets(

--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -186,7 +186,6 @@ async def run_generator_group_event(
     members: list[EventGroupMember],
     generator_definition_id: str,
     context: InfrahubContext,
-    service: InfrahubServices,  # noqa: ARG001
 ) -> None:
     node_ids = [node.id for node in members]
     await add_tags(branches=[branch_name], nodes=node_ids + [generator_definition_id])

--- a/backend/infrahub/branch/tasks.py
+++ b/backend/infrahub/branch/tasks.py
@@ -22,13 +22,12 @@ async def branch_merged(
 ) -> None:
     target_branch = target_branch or registry.default_branch
     log = get_run_logger()
-    await wait_for_schema_to_converge(
-        branch_name=target_branch, component=service.component, db=service.database, log=log
-    )
+
+    async with service.database.start_session() as db:
+        await wait_for_schema_to_converge(branch_name=target_branch, component=service.component, db=db, log=log)
 
     updated_branches = await validate_schema_number_pools(branch_name=target_branch, context=context, service=service)
 
     if updated_branches:
-        await wait_for_schema_to_converge(
-            branch_name=target_branch, component=service.component, db=service.database, log=log
-        )
+        async with service.database.start_session() as db:
+            await wait_for_schema_to_converge(branch_name=target_branch, component=service.component, db=db, log=log)

--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -92,8 +92,8 @@ def shell() -> None:
         )
         initialize_lock(service=service)
 
-        async with service.database as db:
-            await initialization(db=db)
+        async with service.database.start_session() as safe_db:
+            await initialization(db=safe_db)
         await service.component.refresh_schema_hash()
 
         return service

--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -92,8 +92,8 @@ def shell() -> None:
         )
         initialize_lock(service=service)
 
-        async with service.database.start_session() as safe_db:
-            await initialization(db=safe_db)
+        async with service.database.start_session() as db:
+            await initialization(db=db)
         await service.component.refresh_schema_hash()
 
         return service

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -113,8 +113,9 @@ async def prepare_graphql_params(
 
     permissions: PermissionManager | None = None
     if account_session:
-        permissions = PermissionManager(account_session=account_session)
-        await permissions.load_permissions(db=db, branch=branch)
+        async with db.start_session(read_only=True) as database:
+            permissions = PermissionManager(account_session=account_session)
+            await permissions.load_permissions(db=database, branch=branch)
 
     return GraphqlParams(
         schema=gql_schema,

--- a/backend/infrahub/pools/tasks.py
+++ b/backend/infrahub/pools/tasks.py
@@ -22,22 +22,24 @@ async def validate_schema_number_pools(
     service: InfrahubServices,
 ) -> set[str]:
     log = get_run_logger()
-    synchronizer = SchemaNumberPoolSynchronizer(
-        db=service.database,
-        schema_manager=registry.schema,
-        upserter=SchemaNumberPoolUpserter(db=service.database, schema_manager=registry.schema),
-        log=log,
-    )
-    updated_branches = await synchronizer.run(user_id=context.account.account_id)
 
-    if updated_branches:
-        for updated_branch_name in updated_branches:
-            branch = await Branch.get_by_name(db=service.database, name=updated_branch_name)
-            branch.update_schema_hash()
-            await branch.save(db=service.database, user_id=context.account.account_id)
-            log.info(f"Updated schema hash for branch {updated_branch_name} after number pool synchronization")
+    async with service.database.start_session() as db:
+        synchronizer = SchemaNumberPoolSynchronizer(
+            db=db,
+            schema_manager=registry.schema,
+            upserter=SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema),
+            log=log,
+        )
+        updated_branches = await synchronizer.run(user_id=context.account.account_id)
 
-        await service.component.refresh_schema_hash(branches=list(updated_branches))
-        await service.message_bus.send(RefreshRegistryBranches())
+        if updated_branches:
+            for updated_branch_name in updated_branches:
+                branch = await Branch.get_by_name(db=db, name=updated_branch_name)
+                branch.update_schema_hash()
+                await branch.save(db=db, user_id=context.account.account_id)
+                log.info(f"Updated schema hash for branch {updated_branch_name} after number pool synchronization")
+
+            await service.component.refresh_schema_hash(branches=list(updated_branches))
+            await service.message_bus.send(RefreshRegistryBranches())
 
     return updated_branches

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -168,15 +168,14 @@ async def merge_proposed_change(
     await add_tags(nodes=[proposed_change_id])
     database = await get_database()
 
-    proposed_change = await registry.manager.get_one(
-        db=database,
-        id=proposed_change_id,
-        kind=InternalCoreProposedChange,
-        raise_on_error=True,
-        prefetch_relationships=True,
-    )
-
     async with database.start_session() as db:
+        proposed_change = await registry.manager.get_one(
+            db=db,
+            id=proposed_change_id,
+            kind=InternalCoreProposedChange,
+            raise_on_error=True,
+            prefetch_relationships=True,
+        )
         log.info("Validating if all conditions are met to merge the proposed change")
 
         try:

--- a/backend/infrahub/schema/tasks.py
+++ b/backend/infrahub/schema/tasks.py
@@ -20,13 +20,12 @@ async def schema_updated(
     service: InfrahubServices,
 ) -> None:
     log = get_run_logger()
-    await wait_for_schema_to_converge(
-        branch_name=branch_name, component=service.component, db=service.database, log=log
-    )
+
+    async with service.database.start_session() as db:
+        await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
 
     updated_branches = await validate_schema_number_pools(branch_name=branch_name, context=context, service=service)
 
     if updated_branches:
-        await wait_for_schema_to_converge(
-            branch_name=branch_name, component=service.component, db=service.database, log=log
-        )
+        async with service.database.start_session() as db:
+            await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)

--- a/backend/infrahub/services/component.py
+++ b/backend/infrahub/services/component.py
@@ -77,26 +77,27 @@ class InfrahubComponent:
 
     async def refresh_schema_hash(self, branches: list[str] | None = None) -> None:
         branches = branches or list(registry.branch.keys())
-        for branch in branches:
-            if branch == GLOBAL_BRANCH_NAME:
-                continue
-            schema_branch = registry.schema.get_schema_branch(name=branch)
-            hash_value = schema_branch.get_hash()
+        async with self.db.start_session(read_only=True) as safe_db:
+            for branch in branches:
+                if branch == GLOBAL_BRANCH_NAME:
+                    continue
+                schema_branch = registry.schema.get_schema_branch(name=branch)
+                hash_value = schema_branch.get_hash()
 
-            # Use branch name if we cannot find branch id in cache
-            branch_id: str | None = None
-            if branch_obj := await registry.get_branch(branch=branch, db=self.db):
-                branch_id = str(branch_obj.uuid)
+                # Use branch name if we cannot find branch id in cache
+                branch_id: str | None = None
+                if branch_obj := await registry.get_branch(branch=branch, db=safe_db):
+                    branch_id = str(branch_obj.uuid)
 
-            if not branch_id:
-                branch_id = branch
+                if not branch_id:
+                    branch_id = branch
 
-            for component in self.component_names:
-                await self.cache.set(
-                    key=f"workers:schema_hash:branch:{branch_id}:{component}:worker:{WORKER_IDENTITY}",
-                    value=hash_value,
-                    expires=KVTTL.TWO_HOURS,
-                )
+                for component in self.component_names:
+                    await self.cache.set(
+                        key=f"workers:schema_hash:branch:{branch_id}:{component}:worker:{WORKER_IDENTITY}",
+                        value=hash_value,
+                        expires=KVTTL.TWO_HOURS,
+                    )
 
     async def refresh_heartbeat(self) -> None:
         for component in self.component_names:

--- a/backend/infrahub/trigger/setup.py
+++ b/backend/infrahub/trigger/setup.py
@@ -53,11 +53,7 @@ async def setup_triggers_specific(
     async with lock.registry.get(
         name=f"configure-action-rules-{trigger_type.value}", namespace="trigger-rules", local=False
     ):
-        if db:
-            async with db.start_session(read_only=True) as dbs:
-                triggers = await gatherer(dbs)
-        else:
-            triggers = await gatherer(db)
+        triggers = await gatherer(db)
         async with get_client(sync_client=False) as prefect_client:
             return await setup_triggers(
                 client=prefect_client,

--- a/backend/infrahub/webhook/tasks/configure.py
+++ b/backend/infrahub/webhook/tasks/configure.py
@@ -189,11 +189,12 @@ async def _reconcile_all() -> None:
     log = get_run_logger()
 
     database = await get_database()
-    trigger_setup_report = await setup_triggers_specific(
-        gatherer=gather_trigger_webhook,  # type: ignore[arg-type]
-        db=database,
-        trigger_type=TriggerType.WEBHOOK,
-    )
+    async with database.start_session(read_only=True) as db:
+        trigger_setup_report = await setup_triggers_specific(
+            gatherer=gather_trigger_webhook,  # type: ignore[arg-type]
+            db=db,
+            trigger_type=TriggerType.WEBHOOK,
+        )
 
     webhook_ids_to_invalidate = await get_webhooks_to_invalidate(trigger_setup_report)
 

--- a/backend/infrahub/workers/dependencies.py
+++ b/backend/infrahub/workers/dependencies.py
@@ -24,6 +24,11 @@ from infrahub.tls.registry import TlsContextRegistry
 _singletons: dict[str, Any] = {}
 
 
+def clear_singletons() -> None:
+    """Drop every cached singleton"""
+    _singletons.clear()
+
+
 def set_component_type(component_type: ComponentType) -> None:
     if "component_type" not in _singletons:
         _singletons["component_type"] = component_type

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -30,7 +30,14 @@ from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.server import app, lifespan
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_cache, build_client, build_database, build_message_bus, build_workflow
+from infrahub.workers.dependencies import (
+    build_cache,
+    build_client,
+    build_database,
+    build_message_bus,
+    build_workflow,
+    clear_singletons,
+)
 from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
@@ -139,6 +146,12 @@ class TestInfrahubAppBase(TestInfrahub):
         # lifespan events (see https://fastapi.tiangolo.com/advanced/async-tests/#in-detail).
         async def _db(singleton: bool = True) -> InfrahubDatabase:
             return db_class
+
+        # Each class gets its own db_class with its own driver, and lifespan shutdown
+        # closes that driver. Cached singletons (notably the InfrahubComponent) hold
+        # references to the prior class's driver; drop them so the next lifespan()
+        # rebuilds them against the current db_class.
+        clear_singletons()
 
         with dependency_provider.scope(build_database, _db):
             try:

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -20,7 +20,7 @@ from infrahub.git import InfrahubRepository
 from infrahub.server import app, lifespan
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.utils import get_models_dir
-from infrahub.workers.dependencies import build_database
+from infrahub.workers.dependencies import build_database, clear_singletons
 from infrahub.workflows.initialization import setup_task_manager
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_app import TestInfrahubApp
@@ -75,6 +75,12 @@ class TestInfrahubClient:
     ) -> AsyncGenerator[InfrahubTestClient, None]:
         async def _db(singleton: bool = True) -> InfrahubDatabase:
             return db_class
+
+        # Each class gets its own db_class with its own driver, and lifespan shutdown
+        # closes that driver. Cached singletons (notably the InfrahubComponent) hold
+        # references to the prior class's driver; drop them so the next lifespan()
+        # rebuilds them against the current db_class.
+        clear_singletons()
 
         with dependency_provider.scope(build_database, _db):
             async with lifespan(app):

--- a/backend/tests/unit/workflows/test_flow_session_convention.py
+++ b/backend/tests/unit/workflows/test_flow_session_convention.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import TYPE_CHECKING, TypeGuard
+
+import pytest
+
+from infrahub.services import InfrahubServices
+from infrahub.workers.utils import has_parameter
+from infrahub.workflows.catalogue import get_workflows
+
+if TYPE_CHECKING:
+    from infrahub.workflows.models import WorkflowDefinition
+
+_SESSION_OPENERS = ("start_session", "start_transaction")
+
+
+def _is_service_database(node: ast.AST) -> TypeGuard[ast.Attribute]:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "database"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "service"
+    )
+
+
+def _build_parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _scan_flow(workflow: WorkflowDefinition) -> list[str]:
+    flow = workflow.load_function()
+    if not has_parameter(func=flow, types=[InfrahubServices.__name__, InfrahubServices]):
+        return []
+
+    lines, source_start = inspect.getsourcelines(flow.fn)
+    tree = ast.parse(textwrap.dedent("".join(lines)))
+    parents = _build_parent_map(tree)
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not _is_service_database(node):
+            continue
+        parent = parents[node]
+        if isinstance(parent, ast.Attribute) and parent.attr in _SESSION_OPENERS:
+            continue
+        lineno = source_start + node.lineno - 1
+        violations.append(f"{workflow.module}:{lineno} flow={workflow.function!r} -> {ast.unparse(parent)}")
+    return violations
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    [pytest.param(workflow, id=workflow.name) for workflow in get_workflows()],
+)
+def test_flow_does_not_reuse_shared_database_session(workflow: WorkflowDefinition) -> None:
+    """Prefect flows that take a `service: InfrahubServices` parameter must access
+    `service.database` only through `.start_session(` or `.start_transaction(`.
+
+    Passing `service.database` directly (e.g. `db=service.database`) reuses the
+    worker's shared neo4j async session and triggers
+    `RuntimeError: read() called while another coroutine is already waiting for incoming data`
+    when concurrent flows execute. Each flow must scope its own session.
+
+    Aliasing (`database = service.database`) also fails this check on purpose:
+    inline `service.database.start_session(...)` is the required form so the
+    convention stays mechanically verifiable.
+    """
+    violations = _scan_flow(workflow=workflow)
+    assert not violations, "Flow accesses service.database without opening a session:\n" + "\n".join(violations)

--- a/changelog/8871.fixed.md
+++ b/changelog/8871.fixed.md
@@ -1,1 +1,0 @@
-Fix intermittent `RuntimeError: read() called while another coroutine is already waiting for incoming data` that could occur during concurrent Prefect flow execution.

--- a/changelog/8871.fixed.md
+++ b/changelog/8871.fixed.md
@@ -1,0 +1,1 @@
+Fix intermittent `RuntimeError: read() called while another coroutine is already waiting for incoming data` that could occur during concurrent Prefect flow execution.

--- a/changelog/9121.fixed.md
+++ b/changelog/9121.fixed.md
@@ -1,0 +1,1 @@
+Fix a critical race condition where concurrent coroutines in API and task workers could share the same neo4j async driver session, causing non-deterministic failures including `RuntimeError: read() called while another coroutine is already waiting for incoming data`, hung tasks, and in some cases infinite loops.


### PR DESCRIPTION
## Why 

Related to the E2E tests flakiness issue https://github.com/opsmill/infrahub/issues/8871 or no recovery path issue https://github.com/opsmill/infrahub/issues/9121, it seems that database sessions or transactions are not correctly managed during the application lifecycle.

Closes https://github.com/opsmill/infrahub/issues/9121 and [[IFC-2551]](https://opsmill.atlassian.net/browse/IFC-2551)

## What this PR is about

In a specific Prefect worker, same database instance/session is reused through Prefect flows signature when service is injected through `infrahub.workers.utils.inject_service_parameter`.
This PR aims to make sure that when the database is injected through this `service` parameter, that a new database session is created if necessary.

### List of Prefect flows impacted

#### Touch service.database directly (race-condition candidates):

- `validate_schema_number_pools`
- `branch_merged`
- `schema_updated`
- `configure_action_rules`
 
#### Don't touch service.database directly (only service.client HTTP / cache / message_bus):

- `add_node_to_group`
- `remove_node_from_group`
- `run_generator`
- `run_generator_group_event`
- `clean_up_deadlocks`

### Solution 

When the flow use `service.database`:

- make sure that a new database session is created. 
- check other potential callers
- put at the top level the database session creation if it is nested without any value added

When the flow is not using `service.database`:
- remove service parameter from signature if it is unused

### Testing part

A new introspective test has been created in order to ensure that, in each Prefect flow method, we do NOT use `service.database` without calling it in a `start_session()` or `start_transaction()` bloc.

### Additional callers fixed outside Prefect flow scope

The introspective test only scans Prefect flows that take a `service: InfrahubServices` parameter. A manual audit of all `service.database` and `get_database()` callers surfaced four more sites that were running queries against the DRIVER-mode singleton:

- `graphql/initialization.py` — `prepare_graphql_params` was loading permissions via `permissions.load_permissions(db=db, ...)` directly on the passed-in db. Now wrapped in
`start_session(read_only=True)`. (de21cabc)
- `proposed_change/tasks.py` — `merge_proposed_change` was running `registry.manager.get_one()` against the DRIVER db before entering the existing `start_session()` block. Moved the lookup inside the session. (4c2f1907)
- `cli/__init__.py` — the `infrahub shell` command had `async with service.database as db:`, which is a silent no-op because `__aenter__` on a DRIVER-mode `InfrahubDatabase`does not open a neo4j session. Changed to `start_session()`. (68e682c131423ded3f32b853958417ce63f38949)
- `services/component.py` — `InfrahubComponent.refresh_schema_hash` calls `registry.get_branch(db=self.db)` for every branch, where `self.db` is the DRIVER singleton stored at construction. Wrapped the loop in `start_session(read_only=True)`. (74d9f1b4)


[IFC-2551]: https://opsmill.atlassian.net/browse/IFC-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ