### PR TITLE
chore: bump invoke 2.2.0 -> 2.2.1 for Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "types-pyyaml",
     "types-cachetools==6.2.0.20250827",
     "ruff==0.15.0",
-    "invoke==2.2.0",
+    "invoke==2.2.1",
     "pytest-benchmark>=4.0.0,<5",
     "pytest-codspeed>=4.2.0,<5",
     "polyfactory==2.16.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = "==7.13.5" },
     { name = "docker", specifier = "==7.1.0" },
-    { name = "invoke", specifier = "==2.2.0" },
+    { name = "invoke", specifier = "==2.2.1" },
     { name = "ipython", specifier = ">=8,<9" },
     { name = "jwcrypto", specifier = "==1.5.7" },
     { name = "matplotlib", specifier = "==3.10.7" },
@@ -1563,11 +1563,11 @@ wheels = [
 
 [[package]]
 name = "invoke"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5", size = 299835, upload-time = "2023-07-12T18:05:17.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820", size = 160274, upload-time = "2023-07-12T18:05:16.294Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `invoke` from `2.2.0` to `2.2.1` in `pyproject.toml` + `uv.lock`.

## Why

invoke 2.2.0 raises `SystemError` on Python 3.14: the runtime tightened `fcntl` to surface buffer-overflow reads, and invoke's `termios.TIOCGWINSZ` probe was reading too few fields of a 4-field struct. Locally any `uv run invoke <task>` aborts before the task body — `dev.start`, `format`, `lint`, etc. all fail.

invoke 2.2.1 (2025-10-10) unpacks all four fields and discards the unused two — pure compat fix, no behavior change.

Upstream changelog: https://www.pyinvoke.org/changelog.html#2.2.1

## How to reproduce

Using Python 3.14

```
uv pip install invoke==2.2.0
.venv/bin/invoke --list
```

#### Expected output
`SystemError: buffer overflow
`

## Test plan

- [ ] \`uv sync --all-groups\` succeeds.
- [ ] \`uv run invoke --list\` runs without SystemError on Python 3.14.
- [ ] \`uv run invoke format\` and \`uv run invoke lint\` complete.
