### PR TITLE
docs(ipam): embed IP Namespace overview video

### DIFF
--- a/docs/docs/topics/ipam.mdx
+++ b/docs/docs/topics/ipam.mdx
@@ -32,6 +32,10 @@ By default, Infrahub comes with a node inheriting from the `BuiltinIPNamespace` 
 
 IP Namespaces are logical containers that segment and isolate IPAM resources. They allow you to manage separate pools of IP prefixes and addresses within the same Infrahub instance, preventing conflicts and enabling organizational separation of IP resources.
 
+<center>
+  <VideoPlayer url='https://www.youtube.com/watch?v=T5Qiy-13kYg' light />
+</center>
+
 ### Understanding IP Namespaces
 
 If you are familiar with networking concepts, an IP Namespace is analogous to:


### PR DESCRIPTION
## Summary
- Embeds the IP Namespace walkthrough video (https://www.youtube.com/watch?v=T5Qiy-13kYg) at the start of the **IP Namespaces** section in `docs/docs/topics/ipam.mdx`
- Complements the existing written explanation of overlapping IP space, multi-tenant scenarios, and the ISP example already in that section
- Follows the existing `<center><VideoPlayer url='...' light /></center>` pattern used elsewhere in the file

## Test plan
- [ ] `cd docs && npm run build` renders without errors
- [ ] Video player appears under the `## IP Namespaces` heading and plays correctly