### PR TITLE
docs: move Testing Framework to Branches & Change Control + flatten Reference > Message Bus Events

### DIFF
--- a/docs/docs/reference/infrahub-tests.mdx
+++ b/docs/docs/reference/infrahub-tests.mdx
@@ -10,7 +10,7 @@ The file should be formatted as a YAML file, have a filename prefixed with `test
 
 :::info
 
-See [this topic](../topics/resources-testing-framework.mdx) for more details on the available repository configuration options
+See the [Testing Framework](../testing-framework/) page for more details on the available repository configuration options
 
 :::
 

--- a/docs/docs/testing-framework/index.mdx
+++ b/docs/docs/testing-framework/index.mdx
@@ -1,14 +1,14 @@
 ---
-title: Resources testing framework
+title: Testing framework
 ---
 
-# Resources testing framework
+# Testing framework
 
 ## Summary
 
-Infrahub allows users to define tests to ensure that [Transformations](../topics/transformation.mdx) and [checks](../topics/check.mdx) are working as intended. This can be an important step while writing Infrahub related resources as it makes sure that they keep returning the same expected values over time and version bumps.
+Infrahub allows users to define tests to ensure that [Transformations](../topics/transformation.mdx) and [checks](../checks/) are working as intended. This can be an important step while writing Infrahub related resources as it makes sure that they keep returning the same expected values over time and version bumps.
 
-These tests are based on [pytest](https://docs.pytest.org/) but do not require users to write any Python code. Tests can be run via a command line and the `pytest` executable but they are also integrated within the CI pipelines of [proposed changes](../topics/proposed-change.mdx).
+These tests are based on [pytest](https://docs.pytest.org/) but do not require users to write any Python code. Tests can be run via a command line and the `pytest` executable but they are also integrated within the CI pipelines of [proposed changes](../proposed-changes/).
 
 ## Types of test
 

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -151,7 +151,7 @@ export INFRAHUB_DEFAULT_BRANCH_FROM_GIT=true
 
 Testing is crucial for maintaining high-quality code. Infrahub provides a testing framework based on Pytest to simplify unit and integration tests.
 
-Refer to the [Testing Framework Documentation](./resources-testing-framework.mdx) for details.
+Refer to the [Testing Framework](../testing-framework/) for details.
 
 :::warning Under Construction
 

--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -112,4 +112,4 @@ Infrahub provide a framework to create unit tests for your Transformations with 
 
 The tests can be executed locally for development purpose and they will also be executed as part of the CI Pipeline when the platform identify a change that could potentially impact your Transformation.
 
-For more information, please check out the [Resource Testing Framework](../topics/resources-testing-framework.mdx) page.
+For more information, please check out the [Testing Framework](../testing-framework/) page.

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -78,3 +78,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `branches-and-change-control.yml` | Branches & Change Control | TBD |
 | `menu.yml` | Menu Customization | TBD |
 | `schema.yml` | Schema & Data | TBD |
+| `testing-framework-move.yml` | Testing Framework move | TBD |

--- a/docs/redirects-pending/testing-framework-move.yml
+++ b/docs/redirects-pending/testing-framework-move.yml
@@ -1,0 +1,35 @@
+---
+feature: Testing Framework move
+pr: TBD
+description: |
+  Testing Framework page moved out of "Development Resources" into Branches &
+  Change Control as a 5th sub-category, parallel to Checks & Validation. Per
+  Pete Crocker's docs review on May 6: "this is a CI pipeline and branching
+  concept."
+
+  Frontmatter title shortened from "Resources testing framework" to "Testing
+  framework" to match the sidebar label and Pete's preferred name. Wim/Baptiste
+  invited to push back on the rename in PR review.
+
+  Bundled in the same PR: a sidebar-only flatten of Reference > API >
+  Message Bus Events (Message Bus Events promoted to a flat sibling of the
+  API sub-category). The api-server placeholder page stays put for now —
+  removal is in a follow-up PR.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/resources-testing-framework
+    to: /docs/testing-framework/
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/testing-framework/
+    title: Testing Framework
+
+# Internal cross-link references in OTHER files that point at legacy paths.
+# All three inbound links were updated in this PR (not deferred to cleanup) since
+# they're internal cross-section references this PR could address cleanly:
+# - docs/docs/topics/transformation.mdx
+# - docs/docs/topics/developer-guide.mdx
+# - docs/docs/reference/infrahub-tests.mdx
+cross_links_to_update: []

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -224,6 +224,7 @@ const sidebars: SidebarsConfig = {
           ],
         },
         { type: 'doc', id: 'checks/index', label: 'Checks & Validation' },
+        { type: 'doc', id: 'testing-framework/index', label: 'Testing Framework' },
         { type: 'doc', id: 'change-approval/change-approval-workflow', label: 'Change Approval Policy' },
         {
           type: 'category',
@@ -359,7 +360,6 @@ const sidebars: SidebarsConfig = {
       items: [
         { type: 'doc', id: 'topics/developer-guide', label: 'Developer Guide' },
         { type: 'doc', id: 'topics/local-demo-environment', label: 'Local Demo Environment' },
-        { type: 'doc', id: 'topics/resources-testing-framework', label: 'Testing Framework' },
         {
           type: 'category',
           label: 'APIs & interfaces',
@@ -393,9 +393,9 @@ const sidebars: SidebarsConfig = {
           link: { type: 'generated-index' },
           items: [
             'reference/api-server',
-            'reference/message-bus-events',
           ],
         },
+        { type: 'doc', id: 'reference/message-bus-events', label: 'Message Bus Events' },
         {
           type: 'category',
           label: 'CLI',


### PR DESCRIPTION
## Summary

Two scoped reorg moves from the May 6 Yvonne ↔ Pete docs review. Both are mechanical sidebar/file moves with no content rewrites.

## Content changes

- **Item 1 — Testing Framework move**:
  - File renamed: `topics/resources-testing-framework.mdx` → `testing-framework/index.mdx` (folder + `index.mdx` pattern matches the rest of the Branches & Change Control sub-cats: `branches/`, `proposed-changes/`, `checks/`, `change-approval/`, `git-integration/`)
  - Sidebar moved: from `Development Resources > Testing Framework` → `Branches & Change Control > Testing Framework` (5th item, immediately after Checks & Validation, per Pete's "parallel to Checks and Validation" framing in the call)
  - Frontmatter title shortened: `Resources testing framework` → `Testing framework`
  - Three inbound cross-links updated to the new path: `topics/transformation.mdx`, `topics/developer-guide.mdx`, `reference/infrahub-tests.mdx`
- **Item 2 — Message Bus Events flatten** (sidebar-only):
  - Was: `Reference > API > Message Bus Events`
  - Now: `Reference > Message Bus Events` as a flat sibling of the API sub-category
  - File path unchanged; no redirect needed

## What needs reviewer attention

Nothing to read carefully — both items are mechanical moves, no content changes. The only word-level edit was the frontmatter title shortening (`Resources testing framework` → `Testing framework`).

## Open question

In the call you suggested confirming the Testing Framework title and exact BCC placement with Wim or Baptiste. PR proceeds with the simplest defaults — happy to rename or relocate if Wim/Baptiste push back.

## Out of scope (follow-up PRs after Baptiste's input)

- Move Developer Guide + Local Demo Environment into Contributing (open question: Developer Guide content is actually about *user* extensibility — Transformations, Generators, Checks — not internal product development; the move-to-Contributing decision needs reconciling with that)
- Rename "Development Resources" → "APIs & Interfaces" and restructure
- Delete the placeholder `reference/api-server.mdx` page

## Verification

- `cd docs && npm run build` succeeds (no broken links)
- `vale` clean on the 4 changed/new files
- All three inbound links updated in this PR (not deferred to cleanup)

## Test plan

- [ ] Sidebar: Branches & Change Control category shows "Testing Framework" as the 5th item, between Checks & Validation and Change Approval Policy
- [ ] Sidebar: Reference category shows "Message Bus Events" as a flat entry; the API sub-category contains only the api-server placeholder
- [ ] Sidebar: Development Resources category no longer contains Testing Framework
- [ ] Testing Framework page renders at `/testing-framework/` with no broken cross-links
- [ ] Legacy URL `/topics/resources-testing-framework` is recorded for the end-of-Phase-2 redirect installation (no live redirect plugin yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)