### PR TITLE
docs: migrate Installation to hub + Community + Enterprise spokes

### DIFF
--- a/docs/docs/deploy-manage/install-configure/install/community.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/community.mdx
@@ -1,0 +1,309 @@
+---
+title: Install Infrahub Community
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ReferenceLink from "../../../../src/components/Card";
+
+# Install Infrahub Community
+
+Infrahub Community is deployed as a container-based architecture and can be installed using several methods.
+
+<Tabs groupId="install-method" queryString>
+<TabItem value="Docker compose via curl" default>
+
+## Using curl and Docker Compose
+
+To quickly spin up the latest Infrahub locally, retrieve the Docker Compose file from [infrahub.opsmill.io](https://infrahub.opsmill.io).
+
+You can also specify a specific version or the `develop` branch in the URL:
+
+- [https://infrahub.opsmill.io/develop](https://infrahub.opsmill.io/develop)
+- [https://infrahub.opsmill.io/1.3.3](https://infrahub.opsmill.io/1.3.3)
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Start an Infrahub environment
+
+<Tabs groupId="os" queryString>
+<TabItem value="macOS" default>
+
+```bash
+curl https://infrahub.opsmill.io > docker-compose.yml
+docker compose -p infrahub up -d
+```
+
+</TabItem>
+<TabItem value="Linux">
+
+```bash
+curl https://infrahub.opsmill.io > docker-compose.yml
+sudo docker compose -p infrahub up -d
+```
+
+</TabItem>
+</Tabs>
+
+After running the command, you should see Docker downloading the necessary images and starting the containers.
+
+:::success
+
+Verify that Infrahub is running by accessing the web interface or checking container status:
+
+```bash
+docker ps | grep infrahub
+```
+
+:::
+
+### Stop and remove an Infrahub environment
+
+<Tabs groupId="os" queryString>
+<TabItem value="macOS" default>
+
+```bash
+curl https://infrahub.opsmill.io > docker-compose.yml
+docker compose -p infrahub down -v
+```
+
+</TabItem>
+<TabItem value="Linux">
+
+```bash
+curl https://infrahub.opsmill.io > docker-compose.yml
+sudo docker compose -p infrahub down -v
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="Local development (git clone)">
+
+## Cloning the repository
+
+The recommended method for running Infrahub for development uses the Docker Compose files included with the project combined with helper commands defined in `invoke`.
+
+:::info
+
+This method is suitable for local development and demo environments. It is not recommended for production deployments.
+
+:::
+
+### Prerequisites
+
+- [uv](https://docs.astral.sh/uv/)
+- [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
+
+### Step 1: clone the repository
+
+Create the base directory for the Infrahub installation. For this guide, we'll use `/opt/infrahub`.
+
+```bash
+cd /opt/
+```
+
+:::warning
+
+Usage of the `/opt/infrahub` directory is merely a suggestion. You can use any directory on your system, especially for development or demo purposes.
+
+```bash
+mkdir -p ~/source/
+cd ~/source/
+```
+
+:::
+
+Clone Infrahub repository into the current directory:
+
+```bash
+git clone --recursive https://github.com/opsmill/infrahub.git
+```
+
+:::success
+
+The `git clone` command should generate output similar to the following:
+
+```bash
+Cloning into '.'...
+remote: Enumerating objects: 1312, done.
+remote: Counting objects: 100% (1312/1312), done.
+remote: Compressing objects: 100% (1150/1150), done.
+remote: Total 1312 (delta 187), reused 691 (delta 104), pack-reused 0
+Receiving objects: 100% (1312/1312), 33.37 MiB | 14.46 MiB/s, done.
+Resolving deltas: 100% (187/187), done.
+```
+
+:::
+
+### Step 2: install dependencies
+
+Navigate to the cloned Infrahub directory:
+
+```bash
+cd infrahub
+```
+
+Install the Python dependencies by running:
+
+```bash
+uv sync --all-groups
+```
+
+:::success
+
+You should see uv installing the required dependencies. When complete, you'll be returned to the command prompt without errors.
+
+:::
+
+### Step 3: start Infrahub
+
+Start and initialize Infrahub:
+
+```bash
+uv run invoke demo.start
+```
+
+<ReferenceLink title="Explore additional Invoke commands for development" url="/topics/local-demo-environment" />
+
+</TabItem>
+<TabItem value="Kubernetes with Helm">
+
+## Using Helm and Kubernetes
+
+It's possible to deploy Infrahub on Kubernetes using Helm charts. This method is suitable for production deployments and provides a more resilient architecture.
+
+<ReferenceLink title="Infrahub Helm Chart" url="https://github.com/opsmill/infrahub-helm/tree/stable/charts/infrahub" openInNewTab />
+<ReferenceLink title="ArtifactHub" url="https://artifacthub.io/packages/helm/infrahub/infrahub" openInNewTab />
+
+### Prerequisites
+
+- A Kubernetes cluster
+- [Helm](https://helm.sh/docs/intro/install/) installed on your system
+
+:::warning Storage persistence for testing and lab environments
+
+By default, the Helm chart disables storage persistence on all components (Neo4j, RabbitMQ, Redis) to enable quicker deployments using `emptyDir` storage and reduce requirements for test installations.
+
+However, if pods get rescheduled on the Kubernetes cluster for any reason, all data will be lost. This can happen unexpectedly due to node maintenance, resource pressure, or cluster updates.
+
+For long-running tests or lab environments, you should either:
+
+- Enable storage persistence for the Neo4j database at minimum (but also on the other components if possible)
+- Use Docker Compose instead, which provides more predictable behavior for non-production environments
+
+:::
+
+### Production deployment requirements
+
+The following are required for production deployments using Helm:
+
+- Data persistence for the database must be enabled
+- Multiple replicas of the Infrahub API Server and Infrahub Task workers should be deployed: you can use the `affinity` variable to define the affinity policy for the pods
+- S3 storage should be configured for the Infrahub API Server, it is required if you have multiple replicas
+
+:::warning
+
+We do not recommend using the included dependencies (Neo4j, RabbitMQ, Redis) for production.
+They are present to ease deployment on non-production environments.
+
+:::
+
+### Step 1: Fill in the values file
+
+Create a `values.yml` file with the following configuration:
+
+```yaml
+infrahubServer:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: service
+              operator: In
+              values:
+              - infrahub-server
+          topologyKey: topology.kubernetes.io/zone
+  persistence:
+    enabled: false
+  ingress:
+    enabled: true
+  infrahubServer:
+    env:
+      INFRAHUB_ALLOW_ANONYMOUS_ACCESS: "true"
+      INFRAHUB_CACHE_PORT: 6379
+      INFRAHUB_DB_TYPE: neo4j
+      INFRAHUB_LOG_LEVEL: INFO
+      INFRAHUB_PRODUCTION: "true"
+      INFRAHUB_INITIAL_ADMIN_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
+      INFRAHUB_SECURITY_SECRET_KEY: 327f747f-efac-42be-9e73-999f08f86b92
+      INFRAHUB_STORAGE_DRIVER: s3
+      AWS_ACCESS_KEY_ID: xxxx
+      AWS_SECRET_ACCESS_KEY: xxxx
+      AWS_S3_BUCKET_NAME: infrahub-data
+      AWS_S3_ENDPOINT_URL: https://s3
+
+infrahubTaskWorker:
+  replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: service
+              operator: In
+              values:
+              - infrahub-task-worker
+          topologyKey: topology.kubernetes.io/zone
+
+neo4j:
+  services:
+    admin:
+      enabled: true
+  volumes:
+    data:
+      mode: dynamic
+      dynamic:
+        storageClassName: premium-rwo
+        requests:
+          storage: 100Gi
+```
+
+:::warning
+
+Be sure to replace the placeholder values with your actual values. See the [configuration reference](/reference/configuration) for details on all available environment variables.
+
+:::
+
+### Step 2: install the chart
+
+Install using a local chart:
+
+```bash
+helm install infrahub -f values.yml path/to/infrahub/chart
+```
+
+Or install using the OpsMill registry:
+
+```bash
+helm install infrahub -f values.yml oci://registry.opsmill.io/opsmill/chart/infrahub
+```
+
+:::success
+
+Verify the installation by checking that all pods are running:
+
+```bash
+kubectl get pods -l app=infrahub
+```
+
+:::
+
+</TabItem>
+</Tabs>

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -1,0 +1,349 @@
+---
+title: Install Infrahub Enterprise
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ReferenceLink from "../../../../src/components/Card";
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+
+# Install Infrahub Enterprise <EnterpriseBadge />
+
+Infrahub Enterprise is based on the Community version, with several enhancements for:
+
+- Enterprise features
+- High availability
+- Better performance
+- Security hardening (Docker image, etc.)
+
+Infrahub Enterprise can be deployed using the same methods as Infrahub Community.
+
+<Tabs groupId="install-method" queryString>
+<TabItem value="Docker compose via curl" default>
+
+## Using curl and Docker Compose
+
+To quickly spin up the latest Infrahub Enterprise locally, retrieve the Docker Compose file from [infrahub.opsmill.io/enterprise](https://infrahub.opsmill.io/enterprise).
+
+You can also specify a specific version in the URL:
+
+- [https://infrahub.opsmill.io/enterprise/1.3.5](https://infrahub.opsmill.io/enterprise/1.3.5)
+
+You can also specify a sizing preset in the URL. This will automatically configure replica count for each component according to your sizing plan:
+
+- [https://infrahub.opsmill.io/enterprise?size=small](https://infrahub.opsmill.io/enterprise?size=small) (requires 16 GB of RAM)
+- [https://infrahub.opsmill.io/enterprise/1.3.5?size=medium](https://infrahub.opsmill.io/enterprise/1.3.5?size=medium) (requires 32 GB of RAM)
+- [https://infrahub.opsmill.io/enterprise/stable?size=large](https://infrahub.opsmill.io/enterprise/stable?size=large) (requires 64 GB of RAM)
+
+| Size        | Total required memory | API workers | Task workers | Task manager API workers | Task manager background workers | DB heap size | DB page cache size |
+|-------------|-----------------------|-------------|--------------|--------------------------|--------------------------------|--------------|--------------------|
+| small       | 16 GB                 | 4           | 2            | 1                        | 1                              | 8G           | 1G                 |
+| medium      | 32 GB                 | 4           | 4            | 2                        | 2                              | 24G          | 4G                 |
+| medium-data | 32 GB                 | 4           | 2            | 1                        | 1                              | 24G          | 4G                 |
+| large       | 64 GB                 | 4           | 8            | 4                        | 2                              | 31G          | 16G                |
+| large-data  | 64 GB                 | 4           | 2            | 1                        | 1                              | 31G          | 16G                |
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Start an Infrahub Enterprise environment
+
+<Tabs groupId="os" queryString>
+<TabItem value="macOS" default>
+
+```bash
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+docker compose -p infrahub up -d
+```
+
+</TabItem>
+<TabItem value="Linux">
+
+```bash
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+sudo docker compose -p infrahub up -d
+```
+
+</TabItem>
+</Tabs>
+
+### Stop and remove an Infrahub Enterprise environment
+
+<Tabs groupId="os" queryString>
+<TabItem value="macOS" default>
+
+```bash
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+docker compose -p infrahub down -v
+```
+
+</TabItem>
+<TabItem value="Linux">
+
+```bash
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+sudo docker compose -p infrahub down -v
+```
+
+</TabItem>
+</Tabs>
+
+### Enable observability
+
+To deploy Infrahub with a built-in observability stack (Grafana, Prometheus, Loki, Alloy), add the `?observability=true` query parameter to the URL. This can be combined with existing parameters like `size`:
+
+<Tabs groupId="os" queryString>
+<TabItem value="macOS" default>
+
+```bash
+curl "https://infrahub.opsmill.io/enterprise?observability=true" > docker-compose.yml
+docker compose -p infrahub up -d
+```
+
+</TabItem>
+<TabItem value="Linux">
+
+```bash
+curl "https://infrahub.opsmill.io/enterprise?observability=true" > docker-compose.yml
+sudo docker compose -p infrahub up -d
+```
+
+</TabItem>
+</Tabs>
+
+Combined with a sizing preset:
+
+```bash
+curl "https://infrahub.opsmill.io/enterprise?size=small&observability=true" > docker-compose.yml
+```
+
+Once running, Grafana is accessible at [http://localhost:3500](http://localhost:3500) with default credentials `admin` / `admin`.
+
+For instructions on upgrading an existing observability stack, see the [Upgrade guide](../../../guides/upgrade.mdx#upgrading-the-observability-stack).
+
+:::tip Enable request tracing
+
+Infrahub can export OpenTelemetry traces so you can follow a single request as it moves across the API server, task workers, and the database. Traces are sent to the bundled Tempo instance and surfaced in Grafana under the Tempo data source.
+
+To enable it, add the following to a `.env` file alongside the compose file:
+
+```bash
+INFRAHUB_TRACE_ENABLE=true
+INFRAHUB_TRACE_EXPORTER_TYPE=otlp
+INFRAHUB_TRACE_EXPORTER_PROTOCOL=grpc
+INFRAHUB_TRACE_EXPORTER_ENDPOINT=http://infrahub-tempo:4317
+INFRAHUB_TRACE_INSECURE=true
+```
+
+:::
+
+</TabItem>
+<TabItem value="Kubernetes with Helm">
+
+## Using Helm and Kubernetes
+
+The Enterprise Helm chart is based on the original Infrahub chart and uses it as a Helm dependency.
+Most configuration related to Infrahub goes inside the `infrahub` top-level key.
+
+<ReferenceLink title="Infrahub Enterprise Helm Chart" url="https://github.com/opsmill/infrahub-helm/tree/stable/charts/infrahub-enterprise" openInNewTab />
+<ReferenceLink title="ArtifactHub" url="https://artifacthub.io/packages/helm/infrahub-enterprise/infrahub-enterprise" openInNewTab />
+
+### Production deployment requirements
+
+The following are required for production deployments using Helm:
+
+- Data persistence for the database must be enabled
+- Multiple replicas of the Infrahub API Server and Infrahub Task workers should be deployed: you can use the `affinity` variable to define the affinity policy for the pods
+- S3 storage should be configured for the Infrahub API Server, it is required if you have multiple replicas
+
+:::warning
+
+We do not recommend using the included dependencies (Neo4j, RabbitMQ, Redis) for production.
+They are present to ease deployment on non-production environments.
+
+:::
+
+### Prerequisites
+
+- A Kubernetes cluster
+- [Helm](https://helm.sh/docs/intro/install/) installed on your system
+
+:::warning Storage persistence for testing and lab environments
+
+By default, the Helm chart disables storage persistence on all components (Neo4j, RabbitMQ, Redis) to enable quicker deployments using `emptyDir` storage and reduce requirements for test installations.
+
+However, if pods get rescheduled on the Kubernetes cluster for any reason, all data will be lost. This can happen unexpectedly due to node maintenance, resource pressure, or cluster updates.
+
+For long-running tests or lab environments, you should either:
+
+- Enable storage persistence for the Neo4j database at minimum (but also on the other components if possible)
+- Use Docker Compose instead, which provides more predictable behavior for non-production environments
+
+:::
+
+### Step 1: Fill in the values file
+
+Create a `values.yml` file with the following configuration:
+
+```yaml
+infrahub:
+  infrahubServer:
+    replicas: 3
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: service
+                operator: In
+                values:
+                - infrahub-server
+            topologyKey: topology.kubernetes.io/zone
+    persistence:
+      enabled: false
+    ingress:
+      enabled: true
+    infrahubServer:
+      env:
+        INFRAHUB_ALLOW_ANONYMOUS_ACCESS: "true"
+        INFRAHUB_CACHE_PORT: 6379
+        INFRAHUB_DB_TYPE: neo4j
+        INFRAHUB_LOG_LEVEL: INFO
+        INFRAHUB_PRODUCTION: "true"
+        INFRAHUB_INITIAL_ADMIN_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
+        INFRAHUB_SECURITY_SECRET_KEY: 327f747f-efac-42be-9e73-999f08f86b92
+        INFRAHUB_STORAGE_DRIVER: s3
+        AWS_ACCESS_KEY_ID: xxxx
+        AWS_SECRET_ACCESS_KEY: xxxx
+        AWS_S3_BUCKET_NAME: infrahub-data
+        AWS_S3_ENDPOINT_URL: https://s3
+
+  infrahubTaskWorker:
+    replicas: 3
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: service
+                operator: In
+                values:
+                - infrahub-task-worker
+            topologyKey: topology.kubernetes.io/zone
+
+  neo4j:
+    services:
+      admin:
+        enabled: true
+    volumes:
+      data:
+        mode: dynamic
+        dynamic:
+          storageClassName: premium-rwo
+          requests:
+            storage: 100Gi
+```
+
+:::warning
+Be sure to replace the placeholder values with your actual values. See the [configuration reference](/reference/configuration) for details on all available environment variables.
+:::
+
+Starting with version 4.0.0 of the Helm chart, you can use flavored Helm charts that come pre-configured with sizing presets. These charts automatically configure replica counts and resource allocations for each component according to your sizing plan:
+
+| Flavor      | Chart version example | Required memory |
+|-------------|-----------------------|-----------------|
+| small       | 4.0.0-small           | 16 GB           |
+| medium      | 4.0.0-medium          | 32 GB           |
+| medium-data | 4.0.0-medium-data     | 32 GB           |
+| large       | 4.0.0-large           | 64 GB           |
+| large-data  | 4.0.0-large-data      | 64 GB           |
+
+You can review the configuration values for each sizing preset here:
+
+<ReferenceLink title="Small size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.small.yaml" openInNewTab />
+<ReferenceLink title="Medium size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium.yaml" openInNewTab />
+<ReferenceLink title="Medium (data) size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium-data.yaml" openInNewTab />
+<ReferenceLink title="Large size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large.yaml" openInNewTab />
+<ReferenceLink title="Large (data) size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large-data.yaml" openInNewTab />
+
+:::info Redis host configuration for flavored charts
+
+When using a flavored chart (sizing preset), you must also configure the Redis host for the Prefect background services. Add the following to your `values.yml`:
+
+```yaml
+infrahub:
+  prefect-server:
+    backgroundServices:
+      messaging:
+        redis:
+          host: "infrahub-cache-master"
+```
+
+The `host` value should match your Redis service name. If you deployed Redis using the bundled dependency, this defaults to `infrahub-cache-master`. This configuration is only required when using sizing presets — the base chart (for example, `4.0.0`) does not require it.
+
+:::
+
+#### Migrating from chart versions before 4.0.0
+
+If you are upgrading from a Helm chart version earlier than 4.0.0, update your `values.yml` file:
+
+1. **Remove old configuration preset values:** Delete any environment variables and settings that were previously copied from sizing presets (for example, `INFRAHUB_CACHE_ADDRESS`, `PREFECT_REDIS_MESSAGING_HOST`, replica counts, resource limits). The flavored charts now handle these automatically.
+
+2. **Add the Redis host configuration:** Add the following to your `values.yml` file:
+
+```yaml
+infrahub:
+  prefect-server:
+    backgroundServices:
+      messaging:
+        redis:
+          host: "infrahub-cache-master" # Use the value previously set in INFRAHUB_CACHE_ADDRESS or PREFECT_REDIS_MESSAGING_HOST
+```
+
+### Step 2: install the chart
+
+Install using a flavored chart from the OpsMill registry (recommended for production):
+
+```bash
+helm install infrahub -f values.yml oci://registry.opsmill.io/opsmill/chart/infrahub-enterprise --version 4.0.0-medium
+```
+
+Or install the base chart and provide your own sizing configuration:
+
+```bash
+helm install infrahub -f values.yml oci://registry.opsmill.io/opsmill/chart/infrahub-enterprise --version 4.0.0
+```
+
+Install using a local chart:
+
+```bash
+helm install infrahub -f values.yml path/to/infrahub-enterprise/chart
+```
+
+:::success
+
+Verify the installation by checking that all pods are running:
+
+```bash
+kubectl get pods -l app=infrahub
+```
+
+:::
+
+</TabItem>
+<TabItem value="Bare metal">
+
+## Bare metal deployment
+
+Infrahub Enterprise supports bare metal installations for customers who require direct hardware deployment without containerization.
+
+To learn more about bare metal deployment options and requirements, reach out to the OpsMill team:
+
+- **Discord:** [discord.gg/opsmill](https://discord.gg/opsmill)
+- **Email:** [contact@opsmill.com](mailto:contact@opsmill.com)
+- **Schedule a meeting:** [cal.com/team/opsmill/meet](https://cal.com/team/opsmill/meet)
+
+</TabItem>
+</Tabs>

--- a/docs/docs/deploy-manage/install-configure/install/index.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Installation
+---
+
+import VideoPlayer from '../../../../src/components/VideoPlayer';
+import ReferenceLink from "../../../../src/components/Card";
+
+# Installation
+
+Infrahub Community and Enterprise are deployed as container-based architectures. The installation methods below are for non-resilient deployments suitable for development, testing, and single-node production environments.
+
+For high-availability production deployments, see [High availability deployment examples](../../../guides/installation.mdx#high-availability-deployment-examples).
+
+## Prerequisites
+
+- Verify your system meets the [hardware requirements](../hardware-requirements.mdx) before installing Infrahub.
+- Each installation method has additional prerequisites listed in its own section.
+
+:::info
+
+Allocating more CPU cores to the Neo4j database only improves performance on Infrahub Enterprise, which uses parallel query execution.
+
+:::
+
+<div style={{ textAlign: 'center' }}>
+  <VideoPlayer url='https://www.youtube.com/watch?v=onVhaTVFkrM' light />
+</div>
+
+## Installation guides
+
+Choose the edition that matches your license:
+
+- [Install Infrahub Community](./community.mdx) — Docker Compose (curl), git clone, or Kubernetes with Helm.
+- [Install Infrahub Enterprise](./enterprise.mdx) — Docker Compose (curl), Kubernetes with Helm, or bare metal.
+
+## Related resources
+
+- [Database backup and restore](../../../guides/database-backup.mdx)
+- [High availability architecture](../../../topics/architecture.mdx#scalability-and-high-availability)
+- [Local demo environment](../../../topics/local-demo-environment.mdx)
+- [Hardware requirements](../hardware-requirements.mdx)

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -80,3 +80,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `schema.yml` | Schema & Data | TBD |
 | `testing-framework-move.yml` | Testing Framework move | TBD |
 | `deploy-manage-hardware-requirements.yml` | D&M — Hardware Requirements (sidebar scaffold) | TBD |
+| `deploy-manage-installation.yml` | D&M — Installation (hub + Community + Enterprise spokes) | TBD |

--- a/docs/redirects-pending/deploy-manage-installation.yml
+++ b/docs/redirects-pending/deploy-manage-installation.yml
@@ -1,0 +1,70 @@
+---
+feature: Deployment & Management — Installation
+pr: TBD
+description: |
+  Splits the monolithic guides/installation.mdx (924 lines) into a hub + two
+  edition spokes under deploy-manage/install-configure/install/:
+    - index.mdx — hub (intro, prerequisites, edition links, related resources)
+    - community.mdx — Community installation methods (Docker Compose, git clone, Helm)
+    - enterprise.mdx — Enterprise installation methods (Docker Compose, Helm, bare metal)
+  The high-availability deployment examples section (lines 684–917) is not
+  included here — it moves to the HA spoke created in PR 3.
+  The original guides/installation.mdx remains on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/installation
+    to: /docs/deploy-manage/install-configure/install/
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/install-configure/install/
+    title: Installation (hub)
+  - path: /docs/deploy-manage/install-configure/install/community
+    title: Install Infrahub Community
+  - path: /docs/deploy-manage/install-configure/install/enterprise
+    title: Install Infrahub Enterprise
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/development/backend.mdx
+    line: 96
+    current: ../guides/installation.mdx
+    should_be: ../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/faq/faq.mdx
+    line: 70
+    current: ../guides/installation.mdx
+    should_be: ../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/guides/configuration-changes.mdx
+    line: 270
+    current: ./installation.mdx
+    should_be: ../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/guides/upgrade.mdx
+    line: 13
+    current: ./installation.mdx
+    should_be: ../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/guides/upgrade.mdx
+    line: 98
+    current: ./installation.mdx#enterprise
+    should_be: ../deploy-manage/install-configure/install/enterprise.mdx
+  - file: docs/docs/tutorials/getting-started/introduction-to-infrahub.mdx
+    line: 30
+    current: ../../guides/installation.mdx
+    should_be: ../../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/tutorials/getting-started/readme.mdx
+    line: 58
+    current: ../../guides/installation.mdx
+    should_be: ../../deploy-manage/install-configure/install/index.mdx
+  - file: docs/docs/overview/next-steps.mdx
+    line: 49
+    current: ../guides/installation
+    should_be: ../deploy-manage/install-configure/install/
+  - file: docs/docs/topics/architecture.mdx
+    line: 333
+    current: ../guides/installation#high-availability-deployment-examples
+    should_be: ../deploy-manage/install-configure/production-deployment/high-availability.mdx
+  - file: docs/docs/topics/architecture.mdx
+    line: 337
+    current: ../guides/installation.mdx
+    should_be: ../deploy-manage/install-configure/install/index.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -330,8 +330,16 @@ const sidebars: SidebarsConfig = {
           link: { type: 'generated-index' },
           items: [
             { type: 'doc', id: 'deploy-manage/install-configure/hardware-requirements', label: 'Hardware requirements' },
-            // Installation hub + spokes added in PR 2
-            { type: 'doc', id: 'guides/installation', label: 'Installation' },
+            // Installation hub + spokes (PR 2)
+            {
+              type: 'category',
+              label: 'Installation',
+              link: { type: 'doc', id: 'deploy-manage/install-configure/install/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/install-configure/install/community', label: 'Community' },
+                { type: 'doc', id: 'deploy-manage/install-configure/install/enterprise', label: 'Enterprise' },
+              ],
+            },
             // Production Deployment hub + HA spoke added in PR 3
             { type: 'doc', id: 'guides/production-deployment', label: 'Production deployment' },
             // Configure Infrahub added in PR 4


### PR DESCRIPTION
## Summary

Splits the 924-line `guides/installation.mdx` into a hub and two edition spokes under `deploy-manage/install-configure/install/`.

This is PR 2 of 14 in the D&M restructure per the [Deployment & Management Recommendations V2](https://opsmill.atlassian.net/wiki/spaces/Product/pages/579239938). It is stacked on PR 1 (sidebar scaffold).

## What changed

**New files:**
- `install/index.mdx` — hub: intro, prerequisites, video, links to Community and Enterprise spokes, related resources.
- `install/community.mdx` — Community edition: Docker Compose via curl, git clone (repo method), Kubernetes with Helm.
- `install/enterprise.mdx` — Enterprise edition: Docker Compose via curl (with sizing presets and observability), Kubernetes with Helm (with flavored charts and migration notes), bare metal.

**Updated sidebar** (`sidebars.ts`): the `Installation` entry under Install & configure becomes a hub category with Community and Enterprise children.

**Excluded from this PR:** The high-availability deployment examples section (lines 684–917 of the original guide) — that content moves to the HA spoke in PR 3 (Production Deployment).

## What didn't change

- All factual content is copied verbatim from the source guide; no new claims were introduced.
- The original `guides/installation.mdx` remains on disk during iteration.
- Cross-links from 10 other docs files pointing at `guides/installation` continue to resolve via the original file; cleanup entries are tracked in `docs/redirects-pending/deploy-manage-installation.yml`.

## Verification

- `cd docs && npm run build` succeeds
- `vale docs/docs/deploy-manage/install-configure/install/` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)