### PR TITLE
docs: migrate Production Deployment to hub + High Availability spoke

### DIFF
--- a/docs/docs/deploy-manage/install-configure/production-deployment/high-availability.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/high-availability.mdx
@@ -1,0 +1,269 @@
+---
+title: High availability
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import import_deployTf from '!!raw-loader!../../../../../development/deploy.tf';
+import import_infrahubValuesYaml from '!!raw-loader!../../../../../development/k8s/infrahub-values.yaml';
+import import_minioValuesYaml from '!!raw-loader!../../../../../development/k8s/minio-values.yaml';
+import import_neo4jValuesYaml from '!!raw-loader!../../../../../development/k8s/neo4j-values.yaml';
+import import_rabbitmqValuesYaml from '!!raw-loader!../../../../../development/k8s/rabbitmq-values.yaml';
+import import_redisSentinelDeployYaml from '!!raw-loader!../../../../../development/k8s/redis-sentinel-proxy-deploy.yaml';
+import import_redisSentinelSvcYaml from '!!raw-loader!../../../../../development/k8s/redis-sentinel-proxy-svc.yaml';
+import import_redisValuesYaml from '!!raw-loader!../../../../../development/k8s/redis-values.yaml';
+import import_serviceValuesYaml from '!!raw-loader!../../../../../development/k8s/service-values.yaml';
+import import_taskmanagerdbYaml from '!!raw-loader!../../../../../development/k8s/taskmanagerdb.yaml';
+
+# High availability
+
+This guide covers how to deploy Infrahub in a high availability configuration that eliminates single points of failure.
+
+## How HA works in Infrahub
+
+A highly available Infrahub deployment runs redundant instances of every stateful and stateless component, so the system continues to operate even if individual components or availability zones fail:
+
+- **Neo4j cluster** — 3+ nodes for graph database redundancy with automatic failover
+- **Redis Sentinel** — automatic detection of master failures and promotion of replicas
+- **RabbitMQ cluster** — message bus redundancy with mirrored queues
+- **PostgreSQL replication** — task manager database with primary-replica setup
+- **Multiple API and worker instances** — stateless services distributed across availability zones
+- **Redundant load balancers** — fronting the API layer for traffic distribution
+
+For the full architecture diagram and deeper explanation, see [Scalability and High Availability](../../../topics/architecture.mdx#scalability-and-high-availability).
+
+The following sections show how to deploy this architecture using Terraform or Helm.
+
+## Deployment examples
+
+The following examples demonstrate how to deploy Infrahub in a highly available configuration using Kubernetes. These deployments provide resilience, scalability, and are suitable for production environments.
+
+:::warning
+
+These examples are for reference purposes and may require customization for your specific environment. Ensure you understand the requirements and dependencies before deploying to production.
+
+:::
+
+### Using Terraform
+
+<details>
+  <summary>Example HA deployment using Terraform on a 3-node Kubernetes cluster</summary>
+  <CodeBlock language="hcl" title="deploy.tf">{import_deployTf}</CodeBlock>
+</details>
+
+### Using Helm
+
+<details>
+  <summary>Example HA deployment using Helm and kubectl</summary>
+
+  <CodeBlock language="yaml" title="redis-values.yaml">{import_redisValuesYaml}</CodeBlock>
+
+  ```bash
+  helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo update
+  helm install cache bitnami/redis --version 19.5.2 --namespace infrahub --create-namespace --values redis-values.yaml
+  ```
+
+  <CodeBlock language="yaml" title="redis-sentinel-proxy-deploy.yaml">{import_redisSentinelDeployYaml}</CodeBlock>
+
+  <CodeBlock language="yaml" title="redis-sentinel-proxy-svc.yaml">{import_redisSentinelSvcYaml}</CodeBlock>
+
+  ```bash
+  kubectl apply -f redis-sentinel-proxy-deploy.yaml --namespace infrahub
+  kubectl apply -f redis-sentinel-proxy-svc.yaml --namespace infrahub
+  ```
+
+  <CodeBlock language="yaml" title="rabbitmq-values.yaml">{import_rabbitmqValuesYaml}</CodeBlock>
+
+  ```bash
+  helm install messagequeue oci://registry-1.docker.io/bitnamicharts/rabbitmq --version 14.4.1 --namespace infrahub --create-namespace --values rabbitmq-values.yaml
+  ```
+
+  <CodeBlock language="yaml" title="neo4j-values.yaml">{import_neo4jValuesYaml}</CodeBlock>
+
+  ```bash
+  helm repo add neo4j https://helm.neo4j.com/neo4j/
+  helm repo update
+  kubectl create secret generic neo4j-user --namespace infrahub --from-literal=NEO4J_AUTH=neo4j/admin
+  helm install database-0 neo4j/neo4j --version 2025.10.1-4 --namespace infrahub --values neo4j-values.yaml
+  helm install database-1 neo4j/neo4j --version 2025.10.1-4 --namespace infrahub --values neo4j-values.yaml
+  helm install database-2 neo4j/neo4j --version 2025.10.1-4 --namespace infrahub --values neo4j-values.yaml
+  ```
+
+  Once all instances are running, install the headless service:
+
+  <CodeBlock language="yaml" title="service-values.yaml">{import_serviceValuesYaml}</CodeBlock>
+
+  ```bash
+  helm install database-service neo4j/neo4j-headless-service --version 2025.10.1-4 --namespace infrahub --values service-values.yaml
+  ```
+
+  <CodeBlock language="yaml" title="minio-values.yaml">{import_minioValuesYaml}</CodeBlock>
+
+  ```bash
+  helm install objectstore oci://registry-1.docker.io/bitnamicharts/minio --version 15.0.5 --namespace infrahub --create-namespace --values minio-values.yaml
+  ```
+
+  ```bash
+  helm repo add cnpg https://cloudnative-pg.github.io/charts
+  helm repo update
+  helm install cnpg cnpg/cloudnative-pg --version 0.23.2 --namespace infrahub --create-namespace
+  kubectl create secret generic prefect-user --namespace infrahub --from-literal=username=prefect --from-literal=password=prefect
+  ```
+
+  <CodeBlock language="yaml" title="taskmanagerdb.yaml">{import_taskmanagerdbYaml}</CodeBlock>
+
+  ```bash
+  kubectl apply -f taskmanagerdb.yaml --namespace infrahub
+  ```
+
+  <CodeBlock language="yaml" title="infrahub-values.yaml">{import_infrahubValuesYaml}</CodeBlock>
+
+  ```bash
+  helm install infrahub oci://registry.opsmill.io/opsmill/chart/infrahub-enterprise --version 4.2.4-small --namespace infrahub --create-namespace --values infrahub-values.yaml
+  ```
+
+</details>
+
+## Load balancer configuration
+
+For high availability deployments, a load balancer is useful to distribute traffic across multiple Infrahub API server instances. The load balancer must be configured to properly handle both HTTP/HTTPS and WebSocket connections.
+
+<details>
+  <summary>HAProxy configuration example</summary>
+
+```haproxy
+global
+    maxconn 4096
+    log stdout local0
+
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+    option httplog
+
+# Frontend for Infrahub API
+frontend infrahub_frontend
+    bind *:80
+    bind *:443 ssl crt /etc/ssl/certs/infrahub.pem
+
+    # Redirect HTTP to HTTPS
+    redirect scheme https if !{ ssl_fc }
+
+    # ACL for WebSocket connections
+    acl is_websocket hdr(Upgrade) -i WebSocket
+    acl is_websocket_path path_beg /ws /graphql-ws
+
+    # Use WebSocket backend for WS connections
+    use_backend infrahub_websocket if is_websocket || is_websocket_path
+
+    # Default to HTTP backend
+    default_backend infrahub_http
+
+# Backend for regular HTTP/HTTPS traffic
+backend infrahub_http
+    balance roundrobin
+    option httpchk GET /api/health
+    http-check expect status 200
+
+    # Sticky sessions for GraphQL subscriptions
+    cookie SERVERID insert indirect nocache
+
+    server infrahub-api-1 10.0.1.10:8000 check cookie api1
+    server infrahub-api-2 10.0.1.11:8000 check cookie api2
+    server infrahub-api-3 10.0.1.12:8000 check cookie api3
+
+# Backend for WebSocket connections
+backend infrahub_websocket
+    balance source
+    option http-server-close
+    option forceclose
+
+    # WebSocket specific health check
+    option httpchk GET /api/health
+    http-check expect status 200
+
+    server infrahub-api-1 10.0.1.10:8000 check
+    server infrahub-api-2 10.0.1.11:8000 check
+    server infrahub-api-3 10.0.1.12:8000 check
+```
+
+</details>
+
+<details>
+  <summary>NGINX configuration example</summary>
+
+```nginx
+upstream infrahub_backend {
+    # IP hash for session affinity
+    ip_hash;
+
+    server 10.0.1.10:8000 max_fails=3 fail_timeout=30s;
+    server 10.0.1.11:8000 max_fails=3 fail_timeout=30s;
+    server 10.0.1.12:8000 max_fails=3 fail_timeout=30s;
+}
+
+server {
+    listen 80;
+    server_name infrahub.example.com;
+
+    # Redirect HTTP to HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name infrahub.example.com;
+
+    ssl_certificate /etc/ssl/certs/infrahub.pem;
+    ssl_certificate_key /etc/ssl/private/infrahub.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    # Client body size for large GraphQL queries
+    client_max_body_size 10M;
+
+    # Timeouts for long-running operations
+    proxy_connect_timeout 600;
+    proxy_send_timeout 600;
+    proxy_read_timeout 600;
+    send_timeout 600;
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        proxy_pass http://infrahub_backend/api/health;
+    }
+
+    # WebSocket support for GraphQL subscriptions
+    location ~ ^/(ws|graphql-ws) {
+        proxy_pass http://infrahub_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Disable buffering for WebSocket
+        proxy_buffering off;
+    }
+
+    # Regular API traffic
+    location / {
+        proxy_pass http://infrahub_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Enable keepalive
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}
+```
+
+</details>

--- a/docs/docs/deploy-manage/install-configure/production-deployment/index.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/index.mdx
@@ -1,0 +1,128 @@
+---
+title: Production deployment
+---
+
+import ReferenceLink from "../../../../src/components/Card";
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+
+# Production deployment
+
+This guide walks you through deploying Infrahub in a production environment with enhanced security, reliability, and maintainability. By following these steps, you'll set up a production-ready Infrahub instance that follows industry best practices.
+
+:::warning
+This guide is currently under development. Please use it as a reference checklist when preparing your Infrahub environment for production deployment.
+:::
+
+## Prerequisites
+
+Before beginning your production deployment, ensure you have:
+
+- Selected your deployment technology (Docker or Kubernetes)
+- Verified your system meets the [hardware requirements](../hardware-requirements.mdx)
+- Administrative access to your deployment environment
+- Decided between Community or Enterprise edition based on your support and feature needs
+- Access to your organization's identity provider (for SSO configuration)
+- A backup strategy and storage location
+
+## Step 1: Create a hardened configuration file
+
+Production environments require secure configuration settings that differ from development defaults. Create a configuration file that overwrites default values to enhance security.
+
+```shell title=".env"
+# Environment settings
+INFRAHUB_ALLOW_ANONYMOUS_ACCESS=false
+INFRAHUB_PRODUCTION=true
+INFRAHUB_LOG_LEVEL=INFO
+
+# Security keys & tokens (generate strong unique values)
+INFRAHUB_SECURITY_SECRET_KEY=<strong-random-string-at-least-32-chars>
+INFRAHUB_INITIAL_ADMIN_PASSWORD=<strong-admin-password>
+INFRAHUB_INITIAL_ADMIN_TOKEN=<generate-uuid>  # Generate with: uuidgen
+INFRAHUB_INITIAL_AGENT_TOKEN=<generate-uuid>  # Generate with: uuidgen
+
+# Database & message broker security
+INFRAHUB_BROKER_PASSWORD=<strong-broker-password>
+INFRAHUB_DB_PASSWORD=<strong-database-password>
+
+# TLS & Certificates
+INFRAHUB_DB_TLS_ENABLED=true
+INFRAHUB_DB_TLS_CA_FILE=/opt/ssl/ca.pem
+INFRAHUB_BROKER_TLS_ENABLED=true
+INFRAHUB_CACHE_TLS_ENABLED=true
+```
+
+:::warning
+Never use default passwords or tokens in production. Generate strong unique values for each environment. You can generate UUIDs using the `uuidgen` command or an online UUID generator.
+:::
+
+<ReferenceLink title="Complete configuration reference" url="/reference/configuration" />
+
+## Step 2: Install Infrahub
+
+Install Infrahub using your chosen deployment technology, applying your hardened configuration.
+
+:::info
+For high availability deployments on Kubernetes, use the HA manifest which includes proper replication and resource requests/limits.
+:::
+
+<ReferenceLink title="Detailed installation instructions" url="../install/" />
+
+:::success
+Navigate to `https://your-server-address` in your browser. You should see the Infrahub login page.
+:::
+
+## Step 3: Configure SSO (recommended)
+
+Connect Infrahub to your organization's identity provider to enhance security and simplify user management.
+
+<ReferenceLink title="Detailed SSO configuration guide" url="../../../guides/sso" />
+
+## Step 4: Set up database backups
+
+Implement regular database backups to prevent data loss in case of hardware failure or other issues.
+
+<ReferenceLink title="Complete backup and restore guide" url="../../../guides/database-backup" />
+
+:::success
+Test your backup and restore process periodically to ensure it works as expected.
+:::
+
+## Operations and maintenance
+
+### Upgrading Infrahub
+
+To upgrade to a new version of Infrahub:
+
+1. Review the release notes for breaking changes
+2. Create a full backup of your database
+3. Update the container images
+
+:::danger
+Always create a backup before upgrading to ensure you can restore if needed.
+:::
+
+<ReferenceLink title="Detailed upgrade procedures" url="../../../guides/upgrade" />
+
+## Support options
+
+### Community support
+
+- GitHub Issues: [github.com/opsmill/infrahub](https://github.com/opsmill/infrahub)
+- Discord Community: [discord.gg/infrahub](https://discord.gg/infrahub)
+- Documentation: [docs.infrahub.app](https://docs.infrahub.app)
+
+### Enterprise support <EnterpriseBadge />
+
+- 24/7 support with SLA guarantees
+- Dedicated support engineer
+- Professional services for deployment
+- Training and certification programs
+
+Contact [support@opsmill.com](mailto:support@opsmill.com) for enterprise support.
+
+## Related resources
+
+- [Architecture overview](../../../topics/architecture.mdx)
+- [Configuration reference](../../../reference/configuration.mdx)
+- [API server reference](../../../reference/api-server.mdx)
+- [High availability](./high-availability.mdx)

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -81,3 +81,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `testing-framework-move.yml` | Testing Framework move | TBD |
 | `deploy-manage-hardware-requirements.yml` | D&M — Hardware Requirements (sidebar scaffold) | TBD |
 | `deploy-manage-installation.yml` | D&M — Installation (hub + Community + Enterprise spokes) | TBD |
+| `deploy-manage-production-deployment.yml` | D&M — Production Deployment (hub + HA spoke) | TBD |

--- a/docs/redirects-pending/deploy-manage-production-deployment.yml
+++ b/docs/redirects-pending/deploy-manage-production-deployment.yml
@@ -1,0 +1,50 @@
+---
+feature: Deployment & Management — Production Deployment
+pr: TBD
+description: |
+  Migrates guides/production-deployment.mdx into a hub + HA spoke under
+  deploy-manage/install-configure/production-deployment/:
+    - index.mdx   — hub: production checklist (verbatim from source), updated links
+    - high-availability.mdx — HA spoke: new "How HA works" intro (~130 words)
+      + HA deployment examples (Terraform + Helm) + load balancer config,
+      extracted from guides/installation.mdx lines 684–917.
+  The original guides/production-deployment.mdx and guides/installation.mdx
+  remain on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/production-deployment
+    to: /docs/deploy-manage/install-configure/production-deployment/
+
+# Note: /docs/guides/installation#high-availability-deployment-examples redirects
+# to the HA spoke below. The anchor-level redirect is tracked here as a note;
+# the base path redirect for /docs/guides/installation is in deploy-manage-installation.yml.
+redirects_notes:
+  - "The HA anchor in guides/installation (lines 684-917) is now at /docs/deploy-manage/install-configure/production-deployment/high-availability"
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/install-configure/production-deployment/
+    title: Production deployment (hub)
+  - path: /docs/deploy-manage/install-configure/production-deployment/high-availability
+    title: High availability
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/faq/faq.mdx
+    line: 84
+    current: ../guides/production-deployment.mdx
+    should_be: ../deploy-manage/install-configure/production-deployment/index.mdx
+  - file: docs/docs/guides/configuration-changes.mdx
+    line: 269
+    current: ./production-deployment.mdx
+    should_be: ../deploy-manage/install-configure/production-deployment/index.mdx
+  - file: docs/docs/topics/object-storage.mdx
+    line: 112
+    current: ../guides/production-deployment
+    should_be: ../deploy-manage/install-configure/production-deployment/
+  - file: docs/docs/topics/architecture.mdx
+    line: 333
+    current: ../guides/installation#high-availability-deployment-examples
+    should_be: ../deploy-manage/install-configure/production-deployment/high-availability

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -340,8 +340,15 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/install-configure/install/enterprise', label: 'Enterprise' },
               ],
             },
-            // Production Deployment hub + HA spoke added in PR 3
-            { type: 'doc', id: 'guides/production-deployment', label: 'Production deployment' },
+            // Production Deployment hub + HA spoke (PR 3)
+            {
+              type: 'category',
+              label: 'Production deployment',
+              link: { type: 'doc', id: 'deploy-manage/install-configure/production-deployment/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/install-configure/production-deployment/high-availability', label: 'High availability' },
+              ],
+            },
             // Configure Infrahub added in PR 4
             { type: 'doc', id: 'guides/configuration-changes', label: 'Configure Infrahub' },
             // Configuration reference cross-link updated in PR 4


### PR DESCRIPTION
## Summary

Migrates `guides/production-deployment.mdx` into a hub and adds a new High Availability spoke under `deploy-manage/install-configure/production-deployment/`.

This is PR 3 of 14 in the D&M restructure. It is stacked on PR 2 (Installation).

## What changed

**New files:**
- `production-deployment/index.mdx` — hub: the production deployment checklist from `guides/production-deployment.mdx`, verbatim, with links updated for the new directory depth.
- `production-deployment/high-availability.mdx` — HA spoke. Contains:
  - **New prose (~130 words)**: "How HA works in Infrahub" — a bullet-list overview of each redundant component (Neo4j cluster, Redis Sentinel, RabbitMQ cluster, PostgreSQL replication, multiple API/worker instances, redundant load balancers). All claims sourced directly from `topics/architecture.mdx` lines 324–327.
  - **Extracted content**: HA deployment examples (Terraform + Helm) + load balancer config (HAProxy + NGINX), moved from `guides/installation.mdx` lines 684–917.

**Updated sidebar** (`sidebars.ts`): the `Production deployment` entry becomes a hub category with a High availability child.

## What didn't change

- The production checklist in the hub is copied verbatim from the source.
- The HA examples and load balancer config are copied verbatim from `guides/installation.mdx`.
- The original `guides/production-deployment.mdx` and `guides/installation.mdx` remain on disk during iteration.
- Redirects and cross-link cleanup tracked in `docs/redirects-pending/deploy-manage-production-deployment.yml`.

## Content audit (new prose)

The "How HA works in Infrahub" section claims:
- Neo4j cluster — 3+ nodes, automatic failover ✓ (architecture.mdx:324)
- Redis Sentinel — master failure detection, replica promotion ✓ (architecture.mdx:325)
- RabbitMQ cluster — mirrored queues ✓ (architecture.mdx:326)
- PostgreSQL replication — primary-replica ✓ (architecture.mdx:327)
- Multiple API/worker instances — stateless, distributed ✓ (architecture.mdx:315)
- Redundant load balancers ✓ (architecture.mdx:315, installation.mdx:775)

## Verification

- `cd docs && npm run build` succeeds
- `vale docs/docs/deploy-manage/install-configure/production-deployment/` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)