### PR TITLE
docs: move Configure Infrahub guide into deploy-manage/install-configure/

### DIFF
--- a/docs/docs/deploy-manage/install-configure/configure-infrahub.mdx
+++ b/docs/docs/deploy-manage/install-configure/configure-infrahub.mdx
@@ -1,0 +1,270 @@
+---
+title: How to configure Infrahub
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This guide explains how to configure your Infrahub instance by setting environment variables that control various aspects of the system, including timeouts, security settings, and integration parameters.
+
+## What you'll accomplish
+
+By following this guide, you'll learn how to:
+
+- Identify available configuration options
+- Set environment variables in various deployment methods
+- Apply configuration changes to a running Infrahub instance
+- Verify that your changes have been applied correctly
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- A running Infrahub instance
+- Command-line access to the server running Infrahub
+- Basic understanding of environment variables
+- For production deployments, plan a maintenance window as services will be restarted
+
+## Step 1: Identify the configuration option
+
+Determine which configuration setting you want to change.
+
+1. Refer to the [configuration reference](../../reference/configuration.mdx) to find available environment variables
+2. Note the exact variable name and its expected value type
+
+:::info
+
+For this guide, we'll use `INFRAHUB_HTTP_TIMEOUT` as an example. It affects how Infrahub interacts with external HTTP servers such as webhooks and OAuth2 providers. The default value is 10 seconds.
+
+:::
+
+## Step 2: Set the variable
+
+Configure the variable before starting or restarting your Infrahub containers.
+
+<Tabs groupId="installation-method" queryString>
+<TabItem value="docker-compose" label="Docker Compose" default>
+
+:::note
+
+Using a `.env` file keeps your configuration organized and allows you to track changes with version control.
+
+:::
+
+:::warning
+
+Avoid hardcoding information directly in the `docker-compose.yml` file. Part of the upgrade process consists of replacing this file, which could lead to loss of your configuration.
+Avoid mixing multiple configuration methods as it can lead to confusion about which settings are applied.
+
+:::
+
+### Option A: use a .env file (recommended)
+
+Create or edit a `.env` file in the same directory as your `docker-compose.yml` file:
+
+```bash title=".env"
+INFRAHUB_HTTP_TIMEOUT=20
+```
+
+This method is preferred for persistent configuration as Docker Compose automatically loads variables from the `.env` file.
+
+### Option B: export in your shell
+
+Export the environment variable in your shell session:
+
+```bash
+export INFRAHUB_HTTP_TIMEOUT=20
+```
+
+This method works for temporary changes or testing, but the variable persists only for the current shell session.
+
+### Option C: use a .toml file (not recommended)
+
+Create or edit an `infrahub.toml` file with your configuration:
+
+```toml title="infrahub.toml"
+[settings]
+http_timeout = 20
+```
+
+Then reference the TOML file when starting Infrahub. The application will automatically load configuration from the TOML file.
+
+:::note
+
+TOML configuration files use lowercase with underscores for setting names (for example, `http_timeout`) rather than the uppercase environment variable format (for example, `INFRAHUB_HTTP_TIMEOUT`).
+
+:::
+
+</TabItem>
+
+<TabItem value="kubernetes" label="Kubernetes">
+
+### Use Helm values
+
+Update your `values.yaml` or provide values during upgrade:
+
+```yaml title="values.yaml"
+infrahubServer:
+  infrahubServer:
+    env:
+      INFRAHUB_HTTP_TIMEOUT: "20"
+infrahubTaskWorker:
+  infrahubTaskWorker:
+    env:
+      INFRAHUB_HTTP_TIMEOUT: "20"
+```
+
+Or set directly via command line:
+
+```bash
+helm upgrade infrahub opsmill/infrahub \
+  --set infrahubServer.infrahubServer.env.INFRAHUB_HTTP_TIMEOUT=20 --set infrahubTaskWorker.infrahubTaskWorker.env.INFRAHUB_HTTP_TIMEOUT=20 \
+  -n <your-namespace>
+```
+
+</TabItem>
+</Tabs>
+
+## Step 3: Apply the configuration changes
+
+Restart your Infrahub containers to apply the new configuration.
+
+<Tabs groupId="installation-method" queryString>
+<TabItem value="docker-compose" label="Docker Compose" default>
+
+:::note
+
+Depending on your setup, you might need to adjust the commands below to add options.
+
+:::
+
+Recreate and restart your Docker containers to apply the changes:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+The `--force-recreate` flag ensures that containers are recreated even if their configuration and images haven't changed, which is necessary for applying new environment variables.
+
+:::warning
+
+This command restarts all services defined in your `docker-compose.yml` file. There will be a brief service interruption during the restart.
+
+:::
+
+</TabItem>
+
+<TabItem value="kubernetes" label="Kubernetes">
+
+### For Helm deployments
+
+If you're using Helm, upgrade your release with the new values:
+
+```bash
+helm upgrade infrahub opsmill/infrahub \
+  -f values.yaml \
+  -n <your-namespace>
+```
+
+Or with inline values:
+
+```bash
+helm upgrade infrahub opsmill/infrahub \
+  --set infrahubServer.infrahubServer.env.INFRAHUB_HTTP_TIMEOUT=20 --set infrahubTaskWorker.infrahubTaskWorker.env.INFRAHUB_HTTP_TIMEOUT=20 \
+  -n <your-namespace>
+```
+
+:::warning
+
+Rolling out changes will trigger a pod restart. Depending on your deployment configuration (replicas, rolling update strategy), there may be a brief service interruption.
+
+:::
+
+</TabItem>
+</Tabs>
+
+## Step 4: Verify the configuration
+
+Confirm that your configuration change has been applied successfully.
+
+<Tabs groupId="installation-method" queryString>
+<TabItem value="docker-compose" label="Docker Compose" default>
+
+:::note
+
+Depending on your setup, you might need to adjust the commands below to match your container names if you are using a different project name for instance.
+
+:::
+
+Check that the environment variable is set correctly inside the container:
+
+```bash
+docker exec infrahub-server-1 env | grep INFRAHUB_HTTP_TIMEOUT
+```
+
+You should see output similar to:
+
+```bash
+INFRAHUB_HTTP_TIMEOUT=20
+```
+
+:::success
+
+If you see the expected value in the output, your configuration change has been applied successfully.
+
+:::
+
+</TabItem>
+
+<TabItem value="kubernetes" label="Kubernetes">
+
+:::note
+
+Replace `<your-namespace>` and `infrahub-server-*` with your actual namespace and pod name.
+
+:::
+
+First, get the name of your Infrahub pod:
+
+```bash
+kubectl get pods -n <your-namespace> -l app=infrahub-server
+```
+
+Then check the environment variable inside the pod:
+
+```bash
+kubectl exec -n <your-namespace> <pod-name> -- env | grep INFRAHUB_HTTP_TIMEOUT
+```
+
+For example:
+
+```bash
+kubectl exec -n infrahub infrahub-server-7d8f9b5c6d-xyz12 -- env | grep INFRAHUB_HTTP_TIMEOUT
+```
+
+You should see output similar to:
+
+```bash
+INFRAHUB_HTTP_TIMEOUT=20
+```
+
+Alternatively, you can describe the pod to see all environment variables:
+
+```bash
+kubectl describe pod -n <your-namespace> <pod-name>
+```
+
+:::success
+
+If you see the expected value in the output, your configuration change has been applied successfully.
+
+:::
+
+</TabItem>
+</Tabs>
+
+## Related resources
+
+- [Configuration reference](../../reference/configuration.mdx) - Complete list of available environment variables
+- [Production deployment](./production-deployment/index.mdx) - Best practices for deploying Infrahub
+- [Installing Infrahub](./install/index.mdx) - Installation methods for Infrahub

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -82,3 +82,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-hardware-requirements.yml` | D&M — Hardware Requirements (sidebar scaffold) | TBD |
 | `deploy-manage-installation.yml` | D&M — Installation (hub + Community + Enterprise spokes) | TBD |
 | `deploy-manage-production-deployment.yml` | D&M — Production Deployment (hub + HA spoke) | TBD |
+| `deploy-manage-configure-infrahub.yml` | D&M — Configure Infrahub | TBD |

--- a/docs/redirects-pending/deploy-manage-configure-infrahub.yml
+++ b/docs/redirects-pending/deploy-manage-configure-infrahub.yml
@@ -1,0 +1,92 @@
+---
+feature: Deployment & Management — Configure Infrahub
+pr: TBD
+description: |
+  Moves guides/configuration-changes.mdx → deploy-manage/install-configure/configure-infrahub.mdx.
+  The sidebar label "Configure Infrahub" and the page H1 "How to configure Infrahub" are
+  preserved (label matches the existing sidebar entry; H1 matches the page title per Fatih).
+  The Configuration reference (reference/configuration) stays in its canonical
+  Reference location but is cross-linked from the Install & configure sub-category.
+  The original guides/configuration-changes.mdx remains on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/configuration-changes
+    to: /docs/deploy-manage/install-configure/configure-infrahub
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/install-configure/configure-infrahub
+    title: Configure Infrahub (How to configure Infrahub)
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/change-approval/change-approval-workflow.mdx
+    line: 143
+    current: ../guides/configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/change-approval/change-approval-workflow.mdx
+    line: 161
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/git-integration/connect-repository.mdx
+    line: 605
+    current: ../guides/configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/git-integration/connect-repository.mdx
+    line: 629
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/git-integration/branch-synchronization.mdx
+    line: 52
+    current: ../guides/configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/git-integration/branch-synchronization.mdx
+    line: 54
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/schema/file-object.mdx
+    line: 139
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/guides/change-approval-workflow.mdx
+    line: 143
+    current: ./configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/guides/change-approval-workflow.mdx
+    line: 161
+    current: ./configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/guides/repository.mdx
+    line: 605
+    current: ./configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/guides/repository.mdx
+    line: 629
+    current: ./configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/guides/sso.mdx
+    line: 197
+    current: ./configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/guides/sso.mdx
+    line: 292
+    current: ./configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/guides/selective-branch-sync.mdx
+    line: 49
+    current: ./configuration-changes.mdx
+    should_be: ../deploy-manage/install-configure/configure-infrahub.mdx
+  - file: docs/docs/guides/selective-branch-sync.mdx
+    line: 65
+    current: ./configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/topics/object-storage.mdx
+    line: 102
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub
+  - file: docs/docs/topics/file-object.mdx
+    line: 139
+    current: ../guides/configuration-changes
+    should_be: ../deploy-manage/install-configure/configure-infrahub

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -349,9 +349,9 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/install-configure/production-deployment/high-availability', label: 'High availability' },
               ],
             },
-            // Configure Infrahub added in PR 4
-            { type: 'doc', id: 'guides/configuration-changes', label: 'Configure Infrahub' },
-            // Configuration reference cross-link updated in PR 4
+            // Configure Infrahub (PR 4)
+            { type: 'doc', id: 'deploy-manage/install-configure/configure-infrahub', label: 'Configure Infrahub' },
+            // Configuration reference — stays in reference/, cross-linked here (PR 4)
             { type: 'doc', id: 'reference/configuration', label: 'Configuration reference' },
           ],
         },


### PR DESCRIPTION
## Summary

Moves `guides/configuration-changes.mdx` into `deploy-manage/install-configure/configure-infrahub.mdx` as part of the Install & configure sub-category.

This is PR 4 of 14. It is stacked on PR 3 (Production Deployment).

## What changed

- **New file**: `deploy-manage/install-configure/configure-infrahub.mdx` — content verbatim from the source; relative links to `reference/configuration` and `production-deployment` updated for the new directory depth.
- **Sidebar**: the `Configure Infrahub` entry now points at the new path. Configuration reference (`reference/configuration`) stays in the Reference section but is cross-linked here, immediately after Configure Infrahub.
- **Redirects-pending**: `docs/redirects-pending/deploy-manage-configure-infrahub.yml` records the URL change and 17 cross-links in other docs files that point at `guides/configuration-changes`.

## What didn't change

- Page H1 ("How to configure Infrahub") and sidebar label ("Configure Infrahub") are unchanged.
- The original `guides/configuration-changes.mdx` remains on disk during iteration.
- No content changes — this is a structural move only.

## Verification

- `cd docs && npm run build` succeeds
- `vale docs/docs/deploy-manage/install-configure/configure-infrahub.mdx` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)