### PR TITLE
docs: move Tasks, Telemetry, and Activity Log to run-observe sub-category

### DIFF
--- a/docs/docs/deploy-manage/run-observe/activity-log.mdx
+++ b/docs/docs/deploy-manage/run-observe/activity-log.mdx
@@ -1,0 +1,75 @@
+---
+title: Activity log
+---
+
+# Activity log
+
+Changes (events) in Infrahub are documented in the **Activity log**. It helps you see which objects were impacted, when a change was made, and who made it. It can be used to troubleshoot unforeseen changes, audit previous operations, and comprehend the order of updates across various branches.
+
+To export these events to an external SIEM or centralized logging system, see [log forwarding](../../topics/log-forwarding.mdx).
+
+:::warning Permissions
+Because figuring out who may view which changes requires complicated query requirements, we have currently set aside the permission framework for this functionality.
+
+:::
+
+The activity log, in general, compiles and arranges events from several branches and objects into a single timeline:
+
+* **Global view**: A consolidated list of all branch-wide activities (events).
+* **Object-level view**: A timeline that is particular to a single object and only displays events that are pertinent to that object.
+* **Filtering**: You can narrow down your search using a variety of filters (by branch, event type, account, principal node, linked node, date range).
+* **Nested / child events**: Cascade actions are observed when specific top-level events trigger additional child events.
+
+## Accessing the activity log
+
+The activity log can be accessed in any of two ways: globally or at the object level.
+
+1. **Global activity log**:
+   * Menu location: In the main navigation, go to **Activity** → **Activity log**.
+   * URL: `https://<your-instance>/activities`
+
+![Global Activity log page](../../media/topics/activity-logs/activity_log_global.png)
+
+:::info Time and date
+The activity log's date and time are determined by the local time in your browser.
+
+:::
+
+:::info Child Events
+Events containing child events have an extra (blue) icon at the end of the line.
+
+:::
+
+2. **Object-level activity log**:
+   * Node / object detail pages: Within a node's detail view (for example an IP address or device), you'll see a right-hand "Activity logs" panel or a separate tab.
+
+![Device detail page with Activity logs panel](../../media/topics/activity-logs/activity_log_device.png)
+
+## Filters and search
+
+There are several ways to hone your view in the global activity log:
+
+* **Branch**: Select the branch you wish to view the events in, such as `main`.
+* **Event type**: Filter by categories such as `Node Created`, `Branch Deleted`. You can find more information in the [Infrahub Events](../../reference/infrahub-events.mdx) topic.
+* **Account / user**: Only display events that have been initiated by a certain account.
+* **Primary / related node**: Highlight activities associated with a specific node.
+* **Has children**: Whether a certain occurrence led to other smaller ones.
+* **Date range**: Set a start and end time and date for the timeline.
+
+![Activity logs filters - primary](../../media/topics/activity-logs/activity_log_global_filters_primary.png)
+![Activity logs filters - children](../../media/topics/activity-logs/activity_log_global_filters_children.png)
+
+## Viewing event details
+
+If you choose **View more** from the global or object-level list, a separate detail page or popover will show up. Additional details are shown in this view, such as:
+
+* **Event ID**: A unique UUID referencing the event.
+* **Event type**: The type of the event, for example, `infrahub.node.updated`. You can find more information in the [Infrahub Events](../../reference/infrahub-events.mdx) topic.
+* **Occurred at**: The exact moment the incident took place
+* **Account**: The account that carried out the activity.
+* **Primary node**: The primary object that the event affects.
+* **Related nodes**: Additional affected objects.
+* **Changes**: Any before and after adjustments to updated attributes, if any
+
+![Activity details page with children](../../media/topics/activity-logs/activity_log_global_details_children.png)
+![Activity logs details popover](../../media/topics/activity-logs/activity_log_device_popover.png)

--- a/docs/docs/deploy-manage/run-observe/tasks.mdx
+++ b/docs/docs/deploy-manage/run-observe/tasks.mdx
@@ -1,0 +1,27 @@
+---
+title: Tasks
+---
+
+# Tasks
+
+The **Tasks system** in Infrahub is designed to manage and control various backend operations with robust error reporting, improved supervision, and enhanced logging capabilities.
+
+In Infrahub 1.0, we integrated Prefect as the task manager to orchestrate workflows. The task system is comprised of:
+
+* A **Task manager** (based on Prefect) that orchestrates tasks.
+* One or more **Task workers** (written in Python) that execute operations
+
+In Infrahub 1.1, key backend tasks began to be migrated to this framework, and subsequent releases have further refined its functionality.
+
+See the [Architecture](../../topics/architecture.mdx) subject for further information about the Task manager and Task worker as well as the overall system design.
+
+Key operations managed by the task system include:
+
+* Jinja template rendering.
+* Performing checks and Transform functions.
+* Carrying out pull, merge, and diff Git operations.
+
+More logging and oversight are made possible by these enhancements, which increase background task dependability and transparency.
+The tasks indicator at the top right of the Infrahub window is a noticeable feature for users. It provides a quick access to examine both in-progress and finished tasks and changes color while a job is active.
+
+![Tasks list](../../media/tasks_list.png)

--- a/docs/docs/deploy-manage/run-observe/telemetry.mdx
+++ b/docs/docs/deploy-manage/run-observe/telemetry.mdx
@@ -1,0 +1,95 @@
+---
+title: Local Telemetry Storage
+---
+
+# Local Telemetry Storage
+
+Infrahub stores a daily telemetry snapshot locally in the Neo4j database, regardless of whether remote telemetry reporting is enabled. This ensures all deployments - including air-gapped and opted-out environments - retain usage data for support, auditing, and license compliance.
+
+## How it works
+
+The daily telemetry workflow:
+
+1. Gathers anonymous usage data (schema counts, feature usage, database stats)
+2. Stores a `TelemetrySnapshot` in the local Neo4j database
+3. If remote telemetry is enabled, sends the data to the remote endpoint
+4. Records the remote send status (`sent`, `skipped`, or `failed`) on each snapshot
+
+Each snapshot includes a SHA-256 checksum for data integrity verification.
+
+## Viewing stored snapshots
+
+List stored telemetry snapshots:
+
+```bash
+infrahubctl telemetry list
+```
+
+Filter by date range:
+
+```bash
+infrahubctl telemetry list --start-date 2025-01-01 --end-date 2026-01-01
+```
+
+Limit the number of results:
+
+```bash
+infrahubctl telemetry list --limit 10
+```
+
+## Exporting telemetry data
+
+Export all snapshots to a JSON file:
+
+```bash
+infrahubctl telemetry export --output my-telemetry.json
+```
+
+Export snapshots from a specific date range:
+
+```bash
+infrahubctl telemetry export \
+  --start-date 2025-11-01 \
+  --end-date 2026-02-16 \
+  --output last-90-days.json
+```
+
+The export file contains a JSON array of snapshot objects with full telemetry payloads.
+
+## REST API
+
+Retrieve telemetry snapshots programmatically:
+
+```text
+GET /api/telemetry/snapshots
+```
+
+### Query parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `start_date` | string (ISO 8601) | None | Include snapshots created on or after this date |
+| `end_date` | string (ISO 8601) | None | Include snapshots created on or before this date |
+| `limit` | integer | 1000 | Maximum number of snapshots to return |
+| `offset` | integer | 0 | Number of snapshots to skip |
+
+### Example request
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://infrahub.example.com/api/telemetry/snapshots?start_date=2025-01-01&limit=50"
+```
+
+## Permissions
+
+Access to telemetry data requires the `READ_TELEMETRY` global permission. Users with `SUPER_ADMIN` permission have access by default.
+
+To grant access to other users, assign the `READ_TELEMETRY` permission to their role via the Infrahub UI or API.
+
+## Backup inclusion
+
+Telemetry snapshots are stored as standard Neo4j nodes and are automatically included in database backups performed with `neo4j-admin database backup`. No additional configuration is required. Restoring a backup with `neo4j-admin database restore` restores all telemetry snapshots.
+
+## Storage estimates
+
+Each daily snapshot is approximately 3-5 KB. Five years of daily snapshots require less than 50 MB of storage including Neo4j overhead.

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -83,3 +83,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-installation.yml` | D&M — Installation (hub + Community + Enterprise spokes) | TBD |
 | `deploy-manage-production-deployment.yml` | D&M — Production Deployment (hub + HA spoke) | TBD |
 | `deploy-manage-configure-infrahub.yml` | D&M — Configure Infrahub | TBD |
+| `deploy-manage-run-observe.yml` | D&M — Run & observe (Tasks, Telemetry, Activity Log) | TBD |

--- a/docs/redirects-pending/deploy-manage-run-observe.yml
+++ b/docs/redirects-pending/deploy-manage-run-observe.yml
@@ -1,0 +1,41 @@
+---
+feature: Deployment & Management — Run & observe (Tasks, Telemetry, Activity Log)
+pr: TBD
+description: |
+  Moves three pages from legacy topic/guide locations into the new
+  deploy-manage/run-observe/ sub-category:
+    - topics/tasks.mdx           → run-observe/tasks.mdx
+    - guides/telemetry.mdx       → run-observe/telemetry.mdx
+    - topics/activity-log.mdx    → run-observe/activity-log.mdx
+  All content is verbatim; relative links updated for the new directory depth.
+  Original source files remain on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/tasks
+    to: /docs/deploy-manage/run-observe/tasks
+  - from: /docs/guides/telemetry
+    to: /docs/deploy-manage/run-observe/telemetry
+  - from: /docs/topics/activity-log
+    to: /docs/deploy-manage/run-observe/activity-log
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/run-observe/tasks
+    title: Tasks
+  - path: /docs/deploy-manage/run-observe/telemetry
+    title: Telemetry
+  - path: /docs/deploy-manage/run-observe/activity-log
+    title: Activity log
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/release-notes/infrahub/release-1_2_0.mdx
+    line: 115
+    current: ../../topics/activity-log.mdx
+    should_be: ../../deploy-manage/run-observe/activity-log.mdx
+  - file: docs/docs/guides/log-forwarding.mdx
+    line: 250
+    current: ../topics/activity-log.mdx
+    should_be: ../deploy-manage/run-observe/activity-log.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -363,12 +363,12 @@ const sidebars: SidebarsConfig = {
           collapsed: false,
           link: { type: 'generated-index' },
           items: [
-            // Tasks moved in PR 5
-            { type: 'doc', id: 'topics/tasks', label: 'Tasks' },
-            // Telemetry moved in PR 6
-            { type: 'doc', id: 'guides/telemetry', label: 'Telemetry' },
-            // Activity Log moved in PR 7
-            { type: 'doc', id: 'topics/activity-log', label: 'Activity log' },
+            // Tasks (PRs 5/6/7)
+            { type: 'doc', id: 'deploy-manage/run-observe/tasks', label: 'Tasks' },
+            // Telemetry (PRs 5/6/7)
+            { type: 'doc', id: 'deploy-manage/run-observe/telemetry', label: 'Telemetry' },
+            // Activity Log (PRs 5/6/7)
+            { type: 'doc', id: 'deploy-manage/run-observe/activity-log', label: 'Activity log' },
             // Log Forwarding hub + spoke added in PR 8
             { type: 'doc', id: 'topics/log-forwarding', label: 'Log forwarding' },
           ],


### PR DESCRIPTION
## Summary

Moves three pages from their legacy `topics/` and `guides/` locations into the new `deploy-manage/run-observe/` sub-category.

This covers PRs 5/6/7 of the D&M restructure. It is stacked on PR 4 (Configure Infrahub).

## What changed

**New files** (content verbatim from source; relative links adjusted for new depth):
- `run-observe/tasks.mdx` — from `topics/tasks.mdx`
- `run-observe/telemetry.mdx` — from `guides/telemetry.mdx`
- `run-observe/activity-log.mdx` — from `topics/activity-log.mdx`

**Sidebar**: the three entries in Run & observe now point at the new paths.

**Redirects-pending**: `deploy-manage-run-observe.yml` records the three URL changes and two cross-links in other files.

## What didn't change

- No content changes — structural moves only.
- Original source files remain on disk during iteration.
- Two cross-links in other files (`release-notes/release-1_2_0.mdx`, `guides/log-forwarding.mdx`) continue to resolve via the original files; cleanup entries are tracked in the redirects-pending file.

## Verification

- `cd docs && npm run build` succeeds
- `vale docs/docs/deploy-manage/run-observe/` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)