### PR TITLE
docs: migrate Database Backup to hub + 2 spokes under maintain-upgrade/

### DIFF
--- a/docs/docs/deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx
@@ -1,0 +1,391 @@
+---
+title: Backup and restore
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Backup and restore
+
+This guide shows you how to create comprehensive backups of your Infrahub deployment and restore them when needed. You'll learn to backup the Neo4j graph database, object storage, and task management data to ensure complete data recovery capabilities.
+
+For Neo4j cluster deployments, see [Cluster backup and restore](./cluster-backup-and-restore.mdx).
+
+## Prerequisites
+
+- Running Infrahub deployment (Docker Compose or Kubernetes)
+- Administrative access to the Neo4j database
+- Access to the object storage location (S3 or local filesystem)
+- Sufficient storage space for backup files
+- For cluster deployments: Understanding of your cluster topology
+
+## Create a full backup
+
+### Step 1: Install the backup tool
+
+<Tabs groupId="backup-method" queryString>
+<TabItem value="infrahubops" label="infrahub-backup CLI (Recommended)" default>
+
+Install the infrahub-backup CLI tool:
+
+```bash
+curl https://infrahub.opsmill.io/ops/$(uname -s)/$(uname -m)/infrahub-backup -o infrahub-backup
+chmod +x infrahub-backup
+```
+
+</TabItem>
+<TabItem value="k8s" label="Kubernetes Helm">
+
+For Kubernetes deployments using Helm, see the dedicated backup guide:
+
+[Kubernetes Backup Guide](https://docs.infrahub.app/backup/guides/kubernetes-backup)
+
+</TabItem>
+<TabItem value="manual" label="Docker Compose">
+
+If you prefer manual control, proceed to backup each component individually as described in the following steps.
+
+</TabItem>
+<TabItem value="remote" label="Remote Database">
+
+Alternatively, you can use the [legacy tool](#using-the-python-based-backup-utility) to backup a remote Neo4j database.
+
+</TabItem>
+</Tabs>
+
+### Step 2: Backup the databases
+
+<Tabs groupId="backup-method" queryString>
+<TabItem value="infrahubops" label="infrahub-backup CLI" default>
+
+Create a backup of your running Infrahub instance:
+
+```bash
+./infrahub-backup create
+```
+
+The tool automatically:
+
+- Checks for running tasks before starting (use `--force` to skip)
+- Creates a timestamped backup archive (for example, `infrahub_backup_20250129_153045.tar.gz`)
+- Backs up Neo4j database with metadata (configurable with `--neo4jmetadata`)
+- Backs up Prefect/PostgreSQL task management database
+- Calculates SHA256 checksums for integrity verification
+
+:::note
+We plan to add object storage backup in a future release. Handle object storage backups separately for now.
+:::
+
+</TabItem>
+<TabItem value="k8s" label="Kubernetes Helm">
+
+For Kubernetes deployments using Helm, see the dedicated backup guide:
+
+[Kubernetes Backup Guide](https://docs.infrahub.app/backup/guides/kubernetes-backup)
+
+</TabItem>
+<TabItem value="manual" label="Docker Compose">
+
+Connect to your Neo4j container and create a backup:
+
+```bash
+# Connect as neo4j user to avoid permission issues
+docker exec -it -u neo4j infrahub-database-1 bash
+
+# Create backup directory and run backup
+mkdir -p backups
+neo4j-admin database backup --to-path=backups/
+
+# Verify backup creation
+ls backups/
+# Output: neo4j-2025-03-24T19-57-18.backup
+```
+
+Backup the Prefect PostgreSQL database containing task logs and execution history:
+
+```bash
+# Export Prefect database (using default credentials)
+docker compose exec -T task-manager-db \
+  pg_dump -Fc -U postgres -d prefect > prefect.dump
+```
+
+</TabItem>
+<TabItem value="remote" label="Remote Database">
+
+For remote database backups using the Python utility:
+
+```bash
+# Clone the repository or use Docker image
+python -m utilities.db_backup neo4j backup \
+  --database-url=172.28.64.1 \
+  /infrahub_backups
+
+# If network access issues occur, use host network
+python -m utilities.db_backup neo4j backup \
+  --host-network \
+  --database-url=172.28.64.1 \
+  /infrahub_backups
+```
+
+</TabItem>
+</Tabs>
+
+### Step 3: Backup the object storage
+
+The [object storage](../../../topics/object-storage.mdx) layer holds all file content (file objects and artifacts) outside of the graph database. The graph database references this content through `storage_id` values, so both must be backed up together to maintain consistency.
+
+<Tabs groupId="storage-type" queryString>
+<TabItem value="s3" label="S3 Storage" default>
+
+If using S3 for object storage, use AWS CLI or your preferred S3 backup tool:
+
+```bash
+# Sync S3 bucket to local backup directory
+aws s3 sync s3://your-infrahub-bucket /backup/object_store/
+```
+
+</TabItem>
+<TabItem value="local" label="Local Filesystem">
+
+For local filesystem storage, copy the object storage directory:
+
+```bash
+# Copy object storage directory to backup location
+docker compose cp infrahub-server:/opt/infrahub/storage/. /backup/object_store/
+```
+
+</TabItem>
+</Tabs>
+
+## Restore from backup
+
+### Step 1: Prepare the environment
+
+Ensure Infrahub services are running before starting the restore process. You can start from a scratch/blank deployment.
+
+<Tabs groupId="restore-method" queryString>
+<TabItem value="infrahubops" label="infrahub-backup CLI" default>
+
+Restore from a backup archive:
+
+```bash
+./infrahub-backup restore infrahub_backup_20250129_153045.tar.gz
+```
+
+The tool automatically:
+
+- Validates backup integrity using checksums
+- Wipes cache and message queue data
+- Stops application containers
+- Restores PostgreSQL database first
+- Restores Neo4j database with metadata
+- Restarts all services in correct order
+
+</TabItem>
+<TabItem value="k8s" label="Kubernetes Helm">
+
+For Kubernetes deployments using Helm, see the dedicated restore guide:
+
+[Kubernetes Restore Guide](https://docs.infrahub.app/backup/guides/kubernetes-restore)
+
+</TabItem>
+<TabItem value="manual" label="Manual Process">
+
+If restoring manually, follow the steps below for each component.
+
+</TabItem>
+</Tabs>
+
+### Step 2: Restore the databases
+
+<Tabs groupId="restore-method" queryString>
+<TabItem value="infrahubops" label="infrahub-backup CLI" default>
+
+This is automatically handled by infrahub-backup.
+
+</TabItem>
+<TabItem value="k8s" label="Kubernetes Helm">
+
+For Kubernetes deployments using Helm, see the dedicated restore guide:
+
+[Kubernetes Restore Guide](https://docs.infrahub.app/backup/guides/kubernetes-restore)
+
+</TabItem>
+<TabItem value="manual" label="Docker Compose">
+
+```bash
+# Stop app services
+docker compose stop task-worker infrahub-server task-manager
+
+# Copy backup directory to container
+docker cp database-backup infrahub-database-1:/tmp/backup
+
+# Connect to container as neo4j user
+docker exec -it -u neo4j infrahub-database-1 bash
+
+# Drop existing database
+cypher-shell -d system -u neo4j
+DROP DATABASE neo4j;
+exit;
+
+# Clean residual data
+rm -rf /data/databases/neo4j
+rm -rf /data/transactions/neo4j
+
+# Restore from backup
+neo4j-admin database restore \
+  --from-path=/tmp/backup neo4j \
+  --overwrite-destination=true
+
+# Recreate database
+cypher-shell -d system -u neo4j
+CREATE DATABASE neo4j;
+SHOW DATABASES;
+```
+
+Restore the task manager PostgreSQL database
+
+```bash
+# Restore Prefect database
+docker compose exec -T task-manager-db \
+  pg_restore -d postgres -U postgres --clean --create prefect.dump
+
+# Restart task manager to apply changes
+docker compose restart task-manager
+```
+
+</TabItem>
+<TabItem value="remote" label="Remote Database">
+
+```bash
+# Restore using Python utility
+python -m utilities.db_backup neo4j restore \
+  /infrahub_backups \
+  --database-cypher-port=7687
+```
+
+</TabItem>
+</Tabs>
+
+### Step 3: Restore the object storage
+
+<Tabs groupId="storage-type" queryString>
+<TabItem value="s3" label="S3 Storage" default>
+
+```bash
+# Restore S3 bucket from backup
+aws s3 sync /backup/object_store/ s3://your-infrahub-bucket
+```
+
+</TabItem>
+<TabItem value="local" label="Local Filesystem">
+
+```bash
+# Restore object storage directory into the container
+docker compose cp /backup/object_store/. infrahub-server:/opt/infrahub/storage/
+```
+
+</TabItem>
+</Tabs>
+
+### Step 4: Restart Infrahub services
+
+<Tabs groupId="restore-method" queryString>
+<TabItem value="infrahubops" label="infrahub-backup CLI" default>
+
+This is automatically handled by infrahub-backup.
+
+</TabItem>
+<TabItem value="k8s" label="Kubernetes Helm">
+
+For Kubernetes deployments using Helm, see the dedicated restore guide:
+
+[Kubernetes Restore Guide](https://docs.infrahub.app/backup/guides/kubernetes-restore)
+
+</TabItem>
+<TabItem value="manual" label="Docker Compose">
+Restart services in the correct order to ensure proper initialization:
+
+```bash
+# Restart API servers first
+docker compose restart infrahub-server
+
+# Then restart task workers
+docker compose restart task-worker
+```
+
+</TabItem>
+</Tabs>
+
+## Validation
+
+Verify your restoration was successful:
+
+1. **Check database status:**
+
+   ```bash
+   docker compose exec -T database cypher-shell -u neo4j \
+     -c "SHOW DATABASES;"
+   ```
+
+   The Neo4j database should show as "online".
+
+2. **Verify Infrahub API:**
+
+   ```bash
+   curl http://localhost:8000/api/schema/summary
+   ```
+
+   You should receive a valid schema response.
+
+3. **Check task manager:**
+
+   ```bash
+   docker compose logs task-manager --tail 50
+   ```
+
+   Logs should show normal operation without errors.
+
+4. **Test artifact retrieval:**
+   Access the Infrahub UI and verify that stored artifacts (Transformations, queries) are accessible.
+
+## Advanced usage
+
+### Using the Python-based backup utility
+
+:::info Legacy Tool
+The Python-based utility (`utilities/db_backup`) is still available in the main Infrahub repository but is being replaced by infrahub-backup. Use it only if infrahub-backup doesn't meet your specific requirements.
+:::
+
+### Use non-default ports
+
+If your deployment uses custom ports, specify them during backup and restore operations:
+
+```bash
+# Backup with custom backup port
+python -m utilities.db_backup neo4j backup \
+  --database-backup-port=12345 \
+  /infrahub_backups
+
+# Restore with custom Cypher port
+python -m utilities.db_backup neo4j restore \
+  /infrahub_backups \
+  --database-cypher-port=9876
+```
+
+### Run backup tool via Docker
+
+If you don't have the repository cloned locally, run the backup tool directly from the Infrahub Docker image:
+
+```bash
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  registry.opsmill.io/opsmill/infrahub \
+  python -m utilities.db_backup
+```
+
+## Related resources
+
+- [Database backup overview](./index.mdx) - Architecture and backup strategy concepts
+- [Cluster backup and restore](./cluster-backup-and-restore.mdx) - Neo4j cluster-specific backup and restore
+- [infrahub-backup CLI reference](https://docs.infrahub.app/backup/) - Command-line reference for the infrahub-backup tool

--- a/docs/docs/deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore.mdx
@@ -1,0 +1,270 @@
+---
+title: Cluster backup and restore
+---
+
+import EnterpriseBadge from '@site/src/components/EnterpriseBadge';
+
+# Cluster backup and restore <EnterpriseBadge />
+
+If you're running Infrahub with a Neo4j cluster, follow these steps to backup from one node and restore to another while maintaining cluster integrity.
+
+For standalone deployments, see [Backup and restore](./backup-and-restore.mdx).
+
+## Prerequisites for cluster operations
+
+- Neo4j cluster with at least 3 nodes
+- Administrative access to all cluster nodes
+- Understanding of your cluster topology (leader and follower nodes)
+
+:::caution
+Always run backup and restore commands as the `neo4j` user inside containers to avoid permission issues with data files.
+:::
+
+Example cluster topology
+
+| Node             | Role     |
+|------------------|----------|
+| `database`       | Leader   |
+| `database-core2` | Follower |
+| `database-core3` | Follower |
+
+## Backup and restore within a cluster
+
+### Step 1: Create backup from a follower node
+
+```bash
+docker exec -it -u neo4j infrahub-database-core2-1 bash
+mkdir -p backups
+neo4j-admin database backup --to-path=backups/ neo4j
+ls backups
+# Output should include:
+# neo4j-2025-03-24T19-57-18.backup
+```
+
+### Step 2: Transfer backup to target node
+
+```bash
+# Copy from source container to local
+docker cp infrahub-database-core2-1:/var/lib/neo4j/backups/neo4j-2025-03-24T19-57-18.backup .
+
+# Copy from local to target container
+docker cp neo4j-2025-03-24T19-57-18.backup \
+  infrahub-database-core3-1:/var/lib/neo4j/
+```
+
+### Step 3: Drop database cluster-wide
+
+Connect to any cluster node:
+
+```bash
+cypher-shell -d system -u neo4j
+DROP DATABASE neo4j;
+SHOW SERVERS;
+```
+
+<center>
+![drop database](../../../media/guides/database_backup_restore_step3.png)
+</center>
+
+### Step 4: Clean target node data
+
+Connect to the target container:
+
+```bash
+docker exec -it -u neo4j infrahub-database-core3-1 bash
+```
+
+Remove any existing data to avoid corruption:
+
+```bash
+rm -rf /data/databases/neo4j
+rm -rf /data/transactions/neo4j
+```
+
+Then restart the container to ensure a clean state:
+
+```bash
+docker restart infrahub-database-core3-1
+```
+
+### Step 5: Restore backup on target node
+
+Reconnect to the container:
+
+```bash
+docker exec -it -u neo4j infrahub-database-core3-1 bash
+```
+
+Run the restore command:
+
+```bash
+neo4j-admin database restore \
+  --from-path=/var/lib/neo4j/neo4j-2025-03-24T19-57-18.backup neo4j
+```
+
+<center>
+![Restore database](../../../media/guides/database_backup_restore_step3.png)
+</center>
+
+### Step 6: Identify seed instance id
+
+Connect via Cypher shell (on the system database):
+
+```bash
+cypher-shell -d system -u neo4j
+```
+
+Run:
+
+```bash
+SHOW SERVERS;
+```
+
+Note the `serverId` for your target node (example: `d05fce79-e63e-485a-9ce7-1abbf9d18fce`).
+
+<center>
+![Seed database](../../../media/guides/database_backup_restore_step5.png)
+</center>
+
+### Step 7: Recreate database from seed
+
+Run the following Cypher command:
+
+```bash
+CREATE DATABASE neo4j
+TOPOLOGY 3 PRIMARIES
+OPTIONS {
+  existingData: 'use',
+  existingDataSeedInstance: 'd05fce79-e63e-485a-9ce7-1abbf9d18fce'
+};
+```
+
+<center>
+![Choose seed database](../../../media/guides/database_backup_restore_step7.png)
+</center>
+
+### Step 8: Verify cluster sync
+
+Check that the database is coming online:
+
+```bash
+SHOW DATABASES;
+```
+
+<center>
+![Online database](../../../media/guides/database_backup_restore_step8_1.png)
+</center>
+
+Then validate cluster sync status:
+
+```bash
+SHOW SERVERS;
+```
+
+<center>
+![Status sync servers](../../../media/guides/database_backup_restore_step8_2.png)
+</center>
+
+All nodes should eventually show the Neo4j database as online.
+
+:::tip Troubleshooting
+
+- If nodes show as **dirty** or **offline**, check logs and verify `/data/databases/neo4j/neostore` exists
+- The `CREATE DATABASE ... OPTIONS { existingData: 'use' }` command is required to register restored data with the cluster
+
+:::
+
+## Restore cluster backup to standalone instance
+
+If you need to analyze data from a production cluster in an isolated environment, follow these steps to restore a cluster backup to a standalone Neo4j instance.
+
+### Step 1: Create cluster backup
+
+Create a backup from any cluster node:
+
+```bash
+neo4j-admin database backup --to-path=backups/ neo4j
+# Resulting file: neo4j-2025-03-24T19-57-18.backup
+```
+
+### Step 2: Transfer backup to standalone instance
+
+```bash
+docker cp neo4j-2025-03-24T19-57-18.backup \
+  infrahub-database-1:/var/lib/neo4j/
+```
+
+### Step 3: Prepare standalone instance
+
+Connect to the container:
+
+```bash
+docker exec -it -u neo4j infrahub-database-1 bash
+```
+
+Clean any existing Neo4j database (optional but recommended):
+
+```bash
+rm -rf /data/databases/neo4j
+rm -rf /data/transactions/neo4j
+```
+
+Drop the Neo4j Database
+
+```bash
+cypher-shell -d system -u neo4j
+DROP DATABASE neo4j;
+SHOW SERVERS;
+```
+
+<center>
+![Choose seed database](../../../media/guides/database_backup_restore_step7.png)
+</center>
+
+### Step 4: Restore the backup
+
+Restore the backup file:
+
+```bash
+neo4j-admin database restore \
+  --from-path=/var/lib/neo4j/neo4j-2025-03-24T19-57-18.backup neo4j
+```
+
+### Step 5: Create the database
+
+Run the following Cypher command:
+
+```bash
+CREATE DATABASE neo4j
+```
+
+### Step 6: Verify the status
+
+Check that the database is coming online:
+
+```bash
+SHOW DATABASES;
+```
+
+<center>
+![Choose seed database](../../../media/guides/database_backup_restore_standalone_step6_1.png)
+</center>
+
+Then validate database status:
+
+```bash
+SHOW SERVERS;
+```
+
+<center>
+![Choose seed database](../../../media/guides/database_backup_restore_standalone_step6_2.png)
+</center>
+
+:::info
+This process restores only data, not cluster roles, replication, or configuration settings.
+:::
+
+## Related resources
+
+- [Database backup overview](./index.mdx) - Architecture and backup strategy concepts
+- [Backup and restore](./backup-and-restore.mdx) - Step-by-step instructions for standalone deployments

--- a/docs/docs/deploy-manage/maintain-upgrade/database-backup/index.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/database-backup/index.mdx
@@ -1,0 +1,189 @@
+---
+title: Database backup
+---
+
+# Understanding database backup and restore
+
+This topic explains how Infrahub's database backup and restore system works, the architectural decisions behind it, and the various approaches available for protecting your data. Understanding these concepts helps you make informed decisions about your backup strategy and troubleshoot issues when they arise.
+
+## Overview
+
+Infrahub's backup system is designed around three core principles:
+
+1. **Completeness**: Capturing all data necessary for full system recovery
+2. **Consistency**: Ensuring data integrity across distributed components
+3. **Flexibility**: Supporting various deployment scenarios and recovery needs
+
+The backup process involves more than just the Neo4j graph database—it encompasses the entire data ecosystem that Infrahub relies on to function correctly.
+
+## Backup architecture
+
+### Components requiring backup
+
+Infrahub's data is distributed across multiple systems, each serving a specific purpose:
+
+**Neo4j graph database**
+The core of Infrahub's data model, storing all infrastructure relationships, schemas, and configuration data. This uses Neo4j's transactional graph database engine, which maintains ACID compliance and supports point-in-time recovery through transaction logs.
+
+**artifact storage**
+Transformations, queries, and other generated artifacts are stored separately from the graph database. This can be either an S3-compatible object store or local filesystem, depending on your deployment configuration. The separation allows for efficient storage of large files without impacting database performance.
+
+**Task management database**
+Prefect's PostgreSQL database contains task execution history, logs, and workflow state. While not critical for data recovery, this information is valuable for auditing and troubleshooting past operations. The infrahubops tool backs this up using `pg_dump` with the custom format (`-Fc`) for efficient compression and restoration.
+
+### Why multiple components?
+
+This distributed architecture might seem complex, but it serves important purposes:
+
+- **Performance optimization**: artifacts don't belong in a graph database
+- **Scalability**: Each component can be scaled independently
+- **Flexibility**: Different storage backends for different data types
+- **Cost efficiency**: Use appropriate storage tiers for different data
+
+## Backup strategies
+
+### Full vs incremental backups
+
+Neo4j supports both full and incremental backups, each with distinct characteristics:
+
+**Full backups** create a complete copy of the database at a specific point in time. They're self-contained and straightforward to restore but require more storage space and time to complete.
+
+**Incremental backups** only capture changes since the last backup. Neo4j tracks transaction IDs to ensure no data loss even during active database use. The backup tool automatically determines whether to perform a full or incremental backup based on existing backup files in the target directory.
+
+### Online vs offline backups
+
+**Online backups** (the default approach) allow the database to remain operational during the backup process. Neo4j uses a checkpoint mechanism to ensure consistency:
+
+1. A checkpoint is triggered to flush pending transactions
+2. Data files are copied while tracking new transactions
+3. Transaction logs ensure no data loss between checkpoint and completion
+
+**Offline backups** require stopping the database but guarantee a perfectly consistent snapshot. These are typically only necessary for major migrations or when changing database versions.
+
+## The backup process explained
+
+### How Neo4j ensures consistency
+
+Neo4j's backup mechanism uses several techniques to maintain consistency:
+
+1. **Transaction logs**: Every change is written to a transaction log before being applied to the data files
+2. **Checkpoints**: Periodic checkpoints ensure transaction logs are applied to data files
+3. **Backup coordination**: The backup process coordinates with the checkpoint mechanism to capture a consistent view
+
+When you initiate a backup with infrahubops:
+
+```text
+Check Running Tasks → Create Temp Directory → Backup Neo4j → Backup PostgreSQL → Calculate Checksums → Create Tarball → Cleanup
+```
+
+The tool ensures no tasks are running before starting (unless `--force` is used), preventing potential data inconsistencies.
+
+### Helper container approach
+
+The infrahubops tool uses Docker Compose commands to execute operations directly on running containers, providing several benefits:
+
+- **No additional containers**: Unlike the old utility, infrahubops doesn't create helper containers
+- **Direct execution**: Uses `docker compose exec` to run commands in existing containers
+- **Simplified networking**: No need to manage separate Docker networks
+- **Project awareness**: Automatically detects and targets the correct Docker Compose project
+- **Integrity verification**: Calculates and validates SHA256 checksums for all backed-up files
+
+## Restore considerations
+
+### Data consistency during restore
+
+Restoring a database is more disruptive than backing it up because it requires:
+
+1. **Stopping the target database** to prevent concurrent modifications
+2. **Clearing existing data** to avoid conflicts
+3. **Restoring data files** from the backup
+4. **Replaying transaction logs** to reach the backup point
+5. **Recreating metadata** including users, roles, and permissions
+
+### The system database challenge
+
+Neo4j maintains a special `system` database containing:
+
+- User accounts and authentication data
+- Role definitions and permissions
+- Database metadata and configuration
+
+While the backup tool captures the system database, restoring it requires special consideration:
+
+- In standalone deployments, the system database is typically not restored to preserve existing configurations
+- In cluster deployments, system database restoration requires cluster-wide coordination
+- For disaster recovery scenarios, system database restoration may be necessary but requires additional steps
+
+### Cluster restore complexity
+
+Restoring a Neo4j cluster involves additional challenges:
+
+**Cluster topology preservation**
+The backup contains data but not cluster roles (leader/follower relationships). After restoration, you must:
+
+1. Identify a seed instance with the restored data
+2. Use `CREATE DATABASE ... OPTIONS { existingData: 'use' }` to register the data
+3. Allow the cluster to replicate data to other nodes
+
+**Consistency across nodes**
+All nodes must be synchronized to prevent split-brain scenarios. The restoration process typically involves:
+
+- Dropping the database cluster-wide
+- Restoring to a single node
+- Recreating the database from that seed node
+- Monitoring replication to ensure all nodes synchronize
+
+## Alternative approaches
+
+### Direct filesystem copies
+
+While possible, directly copying Neo4j data files has significant limitations:
+
+- Requires complete database shutdown
+- No transaction log coordination
+- Risk of incomplete or corrupted copies
+- No automatic metadata handling
+
+### Logical exports
+
+Using Cypher queries to export and import data:
+
+- **Advantages**: Human-readable, version-independent, selective export
+- **Disadvantages**: Slower, no transaction consistency, requires custom scripting
+
+### Continuous replication
+
+Setting up read replicas for backup purposes:
+
+- **Advantages**: Near-zero RPO (Recovery Point Objective), instant failover capability
+- **Disadvantages**: Requires additional infrastructure, ongoing synchronization overhead
+
+## Implementation details
+
+### Backup file structure
+
+The infrahubops tool creates a tarball with the following structure:
+
+```text
+infrahub_backup_YYYYMMDD_HHMMSS.tar.gz
+├── backup/
+│   ├── backup_information.json    # Metadata and checksums
+│   ├── database/                   # Neo4j backup files
+│   │   └── neo4j-*.backup
+│   └── prefect.dump               # PostgreSQL dump
+```
+
+### Task safety mechanism
+
+Before creating a backup, the tool checks for running tasks using an embedded Python script that queries the Infrahub API. This prevents backing up data in an inconsistent state. The `--force` flag bypasses this check but should be used with caution.
+
+### Checksum validation
+
+Every file in the backup is protected by SHA256 checksums stored in `backup_information.json`. During restoration, these checksums are verified to ensure data integrity. Any mismatch will abort the restoration process.
+
+## Further reading
+
+- [Backup and restore](./backup-and-restore.mdx) - Step-by-step instructions for standalone deployments
+- [Cluster backup and restore](./cluster-backup-and-restore.mdx) - Step-by-step instructions for Neo4j cluster deployments
+- [infrahub-ops-cli source code](https://github.com/opsmill/infrahub-ops-cli) - Implementation details and latest features
+- [infrahub-backup CLI reference](https://docs.infrahub.app/backup/) - Command-line reference for the infrahub-backup tool

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -85,3 +85,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-configure-infrahub.yml` | D&M — Configure Infrahub | TBD |
 | `deploy-manage-run-observe.yml` | D&M — Run & observe (Tasks, Telemetry, Activity Log) | TBD |
 | `deploy-manage-log-forwarding.yml` | D&M — Log Forwarding (hub + Configure spoke) | TBD |
+| `deploy-manage-database-backup.yml` | D&M — Database Backup (hub + 2 spokes) | TBD |

--- a/docs/redirects-pending/deploy-manage-database-backup.yml
+++ b/docs/redirects-pending/deploy-manage-database-backup.yml
@@ -1,0 +1,63 @@
+---
+feature: Deployment & Management — Database Backup (hub + 2 spokes)
+pr: TBD
+description: |
+  Moves two pages from legacy topic/guide locations into the new
+  deploy-manage/maintain-upgrade/database-backup/ sub-category:
+    - topics/database-backup.mdx    → maintain-upgrade/database-backup/index.mdx (hub)
+    - guides/database-backup.mdx    → split into two spokes:
+        backup-and-restore.mdx          (standalone backup/restore + advanced usage)
+        cluster-backup-and-restore.mdx  (Neo4j cluster backup/restore)
+  Original source files remain on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/database-backup
+    to: /docs/deploy-manage/maintain-upgrade/database-backup/
+  - from: /docs/guides/database-backup
+    to: /docs/deploy-manage/maintain-upgrade/database-backup/backup-and-restore
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/maintain-upgrade/database-backup/
+    title: Database backup (hub)
+  - path: /docs/deploy-manage/maintain-upgrade/database-backup/backup-and-restore
+    title: Backup and restore
+  - path: /docs/deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore
+    title: Cluster backup and restore
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/home.mdx
+    line: 91
+    current: "guides/database-backup"
+    should_be: "deploy-manage/maintain-upgrade/database-backup/backup-and-restore"
+  - file: docs/docs/faq/faq.mdx
+    line: 115
+    current: ../topics/database-backup.mdx
+    should_be: ../deploy-manage/maintain-upgrade/database-backup/
+  - file: docs/docs/deploy-manage/install-configure/install/index.mdx
+    line: 38
+    current: ../../../guides/database-backup.mdx
+    should_be: ../../../deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx
+  - file: docs/docs/deploy-manage/install-configure/production-deployment/index.mdx
+    line: 84
+    current: url="../../../guides/database-backup"
+    should_be: url="../../../deploy-manage/maintain-upgrade/database-backup/backup-and-restore"
+  - file: docs/docs/schema/file-object.mdx
+    line: 149
+    current: ../guides/database-backup#step-3-backup-the-object-storage
+    should_be: ../deploy-manage/maintain-upgrade/database-backup/backup-and-restore#step-3-backup-the-object-storage
+  - file: docs/docs/topics/object-storage.mdx
+    line: 122
+    current: ../guides/database-backup#step-3-backup-the-object-storage
+    should_be: ../deploy-manage/maintain-upgrade/database-backup/backup-and-restore#step-3-backup-the-object-storage
+  - file: docs/docs/release-notes/infrahub/release-1_2_0.mdx
+    line: 172
+    current: ../../guides/database-backup.mdx
+    should_be: ../../deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx
+  - file: docs/docs/release-notes/infrahub/release-1_2_0.mdx
+    line: 174
+    current: ../../guides/database-backup.mdx#create-a-full-backup
+    should_be: ../../deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx#create-a-full-backup

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -388,8 +388,16 @@ const sidebars: SidebarsConfig = {
           collapsed: false,
           link: { type: 'generated-index' },
           items: [
-            // Database Backup hub + spokes added in PR 9
-            { type: 'doc', id: 'topics/database-backup', label: 'Database backup' },
+            // Database Backup hub + spokes (PR 9)
+            {
+              type: 'category',
+              label: 'Database backup',
+              link: { type: 'doc', id: 'deploy-manage/maintain-upgrade/database-backup/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/maintain-upgrade/database-backup/backup-and-restore', label: 'Backup and restore' },
+                { type: 'doc', id: 'deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore', label: 'Cluster backup and restore' },
+              ],
+            },
             // Upgrade hub + spokes added in PR 10
             { type: 'doc', id: 'guides/upgrade', label: 'Upgrade' },
           ],


### PR DESCRIPTION
## Summary

Migrate **Database Backup** per the Infrahub docs revamp D&M section restructure.
Pattern: hub + 2 spokes.

## Content changes

- **`deploy-manage/maintain-upgrade/database-backup/index.mdx`** (hub): verbatim from `topics/database-backup.mdx` — architecture concepts (components, backup strategies, online/offline, restore considerations, implementation details). Updated Further reading section to link to both spokes and the external infrahub-backup CLI reference.
- **`deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx`** (spoke 1): from `guides/database-backup.mdx` lines 1–347 (standalone backup/restore) + Advanced usage + Related resources. Covers infrahub-backup CLI, Docker Compose, Kubernetes, and Python-based legacy tool.
- **`deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore.mdx`** (spoke 2): from `guides/database-backup.mdx` lines 349–603 (cluster backup/restore + restore cluster to standalone instance).
- **`sidebars.ts`**: replaced `topics/database-backup` placeholder with hub+spoke category under Maintain & upgrade.
- **`redirects-pending/deploy-manage-database-backup.yml`**: records 2 URL redirects and 8 cross-link cleanup entries.

## What didn't change

- All factual content preserved; no new claims invented
- Original `topics/database-backup.mdx` and `guides/database-backup.mdx` remain on disk (legacy URLs continue to resolve during iteration)

## Verification

- `markdownlint-cli2` clean (0 errors)
- `vale` clean (0 errors, 0 warnings)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)