### PR TITLE
docs: migrate Upgrade guide to hub + 3 spokes under maintain-upgrade/

### DIFF
--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/community.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/community.mdx
@@ -1,0 +1,91 @@
+---
+title: Upgrade Community
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Upgrade Community
+
+The process to migrate your instance of Infrahub to the latest version will vary depending on your deployment of Infrahub. However, at a high-level, it will involve getting the latest version and performing any needed Database Migrations and Schema updates.
+
+For installation instructions, please refer to our [Installation guide](../../install-configure/install/index.mdx).
+
+Follow the instructions below for your current release version and deployment method.
+
+:::warning Upgrade path support
+Upgrades are supported only from the previous minor version (N-1), for example from Infrahub 1.3 to 1.4. If you need to upgrade from N-2 or older, upgrade sequentially one minor version at a time (for example: 1.2 -> 1.3 -> 1.4).
+:::
+
+:::info
+Even though a "smooth" migration is anticipated, we nonetheless strongly suggest creating a backup beforehand. For detailed information, see our [Backup guide](../database-backup/backup-and-restore.mdx).
+:::
+
+:::info
+In Infrahub 1.2 and later, the upgrade process has been streamlined with a unified upgrade command.
+For earlier versions, please refer to the [release notes](../../../release-notes/infrahub/) for specific upgrade instructions.
+:::
+
+## Upgrading to Infrahub 1.2 and after
+
+<Tabs groupId="deployment" queryString>
+<TabItem value="docker" label="Docker" default>
+
+```bash
+# Stop the current instance
+docker compose down
+
+# Retrieve the latest docker-compose version
+curl https://infrahub.opsmill.io > docker-compose.yml
+
+# Run the unified upgrade command
+docker compose run infrahub-server infrahub upgrade
+
+# Restart the instance
+docker compose up -d
+```
+
+:::note
+
+Old Docker images of Infrahub may remain on your machine and consume disk space after an upgrade. To free up space and keep disk usage under control, consider removing unused images.
+
+You can do this with: `docker image prune -a`
+
+:::
+
+</TabItem>
+<TabItem value="helm" label="Helm">
+
+```bash
+# Upgrade the Helm release
+helm upgrade
+
+# Run the unified upgrade command inside the server pod
+kubectl exec infrahub-infrahub-server-xxxxxx -- infrahub upgrade
+
+# Restart deployments to apply changes
+kubectl rollout restart deployment/prefect-server
+kubectl rollout restart deployment/infrahub-infrahub-server
+```
+
+</TabItem>
+
+<TabItem value="devdemo" label="Dev/Demo">
+
+```bash
+# Ensure you pull the latest opsmill/infrahub repo
+git pull
+
+# Stop the current instance
+invoke demo.stop
+
+# Rebuild and run migrations
+invoke demo.pull
+invoke demo.upgrade
+
+# Restart the instance
+invoke demo.start
+```
+
+</TabItem>
+</Tabs>

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/enterprise.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/enterprise.mdx
@@ -1,0 +1,69 @@
+---
+title: Upgrade Enterprise
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+
+# Upgrade Enterprise <EnterpriseBadge />
+
+The process to migrate your instance of Infrahub Enterprise to the latest version will vary depending on your deployment of Infrahub Enterprise. However, at a high-level, it will involve getting the latest version and performing any needed Database Migrations and Schema updates.
+
+For installation instructions, please refer to our [Enterprise installation guide](../../install-configure/install/enterprise.mdx).
+
+Follow the instructions below for your current release version and deployment method.
+
+:::info
+Even though a "smooth" migration is anticipated, we nonetheless strongly suggest creating a backup beforehand. For detailed information, see our [Backup guide](../database-backup/backup-and-restore.mdx).
+:::
+
+:::info
+In Infrahub 1.2 and later, the upgrade process has been streamlined with a unified upgrade command.
+For earlier versions, please refer to the [release notes](/release-notes/infrahub) for specific upgrade instructions.
+:::
+
+## Upgrading to Infrahub Enterprise 1.2 and after
+
+<Tabs groupId="deployment" queryString>
+<TabItem value="docker" label="Docker" default>
+
+```bash
+# Stop the current instance
+docker compose down
+
+# Retrieve the latest docker-compose version
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+
+# Run the unified upgrade command
+docker compose run infrahub-server infrahub upgrade
+
+# Restart the instance
+docker compose up -d
+```
+
+:::note
+
+Old Docker images of Infrahub may remain on your machine and consume disk space after an upgrade. To free up space and keep disk usage under control, consider removing unused images.
+
+You can do this with: `docker image prune -a`
+
+:::
+
+</TabItem>
+<TabItem value="helm" label="Helm">
+
+```bash
+# Upgrade the Helm release
+helm upgrade
+
+# Run the unified upgrade command inside the server pod
+kubectl exec infrahub-infrahub-server-xxxxxx -- infrahub upgrade
+
+# Restart deployments to apply changes
+kubectl rollout restart deployment/prefect-server
+kubectl rollout restart deployment/infrahub-infrahub-server
+```
+
+</TabItem>
+</Tabs>

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/index.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Upgrade
+---
+
+# Upgrade
+
+Upgrading Infrahub involves pulling the latest container images, running database and schema migrations, and restarting services. The specific steps vary by edition (Community vs Enterprise) and deployment method (Docker Compose vs Helm).
+
+## Before you upgrade
+
+**Upgrade path**: Upgrades are supported only from the previous minor version (N-1), for example from Infrahub 1.3 to 1.4. If you need to upgrade from N-2 or older, upgrade sequentially one minor version at a time.
+
+**Backup first**: Even though a smooth migration is anticipated, we strongly recommend creating a backup before upgrading. See [Backup and restore](../database-backup/backup-and-restore.mdx).
+
+**Release notes**: Review the [release notes](../../../release-notes/infrahub/) for any version-specific upgrade instructions. In Infrahub 1.2 and later, the upgrade process was streamlined with a unified upgrade command. For earlier versions, refer to the release notes for specific instructions.
+
+## Upgrade guides
+
+Select the guide for your edition and deployment:
+
+- [Upgrade Community](./community.mdx) — Docker Compose, Helm, and Dev/Demo deployments
+- [Upgrade Enterprise](./enterprise.mdx) — Docker Compose and Helm deployments
+- [Upgrade the observability stack](./observability-stack.mdx) — Force-recreate observability services after compose file changes
+
+## Known issues
+
+### Migration failing because of transaction memory limit reached in Neo4j
+
+For large database/schema migrations, you may encounter a `Transaction memory limit reached` error in Neo4j.
+
+:::info
+
+To work around this, you can disable the transaction memory limit by setting the `dbms.memory.transaction.total.max` to `0` in your Neo4j configuration.
+
+:::
+
+We are working on a more robust solution to handle large migrations without hitting this limit in future releases.

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx
@@ -1,0 +1,11 @@
+---
+title: Upgrade the observability stack
+---
+
+# Upgrade the observability stack
+
+When a new compose file changes the embedded observability configuration, services backed by Docker Compose `configs` do not pick up those changes on a regular `up -d`. Use `--force-recreate` on the affected services to reload the embedded configuration content:
+
+```bash
+docker compose -p infrahub up -d --force-recreate infrahub-alloy infrahub-loki infrahub-tempo infrahub-grafana
+```

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -86,3 +86,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-run-observe.yml` | D&M — Run & observe (Tasks, Telemetry, Activity Log) | TBD |
 | `deploy-manage-log-forwarding.yml` | D&M — Log Forwarding (hub + Configure spoke) | TBD |
 | `deploy-manage-database-backup.yml` | D&M — Database Backup (hub + 2 spokes) | TBD |
+| `deploy-manage-upgrade.yml` | D&M — Upgrade (hub + 3 spokes) | TBD |

--- a/docs/redirects-pending/deploy-manage-upgrade.yml
+++ b/docs/redirects-pending/deploy-manage-upgrade.yml
@@ -1,0 +1,48 @@
+---
+feature: Deployment & Management — Upgrade (hub + 3 spokes)
+pr: TBD
+description: |
+  Splits guides/upgrade.mdx into a hub + 3 spokes under
+  deploy-manage/maintain-upgrade/upgrade/:
+    - index.mdx                 Hub (general overview + known issues; net-new content)
+    - community.mdx             Community upgrade (Docker, Helm, Dev/Demo)
+    - enterprise.mdx            Enterprise upgrade (Docker, Helm)
+    - observability-stack.mdx   Observability stack upgrade
+  No legacy topic file existed for upgrade; only the guide is being moved.
+  Original guides/upgrade.mdx remains on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/upgrade
+    to: /docs/deploy-manage/maintain-upgrade/upgrade/
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/maintain-upgrade/upgrade/
+    title: Upgrade (hub)
+  - path: /docs/deploy-manage/maintain-upgrade/upgrade/community
+    title: Upgrade Community
+  - path: /docs/deploy-manage/maintain-upgrade/upgrade/enterprise
+    title: Upgrade Enterprise
+  - path: /docs/deploy-manage/maintain-upgrade/upgrade/observability-stack
+    title: Upgrade the observability stack
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/home.mdx
+    line: 85
+    current: "guides/upgrade"
+    should_be: "deploy-manage/maintain-upgrade/upgrade/"
+  - file: docs/docs/faq/faq.mdx
+    line: 127
+    current: ../guides/upgrade.mdx
+    should_be: ../deploy-manage/maintain-upgrade/upgrade/
+  - file: docs/docs/deploy-manage/install-configure/production-deployment/index.mdx
+    line: 104
+    current: url="../../../guides/upgrade"
+    should_be: url="../../../deploy-manage/maintain-upgrade/upgrade/"
+  - file: docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+    line: 124
+    current: ../../../guides/upgrade.mdx#upgrading-the-observability-stack
+    should_be: ../../../deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -398,8 +398,17 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore', label: 'Cluster backup and restore' },
               ],
             },
-            // Upgrade hub + spokes added in PR 10
-            { type: 'doc', id: 'guides/upgrade', label: 'Upgrade' },
+            // Upgrade hub + spokes (PR 10)
+            {
+              type: 'category',
+              label: 'Upgrade',
+              link: { type: 'doc', id: 'deploy-manage/maintain-upgrade/upgrade/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/maintain-upgrade/upgrade/community', label: 'Community' },
+                { type: 'doc', id: 'deploy-manage/maintain-upgrade/upgrade/enterprise', label: 'Enterprise' },
+                { type: 'doc', id: 'deploy-manage/maintain-upgrade/upgrade/observability-stack', label: 'Observability stack' },
+              ],
+            },
           ],
         },
         // ── User Management & Security ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Migrate **Upgrade** per the Infrahub docs revamp D&M section restructure.
Pattern: hub + 3 spokes (no source topic file; hub is net-new content).

## Content changes

- **`deploy-manage/maintain-upgrade/upgrade/index.mdx`** (hub): net-new prose covering upgrade prerequisites (N-1 path constraint, backup recommendation, release notes) and the Known issues section (verbatim from guide). Links to the 3 spokes.
- **`deploy-manage/maintain-upgrade/upgrade/community.mdx`** (spoke 1): verbatim from `guides/upgrade.mdx` Community section. Links updated: installation → install/index.mdx, backup → database-backup/backup-and-restore.mdx.
- **`deploy-manage/maintain-upgrade/upgrade/enterprise.mdx`** (spoke 2): verbatim from `guides/upgrade.mdx` Enterprise section. Links updated: enterprise installation → install/enterprise.mdx, backup → database-backup/backup-and-restore.mdx.
- **`deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx`** (spoke 3): verbatim from `guides/upgrade.mdx` observability stack section.
- **`sidebars.ts`**: replaced `guides/upgrade` placeholder with hub+spoke category under Maintain & upgrade.
- **`redirects-pending/deploy-manage-upgrade.yml`**: records 1 URL redirect and 4 cross-link cleanup entries.

## What didn't change

- All factual content preserved
- Original `guides/upgrade.mdx` remains on disk (legacy URL continues to resolve during iteration)

## Verification

- `markdownlint-cli2` clean (0 errors)
- `vale` clean (0 errors; 1 expected false-positive warning on edition proper noun "Community" — same as existing install/community.mdx)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)