### PR TITLE
docs: move Authentication page to deploy-manage/user-management/

### DIFF
--- a/docs/docs/deploy-manage/user-management/authentication.mdx
+++ b/docs/docs/deploy-manage/user-management/authentication.mdx
@@ -1,0 +1,138 @@
+---
+title: Authentication
+---
+import ReferenceLink from "../../../src/components/Card";
+
+# Authentication
+
+Infrahub provides flexible authentication options to fit various organizational needs.
+
+You can authenticate users through a local user store maintained within Infrahub or by integrating with external identity providers through single sign-on protocols.
+
+This topic explains the authentication mechanisms supported by Infrahub and how they integrate with your existing identity management systems.
+
+## User authentication methods
+
+### Local user store
+
+The local user store is Infrahub's built-in user management system. It maintains user accounts directly within Infrahub's database and provides complete control over user authentication without requiring external systems.
+
+Key characteristics of the local user store:
+
+- User accounts are created and managed directly within Infrahub
+- Passwords are securely stored using modern cryptographic standards
+- Ideal for standalone deployments or testing environments
+
+### Single sign-on (SSO)
+
+Single sign-on allows users to authenticate once with an external identity provider and gain access to Infrahub without needing to enter separate credentials. Infrahub integrates seamlessly with popular identity providers such as Microsoft Entra ID (formerly Azure AD), Okta, Google Workspace, and others through industry-standard authentication protocols.
+
+Key characteristics of SSO in Infrahub:
+
+- Supports both OAuth 2.0 and OpenID Connect (OIDC) protocols
+- Multiple identity providers can be configured simultaneously
+- Users authenticated via SSO are automatically created in the local user store
+- Optional automatic group assignment based on identity provider attributes
+- Reduces credential management overhead and improves security
+
+<ReferenceLink title="Configuring Single Sign-On" url="../../guides/sso"/>
+
+:::info Recommendation
+Local user store is suitable for testing and development environments. For production use, integrating with an external identity provider via SSO is recommended for better security and user management.
+:::
+
+## OAuth 2.0 vs OpenID Connect
+
+While both protocols are used in authentication flows, they serve different primary purposes:
+
+### OAuth 2.0
+
+OAuth 2.0 is primarily an authorization framework that enables applications to gain limited access to resources on behalf of users.
+
+- **Primary purpose**: Authorization (controlling what resources a user can access)
+- **Use case**: Granting applications limited access to a user's data
+- **Common scenario**: Third-party applications requesting permissions from services like GitHub, Google, or Microsoft
+- **Limitation**: Does not define standards for user identity verification
+
+### OpenID Connect (OIDC)
+
+OIDC extends OAuth 2.0 by adding a standardized authentication layer.
+
+- **Primary purpose**: Authentication (verifying who a user is) + Authorization
+- **Use case**: Identity verification along with access control
+- **Common scenario**: Enterprise single sign-on implementations
+- **Key feature**: Provides an ID Token (JWT) containing identity claims about the authenticated user
+
+:::info Recommendation
+When configuring an external identity provider, OIDC is generally recommended as it provides standardized identity information.
+:::
+
+<ReferenceLink title="Configuring Single Sign-On" url="../../guides/sso"/>
+
+## User permission management
+
+Users are allocated permissions through a hierarchical system of groups and roles.
+
+- **Users** are members of **Groups**
+- **Groups** are associated with **Roles**
+- **Roles** are allocated specific **Permissions**
+
+:::note Authentication & Authorization
+Authentication works in conjunction with Infrahub's authorization system, which controls what actions authenticated users can perform. While authentication verifies who you are, authorization determines what you can do within the system.
+
+Authentication is the first step - it creates users and assigns them to groups. Authorization then attaches permissions and roles to those groups.
+:::
+
+<ReferenceLink title="Roles and permissions" url="../../topics/permissions-roles"/>
+
+## Anonymous access
+
+By default, Infrahub allows anonymous access in read-only mode. This can be disabled through either:
+
+- The configuration parameter: `main.allow_anonymous_access`
+- The environment variable: `INFRAHUB_ALLOW_ANONYMOUS_ACCESS`
+
+:::warning
+Disabling anonymous access is recommended for production environments to ensure that only authenticated users can access the system.
+:::
+
+## Authentication flow
+
+When a user attempts to access Infrahub, the following authentication flow occurs:
+
+1. The user is presented with available authentication options (local login and configured SSO providers)
+   :::info
+   Multiple SSO providers can be configured simultaneously. Even with SSO providers enabled, local login remains available for fallback scenarios (such as when an identity provider is unavailable).
+   :::
+2. Upon successful authentication:
+   - For local users: Credentials are verified against the local user store
+   - For SSO users: The user is redirected to the identity provider, authenticated there, and returned to Infrahub
+3. A user session is created after successful authentication
+4. For first-time SSO users, a corresponding local user record is automatically created
+5. Group memberships and roles are applied based on configuration
+6. The user is granted access according to their assigned permissions
+
+## Application authentication
+
+Infrahub supports two authentication methods for applications and integrations:
+
+- **JWT Tokens**: Short-lived tokens generated on demand from the API
+- **API Tokens**: Long-lived tokens generated ahead of time for persistent access
+
+### Authentication method compatibility
+
+The table below shows which authentication methods are supported by different Infrahub interfaces:
+
+| Interface          | JWT Token | API Token |
+| ------------------ | :-------: | :-------: |
+| API / GraphQL      | Yes       | Yes       |
+| Frontend           | Yes       | No        |
+| Python SDK         | Yes       | Yes       |
+| infrahubctl        | Yes       | Yes       |
+| GraphQL Playground | No        | Yes       |
+
+<ReferenceLink title="Managing API Tokens Guide" url="../../guides/managing-api-tokens"/>
+
+## Related concepts
+
+- [Roles and permissions topic](../../topics/permissions-roles.mdx)

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -87,3 +87,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-log-forwarding.yml` | D&M — Log Forwarding (hub + Configure spoke) | TBD |
 | `deploy-manage-database-backup.yml` | D&M — Database Backup (hub + 2 spokes) | TBD |
 | `deploy-manage-upgrade.yml` | D&M — Upgrade (hub + 3 spokes) | TBD |
+| `deploy-manage-authentication.yml` | D&M — Authentication (move) | TBD |

--- a/docs/redirects-pending/deploy-manage-authentication.yml
+++ b/docs/redirects-pending/deploy-manage-authentication.yml
@@ -1,0 +1,37 @@
+---
+feature: Deployment & Management — Authentication (move)
+pr: TBD
+description: |
+  Moves topics/authentication.mdx into deploy-manage/user-management/authentication.mdx.
+  This is a single-page move (no split); relative links updated for new directory depth.
+  Original source file remains on disk during iteration.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/authentication
+    to: /docs/deploy-manage/user-management/authentication
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/user-management/authentication
+    title: Authentication
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/reference/sso.mdx
+    line: 10
+    current: ../topics/authentication.mdx
+    should_be: ../deploy-manage/user-management/authentication.mdx
+  - file: docs/docs/tutorials/getting-started/readme.mdx
+    line: 87
+    current: ../../topics/authentication.mdx
+    should_be: ../../deploy-manage/user-management/authentication.mdx
+  - file: docs/docs/guides/sso.mdx
+    line: 35
+    current: ../topics/authentication.mdx
+    should_be: ../deploy-manage/user-management/authentication.mdx
+  - file: docs/docs/guides/sso.mdx
+    line: 449
+    current: ../topics/authentication.mdx
+    should_be: ../deploy-manage/user-management/authentication.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -419,8 +419,8 @@ const sidebars: SidebarsConfig = {
           collapsed: false,
           link: { type: 'generated-index' },
           items: [
-            // Authentication moved in PR 11
-            { type: 'doc', id: 'topics/authentication', label: 'Authentication' },
+            // Authentication (PR 11)
+            { type: 'doc', id: 'deploy-manage/user-management/authentication', label: 'Authentication' },
             // SSO hub + spokes added in PR 12
             { type: 'doc', id: 'guides/sso', label: 'SSO' },
             // Permissions & Roles hub + spoke added in PR 13


### PR DESCRIPTION
## Summary

Migrate **Authentication** per the Infrahub docs revamp D&M section restructure.
Pattern: single-page move.

## Content changes

- **`deploy-manage/user-management/authentication.mdx`**: verbatim from `topics/authentication.mdx`. Link fixes: `../../src/components/Card` → `../../../src/components/Card`; ReferenceLink urls updated for new directory depth.
- **`sidebars.ts`**: replaced `topics/authentication` with new path.
- **`redirects-pending/deploy-manage-authentication.yml`**: records 1 URL redirect and 4 cross-link cleanup entries.

## What didn't change

- All content preserved verbatim
- Original `topics/authentication.mdx` remains on disk

## Verification

- `markdownlint-cli2` clean (0 errors)
- `vale` clean (0 errors, 0 warnings)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)