### PR TITLE
docs: migrate SSO guide to hub + 2 spokes under user-management/

### DIFF
--- a/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
@@ -1,0 +1,133 @@
+---
+title: Advanced SSO configuration
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Advanced SSO configuration
+
+## Multiple identity providers
+
+To configure multiple identity providers:
+
+- Configure each provider using the same steps as above, but with the appropriate slot name (for example `provider1`, `provider2`)
+- Make sure to set the `INFRAHUB_SECURITY_OIDC_PROVIDERS` or `INFRAHUB_SECURITY_OAUTH2_PROVIDERS` variable to include all configured providers
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# Configuration for first provider
+export INFRAHUB_OIDC_PROVIDER1_*
+
+# Configuration for second provider
+export INFRAHUB_OIDC_PROVIDER2_*
+
+# Then enable the providers
+export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1", "provider2"]'
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[security.oidc_provider_settings.provider1]
+# Configuration for first provider
+
+[security.oidc_provider_settings.provider2]
+# Configuration for second provider
+
+[security]
+# Then enable the providers
+oidc_providers = ["provider1", "provider2"]
+```
+
+</TabItem>
+</Tabs>
+
+## Group mapping
+
+Infrahub can automatically assign users to groups based on information from your identity provider.
+
+:::warning
+Infrahub won't automatically create groups based on identity provider data. You must create the corresponding groups in Infrahub first.
+:::
+
+### Step 1: Configure group claims in your identity provider
+
+Configure your identity provider application to include group information in the authentication tokens sent to Infrahub.
+
+:::info
+Refer to your provider's documentation for instructions on "group claims" or "configuring OAuth2/OIDC group mappings".
+:::
+
+### Step 2: Create corresponding groups in Infrahub
+
+Create groups in Infrahub that match the groups sent by your identity provider.
+
+:::danger
+Some providers send group IDs instead of display names. Create groups in Infrahub with the exact same IDs your provider sends, and use the label field to store human-friendly names.
+:::
+
+Follow these steps to create groups:
+
+1. Navigate to `Admin` > `Users and Permissions` > `Groups`
+2. Click `+ Create Account Group`
+3. Enter the exact name of the group as sent by your identity provider
+4. Optionally, add a description and assign permissions
+5. Click `Save`
+6. Repeat for each group you want to map
+
+:::info
+Every SSO authentication attempt is logged in the Infrahub server logs. These logs contain detailed information about the groups received from your identity provider.
+
+For example:
+
+```log
+SSO user authenticated  [infrahub] app=infrahub.api body={'user_name': 'Otto the otter', 'groups': ['Admin Otter']}
+```
+
+:::
+
+:::success
+To confirm group mapping is working, log in through SSO and check your user Profile in Infrahub. You should see the groups assigned based on your identity provider's data.
+:::
+
+### Step 3: Configure default group assignment (optional)
+
+If your identity provider cannot provide group information, configure a default group for SSO users.
+
+:::warning
+You must create this default group in Infrahub before configuring it here.
+:::
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# Set the default group for SSO users
+export INFRAHUB_SECURITY_SSO_USER_DEFAULT_GROUP='default-group'
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[security]
+sso_user_default_group = "default-group"
+```
+
+</TabItem>
+</Tabs>
+
+:::success
+Now that group mapping is configured, manage user permissions in Infrahub by [assigning permissions and roles](../../../guides/accounts-permissions.mdx) to these groups.
+:::
+
+## Related resources
+
+- [SSO overview](./index.mdx)
+- [Configure SSO](./configure-sso.mdx)
+- [Authentication](../authentication.mdx)
+- [SSO reference](../../../reference/sso.mdx)
+- [Permissions and roles](../../../topics/permissions-roles.mdx)

--- a/docs/docs/deploy-manage/user-management/sso/configure-sso.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/configure-sso.mdx
@@ -1,0 +1,332 @@
+---
+title: Configure SSO
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import ReferenceLink from "../../../../src/components/Card";
+
+# Configure SSO (Single sign-on)
+
+This guide walks you through configuring single sign-on (SSO) in Infrahub using OpenID Connect (OIDC) or OAuth2 authentication protocols.
+
+When complete, users will be able to authenticate with Infrahub through your existing organizational identity provider, eliminating the need for separate Infrahub credentials.
+
+## Prerequisites
+
+Before configuring SSO, you need:
+
+- Administrative access to your identity provider (like Entra ID, Okta, Google Workspace, etc.)
+- Administrative access to your Infrahub configuration
+
+## Steps overview
+
+1. Choose your protocol and collect necessary information
+2. Create the application in your identity provider
+3. Configure Infrahub to connect to your identity provider
+4. Validate the SSO integration
+
+## Step 1: Prepare and collect information
+
+### Choose an authentication protocol
+
+Select a protocol based on your identity provider's support. Most modern providers support both OIDC and OAuth2.
+
+:::info
+OIDC provides standardized user information and is recommended for new implementations. See [Authentication](../authentication.mdx) for details on the differences between OIDC and OAuth2.
+:::
+
+<Tabs groupId="selected-protocol" queryString>
+  <TabItem value="oidc" default>
+  OpenID Connect (OIDC) is recommended when available as it provides standardized user Profile information.
+  </TabItem>
+  <TabItem value="oauth2">
+  OAuth2 is a widely supported authorization protocol that may require additional configuration for user Profile mapping.
+  </TabItem>
+</Tabs>
+
+### Select a provider configuration slot
+
+Infrahub provides six configuration slots for identity providers:
+
+- **OIDC slots**: PROVIDER1, PROVIDER2, GOOGLE
+- **OAuth2 slots**: PROVIDER1, PROVIDER2, GOOGLE
+
+:::warning
+This guide uses the first provider slot (`PROVIDER1`). For multiple providers, follow the same steps with the appropriate slot name. Google Workspace integration requires the `GOOGLE` slot.
+:::
+
+### Determine your redirect URI
+
+When registering Infrahub in your identity provider, you'll need a redirect URI - the URL where users are sent after successful authentication.
+
+Use this format:
+
+```text
+https://<your-infrahub-hostname>/auth/<protocol>/<provider-slot>/callback
+```
+
+For a production Infrahub instance at `infrahub.example.com`:
+
+<Tabs groupId="selected-protocol" queryString>
+  <TabItem value="oidc" default>
+  ```
+  https://infrahub.example.com/auth/oidc/provider1/callback
+  ```
+  </TabItem>
+  <TabItem value="oauth2">
+  ```
+  https://infrahub.example.com/auth/oauth2/provider1/callback
+  ```
+  </TabItem>
+</Tabs>
+
+:::note Reverse proxy setup
+Use the `INFRAHUB_PUBLIC_URL` environment variable to specify the externally accessible URL for your Infrahub instance. This configuration is critical when Infrahub is deployed behind a reverse proxy, load balancer, or in containerized environments where the internal and external URLs differ. When configuring SSO ensure this URL matches the redirect URI or callback URL configured in your SSO provider.
+:::
+
+For a local development instance:
+
+<Tabs groupId="selected-protocol" queryString>
+  <TabItem value="oidc" default>
+  ```
+  http://localhost:8000/auth/oidc/provider1/callback
+  ```
+  </TabItem>
+  <TabItem value="oauth2">
+  ```
+  http://localhost:8000/auth/oauth2/provider1/callback
+  ```
+  </TabItem>
+</Tabs>
+
+## Step 2: Configure the identity provider
+
+### Create the application in your identity provider
+
+Create an application in your identity provider that Infrahub will use for authentication.
+
+:::info
+While this guide tries to cover common identity providers, if your specific provider isn't listed, please refer to your provider's documentation for instructions on "creating an application registration" or "configuring OAuth2/OIDC integration."
+:::
+
+<details>
+    <summary><b>Using Entra ID (formerly Azure AD)</b></summary>
+
+#### Create an application in Entra ID
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com)
+2. Navigate to **App registrations**
+3. Click **+ New registration**
+4. Enter a name for your application (for example "Infrahub")
+5. Select the appropriate account type (usually "Accounts in this organizational directory only" for internal use)
+6. Under **Redirect URI**:
+   - Select **Web** for the platform
+   - Enter your redirect URI determined earlier
+7. Click **Register**
+
+#### Create a client secret
+
+1. In your new app registration, navigate to **Certificates & secrets**
+2. Click **+ New client secret**
+3. Add a description and select an expiration period
+4. Click **Add**
+
+:::danger
+Copy the **Value** immediately - you won't be able to see it again after navigating away from this page!
+:::
+
+#### Collect the required information
+
+Make note of the following information for Infrahub configuration:
+
+:::info
+On the registration overview page, click the **Endpoints** tab to find the necessary URLs.
+:::
+
+<Tabs groupId="selected-protocol" queryString>
+<TabItem value="oidc" default>
+| Field | Location/Value |
+|-------|-------|
+| Client ID | The "Application (client) ID" shown on the app overview page |
+| Client Secret | The value of the client secret you created (only visible at creation time) |
+| Discovery URL | Called "OpenID Connect metadata document" under the **Endpoints** tab |
+| Display Label | For example: `Microsoft Entra ID` |
+| Icon | For example: `mdi:microsoft` |
+</TabItem>
+<TabItem value="oauth2">
+| Field | Location/Value |
+|-------|-------|
+| Client ID | The "Application (client) ID" shown on the app overview page |
+| Client Secret | The value of the client secret you created (only visible at creation time) |
+| Authorization URL | The "OAuth 2.0 authorization endpoint (v2)" URL under the **Endpoints** tab |
+| Token URL | The "OAuth 2.0 token endpoint (v2)" URL under the **Endpoints** tab |
+| Userinfo URL | The value is static: `https://graph.microsoft.com/oidc/userinfo` |
+| Display Label | For example: `Microsoft Entra ID` |
+| Icon | For example: `mdi:microsoft` |
+</TabItem>
+</Tabs>
+</details>
+
+:::success
+At the end of this step, you should have gathered all the necessary information to configure SSO in Infrahub.
+
+<Tabs groupId="selected-protocol" queryString>
+<TabItem value="oidc" default>
+
+| Client ID | Client Secret | Discovery URL |
+|-----------|--------------|--------------|
+
+</TabItem>
+<TabItem value="oauth2">
+
+| Client ID | Client Secret | Authorization URL | Token URL | Userinfo URL |
+|-----------|--------------|-------------------|-----------|--------------|
+
+</TabItem>
+</Tabs>
+
+:::
+
+## Step 3: Configure Infrahub
+
+Now configure Infrahub to connect to your identity provider using either environment variables or the `infrahub.toml` configuration file.
+
+:::info
+The configuration process will require a restart of the Infrahub server and depends on your deployment method.
+
+For detailed instructions on how to apply configuration changes to your Infrahub instance, see [Configure Infrahub](../../install-configure/configure-infrahub.mdx).
+
+For detailed configuration options, see the [configuration reference](../../../reference/configuration.mdx).
+
+For multiple identity providers, refer to the [Advanced Configuration Section](./advanced-sso.mdx#multiple-identity-providers).
+:::
+
+<Tabs groupId="selected-protocol" queryString>
+<TabItem value="oidc" default>
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# Replace values with informations collected during the previous step
+export INFRAHUB_OIDC_PROVIDER1_CLIENT_ID="client-id"
+export INFRAHUB_OIDC_PROVIDER1_CLIENT_SECRET="client-secret"
+export INFRAHUB_OIDC_PROVIDER1_DISCOVERY_URL="discovery-url"
+
+# Optional: Set display label and icon for the login screen
+export INFRAHUB_OIDC_PROVIDER1_DISPLAY_LABEL="display-label"
+export INFRAHUB_OIDC_PROVIDER1_ICON="mdi:key"
+
+# Then enable the provider
+export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1"]'
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[security.oidc_provider_settings.provider1]
+# Replace values with informations collected during the previous step
+client_id = "client-id"
+client_secret = "client-secret"
+discovery_url = "discovery-url"
+
+# Optional: Set display label and icon for the login screen
+display_label = "display-label"
+icon = "mdi:key"
+
+[security]
+# Then enable the provider
+oidc_providers = ["provider1"]
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="oauth2">
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# Replace values with informations collected during the previous step
+export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_ID="client-id"
+export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_SECRET="client-secret"
+export INFRAHUB_OAUTH2_PROVIDER1_AUTHORIZATION_URL="authorization-url"
+export INFRAHUB_OAUTH2_PROVIDER1_TOKEN_URL="token-url"
+export INFRAHUB_OAUTH2_PROVIDER1_USERINFO_URL="userinfo-url"
+
+# Optional: Set display label and icon for the login screen
+export INFRAHUB_OAUTH2_PROVIDER1_DISPLAY_LABEL="display-label"
+export INFRAHUB_OAUTH2_PROVIDER1_ICON="mdi:key"
+
+# Then enable the provider
+export INFRAHUB_SECURITY_OAUTH2_PROVIDERS='["provider1"]'
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[security.oauth2_provider_settings.provider1]
+# Replace values with informations collected during the previous step
+client_id = "client-id"
+client_secret = "client-secret"
+authorization_url = "authorization-url"
+token_url = "token-url"
+userinfo_url = "userinfo-url"
+
+# Optional: Set display label and icon for the login screen
+display_label = "display-label"
+icon = "mdi:key"
+
+[security]
+# Then enable the provider
+oauth2_providers = ["provider1"]
+```
+
+</TabItem>
+</Tabs>
+</TabItem>
+</Tabs>
+
+<ReferenceLink title="Configure Infrahub" url="../../install-configure/configure-infrahub" openInNewTab />
+
+:::success
+After restarting, Infrahub will authenticate users through your configured identity provider.
+
+If Infrahub fails to restart, check the [Troubleshooting section](#troubleshooting).
+:::
+
+## Step 4: Validate the SSO configuration
+
+To verify your SSO configuration:
+
+1. Navigate to your Infrahub login page
+2. Look for a button labeled with your configured `display_label` next to the standard login form
+3. Click the SSO button
+4. You should be redirected to your identity provider's login screen
+5. After authenticating, you should be redirected back to Infrahub and logged in
+
+:::success
+When correctly configured, you'll successfully log in through your identity provider.
+
+If authentication fails, check the [Troubleshooting section](#troubleshooting).
+:::
+
+## Troubleshooting
+
+:::info
+Every SSO authentication attempt is logged in the Infrahub server logs. Review these logs for detailed error messages that can help diagnose issues.
+:::
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| "Redirect URI mismatch" error | The redirect URI in your identity provider doesn't match the one Infrahub expects | Verify the redirect URI follows the exact format: `https://<your-infrahub-hostname>/auth/<protocol>/<provider-slot>/callback` |
+| "Invalid client" error | Client ID or secret is incorrect | Double-check your client ID and secret values for typos or extra spaces |
+
+## Related resources
+
+- [SSO overview](./index.mdx)
+- [Advanced SSO configuration](./advanced-sso.mdx)
+- [Authentication](../authentication.mdx)
+- [SSO reference](../../../reference/sso.mdx)

--- a/docs/docs/deploy-manage/user-management/sso/index.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Single sign-on (SSO)
+---
+
+# Single sign-on (SSO)
+
+Single sign-on (SSO) allows users to authenticate once with an external identity provider and gain access to Infrahub without needing separate credentials. Infrahub integrates with popular identity providers — Microsoft Entra ID, Okta, Google Workspace, and others — through industry-standard protocols.
+
+Infrahub supports two authentication protocols:
+
+- **OpenID Connect (OIDC)**: Recommended for new implementations. Provides standardized user Profile information on top of OAuth 2.0. Most modern identity providers support OIDC.
+- **OAuth 2.0**: Widely supported authorization protocol. May require additional configuration for user Profile mapping.
+
+Infrahub provides six configuration slots for identity providers — three OIDC slots (PROVIDER1, PROVIDER2, GOOGLE) and three OAuth2 slots (PROVIDER1, PROVIDER2, GOOGLE). This allows multiple identity providers to be configured simultaneously.
+
+When SSO is enabled, users are redirected to the identity provider's login screen. After successful authentication, they are returned to Infrahub and a corresponding local user record is created automatically if one does not already exist.
+
+For background on authentication concepts and the differences between OIDC and OAuth2, see [Authentication](../authentication.mdx).
+
+## SSO guides
+
+- [Configure SSO](./configure-sso.mdx) — Set up a new SSO integration step by step
+- [Advanced SSO configuration](./advanced-sso.mdx) — Multiple identity providers and group mapping

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -88,3 +88,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-database-backup.yml` | D&M — Database Backup (hub + 2 spokes) | TBD |
 | `deploy-manage-upgrade.yml` | D&M — Upgrade (hub + 3 spokes) | TBD |
 | `deploy-manage-authentication.yml` | D&M — Authentication (move) | TBD |
+| `deploy-manage-sso.yml` | D&M — SSO (hub + 2 spokes) | TBD |

--- a/docs/redirects-pending/deploy-manage-sso.yml
+++ b/docs/redirects-pending/deploy-manage-sso.yml
@@ -1,0 +1,48 @@
+---
+feature: Deployment & Management — SSO (hub + 2 spokes)
+pr: TBD
+description: |
+  Splits guides/sso.mdx into a hub + 2 spokes under
+  deploy-manage/user-management/sso/:
+    - index.mdx            Hub (SSO overview; net-new content)
+    - configure-sso.mdx    Steps 1-4 + Troubleshooting (main configuration guide)
+    - advanced-sso.mdx     Multiple providers + Group mapping
+  No legacy topic file existed for SSO. Original guides/sso.mdx remains on disk.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/sso
+    to: /docs/deploy-manage/user-management/sso/
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/user-management/sso/
+    title: Single sign-on (SSO) (hub)
+  - path: /docs/deploy-manage/user-management/sso/configure-sso
+    title: Configure SSO
+  - path: /docs/deploy-manage/user-management/sso/advanced-sso
+    title: Advanced SSO configuration
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/home.mdx
+    line: 96
+    current: "guides/sso"
+    should_be: "deploy-manage/user-management/sso/"
+  - file: docs/docs/faq/faq.mdx
+    line: 137
+    current: ../guides/sso.mdx
+    should_be: ../deploy-manage/user-management/sso/configure-sso.mdx
+  - file: docs/docs/deploy-manage/user-management/authentication.mdx
+    line: 38
+    current: url="../../guides/sso"
+    should_be: url="./sso/"
+  - file: docs/docs/deploy-manage/user-management/authentication.mdx
+    line: 70
+    current: url="../../guides/sso"
+    should_be: url="./sso/"
+  - file: docs/docs/deploy-manage/install-configure/production-deployment/index.mdx
+    line: 78
+    current: url="../../../guides/sso"
+    should_be: url="../user-management/sso/configure-sso"

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -421,8 +421,16 @@ const sidebars: SidebarsConfig = {
           items: [
             // Authentication (PR 11)
             { type: 'doc', id: 'deploy-manage/user-management/authentication', label: 'Authentication' },
-            // SSO hub + spokes added in PR 12
-            { type: 'doc', id: 'guides/sso', label: 'SSO' },
+            // SSO hub + spokes (PR 12)
+            {
+              type: 'category',
+              label: 'Single sign-on (SSO)',
+              link: { type: 'doc', id: 'deploy-manage/user-management/sso/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/user-management/sso/configure-sso', label: 'Configure SSO' },
+                { type: 'doc', id: 'deploy-manage/user-management/sso/advanced-sso', label: 'Advanced SSO configuration' },
+              ],
+            },
             // Permissions & Roles hub + spoke added in PR 13
             { type: 'doc', id: 'topics/permissions-roles', label: 'Permissions & Roles' },
             // Managing API Tokens moved in PR 14


### PR DESCRIPTION
## Summary

Migrate **SSO (Single sign-on)** per the Infrahub docs revamp D&M section restructure.
Pattern: hub + 2 spokes (no source topic file; hub is net-new content).

## Content changes

- **`deploy-manage/user-management/sso/index.mdx`** (hub): net-new prose introducing SSO in Infrahub — protocols (OIDC/OAuth2), provider slots, user flow. Links to both spokes.
- **`deploy-manage/user-management/sso/configure-sso.mdx`** (spoke 1): verbatim from `guides/sso.mdx` Steps 1–4 + Troubleshooting. Links updated for new depth.
- **`deploy-manage/user-management/sso/advanced-sso.mdx`** (spoke 2): verbatim from `guides/sso.mdx` Advanced usage section (Multiple identity providers + Group mapping).
- **`sidebars.ts`**: replaced `guides/sso` placeholder with hub+spoke category under User Management & Security.
- **`redirects-pending/deploy-manage-sso.yml`**: records 1 URL redirect and 5 cross-link cleanup entries.

## What didn't change

- All factual content preserved verbatim
- Original `guides/sso.mdx` remains on disk

## Verification

- `markdownlint-cli2` clean (0 errors)
- `vale` exit code 0 (2 expected false-positive warnings on proper nouns "SSO" and heading capitalization — same pattern as other migrated files)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)