### PR TITLE
docs: migrate Permissions & Roles to deploy-manage/user-management (PR 13)

### DIFF
--- a/docs/docs/deploy-manage/user-management/authentication.mdx
+++ b/docs/docs/deploy-manage/user-management/authentication.mdx
@@ -83,7 +83,7 @@ Authentication works in conjunction with Infrahub's authorization system, which 
 Authentication is the first step - it creates users and assigns them to groups. Authorization then attaches permissions and roles to those groups.
 :::
 
-<ReferenceLink title="Roles and permissions" url="../../topics/permissions-roles"/>
+<ReferenceLink title="Roles and permissions" url="./permissions-roles/"/>
 
 ## Anonymous access
 
@@ -135,4 +135,4 @@ The table below shows which authentication methods are supported by different In
 
 ## Related concepts
 
-- [Roles and permissions topic](../../topics/permissions-roles.mdx)
+- [Roles and permissions](./permissions-roles/index.mdx)

--- a/docs/docs/deploy-manage/user-management/permissions-roles/index.mdx
+++ b/docs/docs/deploy-manage/user-management/permissions-roles/index.mdx
@@ -1,0 +1,90 @@
+---
+title: Permissions and roles
+---
+import ReferenceLink from "../../../../src/components/Card";
+
+# Permissions and roles
+
+Roles and permissions are essential for controlling user access and behavior in Infrahub. Within the platform, they provide precise control over what users can see, modify, or manage.
+
+Permissions fall into two categories: **global** and **object-specific**, while roles act as convenient bundles of permissions. To simplify management, account groups let you manage permissions for multiple users at once.
+
+- **GlobalPermissions**: Provide users with system-wide rights to perform specific actions. [See full list of available global permissions](../../../reference/permissions.mdx#global-permissions).
+- **ObjectPermissions**: Are tied to individual objects within Infrahub and control what actions users can take on those objects. [See full list of available object permissions](../../../reference/permissions.mdx#object-permissions).
+- **AccountRoles**: Function as groups of permissions you can assign to accounts.
+- **AccountGroups**: Allow you to manage permissions for multiple users all at once.
+
+## User permission management
+
+Users are allocated permissions through a hierarchical system of groups and roles:
+
+- **Users** are members of **Groups**
+- **Groups** are associated with **Roles**
+- **Roles** are allocated specific **Permissions**
+
+:::note Authentication & Authorization
+Authentication works in conjunction with Infrahub's authorization system, which controls what actions authenticated users can perform. While authentication verifies who you are, authorization determines what you can do within the system.
+
+Authentication is the first step - it creates users and assigns them to groups. Authorization then attaches permissions and roles to those groups.
+:::
+
+<ReferenceLink title="Authentication" url="../authentication"/>
+
+## Types of permissions
+
+### Global permissions
+
+With a global permission, a user can act on the entire system, not just on particular objects. For example, a person with the permission to manage accounts can do so across the entire platform. If the required permission is not granted, the action is blocked.
+
+<details>
+    <summary>Global permission example</summary>
+
+    Take the `global:manage_accounts:allow_all` permission:
+
+    - **Action**: `manage_accounts`
+    - **Decision**: `allow_all`
+
+    This gives the user the ability to manage all user accounts throughout the system.
+
+    <ReferenceLink title="Permissions and roles reference" url="../../../reference/permissions"/>
+</details>
+
+### Object permissions
+
+Object permissions specify actions that apply to a certain kind of object. Actions like create, update, remove, and view are supported. Depending on the kind of object or branch, object permissions may be granted or refused.
+
+Key features:
+
+- Supports wildcards (`*`) to apply permissions across multiple object types
+- Can define different permissions per branch type (default or non-default branches)
+- Grants or denies actions based on the assigned permission
+
+<details>
+    <summary>Object permission example</summary>
+
+    Here are some examples of object permissions and their descriptions:
+
+    | Identifier | Object Type | Action | Decision | Description |
+    |------------|-------------|--------|----------|-------------|
+    | `object:*:*:create:allow_other` | `*` (all types) | `create` | `allow_other` | Allows creating any object, but only on non-default branches. |
+    | `object:*:*:view:allow_all` | `*` (all types) | `view` | `allow_all` | Allows viewing any object, anywhere, across both default and non-default branches. |
+    | `object:Builtin:Tag:update:deny` | `BuiltinTag` | `update` | `deny` | Denies the ability to update any object of type BuiltinTag, across all branches. |
+    | `object:*:Generic:view:allow_all` | `*Generic` | `view` | `allow_all` | Allows viewing all objects that contain 'Generic' in their type (example: LocationGeneric, DeviceGeneric) in all namespaces, across all branches. |
+
+    <ReferenceLink title="Permissions and roles reference" url="../../../reference/permissions"/>
+</details>
+
+## Future developments
+
+The authorization structure for Infrahub is constantly evolving. Here are some upcoming features:
+
+- **Attribute-based permissions**: Grant permissions at the attribute level within objects
+- **Metadata-based permissions**: Use metadata to specify access controls
+- **Group-based permissions**: Deepen the integration of group memberships for permission assignments
+
+These new features will make Infrahub's permission system even more powerful and flexible in the future.
+
+## Related concepts
+
+- [Authentication](../authentication.mdx)
+- [Permissions and roles reference](../../../reference/permissions.mdx)

--- a/docs/docs/deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions.mdx
+++ b/docs/docs/deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions.mdx
@@ -1,0 +1,234 @@
+---
+title: Manage accounts and permissions
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Manage accounts and permissions
+
+In Infrahub, managing access and control starts with creating accounts, assigning them to groups, and managing their roles and permissions.
+This guide outlines how to create new accounts, accounts groups, and assign roles and permissions.
+
+For more information on roles and permissions, see the [Permissions and roles](./index.mdx) overview.
+
+## Creating a new account
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+  ### Via the Web Interface
+
+  1. Log in to the Infrahub UI as an administrator.
+  2. Go to **Admin > Role Management** in the left side menu.
+  3. In the **Accounts** tab, click on **Create Account**.
+  4. Fill in the account's details (name, email, and password).
+  5. Optionally, assign the account to a group.
+  6. Click **Create** to create the account.
+
+  ![New Account](../../../media/guides/permissions/permissions_account.png)
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+  ### Via the GraphQL Interface
+
+  In the GraphQL sandbox, execute the following mutation to create a new account, replacing the appropriate values as needed:
+
+  ```graphql
+  mutation AddAccount {
+    CoreAccountCreate(
+      data: {
+        name: {value: "<ACCOUNT-NAME>"},
+        password: {value: "<ACCOUNT-PASSWORD>"}
+        # Optional - Assign the account to an existing group
+        member_of_groups: [{hfid: "Infrahub Users"}]
+      }
+    ) {
+      ok
+      object {
+        hfid
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Creating a new account group
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+  ### Via the Web Interface
+
+  1. Log in to the Infrahub UI as an administrator.
+  2. Go to **Admin > Role Management** in the left side menu.
+  3. In the **Groups** tab, click on **Create Account Group**.
+  4. Enter a name for the group.
+  5. Optionally, assign roles to the group.
+  6. Click **Create** to create the group.
+
+  ![New Group](../../../media/guides/permissions/permissions_group.png)
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+  ### Via the GraphQL Interface
+
+  In the GraphQL sandbox, execute the following mutation to create a new group:
+
+  ```graphql
+  mutation AddGroup {
+    CoreAccountGroupCreate(
+      data: {
+        name: {value: "<GROUP-NAME>"},
+        # Optional - Assign existing roles
+        roles: [{hfid: "General Access"}]
+      }
+    ) {
+      ok
+      object {
+        hfid
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Creating and assigning roles
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+  ### Via the Web Interface
+
+  1. Log in to the Infrahub UI as an administrator.
+  2. Go to **Admin > Role Management** in the left side menu.
+  3. In the **Roles** tab, click on **Create Account Role**.
+  4. Provide a name for the role.
+  5. Select the permissions you wish to assign to the role.
+  6. Optionally, assign the role to an existing group.
+  7. Click **Create** to create the role.
+
+  ![New Role](../../../media/guides/permissions/permissions_role.png)
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+  ### Via the GraphQL Interface
+
+  In the GraphQL sandbox, execute the following mutation to create a new role:
+
+  ```graphql
+  mutation AddRole {
+    CoreAccountRoleCreate(
+      data: {
+        name: {value: "test role"},
+        # Optional - Assign the role to an existing group
+        groups: [{hfid: "Infrahub Users"}]
+      }
+    ) {
+      ok
+      object {
+        hfid
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Managing permissions
+
+Permissions can be managed through roles assigned to users or groups.
+Infrahub supports **Global** and **Object-specific** permissions, allowing fine-grained control over what users can do within the system.
+For a complete list of available global and object permissions, see the [Roles and Permissions documentation](../../../reference/permissions.mdx).
+
+### Creating and global permissions
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+  ### Via the Web Interface
+
+  1. Log in to the Infrahub UI as an administrator.
+  2. Go to **Admin > Role Management** in the left side menu.
+  3. In the **Global Permissions** tab, click on **Create Global Permission**.
+  4. Select the action you which to use.
+  5. Select the decision for this action.
+  6. Optionally, assign the permission to an existing role.
+  7. Click **Create** to create the permission.
+
+  {/*TODO: Generate this screen*/}
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+  ### Via the GraphQL Interface
+
+  In the GraphQL sandbox, execute the following mutation to create a new global permission:
+
+  ```graphql
+  mutation AddGlobalPermissions {
+    CoreGlobalPermissionCreate(
+      data: {
+        action: {value: "manage_accounts"},
+        # 6 is the enum value for "allow"
+        decision: {value: 6}
+      }
+    ) {
+      ok
+      object {
+        identifier {
+          value
+        }
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+### Creating and objects permissions
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+  ### Via the Web Interface
+
+  1. Log in to the Infrahub UI as an administrator.
+  2. Go to **Admin > Role Management** in the left side menu.
+  3. In the **Objects Permissions** tab, click on **Create Object Permission**..
+  4. Provide the namespace and name of the object(s) you want to interact with.
+  5. Select the action and decision you wish to use for this permission.
+  6. Optionally, assign the permission to an existing role.
+  7. Click **Create** to create the permission.
+
+  {/*TODO: Generate this screen*/}
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+  ### Via the GraphQL Interface
+
+  In the GraphQL sandbox, execute the following mutation to create a new global permission:
+
+  ```graphql
+  mutation AddObjectPermissions {
+    CoreObjectPermissionCreate(
+      data: {
+        namespace: {value: "Builtin"},
+        name: {value: "Tag"},
+        action: {value: "view"},
+        # 4 is the enum value for "allow_other"
+        decision: {value: 4 }
+      }
+    ) {
+      ok
+      object {
+        identifier {
+          value
+        }
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>

--- a/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
@@ -121,7 +121,7 @@ sso_user_default_group = "default-group"
 </Tabs>
 
 :::success
-Now that group mapping is configured, manage user permissions in Infrahub by [assigning permissions and roles](../../../guides/accounts-permissions.mdx) to these groups.
+Now that group mapping is configured, manage user permissions in Infrahub by [assigning permissions and roles](../permissions-roles/manage-accounts-and-permissions.mdx) to these groups.
 :::
 
 ## Related resources
@@ -130,4 +130,4 @@ Now that group mapping is configured, manage user permissions in Infrahub by [as
 - [Configure SSO](./configure-sso.mdx)
 - [Authentication](../authentication.mdx)
 - [SSO reference](../../../reference/sso.mdx)
-- [Permissions and roles](../../../topics/permissions-roles.mdx)
+- [Permissions and roles](../permissions-roles/index.mdx)

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -89,3 +89,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-upgrade.yml` | D&M — Upgrade (hub + 3 spokes) | TBD |
 | `deploy-manage-authentication.yml` | D&M — Authentication (move) | TBD |
 | `deploy-manage-sso.yml` | D&M — SSO (hub + 2 spokes) | TBD |
+| `deploy-manage-permissions-roles.yml` | D&M — Permissions & Roles (hub + 1 spoke) | TBD |

--- a/docs/redirects-pending/deploy-manage-permissions-roles.yml
+++ b/docs/redirects-pending/deploy-manage-permissions-roles.yml
@@ -1,0 +1,84 @@
+---
+feature: Deployment & Management — Permissions & Roles (hub + 1 spoke)
+pr: TBD
+description: |
+  Moves topics/permissions-roles.mdx and guides/accounts-permissions.mdx into a
+  hub + spoke under deploy-manage/user-management/permissions-roles/:
+    - index.mdx                          Hub (permissions and roles overview; verbatim from topic)
+    - manage-accounts-and-permissions.mdx  Spoke (account/group/role/permission creation; from guide)
+  Original source files remain on disk. Spoke title changed from
+  "Creating accounts, groups, roles, and permissions" to "Manage accounts and permissions".
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/permissions-roles
+    to: /docs/deploy-manage/user-management/permissions-roles/
+  - from: /docs/guides/accounts-permissions
+    to: /docs/deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/user-management/permissions-roles/
+    title: Permissions and roles (hub)
+  - path: /docs/deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions
+    title: Manage accounts and permissions
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/schema/file-object.mdx
+    line: 98
+    current: ../topics/permissions-roles
+    should_be: ../../../deploy-manage/user-management/permissions-roles/
+  - file: docs/docs/schema/file-object.mdx
+    line: 124
+    current: ../topics/permissions-roles
+    should_be: ../../../deploy-manage/user-management/permissions-roles/
+  - file: docs/docs/change-approval/change-approval-workflow.mdx
+    line: 41
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/change-approval/change-approval-workflow.mdx
+    line: 287
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/guides/sso.mdx
+    line: 451
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/schema/field-visibility.mdx
+    line: 78
+    current: ../topics/permissions-roles
+    should_be: ../../../deploy-manage/user-management/permissions-roles/
+  - file: docs/docs/schema/field-visibility.mdx
+    line: 90
+    current: ../topics/permissions-roles
+    should_be: ../../../deploy-manage/user-management/permissions-roles/
+  - file: docs/docs/guides/groups.mdx
+    line: 299
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/guides/change-approval-workflow.mdx
+    line: 41
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/guides/change-approval-workflow.mdx
+    line: 287
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/reference/permissions.mdx
+    line: 11
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/release-notes/infrahub/release-1_0_0.mdx
+    line: 117
+    current: ../../guides/accounts-permissions.mdx
+    should_be: ../../deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions.mdx
+  - file: docs/docs/release-notes/infrahub/release-1_0_0.mdx
+    line: 118
+    current: ../../topics/permissions-roles.mdx
+    should_be: ../../deploy-manage/user-management/permissions-roles/index.mdx
+  - file: docs/docs/proposed-changes/index.mdx
+    line: 131
+    current: ../topics/permissions-roles.mdx
+    should_be: ../deploy-manage/user-management/permissions-roles/index.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -431,8 +431,15 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/user-management/sso/advanced-sso', label: 'Advanced SSO configuration' },
               ],
             },
-            // Permissions & Roles hub + spoke added in PR 13
-            { type: 'doc', id: 'topics/permissions-roles', label: 'Permissions & Roles' },
+            // Permissions & Roles hub + spoke (PR 13)
+            {
+              type: 'category',
+              label: 'Permissions & roles',
+              link: { type: 'doc', id: 'deploy-manage/user-management/permissions-roles/index' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions', label: 'Manage accounts and permissions' },
+              ],
+            },
             // Managing API Tokens moved in PR 14
             { type: 'doc', id: 'guides/managing-api-tokens', label: 'Managing API Tokens' },
           ],


### PR DESCRIPTION
## Summary

Migrate **Permissions & Roles** to the new `deploy-manage/user-management/` section. Pattern: hub + spoke.

- **Hub** (`permissions-roles/index.mdx`) — concept page verbatim from `topics/permissions-roles.mdx`
- **Spoke** (`permissions-roles/manage-accounts-and-permissions.mdx`) — how-to page from `guides/accounts-permissions.mdx`; title updated to "Manage accounts and permissions"

## Content changes

- `topics/permissions-roles.mdx` → hub at `deploy-manage/user-management/permissions-roles/index.mdx` (verbatim, link depths adjusted)
- `guides/accounts-permissions.mdx` → spoke at `deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions.mdx` (verbatim, link depths adjusted)
- Fixed stale permissions-roles links in `authentication.mdx` and `sso/advanced-sso.mdx` (within the migrated section)

## What didn't change

- All factual content preserved; no new claims invented
- Original `topics/permissions-roles.mdx` and `guides/accounts-permissions.mdx` remain on disk (cleanup happens in a separate PR before production merge)

## Verification

- `cd docs && npm run build` succeeds
- markdownlint: 0 errors
- Vale: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)