### PR TITLE
docs: migrate Managing API Tokens to deploy-manage/user-management (PR 14)

### DIFF
--- a/docs/docs/deploy-manage/user-management/authentication.mdx
+++ b/docs/docs/deploy-manage/user-management/authentication.mdx
@@ -131,7 +131,7 @@ The table below shows which authentication methods are supported by different In
 | infrahubctl        | Yes       | Yes       |
 | GraphQL Playground | No        | Yes       |
 
-<ReferenceLink title="Managing API Tokens Guide" url="../../guides/managing-api-tokens"/>
+<ReferenceLink title="Managing API Tokens Guide" url="./managing-api-tokens"/>
 
 ## Related concepts
 

--- a/docs/docs/deploy-manage/user-management/managing-api-tokens.mdx
+++ b/docs/docs/deploy-manage/user-management/managing-api-tokens.mdx
@@ -1,0 +1,91 @@
+---
+title: Managing API tokens
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Managing API tokens
+
+API tokens can be used as an authentication mechanism for Infrahub's REST- and GraphQL API, the Python SDK and infrahubctl.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+1. Login to Infrahub's web interface as an administrator.
+2. Click on the user in the left side menu.
+3. Navigate to the **Account settings**.
+4. In the user Profile page, click on **Tokens** tab.
+![Profile Tokens](../../media/profile_tokens.png)
+5. Click **+ Add Account Token**.
+![Creating an API Token](../../media/profile_tokens_create.png)
+6. Fill in the details and click **Save**.
+7. Copy the generated token and store in a safe location.
+![Copy API Token](../../media/profile_tokens_copy.png)
+8. Deleting a token can be achieved by selecting the trash icon on the token table item.
+
+  </TabItem>
+
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+## Creating a new API Token
+
+In the GraphQL sandbox, execute the following mutation, replace the name of the token in the mutation with a value that is appropriate for your use case:
+
+```graphql
+mutation {
+  InfrahubAccountTokenCreate(data: {name: "token name"}) {
+    object {
+      token {
+        value
+      }
+    }
+  }
+}
+```
+
+The result of the query will show you the value of the token that was generated for the token. Store the token in a secure location, as there will be no way to retrieve the token from Infrahub at a later stage.
+
+## Listing existing API Tokens for a user
+
+In the GraphQL sandbox, execute the following query:
+
+```graphql
+query {
+  InfrahubAccountToken {
+    edges {
+      node {
+        name
+        expiration
+        id
+      }
+    }
+  }
+}
+```
+
+## Deleting an API token for a user
+
+In the GraphQL sandbox, execute the following mutation, replace the id of the token in the mutation with the id of the token that you want to delete:
+
+```graphql
+mutation {
+  InfrahubAccountTokenDelete(data: {id: "17d8cde3-d36b-a0a3-370e-c51707234f19"}) {
+    ok
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## Using API tokens
+
+:::info
+
+While using the API, the authentication token must be provided in the header:
+
+```yaml
+X-INFRAHUB-KEY: 06438eb2-8019-4776-878c-0941b1f1d1ec
+```
+
+:::

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -90,3 +90,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-authentication.yml` | D&M — Authentication (move) | TBD |
 | `deploy-manage-sso.yml` | D&M — SSO (hub + 2 spokes) | TBD |
 | `deploy-manage-permissions-roles.yml` | D&M — Permissions & Roles (hub + 1 spoke) | TBD |
+| `deploy-manage-api-tokens.yml` | D&M — Managing API Tokens (page move) | TBD |

--- a/docs/redirects-pending/deploy-manage-api-tokens.yml
+++ b/docs/redirects-pending/deploy-manage-api-tokens.yml
@@ -1,0 +1,25 @@
+---
+feature: Deployment & Management — Managing API Tokens (page move)
+pr: TBD
+description: |
+  Moves guides/managing-api-tokens.mdx into deploy-manage/user-management/managing-api-tokens.mdx.
+  Single-page move; image paths adjusted for new directory depth.
+  Original guides/managing-api-tokens.mdx remains on disk.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/guides/managing-api-tokens
+    to: /docs/deploy-manage/user-management/managing-api-tokens
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/deploy-manage/user-management/managing-api-tokens
+    title: Managing API tokens
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (resolve via redirect at runtime; update to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/faq/faq.mdx
+    line: 137
+    current: ../guides/managing-api-tokens.mdx
+    should_be: ../deploy-manage/user-management/managing-api-tokens.mdx

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -440,8 +440,8 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/user-management/permissions-roles/manage-accounts-and-permissions', label: 'Manage accounts and permissions' },
               ],
             },
-            // Managing API Tokens moved in PR 14
-            { type: 'doc', id: 'guides/managing-api-tokens', label: 'Managing API Tokens' },
+            // Managing API Tokens (PR 14)
+            { type: 'doc', id: 'deploy-manage/user-management/managing-api-tokens', label: 'Managing API tokens' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary

Migrate **Managing API Tokens** to the new `deploy-manage/user-management/` section. Pattern: single-page move.

- `guides/managing-api-tokens.mdx` → `deploy-manage/user-management/managing-api-tokens.mdx`
- Image paths adjusted for new directory depth (`../media/` → `../../media/`)
- Fixed stale api-tokens link in `authentication.mdx` (within the migrated section)

## What didn't change

- All content preserved verbatim
- Original `guides/managing-api-tokens.mdx` remains on disk (cleanup happens in a separate PR before production merge)

## Verification

- `cd docs && npm run build` succeeds
- markdownlint: 0 errors
- Vale: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)