### PR TITLE
Migrate object doc

### DIFF
--- a/dev/specs/2026-05-07-object-doc-migration-plan.md
+++ b/dev/specs/2026-05-07-object-doc-migration-plan.md
@@ -1,0 +1,106 @@
+# Plan: Migrate Objects & Object Templates docs
+
+## Context
+
+The V3 nav restructure introduced "Schema & Data" as a top-level section. Two sub-sections need to be wired up properly:
+
+- **Object Templates** — currently lives as a legacy topic/guide pair (`topics/object-template.mdx` + `guides/object-template.mdx`). The sidebar shows a one-item category with no real hub. Needs to become a hub + 3 spokes that match the structured guide.
+- **Objects** — currently uses `generated-index` as its hub (no real landing page). Needs a proper "About Objects" page that defines the concept.
+
+Constraints: no content changes, no deletion of old pages, one genuinely new page (About Objects).
+
+---
+
+## Files to Create
+
+### Object Templates
+
+| File | Label in sidebar | Origin |
+|------|-----------------|--------|
+| `docs/docs/object-templates/index.mdx` | Object Templates (hub) | Content from `topics/object-template.mdx` |
+| `docs/docs/object-templates/use.mdx` | Use object templates | 3 core sections from `guides/object-template.mdx` |
+| `docs/docs/object-templates/with-profiles.mdx` | Assign Profiles to a template | Split from guide |
+| `docs/docs/object-templates/allocate-resources-from-pools.mdx` | Allocate resources from pools | Split from guide |
+
+### Objects
+
+| File | Label in sidebar | Origin |
+|------|-----------------|--------|
+| `docs/docs/objects/index.mdx` | Objects (hub) | New content |
+| `docs/docs/objects/convert-object-kind.mdx` | Convert object kind | Moved from `topics/object-conversion.mdx` |
+| `docs/docs/objects/metadata.mdx` | Metadata & lineage | Moved from `topics/metadata.mdx` |
+| `docs/docs/objects/load-from-yaml.mdx` | Load data in bulk using YAML file | Moved from `guides/object-load.mdx` |
+
+---
+
+## Files to Keep Unchanged (legacy)
+
+- `docs/docs/topics/object-template.mdx`
+- `docs/docs/guides/object-template.mdx`
+- `docs/docs/topics/object-conversion.mdx`
+- `docs/docs/topics/metadata.mdx`
+- `docs/docs/guides/object-load.mdx`
+
+---
+
+## File to Modify
+
+### `docs/sidebars.ts`
+
+**Object Templates category** — replace `Templates` (hub: `topics/object-template`, one spoke) with:
+
+```typescript
+{
+  type: 'category',
+  label: 'Object Templates',
+  link: { type: 'doc', id: 'object-templates/index' },
+  items: [
+    { type: 'doc', id: 'object-templates/use', label: 'Use object templates' },
+    { type: 'doc', id: 'object-templates/with-profiles', label: 'Assign Profiles to a template' },
+    { type: 'doc', id: 'object-templates/allocate-resources-from-pools', label: 'Allocate resources from pools' },
+  ],
+},
+```
+
+**Objects category** — replace `generated-index` hub with:
+
+```typescript
+{
+  type: 'category',
+  label: 'Objects',
+  link: { type: 'doc', id: 'objects/index' },
+  items: [
+    { type: 'doc', id: 'objects/convert-object-kind', label: 'Convert object kind' },
+    { type: 'doc', id: 'objects/metadata', label: 'Metadata & lineage' },
+    { type: 'doc', id: 'objects/load-from-yaml', label: 'Load data in bulk using YAML file' },
+  ],
+},
+```
+
+---
+
+## Execution Order
+
+1. Create `docs/docs/object-templates/index.mdx`
+2. Create `docs/docs/object-templates/use.mdx`
+3. Create `docs/docs/object-templates/with-profiles.mdx`
+4. Create `docs/docs/object-templates/allocate-resources-from-pools.mdx`
+5. Create `docs/docs/objects/index.mdx`
+6. Create `docs/docs/objects/convert-object-kind.mdx`
+7. Create `docs/docs/objects/metadata.mdx`
+8. Create `docs/docs/objects/load-from-yaml.mdx`
+9. Update `docs/sidebars.ts`
+
+---
+
+## Verification
+
+```bash
+cd docs && node_modules/.bin/docusaurus build
+```
+
+- Schema & Data → Object Templates → hub page loads
+- Each of the 3 spokes loads
+- Schema & Data → Objects → hub page loads (not a generated index)
+- All 3 Objects sub-pages present and linked
+- Old `topics/object-template` and `guides/object-template` still accessible by direct URL

--- a/dev/specs/2026-05-07-object-doc-migration-summary.md
+++ b/dev/specs/2026-05-07-object-doc-migration-summary.md
@@ -1,0 +1,65 @@
+# Session Summary — Objects & Object Templates Migration
+
+## New files created
+
+### `docs/docs/object-templates/` (new directory)
+
+| File | Sidebar label | Origin |
+|------|--------------|--------|
+| `index.mdx` | Object Templates (hub) | Content from `topics/object-template.mdx` |
+| `use.mdx` | Use object templates | 3 core sections from `guides/object-template.mdx` |
+| `with-profiles.mdx` | Assign Profiles to a template | Split from guide |
+| `allocate-resources-from-pools.mdx` | Allocate resources from pools | Split from guide |
+
+### `docs/docs/objects/` (new directory)
+
+| File | Sidebar label | Origin |
+|------|--------------|--------|
+| `index.mdx` | Objects (hub) | New content |
+| `convert-object-kind.mdx` | Convert object kind | Moved from `topics/object-conversion.mdx` |
+| `metadata.mdx` | Metadata & lineage | Moved from `topics/metadata.mdx` |
+| `load-from-yaml.mdx` | Load data in bulk using YAML file | Moved from `guides/object-load.mdx` |
+
+---
+
+## Sidebar changes (`docs/sidebars.ts`)
+
+| Before | After |
+|--------|-------|
+| `Templates` → hub: `topics/object-template`, 1 spoke | `Object Templates` → hub: `object-templates/index`, 3 spokes |
+| `Objects` → `generated-index` (no hub), 3 legacy paths | `Objects` → hub: `objects/index`, 3 new paths |
+
+---
+
+## Content improvements
+
+| File | Change |
+|------|--------|
+| `object-templates/index.mdx` | Replaced 3 inline links with `<ReferenceLink>` card components; added import |
+| `object-templates/use.mdx` | Added `{57}` line highlight on `generate_template: true` in the YAML block |
+| `object-templates/allocate-resources-from-pools.mdx` | "Update the schema" section converted to collapsible `<details>` prerequisite; section headings promoted from `###` to `##` |
+| `objects/index.mdx` | Branch awareness section nuanced to cover branch-agnostic schema nodes |
+| `objects/load-from-yaml.mdx` | "Loading an example schema" section converted to collapsible `<details>` prerequisite |
+
+---
+
+## Naming decisions
+
+| Before | After | Reason |
+|--------|-------|--------|
+| "Templates" (sidebar label) | "Object Templates" | More specific, avoids ambiguity |
+| "Use Templates" | "Use object templates" | Consistent verb-first pattern |
+| "Templates with Profiles" | "Assign Profiles to a template" | Action-oriented, parallel to "Use object templates" |
+| "Allocate resources via templates" | "Allocate resources from pools" | Focuses on the mechanism, not the context |
+| `allocate-resources.mdx` | `allocate-resources-from-pools.mdx` | Matches renamed label |
+| "Load data from YAML file" | "Load data in bulk using YAML file" | Clearer intent |
+
+---
+
+## Files left unchanged (legacy)
+
+- `docs/docs/topics/object-template.mdx`
+- `docs/docs/guides/object-template.mdx`
+- `docs/docs/topics/object-conversion.mdx`
+- `docs/docs/topics/metadata.mdx`
+- `docs/docs/guides/object-load.mdx`

--- a/docs/docs/object-templates/allocate-resources-from-pools.mdx
+++ b/docs/docs/object-templates/allocate-resources-from-pools.mdx
@@ -1,0 +1,265 @@
+---
+title: Allocate resources from pools
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Object templates support automatic resource allocation. This guide extends the device and interface example from [Use object templates](./use) to show how to wire a `CoreIPAddressPool` to the interface template so that IP addresses are allocated automatically on object creation.
+
+## Prerequisites
+
+- A running Infrahub instance with the schema from [Use object templates](./use) already loaded
+
+<details>
+<summary>Schema extension used in this guide</summary>
+
+Add the two IPAM nodes and an `ip_address` relationship to `InfraInterface`. Adapt the type names to match your own schema.
+
+```yaml
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: IPAddress
+    namespace: Ipam
+    label: "IP Address"
+    display_label: "{{ address__value }}"
+    inherit_from:
+      - BuiltinIPAddress
+
+  - name: IPPrefix
+    namespace: Ipam
+    label: "IP Prefix"
+    display_label: "{{ prefix__value }}"
+    inherit_from:
+      - BuiltinIPPrefix
+
+  - name: Interface
+    namespace: Infra
+    label: "Interface"
+    include_in_menu: true
+    icon: "mdi:ethernet"
+    display_label: "{{ name__value }}"
+    order_by:
+      - name__value
+    uniqueness_constraints:
+      - ["device", "name__value"]
+    human_friendly_id: ["device__name__value", "name__value"]
+    attributes:
+      - name: name
+        kind: Text
+      - name: description
+        kind: Text
+        optional: true
+      - name: enable
+        kind: Boolean
+        optional: false
+        default_value: false
+    relationships:
+      - name: device
+        peer: InfraDevice
+        optional: false
+        cardinality: one
+        kind: Parent
+      - name: ip_address
+        peer: IpamIPAddress
+        optional: true
+        cardinality: one
+        kind: Attribute
+```
+
+Once `IpamIPAddress` is in the schema, Infrahub automatically generates an `ip_address_from_resource_pool` field on `TemplateInfraInterface` — this is what connects the template to the pool.
+
+Load the schema before continuing:
+
+```bash
+infrahubctl schema load /path/to/schema-extension.yml
+```
+
+</details>
+
+## Create the resource pool
+
+First create a prefix to draw addresses from, then create the pool backed by that prefix.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  **Create the IP prefix:**
+
+  1. Navigate to `IPAM` > `Prefixes`
+  2. Click `+ Add IP Prefix`
+  3. Fill in:
+      - **Prefix**: `192.168.0.0/16`
+      - **Member Type**: `address`
+      - **Is Pool**: `true`
+  4. Save
+
+  **Create the IP address pool:**
+
+  1. Navigate to `Resource Manager` > `IP Address Pool`
+  2. Click `+ Add IP Address Pool`
+  3. Fill in:
+      - **Name**: `Interface IP Pool`
+      - **Default Address Type**: `IpamIPAddress`
+      - **IP Namespace**: `default`
+      - **Resources**: select `192.168.0.0/16`
+  4. Save
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+  ```graphql
+  mutation CreatePrefix {
+    IpamIPPrefixCreate(
+      data: {prefix: {value: "192.168.0.0/16"}, member_type: {value: "address"}, is_pool: {value: true}}
+    ) {
+      ok
+      object { id }
+    }
+  }
+  ```
+
+  Then use the returned prefix ID to create the pool:
+
+  ```graphql
+  mutation CreatePool($prefixId: String!) {
+    CoreIPAddressPoolCreate(
+      data: {
+        name: {value: "Interface IP Pool"}
+        default_address_type: {value: "IpamIPAddress"}
+        ip_namespace: {hfid: ["default"]}
+        resources: [{id: $prefixId}]
+      }
+    ) {
+      ok
+    }
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="object-file" label="Via an Object File">
+
+  ```yaml
+  ---
+  apiVersion: infrahub.app/v1
+  kind: Object
+  spec:
+    kind: CoreIPAddressPool
+    data:
+      - name: "Interface IP Pool"
+        default_address_type: IpamIPAddress
+        ip_namespace: default
+        resources:
+          kind: IpamIPPrefix
+          data:
+            - prefix: 192.168.0.0/16
+              member_type: address
+              is_pool: true
+  ```
+
+  Load with: `infrahubctl object load pools.yml`
+
+  </TabItem>
+  <TabItem value="python-sdk" label="Via the Python SDK">
+
+  ```python
+  async def run(client: InfrahubClient, log: logging.Logger, branch: str) -> None:
+      prefix = await client.create(
+          kind="IpamIPPrefix",
+          data={"prefix": "192.168.0.0/16", "member_type": "address", "is_pool": True},
+      )
+      await prefix.save(allow_upsert=True)
+
+      pool = await client.create(
+          kind="CoreIPAddressPool",
+          data={
+              "name": "Interface IP Pool",
+              "default_address_type": "IpamIPAddress",
+              "ip_namespace": {"hfid": ["default"]},
+              "resources": [{"id": prefix.id}],
+          },
+      )
+      await pool.save(allow_upsert=True)
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Assign the pool to the interface template
+
+With the pool created, update the interface template from the previous section to allocate an IP address from it whenever a new interface is created.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  1. Navigate to `Object Management` > `Templates`
+  2. Open `Template-SwitchModel123-Ethernet1` (or any interface template)
+  3. On the `IP Address` field, click the pool selector button and choose `Interface IP Pool`
+  4. The field will show an `Allocated by pool` badge
+  5. Save
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+  ```graphql
+  mutation {
+    TemplateInfraInterfaceUpdate(
+      data: {
+        hfid: ["Template-SwitchModel123", "Template-SwitchModel123-Ethernet1"]
+        ip_address_from_resource_pool: {hfid: ["Interface IP Pool"]}
+      }
+    ) {
+      ok
+    }
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="object-file" label="Via an Object File">
+
+  ```yaml
+  ---
+  apiVersion: infrahub.app/v1
+  kind: Object
+  spec:
+    kind: TemplateInfraInterface
+    data:
+      - template_name: "Template-SwitchModel123-Ethernet1"
+        device: "Template-SwitchModel123"
+        ip_address_from_resource_pool: "Interface IP Pool"
+  ```
+
+  </TabItem>
+  <TabItem value="python-sdk" label="Via the Python SDK">
+
+  ```python
+  async def run(client: InfrahubClient, log: logging.Logger, branch: str) -> None:
+      pool = await client.get(kind="CoreIPAddressPool", hfid=["Interface IP Pool"])
+
+      iface_template = await client.get(
+          kind="TemplateInfraInterface",
+          hfid=["Template-SwitchModel123", "Template-SwitchModel123-Ethernet1"],
+      )
+      iface_template.ip_address_from_resource_pool = {"id": pool.id}
+      await iface_template.save(allow_upsert=True)
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Create objects — IP addresses are allocated automatically
+
+Creating a device from the template works exactly as described in the [Create object instances](./use#create-object-instances-using-the-predefined-template) section. No additional steps are required — when the device is saved, Infrahub allocates an available IP address from `Interface IP Pool` and assigns it to each interface's `ip_address` field.
+
+:::info
+
+Resource allocation happens at object creation time, not at template creation time. Each new device gets its own unique address drawn from the pool.
+
+:::
+
+For more information about resource pools, see:
+
+- [Managing resource pools](../guides/resource-manager.mdx) - Guide for creating and using pools
+- [Resource Manager concepts](../topics/resource-manager.mdx) - Deep dive into allocation behaviour

--- a/docs/docs/object-templates/index.mdx
+++ b/docs/docs/object-templates/index.mdx
@@ -1,0 +1,60 @@
+---
+title: Object Templates
+---
+
+import ReferenceLink from "../../src/components/Card";
+
+In many infrastructures, multiple instances of objects share a common structure. Consider network devices: we know in advance the port setup for a given model. When documenting this in our source of truth, repeatedly entering the same port details is both inefficient and error-prone. The Object Template feature allows you to create a reusable blueprint for any object. This blueprint can be used to generate multiple instances that adhere to the predefined structure, ensuring uniformity while reducing manual effort.
+
+![Template High Level](../media/guides/object-template/object_template_mockup.png)
+
+Within a template, you can define:
+
+- **Node attributes** - Standard properties and characteristics of the object.
+- **Relationships** - Connections to other nodes in the infrastructure.
+- **Components** - Sub-elements or modules that belong to the object.
+
+When creating a new object instance, users can optionally select a template. If chosen, Infrahub automatically applies the corresponding template. Users can then customize each instance by overriding specific attributes or relationships, ensuring both flexibility and consistency.
+
+![Template Choice](../media/guides/object-template/template_or_from_scratch.png)
+
+<ReferenceLink title="Use object templates" url="./use" />
+
+## Component relationship
+
+When enabling template generation on a given schema node, Infrahub automatically detects whether the object has any component relationships. If it does, Infrahub will generate corresponding templates for those related objects as well.
+
+## Integration with Profiles
+
+When both `generate_template` and `generate_profile` are configured on a schema node, Profiles can be assigned to templates. This integration enables powerful configuration management workflows:
+
+- **Bulk configuration**: Assign Profiles to templates to define common configuration that applies to all objects created from that template
+- **Automatic inheritance**: Objects created from a template automatically inherit the Profiles assigned to that template
+- **Value precedence**: Template values (when explicitly configured) take precedence over Profile values, while Profiles provide values for attributes not set on the template
+- **Multiple Profiles**: Templates support multiple Profile assignments with proper priority handling
+
+This combination allows you to use templates for structural definition (which ports exist) while Profiles handle configuration values (port settings), enabling updates to values in bulk by modifying the Profile rather than individual objects. Templates can still override specific Profile values when needed.
+
+<ReferenceLink title="Creating and assigning Profiles" url="../guides/profiles" />
+
+## Integration with Resource Pools
+
+Templates can be wired to resource pools so that unique values are allocated automatically when objects are created from the template. Rather than manually assigning an IP address or number attribute to each new object, you define once on the template which pool to draw from and Infrahub handles allocation at creation time.
+
+### How it works
+
+When a schema node has a relationship or attribute whose peer type supports resource pool allocation (for example, a relationship to an IP address node, or a number attribute), Infrahub automatically generates a `<attribute_or_relationship_name>_from_resource_pool` field on the corresponding template node. Assigning a pool to that field is all that is needed — no changes to object creation are required.
+
+Allocation happens at object creation time, not at template creation time. Each object created from the template receives its own unique value drawn from the pool.
+
+### Why this matters
+
+Without pool integration, templates can only set static values. Any attribute that must be unique per object (IP addresses, circuit IDs, interface numbers) would have to be filled in manually each time. Pool integration closes that gap: the template defines the structural intent and the pool ensures each instance gets a valid, non-conflicting value automatically.
+
+<ReferenceLink title="Allocate resources from pools" url="./allocate-resources-from-pools" />
+
+
+## Limitations
+
+- Templates are created only for component relationships. Other types of relationships will continue to reference actual objects in the database rather than templates.
+- Modifications to a template will not retroactively update objects that were previously created using that template.

--- a/docs/docs/object-templates/use.mdx
+++ b/docs/docs/object-templates/use.mdx
@@ -1,0 +1,314 @@
+---
+title: Use object templates
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This guide provides a structured approach to defining an object template and creating object instances based on that template.
+
+At a high level, the process consists of three key steps:
+
+- Enable template support within the schema
+- Populate the template with data
+- Create object instances using the predefined template
+
+To illustrate this process, we will use a common use case: Creating ports for a device.
+
+For more details, refer to the [Object Templates](./index.mdx) topic.
+
+## Enable template support within the schema
+
+If you are already familiar with [Schema Development](../guides/create-schema.mdx) in Infrahub, enabling template generation is straightforward.
+
+At the node level, the `generate_template` property allows users to enable template generation for a given node and its associated components.
+
+:::warning
+`generate_template` is only available on **node** definitions. It does not exist on generics.
+:::
+
+```yaml {57}
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: Interface
+    namespace: Infra
+    label: "Interface"
+    include_in_menu: true
+    icon: "mdi:ethernet"
+    display_label: "{{ name__value }}"
+    order_by:
+      - name__value
+    uniqueness_constraints:
+      - ["device", "name__value"]
+    human_friendly_id: ["device__name__value", "name__value"]
+    attributes:
+      - name: name
+        kind: Text
+      - name: description
+        kind: Text
+        optional: true
+      - name: enable
+        kind: Boolean
+        optional: false
+        default_value: false
+    relationships:
+      - name: device
+        peer: InfraDevice
+        optional: false
+        cardinality: one
+        kind: Parent
+
+  - name: DeviceType
+    namespace: Infra
+    label: "Device Type"
+    icon: "mdi:server"
+    human_friendly_id: ["name__value"]
+    order_by:
+      - name__value
+    display_label: "{{ name__value }}"
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+      - name: number_of_u
+        kind: Number
+        default_value: 1
+    relationships:
+      - name: devices
+        peer: InfraDevice
+        optional: true
+        cardinality: many
+
+  - name: Device
+    namespace: Infra
+    generate_template: true # This flag enables template for Device and Interfaces
+    label: "Device"
+    icon: "mdi:server"
+    human_friendly_id: ["name__value"]
+    order_by:
+      - name__value
+    display_label: "{{ name__value }}"
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+      - name: description
+        kind: Text
+        optional: true
+      - name: serial
+        kind: Text
+        optional: true
+    relationships:
+      - name: device_type
+        label: device_type
+        peer: InfraDeviceType
+        optional: false
+        cardinality: one
+        kind: Attribute
+      - name: interfaces # As this relationship's kind is component, it will automatically be covered by the template
+        peer: InfraInterface
+        optional: true
+        cardinality: many
+        kind: Component
+
+```
+
+You can now **load this schema into your Infrahub instance**. For more details, refer to the [Import Schema Guide](../guides/import-schema.mdx).
+
+## Populate the template with data
+
+Heading back to Infrahub you will notice new entries in the left-hand menu. Before entering template information we will create a device type, this will be useful for later.
+
+### Create a device type
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  1. Navigate to the left-hand menu and select `Device Type`
+  2. Click the `+ Add new Device Type` button
+  3. Then fill the form
+      - **Name**: SwitchModel123
+      - **Number of U**: 2
+  4. Hit the save button
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+  ```graphql
+  mutation {
+    InfraDeviceTypeCreate(
+      data: {name: {value: "SwitchModel123"}, number_of_u: {value: 2}}
+    ) {
+      ok
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+Now that the device type is created, we can proceed to work on the template itself.
+
+:::warning
+
+In Infrahub's implementation of object template, **the template doesn't hold any information about the device model** (for example the Number of U). This information is stored in the device type object. Fortunately we can link the template to a device type object, this will be transferred to the object.
+
+:::
+
+### Create a device template
+
+All template-related records can be found in the menu under the dedicated section `Object Management` > `Templates`.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  1. Go to `Object Management` > `Templates`
+  2. Click the `+ Add Object Templates` button
+  3. In the drop-down list pick `Device`
+  4. Then fill the form
+      - **Template Name**: Template-SwitchModel123
+      - **Device Type**: SwitchModel123
+  5. Hit the save button
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+  ```graphql
+  mutation {
+    TemplateInfraDeviceCreate(
+      data: {template_name: {value: "Template-SwitchModel123"}, device_type: {hfid: ["SwitchModel123"]}}
+    ) {
+      ok
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+:::important
+
+In the device template, you specify the actual device type object. This means that **creating a device using your template will automatically set up a relationship between the new device and the specified device type**.
+Some fields can be left empty because the device template doesn't apply to them. Take the serial number, by definition it will be different from one device to another.
+
+:::
+
+### Create an interface template
+
+:::note
+
+Ensure you **reference the device template created in the previous step**. For demonstration purposes, you can create multiple interface templates.
+
+:::
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  1. Click the `+ Add Object Templates` button
+  2. In the drop-down list pick `Object template Interface`
+  3. Then fill-out the fields
+      - **Template Name**: Template-SwitchModel123-Ethernet1; Template-SwitchModel123-Ethernet2; Template-SwitchModel123-Ethernet3
+      - **Device**: Template-SwitchModel123
+      - **Name**: Ethernet1; Ethernet2; Ethernet3
+  4. Hit the save button
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+
+  ```graphql
+  mutation {
+    CreateTemplateEthernet1: TemplateInfraInterfaceCreate(
+      data: {name: {value: "Ethernet1"}, template_name: {value: "Template-SwitchModel123-Ethernet1"}, device: {hfid: ["Template-SwitchModel123"]}}
+    ) {
+      ok
+    }
+    CreateTemplateEthernet2: TemplateInfraInterfaceCreate(
+      data: {name: {value: "Ethernet2"}, template_name: {value: "Template-SwitchModel123-Ethernet2"}, device: {hfid: ["Template-SwitchModel123"]}}
+    ) {
+      ok
+    }
+    CreateTemplateEthernet3: TemplateInfraInterfaceCreate(
+      data: {name: {value: "Ethernet3"}, template_name: {value: "Template-SwitchModel123-Ethernet3"}, device: {hfid: ["Template-SwitchModel123"]}}
+    ) {
+      ok
+    }
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+![Template List](../media/guides/object-template/template_list.png)
+
+:::success
+
+With the device template and interface templates in place, you're all set to create new instances based on them!
+
+:::
+
+## Create object instances using the predefined template
+
+Heading back to the main menu we will create a device object.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Via the Web Interface" default>
+
+  1. Click `Device` item in the left hand side menu
+  2. Hit `+ Add Device` button
+  3. Pick the template option and select the template you created in the previous step
+
+  ![Template Choice](../media/guides/object-template/template_or_from_scratch.png)
+
+  :::important
+
+  At this stage, you can either create your device from scratch, following the standard process, or **start from a predefined template!**
+
+  :::
+
+  4. You can fill the missing information (for instance the `serial` field)
+
+  ![Fields Pre-populated From Template](../media/guides/object-template/form_with_template.png)
+
+  :::note
+
+  Information sourced from the template is indicated by a small chip above the form inputs. You can override this information at any time.
+
+  :::
+
+  5. Hit the save button
+
+  </TabItem>
+  <TabItem value="graphql" label="Via the GraphQL Interface">
+    ```graphql
+    mutation {
+      InfraDeviceCreate(
+        data: {object_template: {hfid: ["Template-SwitchModel123"]}, serial: {value: "OWI62IUHQ"}, description: {value: "This is a Core Switch"}}
+      ) {
+        ok
+      }
+    }
+    ```
+  </TabItem>
+    <TabItem value="python-sdk" label="Via the Python SDK">
+    ```python
+    device = await client.create(
+      kind="InfraDevice",
+      object_template="Template-SwitchModel123", # This is the template name
+      name="my-device",
+      serial="OWI62IUHQ",
+      description="This is a Core Switch",
+    )
+    await device.save()
+    ```
+  </TabItem>
+</Tabs>
+
+![Component List](../media/guides/object-template/object_components_created_using_template.png)
+
+:::success
+
+When viewing your newly created device object, navigate to the Interfaces tab to see a **list of interfaces pre-populated based on the template you defined**. Keep in mind that **any modifications made to the template will not retroactively apply to objects that have already been created from it**.
+
+:::

--- a/docs/docs/object-templates/with-profiles.mdx
+++ b/docs/docs/object-templates/with-profiles.mdx
@@ -1,0 +1,22 @@
+---
+title: Assign Profiles to a template
+---
+
+When both `generate_template` and `generate_profile` are configured on a schema node, you can assign Profiles to templates to enable bulk configuration updates. Objects created from templates automatically inherit the Profiles assigned to those templates, allowing you to update values in bulk by modifying the Profile.
+
+:::info Profile and template integration
+
+When a Profile is assigned to a template:
+
+- Objects created from the template automatically inherit the template's Profiles
+- Template values (when explicitly configured) take precedence over Profile values
+- Profiles provide values for attributes not explicitly set on the template
+- Multiple Profiles can be assigned to a template with proper priority handling
+- This enables consistent configuration management across templated objects
+
+:::
+
+For more information about Profiles and templates, see:
+
+- [Creating and assigning Profiles](../guides/profiles.mdx) - Guide for working with Profiles
+- [Understanding Profiles in Infrahub](../topics/profiles.mdx) - Deep dive into Profile concepts

--- a/docs/docs/objects/convert-object-kind.mdx
+++ b/docs/docs/objects/convert-object-kind.mdx
@@ -1,0 +1,106 @@
+---
+title: Object conversion
+---
+
+# Object conversion
+
+Object conversion in Infrahub provides a powerful mechanism to transform existing objects from one schema type to another without losing data or breaking relationships. This capability addresses the common infrastructure management challenge of evolving data models while preserving existing configurations and connections.
+
+## Introduction
+
+In dynamic infrastructure environments, the need to change an object's type often arises as requirements evolve. Traditional approaches typically require deleting the original object and manually recreating it with the new type, leading to data loss and broken relationships. Infrahub's object conversion feature eliminates this friction by providing a seamless Transformation process.
+
+## How object conversion works
+
+### Field mapping and equivalence
+
+Object conversion operates on the principle of field equivalence between source and destination schema types. The system automatically identifies compatible fields using specific criteria:
+
+**Attribute field equivalence:**
+
+- Fields must have identical names
+- Fields must have compatible value types
+- Data validation rules are preserved during conversion
+
+**Relationship field equivalence:**
+
+- Fields must have identical names
+- Fields must reference the same peer schema type
+- Cardinality constraints (one-to-one, one-to-many) must match
+
+### Automatic mapping process
+
+When initiating a conversion, Infrahub performs these steps:
+
+1. **Schema analysis**: Compares source and destination schema definitions to identify equivalent fields
+2. **Compatibility check**: Validates that the conversion is technically feasible
+3. **Mandatory field identification**: Highlights destination fields that require explicit values
+4. **Data transformation**: Executes the conversion while preserving data integrity
+
+### Handling non-equivalent fields
+
+Not all fields between schema types will have direct equivalents. The conversion process handles these scenarios:
+
+**Missing source fields:**
+
+- Destination fields without source equivalents must be manually specified
+- Mandatory destination fields require explicit values or use of defaults
+- Optional fields can leverage schema-defined default values
+
+**Surplus source fields:**
+
+- Source fields without destination equivalents are gracefully ignored
+- Data from these fields is not transferred but doesn't impede conversion
+- Historical data remains accessible through version control
+
+## Design considerations and constraints
+
+### Version control integration
+
+Object conversion integrates deeply with Infrahub's Git-like branching model, but this creates important constraints:
+
+**Branch-aware attributes:**
+
+Objects containing branch-aware attributes (fields that can have different values across branches) require special handling. These conversions:
+
+- Must occur on the default branch to maintain data consistency
+- Trigger automatic rebase requirements for other branches
+- May result in data loss on non-conversion branches
+
+**Commit preservation:**
+The conversion process maintains object history and commit lineage, ensuring auditability and rollback capabilities.
+
+### Data integrity safeguards
+
+Several mechanisms protect data integrity during conversion:
+
+**Validation enforcement:**
+
+- All destination schema constraints are validated before conversion
+- Referential integrity for relationships is maintained
+- Data type compatibility is strictly enforced
+
+**Atomic operations:**
+
+- Conversions execute as atomic transactions
+- Failures result in complete rollback with no partial state
+- Concurrent modifications are handled through Infrahub's conflict resolution
+
+## Common use cases
+
+### Infrastructure evolution
+
+**Network interface type changes:**
+Converting between Layer 2 and Layer 3 interfaces as network designs evolve, preserving device associations and configuration parameters while adapting to new operational requirements.
+
+**Repository access model changes:**
+Transforming read-only repositories to read-write repositories when teams gain modification privileges, maintaining Git integration while expanding access controls.
+
+## Related concepts
+
+Object conversion intersects with several other Infrahub concepts:
+
+- **[Schema management](../topics/schema)**: Understanding how schema types define conversion possibilities
+- **[Version control](../topics/version-control)**: How conversions interact with branch and merge operations
+- **[Metadata](./metadata)**: How object metadata is preserved during conversion
+- **[GraphQL](../topics/graphql)**: The API mechanisms that enable conversion operations

--- a/docs/docs/objects/index.mdx
+++ b/docs/docs/objects/index.mdx
@@ -1,0 +1,42 @@
+---
+title: Objects
+---
+
+An object is a record stored in Infrahub that conforms to a schema node definition. If schema nodes are the blueprints, objects are the actual data — a specific router, an interface, a BGP session, a rack.
+
+## What is an object?
+
+Schema nodes define the shape of data: which attributes exist, what types they are, which relationships they have. Objects are individual instances of those definitions, each holding concrete values.
+
+For example, a schema node named `InfraDevice` defines that every device has a `name`, a `serial`, and a relationship to `interfaces`. An object of kind `InfraDevice` is then a real record — `core-router-01`, serial `ABC123`, with three interfaces attached.
+
+Objects are the primary unit of data in Infrahub. Everything you store, query, and manage — IP addresses, devices, locations, services — exists as objects.
+
+## How objects work
+
+**Attributes and relationships**
+
+Each object holds values for the attributes defined on its schema node and can be linked to other objects through relationships. Relationships are typed and carry semantics (parent/child, attribute, generic) that govern how objects interact.
+
+**Branch awareness**
+
+How an object behaves across branches depends on its schema definition. By default, objects are branch-aware: creating, editing, or deleting a record is tracked on the active branch and the change remains isolated until merged. When a schema node is marked as branch-agnostic however, objects of that kind exist globally — a change on any branch is immediately visible everywhere, with no merge required.
+
+**Metadata and data lineage**
+
+Every attribute value on an object carries metadata that records where the value came from and when it was last changed. This lets you trace the origin of any piece of data — whether it was set manually, inherited from a Profile, or allocated from a resource pool.
+
+## Objects and related concepts
+
+| Concept | What it is |
+|---------|-----------|
+| Schema node | The type definition — attributes, relationships, constraints |
+| Object | A concrete record that follows a schema node definition |
+| Object Template | A reusable structural starting point for creating objects of a given kind |
+| Group | A collection of objects used for querying or automation targeting |
+
+## What you can do with objects
+
+- **[Convert object kind](./convert-object-kind)** — Change the schema kind of an existing object while preserving its data
+- **[Metadata & lineage](./metadata)** — Inspect where each attribute value came from and track data origin
+- **[Load data in bulk using YAML file](./load-from-yaml)** — Bulk-create or update objects by loading structured YAML files

--- a/docs/docs/objects/index.mdx
+++ b/docs/docs/objects/index.mdx
@@ -2,7 +2,7 @@
 title: Objects
 ---
 
-An object is a record stored in Infrahub that conforms to a schema node definition. If schema nodes are the blueprints, objects are the actual data — a specific router, an interface, a BGP session, a rack.
+An object is a record stored in Infrahub that conforms to a schema node definition. If schema nodes are the blueprints, objects are the actual instances of data — a specific router, an interface, a BGP session, a rack.
 
 ## What is an object?
 
@@ -24,7 +24,7 @@ How an object behaves across branches depends on its schema definition. By defau
 
 **Metadata and data lineage**
 
-Every attribute value on an object carries metadata that records where the value came from and when it was last changed. This lets you trace the origin of any piece of data — whether it was set manually, inherited from a Profile, or allocated from a resource pool.
+Objects, their attribute values, and their relationships all carry metadata. At the object level, this includes ownership and source tracking. At the attribute level, each value records where it came from and when it was last changed — whether set manually, inherited from a Profile, or allocated from a resource pool. Relationship metadata tracks the same lineage for each link between objects. This lets you trace the origin of any piece of data across the entire record.
 
 ## Objects and related concepts
 

--- a/docs/docs/objects/load-from-yaml.mdx
+++ b/docs/docs/objects/load-from-yaml.mdx
@@ -1,0 +1,163 @@
+---
+title: Load data in bulk using YAML file
+---
+
+# Object files
+
+An Object file is a YAML file that allows you to manage data to be loaded in Infrahub based on your own custom schema. It provides a declarative way to define and manage resources in your Infrahub instance.
+
+Object files work well for models that don't change too often and/or that need to be tracked in Git. Examples include: Groups, tags, Users, etc.
+
+The goal of this guide is to show you how you define and load an object file.
+
+## Prerequisites
+
+- A running Infrahub instance
+
+<details>
+<summary>Schema used in this guide</summary>
+
+The examples on this page use the following schema. Adapt the type names to match your own schema.
+
+```yaml
+---
+version: "1.0"
+generics:
+  - name: Generic
+    namespace: Location
+    include_in_menu: false
+    hierarchical: true
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+        unique: true
+nodes:
+  - name: Country
+    namespace: Location
+    inherit_from:
+      - LocationGeneric
+    parent: ""
+    children: LocationSite
+  - name: Site
+    namespace: Location
+    inherit_from:
+      - LocationGeneric
+    parent: LocationCountry
+    children: ""
+    relationships:
+      - name: devices
+        kind: Generic
+        peer: NetworkDevice
+        cardinality: many
+        optional: true
+  - name: Device
+    namespace: Network
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+        unique: true
+    relationships:
+      - name: site
+        kind: Attribute
+        cardinality: one
+        optional: true
+        peer: LocationSite
+      - name: interfaces
+        kind: Component
+        cardinality: many
+        optional: true
+        peer: NetworkInterface
+  - name: Interface
+    namespace: Network
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+    relationships:
+      - name: device
+        kind: Parent
+        optional: false
+        cardinality: one
+        peer: NetworkDevice
+```
+
+Load the schema before continuing:
+
+```bash
+infrahubctl schema load /path/to/schema.yml
+```
+
+</details>
+
+## Defining a object file
+
+Our goal is to define data that can be loaded into Infrahub based on the schema we just defined. We will create an object file that defines a Country and a Site.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: LocationCountry
+  data:
+    - name: United Kingdom
+      children:
+        kind: LocationSite
+        data:
+          - name: Stonehenge Visitor Centre
+          - name: Tower of London
+          - name: Edinburgh Castle
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: NetworkDevice
+  data:
+    - name: sw01-svc01
+      site: Stonehenge Visitor Centre
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: NetworkInterface
+  data:
+    - name: eth0
+      device: sw01-svc01
+    - name: eth1
+      device: sw01-svc01
+    - name: eth2
+      device: sw01-svc01
+    - name: eth3
+      device: sw01-svc01
+    - name: eth4
+      device: sw01-svc01
+    - name: eth5
+      device: sw01-svc01
+```
+
+> Note that these definitions can be in separate files but for simplicity we have put them all in one file using `---` to separate the different objects.
+
+For a more detailed information on the structure and relationship management within an object file, visit the [SDK Object File]($(base_url)python-sdk/topics/object_file) docs.
+
+## Loading a object file
+
+You can load the object files into Infrahub using `object` subcommand of the `infrahubctl` utility.
+
+Load the objects into Infrahub using the following command
+
+```bash
+infrahubctl object load /path/to/objects.yml
+```
+
+More information on `infrahubctl` command line utility can be found in the [infrahubctl documentation]($(base_url)infrahubctl/infrahubctl).
+More information on the `object` subcommand can be found in the [infrahubctl object documentation]($(base_url)infrahubctl/infrahubctl-object).
+
+Objects can also be loaded into Infrahub using the git repository integration. To do this, you need to add the object file to the `.infrahub.yml` details can be seen in the [.infrahub.yml](../topics/infrahub-yml.mdx) documentation.
+
+:::info
+
+Loading objects using git or via the command line will load folders/files in alphabetical order.
+
+:::

--- a/docs/docs/objects/metadata.mdx
+++ b/docs/docs/objects/metadata.mdx
@@ -1,0 +1,143 @@
+---
+title: Data lineage and metadata
+---
+
+# Data lineage and metadata
+
+## Data lineage
+
+Data lineage tracks the origin and ownership of the data, and how the data changes and moves over time. Data lineage provides visibility and simplifies tracing errors back to the root cause in a data analytics process.
+
+In Infrahub, data points such as attributes and relationships have data lineage associated with the object, provided via `metadata`.
+
+## Metadata
+
+One of the core features of Infrahub is that we can define `metadata` on all data points: attributes and relationships.
+
+The current supported metadata are:
+
+- **Source**: Where is the data coming from. (By default, it can be an `Account` or a `Repository`)
+- **Owner**: Who is the owner of this data (By default, it be a `Group`, an `Account` or a `Repository`)
+- **Is Protected**: Flag to indicate if a value should be protected or not
+
+:::info
+
+Currently the list of metadata available is fixed, but in the future it will be possible to define your own list of metadata.
+
+:::
+
+## Protected fields
+
+When a field is marked as protected, all users that aren't listed as the owner won't be able to modify this specific attribute when trying to edit the object. They will still be able to modify the other attributes.
+
+:::info
+
+Note that accounts defined with the role of `admin` can always update protected fields, regardless of `Owner`.
+
+:::
+
+## Object-level metadata
+
+In addition to attribute and relationship metadata, Infrahub automatically tracks **object-level metadata** for every node in your infrastructure data. This provides complete audit trails and accountability, enabling you to determine who created or modified an object and when.
+
+Object-level metadata is distinct from the attribute-level metadata described above (Source, Owner, Is Protected). While attribute metadata tracks lineage for individual data points, object-level metadata tracks the lifecycle of the entire object.
+
+The following fields are available on every object:
+
+- **created_at**: The timestamp when the object was created
+- **created_by**: The account that created the object
+- **updated_at**: The timestamp of the last modification to the object
+- **updated_by**: The account that last modified the object
+
+### Accessing object-level metadata
+
+Object-level metadata is available through the UI, GraphQL API, and Python SDK.
+
+#### GraphQL
+
+In GraphQL queries, object-level metadata is accessed via the `node_metadata` field on edges. This is separate from the `node` field which contains the object's attributes and relationships.
+
+```graphql
+{
+  BuiltinTag(order: {node_metadata: {created_at: DESC}}) {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+      node_metadata {
+        created_at
+        updated_at
+        updated_by {
+          display_label
+        }
+        created_by {
+          display_label
+        }
+      }
+    }
+  }
+}
+```
+
+The `created_by` and `updated_by` fields return account objects, which have a `display_label` property for a human-readable name.
+
+### Ordering by metadata
+
+Query results can be ordered by object-level metadata timestamps using the `order` parameter with `node_metadata`. The example above demonstrates ordering by `created_at` in descending order to show the most recently created objects first. You can also order by `updated_at` to sort by modification time.
+
+### Filtering by metadata
+
+Query results can be filtered by object-level metadata using the following filter parameters:
+
+| Filter | Description |
+|--------|-------------|
+| `node_metadata__created_by__id` | Filter by a single creator account UUID |
+| `node_metadata__created_by__ids` | Filter by multiple creator account UUIDs |
+| `node_metadata__created_at` | Filter by exact creation timestamp (see date range shorthand below) |
+| `node_metadata__created_at__before` | Filter for objects created before a timestamp |
+| `node_metadata__created_at__after` | Filter for objects created after a timestamp |
+| `node_metadata__updated_by__id` | Filter by a single updater account UUID |
+| `node_metadata__updated_by__ids` | Filter by multiple updater account UUIDs |
+| `node_metadata__updated_at` | Filter by exact update timestamp (see date range shorthand below) |
+| `node_metadata__updated_at__before` | Filter for objects updated before a timestamp |
+| `node_metadata__updated_at__after` | Filter for objects updated after a timestamp |
+
+#### Date range shorthand
+
+When filtering by `node_metadata__created_at` or `node_metadata__updated_at`, there is special handling for timestamps that end in `00:00:00`. If the input datetime ends in `00:00:00` (regardless of timezone), Infrahub will automatically expand this to a 24-hour range query covering that entire day.
+
+For example, the following filter:
+
+```graphql
+{
+  BuiltinTag(node_metadata__created_at: "2025-03-15T00:00:00+08:00") {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+Will return all objects created on March 15, 2025 in the `+08:00` timezone. Internally, this is transformed into a range query:
+
+- `node_metadata__created_at__after` is set to one microsecond before midnight (to include objects created at exactly midnight)
+- `node_metadata__created_at__before` is set to midnight of the next day
+
+This makes it convenient to query all objects created or updated on a specific day without needing to manually specify both `__after` and `__before` parameters.
+
+### Backfill behavior for existing data
+
+:::info
+
+For objects that existed before this feature was introduced:
+
+- `created_at` and `updated_at` are set for all objects
+- `created_by` and `updated_by` are only set for objects that have been created or updated after the feature release; existing objects that have not been modified will not have these fields populated
+
+:::

--- a/docs/redirects-pending/objects.yml
+++ b/docs/redirects-pending/objects.yml
@@ -1,0 +1,73 @@
+---
+feature: Objects & Object Templates
+pr: https://github.com/opsmill/infrahub/pull/9178
+description: |
+  Migration of Objects and Object Templates docs. topics/object-template.mdx and
+  guides/object-template.mdx replaced by a hub + 3 spokes under object-templates/.
+  topics/object-conversion.mdx, topics/metadata.mdx, and guides/object-load.mdx
+  moved under objects/. A new objects/index.mdx hub page was created (no prior
+  equivalent — the section previously used a generated-index).
+
+redirects:
+  - from: /docs/topics/object-template
+    to: /docs/object-templates/
+  - from: /docs/guides/object-template
+    to: /docs/object-templates/use
+  - from: /docs/topics/object-conversion
+    to: /docs/objects/convert-object-kind
+  - from: /docs/topics/metadata
+    to: /docs/objects/metadata
+  - from: /docs/guides/object-load
+    to: /docs/objects/load-from-yaml
+
+new_pages:
+  - path: /docs/objects/
+    title: Objects (hub)
+  - path: /docs/objects/convert-object-kind
+    title: Convert object kind
+  - path: /docs/objects/metadata
+    title: Metadata & lineage
+  - path: /docs/objects/load-from-yaml
+    title: Load data in bulk using YAML file
+  - path: /docs/object-templates/
+    title: Object Templates (hub)
+  - path: /docs/object-templates/use
+    title: Use object templates
+  - path: /docs/object-templates/with-profiles
+    title: Assign Profiles to a template
+  - path: /docs/object-templates/allocate-resources-from-pools
+    title: Allocate resources from pools
+
+cross_links_to_update:
+  - file: docs/docs/schema/nodes-and-attributes.mdx
+    line: 274
+    current: ../topics/object-template
+    should_be: ../object-templates/
+  - file: docs/docs/schema/relationships.mdx
+    line: 62
+    current: ../topics/object-template
+    should_be: ../object-templates/
+  - file: docs/docs/profiles/index.mdx
+    line: 72
+    current: ../topics/object-template.mdx
+    should_be: ../object-templates/
+  - file: docs/docs/profiles/index.mdx
+    line: 83
+    current: ../topics/object-template.mdx#integration-with-profiles
+    should_be: ../object-templates/#integration-with-profiles
+  - file: docs/docs/profiles/index.mdx
+    line: 268
+    current: ../topics/object-template.mdx
+    should_be: ../object-templates/
+  - file: docs/docs/profiles/index.mdx
+    line: 270
+    current: ../topics/metadata.mdx
+    should_be: ../objects/metadata
+  - file: docs/docs/overview/overview.mdx
+    line: 59
+    current: ../topics/metadata.mdx
+    should_be: ../objects/metadata
+  - file: docs/docs/tutorials/getting-started/lineage-information.mdx
+    line: 9
+    current: ../../topics/metadata.mdx
+    should_be: ../../objects/metadata

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -136,10 +136,12 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Templates', // [Object Blueprints — rename pending]
-          link: { type: 'doc', id: 'topics/object-template' }, // hub
+          label: 'Objects',
+          link: { type: 'doc', id: 'objects/index' }, // hub
           items: [
-            { type: 'doc', id: 'guides/object-template', label: 'Use Templates' },
+            { type: 'doc', id: 'objects/convert-object-kind', label: 'Convert object kind' },
+            { type: 'doc', id: 'objects/metadata', label: 'Metadata & lineage' },
+            { type: 'doc', id: 'objects/load-from-yaml', label: 'Load data in bulk using YAML file' },
           ],
         },
         {
@@ -154,16 +156,6 @@ const sidebars: SidebarsConfig = {
           ],
         },
         { type: 'doc', id: 'topics/ipam', label: 'IPAM' },
-        {
-          type: 'category',
-          label: 'Objects',
-          link: { type: 'generated-index' }, // About Objects hub page not yet authored
-          items: [
-            { type: 'doc', id: 'topics/object-conversion', label: 'Convert object kind' },
-            { type: 'doc', id: 'topics/metadata', label: 'Metadata & lineage' },
-            { type: 'doc', id: 'guides/object-load', label: 'Load data from YAML file' },
-          ],
-        },
         {
           type: 'category',
           label: 'Groups',
@@ -188,6 +180,16 @@ const sidebars: SidebarsConfig = {
             'profiles/override-values',
             'profiles/update',
             'profiles/use-multiple',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Object Templates',
+          link: { type: 'doc', id: 'object-templates/index' }, // hub
+          items: [
+            { type: 'doc', id: 'object-templates/use', label: 'Use object templates' },
+            { type: 'doc', id: 'object-templates/with-profiles', label: 'Assign Profiles to a template' },
+            { type: 'doc', id: 'object-templates/allocate-resources-from-pools', label: 'Allocate resources from pools' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary                                                                                                                    
                                                                                                                              
  Migrates the **Objects** and **Object Templates** sub-sections under Schema & Data to the V3 hub + spokes navigation pattern. 
  No content has been changed — only reorganised into feature directories and wired into the sidebar.
                                                                                                                                
  ### Object Templates                                      

  Replaces the single `Templates` category (one legacy topic + one guide) with a proper hub and three focused spokes:           
  
  | File | Description |                                                                                                        
  |------|-------------|                                    
  | `docs/docs/object-templates/index.mdx` | Hub page (content from `topics/object-template.mdx`) |
  | `docs/docs/object-templates/use.mdx` | Core workflow — enable, populate, instantiate |                                      
  | `docs/docs/object-templates/with-profiles.mdx` | Assigning Profiles to a template |                                         
  | `docs/docs/object-templates/allocate-resources-from-pools.mdx` | Wiring resource pools to templates |                       
                                                                                                                                
  ### Objects                                                                                                                   
                                                                                                                                
  Replaces the `generated-index` placeholder with a real hub page and moves the three existing pages into a dedicated directory:
  
  | File | Description |                                                                                                        
  |------|-------------|                                    
  | `docs/docs/objects/index.mdx` | New hub page — defines what an object is and how it relates to schema, templates, and
  profiles |                                                                                                                    
  | `docs/docs/objects/convert-object-kind.mdx` | Moved from `topics/object-conversion.mdx` |
  | `docs/docs/objects/metadata.mdx` | Moved from `topics/metadata.mdx` |                                                       
  | `docs/docs/objects/load-from-yaml.mdx` | Moved from `guides/object-load.mdx` |                                              
                                                                                                                                
  ### Sidebar                                                                                                                   
                                                                                                                                
  - `Templates` → `Object Templates`, hub switched to `object-templates/index`                                                  
  - `Objects` → hub switched from `generated-index` to `objects/index`, spokes updated to new paths
                                                                                                                                
  ### Legacy files                                                                                                              
                                                                                                                                
  All original files under `topics/` and `guides/` are kept in place. No redirects needed at this stage.                        
                                                            
  ### Session artefacts                                                                                                         
                                                            
  - `dev/specs/2026-05-07-object-doc-migration-plan.md` — implementation plan                                                   
  - `dev/specs/2026-05-07-object-doc-migration-summary.md` — full change log with naming decisions