### PR TITLE
docs: migrate GraphQL to hub + 4 spokes under development-resources/

### DIFF
--- a/docs/docs/development-resources/developer-guide.mdx
+++ b/docs/docs/development-resources/developer-guide.mdx
@@ -1,0 +1,183 @@
+---
+title: Developer Guide
+---
+
+# Developer guide
+
+Infrahub support various form of extensibility that rely on users providing their own code that then will be executed by Infrahub.
+This guide provides best practices to help you develop robust, efficient, and maintainable extensions.
+
+The following features in Infrahub are based on user provided code :
+
+- [**Transformations** (Python and Jinja2)](../topics/transformation.mdx): Used to generate [artifacts](../topics/artifact.mdx) and define [Computed Attributes](../computed-attributes/index.mdx).
+- [**Generators**](../topics/generator.mdx): Automate complex tasks by generating outputs dynamically.
+- [**Checks**](../topics/check.mdx): Validate your infrastructure with custom rules.
+
+## Development lifecycle
+
+### Initializing an Infrahub repository
+
+Before you start developing extensions or custom code for Infrahub, you need to initialize a repository. This sets up the directory structure and configuration files required for Infrahub to manage your infrastructure data.
+
+To initialize a new Infrahub repository, run the following command (replace `<project-name>` with your desired project name):
+
+```shell
+uv tool run --from 'copier' copier copy https://github.com/opsmill/infrahub-template <project-name>
+```
+
+This uses [copier](https://copier.readthedocs.io/) to create a new Infrahub repository from the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template). The command will guide you through interactive prompts to customize your repository (such as including example Generators, Transformations, and scripts). No separate installation is needed as `uv tool run` handles everything automatically.
+
+Once complete, your new repository will be ready for you to add schemas, Transformations, and Generators.
+
+<details>
+  <summary>Recommended file structure for manually creating an Infrahub repository</summary>
+
+If you prefer to create your Infrahub repository manually, use the following folder structure as a reference:
+
+```bash
+├── .gitignore
+├── .infrahub.yml
+├── .vscode
+│   └── extensions.json
+├── generators
+├── lib
+│   ├── __init__.py
+│   └── example.py
+├── menus
+├── objects
+│   └── example.yml
+├── pyproject.toml
+├── queries
+├── README.md
+├── schemas
+│   └── example.yml
+├── scripts
+│   └── example_script.py
+├── tests
+│   ├── __init__.py
+│   └── integration
+│       ├── conftest.py
+│       └── test_infrahub.py
+├── transformations
+│   └── templates
+└── uv.lock
+```
+
+</details>
+
+### Development
+
+#### Execute your code locally
+
+During development, you can use the `infrahubctl` CLI to execute your code locally. This provides an environment similar to Infrahub's execution environment, enabling quick testing without deploying your code.
+
+Key points:
+
+- Your code can be executed locally without needing to be checked into Git or pushed to the server.
+- GraphQL queries, if required, will be discovered and executed locally.
+- The branch to use in Infrahub can be auto-detected from Git or specified explicitly in the CLI.
+
+Refer to the command documentation for details:
+
+| Command                        | Description                                                  |
+|--------------------------------|--------------------------------------------------------------|
+| [`infrahubctl transform`]($(base_url)infrahubctl/infrahubctl-transform) | Execute Python Transformations locally.                          |
+| [`infrahubctl render`]($(base_url)infrahubctl/infrahubctl-render)       | Render Jinja2 Transformations locally.                           |
+| [`infrahubctl generator`]($(base_url)infrahubctl/infrahubctl-generator) | Test custom generators.                                     |
+| [`infrahubctl check`]($(base_url)infrahubctl/infrahubctl-check)         | Run local checks                                            |
+
+#### Typing & protocols (Python)
+
+Infrahub supports Python Typing and Protocols to improve the developer experience by providing static analysis and detecting issues early.
+
+:::info What are Protocols?
+
+Protocols are a way to define structural subtyping in Python, allowing you to specify expected behavior without requiring inheritance. Infrahub leverages this to enforce typing for flexible schemas.
+
+:::
+
+##### Generating protocols
+
+You can generate Protocols for your schema with the `infrahubctl protocols` command. The schema can be provided locally or pulled from a running Infrahub instance.
+
+```shell
+infrahubctl protocols --schema my-schema.yaml --output protocols.py
+```
+
+> If you don't have a Python module, save the protocols in a protocols.py file in the same directory as your script.
+
+##### Using protocols in code
+
+The Python SDK natively supports Protocol in place of `kind` for most functions that interact with objects (`all`, `filters`, `get`, `create`)
+
+```python
+# With Protocols
+from infrahub_sdk.protocols import BuiltinTag
+
+tags = await client.all(kind=BuiltinTag)
+for tag in tags:
+    print(tag.name.value)  # Type-safe access to the 'name' attribute
+```
+
+Same code without Protocols
+
+```python
+# Without Protocols
+tags = await client.all(kind="BuiltinTag")
+for tag in tags:
+    print(tag.name.value)  # May raise type errors as attributes are not checked
+```
+
+:::info Protocol for Infrahub Schema
+
+Protocols for all objects natively provided by Infrahub are available within the SDK in `infrahub_sdk.protocols`
+
+:::
+
+##### Learn more about Python protocols
+
+- [Python Protocols: Leveraging Structural Subtyping - Real Python](https://realpython.com/python-protocol/)
+- [What are "Protocols" In Python? - YouTube](https://www.youtube.com/watch?v=2jN11lyKvfA)
+
+#### Git integration
+
+Infrahub integrates seamlessly with Git, allowing you to use your current branch name as the default branch. To enable this feature, set the environment variable:
+
+```shell
+export INFRAHUB_DEFAULT_BRANCH_FROM_GIT=true
+```
+
+### Testing
+
+Testing is crucial for maintaining high-quality code. Infrahub provides a testing framework based on Pytest to simplify unit and integration tests.
+
+Refer to the [Testing Framework](../testing-framework/) for details.
+
+:::warning Under Construction
+
+This section is still under development. Contact the team via Discord for additional resources.
+
+:::
+
+## Logging (Python)
+
+You can use Python's standard logging library to gain insights into the execution of your code. Infrahub captures logs from the `infrahub.tasks` logger by default.
+
+The logger `infrahub.tasks` is configure by default and it's possible to configure additional loggers using the settings (see below)
+
+```python
+import logging
+
+log = logging.getLogger("infrahub.tasks")
+log.info("This log will be captured within the task")
+```
+
+### Configuring additional loggers
+
+To capture logs from additional loggers, configure them using the environment variable `INFRAHUB_WORKFLOW_EXTRA_LOGGERS`.
+The level of the extra loggers can be controlled with the environment variable `INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL`.
+
+```shell
+export INFRAHUB_WORKFLOW_EXTRA_LOGGERS = '["mylogger", "otherlogger"]'
+export INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL = "DEBUG"
+```

--- a/docs/docs/development-resources/graphql-fragments.mdx
+++ b/docs/docs/development-resources/graphql-fragments.mdx
@@ -1,0 +1,233 @@
+---
+title: Using GraphQL fragments
+---
+
+# Using GraphQL fragments
+
+GraphQL fragments are reusable field selections that can be shared across multiple stored queries. Instead of duplicating the same nested field selections in every query, you define them once as a fragment and reference them using the standard GraphQL spread syntax (`...fragmentName`).
+
+This is particularly useful when multiple [Transformations](../topics/transformation.mdx) or [Generators](../topics/generator.mdx) need to query the same fields from a model. Update the fragment once, and all queries that reference it pick up the change on their next execution.
+
+## How fragments work in Infrahub
+
+Fragment files are `.gql` files containing one or more `fragment ... on Type { }` definitions. They are declared in the [`.infrahub.yml`](../topics/infrahub-yml.mdx) configuration file under `graphql_fragments`:
+
+```yaml
+graphql_fragments:
+  - name: interface_fields
+    file_path: "fragments/interface_fields.gql"
+```
+
+When Infrahub imports a query from a Git repository, it checks for fragment spread references (`...fragmentName`). If any are found, the corresponding fragment definitions are resolved from the declared fragment files and included inline in the query before it is stored in the database.
+
+### Fragment resolution behavior
+
+- **Transitive resolution**: If fragment A references fragment B, both are included automatically
+- **Duplicate detection**: A fragment name defined in multiple files raises an error
+- **Circular dependency detection**: Fragments that reference each other in a cycle are rejected
+- **Directory support**: The `file_path` in `.infrahub.yml` can point to a directory, loading all `.gql` files within it
+
+### Using fragments in queries
+
+Reference a fragment in any query file declared in the same repository:
+
+```graphql
+query DeviceInterfaces($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        interfaces {
+          edges {
+            node {
+              ...interfaceFields
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Prerequisites
+
+- A running Infrahub instance
+- An [external Git repository](../guides/repository.mdx) connected to Infrahub (or a local repository for testing with `infrahubctl`)
+- Familiarity with [GraphQL queries](./graphql/) in Infrahub
+
+## 1. Define a fragment file
+
+Create a `.gql` file containing one or more fragment definitions. Each fragment targets a specific GraphQL type and selects the fields you want to reuse.
+
+Create a file named `fragments/interface_fields.gql`:
+
+```graphql
+fragment interfaceFields on InfraInterfaceL3 {
+  name {
+    value
+  }
+  description {
+    value
+  }
+  speed {
+    value
+  }
+  ip_addresses {
+    edges {
+      node {
+        address {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+:::info
+
+The type after `on` must match a valid model in your Infrahub schema. In this example, `InfraInterfaceL3` refers to the model kind as it appears in GraphQL queries.
+
+:::
+
+## 2. Declare the fragment in `.infrahub.yml`
+
+Add a `graphql_fragments` section to your `.infrahub.yml` file. Each entry requires a `name` and a `file_path` relative to the repository root.
+
+```yaml
+graphql_fragments:
+  - name: interface_fields
+    file_path: "fragments/interface_fields.gql"
+
+queries:
+  - name: device_interfaces_query
+    file_path: "queries/device_interfaces.gql"
+```
+
+The `file_path` field accepts either a single `.gql` file or a directory. When pointing to a directory, Infrahub loads all `.gql` files within it.
+
+## 3. Reference fragments in a query
+
+Use the standard GraphQL spread syntax (`...fragmentName`) to reference a fragment in any query file declared in the same repository.
+
+Create a file named `queries/device_interfaces.gql`:
+
+```graphql
+query DeviceInterfaces($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        name {
+          value
+        }
+        interfaces {
+          edges {
+            node {
+              ...interfaceFields
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+When Infrahub imports this query from the repository, it detects the `...interfaceFields` spread, resolves it against the declared fragment files, and stores the complete query with the fragment definition included inline.
+
+## 4. Sync the repository
+
+After committing the fragment file, the `.infrahub.yml` update, and the query file, sync the repository with Infrahub. Fragments are processed during the same repository sync that imports GraphQL queries.
+
+If you are testing locally with `infrahubctl`, the fragment resolution happens automatically when rendering Transformations:
+
+```shell
+infrahubctl render device_config_transform device_name=router01
+```
+
+## 5. Verify the result
+
+Open the GraphQL query in the Infrahub web interface or query it via the API. The stored query contains the fragment definition included inline alongside the operation, so it executes without any additional resolution at runtime.
+
+```shell
+curl -s "https://<host>/api/query/device_interfaces_query?device_name=router01" | python -m json.tool
+```
+
+## Advanced usage
+
+### Multiple fragments per file
+
+A single `.gql` file can contain multiple fragment definitions:
+
+```graphql
+fragment interfaceFields on InfraInterfaceL3 {
+  name {
+    value
+  }
+  speed {
+    value
+  }
+}
+
+fragment addressFields on InfraIPAddress {
+  address {
+    value
+  }
+  prefix_length {
+    value
+  }
+}
+```
+
+Both fragments become available to any query in the repository.
+
+### Directory-based declarations
+
+Point `file_path` to a directory to load all `.gql` files within it:
+
+```yaml
+graphql_fragments:
+  - name: all_fragments
+    file_path: "fragments/"
+```
+
+Infrahub loads all `.gql` files in the `fragments/` directory in alphabetical order.
+
+### Transitive fragments
+
+Fragments can reference other fragments. Infrahub resolves dependencies transitively and detects circular references.
+
+```graphql
+fragment deviceDetails on InfraDevice {
+  name {
+    value
+  }
+  interfaces {
+    edges {
+      node {
+        ...interfaceFields
+      }
+    }
+  }
+}
+```
+
+When a query uses `...deviceDetails`, Infrahub automatically includes both `deviceDetails` and `interfaceFields` in the resolved query.
+
+## Error handling
+
+Infrahub validates fragments during repository sync and raises specific errors:
+
+| Error | Cause |
+|-------|-------|
+| `FragmentFileNotFoundError` | The `file_path` in `.infrahub.yml` does not exist in the repository |
+| `FragmentNotFoundError` | A query references a fragment name that is not defined in any declared fragment file |
+| `DuplicateFragmentError` | The same fragment name is defined in multiple files |
+| `CircularFragmentError` | Two or more fragments reference each other, creating a dependency cycle |
+
+## Related resources
+
+- [GraphQL in Infrahub](./graphql/) — query format, stored queries, and endpoint reference
+- [`.infrahub.yml` configuration](../topics/infrahub-yml.mdx) — repository manifest structure and resource types
+- [Creating a Jinja Transformation](../guides/jinja2-transform.mdx) — using queries with Jinja2 templates
+- [Creating a Python Transformation](../guides/python-transform.mdx) — using queries with Python code

--- a/docs/docs/development-resources/graphql/groups.mdx
+++ b/docs/docs/development-resources/graphql/groups.mdx
@@ -1,0 +1,105 @@
+---
+title: Working with groups
+---
+
+# Working with groups
+
+[Groups](../../groups/index.mdx) are first-class objects in Infrahub that can be queried and manipulated through GraphQL. Groups provide powerful ways to organize and operate on collections of infrastructure objects.
+
+## Querying groups and their members
+
+Query a specific group and its members:
+
+```graphql
+query {
+  CoreStandardGroup(name__value: "ProductionRouters") {
+    edges {
+      node {
+        name {
+          value
+        }
+        members {
+          edges {
+            node {
+              display_label
+              __typename
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Finding groups for an object
+
+Every object automatically gains relationships to find its group memberships:
+
+```graphql
+query {
+  InfraDevice(name__value: "router01") {
+    edges {
+      node {
+        name {
+          value
+        }
+        member_of_groups {
+          edges {
+            node {
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Query groups for bulk operations
+
+Groups enable efficient bulk queries across related objects:
+
+```graphql
+query {
+  CoreStandardGroup(name__value: "EdgeDevices") {
+    edges {
+      node {
+        members {
+          edges {
+            node {
+              ... on InfraDevice {
+                interfaces {
+                  edges {
+                    node {
+                      name {
+                        value
+                      }
+                      ip_addresses {
+                        edges {
+                          node {
+                            address {
+                              value
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This pattern enables powerful operations where you can process all objects in a group with a single query, making groups essential for scalable infrastructure management.
+
+See [organizing objects with groups](../../guides/groups.mdx) for creating and managing groups, and [understanding groups](../../groups/index.mdx) for architectural concepts.

--- a/docs/docs/development-resources/graphql/index.mdx
+++ b/docs/docs/development-resources/graphql/index.mdx
@@ -1,0 +1,25 @@
+---
+title: GraphQL
+---
+import VideoPlayer from '../../../src/components/VideoPlayer';
+
+# GraphQL
+
+The GraphQL interface is the main interface to interact with Infrahub. The GraphQL schema is automatically generated based on the core models and the user-defined schema models.
+
+The endpoint to interact with the main branch is accessible at `https://<host>/graphql`.
+To interact with a branch the URL must include the name of the branch, such as `https://<host>/graphql/<branch_name>`.
+If you need to extract the current GraphQL schema in your environment you can issue an HTTP get request to:
+
+- `https://<host>/schema.graphql`
+- `https://<host>/schema.graphql?branch=some-other-branch`
+
+## Introduction to GraphQL videos
+
+<VideoPlayer url="https://www.youtube.com/watch?v=KrEY4P6Pgn4" light />
+
+This short demo shows how to use the GraphQL query interface to explore and read data from Infrahub. It walks through how to open the built-in GraphQL interface and run your first queries.
+
+<VideoPlayer url="https://www.youtube.com/watch?v=ZXjL6leaaAc" light />
+
+This video demonstrates how to use filters and relationships in GraphQL to find specific information, such as IP addresses for a particular device, using the Infrahub query interface.

--- a/docs/docs/development-resources/graphql/queries-and-mutations.mdx
+++ b/docs/docs/development-resources/graphql/queries-and-mutations.mdx
@@ -1,0 +1,203 @@
+---
+title: Queries & mutations
+---
+
+# Queries & mutations
+
+In GraphQL, a query is used to fetch data and mutations are used to create/update or delete data. In Infrahub, a GraphQL query and 4 mutations will be generated for each model you define in the schema. The name of the query or mutation is based on the namespace and name of the model.
+
+For example, for the model `CoreRepository` the following query and mutations have been generated:
+
+- `Query` : **CoreRepository** to fetch `CoreRepository` nodes from Infrahub
+- `Mutation` : **CoreRepositoryCreate** to create a `CoreRepository` node
+- `Mutation` : **CoreRepositoryUpdate** to update an existing `CoreRepository` node
+- `Mutation` : **CoreRepositoryUpsert** to create or update a `CoreRepository` node
+- `Mutation` : **CoreRepositoryDelete** to delete a `CoreRepository` node
+
+## Query format
+
+The top level query for each model will always return a list of objects and the query will have the following format `CoreRepository` > `edges` > `node` > `display_label`
+
+```graphql
+query {
+  CoreRepository {            # PaginatedCoreRepository object
+    count
+    edges {                 # EdgedCoreRepository object
+      node {                # CoreRepository object
+        id
+        hfid
+        display_label
+        __typename
+      }
+    }
+  }
+}
+```
+
+:::info
+
+All list of objects will be nested under `edges` & `node` to make it possible to control the pagination and access the attribute `count`.
+
+:::
+
+### `ID`, `hfid` and `display_label`
+
+For all nodes, the attribute `id`, `hfid` and `display_label` are automatically available.
+
+The value used to generate the `display_label` can be defined for each model in the schema. If no value has been provided a generic display label with the kind and the ID of the Node will be generated.
+
+The value used to generate the `hfid` can be defined for each model in the schema. If no value has been provided and the `model` has a single uniqueness constraint defined, then the `hfid` will be automatically generated from the uniqueness constraint.
+
+At the object level, there are mainly 3 types of resources that can be accessed, each with a different format:
+
+- `Attribute`
+- `Relationship` of `Cardinality One`
+- `Relationship` of `Cardinality Many`
+
+### Attribute
+
+Each attribute is its own object in GraphQL to expose the value and all the metadata.
+
+In the query below, to access the attribute **name** of the object the query must be `CoreRepository` > `edges` > `node` > `name` > `value`.
+At the same level all the metadata of the attribute are also available, for example: `is_protected`, `source` & `owner`
+
+```graphql {6-14} title="Example query to access the value and the properties of the attribute 'name'"
+query {
+  CoreRepository {
+    count
+    edges {
+      node {
+        name {              # TextAttribute object
+          value
+          is_protected
+          source {
+            id
+            display_label
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Relationship of `Cardinality One`
+
+A relationship to another model with a cardinality of `One` will be represented with a `NestedEdged` object composed of a `node` and a `properties` objects. The `node` gives access to the remote `node` (the peer of the relationship) while `properties` gives access to the properties of the relationship itself.
+
+```graphql {6-19} title="Example query to access the peer and the properties of the relationship 'account', with a cardinality of one."
+query {
+  CoreRepository {
+    count
+    edges {
+      node {
+        account {
+          properties {
+            is_protected
+            source {
+              id
+              display_label
+            }
+          }
+          node {
+            display_label
+            hfid
+            id
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Relationship of `Cardinality Many`
+
+A relationship with a cardinality of `Many` will be represented with a `NestedPaginated` object composed. It was the same format as the top level `PaginatedObject` with `count` and `edges` but the child element will expose both `node` and `properties`. The `node` gives access to the remote `node` (the peer of the relationship) while `properties` gives access to the properties of the relationship itself.
+
+```graphql {6-20} title="Example query to access the relationship 'tags', with a cardinality of Many."
+query {
+  CoreRepository {
+    count
+    edges {
+      node {
+        tags {                      # NestedPaginatedBuiltinTag object
+          count
+          edges {                   # NestedEdgedBuiltinTag object
+            properties {
+              is_protected
+              source {
+                id
+              }
+            }
+            node {
+              display_label
+              hfid
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Mutations format
+
+The format of the mutation to `Create`, `Update` and `Upsert` an object has some similarities with the query format. The format will be slightly different for:
+
+- An `Attribute`
+- A relationship of `Cardinality One`
+- A relationship of `Cardinality Many`
+
+### Create, update and upsert
+
+To `Create`, `Update` or `Upsert` an object, the mutations will have the following properties.
+
+- The input for the mutation must be provided inside `data`.
+- All mutations will return `ok` and `object` to access some information after the mutation has been executed.
+- `Update` mutations require you to provide an `id` or `hfid` to identify the object you want to update.
+- `Upsert` mutations do not require you to provide the `id` or the `hfid`, but enough information needs to be provided for the back-end to uniquely identify the node. Typically this means that all the attribute or relationship values need to be provided that make up the `hfid` or `uniqueness_constraints` of the node.
+
+```graphql
+mutation {
+  CoreRepositoryCreate(
+    data: {
+      name: { value: "myrepop" },           # Attribute
+      location: { value: "myrepop" },       # Attribute
+      account: { hfid: ["my_account"] },         # Relationship One
+      tags: [ { hfid: ["my_tag"] } ]}            # Relationship Many
+  ) {
+    ok
+    object {
+      id
+      hfid
+    }
+  }
+}
+```
+
+### Delete
+
+For a `Delete` mutation, we have to provide the `id` or the `hfid` of the node as part of the `data` argument.
+
+```graphql
+mutation {
+  CoreRepositoryDelete(data: {hfid: ["myrepo"]}) {
+    ok
+  }
+}
+```
+
+## Branch management
+
+In addition to the queries and the mutations automatically generated based on the schema, there are some queries and mutations to interact with the branches.
+
+- **Query**: `Branch`, Query a list of all branches
+- **Mutation**: `BranchCreate`, Create a new branch
+- **Mutation**: `BranchUpdate`, Update the description of a branch
+- **Mutation**: `BranchDelete`, Delete an existing branch
+- **Mutation**: `BranchRebase`, Rebase an existing branch with the main branch
+- **Mutation**: `BranchMerge`, Merge a branch into main
+- **Mutation**: `BranchValidate`, Validate if a branch has some conflicts

--- a/docs/docs/development-resources/graphql/single-target-queries.mdx
+++ b/docs/docs/development-resources/graphql/single-target-queries.mdx
@@ -1,0 +1,186 @@
+---
+title: Single-target queries
+---
+
+# Single-target queries
+
+When writing GraphQL queries for [transformations](../../topics/transformation.mdx), [generators](../../topics/generator.mdx), [artifacts](../../topics/artifact.mdx), and [computed attributes](../../computed-attributes/index.mdx), it's critical to use a **single-target query pattern** to ensure proper tracking by the system.
+
+## What is a single-target query?
+
+A single-target query is a GraphQL query that targets a **unique node** using a unique attribute or ID. This pattern enables Infrahub to identify exactly which objects are affected by a change, allowing it to selectively trigger the necessary action instead of everything.
+
+## Why is this important?
+
+Without single-target queries, Infrahub cannot determine which specific actions need to be triggered when data changes. This can lead to excessive processing that significantly impacts performance.
+
+**Real-world impact:** In one production scenario, a proposed change pipeline generated 600 artifact regenerations when only 5 actually required execution. Properly using single-target queries resolved this issue.
+
+## Requirements for a valid single-target query
+
+For a query to be recognized as single-target, it must meet **all** of these criteria:
+
+1. **Filter on a unique identifier**: Use either `id` or a unique attribute like `name__value`
+2. **Use a required variable**: The filter must use a required variable, for example, `$name: String!`. A literal value is also valid but limits the query to a single fixed object
+3. **Use exact match filters**: Use singular filters, for example, `name__value: $name`, **not** list filters, for example, `name__values: $name`
+
+## Valid single-target query examples
+
+**Using a unique attribute with required variable:**
+
+```graphql
+query DeviceConfig($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+        interfaces {
+          edges {
+            node {
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Using ID with required variable:**
+
+```graphql
+query DeviceById($device_id: String!) {
+  InfraDevice(ids: [$device_id]) {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+## Invalid query examples (will cause excessive artifact generation)
+
+**Missing filter (queries all objects):**
+
+```graphql
+query AllDevices {
+  InfraDevice {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+**Using optional variable:**
+
+```graphql
+query DeviceConfig($device_name: String) {  # NOT required (no !)
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+**Using list filter instead of exact match:**
+
+```graphql
+query DeviceConfig($device_name: String!) {
+  InfraDevice(name__values: $device_name) {  # name__values instead of name__value
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+**Filtering on non-unique attribute:**
+
+```graphql
+query DevicesByRole($role: String!) {
+  InfraDevice(role__value: $role) {  # role is not unique
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+**Part of the query is not unique:**
+
+```graphql
+query DeviceConfig($device_name: String!) {
+  InfraDevice(name__value: $device_name) {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+  BuiltinTag {  # This part is not unique
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+## Ensuring your query is single-target
+
+There is currently no automated way to verify that a query is single-target. The best way to verify is to review the query and ensure it meets all the criteria outlined above.
+
+When loaded into the system, Infrahub will analyze the query and determine if it is single-target or not. If it is not single-target, Infrahub will log a warning.
+
+It's planned to add more integrated checks in the future to streamline the development process and ensure that queries are correctly structured directly during development.
+
+## When single-target queries are required
+
+Single-target queries are **required** for:
+
+- **Python transformations** - See [Creating a Python transformation](../../guides/python-transform.mdx)
+- **Jinja2 transformations** - See [Creating a Jinja transformation](../../guides/jinja2-transform.mdx)
+- **Generators** - See [Generators](../../topics/generator.mdx)
+- **Artifact definitions** - See [Artifacts](../../topics/artifact.mdx)
+- **Computed attributes** - See [Computed attributes](../../computed-attributes/index.mdx)
+
+## When single-target queries are NOT required
+
+You do **not** need single-target queries for:
+
+- **Ad-hoc queries** via the GraphQL interface or API
+- **Reporting queries** that intentionally fetch multiple objects
+- **Dashboard queries** for UI components
+- **Bulk data exports**
+
+In these cases, you can freely query multiple objects without unique filters.

--- a/docs/docs/development-resources/graphql/stored-queries.mdx
+++ b/docs/docs/development-resources/graphql/stored-queries.mdx
@@ -1,0 +1,36 @@
+---
+title: Stored queries
+---
+
+# Stored queries
+
+Infrahub can store GraphQL queries in the database to simplify execution and associate them with other internal objects such as [Transformations](../../topics/transformation.mdx).
+
+## Stored GraphQL queries in the database
+
+The `GraphQLQuery` model has been designed to store a GraphQL query in order to simplify its execution and to associate it with other internal objects like `Transformation`.
+
+A `GraphQLQuery` object can be created via the web interface, the API or it can be imported from a Git repository.
+
+Every time a `GraphQLQuery` is created or updated, the content of the query will be analyzed to:
+
+- Ensure the query is valid and compatible with the schema.
+- Extract some information about the query itself (see below).
+
+### Information extracted from the query
+
+- Type of operations present in the Query [Query, Mutation, Subscription]
+- Variables accepted by the query
+- Depth, number of nested levels in the query
+- Height, total number of fields requested in the query
+- List of Infrahub models referenced in the query
+
+### Import from a Git repository
+
+GraphQL queries could be defined in file(s) with a `.gql` extension in a remote repository. Then queries must also be explicitly identified in the `.infrahub.yml` file under `queries`.
+
+More details on the `.infrahub.yml` file format can be found in [.infrahub.yml topic](../../topics/infrahub-yml.mdx).
+
+### Executing stored GraphQL queries
+
+Stored GraphQL queries can be executed by using the `/api/query/{query_id}` REST API endpoint. The `{query_id}` can be the name or the id of the `GraphQLQuery` node in the database. More information can be found in the [Swagger documentation](http://localhost:8000/api/docs).

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -91,3 +91,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `deploy-manage-sso.yml` | D&M — SSO (hub + 2 spokes) | TBD |
 | `deploy-manage-permissions-roles.yml` | D&M — Permissions & Roles (hub + 1 spoke) | TBD |
 | `deploy-manage-api-tokens.yml` | D&M — Managing API Tokens (page move) | TBD |
+| `development-resources.yml` | Development Resources — GraphQL hub + spokes | TBD |

--- a/docs/redirects-pending/development-resources.yml
+++ b/docs/redirects-pending/development-resources.yml
@@ -1,0 +1,55 @@
+---
+feature: Development Resources — GraphQL hub + spokes
+pr: TBD
+description: |
+  Splits the flat GraphQL topic page into a hub + 4 spokes under
+  development-resources/graphql/, moves developer-guide and graphql-fragments
+  into development-resources/, merges the GraphQL fragments concept section
+  into graphql-fragments.mdx, and removes the REST API cross-link from the
+  APIs & interfaces sidebar category.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /docs/topics/developer-guide
+    to: /docs/development-resources/developer-guide
+  - from: /docs/topics/graphql
+    to: /docs/development-resources/graphql/
+  - from: /docs/guides/graphql-fragment
+    to: /docs/development-resources/graphql-fragments
+
+# Net-new pages introduced by this migration (canonical URLs for cross-reference)
+new_pages:
+  - path: /docs/development-resources/developer-guide
+    title: Developer Guide
+  - path: /docs/development-resources/graphql/
+    title: GraphQL (hub)
+  - path: /docs/development-resources/graphql/queries-and-mutations
+    title: Queries & mutations
+  - path: /docs/development-resources/graphql/stored-queries
+    title: Stored queries
+  - path: /docs/development-resources/graphql/single-target-queries
+    title: Single-target queries
+  - path: /docs/development-resources/graphql/groups
+    title: Working with groups
+  - path: /docs/development-resources/graphql-fragments
+    title: Using GraphQL fragments
+
+# Internal cross-link references in OTHER files that point at legacy paths
+# (will resolve via redirect at runtime but should be updated to new paths at cleanup)
+cross_links_to_update:
+  - file: docs/docs/topics/graphql.mdx
+    line: 301
+    current: ../guides/graphql-fragment.mdx
+    should_be: ../development-resources/graphql-fragments.mdx
+  - file: docs/docs/topics/transformation.mdx
+    line: ~
+    current: topics/graphql (any reference)
+    should_be: development-resources/graphql/
+  - file: docs/docs/topics/generator.mdx
+    line: ~
+    current: topics/graphql (any reference)
+    should_be: development-resources/graphql/
+  - file: docs/docs/topics/artifact.mdx
+    line: ~
+    current: topics/graphql (any reference)
+    should_be: development-resources/graphql/

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -454,7 +454,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       link: { type: 'generated-index', slug: 'development-resources' },
       items: [
-        { type: 'doc', id: 'topics/developer-guide', label: 'Developer Guide' },
+        { type: 'doc', id: 'development-resources/developer-guide', label: 'Developer Guide' },
         { type: 'doc', id: 'topics/local-demo-environment', label: 'Local Demo Environment' },
         {
           type: 'category',
@@ -462,9 +462,18 @@ const sidebars: SidebarsConfig = {
           collapsible: true,
           collapsed: true,
           items: [
-            { type: 'doc', id: 'topics/graphql', label: 'GraphQL' },
-            { type: 'doc', id: 'guides/graphql-fragment', label: 'GraphQL fragments' },
-            { type: 'ref', id: 'reference/api-server', label: 'REST API' },
+            {
+              type: 'category',
+              label: 'GraphQL',
+              link: { type: 'doc', id: 'development-resources/graphql/index' },
+              items: [
+                { type: 'doc', id: 'development-resources/graphql/queries-and-mutations', label: 'Queries & mutations' },
+                { type: 'doc', id: 'development-resources/graphql/stored-queries', label: 'Stored queries' },
+                { type: 'doc', id: 'development-resources/graphql/single-target-queries', label: 'Single-target queries' },
+                { type: 'doc', id: 'development-resources/graphql/groups', label: 'Working with groups' },
+              ],
+            },
+            { type: 'doc', id: 'development-resources/graphql-fragments', label: 'GraphQL fragments' },
             { type: 'link', label: 'Python SDK ↗', href: 'https://TODO-FILL-IN-python-sdk.example.com' },
             { type: 'link', label: 'Infrahubctl CLI ↗', href: 'https://TODO-FILL-IN-infrahubctl.example.com' },
             { type: 'link', label: 'MCP Server ↗', href: 'https://TODO-FILL-IN-mcp-server.example.com' },


### PR DESCRIPTION
## Summary

Migrates **GraphQL** docs per the Infrahub docs revamp.
Pattern: hub + 4 spokes. Also moves `developer-guide` and `graphql-fragments` into `development-resources/` (re-doing work from PR #9181 which was merged into the wrong base branch).

## Content changes

| File | Change |
|---|---|
| `development-resources/graphql/index.mdx` | Hub — intro paragraph, endpoint URLs (double-slash typo fixed), both intro videos |
| `development-resources/graphql/queries-and-mutations.mdx` | Spoke — full Query & mutations section + Branch management from `topics/graphql.mdx` (typo fix: "mutations are use to" → "mutations are used to") |
| `development-resources/graphql/stored-queries.mdx` | Spoke — Stored GraphQL queries section; pure move |
| `development-resources/graphql/single-target-queries.mdx` | Spoke — Single-target query pattern section; pure move, link depth updated |
| `development-resources/graphql/groups.mdx` | Spoke — Working with groups in GraphQL; pure move, link depth updated |
| `development-resources/graphql-fragments.mdx` | Moved from `guides/graphql-fragment.mdx`; GraphQL fragments concept section (was in `topics/graphql.mdx`) merged as intro; self-referential "see step-by-step" link removed |
| `development-resources/developer-guide.mdx` | Moved from `topics/developer-guide.mdx`; cross-links updated to new depth |
| `sidebars.ts` | GraphQL flat `doc` entry replaced with hub+spokes `category`; `developer-guide` and `graphql-fragments` paths updated; REST API cross-link removed from APIs & interfaces |
| `redirects-pending/development-resources.yml` | Redirect records for all three moved legacy paths |

## What didn't change

- All factual content preserved; no new claims invented
- Original files (`topics/graphql.mdx`, `topics/developer-guide.mdx`, `guides/graphql-fragment.mdx`) left on disk — cleanup happens in the end-of-phase-2 PR

## Verification

- `cd docs && npm run build` succeeds
- `markdownlint-cli2` — 0 errors
- `vale` — 0 errors, 0 warnings
- Pre-PR audit completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)