### PR TITLE
add restrict_namespaces to core generics with special handling

### DIFF
--- a/backend/infrahub/actions/schema.py
+++ b/backend/infrahub/actions/schema.py
@@ -29,6 +29,7 @@ core_trigger_rule = GenericSchema(
     branch=BranchSupportType.AGNOSTIC,
     uniqueness_constraints=[["name__value"]],
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="name",
@@ -90,6 +91,7 @@ core_action = GenericSchema(
     branch=BranchSupportType.AGNOSTIC,
     uniqueness_constraints=[["name__value"]],
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="name",
@@ -129,6 +131,7 @@ core_node_trigger_match = GenericSchema(
     label="Node Trigger Match",
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[],
     relationships=[
         Rel(

--- a/backend/infrahub/core/schema/definitions/core/account.py
+++ b/backend/infrahub/core/schema/definitions/core/account.py
@@ -113,6 +113,7 @@ core_credential = GenericSchema(
     branch=BranchSupportType.AGNOSTIC,
     uniqueness_constraints=[["name__value"]],
     documentation="/topics/auth",
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="name", kind="Text", unique=True, order_weight=1000),
         Attr(name="label", kind="Text", optional=True, order_weight=2000),
@@ -134,6 +135,7 @@ core_generic_account = GenericSchema(
     branch=BranchSupportType.AGNOSTIC,
     documentation="/topics/auth",
     uniqueness_constraints=[["name__value"]],
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="name", kind="Text", unique=True),
         Attr(name="password", kind="HashedPassword", unique=False),

--- a/backend/infrahub/core/schema/definitions/core/key_value.py
+++ b/backend/infrahub/core/schema/definitions/core/key_value.py
@@ -20,6 +20,7 @@ core_key_value = GenericSchema(
     icon="mdi:key-variant",
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="name",

--- a/backend/infrahub/core/schema/definitions/core/menu.py
+++ b/backend/infrahub/core/schema/definitions/core/menu.py
@@ -16,6 +16,7 @@ generic_menu_item = GenericSchema(
     human_friendly_id=["namespace__value", "name__value"],
     display_label="label__value",
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="namespace",

--- a/backend/infrahub/core/schema/definitions/core/permission.py
+++ b/backend/infrahub/core/schema/definitions/core/permission.py
@@ -25,6 +25,7 @@ core_base_permission = GenericSchema(
     icon="mdi:user-key",
     include_in_menu=False,
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="description", kind="Text", optional=True),
         Attr(

--- a/backend/infrahub/core/schema/definitions/core/propose_change_comment.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change_comment.py
@@ -21,6 +21,7 @@ core_propose_change_comment = GenericSchema(
     display_label="text__value",
     include_in_menu=False,
     branch=BranchSupportType.AGNOSTIC,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="text", kind="TextArea", description="Content of the comment", unique=False, optional=False),
     ],
@@ -34,6 +35,7 @@ core_thread = GenericSchema(
     label="Thread",
     branch=BranchSupportType.AGNOSTIC,
     include_in_menu=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="label", kind="Text", optional=True),
         Attr(

--- a/backend/infrahub/core/schema/definitions/core/propose_change_validator.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change_validator.py
@@ -28,6 +28,7 @@ core_propose_change_validator = GenericSchema(
     order_by=["started_at__value"],
     display_label="label__value",
     branch=BranchSupportType.AGNOSTIC,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="label", kind="Text", optional=True),
         Attr(

--- a/backend/infrahub/core/schema/definitions/core/resource_pool.py
+++ b/backend/infrahub/core/schema/definitions/core/resource_pool.py
@@ -42,7 +42,6 @@ core_weighted_pool_resource = GenericSchema(
     include_in_menu=False,
     branch=BranchSupportType.AWARE,
     generate_profile=False,
-    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="allocation_weight",

--- a/backend/infrahub/core/schema/definitions/core/resource_pool.py
+++ b/backend/infrahub/core/schema/definitions/core/resource_pool.py
@@ -27,6 +27,7 @@ core_resource_pool = GenericSchema(
     branch=BranchSupportType.AGNOSTIC,
     uniqueness_constraints=[["name__value"]],
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="name", kind="Text", order_weight=1000, unique=True),
         Attr(name="description", kind="Text", optional=True, order_weight=2000),
@@ -41,6 +42,7 @@ core_weighted_pool_resource = GenericSchema(
     include_in_menu=False,
     branch=BranchSupportType.AWARE,
     generate_profile=False,
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(
             name="allocation_weight",
@@ -61,6 +63,7 @@ core_ip_pool = GenericSchema(
     include_in_menu=False,
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
+    restricted_namespaces=["Core"],
 )
 
 core_ip_prefix_pool = NodeSchema(

--- a/backend/infrahub/core/schema/definitions/core/transform.py
+++ b/backend/infrahub/core/schema/definitions/core/transform.py
@@ -25,6 +25,7 @@ core_transform = GenericSchema(
     branch=BranchSupportType.AWARE,
     documentation="/topics/proposed-change",
     uniqueness_constraints=[["name__value"]],
+    restricted_namespaces=["Core"],
     attributes=[
         Attr(name="name", kind="Text", unique=True),
         Attr(name="label", kind="Text", optional=True),

--- a/changelog/+restrict-internal-generics-namespaces.changed.md
+++ b/changelog/+restrict-internal-generics-namespaces.changed.md
@@ -7,7 +7,6 @@ The newly restricted generics are:
 - `CoreCredential`
 - `CoreGenericAccount`
 - `CoreResourcePool`
-- `CoreWeightedPoolResource`
 - `CoreIPPool`
 - `CoreTransformation`
 - `CoreBasePermission`

--- a/changelog/+restrict-internal-generics-namespaces.changed.md
+++ b/changelog/+restrict-internal-generics-namespaces.changed.md
@@ -1,0 +1,21 @@
+Several built-in `Core` generic schemas that have special handling in Infrahub now restrict inheritance to the `Core` namespace via the `restricted_namespaces` field. This prevents user-defined schemas from inheriting from generics whose code paths assume a specific internal structure.
+
+**Breaking change.** Any user-defined node schema that inherits from one of the generics listed below must be removed (and its data deleted) before upgrading. Infrahub will refuse to load a schema that violates these restrictions and the upgrade will not complete.
+
+The newly restricted generics are:
+
+- `CoreCredential`
+- `CoreGenericAccount`
+- `CoreResourcePool`
+- `CoreWeightedPoolResource`
+- `CoreIPPool`
+- `CoreTransformation`
+- `CoreBasePermission`
+- `CoreMenu`
+- `CoreComment`
+- `CoreThread`
+- `CoreValidator`
+- `CoreKeyValue`
+- `CoreTriggerRule`
+- `CoreAction`
+- `CoreNodeTriggerMatch`


### PR DESCRIPTION
add `restricted_namespaces` to some of our internal generic schemas to prevent users from making node schemas that inherit from these generics. the restricted generics are ones that we have specific internal logic for that should not be extensible by users.

these are the generic schemas restricted in this PR. please review carefully to check if any are missing or should be removed
- `CoreCredential`
- `CoreGenericAccount`
- `CoreResourcePool`
- `CoreIPPool`
- `CoreTransformation`
- `CoreBasePermission`
- `CoreMenu`
- `CoreComment`
- `CoreThread`
- `CoreValidator`
- `CoreKeyValue`
- `CoreTriggerRule`
- `CoreAction`
- `CoreNodeTriggerMatch`
