### PR TITLE
docs: tighten sidebar padding on spoke items

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -185,3 +185,11 @@ body {
 .theme-doc-sidebar-item-link-level-1 {
   margin-bottom: 1rem;
 }
+
+/* Spoke items (L3 links and deeper) — tighter vertical padding so they read
+   as a compact list under their parent category rather than equal-weight peers */
+.theme-doc-sidebar-item-link-level-3 > .menu__link,
+.theme-doc-sidebar-item-link-level-4 > .menu__link {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+}


### PR DESCRIPTION
## Summary

Reduces vertical padding on L3/L4 sidebar links (spoke items inside an expanded category) so they read as a compact list under their parent rather than equal-weight peers with the top-level category items.

**One rule added to `docs/src/css/custom.css`:**

```css
.theme-doc-sidebar-item-link-level-3 > .menu__link,
.theme-doc-sidebar-item-link-level-4 > .menu__link {
  padding-top: 0.2rem;
  padding-bottom: 0.2rem;
}
```

Default Docusaurus padding is `0.375rem` top/bottom. This drops spoke items to `0.2rem`, leaving category-level items unchanged.

## Visual

| Current | Proposed |
|---|---|
| All rows same vertical weight | Spokes tighter, categories breathe more |

(See Cloudflare preview for live comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)