### PR TITLE
chore(docs): override vulnerable transitive deps

### DIFF
--- a/changelog/+docs-deps-security-overrides.security.md
+++ b/changelog/+docs-deps-security-overrides.security.md
@@ -1,0 +1,1 @@
+Bumped transitive docs dependencies to address Dependabot advisories: `dompurify` >= 3.4.0, `follow-redirects` >= 1.16.0, `lodash` and `lodash-es` >= 4.18.0, `postcss` >= 8.5.10, and `uuid` (v11) >= 11.1.1.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9819,9 +9819,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10943,9 +10943,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -12834,15 +12834,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16632,9 +16632,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -21074,9 +21074,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/docs/package.json
+++ b/docs/package.json
@@ -56,7 +56,13 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "^8.58.0",
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.4",
+    "dompurify": "^3.4.0",
+    "follow-redirects": "^1.16.0",
+    "lodash": "^4.18.0",
+    "lodash-es": "^4.18.0",
+    "postcss": "^8.5.10",
+    "uuid@11": "^11.1.1"
   },
   "engines": {
     "node": ">=24.0"


### PR DESCRIPTION
## Summary

- Adds an `overrides` block in `docs/package.json` to force patched versions of transitive dependencies pulled in by docusaurus and its plugins (mermaid, http-proxy, postcss-preset-env, etc.).
- Closes 11 open Dependabot advisories against `docs/package-lock.json`.
- Build-tooling-only fixes — no runtime behavior change for the published static site.

## Advisories closed

| Package | Was | Now | Advisories |
|---|---|---|---|
| `postcss` | 8.5.9 | 8.5.14 | GHSA-qx2v-qp2m-jg93 |
| `dompurify` | 3.3.3 | 3.4.2 | GHSA-crv5-9vww-q3g8, h7mw-gpvr-xq4m, v9jr-rg53-9pgp, 39q2-94rc-95cp |
| `follow-redirects` | 1.15.11 | 1.16.0 | GHSA-r4q5-vmmm-2653 |
| `lodash` | 4.17.23 | 4.18.1 | GHSA-r5fr-rjxr-66jc, f23m-r3pf-42rh |
| `lodash-es` | 4.17.23 | 4.18.1 | GHSA-r5fr-rjxr-66jc, f23m-r3pf-42rh |
| `uuid` (v11) | 11.1.0 | 11.1.1 | GHSA-w5hq-g745-h8pq |

The `uuid` override is scoped to `uuid@11` so `sockjs`'s transitive `uuid@8.3.2` (unaffected) stays put.

## Why overrides instead of waiting for Docusaurus

Most of these are 2–3 levels deep through `mermaid`, `http-proxy`, `chevrotain`, etc. Docusaurus 3.x doesn't pin tight versions on these — they get whatever npm resolves. Waiting on Docusaurus would actually mean waiting on each upstream (mermaid → dompurify, postcss-preset-env → postcss) before Docusaurus rolls them up. Overrides are the same fix, now.

This repo already uses the same `overrides` mechanism for `@typescript-eslint/utils` and `serialize-javascript`, so the pattern is consistent.

## Risk

- Mostly patch-level bumps; the `lodash` 4.17 → 4.18 minor bump is the only one worth eyeballing. The 4.18 release notes target the `_.unset` / `_.omit` / `_.template` advisories — `docs/src/` doesn't use lodash directly, so the surface is whatever docusaurus internals exercise.
- All vulnerabilities listed are in build-time tooling (postcss, autoprefixer, follow-redirects in dev server, lodash inside docusaurus core). Real exposure of the published static site is minimal; this is primarily about clearing the alert list.

## Test plan

- [x] `npm install` in `docs/` regenerates the lockfile with target versions resolved (verified).
- [x] `npm run build` in `docs/` completes successfully (verified locally).
- [ ] CI build passes.
- [ ] Dependabot re-evaluates the alerts after merge and closes #397, #393, #390, #389, #388, #383, #381, #363, #362, #361, #360.