### PR TITLE
Skip orphan artifacts when validating artifact generation

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -112,6 +112,8 @@ from .branch_diff import get_diff_summary_cache, get_modified_kinds
 from .checker import verify_proposed_change_is_mergeable
 
 if TYPE_CHECKING:
+    import logging
+
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
@@ -720,9 +722,11 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         client=client, branch=model.source_branch, definition=artifact_definition
     )
 
-    artifacts_by_member = {}
-    for artifact in existing_artifacts:
-        artifacts_by_member[artifact.object.peer.id] = artifact.id
+    artifacts_by_member = _map_artifacts_by_member(
+        existing_artifacts=existing_artifacts,
+        definition_name=model.artifact_definition.definition_name,
+        log=log,
+    )
 
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
 
@@ -842,6 +846,26 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         proposed_change_id=model.proposed_change,
         context=context,
     )
+
+
+def _map_artifacts_by_member(
+    existing_artifacts: list[InfrahubNode],
+    definition_name: str,
+    log: logging.Logger | logging.LoggerAdapter,
+) -> dict[str, str]:
+    """Map each member id to its existing artifact id, skipping artifacts whose
+    `object` peer cannot be resolved. Such orphan rows can appear when a target
+    node has been removed via a path that does not cascade-delete artifacts."""
+    artifacts_by_member: dict[str, str] = {}
+    for artifact in existing_artifacts:
+        object_id = artifact.object.id
+        if object_id is None:
+            log.warning(
+                f"Skipping orphan artifact {artifact.id} for definition {definition_name}: object peer unresolvable"
+            )
+            continue
+        artifacts_by_member[object_id] = artifact.id
+    return artifacts_by_member
 
 
 def _should_render_artifact(

--- a/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
+++ b/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
@@ -200,6 +200,25 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         )
         await artdef_partial_node.save(db=db)
 
+        # --- Group + Artifact definition used to exercise an orphan artifact ---
+        # The group contains dev1 (kept) so the dispatch loop has something to act on
+        # after we skip the orphan row.
+        orphan_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await orphan_group.new(db=db, name="device-targets-orphan", members=[dev1])
+        await orphan_group.save(db=db)
+
+        artdef_orphan_node = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+        await artdef_orphan_node.new(
+            db=db,
+            name="artifact-orphan",
+            targets=orphan_group,
+            transformation=transform,
+            content_type="application/json",
+            artifact_name="device-orphan-config",
+            parameters={"value": {"name": "name__value"}},
+        )
+        await artdef_orphan_node.save(db=db)
+
         # --- Create source branch AFTER all AWARE nodes are on main ---
         # This ensures the branch inherits them all via the graph branching model.
         source_branch_obj = await create_branch(branch_name=SOURCE_BRANCH, db=db)
@@ -259,6 +278,30 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             content_type="application/json",
         )
         await art4.save(db=db)
+
+        # --- Phantom device + orphan artifact on source_branch ---
+        # The phantom device is created so an artifact can be linked to it; once the
+        # device is deleted the artifact's `object` relationship is left dangling. This
+        # mirrors production rows where a target was removed via a path the artifact
+        # cascade does not cover (branch-merge, schema reload, migration, etc.).
+        phantom_dev = await Node.init(db=db, schema="TestNetworkDevice", branch=source_branch_obj)
+        await phantom_dev.new(db=db, name="phantom", color="grey", description="To be deleted")
+        await phantom_dev.save(db=db)
+
+        art_orphan = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
+        await art_orphan.new(
+            db=db,
+            name="device-orphan-config",
+            definition=artdef_orphan_node,
+            status="Ready",
+            object=phantom_dev,
+            storage_id=str(uuid.uuid4()),
+            checksum="oooo",
+            content_type="application/json",
+        )
+        await art_orphan.save(db=db)
+
+        await phantom_dev.delete(db=db)
 
         # --- Artifacts for artdef_partial on source_branch (only dev1 and dev2) ---
         art1_p = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=source_branch_obj)
@@ -418,6 +461,21 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             timeout=60,
         )
 
+        artdef_orphan = ProposedChangeArtifactDefinition(
+            definition_id=artdef_orphan_node.id,
+            definition_name="artifact-orphan",
+            artifact_name="device-orphan-config",
+            query_name="GetNetworkDevice",
+            query_id=query_unique.id,
+            query_models=["TestNetworkDevice"],
+            query_payload=QUERY_UNIQUE_TARGETS,
+            repository_id=repo.id,
+            transform_kind=InfrahubKind.TRANSFORMJINJA2,
+            template_path="device.j2",
+            content_type="application/json",
+            timeout=60,
+        )
+
         return {
             "source_branch": SOURCE_BRANCH,
             "proposed_change_id": pc.id,
@@ -435,6 +493,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             "artdef_full": artdef_full,
             "artdef_full_non_unique": artdef_full_non_unique,
             "artdef_partial": artdef_partial,
+            "artdef_orphan": artdef_orphan,
+            "art_orphan_id": art_orphan.id,
         }
 
     def _make_context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
@@ -751,6 +811,40 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             artifact_dataset["dev3_id"],
             artifact_dataset["dev4_id"],
         }
+
+    async def test_orphan_artifact_does_not_block_dispatch(
+        self,
+        artifact_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        """An artifact whose `object` peer can no longer be resolved must not
+        prevent the validator from dispatching artifact creation for the rest of
+        the group. dev1 is a member of the orphan group with no existing artifact
+        for that definition, so it should always be regenerated."""
+        pipeline_id = uuid.uuid4()
+        context = self._make_context(admin_account, default_branch)
+        diff_summary: list[dict] = []
+        branch_diff = await self._make_branch_diff(
+            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
+        )
+
+        model = RequestArtifactDefinitionCheck(
+            artifact_definition=artifact_dataset["artdef_orphan"],
+            branch_diff=branch_diff,
+            proposed_change=artifact_dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=False,
+            destination_branch=default_branch.name,
+        )
+
+        await self._run(model=model, context=context, diff_summary=diff_summary, memory_cache=memory_cache)
+
+        triggered_ids = {c["parameters"]["model"].target_id for c in workflow_recorder.execute_calls}
+        assert triggered_ids == {artifact_dataset["dev1_id"]}
 
     async def test_managed_branch_without_file_changes_uses_field_targeting(
         self,

--- a/changelog/9188.fixed.md
+++ b/changelog/9188.fixed.md
@@ -1,0 +1,1 @@
+Skip artifacts whose `object` peer can no longer be resolved when validating artifact generation in a Proposed Change. A single orphan row no longer prevents `CheckArtifactCreate` from being dispatched for the rest of the group.


### PR DESCRIPTION
# Why

Orphaned artifacts were preventing the artifact generation in the pipeline to work, this change ensures that the pipeline doesn't get impacted if something like this were to happen.

Closes #9188

## What changed

* A new check to avoid including orphans which would break cause later exceptions
* Small refactoring to break out a piece of the code to an external function. The reason for this was that the code body was getting too long and complex. It's still hard to read and parse and could benefit from a larger refactoring.
* Added tests