### PR TITLE
Merge 'stable' into 'develop' with resolved conflicts

### DIFF
--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -222,7 +222,6 @@ async def _get_targets(
     client: InfrahubClient,
 ) -> dict[str, dict[str, InfrahubNode]]:
     """Get the targets per kind in order to extract the variables."""
-
     targets_per_kind: dict[str, dict[str, InfrahubNode]] = defaultdict(dict)
 
     for target in targets:
@@ -260,6 +259,7 @@ async def _run_generators(
     Raises:
         ValueError: If the generator definition is not found or none of the requested
             targets are members of the target group.
+
     """
     response = await client.execute_graphql(
         query=get_generator_run_query(definition_id=generator_definition_id, target_ids=node_ids).render(),

--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -66,8 +66,7 @@ class SearchDocs:
         self._heading_index: Index | None = None
 
     def _load_json(self) -> None:
-        """
-        The structure of search-index.json is organized into an array of 3 arrays representing indexes for:
+        """The structure of search-index.json is organized into an array of 3 arrays representing indexes for:
         [titleDocuments, headingDocuments, contentDocuments]
 
         For titleDocuments, it consists of an array of dictionaries with the following structure:
@@ -97,7 +96,6 @@ class SearchDocs:
             p: title_id,
         }
         """
-
         try:
             with config.SETTINGS.main.docs_index_path.open(encoding="utf-8") as f:
                 search_index = ujson.loads(f.read())

--- a/backend/infrahub/api/storage/file_object.py
+++ b/backend/infrahub/api/storage/file_object.py
@@ -66,6 +66,7 @@ def build_content_disposition(filename: str, preview: bool = False) -> str:
     Args:
         filename: The filename to include in the header.
         preview: If True, use 'inline' disposition (display in browser). If False, use 'attachment' (force download).
+
     """
     ascii_filename, encoded_filename = sanitize_filename(filename)
     disposition = "inline" if preview else "attachment"

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -467,6 +467,7 @@ def safe_get_response_body(response: httpx.Response, raise_error_on_empty_body: 
 
     Raises:
         GatewayError: When the response body cannot be parsed or is empty
+
     """
     # Try to parse as JSON first
     try:
@@ -503,6 +504,7 @@ def extract_auth_error_message(response_body: str | dict[str, Any], base_message
 
     Returns:
         Formatted error message with provider details if available
+
     """
     if not isinstance(response_body, dict):
         return base_message
@@ -528,6 +530,7 @@ def validate_auth_response(response: httpx.Response, provider_type: str = "authe
 
     Raises:
         GatewayError: When the response indicates an error or invalid state
+
     """
     # If the status code is successful, simply return
     if 200 <= response.status_code <= 299:

--- a/backend/infrahub/auth_pkce.py
+++ b/backend/infrahub/auth_pkce.py
@@ -21,6 +21,7 @@ def generate_code_verifier() -> str:
 
     Returns:
         A 43-character URL-safe string (256 bits of entropy).
+
     """
     return secrets.token_urlsafe(32)
 
@@ -36,6 +37,7 @@ def compute_code_challenge(code_verifier: str) -> str:
 
     Returns:
         Base64URL-encoded SHA256 hash without padding.
+
     """
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -90,9 +90,7 @@ class IndexAction(StrEnum):
 
 @app.callback()
 def callback() -> None:
-    """
-    Manage the graph in the database.
-    """
+    """Manage the graph in the database."""
 
 
 async def do_migrate(
@@ -108,6 +106,7 @@ async def do_migrate(
         root_node: The root node containing the current graph version.
         check: If True, only check which migrations need to run without applying them.
         migration_number: If provided, run only this specific migration.
+
     """
     migrations = await detect_migration_to_run(
         current_graph_version=root_node.graph_version, migration_number=migration_number
@@ -404,6 +403,7 @@ async def migrate_database(
         migrations: Sequence of migrations to apply.
         initialize: Whether to initialize the registry before running migrations.
         update_graph_version: Whether to update the graph version after each migration.
+
     """
     if not migrations:
         return True
@@ -761,8 +761,7 @@ async def load_export_cmd(
     query_limit: int = typer.Option(1000, help="Maximum batch size of import query"),
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
 ) -> None:
-    """
-    Cannot be used for backup/restore functionality.
+    """Cannot be used for backup/restore functionality.
     Loads an anonymized export into Neo4j.
     Only used for analysis of output of the selected-export command.
     """
@@ -919,6 +918,7 @@ async def run_database_checks(db: InfrahubDatabase, output_dir: Path) -> None:
     Args:
         db: The database object.
         output_dir: Directory to save detailed check results.
+
     """
     get_migration_console().log("Running database health checks...")
 

--- a/backend/infrahub/cli/db_commands/check_inheritance.py
+++ b/backend/infrahub/cli/db_commands/check_inheritance.py
@@ -27,8 +27,7 @@ log = get_logger()
 
 
 class GetSchemaWithUpdatedInheritance(Query):
-    """
-    Get the name, namespace, and branch of any SchemaNodes with _updated_ inheritance
+    """Get the name, namespace, and branch of any SchemaNodes with _updated_ inheritance
     This query will only return schemas that have had `inherit_from` updated after they were created
     """
 
@@ -122,9 +121,7 @@ class KindLabelCountCorrected(KindLabelCount):
 
 
 class GetAllKindsAndLabels(Query):
-    """
-    Get the kind, labels, and number of nodes for the given kinds and branch
-    """
+    """Get the kind, labels, and number of nodes for the given kinds and branch"""
 
     name = "get_all_kinds_and_labels"
     type = QueryType.READ
@@ -187,8 +184,7 @@ def display_kind_label_counts(kind_label_counts_by_branch: dict[str, list[KindLa
 
 
 async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> bool:
-    """
-    Run migrations to update the inheritance of any nodes with incorrect inheritance from a failed migration
+    """Run migrations to update the inheritance of any nodes with incorrect inheritance from a failed migration
     1. Identifies node schemas that have had their inheritance updated after they were created
         a. includes the kind and branch of the inheritance update
     2. Checks nodes of the given kinds on the given branch to verify their inheritance is correct
@@ -196,7 +192,6 @@ async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> bool:
     4. If fix is True, runs migrations to update the inheritance of any nodes with incorrect inheritance
         on the correct branch
     """
-
     updated_inheritance_query = await GetSchemaWithUpdatedInheritance.init(db=db)
     await updated_inheritance_query.execute(db=db)
     updated_inheritance_kinds_by_branch = updated_inheritance_query.get_updated_inheritance_kinds_by_branch()

--- a/backend/infrahub/cli/db_commands/clean_duplicate_schema_fields.py
+++ b/backend/infrahub/cli/db_commands/clean_duplicate_schema_fields.py
@@ -72,8 +72,7 @@ WHERE size(fields_reverse_chron) > 1
 
 
 class GetDuplicateSchemaFields(DuplicateSchemaFields):
-    """
-    Get the kind, field type, and field name for any duplicated attributes or relationships on a given schema
+    """Get the kind, field type, and field name for any duplicated attributes or relationships on a given schema
     on the default branch
     """
 
@@ -123,9 +122,7 @@ ORDER BY schema_kind ASC, is_attribute DESC, field_name ASC
 
 
 class FixDuplicateSchemaFields(DuplicateSchemaFields):
-    """
-    Fix the duplicate schema fields by hard deleting the earlier duplicate(s)
-    """
+    """Fix the duplicate schema fields by hard deleting the earlier duplicate(s)"""
 
     name = "fix_duplicate_schema_fields"
     type = QueryType.WRITE
@@ -187,11 +184,9 @@ def display_duplicate_schema_fields(duplicate_schema_fields: list[SchemaFieldDet
 
 
 async def clean_duplicate_schema_fields(db: InfrahubDatabase, fix: bool = False) -> bool:
-    """
-    Identify any attributes or relationships that are duplicated in a schema on the default branch
+    """Identify any attributes or relationships that are duplicated in a schema on the default branch
     If fix is True, runs cypher queries to hard delete the earlier duplicate
     """
-
     duplicate_schema_fields_query = await GetDuplicateSchemaFields.init(db=db)
     await duplicate_schema_fields_query.execute(db=db)
     duplicate_schema_fields = duplicate_schema_fields_query.get_schema_field_details()

--- a/backend/infrahub/cli/dev.py
+++ b/backend/infrahub/cli/dev.py
@@ -38,7 +38,6 @@ async def export_graphql_schema(
     out: Path = typer.Option("schema.graphql"),  # noqa: B008
 ) -> None:
     """Export the Core GraphQL schema to a file."""
-
     config.load_and_exit(config_file_name=config_file)
 
     schema = SchemaRoot(**internal_schema)
@@ -95,7 +94,6 @@ async def database_init(
     ),
 ) -> None:
     """Erase the content of the database and initialize it with the core schema."""
-
     log = get_logger()
 
     # --------------------------------------------------
@@ -126,7 +124,6 @@ async def load_test_data(
     dataset: str = "dataset01",
 ) -> None:
     """Load test data into the database from the `test_data` directory."""
-
     logging.getLogger("neo4j").setLevel(logging.ERROR)
     config.load_and_exit(config_file_name=config_file)
 

--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -44,9 +44,7 @@ signal.signal(signal.SIGINT, signal_handler)
 
 @app.callback()
 def callback() -> None:
-    """
-    Control the Git Agent.
-    """
+    """Control the Git Agent."""
 
 
 async def initialize_git_agent(service: InfrahubServices) -> None:

--- a/backend/infrahub/cli/server.py
+++ b/backend/infrahub/cli/server.py
@@ -12,9 +12,7 @@ app = typer.Typer()
 
 @app.callback()
 def callback() -> None:
-    """
-    Control the API Server.
-    """
+    """Control the API Server."""
 
 
 log_config = {
@@ -49,7 +47,6 @@ def start(
     debug: bool = typer.Option(False, help="Enable advanced logging and troubleshooting"),
 ) -> None:
     """Start Infrahub in Debug Mode with reload enabled."""
-
     # it's not possible to pass the location of the config file directly to uvicorn.run
     # so we must rely on the environment variable
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -61,7 +61,6 @@ async def upgrade_cmd(
     ),
 ) -> None:
     """Upgrade Infrahub to the latest version."""
-
     logging.getLogger("infrahub").setLevel(logging.WARNING)
     logging.getLogger("neo4j").setLevel(logging.ERROR)
     logging.getLogger("prefect").setLevel(logging.ERROR)

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -137,9 +137,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
         trigger_node: ComputedAttributeTriggerNode,
         branches_out_of_scope: list[str] | None = None,
     ) -> Self:
-        """
-        This function is used to create a trigger definition for a computed attribute of type Jinja2.
-        """
+        """This function is used to create a trigger definition for a computed attribute of type Jinja2."""
         event_trigger = EventTrigger()
         event_trigger.events.add(NodeUpdatedEvent.event_name)
         if computed_attribute.attribute.optional:

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -234,6 +234,7 @@ async def process_jinja2(
 
     Returns:
         None
+
     """
     log = get_run_logger()
     client = get_client()

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -1227,6 +1227,7 @@ def load_and_exit(config_file_name: Path | str = "infrahub.toml", config_data: d
     Args:
         config_file_name (str, optional): [description]. Defaults to "pyproject.toml".
         config_data (dict, optional): [description]. Defaults to None.
+
     """
     try:
         SETTINGS.settings = load(config_file_name=config_file_name, config_data=config_data)

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -55,8 +55,7 @@ MAX_STRING_LENGTH = 4096
 
 
 def validate_string_length(value: str | None) -> None:
-    """
-    Validates input string length does not exceed a given threshold, as Neo4J cannot index string values larger than 8167 bytes,
+    """Validates input string length does not exceed a given threshold, as Neo4J cannot index string values larger than 8167 bytes,
     see https://neo4j.com/developer/kb/index-limitations-and-workaround/.
     Note `value` parameter is optional as this function could be called from an attribute class
     with optional value such as StringOptional.
@@ -173,6 +172,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         Returns:
             Branch:
+
         """
         if self.schema.branch == BranchSupportType.AGNOSTIC:
             return registry.get_global_branch()
@@ -252,6 +252,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         Raises:
             ValidationError: Format of the attribute value is not valid
+
         """
         value_to_check = value
         if schema.enum and isinstance(value, Enum):
@@ -270,6 +271,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         Raises:
             ValidationError: Content of the attribute value is not valid
+
         """
         if regex := schema.get_regex():
             if schema.kind == "List":
@@ -368,7 +370,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None
     ) -> AttributeChangelog | None:
         """Create or Update the Attribute in the database."""
-
         save_at = Timestamp(at)
 
         if not self.id:
@@ -384,6 +385,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         Returns:
             Branch: The branch to use for the delete operation
+
         """
         if (
             self.schema.branch == BranchSupportType.AGNOSTIC
@@ -427,7 +429,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
          - If the value is different, create new node and update relationship
 
         """
-
         update_at = Timestamp(at)
 
         # Validate if the value is still correct, will raise a ValidationError if not
@@ -539,7 +540,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         include_properties: bool = True,
     ) -> dict:
         """Generate GraphQL Payload for this attribute."""
-
         response: dict[str, Any] = {"id": self.id}
 
         if fields and isinstance(fields, dict):
@@ -620,7 +620,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
     async def from_graphql(self, data: dict, db: InfrahubDatabase, process_pools: bool = True) -> bool:
         """Update attr from GraphQL payload"""
-
         changed = False
         if "value" in data:
             if self.is_enum:
@@ -749,11 +748,9 @@ class Integer(BaseAttribute):
 
     @classmethod
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
-        """
-        Make sure boolean objects are not accepted as value. Need to override `validate_format`
+        """Make sure boolean objects are not accepted as value. Need to override `validate_format`
         as `isinstance(True, int)` is True.
         """
-
         value_to_check = value
         if schema.enum and isinstance(value, Enum):
             value_to_check = value.value
@@ -974,6 +971,7 @@ class IPNetwork(BaseAttribute):
 
         Raises:
             ValidationError: Format of the attribute value is not valid
+
         """
         super().validate_format(value=value, name=name, schema=schema)
 
@@ -984,7 +982,6 @@ class IPNetwork(BaseAttribute):
 
     def serialize_value(self) -> str:
         """Serialize the value before storing it in the database. If network is an IPv6 network, it is converted to collapsed form."""
-
         return ipaddress.ip_network(self.value).with_prefixlen
 
     def get_db_node_type(self) -> AttributeDBNodeType:
@@ -1110,6 +1107,7 @@ class IPHost(BaseAttribute):
 
         Raises:
             ValidationError: Format of the attribute value is not valid
+
         """
         super().validate_format(value=value, name=name, schema=schema)
 
@@ -1120,7 +1118,6 @@ class IPHost(BaseAttribute):
 
     def serialize_value(self) -> str:
         """Adds a prefix to address before storing it in the database. If address in an IPv6 address, it is converted to collapsed form."""
-
         return ipaddress.ip_interface(self.value).with_prefixlen
 
     def get_db_node_type(self) -> AttributeDBNodeType:
@@ -1234,6 +1231,7 @@ class MacAddress(BaseAttribute):
 
         Raises:
             ValidationError: Format of the attribute value is not valid
+
         """
         super().validate_format(value=value, name=name, schema=schema)
 

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -244,7 +244,6 @@ class Branch(StandardNode):
 
     def get_branches_and_times_to_query(self, at: Optional[Timestamp] = None) -> dict[frozenset, str]:
         """Return all the names of the branches that are constituing this branch with the associated times excluding the global branch"""
-
         at = Timestamp(at)
 
         if self.is_default:
@@ -267,7 +266,6 @@ class Branch(StandardNode):
         is_isolated: bool = True,
     ) -> dict[frozenset, str]:
         """Return all the names of the branches that are constituting this branch with the associated times."""
-
         at = Timestamp(at)
 
         if self.is_default:
@@ -288,7 +286,6 @@ class Branch(StandardNode):
         self, start_time: Timestamp, end_time: Timestamp
     ) -> tuple[dict[str, str], dict[str, str]]:
         """Return the names of the branches that are constituing this branch with the start and end times."""
-
         start = {}
         end = {}
 
@@ -335,10 +332,7 @@ class Branch(StandardNode):
     def get_query_filter_relationships(
         self, rel_labels: list, at: Optional[Timestamp] = None, include_outside_parentheses: bool = False
     ) -> tuple[list, dict]:
-        """
-        Generate a CYPHER Query filter based on a list of relationships to query a part of the graph at a specific time and on a specific branch.
-        """
-
+        """Generate a CYPHER Query filter from a list of relationships to query a part of the graph at a specific time and on a specific branch."""
         filters = []
         params: dict[str, Any] = {}
 
@@ -377,8 +371,7 @@ class Branch(StandardNode):
         variable_name: str = "r",
         params_prefix: str = "",
     ) -> tuple[str, dict]:
-        """
-        Generate a CYPHER Query filter based on a path to query a part of the graph at a specific time and on a specific branch.
+        """Generate a CYPHER Query filter based on a path to query a part of the graph at a specific time and on a specific branch.
 
         Examples:
             >>> rels_filter, rels_params = self.branch.get_query_filter_path(at=self.at)
@@ -386,6 +379,7 @@ class Branch(StandardNode):
             >>> query += "\n WHERE all(r IN relationships(p) WHERE %s)" % rels_filter
 
             There is a currently an assumption that the relationship in the path will be named 'r'
+
         """
         pp = params_prefix
         params: dict[str, Any] = {}
@@ -424,7 +418,6 @@ class Branch(StandardNode):
         self, db: InfrahubDatabase, at: str | Timestamp | None = None, user_id: str = SYSTEM_USER_ID
     ) -> None:
         """Rebase the current Branch with its origin branch"""
-
         at = Timestamp(at)
 
         await self.rebase_graph(db=db, at=at)

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -336,7 +336,6 @@ async def _rollback_merge(
     Returns True if all rollback succeeded and the branch changes are fully rolled back. If rollback
     succeeds, then Branch's status is set to OPEN. Returns False if any sub-step failed. Does not raise.
     """
-
     try:
         await merger.rollback()
     except Exception:

--- a/backend/infrahub/core/convert_object_type/object_conversion.py
+++ b/backend/infrahub/core/convert_object_type/object_conversion.py
@@ -41,8 +41,8 @@ async def get_out_rels_peers_ids(node: Node, db: InfrahubDatabase, at: Timestamp
 
 async def build_data_new_node(db: InfrahubDatabase, mapping: dict[str, ConversionFieldInput], node: Node) -> dict:
     """Value of a given field on the target kind to convert is either an input source attribute/relationship of the source node,
-    or a raw value."""
-
+    or a raw value.
+    """
     data = {}
     for dest_field_name, conv_field_input in mapping.items():
         if conv_field_input.source_field is not None:
@@ -72,10 +72,7 @@ async def build_data_new_node(db: InfrahubDatabase, mapping: dict[str, Conversio
 async def get_unidirectional_rels_peers_ids(
     node: Node, branch: Branch, db: InfrahubDatabase, at: Timestamp
 ) -> list[str]:
-    """
-    Returns peers ids of nodes connected to input `node` through an incoming unidirectional relationship.
-    """
-
+    """Returns peers ids of nodes connected to input `node` through an incoming unidirectional relationship."""
     out_rels_identifier = [rel.identifier for rel in node.get_schema().relationships]
     branch_agnostic = node.get_schema().branch == BranchSupportType.AGNOSTIC
     query = await GetAllPeersIds.init(
@@ -146,8 +143,8 @@ async def convert_object_type(
     db: InfrahubDatabase,
 ) -> Node:
     """Delete the node and return the new created one. If creation fails, the node is not deleted, and raise an error.
-    An extra check is performed on input node peers relationships to make sure they are still valid."""
-
+    An extra check is performed on input node peers relationships to make sure they are still valid.
+    """
     node_schema = node.get_schema()
     if not isinstance(node_schema, NodeSchema):
         raise ValueError(f"Only a node with a NodeSchema can be converted, got {type(node_schema)}")

--- a/backend/infrahub/core/convert_object_type/repository_conversion.py
+++ b/backend/infrahub/core/convert_object_type/repository_conversion.py
@@ -25,8 +25,8 @@ async def convert_repository_type(
     repository_post_creator: RepositoryFinalizer,
 ) -> Node:
     """Delete the node and return the new created one. If creation fails, the node is not deleted, and raise an error.
-    An extra check is performed on input node peers relationships to make sure they are still valid."""
-
+    An extra check is performed on input node peers relationships to make sure they are still valid.
+    """
     repo_name = repository.name.value
     async with lock.registry.get(name=repo_name, namespace="repository"):
         async with db.start_transaction() as dbt:

--- a/backend/infrahub/core/convert_object_type/schema_mapping.py
+++ b/backend/infrahub/core/convert_object_type/schema_mapping.py
@@ -29,14 +29,12 @@ def _are_branch_support_matching(
 
 
 def get_schema_mapping(source_schema: NodeSchema, target_schema: NodeSchema) -> SchemaMapping:
-    """
-    Return fields mapping meant to be used for converting a node from `source_kind` to `target_kind`.
+    """Return fields mapping meant to be used for converting a node from `source_kind` to `target_kind`.
     For any field of the target kind, field of the source kind will be matched if:
     - It's an attribute with identical name and type.
     - It's a relationship with identical peer kind and cardinality.
     If there is no match, the mapping will only indicate whether the field is mandatory or not.
     """
-
     target_field_to_source_field = {}
 
     # Create lookup dictionaries for source attributes and relationships

--- a/backend/infrahub/core/diff/branch_differ.py
+++ b/backend/infrahub/core/diff/branch_differ.py
@@ -53,8 +53,8 @@ class BranchDiffer:
 
         Raises:
             ValueError: if diff_from and diff_to are not correct
-        """
 
+        """
         self.branch = branch
         self.branch_only = branch_only
         self.origin_branch = origin_branch
@@ -145,7 +145,6 @@ class BranchDiffer:
         commit_to: str,
     ) -> list[FileDiffElement]:
         """Return all the files that have added, changed or removed for a given repository between 2 commits."""
-
         files = []
 
         model = GitDiffNamesOnly(

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -529,9 +529,8 @@ class DiffCoordinator:
         diff_request: EnrichedDiffRequest,
         partial_enriched_diffs: list[EnrichedDiffsMetadata] | None,
     ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata, set[NodeIdentifier]]:
-        """
-        If return is an EnrichedDiffsMetadata, it acts as a pointer to a diff in the database that has all the
-            necessary data for this diff_request. Might have a different time range and/or tracking_id
+        """If return is an EnrichedDiffsMetadata, it acts as a pointer to a diff in the database that has all the
+        necessary data for this diff_request. Might have a different time range and/or tracking_id
         """
         aggregated_enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata | None = None
         if not partial_enriched_diffs:
@@ -612,8 +611,7 @@ class DiffCoordinator:
         diff_or_request_list: Sequence[EnrichedDiffsMetadata | EnrichedDiffRequest | None],
         full_diff_request: EnrichedDiffRequest,
     ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata | None, set[NodeIdentifier]]:
-        """
-        Returns None if diff_or_request_list is empty or all Nones
+        """Returns None if diff_or_request_list is empty or all Nones
             meaning there are no changes for the diff during this time period
         Returns EnrichedDiffsMetadata if diff_or_request_list includes one EnrichedDiffsMetadata and no EnrichedDiffRequests
             meaning no diffs needed to be hydrated and combined

--- a/backend/infrahub/core/diff/models.py
+++ b/backend/infrahub/core/diff/models.py
@@ -2,8 +2,7 @@ from pydantic import BaseModel, Field
 
 
 class RequestDiffUpdate(BaseModel):
-    """
-    Request diff to be updated.
+    """Request diff to be updated.
 
     If the message only include a branch_name, it is assumed to be for updating the diff that tracks
     the lifetime changes of a branch

--- a/backend/infrahub/core/diff/query/field_summary.py
+++ b/backend/infrahub/core/diff/query/field_summary.py
@@ -8,9 +8,7 @@ from ..model.path import NodeDiffFieldSummary, TrackingId
 
 
 class EnrichedDiffNodeFieldSummaryQuery(Query):
-    """
-    Get node kind and names of all altered attributes and relationships for each kind
-    """
+    """Get node kind and names of all altered attributes and relationships for each kind"""
 
     name = "enriched_diff_node_field_summary"
     type = QueryType.READ

--- a/backend/infrahub/core/diff/query/time_range_query.py
+++ b/backend/infrahub/core/diff/query/time_range_query.py
@@ -8,8 +8,7 @@ from ..model.path import TimeRange
 
 
 class EnrichedDiffTimeRangeQuery(Query):
-    """
-    Get the time ranges of all EnrichedDiffRoots for the given branches that are within the given timeframe in
+    """Get the time ranges of all EnrichedDiffRoots for the given branches that are within the given timeframe in
     chronological order
     """
 

--- a/backend/infrahub/core/file_processor.py
+++ b/backend/infrahub/core/file_processor.py
@@ -56,6 +56,7 @@ class FileUploadProcessor:
 
         Returns:
             A human-readable string like "1.5 MB" or "256 KB".
+
         """
         value = float(size_bytes)
         for unit in ("B", "KB", "MB", "GB", "TB"):
@@ -75,6 +76,7 @@ class FileUploadProcessor:
 
         Returns:
             True if the content looks like text, False otherwise.
+
         """
         if b"\x00" in content:
             return False
@@ -97,6 +99,7 @@ class FileUploadProcessor:
 
         Returns:
             The detected MIME type string.
+
         """
         with contextlib.suppress(puremagic.PureError):
             results = puremagic.magic_string(content, filename=filename)
@@ -120,6 +123,7 @@ class FileUploadProcessor:
 
         Raises:
             RuntimeError: If metadata has not been extracted yet.
+
         """
         if not self._metadata:
             raise RuntimeError("File metadata has not been extracted yet.")
@@ -131,6 +135,7 @@ class FileUploadProcessor:
 
         Returns:
             The file size in bytes.
+
         """
         # Access underlying file object which supports seek with whence parameter
         # Starlette's UploadFile.seek() only accepts offset, not whence
@@ -146,6 +151,7 @@ class FileUploadProcessor:
 
         Returns:
             The checksum as a hex string.
+
         """
         await self.file.seek(0)
         hasher = hashlib.sha1(usedforsecurity=False)
@@ -160,6 +166,7 @@ class FileUploadProcessor:
 
         Raises:
             ValidationError: If the file exceeds the maximum allowed size.
+
         """
         if self._metadata:
             return
@@ -189,6 +196,7 @@ class FileUploadProcessor:
 
         Returns:
             True if the file should be stored, False if storage can be skipped.
+
         """
         # Skip storage only if node exists, is a FileObject, and checksums match
         return not (
@@ -202,6 +210,7 @@ class FileUploadProcessor:
 
         Returns:
             FileUploadResult containing all file metadata including storage_id.
+
         """
         self.storage_id = str(UUIDT())
         # Update file_name to use storage_id if original was unnamed
@@ -227,6 +236,7 @@ class FileUploadProcessor:
 
         Raises:
             ValidationError: If the file exceeds the maximum allowed size.
+
         """
         await self._extract_metadata()
 

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -294,7 +294,8 @@ async def create_branch(
 ) -> Branch:
     """Create a new Branch, currently all the branches are based on Main
 
-    Because all branches are based on main, the hierarchy_level of hardcoded to 2."""
+    Because all branches are based on main, the hierarchy_level of hardcoded to 2.
+    """
     description = description or f"Branch {branch_name}"
     branch = Branch(
         name=branch_name,

--- a/backend/infrahub/core/ipam/resource_allocator.py
+++ b/backend/infrahub/core/ipam/resource_allocator.py
@@ -45,6 +45,7 @@ class IPAMResourceAllocator:
             namespace: IP namespace node or its ID. If None, uses the default namespace.
             branch: Branch to query. If None, uses the default branch.
             branch_agnostic: If True, queries across all branches.
+
         """
         self.db = db
         self.namespace = namespace
@@ -67,6 +68,7 @@ class IPAMResourceAllocator:
         Returns:
             The next available IPv4 prefix, or None if no space is available
             or if the target_prefix_length is invalid.
+
         """
         if target_prefix_length < 0 or target_prefix_length > 32:
             return None
@@ -107,6 +109,7 @@ class IPAMResourceAllocator:
         Returns:
             The next available IPv6 prefix, or None if no space is available
             or if the target_prefix_length is invalid.
+
         """
         if target_prefix_length < 0 or target_prefix_length > 128:
             return None
@@ -147,6 +150,7 @@ class IPAMResourceAllocator:
 
         Returns:
             The next available prefix, or None if no space is available.
+
         """
         if ip_prefix.version == 4:
             return await self._get_next_ipv4_prefix(
@@ -169,6 +173,7 @@ class IPAMResourceAllocator:
 
         Returns:
             The next available IP address, or None if no addresses are available.
+
         """
         # Use IPv6-specific query for IPv6 to avoid 64-bit integer overflow
         query_class = IPv6PrefixIPAddressFetchFree if ip_prefix.version == 6 else IPPrefixIPAddressFetchFree
@@ -193,6 +198,7 @@ class IPAMResourceAllocator:
 
         Returns:
             Iterable of IPPrefixData objects representing child subnets.
+
         """
         query = await IPPrefixSubnetFetch.init(
             db=self.db,
@@ -216,6 +222,7 @@ class IPAMResourceAllocator:
 
         Returns:
             Iterable of IPAddressData objects representing addresses in the prefix.
+
         """
         query = await IPPrefixIPAddressFetch.init(
             db=self.db,

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -150,8 +150,8 @@ class NodeManager:
 
         Returns:
             list[Node]: List of Node object
-        """
 
+        """
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
@@ -221,8 +221,8 @@ class NodeManager:
 
         Returns:
             int: The number of responses found
-        """
 
+        """
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
@@ -1104,7 +1104,6 @@ class NodeManager:
         branch_agnostic: bool = False,
     ) -> dict[str, Node]:
         """Return a list of nodes based on their IDs."""
-
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -27,9 +27,7 @@ class Migration017(InternalSchemaMigration):
         return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
-        """
-        Load CoreProfile schema node in db.
-        """
+        """Load CoreProfile schema node in db."""
         db = migration_input.db
         at = migration_input.at
         user_id = migration_input.user_id

--- a/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
@@ -22,12 +22,10 @@ log = get_logger()
 
 
 async def validate_nulls_in_uniqueness_constraints(db: InfrahubDatabase) -> MigrationResult:
-    """
-    Validate any schema that include optional attributes in the uniqueness constraints
+    """Validate any schema that include optional attributes in the uniqueness constraints
 
     An update to uniqueness constraint validation now handles NULL values as unique instead of ignoring them
     """
-
     default_branch = registry.get_branch_from_registry()
     build_component_registry()
     component_registry = get_component_registry()

--- a/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
+++ b/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
@@ -20,12 +20,10 @@ class FixBranchAwareEdgesQuery(Query):
     insert_return = False
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        """
-        Between a Node and a Relationship, if Relationship.branch_support=aware, replace any global edge
+        """Between a Node and a Relationship, if Relationship.branch_support=aware, replace any global edge
         to the branch of a non-global edge leaving out of the Relationship node. Note that there can't
         be multiple non-global branches on these edges, as a dedicated Relationship node would exist for that.
         """
-
         query = """
         MATCH (node:Node)-[global_edge:IS_RELATED {branch: $global_branch}]-(rel:Relationship)
         WHERE rel.branch_support=$branch_aware
@@ -50,12 +48,10 @@ class SetMissingToTimeQuery(Query):
     insert_return = False
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        """
-        If both a deleted edge and an active edge with no time exist between 2 nodes on the same branch,
+        """If both a deleted edge and an active edge with no time exist between 2 nodes on the same branch,
         set `to` time of active edge using `from` time of the deleted one. This would typically happen after having
         replaced a deleted edge on global branch by correct branch with above query.
         """
-
         query = """
         MATCH (node:Node)-[deleted_edge:IS_RELATED {status: "deleted"}]-(rel:Relationship)
         MATCH (rel)-[active_edge:IS_RELATED {status: "active"}]-(node)
@@ -72,12 +68,10 @@ class DeleteNodesRelsQuery(Query):
     insert_return = False
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        """
-        Some nodes may have been incorrectly deleted, typically, while these nodes edges connected to Root
+        """Some nodes may have been incorrectly deleted, typically, while these nodes edges connected to Root
         are correctly deleted, edges connected to other `Node` through a `Relationship` node may still be active.
         Following query correctly deletes these edges by both setting correct to time and creating corresponding deleted edge.
         """
-
         query = """
         MATCH (deleted_node: Node)-[deleted_edge:IS_PART_OF {status: "deleted"}]->(:Root)
         MATCH (deleted_node)-[:IS_RELATED]-(rel:Relationship)
@@ -211,8 +205,7 @@ class DeleteNodesRelsQuery(Query):
 
 
 class Migration019(GraphMigration):
-    """
-    Fix corrupted state introduced by Migration012 when duplicating a CoreAccount (branch Aware)
+    """Fix corrupted state introduced by Migration012 when duplicating a CoreAccount (branch Aware)
     being part of a CoreStandardGroup (branch Agnostic). Database is corrupted at multiple points:
     - Old CoreAccount node <> group_member node `active` edge has no `to` time (possibly because of #5590).
     - Old CoreAccount node <> group_member node `deleted` edge is on `$global_branch` branch instead of `main`.

--- a/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
+++ b/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
@@ -116,8 +116,7 @@ class DeleteDuplicateIsProtectedEdgesQuery(DeleteDuplicateBooleanEdgesQuery):
 
 
 class Migration020(GraphMigration):
-    """
-    1. Find duplicate edges. These can be duplicated if multiple AttributeValue nodes with the same value exist b/c of concurrent
+    """1. Find duplicate edges. These can be duplicated if multiple AttributeValue nodes with the same value exist b/c of concurrent
         database updates.
         a. (a:Attribute)-[e:HAS_VALUE]->(av:AttributeValue)
             grouped by (a, e.branch, e.from, e.to, e.status, av.value, av.is_default) to determine the number of duplicates.

--- a/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
+++ b/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
@@ -36,8 +36,7 @@ class SetMissingHierarchyQuery(Query):
 
 
 class Migration021(GraphMigration):
-    """
-    A bug in diff merge logic caused the hierarchy information on IS_RELATED edges to be lost when merged into
+    """A bug in diff merge logic caused the hierarchy information on IS_RELATED edges to be lost when merged into
     main. This migration sets the missing hierarchy data.
     """
 

--- a/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
@@ -24,11 +24,9 @@ class DedupCardinalityOneRelsQuery(Query):
     insert_return = False
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        """
-        Nodes having cardinality one relationship might end up with more than one relationship due to some concurrency
+        """Nodes having cardinality one relationship might end up with more than one relationship due to some concurrency
         issue. In that case, this query keeps only the most recent relationship.
         """
-
         # load schemas from database into registry
         initialize_lock()
         await initialization(db=db)

--- a/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
+++ b/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
@@ -53,8 +53,7 @@ class BackfillMissingHierarchyQuery(Query):
 
 
 class Migration024(GraphMigration):
-    """
-    A bug in diff merge logic caused the hierarchy information on IS_RELATED edges to be lost when merged into
+    """A bug in diff merge logic caused the hierarchy information on IS_RELATED edges to be lost when merged into
     main. This migration backfills the missing hierarchy data and accounts for the case when the branch that
     created the data has been deleted.
     """

--- a/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
+++ b/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
@@ -34,8 +34,7 @@ class DeleteIsolatedNodesQuery(Query):
 
 
 class Migration027(GraphMigration):
-    """
-    While deleting a branch containing some allocated nodes from a resource pool, relationship
+    """While deleting a branch containing some allocated nodes from a resource pool, relationship
     between pool node and resource node might be agnostic (eg: for IPPrefixPool) and incorrectly deleted,
     resulting in a node still linked to the resource pool but not linked to Root anymore.
     This query deletes nodes not linked to Root and their relationships (supposed to be agnostic).

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -17,8 +17,7 @@ log = get_logger()
 
 
 class CleanUpDuplicatedUuidVertices(Query):
-    """
-    Find vertexes that include the given label and have the same UUID and same set of labels
+    """Find vertexes that include the given label and have the same UUID and same set of labels
     For each of these duplicate vertex groups, keep one and mark all the others to be deleted by the PerformHardDeletesQuery
       - Group all of the edges touching a vertex in this vertex group by branch, edge_type, peer_element_id, and direction
         - For each edge group, we will link one edge to the vertex we are keeping for this vertex group and mark all of the others to be deleted
@@ -338,8 +337,7 @@ RETURN more_nodes_to_process
 
 
 class DeleteDuplicatedEdgesQuery(Query):
-    """
-    For all Node vertices, find duplicated or overlapping edges of the same status, type, direction, and branch to update and delete
+    """For all Node vertices, find duplicated or overlapping edges of the same status, type, direction, and branch to update and delete
     - one edge will be kept for each pair of nodes and a given status, type, direction, and branch. it will be
         updated to have the earliest "from" and latest "to" times in this group
     - all the other duplicate/overlapping edges will be deleted
@@ -417,8 +415,7 @@ CALL (node_with_dup_edges, edge_type, edge_branch, peer, is_outbound) {
 
 
 class DeleteIllegalRelationships(Query):
-    """
-    Find all Relationship vertices with the same UUID (in a valid database, there are none)
+    """Find all Relationship vertices with the same UUID (in a valid database, there are none)
     If any of these Relationships have an IS_RELATED edge to a deleted Node, then delete them
         this includes if an IS_RELATED edge was added on a branch after the Node was deleted on main or -global-
     If any of these Relationships are now only connected to a single Node, then delete them
@@ -488,8 +485,7 @@ DETACH DELETE rel
 
 
 class DeleteDuplicateRelationships(Query):
-    """
-    There can also be leftover duplicate active Relationships that do not have the same UUID.
+    """There can also be leftover duplicate active Relationships that do not have the same UUID.
     They are linked to the same Nodes, have the same Relationship.name, and are on the same branch.
     In this case, we want to DETACH DELETE the later Relationship. We won't lose any information b/c the exact
     same Relationship (maybe with an earlier from time) still exists.
@@ -550,8 +546,7 @@ CALL () {
 
 
 class Migration029(ArbitraryMigration):
-    """
-    Clean up a variety of bad data created during bugged merges for node kind/inheritance updates
+    """Clean up a variety of bad data created during bugged merges for node kind/inheritance updates
 
     1. Identify improperly duplicated nodes (ie nodes with the same UUID and the same database labels)
         a. Consolidate edges onto a single duplicated node, making sure that the edges remain active if ANY active path exists

--- a/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
+++ b/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
@@ -69,9 +69,7 @@ DETACH DELETE peer
 
 
 class Migration030(GraphMigration):
-    """
-    Edges could have been added to Nodes after the Node was deleted, so we need to hard-delete those illegal edges
-    """
+    """Edges could have been added to Nodes after the Node was deleted, so we need to hard-delete those illegal edges"""
 
     name: str = "030_delete_illegal_edges"
     minimum_version: int = 29

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -25,8 +25,7 @@ log = get_logger()
 
 
 class Migration031(InternalSchemaMigration):
-    """
-    Some nodes with invalid number attributes may have been created as min/max/excluded_values were not working properly.
+    """Some nodes with invalid number attributes may have been created as min/max/excluded_values were not working properly.
     This migration indicates corrupted nodes. If strict mode is disabled, both this migration and min/max/excludes_values constraints are disabled,
     so that users can carry one with their corrupted data without any failure.
     """
@@ -37,8 +36,8 @@ class Migration031(InternalSchemaMigration):
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Retrieve all number attributes that have a min/max/excluded_values
-        For any of these attributes, check if corresponding existing nodes are valid."""
-
+        For any of these attributes, check if corresponding existing nodes are valid.
+        """
         if not config.SETTINGS.main.schema_strict_mode:
             return MigrationResult()
 

--- a/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
@@ -16,9 +16,7 @@ log = get_logger()
 
 
 class DeletedBranchCleanupQuery(Query):
-    """
-    Find all unique edge branch names for which there is no Branch object
-    """
+    """Find all unique edge branch names for which there is no Branch object"""
 
     name = "deleted_branch_cleanup"
     type = QueryType.WRITE
@@ -38,9 +36,7 @@ RETURN DISTINCT (e.branch) AS branch_name
 
 
 class DeleteOrphanRelationshipsQuery(Query):
-    """
-    Find all Relationship vertices that link to fewer than 2 Node vertices and delete them
-    """
+    """Find all Relationship vertices that link to fewer than 2 Node vertices and delete them"""
 
     name = "delete_orphan_relationships"
     type = QueryType.WRITE
@@ -58,9 +54,7 @@ DETACH DELETE r
 
 
 class Migration032(ArbitraryMigration):
-    """
-    Delete edges for branches that were not completely deleted
-    """
+    """Delete edges for branches that were not completely deleted"""
 
     name: str = "032_cleanup_deleted_branches"
     minimum_version: int = 31

--- a/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
+++ b/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
@@ -14,8 +14,7 @@ log = get_logger()
 
 
 class DeduplicateRelationshipVerticesQuery(Query):
-    """
-    For each group of duplicate Relationships with the same UUID, delete any Relationship that meets the following criteria:
+    """For each group of duplicate Relationships with the same UUID, delete any Relationship that meets the following criteria:
     - is linked to a deleted node (only if the delete time is before the Relationship's from time)
     - is linked to a node on an incorrect branch (ie Relationship added on main, but Node is on a branch)
     """
@@ -83,8 +82,7 @@ DETACH DELETE rel
 
 
 class Migration033(GraphMigration):
-    """
-    Identifies duplicate Relationship vertices that have the same UUID property. Deletes any duplicates that
+    """Identifies duplicate Relationship vertices that have the same UUID property. Deletes any duplicates that
     are linked to deleted nodes or nodes on in incorrect branch.
     """
 

--- a/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
+++ b/backend/infrahub/core/migrations/graph/m034_find_orphaned_schema_fields.py
@@ -47,8 +47,7 @@ WHERE is_deleted = FALSE
 
 
 class Migration034(ArbitraryMigration):
-    """
-    Finds active SchemaRelationship and SchemaAttribute vertices with deleted relationships to SchemaNodes or
+    """Finds active SchemaRelationship and SchemaAttribute vertices with deleted relationships to SchemaNodes or
     SchemaGenerics and deletes them on the same branch at the same time
     """
 

--- a/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m035_orphan_relationships.py
@@ -27,9 +27,7 @@ DETACH DELETE rel
 
 
 class Migration035(GraphMigration):
-    """
-    Remove Relationship vertices that only have a single peer
-    """
+    """Remove Relationship vertices that only have a single peer"""
 
     name: str = "035_clean_up_orphaned_relationships"
     minimum_version: int = 34

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -439,8 +439,7 @@ REMOVE av_no_index:AttributeValueNonIndexed
 
 
 class Migration037(ArbitraryMigration):
-    """
-    Update AttributeValue vertices to be AttributeValueIndexed, unless they include values for LARGE_ATTRIBUTE_TYPES
+    """Update AttributeValue vertices to be AttributeValueIndexed, unless they include values for LARGE_ATTRIBUTE_TYPES
 
     0. Drop the index on the AttributeValueIndexed vertex, there are no AttributeValueIndexed vertices at this point anyway
     1. For all attributes of all schema on all branches, determine if the attribute is a LARGE_ATTRIBUTE_TYPE and when

--- a/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
@@ -20,8 +20,7 @@ log = get_logger()
 
 
 class Migration038(InternalSchemaMigration):
-    """
-    Re-run migration 026 after Migration037 updates AttributeValueIndexed vertices correctly so that the call to
+    """Re-run migration 026 after Migration037 updates AttributeValueIndexed vertices correctly so that the call to
     NodeManager.query will work
 
     If someone is upgrading from 1.2.4 (release before migration 026) or earlier to 1.4.x or later, then migration 026

--- a/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
+++ b/backend/infrahub/core/migrations/graph/m039_ipam_reconcile.py
@@ -212,8 +212,7 @@ DELETE e1, e2
 
 
 class Migration039(ArbitraryMigration):
-    """
-    Identify all IP prefixes/addresses that have been updated on a branch and reconcile them on that branch
+    """Identify all IP prefixes/addresses that have been updated on a branch and reconcile them on that branch
     If any of the identified IP prefixes/addresses are their own parent/child, delete those illegal edges before reconciling.
     """
 

--- a/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m042_profile_attrs_in_db.py
@@ -23,9 +23,7 @@ log = get_logger()
 
 
 class GetUpdatedProfilesForBranchQuery(Query):
-    """
-    Get CoreProfile UUIDs with updated attributes on this branch
-    """
+    """Get CoreProfile UUIDs with updated attributes on this branch"""
 
     name = "get_profiles_by_branch"
     type = QueryType.READ
@@ -46,9 +44,7 @@ WITH DISTINCT profile.uuid AS profile_uuid
 
 
 class GetNodesWithProfileUpdatesForBranchQuery(Query):
-    """
-    Get Node UUIDs by which branches they have updated profiles on
-    """
+    """Get Node UUIDs by which branches they have updated profiles on"""
 
     name = "get_nodes_with_profile_updates_by_branch"
     type = QueryType.READ
@@ -70,8 +66,7 @@ WITH DISTINCT node.uuid AS node_uuid
 
 
 class Migration042(MigrationRequiringRebase):
-    """
-    Save profile attribute values on each node using the profile in the database
+    """Save profile attribute values on each node using the profile in the database
     For any profile that has updates on a given branch (including default branch)
     - run NodeProfilesApplier.apply_profiles on each node related to the profile on that branch
     For any node that has an updated relationship to a profile on a given branch

--- a/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m044_backfill_hfid_display_label_in_db.py
@@ -31,8 +31,7 @@ console = get_migration_console()
 
 
 class DefaultBranchNodeCount(Query):
-    """
-    Get the number of Node vertices on the given branches that are not in the kinds_to_skip list
+    """Get the number of Node vertices on the given branches that are not in the kinds_to_skip list
     Only works for default and global branches. Non-default branches would only return a count of nodes
     created on the given branches
     """
@@ -75,9 +74,7 @@ WITH count(*) AS num_nodes
 
 class GetResultMapQuery(Query):
     def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str | None]]:
-        """
-        Get the values for the given schema paths for all the Nodes captured by this query
-        """
+        """Get the values for the given schema paths for all the Nodes captured by this query"""
         # the query results for attribute and schema paths are unordered
         # so we make this list of keys for ordering the results from the query
         schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
@@ -302,8 +299,7 @@ WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_attr_
 
 
 class GetPathDetailsDefaultBranch(GetResultMapQuery):
-    """
-    Get the values of the given schema paths for the given kind of node on the default and global branches
+    """Get the values of the given schema paths for the given kind of node on the default and global branches
     Supports limit and offset for pagination
     """
 
@@ -419,8 +415,7 @@ WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_val])
 
 
 class UpdateAttributeValuesQuery(Query):
-    """
-    Update the values of the given attribute schema for the input Node-id-to-value map
+    """Update the values of the given attribute schema for the input Node-id-to-value map
     Includes special handling for updating large-type attributes b/c they are not indexed and will be slow to update
     on large data sets
     """
@@ -610,9 +605,7 @@ CALL (n, attr) {
 
 
 class Migration044(MigrationRequiringRebase):
-    """
-    Backfill `human_friendly_id` and `display_label` attributes for nodes with schemas that define them.
-    """
+    """Backfill `human_friendly_id` and `display_label` attributes for nodes with schemas that define them."""
 
     name: str = "044_backfill_hfid_display_label_in_db"
     minimum_version: int = 43

--- a/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
+++ b/backend/infrahub/core/migrations/graph/m045_backfill_hfid_display_label_in_db_profile_template.py
@@ -21,9 +21,7 @@ console = get_migration_console()
 
 
 class Migration045(Migration044):
-    """
-    Backfill `human_friendly_id` and `display_label` attributes for profile and template nodes with schemas that define them.
-    """
+    """Backfill `human_friendly_id` and `display_label` attributes for profile and template nodes with schemas that define them."""
 
     name: str = "045_backfill_hfid_display_label_in_db_profile_template"
     minimum_version: int = 44

--- a/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
+++ b/backend/infrahub/core/migrations/graph/m046_fill_agnostic_hfid_display_labels.py
@@ -48,8 +48,7 @@ CALL (attr) {
 
 
 class Migration046(ArbitraryMigration):
-    """
-    Delete any branch-aware human_friendly_id and display_label attributes added to branch-agnostic nodes
+    """Delete any branch-aware human_friendly_id and display_label attributes added to branch-agnostic nodes
     Add human_friendly_id and display_label attributes to branch-agnostic nodes
     Set human_friendly_id and display_label attributes for branch-agnostic nodes on global branch
 

--- a/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
+++ b/backend/infrahub/core/migrations/graph/m047_backfill_or_null_display_label.py
@@ -232,8 +232,7 @@ CREATE (a)-[:IS_VISIBLE { branch: $branch, branch_level: $branch_level, status: 
 
 
 class Migration047(MigrationRequiringRebase):
-    """
-    Backfill `display_label` attributes for all nodes:
+    """Backfill `display_label` attributes for all nodes:
     - If schema does not define display_label OR attribute doesn't exist: insert NULL value
     - If schema defines display_label: compute and store the value, invalidate NULL value if exists
     """

--- a/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
+++ b/backend/infrahub/core/migrations/graph/m048_undelete_rel_props.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
 
 
 class UndeleteRelationshipProperties(Query):
-    """
-    Find Relationship vertices that are missing IS_VISIBLE and/or IS_PROTECTED edges linking them to Boolean vertices
+    """Find Relationship vertices that are missing IS_VISIBLE and/or IS_PROTECTED edges linking them to Boolean vertices
 
     Use the existing IS_RELATED edges to determine when the IS_VISIBLE/IS_PROTECTED edges should exist on each branch
     and add the missing edges
@@ -131,8 +130,7 @@ CALL (rel, latest_deleted_edge, has_protected) {
 
 
 class Migration048(ArbitraryMigration):
-    """
-    Fix Relationship vertices that are missing IS_VISIBLE and/or IS_PROTECTED edges.
+    """Fix Relationship vertices that are missing IS_VISIBLE and/or IS_PROTECTED edges.
 
     This can happen due to a bug in Migration041 that deleted these edges incorrectly.
     """

--- a/backend/infrahub/core/migrations/graph/m052_fix_global_branch_level.py
+++ b/backend/infrahub/core/migrations/graph/m052_fix_global_branch_level.py
@@ -32,8 +32,7 @@ class FixGlobalBranchLevelQuery(Query):
 
 
 class Migration052(GraphMigration):
-    """
-    Fix edges on the global branch that have incorrect branch_level.
+    """Fix edges on the global branch that have incorrect branch_level.
 
     Edges on the global branch ("-global-") should always have branch_level = 1.
     This migration corrects any edges that were incorrectly created with a different

--- a/backend/infrahub/core/migrations/graph/m053_fix_branch_level_zero.py
+++ b/backend/infrahub/core/migrations/graph/m053_fix_branch_level_zero.py
@@ -41,8 +41,7 @@ class FixBranchLevelZeroQuery(Query):
 
 
 class Migration053(GraphMigration):
-    """
-    Fix edges with branch_level=0 to have the correct branch_level.
+    """Fix edges with branch_level=0 to have the correct branch_level.
 
     Edges with branch_level=0 indicate a bug where the branch level was not
     properly set during creation. This migration fixes them:

--- a/backend/infrahub/core/migrations/graph/m054_cleanup_orphaned_nodes.py
+++ b/backend/infrahub/core/migrations/graph/m054_cleanup_orphaned_nodes.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
 
 
 class CleanupOrphanedNodesQuery(Query):
-    """
-    Clean up orphaned Node vertices (no IS_PART_OF edge to Root) and their linked
+    """Clean up orphaned Node vertices (no IS_PART_OF edge to Root) and their linked
     Attributes and Relationships.
     """
 
@@ -63,8 +62,7 @@ CALL (n) {
 
 
 class Migration054(GraphMigration):
-    """
-    Clean up orphaned Node vertices that have no IS_PART_OF edge to Root.
+    """Clean up orphaned Node vertices that have no IS_PART_OF edge to Root.
 
     This can happen when a branch-aware node is deleted during branch deletion,
     but its branch-agnostic attributes or relationships are not properly cleaned up.

--- a/backend/infrahub/core/migrations/graph/m061_link_proposed_changes_to_diff_roots.py
+++ b/backend/infrahub/core/migrations/graph/m061_link_proposed_changes_to_diff_roots.py
@@ -12,8 +12,7 @@ if TYPE_CHECKING:
 
 
 class LinkOpenProposedChangesToDiffRootsQuery(Query):
-    """
-    Link open proposed changes to their DiffRoots.
+    """Link open proposed changes to their DiffRoots.
 
     For open PCs, find DiffRoots where:
     - diff_branch matches the PC's source_branch
@@ -72,8 +71,7 @@ class LinkOpenProposedChangesToDiffRootsQuery(Query):
 
 
 class LinkMergedProposedChangesToDiffRootsQuery(Query):
-    """
-    Link merged proposed changes to their DiffRoots.
+    """Link merged proposed changes to their DiffRoots.
 
     For merged PCs, find DiffRoots where:
     - diff_branch matches the PC's source_branch

--- a/backend/infrahub/core/migrations/graph/m066_consolidate_duplicate_number_pools.py
+++ b/backend/infrahub/core/migrations/graph/m066_consolidate_duplicate_number_pools.py
@@ -204,6 +204,7 @@ class Migration066(ArbitraryMigration):
 
         Args:
             pool_id_map: Mapping of {duplicate_uuid: survivor_uuid} for all pools to replace.
+
         """
         query = """
         // -------------------------------------------

--- a/backend/infrahub/core/migrations/graph/m070_normalize_mac_address_values_to_colon.py
+++ b/backend/infrahub/core/migrations/graph/m070_normalize_mac_address_values_to_colon.py
@@ -101,7 +101,8 @@ def _collect_plans(schema_branch: SchemaBranch, branch_filter: tuple[BranchSuppo
 
 class Migration070(MigrationRequiringRebase):
     """Rewrite stored MacAddress attribute values to colon-uppercase form and recompute hfid/display_label
-    for any schema that depends on a MacAddress attribute."""
+    for any schema that depends on a MacAddress attribute.
+    """
 
     name: str = "070_normalize_mac_address_values_to_colon"
     minimum_version: int = 69

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -21,8 +21,7 @@ class SchemaNodeInfo(BaseModel):
 
 
 class NodeDuplicateQuery(Query):
-    """
-    Duplicates a Node to use a new kind or inheritance.
+    """Duplicates a Node to use a new kind or inheritance.
     Creates a copy of each affected Node and sets the new kind/inheritance.
     Adds duplicate edges to the new Node that match all the active edges on the old Node.
     Sets all the edges on the old Node to deleted.

--- a/backend/infrahub/core/migrations/query/path_details.py
+++ b/backend/infrahub/core/migrations/query/path_details.py
@@ -16,8 +16,7 @@ SCHEMA_KINDS_TO_SKIP: list[str] = ["SchemaNode", "SchemaAttribute", "SchemaRelat
 
 
 class DefaultBranchNodeCount(Query):
-    """
-    Get the number of Node vertices on the given branches that are not in the kinds_to_skip list
+    """Get the number of Node vertices on the given branches that are not in the kinds_to_skip list
     Only works for default and global branches. Non-default branches would only return a count of nodes
     created on the given branches
     """
@@ -60,9 +59,7 @@ WITH count(*) AS num_nodes
 
 class GetResultMapQuery(Query):
     def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str | None]]:
-        """
-        Get the values for the given schema paths for all the Nodes captured by this query
-        """
+        """Get the values for the given schema paths for all the Nodes captured by this query"""
         # the query results for attribute and schema paths are unordered
         # so we make this list of keys for ordering the results from the query
         schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
@@ -289,8 +286,7 @@ WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_attr_
 
 
 class GetPathDetailsDefaultBranch(GetResultMapQuery):
-    """
-    Get the values of the given schema paths for the given kind of node on the default and global branches
+    """Get the values of the given schema paths for the given kind of node on the default and global branches
     Supports limit and offset for pagination
     """
 

--- a/backend/infrahub/core/migrations/query/update_attribute_values.py
+++ b/backend/infrahub/core/migrations/query/update_attribute_values.py
@@ -12,8 +12,7 @@ if TYPE_CHECKING:
 
 
 class UpdateAttributeValuesQuery(Query):
-    """
-    Update the values of the given attribute schema for the input node-id-to-value map.
+    """Update the values of the given attribute schema for the input node-id-to-value map.
 
     This version only expires existing values when they're different from the new value,
     making it safe to run idempotently without clearing correct existing values.

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -17,7 +17,8 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
     def _branch_from_existing(self, existing: str) -> str:
         """Return a Cypher fragment that computes (new_branch, new_branch_level) for a new
         "deleted" edge based on an existing edge variable. Agnostic edges stay on the global
-        branch; all others go on the migration branch."""
+        branch; all others go on the migration branch.
+        """
         return (
             f"CASE WHEN {existing}.branch = $global_branch THEN $global_branch ELSE $branch END AS new_branch, "
             f"CASE WHEN {existing}.branch = $global_branch "

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -76,9 +76,7 @@ class SchemaBranchHash(BaseModel):
 
     @property
     def is_valid(self) -> bool:
-        """
-        TODO: This is a temporary solution to avoid comparing schema hashes if there are less than 2 nodes or generics.
-        """
+        """TODO: This is a temporary solution to avoid comparing schema hashes if there are less than 2 nodes or generics."""
         if len(self.nodes) < 2 and len(self.generics) < 2:
             return False
         return True
@@ -424,7 +422,6 @@ class HashableModel(BaseModel):
         In order for this function to work, it's recommended to exclude all objects or list of objects with _exclude_from_hash
         List of hashable elements are fine and they will be converted automatically to Tuple.
         """
-
         values = []
         md5hash = hashlib.md5(usedforsecurity=False)
         for field_name in sorted(self.__class__.model_fields.keys()):
@@ -525,12 +522,10 @@ class HashableModel(BaseModel):
     def update_list_hashable_model(
         field_name: str, attr_local: list[HashableModel], attr_other: list[HashableModel]
     ) -> list[Any]:
-        """
-        Merging the list is not easy,
+        """Merging the list is not easy,
         we need to create a unique id based on the sorting keys
         and if we have 2 sub items with the same key we can merge them recursively with update()
         """
-
         # Identify all nodes that are sharing a real IDs
         local_sub_real_ids = {item.id for item in attr_local if item.id}
         other_sub_real_ids = {item.id for item in attr_other if item.id}
@@ -579,7 +574,6 @@ class HashableModel(BaseModel):
 
         TODO Implement other fields type like dict
         """
-
         for field_name in other.__class__.model_fields.keys():
             if not hasattr(self, field_name):
                 with contextlib.suppress(ValueError):

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -272,7 +272,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind
-        and the list of Generic this object is inheriting from."""
+        and the list of Generic this object is inheriting from.
+        """
         labels: list[str] = []
         if isinstance(self._schema, NodeSchema):
             labels = [self.get_kind()] + self._schema.inherit_from
@@ -295,6 +296,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         Returns:
             Branch:
+
         """
         if self._schema.branch == BranchSupportType.AGNOSTIC:
             return registry.get_global_branch()
@@ -1067,7 +1069,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         self, db: InfrahubDatabase, user_id: str, at: Timestamp | None = None, fields: list[str] | None = None
     ) -> NodeChangelog:
         """Update the node in the database if needed."""
-
         update_at = Timestamp(at)
         node_changelog = NodeChangelog(node_id=self.get_id(), node_kind=self.get_kind(), display_label="")
 
@@ -1148,7 +1149,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def delete(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None) -> None:
         """Delete the Node in the database."""
-
         delete_at = Timestamp(at)
 
         node_changelog = NodeChangelog(
@@ -1208,8 +1208,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
         Returns:
             (dict): Return GraphQL Payload
-        """
 
+        """
         response: dict[str, Any] = {"id": self.id, KIND_GRAPHQL_FIELD_NAME: self.get_kind()}
 
         if related_node_ids is not None:
@@ -1307,7 +1307,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
 
     async def from_graphql(self, data: dict, db: InfrahubDatabase, process_pools: bool = True) -> bool:
         """Update object from a GraphQL payload."""
-
         changed = False
 
         for key, value in data.items():

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -286,7 +286,6 @@ async def create_node(
     user_id: str = SYSTEM_USER_ID,
 ) -> Node:
     """Create a node in the database if constraint checks succeed."""
-
     if isinstance(schema, GenericSchema):
         raise ValueError(f"Node of generic schema `{schema.name=}` can not be instantiated.")
 

--- a/backend/infrahub/core/node/lock_utils.py
+++ b/backend/infrahub/core/node/lock_utils.py
@@ -15,13 +15,11 @@ RELATIONSHIP_COUNT_LOCK_NAMESPACE = "relationship_count"
 
 
 def _get_kinds_to_lock_on_object_mutation(kind: str, schema_branch: SchemaBranch) -> list[str]:
-    """
-    Return kinds for which we want to lock during creating / updating an object of a given schema node.
+    """Return kinds for which we want to lock during creating / updating an object of a given schema node.
     Lock should be performed on schema kind and its generics having a uniqueness_constraint defined.
     If a generic uniqueness constraint is the same as the node schema one,
     it means node schema overrided this constraint, in which case we only need to lock on the generic.
     """
-
     node_schema = schema_branch.get(name=kind, duplicate=False)
 
     schema_uc = None
@@ -55,12 +53,10 @@ def _hash(value: str) -> str:
 
 
 def get_lock_names_on_object_mutation(node: Node, schema_branch: SchemaBranch) -> list[str]:
-    """
-    Return lock names for object on which we want to avoid concurrent mutation (create/update).
+    """Return lock names for object on which we want to avoid concurrent mutation (create/update).
     Lock names include kind, some generic kinds, resource pool ids, peer ids for cardinality one relationships,
     and values of attributes of corresponding uniqueness constraints.
     """
-
     lock_names: set[str] = set()
 
     # Check if node is using resource manager allocation via attributes

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 class CoreNumberPool(Node):
     def get_attribute_nb_excluded_values(self) -> int:
         """Returns the number of excluded values for the attribute of the number pool."""
-
         pool_node = registry.schema.get(name=self.node.value)  # type: ignore [attr-defined]
         attribute = next(attribute for attribute in pool_node.attributes if attribute.name == self.node_attribute.value)  # type: ignore [attr-defined]
         if not isinstance(attribute.parameters, NumberAttributeParameters):
@@ -46,7 +45,6 @@ class CoreNumberPool(Node):
         branch: Branch,
     ) -> list[int]:
         """Returns a list of used numbers in the pool."""
-
         query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
         await query.execute(db=db)
         used = [result.value for result in query.iter_results()]
@@ -65,8 +63,8 @@ class CoreNumberPool(Node):
 
         Returns:
             The next free number, or None if no free numbers are available.
-        """
 
+        """
         query = await NumberPoolGetFree.init(
             db=db, branch=branch, pool=self, branch_agnostic=True, min_value=min_value, max_value=max_value
         )
@@ -76,7 +74,6 @@ class CoreNumberPool(Node):
 
     async def reserve(self, db: InfrahubDatabase, number: int, identifier: str, at: Timestamp | None = None) -> None:
         """Reserve a number in the pool for a specific identifier."""
-
         query = await NumberPoolSetReserved.init(
             db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at
         )
@@ -122,6 +119,7 @@ class CoreNumberPool(Node):
 
         Raises:
             PoolExhaustedError: If no valid numbers are available in the pool.
+
         """
         parameters = attribute.parameters if isinstance(attribute.parameters, NumberAttributeParameters) else None
 

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -168,7 +168,6 @@ class StandardNode(BaseModel):
 
     async def save(self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID) -> bool:
         """Create or Update the Node in the database."""
-
         if self.id:
             return await self.update(db=db, user_id=user_id)
 
@@ -176,7 +175,6 @@ class StandardNode(BaseModel):
 
     async def delete(self, db: InfrahubDatabase) -> None:
         """Delete the Node in the database."""
-
         query: Query = await StandardNodeDeleteQuery.init(db=db, node=self)
         await query.execute(db=db)
 
@@ -214,7 +212,6 @@ class StandardNode(BaseModel):
     @classmethod
     async def get(cls, id: str, db: InfrahubDatabase) -> Optional[Self]:
         """Get a node from the database identified by its ID."""
-
         node = await cls._get_item_raw(id=id, db=db)
         if node:
             return cls.from_db(node)
@@ -241,8 +238,8 @@ class StandardNode(BaseModel):
 
         Returns:
             StandardNode: Proper StandardNode object
-        """
 
+        """
         attrs = {}
         node_data = dict(node)
         extras = extras or {}

--- a/backend/infrahub/core/property.py
+++ b/backend/infrahub/core/property.py
@@ -131,8 +131,8 @@ class NodePropertyMixin:
         """Set the value of the node_property.
         If the value is a string, we assume it's an ID and we'll save it to query it later (if needed)
         If the value is a Node, we save the node and we extract the ID
-        if the value is None, we just initialize the 2 variables."""
-
+        if the value is None, we just initialize the 2 variables.
+        """
         if isinstance(value, str | UUID):
             setattr(self, f"{name}_id", value)
             setattr(self, f"_{name}", None)
@@ -150,7 +150,6 @@ class NodePropertyMixin:
 
     async def _retrieve_node_property(self, db: InfrahubDatabase, name: str) -> None:
         """Query the node associated with this node_property from the database."""
-
         node = await registry.manager.get_one(db=db, id=getattr(self, f"{name}_id"), branch=self.branch, at=self.at)
         setattr(self, f"_{name}", node)
         if node:

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -37,7 +37,6 @@ def sort_results_by_time(results: list[QueryResult], rel_label: str) -> list[Que
         We are adding more weight (500) to the record for which the last action was to set "from"
          versus a record with "from" and "to" set.
     """
-
     results_dict = {}
 
     for result in results:
@@ -275,7 +274,6 @@ class QueryResult:
 
     def get_rels(self) -> Generator[Neo4jRelationship, None, None]:
         """Return all relationships."""
-
         for item in self.data:
             if isinstance(item, Neo4jRelationship):
                 yield item
@@ -415,7 +413,8 @@ class Query:
 
     def get_context(self) -> dict[str, str]:
         """Provide additional context for this query, beyond the name.
-        Right now it's mainly used to add more labels to the metrics."""
+        Right now it's mainly used to add more labels to the metrics.
+        """
         return {}
 
     @staticmethod
@@ -427,8 +426,8 @@ class Query:
         """Add a new section at the end of the query.
 
         A string with multiple lines will be broken down into multiple entries in self.query_lines
-        Trailing and leading spaces per line will be removed."""
-
+        Trailing and leading spaces per line will be removed.
+        """
         if isinstance(query, list):
             for item in query:
                 self.add_to_query(query=item)
@@ -524,7 +523,6 @@ class Query:
 
         The params string must be executed on its own window in Neo4j, before executing the query.
         """
-
         params = []
 
         for key, value in self.params.items():
@@ -598,7 +596,6 @@ class Query:
         """Count the number of results matching a READ query.
         OFFSET and LIMIT are automatically excluded when counting.
         """
-
         if self.type == QueryType.WRITE:
             raise TypeError("Unable to count the number of response on a Write query.")
         if self.type != QueryType.READ:
@@ -615,7 +612,6 @@ class Query:
 
     def get_result(self) -> QueryResult | None:
         """Return a single Result."""
-
         if not self.has_been_executed:
             return None
 
@@ -629,7 +625,6 @@ class Query:
 
     def get_results(self) -> Generator[QueryResult, None, None]:
         """Get all the results sorted by score."""
-
         score_idx = {}
         for idx, result in enumerate(self.results):
             score_idx[idx] = result.branch_score
@@ -642,8 +637,8 @@ class Query:
 
         Examples:
             get_results_group_by(("n", "uuid"), ("a", "name")):
-        """
 
+        """
         attrs_info = defaultdict(list)
 
         # Extract all attrname and relationships on all branches

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -28,7 +28,6 @@ class DiffQuery(Query):
         **kwargs,
     ) -> None:
         """A diff is always in the context of a branch"""
-
         if not diff_from and branch.is_default:
             raise ValueError("diff_from is mandatory when the diff is on the main branch.")
 

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1089,6 +1089,7 @@ class IPPrefixUtilization(Query):
 
         Returns:
             List of IPPrefixUtilizationResult containing prefix child allocation data.
+
         """
         return [IPPrefixUtilizationResult.from_db(result) for result in self.get_results()]
 
@@ -1543,6 +1544,7 @@ class IPPrefixReconcileQuery(Query):
         Returns:
             IPPrefixReconcileQueryResult containing reconciliation data,
             or None if no results found.
+
         """
         results = list(self.get_results())
         if not results:

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -1473,7 +1473,6 @@ WITH n, r_is_part_of, head(collect(updated_at)) AS updated_at, head(collect(upda
 
     async def get_nodes(self, db: InfrahubDatabase, duplicate: bool = False) -> AsyncIterator[NodeToProcess]:
         """Return all the node objects as NodeToProcess."""
-
         for result in self.get_results():
             raw_labels: list[str] = result.get_as_type(label="node_labels", return_type=list)
             labels = [str(lbl) for lbl in raw_labels]
@@ -2050,6 +2049,7 @@ WITH %(tracked_vars)s,
 
         Returns:
             Tuple of (field_name, operator) like ("created_at", "before"), or None if not a metadata filter.
+
         """
         if not filter_key.startswith(NODE_METADATA_PREFIX):
             return None

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -980,7 +980,6 @@ RETURN updated_at, updated_by
 
     def get_peer_ids(self) -> list[str]:
         """Return a list of UUID of nodes associated with this relationship."""
-
         return [peer.peer_id for peer in self.get_peers()]
 
     def get_peers(self) -> Generator[RelationshipPeerData, None, None]:
@@ -1195,6 +1194,7 @@ class RelationshipCountPerNodeQuery(Query):
 
         Returns:
             List of RelationshipCountPerNodeResult containing peer count info.
+
         """
         return [RelationshipCountPerNodeResult.from_db(result) for result in self.get_results()]
 
@@ -1238,8 +1238,7 @@ class RelationshipDeleteAllQueryResult:
 
 
 class RelationshipDeleteAllQuery(Query):
-    """
-    Delete all relationships linked to a given node on a given branch at a given time. For every IS_RELATED edge:
+    """Delete all relationships linked to a given node on a given branch at a given time. For every IS_RELATED edge:
     - Set `to` time if an active edge exist on the same branch.
     - Create `deleted` edge.
     - Apply above to every edges linked to any connected Relationship node.
@@ -1373,6 +1372,7 @@ class RelationshipDeleteAllQuery(Query):
 
         Returns:
             List of RelationshipDeleteAllQueryResult containing deleted relationship info.
+
         """
         return [RelationshipDeleteAllQueryResult.from_db(result) for result in self.get_results()]
 
@@ -1419,9 +1419,7 @@ class RelationshipDeleteAllQuery(Query):
 
 
 class GetAllPeersIds(Query):
-    """
-    Return all peers ids connected to input node. Some peers can be excluded using `exclude_identifiers`.
-    """
+    """Return all peers ids connected to input node. Some peers can be excluded using `exclude_identifiers`."""
 
     name = "get_peers_ids"
     type: QueryType = QueryType.READ

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -102,6 +102,7 @@ class IPAddressPoolGetIdentifiers(Query):
 
         Returns:
             List of PoolIdentifierResult containing allocation and identifier data.
+
         """
         return [PoolIdentifierResult.from_db(result) for result in self.get_results()]
 
@@ -240,6 +241,7 @@ class NumberPoolGetAllocated(Query):
 
         Returns:
             List of NumberPoolAllocatedResult containing allocated number info.
+
         """
         return [
             NumberPoolAllocatedResult(
@@ -301,6 +303,7 @@ class NumberPoolGetReserved(Query):
 
         Returns:
             The reserved integer value, or None if no reservation exists.
+
         """
         result = self.get_result()
         if result:
@@ -312,6 +315,7 @@ class NumberPoolGetReserved(Query):
 
         Returns:
             List of NumberPoolIdentifierData containing value and identifier.
+
         """
         return [
             NumberPoolIdentifierData(
@@ -326,6 +330,7 @@ class NumberPoolGetReserved(Query):
 
         Yields:
             NumberPoolIdentifierData for each reservation.
+
         """
         yield from self.get_data()
 
@@ -448,6 +453,7 @@ class NumberPoolGetUsed(Query):
 
         Yields:
             NumberPoolIdentifierData for each used value in the pool.
+
         """
         for result in self.get_results():
             yield NumberPoolIdentifierData(
@@ -536,6 +542,7 @@ class NumberPoolGetFree(Query):
 
         Returns:
             The free number if found, None if pool is exhausted in queried range.
+
         """
         result_data = self.get_free_data()
         if result_data is None:
@@ -626,6 +633,7 @@ class PrefixPoolGetIdentifiers(Query):
 
         Returns:
             List of PoolIdentifierResult containing allocation and identifier data.
+
         """
         return [PoolIdentifierResult.from_db(result) for result in self.get_results()]
 

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -146,8 +146,8 @@ class Registry:
 
         Returns:
             Branch: A Branch Object
-        """
 
+        """
         if branch and not isinstance(branch, str):
             return branch
 
@@ -184,8 +184,8 @@ class Registry:
 
         Returns:
             Branch: A Branch Object
-        """
 
+        """
         if branch and not isinstance(branch, str):
             return branch
 

--- a/backend/infrahub/core/relationship/constraints/interface.py
+++ b/backend/infrahub/core/relationship/constraints/interface.py
@@ -12,5 +12,6 @@ class RelationshipManagerConstraintInterface(ABC):
 
     def expand_filters(self, field_filters: list[str], node_schema: MainSchemaTypes) -> list[str]:  # noqa: ARG002
         """Expand field_filters to include additional relationships this constraint needs checked. Override in
-        subclasses that need cross-field validation."""
+        subclasses that need cross-field validation.
+        """
         return field_filters

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -155,7 +155,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
     def __hash__(self) -> int:
         """Generate a hash based on the Peer and the properties."""
-
         values = [self.id, self.db_id, self.peer_id]
         for prop_name in self._flag_properties:
             values.append(getattr(self, prop_name))
@@ -191,6 +190,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         Returns:
             Branch:
+
         """
         if self.schema.branch == BranchSupportType.AGNOSTIC:
             return registry.get_global_branch()
@@ -416,7 +416,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
     async def _create(self, db: InfrahubDatabase, user_id: str, at: Timestamp | None = None) -> None:
         """Add a relationship with another object by creating a new relationship node."""
-
         create_at = Timestamp(at)
         self._set_created_by(value=user_id)
         self._set_created_at(value=create_at)
@@ -449,7 +448,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         at: Timestamp | None = None,
     ) -> None:
         """Update the properties of an existing relationship."""
-
         update_at = Timestamp(at)
         branch = self.get_branch_based_on_support_type()
 
@@ -529,7 +527,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         user_id: str = SYSTEM_USER_ID,
     ) -> None:
         """Resolve the peer of the relationship."""
-
         fields = fields or []
         query_fields = dict.fromkeys(fields)
         if "display_label" not in query_fields:
@@ -599,7 +596,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
     async def save(self, db: InfrahubDatabase, at: Timestamp | None = None, user_id: str = SYSTEM_USER_ID) -> Self:
         """Create or Update the Relationship in the database."""
-
         save_at = Timestamp(at)
 
         if not self.id:
@@ -610,7 +606,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
     async def to_graphql(self, fields: dict | None, db: InfrahubDatabase, related_node_ids: set | None = None) -> dict:
         """Generate GraphQL Payload for the associated Peer."""
-
         if not fields:
             peer_fields, rel_fields = {}, {}
         else:
@@ -691,6 +686,7 @@ class RelationshipValidatorList:
 
     Raises:
         ValidationError: If the number of relationships is not within the min and max count.
+
     """
 
     def __init__(
@@ -704,6 +700,7 @@ class RelationshipValidatorList:
 
         Raises:
             ValidationError: The number of relationships is not within the min and max count.
+
         """
         if max_count is not None and min_count is not None and max_count < min_count:
             raise ValidationError({"msg": "max_count must be greater than min_count"})
@@ -1069,6 +1066,7 @@ class RelationshipManager:
 
         Returns:
             Branch:
+
         """
         if self.schema.branch == BranchSupportType.AGNOSTIC:
             return registry.get_global_branch()
@@ -1135,7 +1133,6 @@ class RelationshipManager:
         force_refresh: bool = True,
     ) -> None:
         """Fetch the latest relationships from the database and update the local cache."""
-
         details = await self.fetch_relationship_ids(
             at=at, db=db, branch_agnostic=branch_agnostic, force_refresh=force_refresh
         )
@@ -1319,7 +1316,6 @@ class RelationshipManager:
         db: InfrahubDatabase,
     ) -> bool:
         """Remove a peer id from the local relationships list"""
-
         for idx, rel in enumerate(await self.get_relationships(db=db)):
             if str(rel.peer_id) != str(peer_id):
                 continue
@@ -1368,7 +1364,6 @@ class RelationshipManager:
         self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None
     ) -> RelationshipCardinalityManyChangelog | RelationshipCardinalityOneChangelog:
         """Create or Update the Relationship in the database."""
-
         await self.resolve(db=db, user_id=user_id)
         branch_agnostic = self.schema.branch is BranchSupportType.AGNOSTIC
 
@@ -1416,7 +1411,6 @@ class RelationshipManager:
         self, db: InfrahubDatabase, at: Timestamp | None = None
     ) -> RelationshipCardinalityManyChangelog | RelationshipCardinalityOneChangelog:
         """Delete all the relationships."""
-
         delete_at = Timestamp(at)
         relationship_mapper = ChangelogRelationshipMapper(schema=self.schema)
 

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -72,7 +72,6 @@ class SchemaRoot(BaseModel):
     @classmethod
     def has_schema(cls, values: dict[str, Any], name: str) -> bool:
         """Check if a schema exist locally as a node or as a generic."""
-
         available_schemas = [item.kind for item in values.get("nodes", []) + values.get("generics", [])]
         if name not in available_schemas:
             return False
@@ -81,7 +80,6 @@ class SchemaRoot(BaseModel):
 
     def get(self, name: str) -> NodeSchema | GenericSchema:
         """Check if a schema exist locally as a node or as a generic."""
-
         for item in self.nodes + self.generics:
             if item.kind == name:
                 return item
@@ -155,7 +153,8 @@ class SchemaRoot(BaseModel):
 
     def generate_uuid(self) -> None:
         """Generate UUID for all nodes, attributes & relationships
-        Mainly useful during unit tests."""
+        Mainly useful during unit tests.
+        """
         for node in self.nodes + self.generics:
             if not node.id:
                 node.id = str(uuid.uuid4())

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -34,6 +34,7 @@ class AttributeParameters(HashableModel):
 
         Returns:
             A new instance of the target class with compatible fields populated
+
         """
         source_data = source.model_dump()
         return cls.convert_from_dict(source_data=source_data)
@@ -47,6 +48,7 @@ class AttributeParameters(HashableModel):
 
         Returns:
             A new instance of the target class with compatible fields populated
+
         """
         target_fields = set(cls.model_fields.keys())
         filtered_data = {k: v for k, v in source_data.items() if k in target_fields}
@@ -205,7 +207,5 @@ class NumberPoolParameters(AttributeParameters):
         return self
 
     def get_pool_size(self) -> int:
-        """
-        Returns the size of the pool based on the defined ranges.
-        """
+        """Returns the size of the pool based on the defined ranges."""
         return self.end_range - self.start_range + 1

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -42,10 +42,9 @@ OPTIONAL_TEXT_FIELDS = [
 
 
 def _json_schema_extra(schema: JsonDict) -> None:
-    """
-    Mutate the generated JSON Schema in place to:
-      - allow `null` for `display_labels`
-      - mark the non-null branch as deprecated
+    """Mutate the generated JSON Schema in place to:
+    - allow `null` for `display_labels`
+    - mark the non-null branch as deprecated
     """
     props = schema.get("properties")
     if not isinstance(props, dict):
@@ -132,7 +131,8 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
     def __hash__(self) -> int:
         """Return a hash of the object.
-        Be careful hash generated from hash() have a salt by default and they will not be the same across run"""
+        Be careful hash generated from hash() have a salt by default and they will not be the same across run
+        """
         return hash(self.get_hash())
 
     @field_validator("attributes", mode="before")
@@ -180,7 +180,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
     def get_hash(self, display_values: bool = False) -> str:
         """Extend the Hash Calculation to account for attributes and relationships."""
-
         md5hash = hashlib.md5(usedforsecurity=False)
         md5hash.update(super().get_hash(display_values=display_values).encode())
 
@@ -194,7 +193,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
     def diff(self, other: Self) -> HashableModelDiff:
         """Extend the Diff Calculation to account for attributes and relationships."""
-
         node_diff = super().diff(other=other)
 
         # Attribute
@@ -466,7 +464,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
         If display_labels is not defined, we return None which equal to everything.
         """
-
         if not self.display_labels:
             return None
 
@@ -481,7 +478,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
         If display_labels is not defined, we return None which equal to everything.
         """
-
         if not self.human_friendly_id:
             return None
 
@@ -601,8 +597,7 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
     def _update_schema_paths(
         self, schema_paths_list: list[str], field_name_update_map: dict[str, str], deleted_field_names: set[str]
     ) -> list[str]:
-        """
-        For each schema_path (eg name__value, device__name_value), update the field name if the current name is
+        """For each schema_path (eg name__value, device__name_value), update the field name if the current name is
         in field_name_update_map, remove the path if the field name is in deleted_field_names
         """
         updated_element_list = []

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -222,7 +222,6 @@ class SchemaManager(NodeManager):
 
     def register_schema(self, schema: SchemaRoot, branch: str | None = None) -> SchemaBranch:
         """Register all nodes, generics & groups from a SchemaRoot object into the registry."""
-
         branch = branch or registry.default_branch
         schema_branch = self.get_schema_branch(name=branch)
         schema_branch.load_schema(schema=schema)
@@ -239,7 +238,6 @@ class SchemaManager(NodeManager):
         branch: Branch | str | None = None,
     ) -> SchemaBranchDiff:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
-
         branch = await registry.get_branch(branch=branch, db=db)
 
         added_nodes = []
@@ -772,8 +770,8 @@ class SchemaManager(NodeManager):
 
         Returns:
             SchemaBranch
-        """
 
+        """
         branch = await registry.get_branch(branch=branch, db=db)
         schema = schema or SchemaBranch(cache=self._cache, name=branch.name)
 
@@ -882,7 +880,6 @@ class SchemaManager(NodeManager):
 
     def purge_inactive_branches(self, active_branches: list[str]) -> list[str]:
         """Return non active branches that were purged."""
-
         hashes_to_keep: set[str] = set()
         branch_processed: set[str] = set()
         for active_branch in active_branches:

--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -104,8 +104,8 @@ class NodeSchema(GeneratedNodeSchema):
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind
-        and the list of Generic this object is inheriting from."""
-
+        and the list of Generic this object is inheriting from.
+        """
         labels: list[str] = [self.kind] + self.inherit_from
         if self.namespace not in ["Schema", "Internal"] and InfrahubKind.GENERICGROUP not in self.inherit_from:
             labels.append(InfrahubKind.NODE)

--- a/backend/infrahub/core/schema/profile_schema.py
+++ b/backend/infrahub/core/schema/profile_schema.py
@@ -38,8 +38,8 @@ class ProfileSchema(BaseNodeSchema):
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind
-        and the list of Generic this object is inheriting from."""
-
+        and the list of Generic this object is inheriting from.
+        """
         labels: list[str] = [self.kind] + self.inherit_from
         if self.namespace not in ["Schema", "Internal"] and InfrahubKind.GENERICGROUP not in self.inherit_from:
             labels.append(InfrahubKind.PROFILE)

--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -69,7 +69,6 @@ class RelationshipSchema(GeneratedRelationshipSchema):
 
     def get_query_arrows(self) -> QueryArrows:
         """Return (in 4 parts) the 2 arrows for the relationship R1 and R2 based on the direction of the relationship."""
-
         if self.direction == RelationshipDirection.OUTBOUND:
             return QueryArrows(left=QueryArrowOutband(), right=QueryArrowOutband())
         if self.direction == RelationshipDirection.INBOUND:
@@ -97,7 +96,6 @@ class RelationshipSchema(GeneratedRelationshipSchema):
         partial_match: bool = False,
     ) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
         """Generate Query String Snippet to filter the right node."""
-
         query_filter: list[QueryElement] = []
         query_params: dict[str, Any] = {}
         query_where: list[str] = []

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -267,7 +267,6 @@ class SchemaBranch:
 
     def update(self, schema: SchemaBranch) -> None:
         """Update another SchemaBranch into this one."""
-
         local_kinds = self.all_names
         other_kinds = schema.all_names
 
@@ -353,7 +352,6 @@ class SchemaBranch:
 
         If duplicate is set to false, the real object will be returned.
         """
-
         key = None
         if name in self.nodes:
             key = self.nodes[name]
@@ -472,7 +470,6 @@ class SchemaBranch:
 
     def get_all(self, include_internal: bool = False, duplicate: bool = True) -> dict[str, MainSchemaTypes]:
         """Retrieve everything in a single dictionary."""
-
         return {
             name: self.get(name=name, duplicate=duplicate)
             for name in self.all_names
@@ -576,6 +573,7 @@ class SchemaBranch:
         Args:
             schema: If provided, reconcile incoming schema data before merging.
                    If None, reconcile already-loaded schemas (e.g., from database).
+
         """
         if schema:
             # Incoming schema: modify in place
@@ -1021,9 +1019,7 @@ class SchemaBranch:
     def _is_attr_combination_unique(
         self, attrs_paths: list[str], uniqueness_constraints: list[list[str]] | None, unique_attribute_names: list[str]
     ) -> bool:
-        """
-        Return whether at least one combination of any length of `attrs_paths` is unique
-        """
+        """Return whether at least one combination of any length of `attrs_paths` is unique"""
         if unique_attribute_names:
             for attr_path in attrs_paths:
                 for unique_attr_name in unique_attribute_names:
@@ -1191,7 +1187,8 @@ class SchemaBranch:
 
     def validate_restricted_namespaces_from_generic(self) -> None:
         """Ensure that every node which inherit from a generic node containing restricted namespaces are following on
-        the rules"""
+        the rules
+        """
         for name in self.nodes:
             node = self.get_node(name=name, duplicate=False)
 
@@ -1647,8 +1644,7 @@ class SchemaBranch:
                 self.set(name=schema_to_update.kind, schema=schema_to_update)
 
     def process_human_friendly_id(self, kinds: list[str] | None = None, raise_parsing_errors: bool = True) -> None:
-        """
-        For each schema node, if there is no HFID defined, set it with:
+        """For each schema node, if there is no HFID defined, set it with:
         - The first unique attribute if existing
         - Otherwise the first uniqueness constraint with a single attribute
 
@@ -1734,7 +1730,6 @@ class SchemaBranch:
 
         Register the HFIDs after all processing and validation has been done.
         """
-
         self.hfids = HFIDs()
         for name in self.generic_names_without_templates + self.node_names:
             node_schema = self.get(name=name, duplicate=False)
@@ -1814,7 +1809,6 @@ class SchemaBranch:
         """Extend all the nodes with the attributes and relationships
         from the Interface objects defined in inherited_from.
         """
-
         generics_used_by = defaultdict(list)
         node_inheritance_handler = NodeInheritanceHandler()
 
@@ -1878,7 +1872,6 @@ class SchemaBranch:
 
         if either node on a relationship support branch, the relationship must be branch aware.
         """
-
         for name in self.all_names:
             node = self.get(name=name, duplicate=False)
 
@@ -1945,7 +1938,6 @@ class SchemaBranch:
 
     def process_cardinality_counts(self) -> None:
         """Ensure that all relationships with a cardinality of ONE have a min_count and max_count of 1."""
-
         for name in self.all_names:
             node = self.get(name=name, duplicate=False)
 
@@ -2594,6 +2586,7 @@ class SchemaBranch:
 
         Returns:
             A RelationshipSchema for the resource pool relationship, or None if not applicable
+
         """
         if attr.kind != "Number" or not attr.support_templates:
             return None
@@ -2628,6 +2621,7 @@ class SchemaBranch:
 
         Returns:
             A RelationshipSchema for the resource pool relationship, or None if not applicable
+
         """
         peer_schema = self.get(name=relationship.peer, duplicate=False)
         if not isinstance(peer_schema, NodeSchema | GenericSchema):

--- a/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
+++ b/backend/infrahub/core/schema/schema_branch_computed/jinja2.py
@@ -56,7 +56,8 @@ class ComputedAttributeTriggerNode(BaseModel):
 
 class RelationshipDependency(BaseModel):
     """Groups the two facets of a relationship-based computed attribute dependency:
-    the targets to recompute and the peer attributes needed for template rendering."""
+    the targets to recompute and the peer attributes needed for template rendering.
+    """
 
     targets: list[ComputedAttributeTarget] = Field(default_factory=list)
     peer_attributes: set[str] = Field(default_factory=set)
@@ -108,6 +109,7 @@ class RegisteredNodeComputedAttribute(BaseModel):
         Returns:
             Deduplicated list of ResolvedComputedTarget, each pairing a target with the
             query filters needed to locate affected nodes.
+
         """
         resolved: dict[str, ResolvedComputedTarget] = {}
         for attribute, entries in self.local_fields.items():
@@ -242,6 +244,7 @@ class Jinja2ComputedRegistry:
 
         Returns:
             None
+
         """
         # Determine the trigger key: for local attributes it's the node itself,
         # for relationship attributes it's the peer kind.
@@ -283,6 +286,7 @@ class Jinja2ComputedRegistry:
             List of ResolvedComputedTarget entries, each pairing a (kind, attribute) identity with the
             query filters needed to locate affected nodes. The target kind can differ from the input
             kind when the dependency crosses a relationship.
+
         """
         if mapping := self._map.get(kind):
             return mapping.get_targets(updates=updates, trigger_kind=kind)

--- a/backend/infrahub/core/schema/schema_branch_display.py
+++ b/backend/infrahub/core/schema/schema_branch_display.py
@@ -69,7 +69,6 @@ class DisplayLabels:
 
     def register_template_schema_path(self, kind: str, schema_path: SchemaAttributePath, template: str) -> None:
         """Register Jinja2 template based display labels using the schema path of each impacted variable in the node."""
-
         if kind not in self._template_based_display_labels:
             self._template_based_display_labels[kind] = TemplateLabel(template=template)
 

--- a/backend/infrahub/core/schema/template_schema.py
+++ b/backend/infrahub/core/schema/template_schema.py
@@ -37,7 +37,6 @@ class TemplateSchema(BaseNodeSchema):
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind and the list of Generic this object is inheriting from."""
-
         labels: list[str] = [self.kind] + self.inherit_from
         if self.namespace not in ["Schema", "Internal"] and InfrahubKind.GENERICGROUP not in self.inherit_from:
             labels.append(InfrahubKind.OBJECTTEMPLATE)

--- a/backend/infrahub/core/schema/update_coordinator.py
+++ b/backend/infrahub/core/schema/update_coordinator.py
@@ -66,6 +66,7 @@ class SchemaUpdateCoordinator:
             context: Infrahub context (required for WORKFLOW executor)
             migration_executor: How to execute migrations (DIRECT or WORKFLOW)
             logger: Logger to use (defaults to module logger)
+
         """
         self.db = db
         self.branch = branch
@@ -166,8 +167,8 @@ class SchemaUpdateCoordinator:
         Raises:
             MigrationError: If migrations fail and rollback completes
             Exception: Original exception if migrations fail via exception
-        """
 
+        """
         # Step 1: Update schema in DB and/or registry
         updated_hash: str | None = None
         if update_db or update_registry:
@@ -227,8 +228,10 @@ class SchemaUpdateCoordinator:
             limit: Limit to specific schema items
             update_db: If True, update DB via update_schema_branch.
             update_registry: If True, update registry via set_schema_branch.
+
         Returns:
             The updated schema hash
+
         """
         if update_db:
             await self.schema_manager.update_schema_branch(
@@ -301,7 +304,6 @@ class SchemaUpdateCoordinator:
         apply_migration_data: SchemaApplyMigrationData,
     ) -> tuple[list[str], Exception | None]:
         """Execute migrations directly (for branch tasks)."""
-
         error_msgs: list[str] = []
         exception: Exception | None = None
 

--- a/backend/infrahub/core/timestamp.py
+++ b/backend/infrahub/core/timestamp.py
@@ -13,12 +13,10 @@ class Timestamp(BaseTimestamp):
         return self.to_datetime()
 
     def get_query_filter_path(self, rel_name: str = "r") -> tuple[str, dict]:
-        """
-        Generate a CYPHER Query filter based on a path to query a part of the graph at a specific time on all branches.
+        """Generate a CYPHER Query filter based on a path to query a part of the graph at a specific time on all branches.
 
         There is a currently an assumption that the relationship in the path will be named 'r'
         """
-
         params = {"at": self.to_string()}
 
         filters = [

--- a/backend/infrahub/core/utils.py
+++ b/backend/infrahub/core/utils.py
@@ -71,7 +71,6 @@ async def get_paths_between_nodes(
     print_query: bool = False,
 ) -> list[Record]:
     """Return all paths between 2 nodes."""
-
     length_limit = f"..{max_length}" if max_length else ""
 
     relationships_str = ""
@@ -97,7 +96,6 @@ async def get_paths_between_nodes(
 
 async def count_relationships(db: InfrahubDatabase, label: str | None = None) -> int:
     """Return the total number of relationships in the database."""
-
     label_str = f":{label}" if label else ""
 
     query = f"""
@@ -123,7 +121,6 @@ async def get_nodes(db: InfrahubDatabase, label: str) -> list[Neo4jNode]:
 
 async def count_nodes(db: InfrahubDatabase, label: str | None = None) -> int:
     """Return the total number of nodes of a given label in the database."""
-
     label_str = f":{label}" if label else ""
 
     query = f"""

--- a/backend/infrahub/core/validators/checks_runner.py
+++ b/backend/infrahub/core/validators/checks_runner.py
@@ -17,12 +17,10 @@ async def run_checks_and_update_validator(
     event_service: InfrahubEventService,
     proposed_change_id: str,
 ) -> None:
-    """
-    Execute a list of checks coroutines, and set validator fields accordingly.
+    """Execute a list of checks coroutines, and set validator fields accordingly.
     Tasks are retrieved by completion order so as soon as we detect a failing check,
     we set validator conclusion to failure.
     """
-
     # First set validator to in progress, then wait for results
     validator.state.value = ValidatorState.IN_PROGRESS.value
     validator.started_at.value = Timestamp().to_string()

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -187,11 +187,9 @@ class InfrahubDatabase:
         return False
 
     def get_context(self) -> dict[str, Any]:
-        """
-        This method is meant to be overridden by subclasses in order to fill in subclass attributes
+        """This method is meant to be overridden by subclasses in order to fill in subclass attributes
         to methods returning a copy of this object using self.__class__ constructor.
         """
-
         return {}
 
     def add_schema(self, schema: SchemaBranch, name: str | None = None) -> None:
@@ -461,8 +459,8 @@ async def validate_database(
         database_name (str): Name of the database in Neo4j
         retry (int, optional): Number of retry before raising an exception. Defaults to 0.
         retry_interval (int, optional): Time between retries in second. Defaults to 1.
-    """
 
+    """
     try:
         session = driver.session(database=database_name)
         await session.run("SHOW TRANSACTIONS")

--- a/backend/infrahub/database/validation.py
+++ b/backend/infrahub/database/validation.py
@@ -2,8 +2,7 @@ from infrahub.database import InfrahubDatabase
 
 
 async def verify_no_duplicate_relationships(db: InfrahubDatabase) -> None:
-    """
-    Verify that no duplicate active relationships exist at the database level
+    """Verify that no duplicate active relationships exist at the database level
     A duplicate is defined as
     - connecting the same two nodes
     - having the same identifier
@@ -39,9 +38,7 @@ RETURN a.uuid AS node_id1, b.uuid AS node_id2, rel_name, branch, direction, num_
 
 
 async def verify_no_edges_added_after_node_delete(db: InfrahubDatabase) -> None:
-    """
-    Verify that no edges are added to a Node after it is deleted on a given branch
-    """
+    """Verify that no edges are added to a Node after it is deleted on a given branch"""
     query = """
 // ------------
 // find deleted nodes

--- a/backend/infrahub/display_labels/models.py
+++ b/backend/infrahub/display_labels/models.py
@@ -44,10 +44,7 @@ class DisplayLabelTriggerDefinition(TriggerBranchDefinition):
         display_labels: DisplayLabels,
         branches_out_of_scope: list[str] | None = None,
     ) -> list[DisplayLabelTriggerDefinition]:
-        """
-        This function is used to create a trigger definition for a display labels of type Jinja2.
-        """
-
+        """This function is used to create a trigger definition for a display labels of type Jinja2."""
         definitions: list[DisplayLabelTriggerDefinition] = []
 
         for node_kind, template_label in display_labels.get_template_nodes().items():

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -19,8 +19,7 @@ class Error(Exception):
 
 
 class PropagatedFromWorkerError(Error):
-    """
-    Used to re-raise server side an error that happened worker side.
+    """Used to re-raise server side an error that happened worker side.
     Note we might want to improve this so we raise the exact same error that happened worker side.
     """
 

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -94,6 +94,7 @@ def extract_repo_file_information(
 
     Returns:
         RepoFileInformation: Pydantic object to store all information about this file
+
     """
     abs_directory = full_filename.parent.resolve()
     filename = full_filename.name
@@ -140,8 +141,7 @@ class BranchInLocal(BaseModel):
 
 
 class InfrahubRepositoryBase(BaseModel, ABC):
-    """
-    Local version of a Git repository organized to work with Infrahub.
+    """Local version of a Git repository organized to work with Infrahub.
     The idea is that all commits that are being tracked in the graph will be checkout out
     individually as worktree under the <repo_name>/commits subdirectory
 
@@ -276,8 +276,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
         Raises:
             git.exc.InvalidGitRepositoryError if the default directory is not a valid Git repository.
-        """
 
+        """
         if not self.cache_repo:
             self.cache_repo = Repo(self.directory_default)
 
@@ -331,7 +331,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         Returns True if everything is correct
         Raises a RepositoryError exception if something is not correct
         """
-
         directories_to_validate = [
             self.directory_root,
             self.directory_branches,
@@ -379,8 +378,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Ensure the required directory already exist in the filesystem or create them if needed.
 
         Returns
+        -------
             True if the directory has been created,
             False if the directory was already present.
+
         """
         initialize_repositories_directory()
 
@@ -423,7 +424,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def has_worktree(self, identifier: str) -> bool:
         """Return True if a worktree with a given identifier already exist."""
-
         worktrees = self.get_worktrees()
 
         for worktree in worktrees:
@@ -434,7 +434,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def get_worktree(self, identifier: str) -> Worktree:
         """Access a specific worktree by its identifier."""
-
         worktrees = self.get_worktrees()
         for worktree in worktrees:
             if worktree.identifier == identifier:
@@ -444,7 +443,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def get_commit_worktree(self, commit: str) -> Worktree:
         """Access a specific commit worktree."""
-
         worktrees = self.get_worktrees()
 
         for worktree in worktrees:
@@ -471,7 +469,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Return a dict with all the branches present in the graph.
         Query the list of branches first then query the repository for each branch.
         """
-
         response = {}
 
         branches = await self.sdk.branch.all()
@@ -492,7 +489,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def get_branches_from_remote(self) -> dict[str, BranchInRemote]:
         """Return a dict with all the branches present on the remote."""
-
         git_repo = self.get_git_repo_main()
 
         branches = {}
@@ -512,7 +508,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def get_branches_from_local(self, include_worktree: bool = True) -> dict[str, BranchInLocal]:
         """Return a dict with all the branches present locally."""
-
         git_repo = self.get_git_repo_main()
 
         if include_worktree:
@@ -615,8 +610,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         Returns:
             True if the commit has been updated
             False if they already had the same value
-        """
 
+        """
         infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
         log.debug(
             f"Updating commit value to {commit} for branch {branch_name}", repository=self.name, branch=infrahub_branch
@@ -633,7 +628,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         NOTE We need to validate that we are not gonna end up with a race condition
         since a call to the GraphQL API will trigger a new RPC call to add a branch in this repo.
         """
-
         # TODO need to handle the exception properly
         branch = await self.sdk.branch.create(branch_name=branch_name)
 
@@ -642,7 +636,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     async def create_branch_in_git(self, branch_name: str, branch_id: str | None = None) -> bool:
         """Create new branch in the repository, assuming the branch has been created in the graph already."""
-
         repo = self.get_git_repo_main()
 
         # Check if the branch already exists locally, if it does do nothing
@@ -687,7 +680,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def create_commit_worktree(self, commit: str) -> bool | Worktree:
         """Create a new worktree for a given commit."""
-
         # Check of the worktree already exist
         if self.has_worktree(identifier=commit):
             return False
@@ -720,7 +712,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
     def create_branch_worktree(self, branch_name: str, branch_id: str) -> bool:
         """Create a new worktree for a given branch."""
-
         # Check if the worktree already exist
         if self.has_worktree(identifier=branch_name):
             return False
@@ -742,7 +733,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
           - What has changed inside the files
           - Are there some conflicts between the files.
         """
-
         git_repo = self.get_git_repo_main()
 
         commit_to_compare = git_repo.commit(second_commit)
@@ -823,10 +813,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         return filtered_branches
 
     async def compare_local_remote(self) -> tuple[list[str], list[str]]:
-        """
-        Returns:
-            List[str] New Branches in Remote
-            List[str] Branches with different commit in Remote
+        """Returns:
+        List[str] New Branches in Remote
+        List[str] Branches with different commit in Remote
+
         """
         if not self.has_origin:
             return [], []
@@ -907,7 +897,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         update_commit_value: bool = True,
     ) -> bool | str:
         """Pull the latest update from the remote repository on a given branch."""
-
         if not self.has_origin:
             return False
         identifier = branch_name

--- a/backend/infrahub/git/directory.py
+++ b/backend/infrahub/git/directory.py
@@ -14,9 +14,10 @@ def get_repositories_directory() -> Path:
 def initialize_repositories_directory() -> bool:
     """Check if the main repositories_directory already exist, if not create it.
 
-    Return
+    Return:
         True if the directory has been created,
         False if the directory was already present.
+
     """
     repos_dir = get_repositories_directory()
     if not repos_dir.exists():

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -144,8 +144,7 @@ class TransformPythonInformation(BaseModel):
 
 
 class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
-    """
-    This class provides interfaces to read and process information from .infrahub.yml files and can perform
+    """This class provides interfaces to read and process information from .infrahub.yml files and can perform
     actions for objects defined within those files.
 
     This class will later be broken out from the "InfrahubRepository" based classes and instead be a separate
@@ -457,6 +456,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         Raises:
             RepositoryConfigurationError: If the configuration file is missing,
                 cannot be parsed as YAML, or has an invalid format.
+
         """
         branch_wt = self.get_worktree(identifier=commit or branch_name)
         log = get_run_logger()
@@ -898,7 +898,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         file_type: type[InfrahubFile],
     ) -> None:
         """Load one or multiple objects files into Infrahub."""
-
         log = get_run_logger()
         files = await self._load_yamlfile_from_disk(paths=paths, file_type=file_type)
 
@@ -1136,7 +1135,8 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         cls, check: CheckDefinitionInformation, existing_check: CoreCheckDefinition
     ) -> bool:
         """Compare an existing Python Check Object with a Check Class
-        and identify if we need to update the object in the database."""
+        and identify if we need to update the object in the database.
+        """
         if (
             existing_check.query.id != check.query
             or existing_check.file_path.value != check.file_path

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -24,8 +24,7 @@ log = get_logger()
 
 
 class InfrahubRepository(InfrahubRepositoryIntegrator):
-    """
-    Primary type of Git repository, with deep integration within Infrahub.
+    """Primary type of Git repository, with deep integration within Infrahub.
 
     Eventually we should rename this class InfrahubIntegratedRepository
     """
@@ -55,7 +54,6 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         self, branch_name: str, branch_id: str | None = None, push_origin: bool = True
     ) -> bool:
         """Create new branch in the repository, assuming the branch has been created in the graph already."""
-
         response = await super().create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
         if push_origin:
             await self.push(branch_name)
@@ -67,7 +65,6 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         By default the sync will focus only on the branches pulled from origin that have some differences with the local one.
         """
-
         log.info("Starting the synchronization.", repository=self.name)
 
         await self.fetch()
@@ -143,7 +140,6 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
     async def push(self, branch_name: str) -> bool:
         """Push a given branch to the remote Origin repository"""
-
         if not self.has_origin:
             return False
 
@@ -201,16 +197,13 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         After the rebase we need to resync the data
         """
-
         response = await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
 
         return response
 
 
 class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
-    """
-    Repository with only read-only access to the remote repo
-    """
+    """Repository with only read-only access to the remote repo"""
 
     is_read_only: bool = True
     ref: str | None = Field(None, description="Ref to track on the external repository")
@@ -252,6 +245,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 
         Returns:
             True if synchronization was performed, False if local state was already current.
+
         """
         if not commit:
             commit = self.get_commit_value(branch_name=self.ref, remote=True)

--- a/backend/infrahub/git/utils.py
+++ b/backend/infrahub/git/utils.py
@@ -34,7 +34,6 @@ async def get_repositories_commit_per_branch(
 
     NOTE: At some point, we should refactor this function to use a single Database query instead of one per branch
     """
-
     repositories: dict[str, RepositoryData] = {}
 
     for branch in list(registry.branch.values()):

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -1,6 +1,4 @@
-"""
-This code has been forked from https://github.com/ciscorn/starlette-graphene3 in order to support branch and dynamic schema.
-"""
+"""This code has been forked from https://github.com/ciscorn/starlette-graphene3 in order to support branch and dynamic schema."""
 
 from __future__ import annotations
 

--- a/backend/infrahub/graphql/field_extractor.py
+++ b/backend/infrahub/graphql/field_extractor.py
@@ -32,7 +32,6 @@ class GraphQLFieldExtractor:
 
         In the future we'll probably need to redesign how we read GraphQL queries to generate better Database query.
         """
-
         if not selection_set:
             return None
 

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -333,7 +333,6 @@ class GraphQLSchemaManager:
 
     def generate_object_types(self) -> None:
         """Generate all GraphQL objects for the schema and store them in the internal registry."""
-
         full_schema = self.schema.get_all(duplicate=False)
 
         # Pass 1: Generate all GraphQL Interface objects first (without edged/paginated)
@@ -572,7 +571,6 @@ class GraphQLSchemaManager:
 
     def generate_graphql_object(self, schema: MainSchemaTypes, populate_cache: bool = False) -> InfrahubObjectReference:
         """Generate a GraphQL object Type from a Infrahub NodeSchema."""
-
         interfaces: set[type[InfrahubObject]] = set()
         md5hash = hashlib.md5(usedforsecurity=False)
         md5hash.update(f"{schema.kind}{schema.get_hash()}".encode())
@@ -1004,8 +1002,8 @@ class GraphQLSchemaManager:
 
         Returns:
             dict: A Dictionary containing all the filters with their name as the key and their Type as value
-        """
 
+        """
         filters: dict[str, Any] = {"offset": graphene.Int(), "limit": graphene.Int(), "order": OrderInput()}
         default_filters: list[str] = list(filters.keys())
 
@@ -1077,6 +1075,7 @@ class GraphQLSchemaManager:
 
         Returns:
             dict: Filter definitions with names as keys and graphene types as values
+
         """
         return {
             # Account-based filters (created_by)
@@ -1117,7 +1116,6 @@ class GraphQLSchemaManager:
         populate_cache: bool = False,
     ) -> InfrahubEdgedReference:
         """Generate a edged GraphQL object Type from a Infrahub NodeSchema for pagination."""
-
         object_name = f"Edged{schema.kind}"
         if relation_property:
             object_name = f"NestedEdged{schema.kind}"
@@ -1160,7 +1158,6 @@ class GraphQLSchemaManager:
         self, schema: MainSchemaTypes, edge: InfrahubEdgedReference, nested: bool = False, populate_cache: bool = False
     ) -> type[InfrahubObject]:
         """Generate a paginated GraphQL object Type from a Infrahub NodeSchema."""
-
         object_name = f"Paginated{schema.kind}"
         if nested:
             object_name = f"NestedPaginated{schema.kind}"

--- a/backend/infrahub/graphql/metadata.py
+++ b/backend/infrahub/graphql/metadata.py
@@ -79,6 +79,7 @@ def build_metadata_query_options(
 
     Returns:
         MetadataQueryOptions with appropriate flags set for each level.
+
     """
     node_level = get_metadata_options_from_fields(node_metadata_fields or {})
     relationship_level = get_metadata_options_from_fields(relationship_metadata_fields or {})

--- a/backend/infrahub/graphql/mutations/convert_object_type.py
+++ b/backend/infrahub/graphql/mutations/convert_object_type.py
@@ -39,7 +39,6 @@ class ConvertObjectType(Mutation):
         data: ConvertObjectTypeInput,
     ) -> Self:
         """Convert an input node to a given compatible kind."""
-
         graphql_context: GraphqlContext = info.context
 
         node_to_convert = await NodeManager.get_one(

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -129,6 +129,7 @@ class InfrahubMutationMixin:
 
         Returns:
             `True` if a file was stored, `False` otherwise.
+
         """
         if not file_processor:
             return False
@@ -267,10 +268,7 @@ class InfrahubMutationMixin:
         obj: Node,
         skip_uniqueness_check: bool = False,
     ) -> tuple[Node, Self]:
-        """
-        Wrapper around mutate_update to potentially activate locking and call it within a database transaction.
-        """
-
+        """Wrapper around mutate_update to potentially activate locking and call it within a database transaction."""
         # Prepare a clone to compute locks without triggering pool allocations
         preview_obj = await NodeManager.get_one_by_id_or_default_filter(
             db=db,
@@ -385,13 +383,11 @@ class InfrahubMutationMixin:
         database: InfrahubDatabase | None = None,
         file_processor: FileUploadProcessor | None = None,
     ) -> UpsertResult:
-        """
-        First, check whether payload contains data identifying the node, such as id, hfid, or relevant fields for
+        """First, check whether payload contains data identifying the node, such as id, hfid, or relevant fields for
         default_filter. If not, we will try to create the node, but this creation might fail if payload contains
         hfid fields (not `hfid` field itself) that would match an existing node in the database. In that case,
         we would update the node without rerunning uniqueness constraint.
         """
-
         schema = cls._meta.active_schema
         schema_name = schema.kind
 

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -58,6 +58,7 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
 
         Raises:
             ValidationError: If any relationship data contains from_pool.
+
         """
         schema: ProfileSchema = cls._meta.active_schema  # type: ignore[assignment]
         for rel_schema in schema.relationships:

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -294,11 +294,9 @@ class ProposedChangeReview(Mutation):
         info: GraphQLResolveInfo,
         data: ProposedChangeReviewInput,
     ) -> dict[str, bool]:
-        """
-        This mutation is used to approve or reject a proposed change.
+        """This mutation is used to approve or reject a proposed change.
         It can also be used to undo an approval or rejection.
         """
-
         graphql_context: GraphqlContext = info.context
         graphql_context.active_permissions.raise_for_permission(
             permission=GlobalPermission(
@@ -354,7 +352,6 @@ class ProposedChangeReview(Mutation):
         context: GraphqlContext,
     ) -> InfrahubEvent | None:
         """Modify approved_by and rejected_by relationships of the prpoposed change based on the decision."""
-
         approved_by = await proposed_change.approved_by.get_peers(db=db)
         rejected_by = await proposed_change.rejected_by.get_peers(db=db)
         approved_by_ids = [node.id for _, node in approved_by.items()]

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -32,6 +32,7 @@ def standard_node_ordering_from_order_input(order: OrderInput | None = None) -> 
 
     Raises:
         ValidationError: If both created_at and updated_at are specified.
+
     """
     if order is None or not order.node_metadata:
         return StandardNodeOrdering()

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -304,11 +304,9 @@ async def resolve_number_pool_allocation(
 async def resolve_number_pool_utilization(
     db: InfrahubDatabase, pool: Node, at: Timestamp | str | None, branch: Branch
 ) -> dict:
-    """
-    Returns a mapping containg utilization info of a number pool.
+    """Returns a mapping containg utilization info of a number pool.
     The utilization is calculated as the percentage of the total number of values in the pool that are not excluded for the corresponding attribute.
     """
-
     core_number_pool = await registry.manager.get_one_by_id_or_default_filter(db=db, id=pool.id, kind="CoreNumberPool")
     number_pool = NumberUtilizationGetter(db=db, pool=core_number_pool, at=at, branch=branch)
     await number_pool.load_data()

--- a/backend/infrahub/graphql/queries/search.py
+++ b/backend/infrahub/graphql/queries/search.py
@@ -39,7 +39,6 @@ def _collapse_ipv6(s: str) -> str:
     Raises an error if input does not resemble an IPv6 address in extended format. It means this function also raises
     an error if input string is the start of an IPv6 address in collapsed format.
     """
-
     try:
         return str(ipaddress.IPv6Address(s))
     except ipaddress.AddressValueError:

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -65,7 +65,6 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
         - parent
         - info
     """
-
     parent = None
     info = None
     field_name = None
@@ -141,7 +140,6 @@ async def parent_field_name_resolver(parent: dict[str, dict], info: GraphQLResol
 
     An example of this is the permissions field at the top level within default_paginated_list_resolver()
     """
-
     return parent[info.field_name]
 
 

--- a/backend/infrahub/graphql/schema_sort.py
+++ b/backend/infrahub/graphql/schema_sort.py
@@ -26,6 +26,7 @@ def _sort_arguments(args: tuple[InputValueDefinitionNode, ...] | None) -> list[I
 
     Returns:
         Sorted list of input value definition nodes, or None if input was None.
+
     """
     if not args:
         return None
@@ -40,6 +41,7 @@ def _sort_fields(fields: tuple[FieldDefinitionNode, ...] | None) -> list[FieldDe
 
     Returns:
         Sorted list of field definition nodes with sorted arguments, or None if input was None.
+
     """
     if not fields:
         return None
@@ -67,6 +69,7 @@ def _sort_enum_values(values: tuple[EnumValueDefinitionNode, ...] | None) -> lis
 
     Returns:
         Sorted list of enum value definition nodes, or None if input was None.
+
     """
     if not values:
         return None
@@ -81,6 +84,7 @@ def _sort_input_fields(fields: tuple[InputValueDefinitionNode, ...] | None) -> l
 
     Returns:
         Sorted list of input value definition nodes, or None if input was None.
+
     """
     if not fields:
         return None
@@ -95,6 +99,7 @@ def _sort_interfaces(interfaces: tuple[NamedTypeNode, ...] | None) -> list[Named
 
     Returns:
         Sorted list of named type nodes, or None if input was None.
+
     """
     if not interfaces:
         return None
@@ -115,8 +120,8 @@ def sort_schema_ast(document: DocumentNode) -> DocumentNode:
 
     Returns:
         A new DocumentNode with all elements sorted alphabetically by name.
-    """
 
+    """
     sorted_definitions: list[
         ObjectTypeDefinitionNode
         | InterfaceTypeDefinitionNode

--- a/backend/infrahub/graphql/types/upload.py
+++ b/backend/infrahub/graphql/types/upload.py
@@ -35,6 +35,7 @@ class Upload(Scalar):
 
         Returns:
             A Starlette's `UploadFile` object, or `None` if no file was provided.
+
         """
         return value
 

--- a/backend/infrahub/groups/tasks.py
+++ b/backend/infrahub/groups/tasks.py
@@ -11,7 +11,6 @@ from infrahub.workflows.utils import add_tags
 @flow(name="graphql-query-group-update", flow_run_name="Update GraphQLQuery Group '{model.query_name}'")
 async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate) -> None:
     """Create or Update a GraphQLQueryGroup."""
-
     client = get_client()
 
     # If there is only one subscriber, associate the task to it

--- a/backend/infrahub/hfid/models.py
+++ b/backend/infrahub/hfid/models.py
@@ -44,10 +44,7 @@ class HFIDTriggerDefinition(TriggerBranchDefinition):
         hfids: HFIDs,
         branches_out_of_scope: list[str] | None = None,
     ) -> list[HFIDTriggerDefinition]:
-        """
-        This function is used to create a trigger definition for a display labels of type Jinja2.
-        """
-
+        """This function is used to create a trigger definition for a display labels of type Jinja2."""
         definitions: list[HFIDTriggerDefinition] = []
 
         for node_kind, hfid_definition in hfids.get_template_nodes().items():

--- a/backend/infrahub/patch/edge_adder.py
+++ b/backend/infrahub/patch/edge_adder.py
@@ -46,8 +46,7 @@ RETURN edge_to_add.identifier AS abstract_id, %(id_func_name)s(e) AS db_id
         self,
         edges_to_add: list[EdgeToAdd],
     ) -> AsyncGenerator[dict[str, str], None]:
-        """
-        Create edges_to_add on the database.
+        """Create edges_to_add on the database.
         Returns a generator that yields dictionaries mapping EdgeToAdd.identifier to the database-level ID of the newly created edge.
         """
         edges_map_queue: dict[str, list[EdgeToAdd]] = defaultdict(list)

--- a/backend/infrahub/patch/queries/delete_duplicated_edges.py
+++ b/backend/infrahub/patch/queries/delete_duplicated_edges.py
@@ -3,8 +3,7 @@ from .base import PatchQuery
 
 
 class DeleteDuplicatedEdgesPatchQuery(PatchQuery):
-    """
-    For all Node vertices, find duplicated or overlapping edges of the same status, type, and branch to update and delete
+    """For all Node vertices, find duplicated or overlapping edges of the same status, type, and branch to update and delete
     - one edge will be kept for each pair of nodes and a given status, type, and branch. it will be
         updated to have the earliest "from" and "to" times in this group
     - all the other duplicate/overlapping edges will be deleted

--- a/backend/infrahub/patch/vertex_adder.py
+++ b/backend/infrahub/patch/vertex_adder.py
@@ -42,8 +42,7 @@ RETURN vertex_to_add.identifier AS abstract_id, %(id_func_name)s(v) AS db_id
         return abstract_to_concrete_id_map
 
     async def execute(self, vertices_to_add: list[VertexToAdd]) -> AsyncGenerator[dict[str, str], None]:
-        """
-        Create vertices_to_add on the database.
+        """Create vertices_to_add on the database.
         Returns a generator that yields dictionaries mapping VertexToAdd.identifier to the database-level ID of the newly created vertex.
         """
         vertices_map_queue: dict[frozenset[str], list[VertexToAdd]] = defaultdict(list)

--- a/backend/infrahub/pools/prefix.py
+++ b/backend/infrahub/pools/prefix.py
@@ -21,6 +21,7 @@ def get_next_available_prefix(
 
     Raises:
         ValueError: If there are no available subnets in the pool
+
     """
     prefix_ver_map = {4: ipaddress.IPv4Network, 6: ipaddress.IPv6Network}
 

--- a/backend/infrahub/pools/registration.py
+++ b/backend/infrahub/pools/registration.py
@@ -4,7 +4,6 @@ from infrahub.exceptions import SchemaNotFoundError
 
 def get_branches_with_schema_number_pool(kind: str, attribute_name: str) -> list[str]:
     """Return branches where schema defined NumberPool exists"""
-
     registered_branches = []
     active_branches = registry.schema.get_branches()
 

--- a/backend/infrahub/pools/schema_number_pool_synchronizer.py
+++ b/backend/infrahub/pools/schema_number_pool_synchronizer.py
@@ -35,6 +35,7 @@ class SchemaNumberPoolSynchronizer:
         db: Database connection.
         log: Logger instance.
         schema_manager: Schema manager for looking up schemas.
+
     """
 
     def __init__(
@@ -54,6 +55,7 @@ class SchemaNumberPoolSynchronizer:
 
         Returns:
             Set of branch names where schema changes were persisted.
+
         """
         await self._sync_existing_pools_with_schema(user_id=user_id)
         return await self._process_all_branches(user_id=user_id)
@@ -105,6 +107,7 @@ class SchemaNumberPoolSynchronizer:
 
         Returns:
             Set of branch names where schema changes were persisted.
+
         """
         updated_branches: set[str] = set()
 
@@ -163,6 +166,7 @@ class SchemaNumberPoolSynchronizer:
             user_id: The user ID for any save operations.
 
         Returns a NodeSchema or GenericSchema if the schema was updated.
+
         """
         updated_schema: NodeSchema | GenericSchema | None = None
 

--- a/backend/infrahub/pools/schema_number_pool_upserter.py
+++ b/backend/infrahub/pools/schema_number_pool_upserter.py
@@ -42,6 +42,7 @@ class SchemaNumberPoolUpserter:
     Args:
         db: Database connection.
         schema_manager: Schema manager for looking up schemas.
+
     """
 
     def __init__(
@@ -72,6 +73,7 @@ class SchemaNumberPoolUpserter:
 
         Returns:
             The pool ID if found, None otherwise.
+
         """
         # If pool_id is already set on the attribute, return it
         if isinstance(attribute.parameters, NumberPoolParameters) and attribute.parameters.number_pool_id:
@@ -118,6 +120,7 @@ class SchemaNumberPoolUpserter:
 
         Raises:
             ValueError: If the attribute is not a NumberPool type.
+
         """
         if not isinstance(attribute.parameters, NumberPoolParameters):
             raise ValueError(f"Attribute {attribute.name} on {schema_node.kind} is not a NumberPool type")
@@ -194,6 +197,7 @@ class SchemaNumberPoolUpserter:
         Returns:
             InheritedPoolInfo if the generic is found, None otherwise.
             The pool_id may be None if the generic hasn't been assigned a pool yet.
+
         """
         if not isinstance(node_schema, NodeSchema):
             return None
@@ -244,6 +248,7 @@ class SchemaNumberPoolUpserter:
 
         Raises:
             NodeNotFoundError: If pool not found.
+
         """
         if pool_id in self._cache:
             return self._cache[pool_id]

--- a/backend/infrahub/proposed_change/checker.py
+++ b/backend/infrahub/proposed_change/checker.py
@@ -13,10 +13,7 @@ class ProposedChangeChecker(ABC):
     async def verify_proposed_change_is_mergeable(
         self, proposed_change: Node, db: InfrahubDatabase, account_session: AccountSession
     ) -> None:
-        """
-        Raise an error if proposed change cannot be merged.
-        """
-
+        """Raise an error if proposed change cannot be merged."""
         raise NotImplementedError()
 
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -857,7 +857,6 @@ def _should_render_artifact(
     Will return false if:
         * The artifact_id exists and is not in the impacted list
     """
-
     if not artifact_id or managed_branch:
         return True
 
@@ -1596,7 +1595,6 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
     The edge should be of type CoreArtifactDefinition from the query
     * GATHER_ARTIFACT_DEFINITIONS
     """
-
     parsed = []
     for definition in definitions:
         artifact_definition = ProposedChangeArtifactDefinition(

--- a/backend/infrahub/repositories/create_repository.py
+++ b/backend/infrahub/repositories/create_repository.py
@@ -40,11 +40,9 @@ class RepositoryFinalizer:
         db: InfrahubDatabase,
         delete_on_connectivity_failure: bool = True,
     ) -> None:
-        """
-        Method meant to be called after a repository has been created in the database.
+        """Method meant to be called after a repository has been created in the database.
         It mainly checks the connectivity to the remote repository and submit the workflow to create the repository in the local filesystem.
         """
-
         # If the connectivity is not good, we remove the repository to allow the user to add a new one
         if delete_on_connectivity_failure:
             message = messages.GitRepositoryConnectivity(

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -59,10 +59,7 @@ class InfrahubServices:
         component: InfrahubComponent | None = None,
         log_forwarding: LogForwardingService | None = None,
     ) -> None:
-        """
-        This method should not be called directly, use `new` instead for a proper initialization.
-        """
-
+        """This method should not be called directly, use `new` instead for a proper initialization."""
         self._cache = cache
         self._client = client
         self._database = database
@@ -91,11 +88,9 @@ class InfrahubServices:
         http: InfrahubHTTP | None = None,
         log_forwarding: LogForwardingService | None = None,
     ) -> InfrahubServices:
-        """
-        Instantiate InfrahubServices object, and finalize initializations of underlying services having a circular
+        """Instantiate InfrahubServices object, and finalize initializations of underlying services having a circular
         dependency with InfrahubServices.
         """
-
         component_type = component_type or ComponentType.NONE
 
         scheduler = InfrahubScheduler(component_type)

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -24,7 +24,8 @@ class HttpxAdapter(InfrahubHTTP):
     providers. The main purpose is to have a single location to manage
     configuration and error handling with regards to HTTP traffic and
     allow users to define configurations such as timeout, TLS options
-    and eventually proxy settings in one location."""
+    and eventually proxy settings in one location.
+    """
 
     def __init__(self, tls_registry: TlsContextRegistry) -> None:
         self._tls_registry = tls_registry
@@ -49,6 +50,7 @@ class HttpxAdapter(InfrahubHTTP):
 
         Returns:
             False to disable verification, or an SSLContext for verification.
+
         """
         if verify is False:
             return False

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -40,8 +40,7 @@ AioPikaInstrumentor().instrument()
 
 # TODO: remove this once https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1835 is resolved
 def patch_spanbuilder_set_channel() -> None:
-    """
-    The default SpanBuilder.set_channel does not work with aio_pika 9.1 and the refactored connection
+    """The default SpanBuilder.set_channel does not work with aio_pika 9.1 and the refactored connection
     attribute
     """
 

--- a/backend/infrahub/storage.py
+++ b/backend/infrahub/storage.py
@@ -76,6 +76,7 @@ class InfrahubObjectStorage:
 
         Note:
             Silently ignores if the file does not exist.
+
         """
         if isinstance(self._storage, fastapi_storages.FileSystemStorage):
             (self._storage._path / identifier).unlink(missing_ok=True)

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -264,7 +264,6 @@ class PrefectEventData(PrefectEventModel):
 
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
-
         event_specifics = {}
 
         match self.event:

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -61,8 +61,7 @@ class PrefectTask:
         flow_filter: FlowFilter | None = None,
         flow_run_filter: FlowRunFilter | None = None,
     ) -> int:
-        """
-        Method to count the number of flow runs based on a flow_run_filter.
+        """Method to count the number of flow runs based on a flow_run_filter.
         The format of the body is the same as the one generated in read_flow_runs
         """
         body = {
@@ -117,11 +116,9 @@ class PrefectTask:
     async def _get_logs(
         cls, client: PrefectClient, flow_ids: list[UUID], log_limit: int | None, log_offset: int | None
     ) -> FlowLogs:
-        """
-        Return the logs for a flow run, based on log_limit and log_offset.
+        """Return the logs for a flow run, based on log_limit and log_offset.
         At most, NB_LOGS_LIMIT logs will be returned per flow.
         """
-
         logs_flow = FlowLogs()
 
         log_limit = log_limit if log_limit is not None else NB_LOGS_LIMIT
@@ -349,7 +346,6 @@ class PrefectTask:
         batch_size: int = 100,
     ) -> None:
         """Delete flow runs in the specified states and older than specified days."""
-
         logger = get_logger()
 
         async with get_client(sync_client=False) as client:

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -18,10 +18,7 @@ log = get_logger()
 
 
 def update_graphql_schema(branch: Branch, schema_branch: SchemaBranch) -> None:
-    """
-    Update the GraphQL schema for the given branch.
-    """
-
+    """Update the GraphQL schema for the given branch."""
     gqlm = graphql_registry.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     gqlm.get_graphql_schema(
         include_query=True,
@@ -33,7 +30,6 @@ def update_graphql_schema(branch: Branch, schema_branch: SchemaBranch) -> None:
 
 async def create_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
     """Create a new entry in the registry for a given branch."""
-
     log.info("New branch detected, pulling schema", branch=branch.name, worker=WORKER_IDENTITY)
     await registry.schema.load_schema(db=db, branch=branch)
     registry.branch[branch.name] = branch
@@ -43,7 +39,6 @@ async def create_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
 
 async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
     """Update the registry for a branch if the schema hash has changed or the branch was rebased."""
-
     existing_branch: Branch = registry.branch[branch.name]
 
     if not existing_branch.schema_hash:
@@ -92,7 +87,6 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
     If a branch is already present with a different value for the hash
     We pull the new schema from the database and we update the registry.
     """
-
     async with lock.registry.local_schema_lock():
         active_branches = await registry.branch_object.get_list(db=db)
         for active_branch in active_branches:

--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -72,6 +72,7 @@ class TriggerSetupReport(BaseModel):
 
         Returns:
             List of triggers of the specified type from all categories
+
         """
         created = self._created_triggers_with_type(trigger_type=trigger_type)
         updated = self._updated_triggers_with_type(trigger_type=trigger_type)
@@ -96,6 +97,7 @@ class TriggerSetupReport(BaseModel):
 
         Returns:
             List of triggers of the specified type from both created and updated lists
+
         """
         created = self._created_triggers_with_type(trigger_type=trigger_type)
         updated = self._updated_triggers_with_type(trigger_type=trigger_type)
@@ -198,6 +200,7 @@ class ChangeFlowRunStateAction(BaseModel):
 
         Returns:
             A Prefect ChangeFlowRunState action.
+
         """
         return ChangeFlowRunState(  # type: ignore[call-arg]
             state=self.state,

--- a/backend/infrahub/trigger/setup.py
+++ b/backend/infrahub/trigger/setup.py
@@ -24,7 +24,6 @@ def compare_automations(
     """Compare an AutomationCore with an existing Automation object to identify if they are identical,
     if it's a branch specific automation and the branch filter may be different, or if they are different.
     """
-
     if force_update:
         return TriggerComparison.UPDATE
 

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -377,7 +377,8 @@ LARGE_ATTRIBUTE_TYPES = [TextArea, JSON, List]
 
 def get_attribute_type(kind: str = "Default") -> type[InfrahubDataType]:
     """Return an InfrahubDataType object for a given kind
-    If no kind is provided, return the default one."""
+    If no kind is provided, return the default one.
+    """
     return ATTRIBUTE_TYPES.get(kind, Default)
 
 

--- a/backend/infrahub/utils.py
+++ b/backend/infrahub/utils.py
@@ -94,6 +94,7 @@ def has_any_key(data: dict[str, Any], keys: list[str]) -> bool:
 
     Returns:
         True if any of the keys are found at any level of the dictionary, False otherwise
+
     """
     for key, value in data.items():
         if key in keys:

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -106,7 +106,6 @@ class EventContext(BaseModel):
     @classmethod
     def from_event(cls, event_id: str, event_type: str, event_occured_at: str, event_payload: dict[str, Any]) -> Self:
         """Extract the context from the raw event we are getting from Prefect."""
-
         infrahub_context: dict[str, Any] = event_payload.get("context", {})
         account_info: dict[str, Any] = infrahub_context.get("account", {})
         branch_info: dict[str, Any] = infrahub_context.get("branch", {})

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -13,12 +13,10 @@ if TYPE_CHECKING:
 
 
 def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: InfrahubServices) -> None:
-    """
-    `service` object instantiates connections to various services (db, cache...) at worker startup,
+    """`service` object instantiates connections to various services (db, cache...) at worker startup,
     so it is not meant to be sent by the server payload. We inject it here to avoid relying on a global variable.
     This mutates input `parameters`.
     """
-
     # avoid circular imports
     from infrahub.services import InfrahubServices
 

--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -40,6 +40,7 @@ async def add_tags(
         namespace: Whether to add the TAG_NAMESPACE tag (default True).
         db_change: Whether to add a WorkflowTag.DATABASE_CHANGE tag, indicating
             the flow run modifies the database.
+
     """
     client = get_client(httpx_settings={"verify": get_http().verify_tls()}, sync_client=False)
     current_flow_run_id = flow_run.id

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -87,6 +87,7 @@ def neo4j_factory() -> _GraphHydrator:
     Example:
         fields = [123, {"Person"}, {"name": "Alice", "age": 33}, "123"]
         alice = neo4j_factory.hydrate_node(*fields)
+
     """
     hydration_scope = HydrationHandler().new_hydration_scope()
     return hydration_scope._graph_hydrator
@@ -262,7 +263,6 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     - 2 Persons in Main
 
     """
-
     time0 = Timestamp()
     params = {
         "main_branch": "main",
@@ -465,7 +465,6 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
     - 2 Persons in Main
 
     """
-
     time0 = Timestamp()
     params = {
         "main_branch": "main",
@@ -671,7 +670,6 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
         - branch3 was created at time_m70
         - branch4 was created at time_m40
     """
-
     # ---- Create all timestamps and save them in Params -----------------
     time0 = Timestamp()
     params = {
@@ -2202,8 +2200,7 @@ async def hierarchical_groups_data(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> dict[str, Node]:
     def batched(iterable: Any, n: int):
-        """
-        Local implementation of the new batched function that was added to itertools in 3.12
+        """Local implementation of the new batched function that was added to itertools in 3.12
         https://docs.python.org/3/library/itertools.html
         """
         # batched('ABCDEFG', 3) --> ABC DEF G

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -415,7 +415,8 @@ class TestTemplateResourcePoolExclusiveConstraint:
 
 class TestNodeConstraintRunnerPoolFilterExpansion:
     """Tests that NodeConstraintRunner expands field_filters to include _from_resource_pool
-    relationships when an attribute is being updated on a template."""
+    relationships when an attribute is being updated on a template.
+    """
 
     async def test_runner_rejects_attribute_update_when_pool_is_set(
         self,

--- a/backend/tests/component/core/diff/diff_calculator/test_kind_migration.py
+++ b/backend/tests/component/core/diff/diff_calculator/test_kind_migration.py
@@ -1161,7 +1161,8 @@ async def test_migrated_kind_on_main_then_relationship_update_on_branch(
     person_albert_main: Node,
 ) -> None:
     """Test that when a schema kind is migrated on the default branch, relationships to instances
-    of the migrated node can be updated on a branch before the diff is calculated."""
+    of the migrated node can be updated on a branch before the diff is calculated.
+    """
     # Migrate TestPerson kind on default branch
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     original_person_schema = schema_branch.get_node(name="TestPerson")
@@ -1312,7 +1313,8 @@ async def test_relationship_property_added_on_source_branch_kind_migration(
     person_alfred_main: Node,
 ) -> None:
     """Validate diff for relationship when peer kind is migrated on the branch after branch forks
-    and the source property is updated on the branch"""
+    and the source property is updated on the branch
+    """
     branch = await create_branch(db=db, branch_name="branch-src-migration-rel-prop")
     from_time = Timestamp(branch.created_at)
 
@@ -1377,7 +1379,8 @@ async def test_relationship_property_branch_change_with_target_branch_kind_migra
     person_alfred_main: Node,
 ) -> None:
     """Validate diff for relationship source when one of the peers is migrated to a new kind on the target branch
-    after branch forks"""
+    after branch forks
+    """
     branch = await create_branch(db=db, branch_name="branch-tgt-migration-rel-prop")
     from_time = Timestamp(branch.created_at)
 

--- a/backend/tests/component/core/diff/test_coordinator.py
+++ b/backend/tests/component/core/diff/test_coordinator.py
@@ -544,7 +544,8 @@ class TestDiffCoordinator:
         pc_state: ProposedChangeState,
     ) -> None:
         """When update_branch_diff is called without proposed_change_id but an OPEN or MERGING
-        CoreProposedChange exists for the branch, the diff should be linked to it."""
+        CoreProposedChange exists for the branch, the diff should be linked to it.
+        """
         branch = await create_branch(db=db, branch_name="branch")
 
         proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE, branch=default_branch)

--- a/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/component/core/ipam/test_ipam_reconcile_query.py
@@ -771,9 +771,7 @@ async def test_reconcile_query_on_migrated_kind_node(
 async def test_reconcile_query_for_address_with_prefix_added_on_branch_and_merged(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
 ) -> None:
-    """
-    Test for bug that could cause an IP address to be its own parent after an update on a branch was merged
-    """
+    """Test for bug that could cause an IP address to be its own parent after an update on a branch was merged"""
     default_ipnamespace = await get_default_ipnamespace(db=db)
     registry.default_ipnamespace = default_ipnamespace.id
     address_10 = ip_dataset_01["address10"]

--- a/backend/tests/component/core/migrations/graph/test_017.py
+++ b/backend/tests/component/core/migrations/graph/test_017.py
@@ -11,10 +11,7 @@ async def test_migration_017(
     default_branch: Branch,
     register_internal_models_schema: SchemaBranch,
 ) -> None:
-    """
-    Test migration correctly adds CoreProfile schema node.
-    """
-
+    """Test migration correctly adds CoreProfile schema node."""
     item = registry.schema.get(name="CoreProfile")
     # Make sure to remove CoreProfile from database if it is there
     if item.id is not None:

--- a/backend/tests/component/core/migrations/graph/test_018_025.py
+++ b/backend/tests/component/core/migrations/graph/test_018_025.py
@@ -84,9 +84,7 @@ async def test_migration_018_fail(
     car_person_schema: SchemaBranch,
     migration: InternalSchemaMigration,
 ) -> None:
-    """
-    Test migration correctly identifies nodes with NULL attribute values that violate uniqueness constraint
-    """
+    """Test migration correctly identifies nodes with NULL attribute values that violate uniqueness constraint"""
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     await registry.schema.load_schema_to_db(db=db, schema=schema_branch)
     car_red_update = await NodeManager.get_one(db=db, id=car_red.id)

--- a/backend/tests/component/core/migrations/graph/test_019.py
+++ b/backend/tests/component/core/migrations/graph/test_019.py
@@ -16,10 +16,7 @@ async def test_migration_019(
     db: InfrahubDatabase,
     default_branch: Branch,
 ) -> None:
-    """
-    Reproduce corrupted state introduced by migration 12, and apply the migration fixing it.
-    """
-
+    """Reproduce corrupted state introduced by migration 12, and apply the migration fixing it."""
     schema = SchemaRoot(**core_models)
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
@@ -134,11 +131,9 @@ async def test_migration_019(
 async def test_incorrectly_deleted_aware_nodes_and_relationship(
     db: InfrahubDatabase, branch: Branch, car_person_schema_unregistered: SchemaRoot
 ) -> None:
-    """
-    Reproduce a state where a branch aware node would have been incorrectly deleted, this node being
+    """Reproduce a state where a branch aware node would have been incorrectly deleted, this node being
     connected to another node through a branch aware relationship.
     """
-
     registry.schema.register_schema(schema=car_person_schema_unregistered, branch=branch.name)
 
     john = await Node.init(schema="TestPerson", db=db, branch=branch)
@@ -174,11 +169,9 @@ async def test_incorrectly_deleted_aware_nodes_and_relationship(
 async def test_incorrectly_deleted_agnostic_node(
     db: InfrahubDatabase, branch: Branch, car_person_branch_agnostic_schema: dict[str, Any]
 ) -> None:
-    """
-    Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
+    """Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
     connected to another node through 2 relationships, both aware and agnostic.
     """
-
     # await load_schema(db, schema=CAR_SCHEMA)
     registry.schema.register_schema(schema=SchemaRoot(**car_person_branch_agnostic_schema), branch=branch.name)
 
@@ -215,12 +208,10 @@ async def test_incorrectly_deleted_agnostic_node(
 async def test_incorrectly_deleted_aware_node(
     db: InfrahubDatabase, branch: Branch, car_person_branch_agnostic_schema: dict[str, Any]
 ) -> None:
-    """
-    Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
+    """Reproduce a state where a branch agnostic node would have been incorrectly deleted, this node being
     connected to another node through 2 relationships, both aware and agnostic.
     Note that, after deleting an aware node, agnostic edges of this node will not be deleted.
     """
-
     registry.schema.register_schema(schema=SchemaRoot(**car_person_branch_agnostic_schema), branch=branch.name)
 
     aware_person = await Node.init(schema="TestPerson", db=db, branch=branch)

--- a/backend/tests/component/core/migrations/graph/test_023.py
+++ b/backend/tests/component/core/migrations/graph/test_023.py
@@ -18,11 +18,9 @@ from infrahub.database import InfrahubDatabase
 async def test_migration_023(
     db: InfrahubDatabase, branch: Branch, car_person_schema: SchemaBranch, redis: dict[int, int] | None
 ) -> None:
-    """
-    Reproduce corrupted state where two nodes would be connected by multiple relationships while relationship
+    """Reproduce corrupted state where two nodes would be connected by multiple relationships while relationship
     cardinality is one.
     """
-
     person_john = await Node.init(schema="TestPerson", db=db, branch=branch)
     await person_john.new(db=db, name="John")
     await person_john.save(db=db)

--- a/backend/tests/component/core/migrations/graph/test_050.py
+++ b/backend/tests/component/core/migrations/graph/test_050.py
@@ -107,6 +107,7 @@ async def _validate_node_metadata(
         branch: Branch to query
         windows: Expected time windows for the node, its attributes, and its relationships
         branch_agnostic: Whether to query branch-agnostically
+
     """
     node = await NodeManager.get_one(
         db=db,

--- a/backend/tests/component/core/migrations/graph/test_056_update_schema_node_generic_constraints.py
+++ b/backend/tests/component/core/migrations/graph/test_056_update_schema_node_generic_constraints.py
@@ -32,6 +32,7 @@ async def _validate_schema_state(
         db: Database connection
         branch: Branch to check
         expect_old_values: If True, expect old values (pre-migration), if False expect new values (post-migration)
+
     """
     schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
     schema_node = schema_branch.get_node(name="SchemaNode", duplicate=False)

--- a/backend/tests/component/core/migrations/graph/test_059.py
+++ b/backend/tests/component/core/migrations/graph/test_059.py
@@ -171,7 +171,6 @@ class TestMigration059(TestInfrahubApp):
         loaded_schemas: SchemaBranch,
     ) -> None:
         """Create data across default, global, and user branches, run migration, verify all fixes."""
-
         # --- Setup: default branch nodes ---
         role = await Node.init(db=db, schema="TestRole", branch=default_branch)
         await role.new(db=db, name="spine")

--- a/backend/tests/component/core/migrations/graph/test_061_link_proposed_changes_to_diff_roots.py
+++ b/backend/tests/component/core/migrations/graph/test_061_link_proposed_changes_to_diff_roots.py
@@ -1,5 +1,4 @@
-"""
-Tests for Migration 061: Link ProposedChanges to DiffRoots.
+"""Tests for Migration 061: Link ProposedChanges to DiffRoots.
 
 Test scenarios:
 1. DiffRoots with no appropriate proposed change - should remain unlinked
@@ -92,8 +91,7 @@ class TestMigration061:
         is_merged: bool = False,
         tracking_id: TrackingId | None = None,
     ) -> tuple[str, str]:
-        """
-        Create a pair of DiffRoots using the proper DiffRepository API.
+        """Create a pair of DiffRoots using the proper DiffRepository API.
 
         Returns tuple of (diff_branch_root_uuid, base_branch_root_uuid).
         """
@@ -169,9 +167,7 @@ class TestMigration061:
         default_branch: Branch,
         diff_repository: DiffRepository,
     ) -> None:
-        """
-        Comprehensive test covering all scenarios for migration 061.
-        """
+        """Comprehensive test covering all scenarios for migration 061."""
         # Create timestamps for testing
         base_time = Timestamp()
         t0 = base_time.add(seconds=-600)

--- a/backend/tests/component/core/migrations/graph/test_067_freeze_orphaned_branch_tracking_diffs.py
+++ b/backend/tests/component/core/migrations/graph/test_067_freeze_orphaned_branch_tracking_diffs.py
@@ -1,5 +1,4 @@
-"""
-Tests for Migration 067: Freeze orphaned branch-tracking diffs.
+"""Tests for Migration 067: Freeze orphaned branch-tracking diffs.
 
 The migration freezes DiffRoots (and their partners) whose tracking_id starts with "branch."
 when the associated Branch no longer exists, has been merged, or has a different branched_from

--- a/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_supports_generated_schema.py
@@ -313,7 +313,8 @@ async def device_part_schema_read_only_serial(
     db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
 ) -> SchemaBranch:
     """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
-    serial_number starts read_only=True so it is NOT on template instances."""
+    serial_number starts read_only=True so it is NOT on template instances.
+    """
     part = _PART.model_copy(deep=True)
     part.get_attribute("serial_number").read_only = True
     registry.schema.register_schema(
@@ -328,7 +329,8 @@ async def device_part_schema(
     db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
 ) -> SchemaBranch:
     """TestDevice (generate_template=True) has COMPONENT TestPart (generate_template=False).
-    serial_number starts read_only=False so it IS on template instances."""
+    serial_number starts read_only=False so it IS on template instances.
+    """
     registry.schema.register_schema(
         schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
         branch=default_branch.name,

--- a/backend/tests/component/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_remove.py
@@ -63,7 +63,6 @@ async def test_query_in_default_branch(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_camry_main: Node
 ) -> None:
     """This test is a bit silly for now because there is nothing to migrate but it least we validate that the generated query is valid"""
-
     schema = registry.schema.get_schema_branch(name=default_branch.name)
     candidate_schema = schema.duplicate()
     candidate_schema.delete(name="TestCar")

--- a/backend/tests/component/core/profiles/test_mandatory_fields_checker.py
+++ b/backend/tests/component/core/profiles/test_mandatory_fields_checker.py
@@ -70,7 +70,6 @@ class TestExtractProfileIdentifiersFromInput:
 
     def test_objects_with_id_attribute(self) -> None:
         """Profiles can be Node objects with an 'id' attribute."""
-
         node1 = MagicMock(spec=Node, id="uuid1")
         node2 = MagicMock(spec=Node, id="uuid2")
 

--- a/backend/tests/component/core/profiles/test_node_applier.py
+++ b/backend/tests/component/core/profiles/test_node_applier.py
@@ -874,7 +874,8 @@ async def test_node_from_template_with_profile_precedence(
 ) -> None:
     """Test that when creating a node from a template with profiles,
     template's manually defined values take precedence over profile values,
-    while profile values are used for attributes not set on the template."""
+    while profile values are used for attributes not set on the template.
+    """
     profile_schema = registry.schema.get("ProfileTestCriticality", branch=branch)
     template_schema = registry.schema.get("TemplateTestCriticality", branch=branch)
 

--- a/backend/tests/component/core/resource_manager/test_number_pool.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool.py
@@ -55,13 +55,11 @@ async def test_allocate_from_number_pool(
 async def test_resource_utilization(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
-    """
-    Allocates:
+    """Allocates:
     - 1 ticket in first number pool
     - 2 tickets in second number pool
     and verifies resource pool utilization.
     """
-
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     await initialize_registry(db=db)
 

--- a/backend/tests/component/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/component/core/resource_manager/test_number_pool_query.py
@@ -187,7 +187,8 @@ class TestNumberPoolGetAllocated:
         run_number_pool_validation: None,
     ) -> None:
         """When a node is deleted on main branch which is the only branch having this allocated value,
-        NumberPoolGetAllocated should not return it."""
+        NumberPoolGetAllocated should not return it.
+        """
         incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
         incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
         pools: list[CoreNumberPool] = await NodeManager.query(
@@ -278,7 +279,8 @@ class TestNumberPoolGetAllocated:
         run_number_pool_validation: None,
     ) -> None:
         """When HAS_SOURCE is cleared on the same branch it was created on and there are no additional branches which contain
-        this allocation, the allocation must not appear."""
+        this allocation, the allocation must not appear.
+        """
         incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
         incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
         pools: list[CoreNumberPool] = await NodeManager.query(
@@ -309,8 +311,7 @@ class TestNumberPoolGetAllocated:
         default_branch: Branch,
         run_number_pool_validation: None,
     ) -> None:
-        """
-        1. Create incidents on main
+        """1. Create incidents on main
         2. Fork br1 and clear the source on br1
         3. Clear the source on main
         """
@@ -352,8 +353,8 @@ class TestNumberPoolGetAllocated:
         run_number_pool_validation: None,
     ) -> None:
         """Scenario: on a child branch, source=pool -> source=null -> source=pool again; then the
-        main-branch active edge is closed so that it cannot satisfy the query on its own."""
-
+        main-branch active edge is closed so that it cannot satisfy the query on its own.
+        """
         # Step 1: creation on main.
         incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
         incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
@@ -396,7 +397,8 @@ class TestNumberPoolGetAllocated:
         run_number_pool_validation: None,
     ) -> None:
         """Fork a branch from main, clear the source on forked branch. Merge the forked branch back into main. The value
-        should not be allocated anymore."""
+        should not be allocated anymore.
+        """
         incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
         incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
         pools: list[CoreNumberPool] = await NodeManager.query(

--- a/backend/tests/component/core/schema/test_check_dup_schema_fields_cmd.py
+++ b/backend/tests/component/core/schema/test_check_dup_schema_fields_cmd.py
@@ -13,9 +13,7 @@ from infrahub.database import InfrahubDatabase
 async def merge_nodes(
     db: InfrahubDatabase, node_uuids: list[str], source_branch_name: str, target_branch_name: str, at: Timestamp
 ) -> None:
-    """
-    Do a simplified graph merge of any active edges for particular Nodes on a source branch into a target branch.
-    """
+    """Do a simplified graph merge of any active edges for particular Nodes on a source branch into a target branch."""
     query = """
 MATCH (n:Node)
 WHERE n.uuid IN $node_uuids

--- a/backend/tests/component/core/schema_manager/namespace_restriction/test_namespace_restriction.py
+++ b/backend/tests/component/core/schema_manager/namespace_restriction/test_namespace_restriction.py
@@ -43,7 +43,8 @@ class TestNamespaceRestrictionInvalidCases:
         schema_multi_generic_with_one_restricted: SchemaRoot,
     ) -> None:
         """When a node inherits from multiple generics and only one has restricted_namespaces,
-        the restriction from that generic must still be enforced."""
+        the restriction from that generic must still be enforced.
+        """
         schema = SchemaBranch(cache={}, name="test")
         schema.load_schema(schema=schema_multi_generic_with_one_restricted)
 

--- a/backend/tests/component/core/test_branch_diff.py
+++ b/backend/tests/component/core/test_branch_diff.py
@@ -147,7 +147,8 @@ async def test_diff_get_files_repositories_for_branch_case01(
     db: InfrahubDatabase, default_branch: Branch, repos_in_main: dict[str, Node]
 ) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
-    but only one has a different commit value between 2 and from so we expect only 2 files"""
+    but only one has a different commit value between 2 and from so we expect only 2 files
+    """
 
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
         model = GitDiffNamesOnlyResponse(
@@ -188,7 +189,8 @@ async def test_diff_get_files_repositories_for_branch_case02(
     repos_in_main: dict[str, Node],
 ) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
-    both repositories have a new commit value so we expect both to return something"""
+    both repositories have a new commit value so we expect both to return something
+    """
 
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
         model = parameters["model"]
@@ -236,7 +238,8 @@ async def test_diff_get_files_repositories_for_branch_case02(
 
 async def test_diff_get_files(db: InfrahubDatabase, default_branch: Branch, repos_in_main: dict[str, Node]) -> None:
     """Testing the get_modified_paths_repositories_for_branch_case01 method with 2 repositories in the database
-    both repositories have a new commit value so we expect both to return something"""
+    both repositories have a new commit value so we expect both to return something
+    """
 
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
         model = parameters["model"]

--- a/backend/tests/component/core/test_node.py
+++ b/backend/tests/component/core/test_node.py
@@ -1282,8 +1282,7 @@ async def test_node_update_local_attrs_with_metadata(
 async def test_update_related_node(
     db: InfrahubDatabase, data_schema: None, default_branch: Branch, use_branch: bool
 ) -> None:
-    """
-    This test has been written to troubleshoot a specific issue
+    """This test has been written to troubleshoot a specific issue
     where a relationship between 2 nodes was being deleted when one of the node was getting updated.
     """
     # ----------------------------------------------------------------

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -372,7 +372,6 @@ async def test_delete_branch_aware_node_with_agnostic_relationship(
     - Verify the device is deleted on branch2
     - Verify the device and its relationship to the location still exist on branch3
     """
-
     # Create a schema with branch-aware nodes and an explicitly agnostic relationship
     SCHEMA = {
         "nodes": [

--- a/backend/tests/component/core/test_node_query.py
+++ b/backend/tests/component/core/test_node_query.py
@@ -493,9 +493,7 @@ async def test_query_NodeListGetRelationshipsQuery_pagination_and_parallel_runti
     query_limit_of_one: None,
     neo4j_runtime_parallel: None,
 ) -> None:
-    """
-    Test all expected results are returned with pagination and parallel runtime
-    """
+    """Test all expected results are returned with pagination and parallel runtime"""
     tags = []
     for i in range(10):
         tag = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)

--- a/backend/tests/component/core/test_signin_sso_account.py
+++ b/backend/tests/component/core/test_signin_sso_account.py
@@ -17,7 +17,8 @@ async def test_new_user_creates_account_and_identity(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     """A first-time login must bootstrap both the account and the identity node in a single
-    call so that subsequent logins resolve via the stable sub rather than the mutable display name."""
+    call so that subsequent logins resolve via the stable sub rather than the mutable display name.
+    """
     identity = ExternalIdentity(
         sub="sub-new-001",
         provider_name="provider1",
@@ -50,7 +51,8 @@ async def test_returning_user_resolves_via_identity_node(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     """Once an identity node exists the account lookup must use it exclusively, ensuring
-    that renaming the display_name in the provider cannot redirect a login to a different account."""
+    that renaming the display_name in the provider cannot redirect a login to a different account.
+    """
     account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await account.new(db=db, name="Bob Smith", label="Bob Smith", account_type="User", password=str(uuid.uuid4()))
     await account.save(db=db)
@@ -86,7 +88,8 @@ async def test_label_is_updated_when_display_name_changes(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     """The label is the human-readable name shown in the UI. When the provider changes
-    the display name the label must follow so that the UI stays consistent with the IdP."""
+    the display name the label must follow so that the UI stays consistent with the IdP.
+    """
     account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await account.new(db=db, name="Carol Jones", label="Carol Jones", account_type="User", password=str(uuid.uuid4()))
     await account.save(db=db)
@@ -119,7 +122,8 @@ async def test_transition_fallback_unclaimed_account_is_linked(
 ) -> None:
     """Accounts created before this feature was introduced have no identity node. The first
     post-upgrade login must claim the existing account rather than creating a duplicate,
-    preserving the user's history, permissions, and group memberships."""
+    preserving the user's history, permissions, and group memberships.
+    """
     account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await account.new(db=db, name="Eve Turner", account_type="User", password=str(uuid.uuid4()))
     await account.save(db=db)
@@ -152,7 +156,8 @@ async def test_transition_fallback_claimed_account_uses_email_as_name(
 ) -> None:
     """If a name-matched account is already linked to a different provider identity it cannot
     be claimed. A new account must be created using the email as the unique name so that both
-    users can log in without either being locked out or silently redirected to the wrong account."""
+    users can log in without either being locked out or silently redirected to the wrong account.
+    """
     existing_account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await existing_account.new(db=db, name="Frank Hall", account_type="User", password=str(uuid.uuid4()))
     await existing_account.save(db=db)
@@ -193,7 +198,8 @@ async def test_name_and_email_collision_raises_processing_error(
 ) -> None:
     """When both the display name and the email are already taken by other accounts there is no
     safe automatic resolution. A hard error forces an admin to intervene rather than silently
-    dropping the login or overwriting someone else's account."""
+    dropping the login or overwriting someone else's account.
+    """
     account1 = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await account1.new(db=db, name="Grace Lee", account_type="User", password=str(uuid.uuid4()))
     await account1.save(db=db)
@@ -223,7 +229,8 @@ async def test_account_is_added_to_matching_group(
 ) -> None:
     """Group membership is the mechanism for assigning permissions in Infrahub. SSO group claims
     must be reflected at login so that access rights stay in sync with the IdP without requiring
-    manual admin intervention after each user is provisioned."""
+    manual admin intervention after each user is provisioned.
+    """
     group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
     await group.new(db=db, name="network-engineers-001")
     await group.save(db=db)
@@ -252,7 +259,8 @@ async def test_account_already_in_group_is_not_duplicated(
 ) -> None:
     """Group membership relationships must be idempotent. A second login with the same group
     claims must not create a duplicate edge, which would corrupt membership counts and
-    potentially cause permission evaluation to behave unpredictably."""
+    potentially cause permission evaluation to behave unpredictably.
+    """
     group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
     await group.new(db=db, name="network-engineers-002")
     await group.save(db=db)
@@ -278,7 +286,8 @@ async def test_unknown_group_is_silently_ignored(
 ) -> None:
     """The IdP may send group names that have not yet been created in Infrahub. Failing the
     login in that case would lock users out for a misconfiguration that is outside their
-    control, so unknown groups are skipped and the login proceeds."""
+    control, so unknown groups are skipped and the login proceeds.
+    """
     identity = ExternalIdentity(
         sub="sub-nogroup-001",
         provider_name="provider1",
@@ -300,7 +309,8 @@ async def test_two_different_identities_produce_two_accounts(
 ) -> None:
     """Each unique (sub, provider, protocol) triple must map to its own account. This guards
     against a regression where a shared attribute — such as a common display name — would
-    cause two distinct users to be merged into one account."""
+    cause two distinct users to be merged into one account.
+    """
     identity1 = ExternalIdentity(
         sub="sub-two-001",
         provider_name="provider1",

--- a/backend/tests/component/core/test_utils.py
+++ b/backend/tests/component/core/test_utils.py
@@ -19,8 +19,7 @@ def test_convert_ip_to_binary_str(input: ipaddress.IPv4Network | ipaddress.IPv4I
 
 
 async def verify_all_linked_edges_deleted(db: InfrahubDatabase, node_uuid: str, branch_name: str) -> None:
-    """
-    Verify that a node is completely deleted at the database level
+    """Verify that a node is completely deleted at the database level
 
     check that all edges linked to a given node on a given branch are deleted or inactive
     """

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -76,8 +76,8 @@ def branch99() -> BranchData:
 @pytest.fixture
 def git_upstream_repo_01(git_sources_dir: Path) -> dict[str, str | Path]:
     """Git Repository with 4 branches main, branch01, branch02, and clean-branch.
-    There is conflict between branch01 and branch02."""
-
+    There is conflict between branch01 and branch02.
+    """
     name = "infrahub-test-fixture-01"
     here = Path(__file__).parent.resolve()
     fixtures_dir = here.parent.parent / "fixtures"
@@ -124,7 +124,6 @@ async def git_repo_01(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_01 as remote"""
-
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -140,7 +139,6 @@ async def git_repo_01_read_only(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubReadOnlyRepository:
     """Git Repository with git_upstream_repo_01 as remote"""
-
     repo = await InfrahubReadOnlyRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -156,7 +154,6 @@ async def git_repo_01_read_only(
 @pytest.fixture
 async def git_repo_01_w_client(git_repo_01: InfrahubRepository, client: InfrahubClient) -> InfrahubRepository:
     """Same as fixture git_repo_01 but with a Infrahub client initialized."""
-
     git_repo_01.client = client
     return git_repo_01
 
@@ -179,7 +176,6 @@ async def git_repo_03(
     client: InfrahubClient, git_upstream_repo_03: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_03 as remote"""
-
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_03["name"],
@@ -193,7 +189,6 @@ async def git_repo_03(
 @pytest.fixture
 async def git_repo_03_w_client(git_repo_03: InfrahubRepository, client: InfrahubClient) -> InfrahubRepository:
     """Same as fixture git_repo_03 but with a Infrahub client initialized."""
-
     git_repo_03.client = client
     return git_repo_03
 
@@ -207,7 +202,6 @@ async def git_repo_04(
     The content of the branch branch01 has been  updated after the repo has been initialized
     to generate a diff between the local and the remote branch branch01.
     """
-
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_03["name"],
@@ -244,7 +238,6 @@ async def git_repo_05(
     The content of the main branch has been  updated after the repo has been initialized
     to generate a diff between the local and the remote branch main.
     """
-
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -275,7 +268,6 @@ async def git_repo_06(
     The content of the branch branch01 has been  updated both locally and in the remote after the repo has been initialized
     to generate a conflict between the local and the remote branch branch01.
     """
-
     repo = await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
@@ -324,7 +316,6 @@ async def git_repo_jinja(
 
     TODO At some point if would be good to include all these changes in the base repository
     """
-
     upstream = Repo(git_upstream_repo_02["path"])
 
     files_to_add = [
@@ -397,7 +388,6 @@ async def git_repo_checks(
     The main branch contains 2 checks: check01 and check02.
     Check01 always return False and check02 is not valid.
     """
-
     checks_fixture_dir = get_fixtures_dir() / "checks"
     upstream = Repo(git_upstream_repo_02["path"])
 
@@ -427,7 +417,6 @@ async def git_repo_transforms(
     The main branch contains 2 transforms: transform01 and transform02.
     Transform01 will change to uppercase the keys in the data dict always and Transform02 is not valid.
     """
-
     checks_fixture_dir = get_fixtures_dir() / "transforms"
     upstream = Repo(git_upstream_repo_02["path"])
 

--- a/backend/tests/component/git/test_repository_config.py
+++ b/backend/tests/component/git/test_repository_config.py
@@ -31,8 +31,8 @@ class TestGetRepositoryConfig:
 
         Returns:
             The initialized Infrahub repository instance without a config file.
-        """
 
+        """
         # Clone the upstream repo to avoid polluting the shared fixture
         original_path = Path(git_upstream_repo_01["path"])
         clone_path = git_repos_dir / f"clone_no_config_{id(self)}"
@@ -65,8 +65,8 @@ class TestGetRepositoryConfig:
 
         Returns:
             The initialized Infrahub repository instance with an invalid YAML config.
-        """
 
+        """
         # Clone the upstream repo to avoid polluting the shared fixture
         original_path = Path(git_upstream_repo_01["path"])
         clone_path = git_repos_dir / f"clone_invalid_yaml_{id(self)}"
@@ -105,8 +105,8 @@ schemas:
 
         Returns:
             The initialized Infrahub repository instance with an invalid format config.
-        """
 
+        """
         # Clone the upstream repo to avoid polluting the shared fixture
         original_path = Path(git_upstream_repo_01["path"])
         clone_path = git_repos_dir / f"clone_invalid_format_{id(self)}"
@@ -143,8 +143,8 @@ schemas: "should be a list, not a string"
 
         Returns:
             The initialized Infrahub repository instance with a valid config file.
-        """
 
+        """
         # Clone the upstream repo to avoid polluting the shared fixture
         original_path = Path(git_upstream_repo_01["path"])
         clone_path = git_repos_dir / f"clone_valid_config_{id(self)}"

--- a/backend/tests/component/graphql/loaders/test_account.py
+++ b/backend/tests/component/graphql/loaders/test_account.py
@@ -238,7 +238,6 @@ async def test_loader_params_hash_excludes_fields(
     The hash should be consistent across different field selections so that
     loaders with the same branch/timestamp can be reused.
     """
-
     timestamp = Timestamp()
 
     params1 = AccountLoaderParams(branch=default_branch, at=timestamp, fields={"id": {}})

--- a/backend/tests/component/graphql/mutations/test_hfid.py
+++ b/backend/tests/component/graphql/mutations/test_hfid.py
@@ -187,7 +187,8 @@ async def test_update_hfid_sends_node_updated_event(
     first_account: Node,
 ) -> None:
     """UpdateHFID emits a NodeUpdatedEvent whose changelog contains the correct display label,
-    even when the display label template references attributes on the far side of a relationship."""
+    even when the display label template references attributes on the far side of a relationship.
+    """
     schema_root = SchemaRoot(nodes=[COLOR, TSHIRT])
     registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
 

--- a/backend/tests/component/graphql/mutations/test_object_conversion.py
+++ b/backend/tests/component/graphql/mutations/test_object_conversion.py
@@ -19,7 +19,6 @@ async def test_convert_object_type_with_profile_error(
     db: InfrahubDatabase, schemas_conversion: dict[str, Any], default_branch: Branch
 ) -> None:
     """Test that converting an object type with a profile returns the appropriate error message."""
-
     schema = SchemaRoot(**schemas_conversion)
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
 

--- a/backend/tests/component/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/component/graphql/mutations/test_proposed_change.py
@@ -306,7 +306,8 @@ async def test_duplicate_open_proposed_change_validation(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
 ) -> None:
     """Validate that we cannot create a second open proposed change for the same source branch,
-    but can create one after the existing one is closed."""
+    but can create one after the existing one is closed.
+    """
     branch_name = str(uuid4().hex)
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)

--- a/backend/tests/component/graphql/mutations/test_repository.py
+++ b/backend/tests/component/graphql/mutations/test_repository.py
@@ -171,7 +171,8 @@ async def test_import_last_commit_rejects_non_read_only_repository(
     default_permission_backend: None,
 ) -> None:
     """Calling InfrahubReadOnlyRepositoryImportLastCommit on a CoreRepository must fail
-    with a clear error instead of an AttributeError on the missing 'ref' attribute."""
+    with a clear error instead of an AttributeError on the missing 'ref' attribute.
+    """
     repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
     recorder = BusRecorder()
     service = await InfrahubServices.new(database=db, message_bus=recorder, workflow=WorkflowLocalExecution())

--- a/backend/tests/component/graphql/queries/test_event.py
+++ b/backend/tests/component/graphql/queries/test_event.py
@@ -404,8 +404,7 @@ async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
 
 
 def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]) -> dict[str, Any]:
-    """
-    Because we can't guarantee that Prefect is empty at the start of the test easily
+    """Because we can't guarantee that Prefect is empty at the start of the test easily
     we need to exclude all events not created by this test suite.
     """
     filtered_events = [event for event in result_data["InfrahubEvent"]["edges"] if event["node"]["id"] in in_scope_ids]

--- a/backend/tests/component/graphql/queries/test_list_permissions.py
+++ b/backend/tests/component/graphql/queries/test_list_permissions.py
@@ -301,7 +301,6 @@ class TestObjectPermissions:
         self, db: InfrahubDatabase, object_permissions_data: PermissionsTestData
     ) -> None:
         """In other branches the permissions for the first account should be updated if we modify the main branch"""
-
         branch2 = await create_branch(branch_name="pr-123abc", db=db)
 
         session = AccountSession(

--- a/backend/tests/component/graphql/queries/test_search.py
+++ b/backend/tests/component/graphql/queries/test_search.py
@@ -275,9 +275,7 @@ async def test_search_ipv4(
     ip_dataset_01: dict[str, Any],
     branch: Branch,
 ) -> None:
-    """
-    This only tests that ipv6 search specific behavior does not break ipv4 search.
-    """
+    """This only tests that ipv6 search specific behavior does not break ipv4 search."""
     branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, branch=branch)
 

--- a/backend/tests/component/graphql/queries/test_task.py
+++ b/backend/tests/component/graphql/queries/test_task.py
@@ -657,12 +657,10 @@ async def test_task_query_with_log_offset(
     delete_flow_runs: None,
     flow_runs_data: dict[str, FlowRun],
 ) -> None:
-    """
-    In unit tests logs are not forwarded to the Prefect server for unknown reasons.
+    """In unit tests logs are not forwarded to the Prefect server for unknown reasons.
     Therefore this test mainly tests log_offset and log_limit do not break the query when they are specified,
     but their logic itself is not tested on a large amount of logs.
     """
-
     result = await run_query(
         db=db,
         branch=default_branch,

--- a/backend/tests/component/graphql/test_graphql_read_retry.py
+++ b/backend/tests/component/graphql/test_graphql_read_retry.py
@@ -178,7 +178,8 @@ async def test_concurrent_many_relationship_queries_recover_from_pool_exhaustion
     test_data_stp: None,
 ) -> None:
     """Test that concurrent GraphQL queries hitting many-relationship resolvers
-    recover from Neo4j server thread pool exhaustion via retry_db_transaction."""
+    recover from Neo4j server thread pool exhaustion via retry_db_transaction.
+    """
     num_concurrent = 10
     results = await asyncio.gather(
         *[_run_graphql_query(db=db_small_thread_pool, branch=default_branch_stp) for _ in range(num_concurrent)],
@@ -214,7 +215,8 @@ async def test_concurrent_queries_fail_without_retries(
     test_data_stp: None,
 ) -> None:
     """Test that without retries, concurrent queries on a small thread pool fail
-    with TransientError, proving the retry mechanism is needed."""
+    with TransientError, proving the retry mechanism is needed.
+    """
     # Must be significantly higher than thread_pool_max_size to guarantee exhaustion.
     # Each coroutine makes multiple sequential DB calls; we need enough concurrent
     # coroutines so the total in-flight DB requests exceed the server's thread pool.

--- a/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
+++ b/backend/tests/component/graphql/test_inline_fragment_hierarchical.py
@@ -138,7 +138,8 @@ async def test_computed_attr_graphql_query_executes_successfully(
 ) -> None:
     """The GraphQL query generated for a computed attribute that references a
     peer-only parent attribute must use an inline fragment and execute without
-    errors against the database."""
+    errors against the database.
+    """
     continent = await Node.init(db=db, schema="TestingContinent", branch=default_branch)
     await continent.new(db=db, name="Europe", shortname="eu")
     await continent.save(db=db)
@@ -172,7 +173,8 @@ async def test_display_label_graphql_query_executes_successfully(
     hierarchical_schema: SchemaBranch,
 ) -> None:
     """The GraphQL query generated for a display label that references a
-    peer-only parent attribute must use an inline fragment and execute without errors."""
+    peer-only parent attribute must use an inline fragment and execute without errors.
+    """
     continent = await Node.init(db=db, schema="TestingContinent", branch=default_branch)
     await continent.new(db=db, name="Asia", shortname="as")
     await continent.save(db=db)
@@ -204,7 +206,8 @@ async def test_hfid_graphql_query_executes_successfully(
     hierarchical_schema: SchemaBranch,
 ) -> None:
     """The GraphQL query generated for an HFID that references a peer-only
-    parent attribute must use an inline fragment and execute without errors."""
+    parent attribute must use an inline fragment and execute without errors.
+    """
     continent = await Node.init(db=db, schema="TestingContinent", branch=default_branch)
     await continent.new(db=db, name="Africa", shortname="af")
     await continent.save(db=db)

--- a/backend/tests/component/graphql/test_mutation_create.py
+++ b/backend/tests/component/graphql/test_mutation_create.py
@@ -1569,9 +1569,7 @@ async def test_create_with_object_template(
 async def test_create_with_object_template_and_real_object(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
 ) -> None:
-    """
-    Test that relationships on sub-templates will correctly link the created sub-object to an existing object on non-component relationships
-    """
+    """Test that relationships on sub-templates will correctly link the created sub-object to an existing object on non-component relationships"""
     updated_car_schema = CAR_SCHEMA.duplicate()
     manufacturer_schema = updated_car_schema.get(name=TestKind.MANUFACTURER)
     manufacturer_schema.generate_template = True

--- a/backend/tests/component/graphql/test_mutation_upsert.py
+++ b/backend/tests/component/graphql/test_mutation_upsert.py
@@ -534,7 +534,6 @@ async def test_with_constructed_hfid(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaRoot
 ) -> None:
     """Validate that we can construct an HFID out of the payload without specifying all parts."""
-
     person_schema = animal_person_schema.get(name="TestPerson")
 
     person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
@@ -621,7 +620,6 @@ async def test_with_constructed_hfid_with_numbers(
     db: InfrahubDatabase, default_branch: Branch, data_schema: None
 ) -> None:
     """Validate that we can construct an HFID out of the payload without specifying all parts."""
-
     registry.schema.register_schema(schema=SchemaRoot(nodes=[TICKET]), branch=default_branch.name)
 
     first_ticket = await Node.init(schema=TestKind.TICKET, db=db)

--- a/backend/tests/component/graphql/test_query.py
+++ b/backend/tests/component/graphql/test_query.py
@@ -30,7 +30,6 @@ async def execute_query(
     at: Timestamp | str | None = None,
 ) -> ExecutionResult:
     """Helper function to Execute a GraphQL Query."""
-
     if not isinstance(branch, Branch):
         branch = await registry.get_branch(db=db, branch=branch)
     at = Timestamp(at)

--- a/backend/tests/component/message_bus/operations/event/test_branch.py
+++ b/backend/tests/component/message_bus/operations/event/test_branch.py
@@ -49,11 +49,9 @@ async def test_merged(
     context: InfrahubContext,
     init_service: InfrahubServices,
 ) -> None:
-    """
-    Test that merge flow triggers corrects events/workflows. It does not actually test these events/workflows behaviors
+    """Test that merge flow triggers corrects events/workflows. It does not actually test these events/workflows behaviors
     as they are mocked.
     """
-
     source_branch_name = "cr1234"
     target_branch_name = "main"
     right_now = Timestamp()

--- a/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
+++ b/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
@@ -495,7 +495,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """Unique query: dev1 and dev3 change 'name' (queried), dev2 changes 'description' (not queried).
-        Only art1 and art3 should be regenerated."""
+        Only art1 and art3 should be regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -531,7 +532,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """Unique query: all devices change 'description' (not queried).
-        No artifacts should be regenerated."""
+        No artifacts should be regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -567,7 +569,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """Unique query: all 4 devices change 'name' (queried).
-        All 4 artifacts should be regenerated."""
+        All 4 artifacts should be regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -610,7 +613,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
     ) -> None:
         """Unique query with artdef_partial: dev3 changes 'description' (not queried).
         dev1 and dev2 have existing artifacts that are not impacted.
-        dev3 and dev4 have no existing artifacts (artifact_id=None) → always regenerated."""
+        dev3 and dev4 have no existing artifacts (artifact_id=None) → always regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -645,7 +649,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
     ) -> None:
         """Non-unique query: only 'description' (not queried) changes.
         Even though the query can't target specific nodes, the queried fields
-        haven't changed so no regeneration is needed."""
+        haven't changed so no regeneration is needed.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -679,7 +684,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """Non-unique query: dev2 changes 'name' (queried).
-        Because the query cannot identify specific targets, all 4 artifacts must be regenerated."""
+        Because the query cannot identify specific targets, all 4 artifacts must be regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary = [
@@ -718,7 +724,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """When source branch is synced with git and the repository has file changes,
-        all artifacts must be regenerated regardless of which fields changed."""
+        all artifacts must be regenerated regardless of which fields changed.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         # Only description changed (not queried) — but managed_branch=True overrides this
@@ -762,7 +769,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         client: InfrahubClient,
     ) -> None:
         """When source branch is synced with git but no file changes, field-level targeting
-        still applies. Only the artifact for dev1 (name changed) should be regenerated."""
+        still applies. Only the artifact for dev1 (name changed) should be regenerated.
+        """
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         # No files_changed → has_file_modifications=False → managed_branch=False

--- a/backend/tests/component/task_manager/test_event.py
+++ b/backend/tests/component/task_manager/test_event.py
@@ -29,8 +29,7 @@ query {
 
 
 def filter_outofscope_events(events: dict, in_scope_ids: list[str]) -> dict[str, Any]:
-    """
-    Because we can't guarantee that Prefect is empty at the start of the test easily
+    """Because we can't guarantee that Prefect is empty at the start of the test easily
     we need to exclude all events not created by this test suite.
     """
     filtered_events = [event for event in events["edges"] if event["node"]["id"] in in_scope_ids]

--- a/backend/tests/component/templates/test_template_applier.py
+++ b/backend/tests/component/templates/test_template_applier.py
@@ -59,6 +59,7 @@ def _validate_template_fields(
         expected_relationships: List of expected relationship peers
         user_fields: Original user fields (should be preserved as-is)
         excluded_fields: List of field names that should NOT be in the output
+
     """
     user_fields = user_fields or {}
     expected_attrs = expected_attrs or []

--- a/backend/tests/component/webhook/test_invalidate.py
+++ b/backend/tests/component/webhook/test_invalidate.py
@@ -150,7 +150,8 @@ class TestCacheInvalidationFlow:
         self, db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
     ) -> None:
         """When one of two webhooks has its headers deleted, only the remaining one is found. Cache deletion should be
-        managed through the configure flow related to webhooks headers, not this one"""
+        managed through the configure flow related to webhooks headers, not this one
+        """
         default_branch.update_schema_hash()
         kv = await _create_keyvalue(db, default_branch, "x-shared-del", "X-Shared-Del", "shared")
         wh_kept = await _create_webhook(db, default_branch, "hook-kept", headers=[kv])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -316,7 +316,6 @@ async def do_register_core_models_schema(branch: Branch) -> SchemaBranch:
 
 def do_register_simplified_proposed_change_schema(branch: Branch) -> SchemaBranch:
     """Register a minimal CoreProposedChange schema with only the attributes needed for queries."""
-
     minimal_pc = NodeSchema(
         name=core_proposed_change.name,
         namespace=core_proposed_change.namespace,
@@ -726,10 +725,7 @@ async def car_person_schema_unregistered(
 
 @pytest.fixture
 async def person_schema_default_filter(db: InfrahubDatabase, node_group_schema: None, data_schema: None) -> SchemaRoot:
-    """
-    Person schema with no unicity constraint set except default filter.
-    """
-
+    """Person schema with no unicity constraint set except default filter."""
     schema: dict[str, Any] = {
         "nodes": [
             {
@@ -1226,7 +1222,6 @@ class TestHelper:
     @staticmethod
     def import_module_in_fixtures(module: str) -> Any:
         """Import a python module from the fixtures directory."""
-
         sys.path.append(str(TestHelper.get_fixtures_dir()))
         module_name = module.replace("/", ".")
         return importlib.import_module(module_name)

--- a/backend/tests/db_snapshot.py
+++ b/backend/tests/db_snapshot.py
@@ -581,13 +581,12 @@ CALL (n_uuid, vertex_element_ids) {
 
 
 class DbSnapshotterDeduplicated:
-    """
-    DOES NOT WORK QUITE RIGHT FOR SOME RELATIONSHIPS TOUCHING MULTIPLE NODES WITH THE SAME UUID
+    """DOES NOT WORK QUITE RIGHT FOR SOME RELATIONSHIPS TOUCHING MULTIPLE NODES WITH THE SAME UUID
     NEEDS INVESTIGATION BEFORE BEING USED ANYWHERE
 
     Captures the state of all nodes, attributes, and relationships on the database, removing duplicated edges/vertices
 
-    NOTES:
+    Notes:
     - Does not account for the IS_RESERVED edge type
     - Does not fully account for the same attribute/relationship being removed and re-added on the same branch.
       - for example, if I do the following updates
@@ -596,6 +595,7 @@ class DbSnapshotterDeduplicated:
         - (t2) n.car.name = "a"
         - (t3) n.car.name = "b"
       - then the "a" value on n.car will be recorded as active from t0 to t2 and the "b" value will be recorded as active from t1
+
     """
 
     def __init__(self, db: InfrahubDatabase) -> None:

--- a/backend/tests/fixtures/checks/check02.py
+++ b/backend/tests/fixtures/checks/check02.py
@@ -3,7 +3,8 @@ from infrahub_sdk.checks import InfrahubCheck
 
 class Check02(InfrahubCheck):
     """Non valid Check for testing.
-    The query is missing."""
+    The query is missing.
+    """
 
     def validate(self, data: dict) -> None:
         self.log_error("Not Valid")

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.py
@@ -3,9 +3,7 @@ from infrahub_sdk.generator import InfrahubGenerator
 
 class Generator(InfrahubGenerator):
     async def generate(self, data: dict) -> None:
-        """
-        This generator creates a tag for each owner-car association.
-        """
+        """This generator creates a tag for each owner-car association."""
         owner = data["TestingPerson"]["edges"][0]["node"]
         owner_name: str = owner["name"]["value"]
         for car in owner["cars"]["edges"]:

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_title.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_title.py
@@ -3,9 +3,7 @@ from infrahub_sdk.generator import InfrahubGenerator
 
 class Generator(InfrahubGenerator):
     async def generate(self, data: dict) -> None:
-        """
-        This generator creates a tag in TITLE CASE for each owner<>tag association
-        """
+        """This generator creates a tag in TITLE CASE for each owner<>tag association"""
         owner = data["TestingPerson"]["edges"][0]["node"]
         owner_name: str = owner["name"]["value"]
         for car in owner["cars"]["edges"]:

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_upper.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_upper.py
@@ -3,9 +3,7 @@ from infrahub_sdk.generator import InfrahubGenerator
 
 class Generator(InfrahubGenerator):
     async def generate(self, data: dict) -> None:
-        """
-        This generator creates a tag in UPPERCASE for each owner<>tag association
-        """
+        """This generator creates a tag in UPPERCASE for each owner<>tag association"""
         owner = data["TestingPerson"]["edges"][0]["node"]
         owner_name: str = owner["name"]["value"]
         for car in owner["cars"]["edges"]:

--- a/backend/tests/functional/branch/test_delete_agnostic_rel.py
+++ b/backend/tests/functional/branch/test_delete_agnostic_rel.py
@@ -58,8 +58,7 @@ class TestDeleteAgnosticRel(TestInfrahubApp):
         owner_2: InfrahubNode,
         car: InfrahubNode,
     ) -> None:
-        """
-        Loads a car-person agnostic schema, then :
+        """Loads a car-person agnostic schema, then :
         - create a Car
         - link it to a Person
         - changes owner and retrieve the car.

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -32,14 +32,12 @@ from git import Repo
 
 
 def remove_git_worktree_branch(repository_id: str, branch_id: str) -> None:
-    """
-    Removing git worktree branches is needed after a test delete a branch, because when a new branch is then created,
+    """Removing git worktree branches is needed after a test delete a branch, because when a new branch is then created,
     Neo4j might reuse branch id of the deleted one for the new one, and as worktree branch of the deleted branch
     has not been removed, we try to re-recreate a worktree branch already existing (having the id of the previously
     deleted branch), and thus is breaks.
     TODO A solution might be to have worktree branches written in temporary folders while testing so they are automatically deleted.
     """
-
     repo_path = get_repositories_directory() / repository_id / "main"
     worktree_path = get_repositories_directory() / repository_id / "branches" / branch_id
     repo = Repo(repo_path)
@@ -241,10 +239,7 @@ class TestBranchMutations(TestInfrahubApp):
         assert "branch has some conflicts" in exc.value.message
 
     async def test_branch_merge(self, initial_dataset: str, client: InfrahubClient) -> None:
-        """
-        Test BranchMerge graphql endpoint, not actual merge logic.
-        """
-
+        """Test BranchMerge graphql endpoint, not actual merge logic."""
         branch = await client.branch.create(branch_name="branch_to_merge_sync")
 
         query = Mutation(
@@ -258,10 +253,7 @@ class TestBranchMutations(TestInfrahubApp):
         assert result["BranchMerge"]["task"] is None
 
     async def test_branch_merge_async(self, initial_dataset: str, client: InfrahubClient) -> None:
-        """
-        Test BranchMerge graphql endpoint with asynchronous feature, not actual merge logic.
-        """
-
+        """Test BranchMerge graphql endpoint with asynchronous feature, not actual merge logic."""
         branch = await client.branch.create(branch_name="branch_to_merge")
 
         query = Mutation(

--- a/backend/tests/functional/computed_attributes/test_local_computation.py
+++ b/backend/tests/functional/computed_attributes/test_local_computation.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 
 class TestJinja2ComputedAttributeWithRelationship(TestInfrahubApp):
     """Verify trigger structure and runtime recomputation for Jinja2 computed attributes
-    that reference relationship peers (using the TSHIRT/COLOR schema)."""
+    that reference relationship peers (using the TSHIRT/COLOR schema).
+    """
 
     @pytest.fixture(scope="class")
     async def schema_loaded(
@@ -43,7 +44,8 @@ class TestJinja2ComputedAttributeWithRelationship(TestInfrahubApp):
     ) -> None:
         """The TSHIRT schema has a Jinja2 computed 'description' that references both
         local attribute 'name' and peer attribute 'color__name'. The self-targeting trigger
-        (TestingTShirt) should use _trigger_placeholder fields."""
+        (TestingTShirt) should use _trigger_placeholder fields.
+        """
         triggers = await gather_trigger_computed_attribute_jinja2(db=db)
 
         self_triggers = [t for t in triggers if t.targets_self]
@@ -64,7 +66,8 @@ class TestJinja2ComputedAttributeWithRelationship(TestInfrahubApp):
     ) -> None:
         """The remote trigger (TestingColor) should preserve real field names ('name' and
         'description') since the Jinja2 template references color__name__value and
-        color__description__value. It should NOT use placeholder fields."""
+        color__description__value. It should NOT use placeholder fields.
+        """
         triggers = await gather_trigger_computed_attribute_jinja2(db=db)
 
         remote_triggers = [t for t in triggers if not t.targets_self]
@@ -87,7 +90,8 @@ class TestJinja2ComputedAttributeWithRelationship(TestInfrahubApp):
         default_branch: Branch,
     ) -> None:
         """Changing a TShirt's color relationship recomputes the description
-        to reflect the new peer's attributes."""
+        to reflect the new peer's attributes.
+        """
         color_red = await Node.init(db=db, schema="TestingColor", branch=default_branch)
         await color_red.new(db=db, name="Red", description="Bright red")
         await color_red.save(db=db)
@@ -222,7 +226,8 @@ class TestEventConsolidation(TestInfrahubApp):
         default_branch: Branch,
     ) -> None:
         """Updating a local attribute that triggers Jinja2 recomputation produces a single
-        NodeChangelog with both the original attribute and the computed attribute in updated_fields."""
+        NodeChangelog with both the original attribute and the computed attribute in updated_fields.
+        """
         tshirt = await Node.init(db=db, schema="TestingTShirt", branch=default_branch)
         await tshirt.new(db=db, name="Classic", color=color_node)
         await tshirt.save(db=db)
@@ -258,7 +263,8 @@ class TestEventConsolidation(TestInfrahubApp):
         default_branch: Branch,
     ) -> None:
         """If an update does not change the computed attribute value, it should NOT appear
-        in the changelog (no-op recomputation is filtered out)."""
+        in the changelog (no-op recomputation is filtered out).
+        """
         tshirt = await Node.init(db=db, schema="TestingTShirt", branch=default_branch)
         await tshirt.new(db=db, name="Basic", color=color_node)
         await tshirt.save(db=db)

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -135,11 +135,9 @@ class TestConvertRepository(TestInfrahubApp):
         git_repos_source_dir_module_scope: Path,
         local_repo: None,
     ) -> None:
-        """
-        First build fields mapping required to convert a CoreRepository to a CoreReadOnlyRepository,
+        """First build fields mapping required to convert a CoreRepository to a CoreReadOnlyRepository,
         then convert the repository, and finally check that the repository is working properly.
         """
-
         start_time = Timestamp()
 
         query = """ query($source_kind: String!, $target_kind: String!) {
@@ -273,11 +271,9 @@ class TestConvertRepository(TestInfrahubApp):
         local_repo: None,
         git_repos_source_dir_module_scope: Path,
     ) -> None:
-        """
-        First build fields mapping required to convert a CoreReadOnlyRepository to a CoreRepository,
+        """First build fields mapping required to convert a CoreReadOnlyRepository to a CoreRepository,
         then convert the repository, and finally check that the repository is working properly.
         """
-
         start_time = Timestamp()
 
         query_get_mapping = """ query($source_kind: String!, $target_kind: String!) {
@@ -420,11 +416,9 @@ class TestConvertRepository(TestInfrahubApp):
         local_repo: None,
         git_repos_source_dir_module_scope: Path,
     ) -> None:
-        """
-        First build fields mapping required to convert a CoreReadOnlyRepository to a CoreRepository,
+        """First build fields mapping required to convert a CoreReadOnlyRepository to a CoreRepository,
         then convert the repository, and finally check that the repository is working properly.
         """
-
         start_time = Timestamp()
 
         query_get_mapping = """ query($source_kind: String!, $target_kind: String!) {
@@ -572,10 +566,7 @@ class TestConvertRepository(TestInfrahubApp):
     async def _create_proposed_change_and_wait_for_validators(
         self, repository_id: str, client: InfrahubClient, source_branch: str, target_branch: str, db: InfrahubDatabase
     ):
-        """
-        Create a proposed change and make sure validators are attached to the input repository.
-        """
-
+        """Create a proposed change and make sure validators are attached to the input repository."""
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,
             data={"source_branch": source_branch, "destination_branch": target_branch, "name": "test-pc"},

--- a/backend/tests/functional/proposed_change/test_comment_counts.py
+++ b/backend/tests/functional/proposed_change/test_comment_counts.py
@@ -22,11 +22,9 @@ class TestProposedChangeTotalComments(TestInfrahubApp):
         car_person_schema: SchemaBranch,
         unprivileged_client: InfrahubClient,
     ) -> None:
-        """
-        Creates both change comments and thread-attached comments and make sur `total_comments` property
+        """Creates both change comments and thread-attached comments and make sur `total_comments` property
         is computed correctly.
         """
-
         # Create a branch for the proposed change
         source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
 
@@ -86,11 +84,9 @@ class TestProposedChangeTotalComments(TestInfrahubApp):
         car_person_schema: SchemaBranch,
         unprivileged_client: InfrahubClient,
     ) -> None:
-        """
-        Creates both change comments and thread-attached comments and make sur `total_comments` property
+        """Creates both change comments and thread-attached comments and make sur `total_comments` property
         is computed correctly.
         """
-
         # Create a branch for the proposed change
         source_branch = await create_branch(branch_name="branch-proposed-change-2", db=db)
 

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -45,7 +45,6 @@ class TestProposedChangeReview(TestInfrahubApp):
         prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
-
         # Create a branch for the proposed change
         source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
 
@@ -119,7 +118,6 @@ class TestProposedChangeReview(TestInfrahubApp):
         prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
-
         # Create a branch for the proposed change
         source_branch = await create_branch(branch_name="branch-pc-2", db=db)
 
@@ -181,7 +179,6 @@ class TestProposedChangeReview(TestInfrahubApp):
         prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
-
         # Create a branch for the proposed change
         source_branch = await create_branch(branch_name="branch-pc-3", db=db)
 

--- a/backend/tests/functional/proposed_change/test_thread_events.py
+++ b/backend/tests/functional/proposed_change/test_thread_events.py
@@ -33,9 +33,7 @@ class TestProposedChangeThreadEvents(TestInfrahubApp):
         unprivileged_client: InfrahubClient,
         prefect_client: PrefectClient,
     ) -> None:
-        """
-        Create a proposed change thread and then mark it as resolved all of this while asserting that events are being fired.
-        """
+        """Create a proposed change thread and then mark it as resolved all of this while asserting that events are being fired."""
         source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
         proposed_change = await client.create(
             kind=PROPOSEDCHANGE,

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -9,8 +9,7 @@ from infrahub.database import InfrahubDatabase
 
 
 class ValidateNodeRelationshipQuery(Query):
-    """
-    This query will return error message if for any couple (input_node, relationship):
+    """This query will return error message if for any couple (input_node, relationship):
     - If relationship type is agnostic, all edges branches should be -global-
     - Else, there should not be any edge on global branch
     - Considering edges on the input branch:
@@ -94,10 +93,7 @@ class ValidateNodeRelationshipQuery(Query):
 
 
 async def validate_node_relationships(node: Node, branch: Branch, db: InfrahubDatabase) -> None:
-    """
-    Raises an error if validation conditions of the query are not met.
-    """
-
+    """Raises an error if validation conditions of the query are not met."""
     query = await ValidateNodeRelationshipQuery.init(db=db, branch=branch, node_id=node.id)
     await query.execute(db=db)
     for result in query.results:
@@ -280,9 +276,7 @@ RETURN rel.name AS rel_name, rel.uuid AS rel_uuid, branch, active_count
 
 
 async def validate_no_duplicate_attributes(db: InfrahubDatabase, branch: Branch) -> list[str]:
-    """
-    Validate that no Nodes have duplicated attribute or relationship names
-    """
+    """Validate that no Nodes have duplicated attribute or relationship names"""
     branch_filter, branch_params = branch.get_query_filter_path()
 
     query = """

--- a/backend/tests/helpers/diagnostics.py
+++ b/backend/tests/helpers/diagnostics.py
@@ -54,7 +54,6 @@ def _format_stack_block(creation_stack: str | None, indent: str) -> list[str]:
 
 def dump_event_loop_closed_diagnostic(nodeid: str, exc: BaseException) -> None:
     """Print a Redis pool state summary when a "Event loop is closed" RuntimeError is fired"""
-
     lines: list[str] = [
         "Event loop closed during test_client teardown — diagnostic dump",
         f"  node: {nodeid}",

--- a/backend/tests/helpers/graphql.py
+++ b/backend/tests/helpers/graphql.py
@@ -36,10 +36,7 @@ async def graphql(
     execution_context_class: type[ExecutionContext] | None = None,
     is_awaitable: Callable[[Any], bool] | None = None,
 ) -> ExecutionResult:
-    """
-    Call `graphql` from graphql core package, and log potential errors to have full stack trace.
-    """
-
+    """Call `graphql` from graphql core package, and log potential errors to have full stack trace."""
     result = await graphql_core(
         schema=schema,
         source=source,

--- a/backend/tests/helpers/query_benchmark/car_person_generators.py
+++ b/backend/tests/helpers/query_benchmark/car_person_generators.py
@@ -96,15 +96,13 @@ class CarWithDiffInSecondBranchGenerator(CarGenerator):
         return cars
 
     async def load_data(self, nb_elements: int) -> None:
-        """
-        Load cars in main branch, rebase diff branch on main branch, then load changes
+        """Load cars in main branch, rebase diff branch on main branch, then load changes
         within diff branch according to a given ratio.
         Differences are:
         - Updates some cars attributes as well as 1:1, 1:N, N:N relationships.
         - Add new cars.
         Note that we do not delete cars within diff branch as it seems to take too long.
         """
-
         assert self.persons is not None, "'init' method should be called before 'load_data'"
 
         if nb_elements == 0:
@@ -159,11 +157,9 @@ class PersonGenerator(DataGenerator):
         nb_persons: int,
         cars: dict[str, Node] | None = None,
     ) -> dict[str, Node]:
-        """
-        Load persons and return a mapping person_name -> person_node.
+        """Load persons and return a mapping person_name -> person_node.
         If 'cars' is specified, each person created is linked to a few random cars.
         """
-
         default_branch = await registry.get_branch(db=self.db)
         person_schema = registry.schema.get_node_schema(name="TestPerson", branch=default_branch)
 
@@ -204,11 +200,9 @@ class CarGeneratorWithOwnerHavingUniqueCar(CarGenerator):
         self.persons = list(persons.items())
 
     async def load_data(self, nb_elements: int) -> None:
-        """
-        Generate cars with an owner, in a way that an owner can't have multiple cars.
+        """Generate cars with an owner, in a way that an owner can't have multiple cars.
         Also generate distinct nb_seats per car.
         """
-
         default_branch = await registry.get_branch(db=self.db)
         car_schema = registry.schema.get_node_schema(name="TestCar", branch=default_branch)
 

--- a/backend/tests/helpers/query_benchmark/data_generator.py
+++ b/backend/tests/helpers/query_benchmark/data_generator.py
@@ -12,17 +12,13 @@ from tests.helpers.query_benchmark.db_query_profiler import (
 
 
 class DataGenerator:
-    """
-    Abstract class responsible for loading data into a given database.
-    """
+    """Abstract class responsible for loading data into a given database."""
 
     def __init__(self, db: InfrahubDatabaseProfiler) -> None:
         self.db = db
 
     async def init(self) -> None:
-        """
-        Any previous step before loading and profiling data should be implemented here.
-        """
+        """Any previous step before loading and profiling data should be implemented here."""
 
     @abstractmethod
     async def load_data(self, nb_elements: int) -> None:
@@ -39,8 +35,7 @@ async def load_data_and_profile(
     graph_generator: GraphProfileGenerator,
     memory_profiling_rate: int | None = None,
 ) -> None:
-    """
-    Loads data using the provided data generator, profiles the execution at specified loading intervals,
+    """Loads data using the provided data generator, profiles the execution at specified loading intervals,
     and generate profiling graphs.
 
     Args:
@@ -53,8 +48,8 @@ async def load_data_and_profile(
         memory_profiling_rate (int): Indicates at which rate memory should be profiled. Frequency is related to number of function execution times,
                                      not to the number of elements as for 'profile_frequency'. For instance, memory_profiling_rate=25
                                      means memory is profiled every 25 times a function is executed/profiled.
-    """
 
+    """
     await data_generator.init()
 
     q, r = divmod(nb_elements, profile_frequency)

--- a/backend/tests/helpers/query_benchmark/db_query_profiler.py
+++ b/backend/tests/helpers/query_benchmark/db_query_profiler.py
@@ -149,15 +149,13 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
         return response, metadata
 
     def profile(self, profile_memory: bool) -> Self:
-        """
-        This method allows to enable profiling of a InfrahubDatabaseProfiler instance
+        """This method allows to enable profiling of a InfrahubDatabaseProfiler instance
         through a context manager with this syntax:
 
         `with db.profile(profile_memory=...):
             # run code to profile
         `
         """
-
         self.profile_memory = profile_memory
         return self
 

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -10,13 +10,11 @@ from tests.helpers.constants import INFRAHUB_USE_TEST_CONTAINERS, PORT_BOLT_NEO4
 
 
 def get_exposed_port(container: DockerContainer, port: int) -> int:
-    """
-    Use this method instead of DockerContainer.get_exposed_port as it is decorated with wait_container_is_ready
+    """Use this method instead of DockerContainer.get_exposed_port as it is decorated with wait_container_is_ready
     which we do not want to use as it does not perform a real healthcheck. DockerContainer.get_exposed_port
     also introduces extra "Waiting for container" logs as we might call it multiple times for containers exposing
     multiple ports such as rabbitmq.
     """
-
     return int(container.get_docker_client().port(container.get_wrapped_container().id, port))
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -105,14 +105,12 @@ def git_repos_dir(tmp_path_factory: TempPathFactory) -> Path:
 @pytest.fixture(scope="session")
 def git_repo_infrahub_demo_edge_integration(git_sources_dir: Path) -> FileRepo:
     """Git Repository used as part of the  demo-edge tutorial."""
-
     return FileRepo(name="infrahub-demo-edge-integration", sources_directory=git_sources_dir)
 
 
 @pytest.fixture(scope="session")
 def git_repo_car_dealership(git_sources_dir: Path) -> FileRepo:
     """Simple Git Repository used for testing."""
-
     return FileRepo(name="car-dealership", sources_directory=git_sources_dir)
 
 

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -252,7 +252,6 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         client: InfrahubClient,
     ) -> None:
         """Validate if the diff is properly created the first time"""
-
         result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": BRANCH_NAME})
         assert result["DiffUpdate"]["ok"]
 
@@ -266,7 +265,6 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         self, db: InfrahubDatabase, initial_dataset: dict[str, Node], create_diff: None, client: InfrahubClient
     ) -> None:
         """Validate if the diff is properly updated the second time"""
-
         branch1 = registry.get_branch_from_registry(branch=BRANCH_NAME)
 
         bob = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1.name)

--- a/backend/tests/integration/git/test_repository_branch.py
+++ b/backend/tests/integration/git/test_repository_branch.py
@@ -50,7 +50,6 @@ class TestCreateRepository(TestInfrahubApp):
         client: InfrahubClient,
     ) -> None:
         """Validate that we can create a repository, that it gets updated with the commit id and that objects are created."""
-
         branch = await client.branch.create(branch_name=BRANCH_NAME)
 
         client_repository = await client.create(

--- a/backend/tests/integration/profiles/test_template_profile_integration.py
+++ b/backend/tests/integration/profiles/test_template_profile_integration.py
@@ -836,7 +836,6 @@ class TestTemplateProfileWithComponents(TestInfrahubApp):
         interface_profile: Node,
     ) -> Node:
         """Test creating component templates (interfaces) with profiles."""
-
         # Create device template with component interface templates
         device_template_schema = registry.schema.get_template_schema(
             name="TemplateTestingDeviceWithInterfaces", branch=default_branch, duplicate=False
@@ -912,7 +911,6 @@ class TestTemplateProfileWithComponents(TestInfrahubApp):
         device_component_profile: Node,
     ) -> dict[str, str]:
         """Test creating a device template that references component templates."""
-
         # Create device template with component interface templates
         device_template_schema = registry.schema.get_template_schema(
             name="TemplateTestingDeviceWithInterfaces", branch=default_branch, duplicate=False

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -53,12 +53,10 @@ class ErroringBranchMerger(BranchMerger):
 class TestProposedChangePipelineConflict(TestInfrahubApp):
     @pytest.fixture(scope="class")
     def car_dealership_copy(self) -> Generator[tuple[Path, str]]:
-        """
-        Copies car-dealership local repository to a temporary folder, with a new name.
+        """Copies car-dealership local repository to a temporary folder, with a new name.
         This is needed for this test as using car-dealership folder leads to issues most probably
         related to https://github.com/opsmill/infrahub/issues/4296 as some other tests use this same repository.
         """
-
         source_folder = Path(get_fixtures_dir(), "repos", "car-dealership")
         new_folder_name = "car-dealership-copy"
 

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -1706,12 +1706,11 @@ class TestSchemaLifecycleGenericUpdates(SchemaLifecycleGenericBase):
     async def _validate_inherited_schema_fields(
         self, db: InfrahubDatabase, branch: Branch, inheriting_schemas: list[NodeSchema]
     ) -> list[str]:
-        """
-        Validate the following:
-         - SchemaNode nodes do not have relationship to SchemaAttribute or SchemaRelationship nodes for
-            any inherited relationships or attributes
-         - SchemaNode nodes have relationship to SchemaAttribute or SchemaRelationship nodes for
-            all local relationships and attributes
+        """Validate the following:
+        - SchemaNode nodes do not have relationship to SchemaAttribute or SchemaRelationship nodes for
+           any inherited relationships or attributes
+        - SchemaNode nodes have relationship to SchemaAttribute or SchemaRelationship nodes for
+           all local relationships and attributes
         """
         node_kind_map: dict[str, list[str]] = {}
         for node_schema in inheriting_schemas:
@@ -1793,8 +1792,7 @@ RETURN node_kind, relationship_names, collect(anv.value) AS attribute_names
 
 
 class TestSchemaLifecycleGenericUpdatedWithLegacyDuplicates(SchemaLifecycleGenericBase):
-    """
-    Same tests as TestSchemaLifecycleGenericUpdates, but start with duplicated inherited SchemaAttributes
+    """Same tests as TestSchemaLifecycleGenericUpdates, but start with duplicated inherited SchemaAttributes
     and SchemaRelationships in the database b/c this is how we used to store inherited fields of a schema
     And skip the database-level verification in TestSchemaLifecycleGenericUpdates b/c it would fail
     """

--- a/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
@@ -1,5 +1,6 @@
 """Integration tests verifying NodeUniquenessConstraintsUpdateMigration is triggered
-and runs correctly during an end-to-end schema load when uniqueness constraints change."""
+and runs correctly during an end-to-end schema load when uniqueness constraints change.
+"""
 
 from __future__ import annotations
 
@@ -30,7 +31,8 @@ PROFILE_CAR_KIND = "ProfileTestingCar"
 
 class TestUniquenessConstraintMigrationAddToConstraint(TestSchemaLifecycleBase):
     """Verify that adding an attribute to a uniqueness constraint triggers the migration
-    that removes that attribute from existing profile nodes."""
+    that removes that attribute from existing profile nodes.
+    """
 
     @pytest.fixture(scope="class")
     def schema_car_nbr_seats_no_constraint(self) -> dict[str, Any]:
@@ -116,7 +118,8 @@ class TestUniquenessConstraintMigrationAddToConstraint(TestSchemaLifecycleBase):
         schema_step_02: dict[str, Any],
     ) -> None:
         """Loading a schema that adds nbr_seats to a uniqueness constraint triggers the migration
-        that deletes nbr_seats from existing profile nodes."""
+        that deletes nbr_seats from existing profile nodes.
+        """
         response = await client.schema.load(schemas=[schema_step_02])
         assert not response.errors
 
@@ -142,12 +145,14 @@ class TestUniquenessConstraintMigrationAddToConstraint(TestSchemaLifecycleBase):
 
 class TestUniquenessConstraintMigrationRemoveFromConstraint(TestSchemaLifecycleBase):
     """Verify that removing an attribute from a uniqueness constraint triggers the migration
-    that adds that attribute back to existing profile nodes."""
+    that adds that attribute back to existing profile nodes.
+    """
 
     @pytest.fixture(scope="class")
     def schema_car_compound_constraint_only(self) -> dict[str, Any]:
         """Car schema — only a compound uniqueness constraint on (name, nbr_seats).
-        name has no individual unique flag, so nbr_seats is excluded from profiles."""
+        name has no individual unique flag, so nbr_seats is excluded from profiles.
+        """
         return {
             "name": "Car",
             "namespace": "Testing",
@@ -164,7 +169,8 @@ class TestUniquenessConstraintMigrationRemoveFromConstraint(TestSchemaLifecycleB
     @pytest.fixture(scope="class")
     def schema_car_name_unique_no_compound(self, schema_car_compound_constraint_only: dict[str, Any]) -> dict[str, Any]:
         """Car schema — name is individually unique, no compound constraint.
-        nbr_seats is free to be included in profiles."""
+        nbr_seats is free to be included in profiles.
+        """
         schema = copy.deepcopy(schema_car_compound_constraint_only)
         schema["uniqueness_constraints"] = []
         schema["attributes"][0]["unique"] = True
@@ -233,7 +239,8 @@ class TestUniquenessConstraintMigrationRemoveFromConstraint(TestSchemaLifecycleB
         schema_step_02: dict[str, Any],
     ) -> None:
         """Loading a schema that removes nbr_seats from a uniqueness constraint triggers the migration
-        that adds nbr_seats to existing profile nodes."""
+        that adds nbr_seats to existing profile nodes.
+        """
         response = await client.schema.load(schemas=[schema_step_02])
         assert not response.errors
 

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -148,7 +148,6 @@ async def rabbitmq_api(rabbitmq: None) -> RabbitMQManager:
 
 async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
     """Validates creation of exchanges, queues and bindings."""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
@@ -343,7 +342,6 @@ async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
 
 async def test_rabbitmq_publish(rabbitmq_api: RabbitMQManager) -> None:
     """Validate that the adapter publishes messages to the correct queue"""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
@@ -377,7 +375,6 @@ async def test_rabbitmq_publish(rabbitmq_api: RabbitMQManager) -> None:
 
 async def test_rabbitmq_callback(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates that incoming messages gets parsed by the callback method."""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
@@ -394,7 +391,6 @@ async def test_rabbitmq_callback(rabbitmq_api: RabbitMQManager, fake_log: FakeLo
 
 async def test_rabbitmq_callback_with_invalid_routing_key(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validate that messages with an invalid routing key is logged."""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
@@ -411,7 +407,6 @@ async def test_rabbitmq_callback_with_invalid_routing_key(rabbitmq_api: RabbitMQ
 
 async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger, dependency_provider: Provider) -> None:
     """Validates that incoming messages gets parsed by the callback method."""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
     with dependency_provider.scope(build_message_bus, lambda: bus):
@@ -430,7 +425,6 @@ async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger,
 
 async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates the on_message method."""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 
@@ -450,7 +444,6 @@ async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: Fake
 
 async def test_rabbitmq_on_message_invalid_routing_key(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates logging of invalid routing key"""
-
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 

--- a/backend/tests/integration/user_workflows/test_user_worflow.py
+++ b/backend/tests/integration/user_workflows/test_user_worflow.py
@@ -234,11 +234,9 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_query_all_devices(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
-        """
-        Query all devices to ensure that we have some data in the database
+        """Query all devices to ensure that we have some data in the database
         and overall that everything is working correctly
         """
-
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post("/graphql", json={"query": QUERY_GET_ALL_DEVICES}, headers=headers)
@@ -260,12 +258,10 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_query_spine1_loobpack0(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
+        """Query Loopback0 interface on spine one to ensure that the filters are working properly and to store:
+        - the ID of the interface to reuse later
+        - The initial value of the description on this interface
         """
-        Query Loopback0 interface on spine one to ensure that the filters are working properly and to store:
-            - the ID of the interface to reuse later
-            - The initial value of the description on this interface
-        """
-
         intf_name = "Loopback0"
 
         headers = await integration_helper.admin_headers()
@@ -290,10 +286,7 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_query_spine1_ethernet1(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
-        """
-        Query Ethernet1 to gather its ID
-        """
-
+        """Query Ethernet1 to gather its ID"""
         headers = await integration_helper.admin_headers()
 
         intf_name = "Ethernet1"
@@ -321,10 +314,7 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_create_first_branch(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
-        """
-        Create a first Branch from Main
-        """
-
+        """Create a first Branch from Main"""
         headers = await integration_helper.admin_headers()
 
         response = await test_client.post(
@@ -344,9 +334,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         test_client: InfrahubTestClient,
         integration_helper: IntegrationHelper,
     ) -> None:
-        """
-        Update the description of the interface in the new branch and validate that its being properly updated
-        """
+        """Update the description of the interface in the new branch and validate that its being properly updated"""
         headers = await integration_helper.admin_headers()
 
         new_description = f"New description in {branch1}"
@@ -389,9 +377,7 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_update_intf_description_main(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
-        """
-        Update the description of the interface Ethernet1 in the main branch and validate that its being properly updated
-        """
+        """Update the description of the interface Ethernet1 in the main branch and validate that its being properly updated"""
         headers = await integration_helper.admin_headers()
         new_description = f"New description in {main_branch}"
 
@@ -523,9 +509,7 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def test_update_intf_description_branch1_again(
         self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper
     ) -> None:
-        """
-        Update the description of the interface in the new branch again and validate that its being properly updated
-        """
+        """Update the description of the interface in the new branch again and validate that its being properly updated"""
         headers = await integration_helper.admin_headers()
 
         new_description = f"New New description in {branch1}"
@@ -747,9 +731,7 @@ class TestUserWorkflow01(TestInfrahubApp):
         assert intfs[0]["node"]["description"]["value"] == old_description
 
     async def test_rebase_branch2(self, test_client: InfrahubTestClient, integration_helper: IntegrationHelper) -> None:
-        """
-        Rebase Branch 2
-        """
+        """Rebase Branch 2"""
         headers = await integration_helper.admin_headers()
 
         intf_name = "Ethernet1"

--- a/backend/tests/query_benchmark/conftest.py
+++ b/backend/tests/query_benchmark/conftest.py
@@ -102,11 +102,9 @@ async def car_person_schema_root() -> SchemaRoot:
 
 @pytest.fixture(scope="session")
 async def graph_generator() -> GraphProfileGenerator:
-    """
-    Use GraphProfileGenerator as a fixture as it may allow to properly generate graphs from
+    """Use GraphProfileGenerator as a fixture as it may allow to properly generate graphs from
     distinct tests, instead of having each test managing its own display.
     """
-
     return GraphProfileGenerator()
 
 

--- a/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
+++ b/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
@@ -35,10 +35,7 @@ async def benchmark_uniqueness_query(
     test_params_label: str,
     test_name: str,
 ) -> None:
-    """
-    Profile NodeUniqueAttributeConstraintQuery with a given query_request / configuration, using a Car generator.
-    """
-
+    """Profile NodeUniqueAttributeConstraintQuery with a given query_request / configuration, using a Car generator."""
     # Initialization
     queries_names_to_config = {
         NodeUniqueAttributeConstraintQuery.name: QueryConfig(neo4j_runtime=benchmark_config.neo4j_runtime)

--- a/backend/tests/scale/common/protocols.py
+++ b/backend/tests/scale/common/protocols.py
@@ -6,7 +6,7 @@ from infrahub_sdk import Config, InfrahubClientSync
 
 
 class LocustInfrahubClient(InfrahubClientSync):
-    "Locust protocol for Python Infrahub SDK client"
+    """Locust protocol for Python Infrahub SDK client"""
 
     def __init__(self, address: str, config: Config, request_event) -> None:
         super().__init__(address=address, config=config)

--- a/backend/tests/unit/config/test_log_forwarding.py
+++ b/backend/tests/unit/config/test_log_forwarding.py
@@ -385,7 +385,8 @@ def test_log_forwarding_destination_names_rejects_matching_names_from_toml_desti
 def test_log_forwarding_destination_names_survives_revalidation() -> None:
     """Validating the same destinations multiple times succeeds
 
-    This can happen when starting Infrahub"""
+    This can happen when starting Infrahub
+    """
     env = {
         "INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES": "my_syslog",
         "INFRAHUB_LOG_FORWARDING_DESTINATION_MY_SYSLOG_HOST": "syslog.example.com",

--- a/backend/tests/unit/core/schema_branch_computed/test_jinja2_cascade.py
+++ b/backend/tests/unit/core/schema_branch_computed/test_jinja2_cascade.py
@@ -18,7 +18,7 @@ class TestCascadeWithExplicitUpdates:
     """Tests for chained dependency resolution when updates is a concrete list of field names."""
 
     def _make_chain_registry(self, make_target: Callable[..., ComputedAttributeTarget]) -> ComputedAttributes:
-        """name -> label -> fqdn chain on a single kind."""
+        """Name -> label -> fqdn chain on a single kind."""
         label_target = make_target(kind=LOCAL_KIND, attr_name="label")
         fqdn_target = make_target(kind=LOCAL_KIND, attr_name="fqdn")
         return ComputedAttributes(
@@ -38,7 +38,7 @@ class TestCascadeWithExplicitUpdates:
         assert [r.attribute.name for r in results] == ["label", "fqdn"]
 
     def test_respects_dependency_order(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """label must come before fqdn since fqdn depends on label."""
+        """Label must come before fqdn since fqdn depends on label."""
         ca = self._make_chain_registry(make_target)
         results = ca.get_local_jinja2_targets(kind=LOCAL_KIND, updates=["name"])
         names = [r.attribute.name for r in results]
@@ -58,7 +58,7 @@ class TestCascadeWithExplicitUpdates:
         assert [r.attribute.name for r in results] == ["label"]
 
     def test_cascade_cycle_terminates(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """alpha -> beta -> alpha cycle does not loop forever."""
+        """Alpha -> beta -> alpha cycle does not loop forever."""
         target_alpha = make_target(kind=LOCAL_KIND, attr_name="alpha")
         target_beta = make_target(kind=LOCAL_KIND, attr_name="beta")
         ca = ComputedAttributes(
@@ -127,7 +127,8 @@ class TestCascadeWithExplicitUpdates:
 
     def test_cascade_mixed_direct_and_transitive(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
         """When name triggers both label and fqdn, but fqdn also depends on label,
-        label must be recomputed before fqdn regardless of list order in local_fields."""
+        label must be recomputed before fqdn regardless of list order in local_fields.
+        """
         label_target = make_target(kind=LOCAL_KIND, attr_name="label")
         fqdn_target = make_target(kind=LOCAL_KIND, attr_name="fqdn")
         # fqdn listed BEFORE label in the "name" entry to exercise wrong-order scenario
@@ -193,7 +194,7 @@ class TestCascadeWithExplicitUpdates:
         assert names.index("label") < names.index("fqdn")
 
     def test_long_chain_three_levels(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """name -> label -> fqdn -> hostname: 3-hop chain."""
+        """Name -> label -> fqdn -> hostname: 3-hop chain."""
         label_target = make_target(kind=LOCAL_KIND, attr_name="label")
         fqdn_target = make_target(kind=LOCAL_KIND, attr_name="fqdn")
         hostname_target = make_target(kind=LOCAL_KIND, attr_name="hostname")
@@ -213,7 +214,7 @@ class TestCascadeWithExplicitUpdates:
         assert names == ["label", "fqdn", "hostname"]
 
     def test_three_node_cycle(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """alpha -> beta -> gamma -> alpha: 3-node cycle terminates."""
+        """Alpha -> beta -> gamma -> alpha: 3-node cycle terminates."""
         alpha = make_target(kind=LOCAL_KIND, attr_name="alpha")
         beta = make_target(kind=LOCAL_KIND, attr_name="beta")
         gamma = make_target(kind=LOCAL_KIND, attr_name="gamma")
@@ -264,7 +265,7 @@ class TestCascadeWithExplicitUpdates:
         assert results == []
 
     def test_independent_branches_from_single_update(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """name -> [label, desc], label -> summary, desc -> footer.
+        """Name -> [label, desc], label -> summary, desc -> footer.
 
         summary and footer are independent leaves on separate branches.
         """
@@ -290,7 +291,7 @@ class TestCascadeWithExplicitUpdates:
         assert names.index("desc") < names.index("footer")
 
     def test_asymmetric_diamond(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """name -> aaa -> bbb -> ddd and name -> ccc -> ddd: ddd after all deps despite path-length asymmetry."""
+        """Name -> aaa -> bbb -> ddd and name -> ccc -> ddd: ddd after all deps despite path-length asymmetry."""
         aaa = make_target(kind=LOCAL_KIND, attr_name="aaa")
         bbb = make_target(kind=LOCAL_KIND, attr_name="bbb")
         ccc = make_target(kind=LOCAL_KIND, attr_name="ccc")
@@ -315,7 +316,7 @@ class TestCascadeWithExplicitUpdates:
         assert names.index("ccc") < names.index("ddd")
 
     def test_three_way_intra_wave_chain(self, make_target: Callable[..., ComputedAttributeTarget]) -> None:
-        """name -> [aaa, bbb, ccc] with aaa -> bbb -> ccc: all emitted in correct order."""
+        """Name -> [aaa, bbb, ccc] with aaa -> bbb -> ccc: all emitted in correct order."""
         aaa = make_target(kind=LOCAL_KIND, attr_name="aaa")
         bbb = make_target(kind=LOCAL_KIND, attr_name="bbb")
         ccc = make_target(kind=LOCAL_KIND, attr_name="ccc")

--- a/backend/tests/unit/core/test_constants.py
+++ b/backend/tests/unit/core/test_constants.py
@@ -23,8 +23,7 @@ def test_proposed_state_transitions() -> None:
 
 
 def test_infrahubkind_constant_for_all_core_schema_nodes() -> None:
-    "There should be an InfrahubKind constant defined for all the nodes in the core schema"
-
+    """There should be an InfrahubKind constant defined for all the nodes in the core schema"""
     expected_constants = sorted([node["name"].upper() for node in core_models["nodes"]])
 
     for constant in expected_constants:

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -17,7 +17,8 @@ async def test_has_conflicting_changes_no_false_positive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """has_conflicting_changes() should not report false positives when
-    file content contains conflict marker characters like '======='."""
+    file content contains conflict marker characters like '======='.
+    """
     repos_dir = tmp_path / "repositories"
     repos_dir.mkdir()
     monkeypatch.setattr(registry, "_default_branch", "main")

--- a/backend/tests/unit/helpers/test_diagnostics.py
+++ b/backend/tests/unit/helpers/test_diagnostics.py
@@ -25,7 +25,8 @@ from tests.helpers.diagnostics import (
 def _reset_known_loops() -> Generator[None, None, None]:
     """Snapshot and clear the loop-label registry around each test so the session-scope
     `_register_pytest_session_loop` fixture (and any registrations from other tests) do
-    not leak into substring assertions here."""
+    not leak into substring assertions here.
+    """
     snapshot = diagnostics._KNOWN_LOOPS.copy()
     diagnostics._KNOWN_LOOPS.clear()
     try:
@@ -46,7 +47,8 @@ def captured_stderr(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
 def install_service_pool(monkeypatch: pytest.MonkeyPatch) -> Callable[[ConnectionPool | None], None]:
     """Install a service on app.state whose ._cache.connection.connection_pool resolves
     to the given pool. Uses a real redis.Redis for the .connection layer
-    so only the outer service/cache pair is a SimpleNamespace."""
+    so only the outer service/cache pair is a SimpleNamespace.
+    """
 
     def _install(pool: ConnectionPool | None) -> None:
         if pool is None:
@@ -65,7 +67,8 @@ _WriterWithLoop = tuple[asyncio.StreamWriter, asyncio.AbstractEventLoop]
 def closed_loop_writer() -> Generator[_WriterWithLoop, None, None]:
     """Real StreamWriter whose event loop has been closed — mirrors the production
     failure mode. GC of the orphaned writer emits ResourceWarning; callers should
-    use @pytest.mark.filterwarnings("ignore::ResourceWarning")."""
+    use @pytest.mark.filterwarnings("ignore::ResourceWarning").
+    """
     loop = asyncio.new_event_loop()
     sock_a, sock_b = socket.socketpair()
     try:
@@ -217,7 +220,8 @@ def test_dump_surfaces_attribute_error_when_pool_internals_change(
 @pytest.fixture
 def reset_diagnostics_install() -> Generator[None, None, None]:
     """Snapshot and restore the patched redis methods so a test can reinstall
-    from a clean slate without leaking state into other tests."""
+    from a clean slate without leaking state into other tests.
+    """
     original_connect = Connection._connect
     original_disconnect = ConnectionPool.disconnect
     try:

--- a/backend/tests/unit/message_bus/test_mappings.py
+++ b/backend/tests/unit/message_bus/test_mappings.py
@@ -10,8 +10,7 @@ from infrahub.message_bus.operations import COMMAND_MAP
 
 
 def test_message_command_overlap() -> None:
-    """
-    Verify that a command is defined for each message
+    """Verify that a command is defined for each message
     except events that don't need to be associated with a command
     """
     messages = sorted([key for key in MESSAGE_MAP if not key.startswith("event.")])

--- a/backend/tests/unit/services/test_scheduler.py
+++ b/backend/tests/unit/services/test_scheduler.py
@@ -28,7 +28,6 @@ async def test_scheduler_return_on_not_running(fake_log: FakeLogger) -> None:
 
 async def test_scheduler_exit_after_first(fake_log: FakeLogger) -> None:
     """The scheduler should return without writing entries to the log if it is not running."""
-
     service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=1, start_delay=1, function=log_once_and_stop)
     service.scheduler.running = True

--- a/backend/tests/unit/test_lock.py
+++ b/backend/tests/unit/test_lock.py
@@ -17,7 +17,8 @@ async def do_nothing(id: str, wait_sec: float, lock_name: str = "test1") -> tupl
 
 async def do_nothing_global_graph(id: str, wait_sec: float) -> tuple[str, int, int]:
     """Function for testing the global_graph_lock.
-    After acquiring the locks, wait for the indicated amount and return the start time and the end time of the lock."""
+    After acquiring the locks, wait for the indicated amount and return the start time and the end time of the lock.
+    """
     async with lock.registry.global_graph_lock():
         start_time = time.time_ns()
         await sleep(delay=wait_sec)

--- a/backend/tests/unit/workflows/test_catalogue.py
+++ b/backend/tests/unit/workflows/test_catalogue.py
@@ -34,10 +34,7 @@ def test_workflow_definition_flow_names() -> None:
 
 
 def test_workflows_sorted() -> None:
-    """
-    Only test that workflows are defined in an alphabetical way for developer comfort.
-    """
-
+    """Only test that workflows are defined in an alphabetical way for developer comfort."""
     if get_installation_type() != INSTALLATION_TYPE:
         return
 

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -486,7 +486,8 @@ DEVICE_STATUSES = ["active", "provisioning", "drained"]
 class SiteDesign:
     def __init__(self, number_of_device: int) -> None:
         """Takes the number of devices that need to be created on a given site.
-        This method will decide how many device of each type to create and return all those objects as a list."""
+        This method will decide how many device of each type to create and return all those objects as a list.
+        """
         if number_of_device > 0:
             self.number_of_device = number_of_device
         else:
@@ -571,7 +572,6 @@ def site_generator(nbr_site: int = 2) -> list[Site]:
     site_names_generator(nbr_site=12)
         result >> ["atl1", "ord1", "jfk1", "den1", "dfw1", "iad1", "bkk1", "sfo1", "iah1", "mco1", "atl2", "ord2"]
     """
-
     sites: list[Site] = []
 
     # Calculate how many loop over the entire list we need to make
@@ -901,9 +901,7 @@ async def find_and_connect_interfaces(
 
 
 async def apply_interface_profiles_and_groups(client: InfrahubClient, log: logging.Logger, branch: str) -> None:
-    """
-    Apply profiles to upstream/backbone L3 interfaces and add them to their respective groups.
-    """
+    """Apply profiles to upstream/backbone L3 interfaces and add them to their respective groups."""
     log.info("Applying profiles to interfaces and update interface groups")
 
     # Fetch upstream and backbone interfaces.
@@ -979,8 +977,7 @@ async def apply_interface_profiles_and_groups(client: InfrahubClient, log: loggi
 
 
 async def apply_devices_groups(client: InfrahubClient, log: logging.Logger, branch: str) -> None:
-    """
-    Fetch devices from Infrahub, group them based on their role and manufacturer,
+    """Fetch devices from Infrahub, group them based on their role and manufacturer,
     and update the corresponding device groups.
     """
     log.info("Adding devices to groups")
@@ -1873,9 +1870,7 @@ async def generate_site(
 async def branch_scenario_add_upstream(
     client: InfrahubClient, log: logging.Logger, site_name: str, external_pool: CoreNode
 ) -> None:
-    """
-    Create a new branch and Add a new upstream link with GTT on the edge1 device of the given site.
-    """
+    """Create a new branch and Add a new upstream link with GTT on the edge1 device of the given site."""
     log.info("Create a new branch and Add a new upstream link with GTT on the edge1 device of the given site")
     device_name = f"{site_name}-edge1"
 
@@ -1983,9 +1978,7 @@ async def branch_scenario_add_upstream(
 async def branch_scenario_replace_ip_addresses(
     client: InfrahubClient, log: logging.Logger, site_name: str, interconnection_pool: CoreNode
 ) -> None:
-    """
-    Create a new Branch and Change the IP addresses between edge1 and edge2 on the selected site
-    """
+    """Create a new Branch and Change the IP addresses between edge1 and edge2 on the selected site"""
     device1_name = f"{site_name}-edge1"
     device2_name = f"{site_name}-edge2"
 
@@ -2044,9 +2037,7 @@ async def branch_scenario_replace_ip_addresses(
 
 
 async def branch_scenario_remove_colt(client: InfrahubClient, log: logging.Logger, site_name: str) -> None:
-    """
-    Create a new Branch and Delete Colt Upstream Circuit
-    """
+    """Create a new Branch and Delete Colt Upstream Circuit"""
     log.info("Create a new Branch and Delete Colt Upstream Circuit")
     new_branch_name = f"{site_name}-delete-upstream"
     await client.branch.create(
@@ -2109,9 +2100,7 @@ async def branch_scenario_remove_colt(client: InfrahubClient, log: logging.Logge
 
 
 async def branch_scenario_conflict_device(client: InfrahubClient, log: logging.Logger, site_name: str) -> None:
-    """
-    Create a new Branch and introduce some conflicts
-    """
+    """Create a new Branch and introduce some conflicts"""
     log.info("Create a new Branch and introduce some conflicts")
     device1_name = f"{site_name}-edge1"
     f"{site_name}-edge2"
@@ -2152,9 +2141,7 @@ async def branch_scenario_conflict_device(client: InfrahubClient, log: logging.L
 
 
 async def branch_scenario_conflict_platform(client: InfrahubClient, log: logging.Logger) -> None:
-    """
-    Create a new Branch and introduce some conflicts on the platforms for node ADD and DELETE
-    """
+    """Create a new Branch and introduce some conflicts on the platforms for node ADD and DELETE"""
     log.info("Create a new Branch and introduce some conflicts on the platforms for node ADD and DELETE")
     new_branch_name = "platform-conflict"
     await client.branch.create(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -496,12 +496,12 @@ task-tags = ["FIXME", "TODO", "XXX"]
 select = ["ALL"]
 
 ignore = [
-    "D",        # pydocstyle
-    "DOC",      # pydoclint
     "CPY",      # flake8-copyright
     "T201",     # use of `print`
     "ISC",      # flake8-implicit-str-concat
     "COM812",   # missing-trailing-comma
+    "D203",     # incorrect-blank-line-before-class (incompatible with D211)
+    "D213",     # multi-line-summary-second-line (incompatible with D212)
 
     ##################################################################################################
     # Rules below needs to be Investigated                                                           #
@@ -512,6 +512,39 @@ ignore = [
     "G",        # flake8-logging-format
     "RSE",      # flake8-raise
     "BLE",      # flake8-blind-except (BLE)
+
+    ##################################################################################################
+    # Documentation rules - resolve in smaller batches after deciding which of these we want to have #
+    ##################################################################################################
+    # pydocstyle (D)
+    "D100",     # undocumented-public-module
+    "D101",     # undocumented-public-class
+    "D102",     # undocumented-public-method
+    "D103",     # undocumented-public-function
+    "D104",     # undocumented-public-package
+    "D105",     # undocumented-magic-method
+    "D106",     # undocumented-public-nested-class
+    "D107",     # undocumented-public-init
+    "D200",     # unnecessary-multiline-docstring
+    "D202",     # blank-line-after-function
+    "D205",     # missing-blank-line-after-summary
+    "D209",     # new-line-after-last-paragraph
+    "D212",     # multi-line-summary-first-line
+    "D301",     # escape-sequence-in-docstring
+    "D400",     # missing-trailing-period
+    "D401",     # non-imperative-mood
+    "D403",     # first-word-uncapitalized
+    "D404",     # docstring-starts-with-this
+    "D413",     # missing-blank-line-after-last-section
+    "D415",     # missing-terminal-punctuation
+    "D417",     # undocumented-param
+    # pydoclint (DOC)
+    "DOC102",   # docstring-extraneous-parameter
+    "DOC201",   # docstring-missing-returns
+    "DOC202",   # docstring-extraneous-returns
+    "DOC402",   # docstring-missing-yields
+    "DOC501",   # docstring-missing-exception
+    "DOC502",   # docstring-extraneous-exception
 ]
 
 [tool.ruff.lint.flake8-bugbear]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -21,7 +21,6 @@ ns.add_collection(release)
 @task
 def yamllint(context: Context) -> None:
     """Validate formatting of all YAML files with yamllint."""
-
     exec_cmd = "yamllint -s ."
     context.run(exec_cmd, pty=True)
 

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -23,7 +23,6 @@ NAMESPACE = "BACKEND"
 
 def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
-
     print(f" - [{NAMESPACE}] Format code with ruff")
     exec_cmd = f"uv run ruff format {MAIN_DIRECTORY} &&"
     exec_cmd += f"uv run ruff check --fix {MAIN_DIRECTORY}"
@@ -34,7 +33,6 @@ def _format_ruff(context: Context) -> None:
 @task(name="format")
 def format_all(context: Context) -> None:
     """Format all backend Python files with ruff."""
-
     _format_ruff(context)
 
     print(f" - [{NAMESPACE}] All formatters have been executed!")
@@ -46,7 +44,6 @@ def format_all(context: Context) -> None:
 @task
 def ruff(context: Context) -> None:
     """Run ruff linter against backend Python files."""
-
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_cmd = f"uv run ruff check --diff {MAIN_DIRECTORY}"
 
@@ -61,7 +58,6 @@ def ruff(context: Context) -> None:
 @task
 def ty(context: Context) -> None:
     """Run ty type checker against project files."""
-
     print(f" - [{NAMESPACE}] Check code with ty")
     exec_cmd = "uv run ty check ."
 
@@ -72,7 +68,6 @@ def ty(context: Context) -> None:
 @task
 def mypy(context: Context) -> None:
     """Run mypy type checking against backend Python files."""
-
     print(f" - [{NAMESPACE}] Check code with mypy")
     exec_cmd = f"uv run mypy --show-error-codes {MAIN_DIRECTORY}"
 
@@ -206,7 +201,6 @@ def generate(context: Context) -> None:
 @task
 def validate_generated(context: Context, docker: bool = False) -> None:  # noqa: ARG001
     """Validate that generated schemas and protocols are committed to Git."""
-
     _generate_schemas(context=context)
     exec_cmd = "git diff --exit-code backend/infrahub/core/schema/generated"
     with context.cd(ESCAPED_REPO_PATH):

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -51,6 +51,7 @@ def build(
         context (obj): Used to run specific commands
         python_ver (str): Define the Python version docker image to build from
         nocache (bool): Do not use cache when building the image
+
     """
     build_images(
         context=context, service=service, python_ver=python_ver, nocache=nocache, database=database, namespace=NAMESPACE
@@ -185,7 +186,6 @@ def status(
 @task(optional=["database"])
 def start(context: Context, database: str = INFRAHUB_DATABASE, wait: bool = False, reload: bool = False) -> None:
     """Start a local instance of Infrahub within docker compose."""
-
     if reload:
         # Need to use `uvicorn` instead of `gunicorn` for reload option because of this issue:
         # https://github.com/benoitc/gunicorn/issues/2339

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -107,7 +107,6 @@ def validate(context: Context) -> None:
 @task
 def serve(context: Context) -> None:
     """Run documentation server in development mode."""
-
     exec_cmd = "npm run serve"
 
     with context.cd(DOCUMENTATION_DIRECTORY):
@@ -172,7 +171,6 @@ def lint(context: Context) -> None:
 
 def _generate_infrahub_cli_documentation(context: Context) -> None:
     """Generate the documentation for infrahub cli using typer-cli."""
-
     CLI_COMMANDS = (
         ("infrahub.cli.db", "infrahub db", "infrahub-db"),
         ("infrahub.cli.server", "infrahub server", "infrahub-server"),
@@ -275,8 +273,7 @@ def _extract_nested_parameters(
     parent_default: dict | None = None,
     env_prefix: str | None = None,
 ) -> list["ConfigurationSectionParameter"]:
-    """
-    Recursively extract nested parameters for object-type config fields.
+    """Recursively extract nested parameters for object-type config fields.
 
     Args:
         prop_schema: The property schema dictionary.
@@ -288,6 +285,7 @@ def _extract_nested_parameters(
 
     Returns:
         List of ConfigurationSectionParameter objects for nested fields.
+
     """
     from infrahub import config
 
@@ -390,6 +388,7 @@ def _process_section_parameters(
 
     Returns:
         List of ConfigurationSectionParameter objects.
+
     """
     parameters = []
     for param_name, param_schema in section_schema["properties"].items():
@@ -637,8 +636,7 @@ def _generate_infrahub_repository_configuration_documentation() -> None:
 
 
 def _generate_infrahub_bus_events_documentation() -> None:
-    """
-    Generate documentation for all classes in the event system into a single file
+    """Generate documentation for all classes in the event system into a single file
     using a Jinja2 template. Accessible via `invoke generate_infrahub_events_documentation`.
     """
     from infrahub.message_bus import InfrahubMessage, InfrahubResponse
@@ -647,9 +645,7 @@ def _generate_infrahub_bus_events_documentation() -> None:
         classes: dict[str, type[InfrahubMessage | InfrahubResponse]],
         priority_map: dict[str, int] | None = None,
     ) -> dict[str, dict[str, list[dict[str, any]]]]:
-        """
-        Group classes into a nested dictionary by primary and secondary categories, including priority.
-        """
+        """Group classes into a nested dictionary by primary and secondary categories, including priority."""
         grouped = defaultdict(lambda: defaultdict(list))
         for event_name, cls in classes.items():
             parts = event_name.split(".")
@@ -747,6 +743,7 @@ class ConfigurationSection:
         name: The name of the configuration section.
         description: The section's description.
         parameters: The list of parameters in this section.
+
     """
 
     name: str
@@ -755,8 +752,7 @@ class ConfigurationSection:
 
 
 def _generate_infrahub_events_documentation() -> None:
-    """
-    Generate documentation for all Infrahub events into a single MDX file
+    """Generate documentation for all Infrahub events into a single MDX file
     using a Jinja2 template. Accessible via `invoke generate_infrahub_event_documentation`.
 
     Note: Ensure all event classes (like GroupMutatedEvent, CommitUpdatedEvent, etc.) are imported
@@ -778,8 +774,7 @@ def _generate_infrahub_events_documentation() -> None:
             import_module(modname)
 
     def format_event_name(raw_name: str) -> str:
-        """
-        Insert spaces before capitals and remove a trailing "Event", if present.
+        """Insert spaces before capitals and remove a trailing "Event", if present.
         For example: "NodeCreatedEvent" becomes "Node Created Event".
         """
         formatted = re.sub(r"(?<!^)(?=[A-Z])", " ", raw_name)

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -18,7 +18,6 @@ DIRECTORIES = [str(MAIN_DIRECTORY), "models", "utilities", "python_testcontainer
 
 def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
-
     print(f" - [{NAMESPACE}] Format code with ruff")
     exec_cmd = f"uv run ruff format {' '.join(DIRECTORIES)} && "
     exec_cmd += f"uv run ruff check --fix {' '.join(DIRECTORIES)}"
@@ -29,7 +28,6 @@ def _format_ruff(context: Context) -> None:
 @task(name="format", default=True)
 def format_all(context: Context) -> None:
     """Format tasks, models, utilities, and test container Python files with ruff."""
-
     _format_ruff(context)
 
     print(f" - [{NAMESPACE}] All formatters have been executed!")
@@ -37,7 +35,6 @@ def format_all(context: Context) -> None:
 
 def _lint_ruff(context: Context) -> None:
     """Run ruff to check that Python files adherence to standards."""
-
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_cmd = f"uv run ruff check --diff {' '.join(DIRECTORIES)}"
 
@@ -48,7 +45,6 @@ def _lint_ruff(context: Context) -> None:
 @task
 def lint(context: Context) -> None:
     """Run ruff linter against tasks, models, utilities, and test container files."""
-
     _lint_ruff(context)
 
     print(f" - [{NAMESPACE}] All linters have been executed!")
@@ -56,10 +52,7 @@ def lint(context: Context) -> None:
 
 @task(name="scan")
 def scan(context: Context) -> None:
-    """
-    Scan the repository for prohibited keywords.
-    """
-
+    """Scan the repository for prohibited keywords."""
     with context.cd(ESCAPED_REPO_PATH):
         base_cmd = "python utilities/scan.py"
         execute_command(context=context, command=base_cmd)

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -19,7 +19,6 @@ MAIN_DIRECTORY_PATH = REPO_BASE / MAIN_DIRECTORY
 
 def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
-
     print(f" - [{NAMESPACE}] Format code with ruff")
     exec_cmd = f"ruff format {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY / 'pyproject.toml'} && "
     exec_cmd += f"ruff check --fix {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY / 'pyproject.toml'}"
@@ -30,7 +29,6 @@ def _format_ruff(context: Context) -> None:
 @task(name="format")
 def format_all(context: Context) -> None:
     """Format all Python SDK files with ruff."""
-
     _format_ruff(context)
 
     print(f" - [{NAMESPACE}] All formatters have been executed!")
@@ -42,7 +40,6 @@ def format_all(context: Context) -> None:
 @task
 def ruff(context: Context) -> None:
     """Run ruff linter against Python SDK files."""
-
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_directory = MAIN_DIRECTORY_PATH
     exec_cmd = f"ruff check --diff {exec_directory} --config {exec_directory / 'pyproject.toml'}"
@@ -54,7 +51,6 @@ def ruff(context: Context) -> None:
 @task
 def mypy(context: Context) -> None:
     """Run mypy type checking against the Python SDK."""
-
     print(f" - [{NAMESPACE}] Check code with mypy")
     exec_cmd = "mypy --show-error-codes infrahub_sdk/"
     exec_directory = MAIN_DIRECTORY_PATH

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -303,6 +303,7 @@ def init_yaml_obj(line_length: int | None = None) -> YAML:
 
     Returns:
         YAML: Instantiated ruamel.yaml.YAML object.
+
     """
     from ruamel.yaml import YAML
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -48,7 +48,6 @@ ESCAPED_REPO_PATH = escape_path(REPO_BASE)
 
 def project_ver() -> str:
     """Find version from pyproject.toml to use for docker image tagging."""
-
     with (REPO_BASE / "pyproject.toml").open("rb") as file:
         return tomllib.load(file)["project"].get("version", "latest")
 
@@ -74,7 +73,6 @@ def get_group_id(context: Context) -> int:
 
 def str_to_bool(value: str) -> bool:
     """Convert a String to a Boolean"""
-
     if isinstance(value, bool):
         return value
 
@@ -106,7 +104,6 @@ def str_to_bool(value: str) -> bool:
 
 def get_version_from_pyproject() -> str:
     """Retrieve the current version from the pyproject.toml file."""
-
     with (REPO_BASE / "pyproject.toml").open("rb") as file:
         return tomllib.load(file)["project"]["version"]
 

--- a/utilities/infrahub_load_tester.py
+++ b/utilities/infrahub_load_tester.py
@@ -175,7 +175,6 @@ async def run(
     prefix: str = DEFAULT_PREFIX,
 ) -> None:
     """Main entrypoint executed by **infrahubctl run**."""
-
     mode = str(mode).lower()
     prefix = str(prefix)
     n_users = int(n_users)

--- a/utilities/proposed_change_faker.py
+++ b/utilities/proposed_change_faker.py
@@ -1,5 +1,4 @@
-"""
-This script creates all required objects to fake a proposed change with all kind of validators, checks in all possible states.
+"""This script creates all required objects to fake a proposed change with all kind of validators, checks in all possible states.
 
 It tries to be as idempotent as possible to avoid re-creating objects on re-run.
 """

--- a/utilities/scan.py
+++ b/utilities/scan.py
@@ -11,8 +11,7 @@ def find_keyword_violations(
     exclude_dirs: set[str],
     exclude_patterns: tuple[str, ...],
 ) -> list[str]:
-    """
-    Traverse files once and check each line for any prohibited keyword.
+    """Traverse files once and check each line for any prohibited keyword.
 
     Args:
         keywords: List of prohibited keywords (case-insensitive).
@@ -22,6 +21,7 @@ def find_keyword_violations(
 
     Returns:
         List of file paths (as strings) where any keyword was found.
+
     """
     violations = []
     lowered_keywords = [k.lower() for k in keywords]
@@ -43,14 +43,14 @@ def find_keyword_violations(
 
 
 def find_keyword_in_git_commits(keywords: list[str]) -> list[str]:
-    """
-    Scan git commit messages for any prohibited keyword.
+    """Scan git commit messages for any prohibited keyword.
 
     Args:
         keywords: List of prohibited keywords (case-insensitive).
 
     Returns:
         List of commit hashes where a prohibited keyword was found.
+
     """
     violations = []
     lowered_keywords = [k.lower() for k in keywords]
@@ -74,8 +74,7 @@ def find_keyword_in_git_commits(keywords: list[str]) -> list[str]:
 
 
 def main() -> None:
-    """
-    Scan the repository for prohibited keywords.
+    """Scan the repository for prohibited keywords.
 
     This function traverses all files (excluding certain directories and patterns) once,
     checking each line for any of the keywords specified in the KEYWORDS_LIST environment variable.
@@ -93,6 +92,7 @@ def main() -> None:
 
     Examples:
         $ uv run python utilities/scan.py
+
     """
     keyword_list = os.environ.get("KEYWORDS_LIST", "")
     if not keyword_list:


### PR DESCRIPTION

# Why

Resolve merge conflicts between stable and develop after #9199 was merge.

## What changed

* New commits from stable
* Resolved conflicts, of specific note:
    * backend/infrahub/core/schema/basenode_schema.py: generate_fields_for_display_label: kept develop's expanded logic (handles both display_label Jinja2 templates and display_labels list). Discarded stable's docstring tweak because it described the older simpler function that no longer exists.
    * backend/infrahub/cli/db.py: combined develop's new helpers (_get_migration_type_name, _get_migration_display_name, verbose kwargs) with stable's docstring style.
    * backend/infrahub/core/node/standard.py: combined develop's dict[str, Any] annotation with stable's docstring style.
