### PR TITLE
fix: validate negative offset and limit in graphql resolver

### DIFF
--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -183,6 +183,13 @@ def _transform_metadata_day_filters(filters: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def validate_offset_and_limit(offset: int | None, limit: int | None) -> None:
+    if limit is not None and limit < 0:
+        raise GraphQLError("limit must be a non-negative integer")
+    if offset is not None and offset < 0:
+        raise GraphQLError("offset must be a non-negative integer")
+
+
 @trace.get_tracer(__name__).start_as_current_span("default_paginated_list_resolver")
 @retry_db_transaction(name="default_paginated_list_resolver")
 async def default_paginated_list_resolver(
@@ -194,6 +201,7 @@ async def default_paginated_list_resolver(
     partial_match: bool = False,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
+    validate_offset_and_limit(offset, limit)
     schema: MainSchemaTypes = (
         info.return_type.of_type.graphene_type._meta.schema
         if isinstance(info.return_type, GraphQLNonNull)
@@ -235,11 +243,6 @@ async def default_paginated_list_resolver(
             for edge in permissions["edges"]:
                 if edge["node"]["kind"] == schema.kind:
                     permission_set = edge["node"]
-
-        if limit is not None and limit < 0:
-            raise GraphQLError("limit must be a non-negative integer")
-        if offset is not None and offset < 0:
-            raise GraphQLError("offset must be a non-negative integer")
 
         objs = []
         if edges or "hfid" in filters:

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from graphql import GraphQLError
 from graphql.type.definition import GraphQLNonNull
 from opentelemetry import trace
 
@@ -234,6 +235,11 @@ async def default_paginated_list_resolver(
             for edge in permissions["edges"]:
                 if edge["node"]["kind"] == schema.kind:
                     permission_set = edge["node"]
+
+        if limit is not None and limit < 0:
+            raise GraphQLError("limit must be a non-negative integer")
+        if offset is not None and offset < 0:
+            raise GraphQLError("offset must be a non-negative integer")
 
         objs = []
         if edges or "hfid" in filters:

--- a/backend/tests/unit/graphql/resolvers/test_resolver.py
+++ b/backend/tests/unit/graphql/resolvers/test_resolver.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+import pytest
+from graphql import GraphQLError
+
+from infrahub.graphql.resolvers.resolver import default_paginated_list_resolver
+
+
+@pytest.mark.anyio
+async def test_negative_limit_raises() -> None:
+    info = MagicMock()
+    with pytest.raises(GraphQLError, match="limit"):
+        await default_paginated_list_resolver(root=None, info=info, limit=-1)
+
+
+@pytest.mark.anyio
+async def test_negative_offset_raises() -> None:
+    info = MagicMock()
+    with pytest.raises(GraphQLError, match="offset"):
+        await default_paginated_list_resolver(root=None, info=info, offset=-1)

--- a/backend/tests/unit/graphql/resolvers/test_resolver.py
+++ b/backend/tests/unit/graphql/resolvers/test_resolver.py
@@ -1,20 +1,14 @@
-from unittest.mock import MagicMock
-
 import pytest
 from graphql import GraphQLError
 
-from infrahub.graphql.resolvers.resolver import default_paginated_list_resolver
+from infrahub.graphql.resolvers.resolver import validate_offset_and_limit
 
 
-@pytest.mark.anyio
-async def test_negative_limit_raises() -> None:
-    info = MagicMock()
+def test_negative_limit_raises() -> None:
     with pytest.raises(GraphQLError, match="limit"):
-        await default_paginated_list_resolver(root=None, info=info, limit=-1)
+        validate_offset_and_limit(offset=None, limit=-1)
 
 
-@pytest.mark.anyio
-async def test_negative_offset_raises() -> None:
-    info = MagicMock()
+def test_negative_offset_raises() -> None:
     with pytest.raises(GraphQLError, match="offset"):
-        await default_paginated_list_resolver(root=None, info=info, offset=-1)
+        validate_offset_and_limit(offset=-1, limit=None)

--- a/changelog/7474.fixed.md
+++ b/changelog/7474.fixed.md
@@ -1,0 +1,1 @@
+Fixed GraphQL resolver returning an unhelpful database error when negative values were provided for limit or offset query arguments.

--- a/changelog/7474.fixed.md
+++ b/changelog/7474.fixed.md
@@ -1,1 +1,1 @@
-Fixed GraphQL resolver returning an unhelpful database error when negative values were provided for limit or offset query arguments.
+Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments.


### PR DESCRIPTION
Closes #7474

## What

Adds input validation in `default_paginated_list_resolver` to reject negative `limit` and `offset` values with a user-friendly `GraphQLError` before reaching the database layer.

## Before

Negative values were passed through to Neo4j, resulting in a `CypherSyntaxError` with an unhelpful stack trace in the server logs.

## After

The resolver immediately raises a `GraphQLError` with a clear message (`limit must be a non-negative integer` / `offset must be a non-negative integer`).

## Tests

Added unit tests in `backend/tests/unit/graphql/resolvers/test_resolver.py` covering both `limit` and `offset` validation.