### PR TITLE
docs: move info block to top of schema update page

### DIFF
--- a/docs/_templates/schema/validator-migration.j2
+++ b/docs/_templates/schema/validator-migration.j2
@@ -7,18 +7,18 @@ title: Schema Update
 
 # Schema Update
 
-For each element* of the schema, when its value is being updated, Infrahub will determine what should be done from the list of possible actions:
-
-- **allowed** : Nothing is required, the update of this element is allowed
-- **migration_required** : The existing data must be migrated to the new schema
-- **validate_constraint** : The existing data needs to be validated to ensure that its compatible with the new schema
-- **not_supported** : The update of this element is not supported
-
 :::info
 
 In this context, an element represent either a Node, a Generic, an Attribute or a Relationship
 
 :::
+
+For each element of the schema, when its value is being updated, Infrahub will determine what should be done from the list of possible actions:
+
+- **allowed** : Nothing is required, the update of this element is allowed
+- **migration_required** : The existing data must be migrated to the new schema
+- **validate_constraint** : The existing data needs to be validated to ensure that its compatible with the new schema
+- **not_supported** : The update of this element is not supported
 
 ## Reference Guide
 

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -7,18 +7,18 @@ title: Schema Update
 
 # Schema Update
 
-For each element* of the schema, when its value is being updated, Infrahub will determine what should be done from the list of possible actions:
-
-- **allowed** : Nothing is required, the update of this element is allowed
-- **migration_required** : The existing data must be migrated to the new schema
-- **validate_constraint** : The existing data needs to be validated to ensure that its compatible with the new schema
-- **not_supported** : The update of this element is not supported
-
 :::info
 
 In this context, an element represent either a Node, a Generic, an Attribute or a Relationship
 
 :::
+
+For each element of the schema, when its value is being updated, Infrahub will determine what should be done from the list of possible actions:
+
+- **allowed** : Nothing is required, the update of this element is allowed
+- **migration_required** : The existing data must be migrated to the new schema
+- **validate_constraint** : The existing data needs to be validated to ensure that its compatible with the new schema
+- **not_supported** : The update of this element is not supported
 
 ## Reference Guide
 


### PR DESCRIPTION


## Summary
- Move the `:::info` block to the top of the Schema Update reference page so it's the first thing readers see under the heading
- Remove the stray `*` after "element" in the introductory paragraph
- Applied to both the generated `.mdx` and its `.j2` template

### Link to the page
https://demo-groups-diataxis-example.infrahub.pages.dev/reference/schema/validator-migration

### Before
<img width="2098" height="820" alt="image" src="https://github.com/user-attachments/assets/fa5bc27d-a0b5-4ded-a8bd-a2d25f8114ca" />

### After
<img width="1058" height="410" alt="image" src="https://github.com/user-attachments/assets/a8b146a1-3678-4d0f-8510-d926d57e24d7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the `:::info` block to the top of the Schema Update reference page (/reference/schema/validator-migration) so readers see the definition first. Also removes a stray `*` after "element"; applied to both the `.mdx` file and the `.j2` template.

<sup>Written for commit 611fba23e2badb731ef597be2d2b96410f595c0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

