### PR TITLE
fix diff calculation for aware attributes on agnostic schema

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Self
 
 from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
     BranchSupportType,
     DiffAction,
     RelationshipCardinality,
@@ -772,10 +773,11 @@ class DatabasePath:
 
     @property
     def deepest_branch(self) -> str:
-        deepest_edge = max(
-            (self.path_to_node, self.path_to_attribute, self.path_to_property),
-            key=lambda edge: int(edge.get("branch_level")),
-        )
+        # only use the global branch if every branch in the path is global
+        edges = (self.path_to_node, self.path_to_attribute, self.path_to_property)
+        non_global_edges = [edge for edge in edges if str(edge.get("branch")) != GLOBAL_BRANCH_NAME]
+        candidate_edges = non_global_edges or list(edges)
+        deepest_edge = max(candidate_edges, key=lambda edge: int(edge.get("branch_level")))
         return str(deepest_edge.get("branch"))
 
     @property

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -139,10 +139,13 @@ CALL (diff_path) {
     // -------------------------------------
     WITH n, attr_rel, r_node, r_prop
     // 'base_n' instead of 'n' here to get previous value for node with a migrated kind/inheritance
-    OPTIONAL MATCH latest_base_path = (:Root)<-[base_r_root:IS_PART_OF {branch: $base_branch_name}]
-        -(base_n {uuid: n.uuid})-[base_r_node {branch: $base_branch_name}]
-        -(attr_rel)-[base_r_prop {branch: $base_branch_name}]->(base_prop)
-    WHERE type(base_r_node) = type(r_node)
+    OPTIONAL MATCH latest_base_path = (:Root)<-[base_r_root:IS_PART_OF]
+        -(base_n {uuid: n.uuid})-[base_r_node]
+        -(attr_rel)-[base_r_prop]->(base_prop)
+    WHERE base_r_root.branch IN [$base_branch_name, $global_branch_name]
+    AND base_r_node.branch IN [$base_branch_name, $global_branch_name]
+    AND base_r_prop.branch IN [$base_branch_name, $global_branch_name]
+    AND type(base_r_node) = type(r_node)
     AND type(base_r_prop) = type(r_prop)
     AND [%(id_func)s(base_n), type(base_r_node)] <> [%(id_func)s(base_prop), type(base_r_prop)]
     AND all(
@@ -722,7 +725,7 @@ AND (
 AND ALL(
     r_pair IN [[r_root, r_node], [r_node, diff_rel]]
     // filter out paths where a base branch edge follows a branch edge
-    WHERE ((r_pair[0]).branch = $base_branch_name OR (r_pair[1]).branch = $branch_name)
+    WHERE ((r_pair[0]).branch IN [$base_branch_name, $global_branch_name] OR (r_pair[1]).branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
     AND ((r_pair[0]).status = "active" OR (r_pair[1]).status = "deleted")
     // filter out paths where an earlier from time follows a later from time

--- a/backend/tests/component/core/diff/conftest.py
+++ b/backend/tests/component/core/diff/conftest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import BranchSupportType
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.node_schema import NodeSchema
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+REPO_MIRROR_KIND = "TestingRepoMirror"
+
+
+@pytest.fixture
+async def repo_mirror_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """Agnostic schema with aware and agnostic attributes, like CoreReadOnlyRepository"""
+    repo_mirror = NodeSchema(
+        name="RepoMirror",
+        namespace="Testing",
+        branch=BranchSupportType.AGNOSTIC,
+        default_filter="name__value",
+        attributes=[
+            AttributeSchema(
+                name="name",
+                kind="Text",
+                unique=True,
+                branch=BranchSupportType.AGNOSTIC,
+            ),
+            AttributeSchema(
+                name="ref",
+                kind="Text",
+                default_value="main",
+                branch=BranchSupportType.AWARE,
+            ),
+            AttributeSchema(
+                name="commit",
+                kind="Text",
+                optional=True,
+                branch=BranchSupportType.AWARE,
+            ),
+        ],
+    )
+    registry.schema.register_schema(schema=SchemaRoot(nodes=[repo_mirror]), branch=default_branch.name)
+
+
+@pytest.fixture
+async def repo_mirror_main(db: InfrahubDatabase, default_branch: Branch, repo_mirror_schema: None) -> Node:
+    """A TestingRepoMirror node created on default with ref='main', commit='a'*40."""
+    repo = await Node.init(db=db, schema=REPO_MIRROR_KIND, branch=default_branch)
+    await repo.new(db=db, name="mirror-1", ref="main", commit="a" * 40)
+    await repo.save(db=db, user_id="main-user")
+    return repo

--- a/backend/tests/component/core/diff/diff_calculator/test_agnostic_node_aware_attr.py
+++ b/backend/tests/component/core/diff/diff_calculator/test_agnostic_node_aware_attr.py
@@ -1,0 +1,80 @@
+"""Diff calculator coverage for the AGNOSTIC node + AWARE attribute scenario.
+
+Mirrors the real CoreReadOnlyRepository schema shape (AGNOSTIC node with
+AWARE ref/commit attributes). The node exists on default before the branch
+is created; the AWARE attribute is updated on the branch; the diff must
+capture the attribute change against the original value on default.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.constants import DiffAction
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.calculator import DiffCalculator
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.timestamp import Timestamp
+from tests.component.core.diff.conftest import REPO_MIRROR_KIND
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.database import InfrahubDatabase
+
+
+async def test_diff_aware_attribute_update_on_agnostic_node(
+    db: InfrahubDatabase, default_branch: Branch, repo_mirror_main: Node
+) -> None:
+    """Update an AWARE attribute on an AGNOSTIC node on a branch, then verify
+    that the diff captures both the previous (default) and new (branch) values
+    for that attribute."""
+    branch = await create_branch(db=db, branch_name="repo_mirror_branch")
+    from_time = Timestamp(branch.created_at)
+
+    repo_on_branch = await NodeManager.get_one(db=db, branch=branch, id=repo_mirror_main.id)
+    new_commit = "b" * 40
+    repo_on_branch.get_attribute("commit").value = new_commit
+    repo_on_branch.get_attribute("ref").value = "feature"
+    await repo_on_branch.save(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+        include_unchanged=False,
+    )
+
+    branch_root_path = calculated_diffs.diff_branch_diff
+    assert branch_root_path.branch == branch.name
+    assert len(branch_root_path.nodes) == 1
+    node_diff = branch_root_path.nodes[0]
+    assert node_diff.uuid == repo_mirror_main.id
+    assert node_diff.kind == REPO_MIRROR_KIND
+    assert node_diff.action is DiffAction.UPDATED
+
+    attributes_by_name = {attr.name: attr for attr in node_diff.attributes}
+    assert set(attributes_by_name.keys()) == {"commit", "ref"}, (
+        "AWARE attribute updates on an AGNOSTIC node should be captured by the diff; "
+        f"got attributes: {set(attributes_by_name.keys())}"
+    )
+
+    commit_diff = attributes_by_name["commit"]
+    assert commit_diff.action is DiffAction.UPDATED
+    commit_props = {prop.property_type: prop for prop in commit_diff.properties}
+    assert DatabaseEdgeType.HAS_VALUE in commit_props
+    commit_value_prop = commit_props[DatabaseEdgeType.HAS_VALUE]
+    assert commit_value_prop.action is DiffAction.UPDATED
+    assert commit_value_prop.previous_value == "a" * 40
+    assert commit_value_prop.new_value == new_commit
+
+    ref_diff = attributes_by_name["ref"]
+    assert ref_diff.action is DiffAction.UPDATED
+    ref_props = {prop.property_type: prop for prop in ref_diff.properties}
+    ref_value_prop = ref_props[DatabaseEdgeType.HAS_VALUE]
+    assert ref_value_prop.action is DiffAction.UPDATED
+    assert ref_value_prop.previous_value == "main"
+    assert ref_value_prop.new_value == "feature"

--- a/backend/tests/component/core/diff/diff_calculator/test_relationships.py
+++ b/backend/tests/component/core/diff/diff_calculator/test_relationships.py
@@ -834,30 +834,57 @@ async def test_agnostic_source_relationship_update(
     assert base_root_path.nodes == []
     branch_root_path = calculated_diffs.diff_branch_diff
     assert branch_root_path.branch == branch.name
-    assert len(branch_root_path.nodes) == 1
-    diff_node = branch_root_path.nodes.pop()
-    assert diff_node.uuid == new_car.get_id()
-    assert diff_node.action is DiffAction.UPDATED
-    assert diff_node.is_node_kind_migration is False
-    assert diff_node.attributes == []
-    assert len(diff_node.relationships) == 1
-    diff_relationship = diff_node.relationships.pop()
-    assert diff_relationship.name == "owner"
-    assert diff_relationship.action is DiffAction.UPDATED
-    assert len(diff_relationship.relationships) == 1
-    diff_element = diff_relationship.relationships.pop()
-    assert diff_element.peer_id == person_1.get_id()
-    assert diff_element.action is DiffAction.UPDATED
-    diff_props_by_type = {p.property_type: p for p in diff_element.properties}
-    assert set(diff_props_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.HAS_SOURCE}
-    diff_prop_is_related = diff_props_by_type[DatabaseEdgeType.IS_RELATED]
-    assert diff_prop_is_related.previous_value == person_1.get_id()
-    assert diff_prop_is_related.new_value == person_1.get_id()
-    assert diff_prop_is_related.action is DiffAction.UNCHANGED
-    diff_prop_has_source = diff_props_by_type[DatabaseEdgeType.HAS_SOURCE]
-    assert diff_prop_has_source.previous_value is None
-    assert diff_prop_has_source.new_value == person_1.get_id()
-    assert diff_prop_has_source.action is DiffAction.ADDED
+    # The HAS_SOURCE addition on the IS_RELATED edge surfaces under both endpoints:
+    # the AWARE Car (via its `owner` relationship) and the AGNOSTIC Person (via its
+    # inverse `cars` relationship).
+    diff_nodes_by_id = {n.uuid: n for n in branch_root_path.nodes}
+    assert set(diff_nodes_by_id.keys()) == {new_car.get_id(), person_1.get_id()}
+
+    diff_node_car = diff_nodes_by_id[new_car.get_id()]
+    assert diff_node_car.action is DiffAction.UPDATED
+    assert diff_node_car.is_node_kind_migration is False
+    assert diff_node_car.attributes == []
+    assert len(diff_node_car.relationships) == 1
+    diff_relationship_owner = diff_node_car.relationships[0]
+    assert diff_relationship_owner.name == "owner"
+    assert diff_relationship_owner.action is DiffAction.UPDATED
+    assert len(diff_relationship_owner.relationships) == 1
+    diff_element_owner = diff_relationship_owner.relationships[0]
+    assert diff_element_owner.peer_id == person_1.get_id()
+    assert diff_element_owner.action is DiffAction.UPDATED
+    owner_props_by_type = {p.property_type: p for p in diff_element_owner.properties}
+    assert set(owner_props_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.HAS_SOURCE}
+    owner_is_related = owner_props_by_type[DatabaseEdgeType.IS_RELATED]
+    assert owner_is_related.previous_value == person_1.get_id()
+    assert owner_is_related.new_value == person_1.get_id()
+    assert owner_is_related.action is DiffAction.UNCHANGED
+    owner_has_source = owner_props_by_type[DatabaseEdgeType.HAS_SOURCE]
+    assert owner_has_source.previous_value is None
+    assert owner_has_source.new_value == person_1.get_id()
+    assert owner_has_source.action is DiffAction.ADDED
+
+    diff_node_person = diff_nodes_by_id[person_1.get_id()]
+    assert diff_node_person.action is DiffAction.UPDATED
+    assert diff_node_person.is_node_kind_migration is False
+    assert diff_node_person.attributes == []
+    assert len(diff_node_person.relationships) == 1
+    diff_relationship_cars = diff_node_person.relationships[0]
+    assert diff_relationship_cars.name == "cars"
+    assert diff_relationship_cars.action is DiffAction.UPDATED
+    assert len(diff_relationship_cars.relationships) == 1
+    diff_element_cars = diff_relationship_cars.relationships[0]
+    assert diff_element_cars.peer_id == new_car.get_id()
+    assert diff_element_cars.action is DiffAction.UPDATED
+    cars_props_by_type = {p.property_type: p for p in diff_element_cars.properties}
+    assert set(cars_props_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.HAS_SOURCE}
+    cars_is_related = cars_props_by_type[DatabaseEdgeType.IS_RELATED]
+    assert cars_is_related.previous_value == new_car.get_id()
+    assert cars_is_related.new_value == new_car.get_id()
+    assert cars_is_related.action is DiffAction.UNCHANGED
+    cars_has_source = cars_props_by_type[DatabaseEdgeType.HAS_SOURCE]
+    assert cars_has_source.previous_value is None
+    assert cars_has_source.new_value == person_1.get_id()
+    assert cars_has_source.action is DiffAction.ADDED
 
 
 async def test_agnostic_owner_relationship_added(

--- a/backend/tests/component/core/diff/test_diff_and_merge_agnostic_node_aware_attr.py
+++ b/backend/tests/component/core/diff/test_diff_and_merge_agnostic_node_aware_attr.py
@@ -1,0 +1,100 @@
+"""Diff-and-merge coverage for the AGNOSTIC node + AWARE attribute scenario.
+
+Mirrors the real CoreReadOnlyRepository schema shape (AGNOSTIC node with
+AWARE ref/commit attributes). The node exists on default before the branch
+is created; the AWARE attribute is updated on the branch; after the merge,
+the default branch must reflect the value set on the branch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrahub.core.constants import DiffAction
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
+from tests.helpers.db_validation import verify_no_duplicate_paths
+
+from .get_one_node import get_one_diff_node
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestDiffAndMergeAgnosticNodeAwareAttr:
+    @pytest.fixture(autouse=True)
+    async def _setup_core_schema(self, register_core_models_schema: SchemaBranch) -> None:
+        return
+
+    @pytest.fixture
+    async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+
+    async def _get_diff_coordinator(self, db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        return diff_coordinator
+
+    async def _get_diff_merger(self, db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+    async def test_merge_aware_attribute_update_on_agnostic_node(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        repo_mirror_main: Node,
+    ) -> None:
+        """Update an AWARE attribute on a branch and verify the merged value
+        appears on default after merge_graph."""
+        branch = await create_branch(db=db, branch_name="repo_mirror_merge_branch")
+        repo_on_branch = await NodeManager.get_one(db=db, branch=branch, id=repo_mirror_main.id)
+        new_commit = "b" * 40
+        repo_on_branch.get_attribute("ref").value = "feature"
+        repo_on_branch.get_attribute("commit").value = new_commit
+        await repo_on_branch.save(db=db, user_id="branch-user")
+
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch)
+        enriched_diff_metadata = await diff_coordinator.update_branch_diff(
+            base_branch=default_branch, diff_branch=branch
+        )
+        enriched_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff_metadata.diff_branch_name, diff_id=enriched_diff_metadata.uuid
+        )
+        diff_node = get_one_diff_node(diff_root=enriched_diff, node_uuid=repo_mirror_main.id)
+        assert diff_node.action is DiffAction.UPDATED
+
+        diff_merger = await self._get_diff_merger(db=db, branch=branch)
+        merge_at = Timestamp()
+        await diff_merger.merge_graph(at=merge_at)
+
+        # On default branch, the AGNOSTIC node's AWARE attributes must reflect the branch values.
+        updated_repo = await NodeManager.get_one(db=db, branch=default_branch, id=repo_mirror_main.id)
+        assert updated_repo.get_attribute("name").value == "mirror-1", (
+            "AGNOSTIC attribute should be unchanged after the merge"
+        )
+        assert updated_repo.get_attribute("commit").value == new_commit, (
+            f"AWARE attribute on AGNOSTIC node should reflect branch value '{new_commit}' "
+            f"after merge, got '{updated_repo.get_attribute('commit').value}'"
+        )
+        assert updated_repo.get_attribute("ref").value == "feature", (
+            "AWARE attribute on AGNOSTIC node should reflect branch value 'feature' "
+            f"after merge, got '{updated_repo.get_attribute('ref').value}'"
+        )
+
+        await verify_no_duplicate_paths(db=db)

--- a/changelog/9221.fixed.md
+++ b/changelog/9221.fixed.md
@@ -1,0 +1,1 @@
+Fix diff calculation logic to correctly include updates to branch-aware attributes of branch-agnostic schemas.


### PR DESCRIPTION
Closes  #9221

Diff calculation was improperly excluding updates on aware attributes of agnostic schemas.

Updates are a few small changes to the diff calculation queries to properly capture a property edge (`HAS_VALUE`, `IS_PROTECTED`, `HAS_OWNER`, `HAS_SOURCE`) on a user branch or the default branch when it is under an edge on the global branch.

Adds and updates tests to ensure these edges are captured correctly 
