### PR TITLE
fix(backend): scale diff queries with branch changes, not database size

### DIFF
--- a/backend/infrahub/core/graph/index.py
+++ b/backend/infrahub/core/graph/index.py
@@ -25,4 +25,9 @@ rel_indexes: list[IndexItem] = [
     IndexItem(name="attr_branch", label="HAS_ATTRIBUTE", properties=["branch"], type=IndexType.RANGE),
     IndexItem(name="value_from", label="HAS_VALUE", properties=["from"], type=IndexType.RANGE),
     IndexItem(name="value_branch", label="HAS_VALUE", properties=["branch"], type=IndexType.RANGE),
+    IndexItem(name="related_branch", label="IS_RELATED", properties=["branch"], type=IndexType.RANGE),
+    IndexItem(name="protected_branch", label="IS_PROTECTED", properties=["branch"], type=IndexType.RANGE),
+    IndexItem(name="source_branch", label="HAS_SOURCE", properties=["branch"], type=IndexType.RANGE),
+    IndexItem(name="owner_branch", label="HAS_OWNER", properties=["branch"], type=IndexType.RANGE),
+    IndexItem(name="is_part_of_branch", label="IS_PART_OF", properties=["branch"], type=IndexType.RANGE),
 ]

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -274,13 +274,25 @@ class DiffNodePathsQuery(DiffCalculationQuery):
 // -------------------------------------
 // Identify nodes added/removed on branch
 // -------------------------------------
-MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
-WHERE (
-    ($new_node_ids_list IS NOT NULL AND p.uuid IN $new_node_ids_list)
-    OR ($current_node_ids_list IS NOT NULL AND p.uuid IN $current_node_ids_list)
-    OR ($new_node_ids_list IS NULL AND $current_node_ids_list IS NULL)
-)
-AND p.branch_support = $branch_aware
+CALL () {
+        MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
+        WHERE $new_node_ids_list IS NOT NULL
+        AND p.uuid IN $new_node_ids_list
+        RETURN q, diff_rel, p
+    UNION
+        MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
+        WHERE $current_node_ids_list IS NOT NULL
+        AND p.uuid IN $current_node_ids_list
+        RETURN q, diff_rel, p
+    UNION
+        MATCH (q)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p)
+        WHERE $current_node_ids_list IS NULL
+        AND $new_node_ids_list IS NULL
+        RETURN q, diff_rel, p
+}
+WITH q, diff_rel, p
+MATCH (q)<-[diff_rel]-(p)
+WHERE p.branch_support = $branch_aware
 AND (
     (
         ($new_node_ids_list IS NOT NULL AND p.uuid IN $new_node_ids_list)
@@ -419,10 +431,19 @@ class DiffFieldPathsQuery(DiffCalculationQuery):
 // -------------------------------------
 // Identify attributes/relationships added/removed on branch
 // -------------------------------------
-MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel {branch: $branch_name}]-(q)
+CALL () {
+        MATCH (p:Node)
+        WHERE p.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
+        RETURN p
+    UNION
+        MATCH (p)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
+        WHERE $current_node_ids_list IS NULL AND $new_node_ids_list IS NULL
+        RETURN DISTINCT p
+}
+WITH p
+MATCH (root:Root)<-[r_root:IS_PART_OF]-(p)-[diff_rel:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
 // simple filters to start
-WHERE type(diff_rel) IN ["HAS_ATTRIBUTE", "IS_RELATED"]
-AND ("Attribute" IN labels(q) OR "Relationship" IN labels(q))
+WHERE ("Attribute" IN labels(q) OR "Relationship" IN labels(q))
 AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
 AND q.branch_support = $branch_aware
 AND r_root.status = "active"
@@ -613,7 +634,18 @@ class DiffPropertyPathsQuery(DiffCalculationQuery):
 // -------------------------------------
 // Identify properties added/removed on branch
 // -------------------------------------
-MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)
+CALL () {
+        MATCH (n:Node)
+        WHERE n.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
+        RETURN n
+    UNION
+        MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED]-(p)
+            -[diff_rel:IS_PROTECTED|HAS_SOURCE|HAS_OWNER|HAS_VALUE {branch: $branch_name}]->()
+        WHERE $current_node_ids_list IS NULL AND $new_node_ids_list IS NULL
+        RETURN DISTINCT n
+}
+WITH n
+MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n)
     -[r_node:HAS_ATTRIBUTE|IS_RELATED]-(p:Attribute|Relationship)
     -[diff_rel:IS_PROTECTED|HAS_SOURCE|HAS_OWNER|HAS_VALUE {branch: $branch_name}]->(q:Boolean|Node|AttributeValue)
 WHERE p.branch_support = $branch_aware

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -260,36 +260,33 @@ class DiffNodePathsQuery(DiffCalculationQuery):
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         params_dict = self.get_params()
         self.params.update(params_dict)
-        self.params.update(
-            {
-                "new_node_ids_list": self.new_node_field_specifiers.get_uuids_list()
-                if self.new_node_field_specifiers
-                else None,
-                "current_node_ids_list": self.current_node_field_specifiers.get_uuids_list()
-                if self.current_node_field_specifiers
-                else None,
-            }
+        new_uuids = self.new_node_field_specifiers.get_uuids_list() if self.new_node_field_specifiers else None
+        current_uuids = (
+            self.current_node_field_specifiers.get_uuids_list() if self.current_node_field_specifiers else None
         )
-        nodes_path_query = """
+        self.params.update({"new_node_ids_list": new_uuids, "current_node_ids_list": current_uuids})
+        if new_uuids is None and current_uuids is None:
+            entry_clause = """
+CALL () {
+    MATCH (q)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p)
+    RETURN q, diff_rel, p
+}
+"""
+        else:
+            entry_clause = """
+CALL () {
+MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
+WHERE p.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
+RETURN q, diff_rel, p
+}
+"""
+        nodes_path_query = (
+            """
 // -------------------------------------
 // Identify nodes added/removed on branch
-// -------------------------------------
-CALL () {
-        MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
-        WHERE $new_node_ids_list IS NOT NULL
-        AND p.uuid IN $new_node_ids_list
-        RETURN q, diff_rel, p
-    UNION
-        MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
-        WHERE $current_node_ids_list IS NOT NULL
-        AND p.uuid IN $current_node_ids_list
-        RETURN q, diff_rel, p
-    UNION
-        MATCH (q)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p)
-        WHERE $current_node_ids_list IS NULL
-        AND $new_node_ids_list IS NULL
-        RETURN q, diff_rel, p
-}
+// -------------------------------------"""
+            + entry_clause
+            + """
 WITH q, diff_rel, p
 MATCH (q)<-[diff_rel]-(p)
 WHERE p.branch_support = $branch_aware
@@ -396,7 +393,9 @@ CALL (p, q, diff_rel, row_from_time) {
     WITH node, prop, type(r_prop) AS r_prop_type, type(r_node) AS r_node_type, head(collect(path)) AS diff_path
     RETURN diff_path
 }
-""" % {"id_func": db.get_id_function_name()}
+"""
+            % {"id_func": db.get_id_function_name()}
+        )
         self.add_to_query(nodes_path_query)
         self.add_to_query(self.get_previous_base_path_query(db=db))
         self.add_to_query(self.get_relationship_peer_side_query(db=db))
@@ -411,14 +410,14 @@ class DiffFieldPathsQuery(DiffCalculationQuery):
         params_dict = self.get_params()
         self.params.update(params_dict)
 
+        new_uuids = self.new_node_field_specifiers.get_uuids_list() if self.new_node_field_specifiers else None
+        current_uuids = (
+            self.current_node_field_specifiers.get_uuids_list() if self.current_node_field_specifiers else None
+        )
         self.params.update(
             {
-                "current_node_ids_list": self.current_node_field_specifiers.get_uuids_list()
-                if self.current_node_field_specifiers
-                else None,
-                "new_node_ids_list": self.new_node_field_specifiers.get_uuids_list()
-                if self.new_node_field_specifiers
-                else None,
+                "current_node_ids_list": current_uuids,
+                "new_node_ids_list": new_uuids,
                 "current_node_field_specifiers_map": self.current_node_field_specifiers.get_uuid_field_names_map()
                 if self.current_node_field_specifiers is not None
                 else None,
@@ -427,21 +426,26 @@ class DiffFieldPathsQuery(DiffCalculationQuery):
                 else None,
             }
         )
-        fields_path_query = """
+        if new_uuids is None and current_uuids is None:
+            entry_clause = """
+MATCH (p)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
+WITH DISTINCT p
+"""
+        else:
+            entry_clause = """
+MATCH (p:Node)
+WHERE p.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
+WITH p
+"""
+        fields_path_query = (
+            """
 // -------------------------------------
 // Identify attributes/relationships added/removed on branch
-// -------------------------------------
-CALL () {
-        MATCH (p:Node)
-        WHERE p.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
-        RETURN p
-    UNION
-        MATCH (p)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
-        WHERE $current_node_ids_list IS NULL AND $new_node_ids_list IS NULL
-        RETURN DISTINCT p
-}
-WITH p
-MATCH (root:Root)<-[r_root:IS_PART_OF]-(p)-[diff_rel:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
+// -------------------------------------"""
+            + entry_clause
+            + """
+MATCH (root:Root)<-[r_root:IS_PART_OF]-(p)
+    -[diff_rel:HAS_ATTRIBUTE|IS_RELATED {branch: $branch_name}]-(q)
 // simple filters to start
 WHERE ("Attribute" IN labels(q) OR "Relationship" IN labels(q))
 AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
@@ -599,7 +603,9 @@ CALL (q, rel_type, prop, row_from_time) {
 }
 WITH latest_prop_path AS diff_path, has_more_data, intra_branch_update
 WHERE intra_branch_update = FALSE
-        """ % {"id_func": db.get_id_function_name()}
+        """
+            % {"id_func": db.get_id_function_name()}
+        )
         self.add_to_query(fields_path_query)
         self.add_to_query(self.get_previous_base_path_query(db=db))
         self.add_to_query(self.get_relationship_peer_side_query(db=db))
@@ -614,14 +620,14 @@ class DiffPropertyPathsQuery(DiffCalculationQuery):
         params_dict = self.get_params()
         self.params.update(params_dict)
 
+        new_uuids = self.new_node_field_specifiers.get_uuids_list() if self.new_node_field_specifiers else None
+        current_uuids = (
+            self.current_node_field_specifiers.get_uuids_list() if self.current_node_field_specifiers else None
+        )
         self.params.update(
             {
-                "current_node_ids_list": self.current_node_field_specifiers.get_uuids_list()
-                if self.current_node_field_specifiers
-                else None,
-                "new_node_ids_list": self.new_node_field_specifiers.get_uuids_list()
-                if self.new_node_field_specifiers
-                else None,
+                "current_node_ids_list": current_uuids,
+                "new_node_ids_list": new_uuids,
                 "current_node_field_specifiers_map": self.current_node_field_specifiers.get_uuid_field_names_map()
                 if self.current_node_field_specifiers is not None
                 else None,
@@ -630,21 +636,25 @@ class DiffPropertyPathsQuery(DiffCalculationQuery):
                 else None,
             }
         )
-        properties_path_query = """
+        if new_uuids is None and current_uuids is None:
+            entry_clause = """
+MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED]-(p)
+    -[:IS_PROTECTED|HAS_SOURCE|HAS_OWNER|HAS_VALUE {branch: $branch_name}]->()
+WITH DISTINCT n
+"""
+        else:
+            entry_clause = """
+MATCH (n:Node)
+WHERE n.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
+WITH n
+"""
+        properties_path_query = (
+            """
 // -------------------------------------
 // Identify properties added/removed on branch
-// -------------------------------------
-CALL () {
-        MATCH (n:Node)
-        WHERE n.uuid IN COALESCE($current_node_ids_list, []) + COALESCE($new_node_ids_list, [])
-        RETURN n
-    UNION
-        MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED]-(p)
-            -[diff_rel:IS_PROTECTED|HAS_SOURCE|HAS_OWNER|HAS_VALUE {branch: $branch_name}]->()
-        WHERE $current_node_ids_list IS NULL AND $new_node_ids_list IS NULL
-        RETURN DISTINCT n
-}
-WITH n
+// -------------------------------------"""
+            + entry_clause
+            + """
 MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n)
     -[r_node:HAS_ATTRIBUTE|IS_RELATED]-(p:Attribute|Relationship)
     -[diff_rel:IS_PROTECTED|HAS_SOURCE|HAS_OWNER|HAS_VALUE {branch: $branch_name}]->(q:Boolean|Node|AttributeValue)
@@ -848,7 +858,9 @@ CALL (n, p, row_from_time){
 WITH n, p, diff_rel, diff_rel_path, has_more_data, node_or_field_deleted
 WHERE node_or_field_deleted = FALSE
 WITH n, p, type(diff_rel) AS drt, head(collect(diff_rel_path)) AS diff_path, has_more_data
-        """ % {"id_func": db.get_id_function_name()}
+        """
+            % {"id_func": db.get_id_function_name()}
+        )
         self.add_to_query(properties_path_query)
         self.add_to_query(self.get_previous_base_path_query(db=db))
         self.add_to_query(self.get_relationship_peer_side_query(db=db))

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -1336,7 +1336,7 @@ class NodeGetKindQuery(Query):
         self.params["ids"] = self.ids
         query = """
 MATCH (n:Node)-[r:IS_PART_OF {status: "active"}]->(:Root)
-WHERE toString(n.uuid) IN $ids
+WHERE n.uuid IN $ids
         """
         # only add the branch filter logic if a branch is included in the query parameters
         if branch := getattr(self, "branch", None):

--- a/changelog/9224.fixed.md
+++ b/changelog/9224.fixed.md
@@ -1,0 +1,1 @@
+Diff calculation between branches no longer scales with the total size of the database. Diffs now complete in a time proportional to the number of changes on the branch.


### PR DESCRIPTION
# Why

Diff calculation between branches was slow on instances with large datasets,
even when only a few objects had changed on the branch. The diff queries were
picking poor entry points and scanning unexpected parts of the graph — for
example, `diff_property_paths` would scan every `(:Attribute|Relationship)`
vertex at scale.

Closes #9224

## What changed

- **Separate entry paths in the diff queries.** When node-ID lists are
  provided (second pass, on the base branch), the queries seek `Node(uuid)`.
  When they're empty (first pass on the diff branch), they enter via the
  relationship's `branch` property instead. This is built in Python rather
  than a Cypher `UNION` — a `$param IS NULL`-guarded `UNION` branch is not
  pruned by the planner at runtime and still triggers a full scan over
  `IS_PART_OF{branch=$branch_name}` (catastrophic when `$branch_name = main`).
- **Added rel-property indexes** (`branch`, `from`) for `IS_RELATED`,
  `IS_PROTECTED`, `HAS_SOURCE`, `HAS_OWNER`, and `IS_PART_OF` so the rel-side
  entry path is index-backed.
- **Drop a `toString(...)` wrapping on `n.uuid`** in `node_get_kind_query`
  that was preventing the planner from using the `Node(uuid)` index.

## How to test

Run a diff between branches on an instance with a large dataset and only a
handful of changes on the branch — the diff should return quickly and in time
proportional to the number of changes, independently of the size of `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make branch diffs scale with the number of changes instead of database size. This removes full graph scans and speeds up diffs on large instances.

- **Bug Fixes**
  - Dynamically choose entry paths in diff queries: if node UUID lists exist, seek by `Node(uuid)`; otherwise enter via relationship `branch` properties. Build the entry in Python to avoid `UNION` causing scans on the base branch.
  - Add relationship-property indexes on `branch` for `IS_RELATED`, `IS_PROTECTED`, `HAS_SOURCE`, `HAS_OWNER`, and `IS_PART_OF` to back branch-based entry.
  - Stop converting `n.uuid` to string in `node_get_kind_query` so the `Node(uuid)` index is used.

<sup>Written for commit 672b79864e75a84f6d507ce5baa73efaf743e133. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

