### PR TITLE
speckit-reconcile installation

### DIFF
--- a/.github/agents/speckit.reconcile.run.agent.md
+++ b/.github/agents/speckit.reconcile.run.agent.md
@@ -1,0 +1,194 @@
+---
+description: Reconcile implementation drift by updating the feature's own spec, plan,
+  and tasks
+scripts:
+  sh: .specify/scripts/bash/check-prerequisites.sh --json --paths-only --include-tasks
+  ps: .specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly -IncludeTasks
+---
+
+
+<!-- Extension: reconcile -->
+<!-- Config: .specify/extensions/reconcile/ -->
+Act as the **Chief Software Architect** and **Implementation Auditor**.
+A feature implementation has landed, but "artifact drift" has been discovered (e.g., missing routes, updated behavior, or unlinked UI). Your goal is to **reconcile** this drift by surgically amending the feature's own specification, plan, and task artifacts.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+### Input Parsing
+
+The input `$ARGUMENTS` is a **Gap Report** — a natural language description of what is missing or changed in the implementation versus the documentation.
+
+**Examples:**
+- "Backend + tests for Invoice Settings exist; React screen scaffolded. Users can't navigate to it. Need sidebar link + route."
+- "The /api/v1/settings endpoint now requires an 'org_id' header not in the original plan."
+
+If `$ARGUMENTS` contains any of these flags, respect them (optional):
+- `--spec-only` — update only `spec.md`
+- `--plan-only` — update only `plan.md`
+- `--tasks-only` — update only `tasks.md`
+
+If `$ARGUMENTS` is empty, output `ERROR: No gap report provided. Usage: /speckit.reconcile.run [gap report text]` and stop.
+
+---
+
+## Step 0: Discovery & Setup (Gate)
+
+### 0.1 Resolve Paths
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only --include-tasks` to identify the active feature directory and its artifacts. This script is mandatory for path discovery. If the script is missing, stop and inform the user.
+
+Derive absolute paths for:
+- `FEATURE_DIR` (e.g., `specs/###-feature-name/`)
+- `FEATURE_SPEC` (`FEATURE_DIR/spec.md`)
+- `IMPL_PLAN` (`FEATURE_DIR/plan.md`)
+- `TASKS_FILE` (`FEATURE_DIR/tasks.md`)
+
+**Validation**: Ensure `spec.md` and `plan.md` exist. If either is missing, stop with:
+> ⚠️ Missing required files in `FEATURE_DIR`. Expected: spec.md, plan.md.
+> Run `/speckit.specify` and `/speckit.plan` first.
+
+If `tasks.md` does not exist, create it with a `## Remediation: Gaps` heading before appending tasks.
+
+### 0.2 Load Context
+
+Read `FEATURE_SPEC`, `IMPL_PLAN`, and `TASKS_FILE`.
+
+Also read `.specify/memory/constitution.md` if it exists. If found, extract MUST-level constraints and Architecture Standards. These are enforced in Step 1 — any remediation item that conflicts with a MUST principle is flagged as CRITICAL:
+```
+🔴 CONSTITUTION CONFLICT: [remediation item] conflicts with [principle]
+→ This must be resolved in Step 2 clarification before edits proceed.
+```
+
+---
+
+## Step 1: Gap Normalization
+
+Analyze the user's **Gap Report** and normalize it into structured remediation items:
+
+| Category | Typical Issues | Action |
+|----------|----------------|--------|
+| **Wiring & Navigation** | Missing routes, menu items, sidebar links | Add to `plan.md`, create tasks in `tasks.md` |
+| **Contracts** | API field mismatches, missing headers | Update `plan.md` contracts, create tasks |
+| **Acceptance Criteria** | Implementation behaves differently than planned | Update `spec.md` scenarios/criteria |
+| **Test Coverage** | New wiring/navigation without verification | Add task for Integration Test |
+| **Logic/UX** | Success toasts missing, error handling gaps | Add tasks for implementation |
+
+For each normalized item, verify it does not conflict with any MUST-level constitution constraint loaded in Step 0.2. Flag any conflicts as CRITICAL and include them in Step 2 clarification.
+
+---
+
+## Step 2: Clarify (Exactly Once; Max 5 Questions)
+
+If the gap report is ambiguous (e.g., "the button doesn't work" without saying which button), ask targeted questions.
+
+Use this format and **wait for answers**:
+
+```markdown
+## Question [N]: [Topic]
+**Context**: [Relevant implementation detail]
+**Decision Needed**: [1 sentence]
+**Suggested Answers**: [Table with Option A/B/C]
+
+**Your choice**: _[Wait for user response]_
+```
+
+**Rules:**
+- Max 5 questions.
+- Max 3 unresolved `NEEDS CLARIFICATION` markers in output — beyond that, pick reasonable defaults and note them in the Sync Impact Report.
+- Proceed with reasonable defaults if questions aren't strictly necessary.
+
+---
+
+## Step 3: Impact Map
+
+Before making any edits, produce a brief impact map:
+
+```markdown
+### Sync Impact Map
+| Artifact | Changes | Tasks Generated |
+|----------|---------|-----------------|
+| `spec.md` | Update AC-04, add User Scenario "Error Handling" | None |
+| `plan.md` | Add Route `/settings`, update API contract | None |
+| `tasks.md` | Append remediation tasks | T045, T046, T047 |
+```
+
+---
+
+## Step 4: Reconciliation (Surgical Edits)
+
+**Constraint**: Operate strictly in place. Do not create branches, switch branches, or run feature-creation scripts. All edits target existing files in `FEATURE_DIR`.
+
+### 4.1 Update Specification (`spec.md`)
+- **Acceptance Criteria**: Amend existing criteria or add new ones to reflect the shipped reality.
+- **User Scenarios**: Add missing scenarios discovered during implementation (e.g., specific edge cases).
+- **Revision Note**: Add a block at the bottom:
+  ```markdown
+  ### Revision: Implementation Sync [YYYY-MM-DD]
+  - Reason: [Summary of drift reconciled]
+  ```
+
+### 4.2 Update Plan (`plan.md`)
+- **Routing & Navigation**: Add any missing routes, endpoints, or UI wiring details.
+- **Integration Contracts**: Update API schemas, request/response headers, or payloads.
+- **Testing Strategy**: Ensure the strategy covers the newly identified gaps.
+- **Revision Note**: Append a revision note (same format as spec.md) if plan sections were modified.
+
+### 4.3 Update Tasks (`tasks.md`)
+This is the most critical step. Create remediation tasks to close the drift.
+
+**Task Formatting**:
+`- [ ] T{NNN} [P] [{story}] {action verb} {what} in {exact/file/path.ext} [Sync: Gap Report]`
+
+Where `[P]` is an optional priority flag — include it only for tasks that are blocking or high-urgency. Omit for normal priority. The `[Sync: Gap Report]` tag is always appended for traceability.
+
+**Rules for Tasks**:
+1. **Increment IDs**: Find the highest `T###` in `tasks.md`. Start new tasks from `max + 1`. Never reuse or renumber.
+2. **Phase Placement**: Place new tasks under the relevant User Story phase (e.g., `## [US2] Settings Dashboard`). If no phase fits, create a `## Remediation: Gaps` section at the end.
+3. **Exact Paths**: Every task MUST include an exact file path where the change is needed.
+4. **Mandatory Integration Test**: If you identified a **Wiring & Navigation** gap, you MUST add a task for an Integration Test to verify it.
+
+---
+
+## Step 5: Sync Impact Report
+
+Output the final report:
+
+```markdown
+# Sync Impact Report
+
+## Changed Files
+| File (absolute path) | Change Summary |
+|----------------------|----------------|
+| `/absolute/path/to/spec.md` | Updated AC, Scenarios |
+| `/absolute/path/to/plan.md` | Updated Routing/Contracts |
+| `/absolute/path/to/tasks.md` | Added [N] remediation tasks |
+
+## New Remediation Tasks
+[List the new tasks added, e.g.]
+- **T045**: Add sidebar link in `src/components/Sidebar.tsx`
+- **T046**: Update router in `src/router/index.ts`
+- **T047**: Integration test: navigate to Settings in `tests/integration/navigation.test.ts`
+
+## Outstanding Decisions
+[List any `NEEDS CLARIFICATION` items or "None"]
+
+## Next Step
+[Recommend based on what changed:]
+- If remediation tasks were added → `/speckit.implement` to execute them
+- If plan was significantly updated → `/speckit.plan` to review architecture
+- If only spec was updated → Review changes and proceed with implementation
+```
+
+---
+
+## Done Criteria
+- Gap report parsed and categorized.
+- Feature's own `spec.md` and `plan.md` surgically updated.
+- `tasks.md` updated with incremented `T###` IDs and exact file paths.
+- Mandatory integration test task added for wiring gaps.
+- Revision note added to artifacts.
+- Sync Impact Report printed.

--- a/.github/prompts/speckit.reconcile.run.prompt.md
+++ b/.github/prompts/speckit.reconcile.run.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.reconcile.run
+---

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -18,6 +18,23 @@
       },
       "registered_skills": [],
       "installed_at": "2026-04-10T12:40:51.752899+00:00"
+    },
+    "reconcile": {
+      "version": "1.0.0",
+      "source": "local",
+      "manifest_hash": "sha256:e1674fb7e16923c0e9e32eee78ef5a04626d05f092c56cc7c59e26fab07c210b",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "claude": [
+          "speckit.reconcile.run"
+        ],
+        "copilot": [
+          "speckit.reconcile.run"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-05-12T09:23:15.955528+00:00"
     }
   }
 }

--- a/.specify/extensions/reconcile/LICENSE
+++ b/.specify/extensions/reconcile/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stanislav Deviatov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.specify/extensions/reconcile/README.md
+++ b/.specify/extensions/reconcile/README.md
@@ -1,0 +1,47 @@
+# Spec-Kit Reconcile
+
+A Spec-Kit extension to reconcile documentation with implementation drift.
+
+## Overview
+
+The `speckit.reconcile.run` command is a **Post-Implementation Gap Closer**. It analyzes a natural-language gap report, resolves paths, surgically updates the feature's `spec.md` and `plan.md`, and appends actionable remediation tasks to `tasks.md`.
+
+This extension acts as the "Inner Loop" of the Double-Loop Parity framework: it ensures that during the PR phase, the *feature artifacts* are continuously aligned with the shipped code.
+
+## Features
+
+- **Gap Report Input**: Accepts free-form natural language observations about what was missed or changed during implementation.
+- **Remediation Engine**: Appends new tasks (`T###`) to `tasks.md` with auto-incremented IDs and exact file paths.
+- **Enforced Verification**: Automatically mandates integration test tasks for any discovered wiring or navigation gaps.
+- **Compliance Checks**: Includes lightweight validations against the project's `constitution.md` to prevent violating core "MUSTs".
+- **Actionable Reporting**: Provides a conditional "Next Step" in the Sync Impact Report.
+
+## Installation
+
+You can install this extension via the Spec-Kit CLI:
+
+```bash
+specify extension add reconcile --from https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.0.0.zip
+```
+*(Note: Replace `v1.0.0` with the latest release version)*
+
+## Usage
+
+Provide a plain-text gap report to the command describing the implementation drift:
+
+```bash
+/speckit.reconcile.run "Backend exists, but React screen is unreachable; need sidebar link and route"
+```
+
+You can optionally restrict the scope of the updates:
+- `--spec-only` — update only `spec.md`
+- `--plan-only` — update only `plan.md`
+- `--tasks-only` — update only `tasks.md`
+
+## Workflow
+
+1.  **Parse the Gap Report** to determine what drift occurred.
+2.  **Run the core Spec-Kit `check-prerequisites.sh` script** to identify target feature artifacts.
+3.  **Normalize Gaps** into categories (Wiring & Navigation, Contracts, Test Coverage, etc.).
+4.  **Surgically Edit** the feature's specific `spec.md`, `plan.md`, and `tasks.md`.
+5.  **Output a Sync Impact Report** detailing the created tasks and next steps (e.g., routing to `/speckit.implement`).

--- a/.specify/extensions/reconcile/commands/reconcile.md
+++ b/.specify/extensions/reconcile/commands/reconcile.md
@@ -1,0 +1,189 @@
+---
+description: "Reconcile implementation drift by updating the feature's own spec, plan, and tasks"
+scripts:
+  sh: ../../scripts/bash/check-prerequisites.sh --json --paths-only --include-tasks
+  ps: ../../scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly -IncludeTasks
+---
+Act as the **Chief Software Architect** and **Implementation Auditor**.
+A feature implementation has landed, but "artifact drift" has been discovered (e.g., missing routes, updated behavior, or unlinked UI). Your goal is to **reconcile** this drift by surgically amending the feature's own specification, plan, and task artifacts.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+### Input Parsing
+
+The input `$ARGUMENTS` is a **Gap Report** — a natural language description of what is missing or changed in the implementation versus the documentation.
+
+**Examples:**
+- "Backend + tests for Invoice Settings exist; React screen scaffolded. Users can't navigate to it. Need sidebar link + route."
+- "The /api/v1/settings endpoint now requires an 'org_id' header not in the original plan."
+
+If `$ARGUMENTS` contains any of these flags, respect them (optional):
+- `--spec-only` — update only `spec.md`
+- `--plan-only` — update only `plan.md`
+- `--tasks-only` — update only `tasks.md`
+
+If `$ARGUMENTS` is empty, output `ERROR: No gap report provided. Usage: /speckit.reconcile.run [gap report text]` and stop.
+
+---
+
+## Step 0: Discovery & Setup (Gate)
+
+### 0.1 Resolve Paths
+
+Run `{SCRIPT}` to identify the active feature directory and its artifacts. This script is mandatory for path discovery. If the script is missing, stop and inform the user.
+
+Derive absolute paths for:
+- `FEATURE_DIR` (e.g., `specs/###-feature-name/`)
+- `FEATURE_SPEC` (`FEATURE_DIR/spec.md`)
+- `IMPL_PLAN` (`FEATURE_DIR/plan.md`)
+- `TASKS_FILE` (`FEATURE_DIR/tasks.md`)
+
+**Validation**: Ensure `spec.md` and `plan.md` exist. If either is missing, stop with:
+> ⚠️ Missing required files in `FEATURE_DIR`. Expected: spec.md, plan.md.
+> Run `/speckit.specify` and `/speckit.plan` first.
+
+If `tasks.md` does not exist, create it with a `## Remediation: Gaps` heading before appending tasks.
+
+### 0.2 Load Context
+
+Read `FEATURE_SPEC`, `IMPL_PLAN`, and `TASKS_FILE`.
+
+Also read `.specify/memory/constitution.md` if it exists. If found, extract MUST-level constraints and Architecture Standards. These are enforced in Step 1 — any remediation item that conflicts with a MUST principle is flagged as CRITICAL:
+```
+🔴 CONSTITUTION CONFLICT: [remediation item] conflicts with [principle]
+→ This must be resolved in Step 2 clarification before edits proceed.
+```
+
+---
+
+## Step 1: Gap Normalization
+
+Analyze the user's **Gap Report** and normalize it into structured remediation items:
+
+| Category | Typical Issues | Action |
+|----------|----------------|--------|
+| **Wiring & Navigation** | Missing routes, menu items, sidebar links | Add to `plan.md`, create tasks in `tasks.md` |
+| **Contracts** | API field mismatches, missing headers | Update `plan.md` contracts, create tasks |
+| **Acceptance Criteria** | Implementation behaves differently than planned | Update `spec.md` scenarios/criteria |
+| **Test Coverage** | New wiring/navigation without verification | Add task for Integration Test |
+| **Logic/UX** | Success toasts missing, error handling gaps | Add tasks for implementation |
+
+For each normalized item, verify it does not conflict with any MUST-level constitution constraint loaded in Step 0.2. Flag any conflicts as CRITICAL and include them in Step 2 clarification.
+
+---
+
+## Step 2: Clarify (Exactly Once; Max 5 Questions)
+
+If the gap report is ambiguous (e.g., "the button doesn't work" without saying which button), ask targeted questions.
+
+Use this format and **wait for answers**:
+
+```markdown
+## Question [N]: [Topic]
+**Context**: [Relevant implementation detail]
+**Decision Needed**: [1 sentence]
+**Suggested Answers**: [Table with Option A/B/C]
+
+**Your choice**: _[Wait for user response]_
+```
+
+**Rules:**
+- Max 5 questions.
+- Max 3 unresolved `NEEDS CLARIFICATION` markers in output — beyond that, pick reasonable defaults and note them in the Sync Impact Report.
+- Proceed with reasonable defaults if questions aren't strictly necessary.
+
+---
+
+## Step 3: Impact Map
+
+Before making any edits, produce a brief impact map:
+
+```markdown
+### Sync Impact Map
+| Artifact | Changes | Tasks Generated |
+|----------|---------|-----------------|
+| `spec.md` | Update AC-04, add User Scenario "Error Handling" | None |
+| `plan.md` | Add Route `/settings`, update API contract | None |
+| `tasks.md` | Append remediation tasks | T045, T046, T047 |
+```
+
+---
+
+## Step 4: Reconciliation (Surgical Edits)
+
+**Constraint**: Operate strictly in place. Do not create branches, switch branches, or run feature-creation scripts. All edits target existing files in `FEATURE_DIR`.
+
+### 4.1 Update Specification (`spec.md`)
+- **Acceptance Criteria**: Amend existing criteria or add new ones to reflect the shipped reality.
+- **User Scenarios**: Add missing scenarios discovered during implementation (e.g., specific edge cases).
+- **Revision Note**: Add a block at the bottom:
+  ```markdown
+  ### Revision: Implementation Sync [YYYY-MM-DD]
+  - Reason: [Summary of drift reconciled]
+  ```
+
+### 4.2 Update Plan (`plan.md`)
+- **Routing & Navigation**: Add any missing routes, endpoints, or UI wiring details.
+- **Integration Contracts**: Update API schemas, request/response headers, or payloads.
+- **Testing Strategy**: Ensure the strategy covers the newly identified gaps.
+- **Revision Note**: Append a revision note (same format as spec.md) if plan sections were modified.
+
+### 4.3 Update Tasks (`tasks.md`)
+This is the most critical step. Create remediation tasks to close the drift.
+
+**Task Formatting**:
+`- [ ] T{NNN} [P] [{story}] {action verb} {what} in {exact/file/path.ext} [Sync: Gap Report]`
+
+Where `[P]` is an optional priority flag — include it only for tasks that are blocking or high-urgency. Omit for normal priority. The `[Sync: Gap Report]` tag is always appended for traceability.
+
+**Rules for Tasks**:
+1. **Increment IDs**: Find the highest `T###` in `tasks.md`. Start new tasks from `max + 1`. Never reuse or renumber.
+2. **Phase Placement**: Place new tasks under the relevant User Story phase (e.g., `## [US2] Settings Dashboard`). If no phase fits, create a `## Remediation: Gaps` section at the end.
+3. **Exact Paths**: Every task MUST include an exact file path where the change is needed.
+4. **Mandatory Integration Test**: If you identified a **Wiring & Navigation** gap, you MUST add a task for an Integration Test to verify it.
+
+---
+
+## Step 5: Sync Impact Report
+
+Output the final report:
+
+```markdown
+# Sync Impact Report
+
+## Changed Files
+| File (absolute path) | Change Summary |
+|----------------------|----------------|
+| `/absolute/path/to/spec.md` | Updated AC, Scenarios |
+| `/absolute/path/to/plan.md` | Updated Routing/Contracts |
+| `/absolute/path/to/tasks.md` | Added [N] remediation tasks |
+
+## New Remediation Tasks
+[List the new tasks added, e.g.]
+- **T045**: Add sidebar link in `src/components/Sidebar.tsx`
+- **T046**: Update router in `src/router/index.ts`
+- **T047**: Integration test: navigate to Settings in `tests/integration/navigation.test.ts`
+
+## Outstanding Decisions
+[List any `NEEDS CLARIFICATION` items or "None"]
+
+## Next Step
+[Recommend based on what changed:]
+- If remediation tasks were added → `/speckit.implement` to execute them
+- If plan was significantly updated → `/speckit.plan` to review architecture
+- If only spec was updated → Review changes and proceed with implementation
+```
+
+---
+
+## Done Criteria
+- Gap report parsed and categorized.
+- Feature's own `spec.md` and `plan.md` surgically updated.
+- `tasks.md` updated with incremented `T###` IDs and exact file paths.
+- Mandatory integration test task added for wiring gaps.
+- Revision note added to artifacts.
+- Sync Impact Report printed.

--- a/.specify/extensions/reconcile/extension.yml
+++ b/.specify/extensions/reconcile/extension.yml
@@ -1,0 +1,23 @@
+schema_version: "1.0"
+extension:
+  id: "reconcile"
+  name: "Spec-Kit Reconcile"
+  version: "1.0.0"
+  description: "Reconcile implementation drift by surgically updating the feature's own spec, plan, and tasks."
+  author: "Stanislav Deviatov"
+  repository: "https://github.com/stn1slv/spec-kit-reconcile"
+  license: "MIT"
+requires:
+  speckit_version: ">=0.1.0"
+  scripts:
+    - "check-prerequisites.sh"
+provides:
+  commands:
+    - name: "speckit.reconcile.run"
+      file: "commands/reconcile.md"
+      description: "Reconcile implementation drift from a gap report"
+tags:
+  - "reconcile"
+  - "drift"
+  - "tasks"
+  - "remediation"

--- a/dev/skills/speckit-reconcile-run/SKILL.md
+++ b/dev/skills/speckit-reconcile-run/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: speckit-reconcile-run
+description: Reconcile implementation drift by updating the feature's own spec, plan,
+  and tasks
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: reconcile:commands/reconcile.md
+---
+
+Act as the **Chief Software Architect** and **Implementation Auditor**.
+A feature implementation has landed, but "artifact drift" has been discovered (e.g., missing routes, updated behavior, or unlinked UI). Your goal is to **reconcile** this drift by surgically amending the feature's own specification, plan, and task artifacts.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+### Input Parsing
+
+The input `$ARGUMENTS` is a **Gap Report** — a natural language description of what is missing or changed in the implementation versus the documentation.
+
+**Examples:**
+- "Backend + tests for Invoice Settings exist; React screen scaffolded. Users can't navigate to it. Need sidebar link + route."
+- "The /api/v1/settings endpoint now requires an 'org_id' header not in the original plan."
+
+If `$ARGUMENTS` contains any of these flags, respect them (optional):
+- `--spec-only` — update only `spec.md`
+- `--plan-only` — update only `plan.md`
+- `--tasks-only` — update only `tasks.md`
+
+If `$ARGUMENTS` is empty, output `ERROR: No gap report provided. Usage: /speckit.reconcile.run [gap report text]` and stop.
+
+---
+
+## Step 0: Discovery & Setup (Gate)
+
+### 0.1 Resolve Paths
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only --include-tasks` to identify the active feature directory and its artifacts. This script is mandatory for path discovery. If the script is missing, stop and inform the user.
+
+Derive absolute paths for:
+- `FEATURE_DIR` (e.g., `specs/###-feature-name/`)
+- `FEATURE_SPEC` (`FEATURE_DIR/spec.md`)
+- `IMPL_PLAN` (`FEATURE_DIR/plan.md`)
+- `TASKS_FILE` (`FEATURE_DIR/tasks.md`)
+
+**Validation**: Ensure `spec.md` and `plan.md` exist. If either is missing, stop with:
+> ⚠️ Missing required files in `FEATURE_DIR`. Expected: spec.md, plan.md.
+> Run `/speckit.specify` and `/speckit.plan` first.
+
+If `tasks.md` does not exist, create it with a `## Remediation: Gaps` heading before appending tasks.
+
+### 0.2 Load Context
+
+Read `FEATURE_SPEC`, `IMPL_PLAN`, and `TASKS_FILE`.
+
+Also read `.specify/memory/constitution.md` if it exists. If found, extract MUST-level constraints and Architecture Standards. These are enforced in Step 1 — any remediation item that conflicts with a MUST principle is flagged as CRITICAL:
+```
+🔴 CONSTITUTION CONFLICT: [remediation item] conflicts with [principle]
+→ This must be resolved in Step 2 clarification before edits proceed.
+```
+
+---
+
+## Step 1: Gap Normalization
+
+Analyze the user's **Gap Report** and normalize it into structured remediation items:
+
+| Category | Typical Issues | Action |
+|----------|----------------|--------|
+| **Wiring & Navigation** | Missing routes, menu items, sidebar links | Add to `plan.md`, create tasks in `tasks.md` |
+| **Contracts** | API field mismatches, missing headers | Update `plan.md` contracts, create tasks |
+| **Acceptance Criteria** | Implementation behaves differently than planned | Update `spec.md` scenarios/criteria |
+| **Test Coverage** | New wiring/navigation without verification | Add task for Integration Test |
+| **Logic/UX** | Success toasts missing, error handling gaps | Add tasks for implementation |
+
+For each normalized item, verify it does not conflict with any MUST-level constitution constraint loaded in Step 0.2. Flag any conflicts as CRITICAL and include them in Step 2 clarification.
+
+---
+
+## Step 2: Clarify (Exactly Once; Max 5 Questions)
+
+If the gap report is ambiguous (e.g., "the button doesn't work" without saying which button), ask targeted questions.
+
+Use this format and **wait for answers**:
+
+```markdown
+## Question [N]: [Topic]
+**Context**: [Relevant implementation detail]
+**Decision Needed**: [1 sentence]
+**Suggested Answers**: [Table with Option A/B/C]
+
+**Your choice**: _[Wait for user response]_
+```
+
+**Rules:**
+- Max 5 questions.
+- Max 3 unresolved `NEEDS CLARIFICATION` markers in output — beyond that, pick reasonable defaults and note them in the Sync Impact Report.
+- Proceed with reasonable defaults if questions aren't strictly necessary.
+
+---
+
+## Step 3: Impact Map
+
+Before making any edits, produce a brief impact map:
+
+```markdown
+### Sync Impact Map
+| Artifact | Changes | Tasks Generated |
+|----------|---------|-----------------|
+| `spec.md` | Update AC-04, add User Scenario "Error Handling" | None |
+| `plan.md` | Add Route `/settings`, update API contract | None |
+| `tasks.md` | Append remediation tasks | T045, T046, T047 |
+```
+
+---
+
+## Step 4: Reconciliation (Surgical Edits)
+
+**Constraint**: Operate strictly in place. Do not create branches, switch branches, or run feature-creation scripts. All edits target existing files in `FEATURE_DIR`.
+
+### 4.1 Update Specification (`spec.md`)
+- **Acceptance Criteria**: Amend existing criteria or add new ones to reflect the shipped reality.
+- **User Scenarios**: Add missing scenarios discovered during implementation (e.g., specific edge cases).
+- **Revision Note**: Add a block at the bottom:
+  ```markdown
+  ### Revision: Implementation Sync [YYYY-MM-DD]
+  - Reason: [Summary of drift reconciled]
+  ```
+
+### 4.2 Update Plan (`plan.md`)
+- **Routing & Navigation**: Add any missing routes, endpoints, or UI wiring details.
+- **Integration Contracts**: Update API schemas, request/response headers, or payloads.
+- **Testing Strategy**: Ensure the strategy covers the newly identified gaps.
+- **Revision Note**: Append a revision note (same format as spec.md) if plan sections were modified.
+
+### 4.3 Update Tasks (`tasks.md`)
+This is the most critical step. Create remediation tasks to close the drift.
+
+**Task Formatting**:
+`- [ ] T{NNN} [P] [{story}] {action verb} {what} in {exact/file/path.ext} [Sync: Gap Report]`
+
+Where `[P]` is an optional priority flag — include it only for tasks that are blocking or high-urgency. Omit for normal priority. The `[Sync: Gap Report]` tag is always appended for traceability.
+
+**Rules for Tasks**:
+1. **Increment IDs**: Find the highest `T###` in `tasks.md`. Start new tasks from `max + 1`. Never reuse or renumber.
+2. **Phase Placement**: Place new tasks under the relevant User Story phase (e.g., `## [US2] Settings Dashboard`). If no phase fits, create a `## Remediation: Gaps` section at the end.
+3. **Exact Paths**: Every task MUST include an exact file path where the change is needed.
+4. **Mandatory Integration Test**: If you identified a **Wiring & Navigation** gap, you MUST add a task for an Integration Test to verify it.
+
+---
+
+## Step 5: Sync Impact Report
+
+Output the final report:
+
+```markdown
+# Sync Impact Report
+
+## Changed Files
+| File (absolute path) | Change Summary |
+|----------------------|----------------|
+| `/absolute/path/to/spec.md` | Updated AC, Scenarios |
+| `/absolute/path/to/plan.md` | Updated Routing/Contracts |
+| `/absolute/path/to/tasks.md` | Added [N] remediation tasks |
+
+## New Remediation Tasks
+[List the new tasks added, e.g.]
+- **T045**: Add sidebar link in `src/components/Sidebar.tsx`
+- **T046**: Update router in `src/router/index.ts`
+- **T047**: Integration test: navigate to Settings in `tests/integration/navigation.test.ts`
+
+## Outstanding Decisions
+[List any `NEEDS CLARIFICATION` items or "None"]
+
+## Next Step
+[Recommend based on what changed:]
+- If remediation tasks were added → `/speckit.implement` to execute them
+- If plan was significantly updated → `/speckit.plan` to review architecture
+- If only spec was updated → Review changes and proceed with implementation
+```
+
+---
+
+## Done Criteria
+- Gap report parsed and categorized.
+- Feature's own `spec.md` and `plan.md` surgically updated.
+- `tasks.md` updated with incremented `T###` IDs and exact file paths.
+- Mandatory integration test task added for wiring gaps.
+- Revision note added to artifacts.
+- Sync Impact Report printed.


### PR DESCRIPTION
### Why 

Reconcile spec-kit extension is meant to help to propagate a new different into specifications into all related files. https://github.com/stn1slv/spec-kit-reconcile.

I found it useful when you have to adapt slight elements in a specification and do not want to regenerate all the tasks. 

### What this PR does

`specify extension add reconcile --from https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.0.0.zip`


### What this PR does not

Adapt the extension into an infrahub dedicated preset. This would be a following PR once we have rationalized this extension.

### How to use it

In Claude, use `/speckit-reconcile-run` command/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Spec‑Kit Reconcile extension and a new `/speckit.reconcile.run` command to keep feature `spec.md`, `plan.md`, and `tasks.md` aligned with shipped code. This enables generating remediation tasks from a simple, natural‑language gap report.

- **New Features**
  - Adds `reconcile` extension under `.specify/extensions/reconcile` (command, README, LICENSE, `extension.yml`).
  - Registers `speckit.reconcile.run` in `.specify/extensions/.registry` for `claude` and `copilot`.
  - Adds `.github/agents/speckit.reconcile.run.agent.md` and prompt to wire the command.
  - Adds developer skill at `dev/skills/speckit-reconcile-run/SKILL.md`.

- **Migration**
  - Usage: run `/speckit.reconcile.run "your gap report"` (supports `--spec-only`, `--plan-only`, `--tasks-only`).
  - Requires a Spec‑Kit project with `.specify/scripts/*/check-prerequisites.*` available.
  - To install elsewhere: `specify extension add reconcile --from https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.0.0.zip`.

<sup>Written for commit e4a6b9440dd37fe500f20210e0e76d789361ca0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

