### PR TITLE
docs: add announcement bar for docs restructure

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -85,7 +85,7 @@ const config: Config = {
   themeConfig: {
     announcementBar: {
       id: 'docs-restructure-2026',
-      content: '📚 New docs structure: content is now grouped by capability, not split across Topics and Guides. <a href="/docs/release-notes/infrahub/docs-restructure"><strong>See what changed →</strong></a>',
+      content: '📚 New docs structure: content is now grouped by capability, not split across Topics and Guides. <a href="/release-notes/infrahub/docs-restructure"><strong>See what changed →</strong></a>',
       isCloseable: true,
     },
     navbar: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -83,10 +83,11 @@ const config: Config = {
     ],
   ],
   themeConfig: {
-    // announcementBar: {
-    //   content: 'Welcome to our brand new docs!',
-    //   isCloseable: true,
-    // },
+    announcementBar: {
+      id: 'docs-restructure-2026',
+      content: '📚 New docs structure: content is now grouped by capability, not split across Topics and Guides. <a href="/docs/release-notes/infrahub/docs-restructure"><strong>See what changed →</strong></a>',
+      isCloseable: true,
+    },
     navbar: {
       logo: {
         alt: "Infrahub",


### PR DESCRIPTION
## Summary

Enables the Docusaurus `announcementBar` to notify users that the docs have been reorganized. The bar appears across the top of the site with a link to the docs-restructure release notes.

**Banner text:**
> 📚 New docs structure: content is now grouped by capability, not split across Topics and Guides. **See what changed →**

- `id: 'docs-restructure-2026'` — persists dismissal state per user (won't re-show after closing)
- `isCloseable: true` — users can dismiss it
- Links to `/docs/release-notes/infrahub/docs-restructure`

## What didn't change

- One line uncommented + content updated — no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)