### PR TITLE
Improve forms error message for state and context

### DIFF
--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.test.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import { render } from "../../../../../tests/components/render";
+import { DependenciesModeSidebar } from "./dependencies-mode-sidebar";
+
+describe("DependenciesModeForm validation", () => {
+  test("shows required errors when submitting with empty fields", async () => {
+    const component = await render(<DependenciesModeSidebar />);
+
+    await component.getByRole("button", { name: /find dependencies/i }).click();
+
+    await expect.element(component.getByText("Source is required")).toBeVisible();
+    await expect.element(component.getByText("Select at least one target kind")).toBeVisible();
+  });
+});

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -81,8 +81,11 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
                 type="number"
                 min={1}
                 max={20}
-                value={(field.value as number) ?? 5}
-                onChange={(e) => field.onChange(Number(e.target.value))}
+                value={(field.value as number) ?? ""}
+                onChange={(e) => {
+                  const value = e.target.valueAsNumber;
+                  field.onChange(isNaN(value) ? null : value);
+                }}
               />
             </FormInput>
             <FormMessage />

--- a/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-form.test.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-form.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import { render } from "../../../../../tests/components/render";
+import { PathModeSidebar } from "./path-mode-sidebar";
+
+describe("PathModeForm validation", () => {
+  test("shows required errors when submitting with empty source and destination", async () => {
+    const component = await render(<PathModeSidebar />);
+
+    await component.getByRole("button", { name: /find paths/i }).click();
+
+    await expect.element(component.getByText("Source is required")).toBeVisible();
+    await expect.element(component.getByText("Destination is required")).toBeVisible();
+  });
+});

--- a/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-form.tsx
@@ -100,8 +100,11 @@ export function PathModeForm({ form, onSubmit, isPending }: PathModeFormProps) {
                           type="number"
                           min={1}
                           max={20}
-                          value={(field.value as number) ?? 5}
-                          onChange={(e) => field.onChange(Number(e.target.value))}
+                          value={(field.value as number) ?? ""}
+                          onChange={(e) => {
+                            const value = e.target.valueAsNumber;
+                            field.onChange(isNaN(value) ? null : value);
+                          }}
                         />
                       </FormInput>
                       <FormMessage />
@@ -125,8 +128,11 @@ export function PathModeForm({ form, onSubmit, isPending }: PathModeFormProps) {
                           type="number"
                           min={1}
                           max={100}
-                          value={(field.value as number) ?? 10}
-                          onChange={(e) => field.onChange(Number(e.target.value))}
+                          value={(field.value as number) ?? ""}
+                          onChange={(e) => {
+                            const value = e.target.valueAsNumber;
+                            field.onChange(isNaN(value) ? null : value);
+                          }}
                         />
                       </FormInput>
                       <FormMessage />

--- a/frontend/app/src/shared/components/ui/form.tsx
+++ b/frontend/app/src/shared/components/ui/form.tsx
@@ -8,6 +8,7 @@ import {
   type UseFormReturn,
   useForm,
   useFormContext,
+  useFormState,
 } from "react-hook-form";
 
 import { SlideOverContext } from "@/shared/components/display/slide-over";
@@ -97,8 +98,9 @@ export const FormLabel = ({ ...props }: LabelProps) => {
 interface FormInputProps extends React.ComponentProps<typeof Slot> {}
 
 export const FormInput = ({ className, ref, ...props }: FormInputProps) => {
-  const { getFieldState, formState } = useFormContext();
+  const { getFieldState } = useFormContext();
   const { id, name } = React.use(FormFieldContext);
+  const formState = useFormState({ name });
   const { error } = getFieldState(name, formState);
 
   return (
@@ -117,9 +119,9 @@ export const FormMessage = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLParagraphElement>) => {
-  const { getFieldState, formState } = useFormContext();
+  const { getFieldState } = useFormContext();
   const { name } = React.use(FormFieldContext);
-
+  const formState = useFormState({ name });
   const { error } = getFieldState(name, formState);
 
   const message = error?.message?.toString() ?? children;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes validation and error messages in the path traversal forms. Number inputs now handle empty values correctly, and field-level errors render reliably.

- **Bug Fixes**
  - Read field errors with `useFormState({ name })` to show accurate messages and avoid stale state in nested forms.
  - Update number inputs to use `value=""` and `e.target.valueAsNumber`, storing `null` when empty so required rules trigger.
  - Add tests to confirm required errors show for Path Mode (Source/Destination) and Dependencies Mode (Source/Target kind).

<sup>Written for commit 7b2e38f128f894fa6c5e04c2df1000fe2772a5cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

