### PR TITLE
Fix IPPrefix utilisation on new branch

### DIFF
--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -19,9 +19,10 @@ class PrefixChildDetails:
 
 
 class PrefixUtilizationGetter:
-    """Single-branch utilization: counts allocations visible from ``branch``.
+    """Counts allocations visible from a single branch.
 
-    To compare two branches, e.g. main against a feature branch for a pool view, instantiate one getter per branch and subtract.
+    Use one instance per branch and combine the results externally if a
+    cross-branch comparison is required.
     """
 
     def __init__(

--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -19,27 +19,24 @@ class PrefixChildDetails:
 
 
 class PrefixUtilizationGetter:
+    """Single-branch utilization: counts allocations visible from ``branch``.
+
+    To compare two branches, e.g. main against a feature branch for a pool view, instantiate one getter per branch and subtract.
+    """
+
     def __init__(
-        self,
-        db: InfrahubDatabase,
-        ip_prefixes: list[Node],
-        at: Timestamp | str | None = None,
-        branch: Branch | None = None,
+        self, db: InfrahubDatabase, ip_prefixes: list[Node], branch: Branch, at: Timestamp | str | None = None
     ) -> None:
         self.db = db
         self.ip_prefixes = ip_prefixes
-        self.at = at
         self.branch = branch
+        self.at = at
         self._has_data = False
-        self._results_by_prefix_id: dict[str, dict[str, list[PrefixChildDetails]]] = {}
+        self._results_by_prefix_id: dict[str, list[PrefixChildDetails]] = {}
 
     async def _fetch_data(self) -> None:
-        if self._has_data is False:
-            await self._run_and_parse_query()
-        self._has_data = True
-
-    async def _run_and_parse_query(self) -> None:
-        self._results_by_prefix_id = {}
+        if self._has_data:
+            return
         query = await IPPrefixUtilization.init(
             db=self.db,
             at=self.at,
@@ -49,93 +46,60 @@ class PrefixUtilizationGetter:
         )
         await query.execute(db=self.db)
 
+        results: dict[str, list[PrefixChildDetails]] = {}
         for item in query.get_data():
-            if InfrahubKind.IPADDRESS in item.child_labels:
-                child_type = PrefixMemberType.ADDRESS
-            else:
-                child_type = PrefixMemberType.PREFIX
-
-            if item.prefix_uuid not in self._results_by_prefix_id:
-                self._results_by_prefix_id[item.prefix_uuid] = {}
-            if item.branch not in self._results_by_prefix_id[item.prefix_uuid]:
-                self._results_by_prefix_id[item.prefix_uuid][item.branch] = []
-            self._results_by_prefix_id[item.prefix_uuid][item.branch].append(
+            child_type = (
+                PrefixMemberType.ADDRESS if InfrahubKind.IPADDRESS in item.child_labels else PrefixMemberType.PREFIX
+            )
+            results.setdefault(item.prefix_uuid, []).append(
                 PrefixChildDetails(child_type=child_type, prefixlen=item.prefixlen, ip_value=item.ip_value)
             )
+        self._results_by_prefix_id = results
+        self._has_data = True
 
     async def get_children(
         self,
         ip_prefixes: list[Node] | None = None,
         prefix_member_type: PrefixMemberType | None = None,
-        branch_names: list[str] | None = None,
     ) -> list[PrefixChildDetails]:
-        if branch_names is not None and self.branch is not None:
-            raise ValueError(
-                "branch_names is incompatible with a branch-scoped PrefixUtilizationGetter; "
-                "the query is already restricted to the branch's visible set"
-            )
         await self._fetch_data()
-        prefix_child_details_list: list[PrefixChildDetails] = []
         if ip_prefixes is None:
             ip_prefixes = self.ip_prefixes
-        prefix_ids = {prefix.get_id() for prefix in ip_prefixes}
-        prefix_ids &= set(self._results_by_prefix_id.keys())
-        if not prefix_ids:
-            return prefix_child_details_list
-        for prefix_id in prefix_ids:
-            child_details_by_branch = self._results_by_prefix_id[prefix_id]
-            branch_names_to_check = branch_names or list(child_details_by_branch.keys())
-            for branch_name in branch_names_to_check:
-                for child_details in child_details_by_branch.get(branch_name, []):
-                    if prefix_member_type and child_details.child_type != prefix_member_type:
-                        continue
-                    prefix_child_details_list.append(child_details)
-        return prefix_child_details_list
+        result: list[PrefixChildDetails] = []
+        for prefix in ip_prefixes:
+            for child in self._results_by_prefix_id.get(prefix.get_id(), []):
+                if prefix_member_type and child.child_type != prefix_member_type:
+                    continue
+                result.append(child)
+        return result
 
     async def get_num_children_in_use(
         self,
         ip_prefixes: list[Node] | None = None,
         prefix_member_type: PrefixMemberType | None = None,
-        branch_names: list[str] | None = None,
     ) -> int:
-        children = await self.get_children(
-            ip_prefixes=ip_prefixes, prefix_member_type=prefix_member_type, branch_names=branch_names
-        )
+        children = await self.get_children(ip_prefixes=ip_prefixes, prefix_member_type=prefix_member_type)
         return len(children)
 
-    async def _get_prefix_use_fraction(
-        self, ip_prefixes: list[Node] | None = None, branch_names: list[str] | None = None
-    ) -> tuple[int, int]:
+    async def _get_prefix_use_fraction(self, ip_prefixes: list[Node]) -> tuple[int, int]:
         total_prefix_space = 0
         total_used_space = 0
-        if ip_prefixes is None:
-            ip_prefixes = self.ip_prefixes
         for ip_prefix in ip_prefixes:
             total_prefix_space += get_prefix_space(ip_prefix=ip_prefix)
             max_prefixlen = ip_prefix.prefix.obj.max_prefixlen  # type: ignore[attr-defined]
-            children = await self.get_children(
-                ip_prefixes=[ip_prefix], prefix_member_type=PrefixMemberType.PREFIX, branch_names=branch_names
-            )
+            children = await self.get_children(ip_prefixes=[ip_prefix], prefix_member_type=PrefixMemberType.PREFIX)
             for child in children:
                 total_used_space += 2 ** (max_prefixlen - child.prefixlen)
         return total_used_space, total_prefix_space
 
-    async def _get_address_use_fraction(
-        self, ip_prefixes: list[Node] | None = None, branch_names: list[str] | None = None
-    ) -> tuple[int, int]:
-        total_prefix_space = 0
-        if ip_prefixes is None:
-            ip_prefixes = self.ip_prefixes
-        for ip_prefix in ip_prefixes:
-            total_prefix_space += get_prefix_space(ip_prefix=ip_prefix)
+    async def _get_address_use_fraction(self, ip_prefixes: list[Node]) -> tuple[int, int]:
+        total_prefix_space = sum(get_prefix_space(ip_prefix=ip_prefix) for ip_prefix in ip_prefixes)
         total_used_space = await self.get_num_children_in_use(
-            ip_prefixes=ip_prefixes, prefix_member_type=PrefixMemberType.ADDRESS, branch_names=branch_names
+            ip_prefixes=ip_prefixes, prefix_member_type=PrefixMemberType.ADDRESS
         )
         return total_used_space, total_prefix_space
 
-    async def get_use_percentage(
-        self, ip_prefixes: list[Node] | None = None, branch_names: list[str] | None = None
-    ) -> float:
+    async def get_use_percentage(self, ip_prefixes: list[Node] | None = None) -> float:
         grand_total_used, grand_total_space = 0, 0
         address_prefixes, prefix_prefixes = [], []
         if ip_prefixes is None:
@@ -146,15 +110,11 @@ class PrefixUtilizationGetter:
             else:
                 prefix_prefixes.append(ip_prefix)
         if address_prefixes:
-            address_total_used, address_total_space = await self._get_address_use_fraction(
-                ip_prefixes=address_prefixes, branch_names=branch_names
-            )
+            address_total_used, address_total_space = await self._get_address_use_fraction(ip_prefixes=address_prefixes)
             grand_total_used += address_total_used
             grand_total_space += address_total_space
         if prefix_prefixes:
-            prefix_total_used, prefix_total_space = await self._get_prefix_use_fraction(
-                ip_prefixes=prefix_prefixes, branch_names=branch_names
-            )
+            prefix_total_used, prefix_total_space = await self._get_prefix_use_fraction(ip_prefixes=prefix_prefixes)
             grand_total_used += prefix_total_used
             grand_total_space += prefix_total_space
         if grand_total_space == 0:

--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.query.ipam import IPPrefixUtilization
@@ -18,10 +19,17 @@ class PrefixChildDetails:
 
 
 class PrefixUtilizationGetter:
-    def __init__(self, db: InfrahubDatabase, ip_prefixes: list[Node], at: Timestamp | str | None = None) -> None:
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        ip_prefixes: list[Node],
+        at: Timestamp | str | None = None,
+        branch: Branch | None = None,
+    ) -> None:
         self.db = db
         self.ip_prefixes = ip_prefixes
         self.at = at
+        self.branch = branch
         self._has_data = False
         self._results_by_prefix_id: dict[str, dict[str, list[PrefixChildDetails]]] = {}
 
@@ -35,6 +43,7 @@ class PrefixUtilizationGetter:
         query = await IPPrefixUtilization.init(
             db=self.db,
             at=self.at,
+            branch=self.branch,
             ip_prefixes=self.ip_prefixes,
             allocated_kinds=[InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS],
         )
@@ -60,6 +69,11 @@ class PrefixUtilizationGetter:
         prefix_member_type: PrefixMemberType | None = None,
         branch_names: list[str] | None = None,
     ) -> list[PrefixChildDetails]:
+        if branch_names is not None and self.branch is not None:
+            raise ValueError(
+                "branch_names is incompatible with a branch-scoped PrefixUtilizationGetter; "
+                "the query is already restricted to the branch's visible set"
+            )
         await self._fetch_data()
         prefix_child_details_list: list[PrefixChildDetails] = []
         if ip_prefixes is None:

--- a/backend/infrahub/core/node/ipam.py
+++ b/backend/infrahub/core/node/ipam.py
@@ -44,7 +44,7 @@ class BuiltinIPPrefix(Node):
                     self.prefix = retrieved.prefix  # type: ignore[attr-defined,union-attr]
                 utilization_getter = PrefixUtilizationGetter(db=db, ip_prefixes=[self])
                 utilization = await utilization_getter.get_use_percentage(
-                    ip_prefixes=[self], branch_names=[self._branch.name]
+                    ip_prefixes=[self], branch_names=self._branch.get_branches_in_scope()
                 )
                 response["utilization"] = {"value": int(utilization)}
 

--- a/backend/infrahub/core/node/ipam.py
+++ b/backend/infrahub/core/node/ipam.py
@@ -42,10 +42,8 @@ class BuiltinIPPrefix(Node):
                     )
                     self.member_type = retrieved.member_type  # type: ignore[attr-defined,union-attr]
                     self.prefix = retrieved.prefix  # type: ignore[attr-defined,union-attr]
-                utilization_getter = PrefixUtilizationGetter(db=db, ip_prefixes=[self])
-                utilization = await utilization_getter.get_use_percentage(
-                    ip_prefixes=[self], branch_names=self._branch.get_branches_in_scope()
-                )
+                utilization_getter = PrefixUtilizationGetter(db=db, ip_prefixes=[self], branch=self._branch)
+                utilization = await utilization_getter.get_use_percentage(ip_prefixes=[self])
                 response["utilization"] = {"value": int(utilization)}
 
         return response

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1006,21 +1006,6 @@ class IPPrefixUtilizationResult:
     prefixlen: int
     """Prefix length of the child IP value."""
 
-    @classmethod
-    def from_db(cls, result: QueryResult) -> IPPrefixUtilizationResult:
-        """Convert raw QueryResult to typed dataclass."""
-        pfx = result.get_node("pfx")
-        child = result.get_node("child")
-        av = result.get_node("av")
-        return cls(
-            prefix_uuid=str(pfx.get("uuid")),
-            child_uuid=str(child.get("uuid")),
-            child_kind=child.get("kind"),
-            child_labels=tuple(child.labels),
-            ip_value=av.get("value"),
-            prefixlen=av.get("prefixlen"),
-        )
-
 
 class IPPrefixUtilization(Query):
     """Counts child allocations of one or more parent prefixes from the perspective of a single branch."""
@@ -1097,13 +1082,23 @@ class IPPrefixUtilization(Query):
         self.add_to_query(query)
 
     def get_data(self) -> list[IPPrefixUtilizationResult]:
-        """Return results as typed dataclass instances.
-
-        Returns:
-            List of IPPrefixUtilizationResult containing prefix child allocation data.
-
-        """
-        return [IPPrefixUtilizationResult.from_db(result) for result in self.get_results()]
+        """Return results as typed dataclass instances."""
+        results: list[IPPrefixUtilizationResult] = []
+        for result in self.get_results():
+            pfx = result.get_node("pfx")
+            child = result.get_node("child")
+            av = result.get_node("av")
+            results.append(
+                IPPrefixUtilizationResult(
+                    prefix_uuid=str(pfx.get("uuid")),
+                    child_uuid=str(child.get("uuid")),
+                    child_kind=child.get("kind"),
+                    child_labels=tuple(child.labels),
+                    ip_value=av.get("value"),
+                    prefixlen=av.get("prefixlen"),
+                )
+            )
+        return results
 
 
 @dataclass(frozen=True)

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1087,11 +1087,11 @@ class IPPrefixUtilization(Query):
             r_rel2.from AS r_rel2_from,
             r_attr.from AS r_attr_from,
             r_attr_val.from AS r_attr_val_from
-        ORDER BY pfx.uuid, child.uuid, av.uuid, sum_branch_level DESC, r_rel1_from DESC, r_rel2_from DESC, r_attr_from DESC, r_attr_val_from DESC
+        ORDER BY pfx.uuid, child.uuid, sum_branch_level DESC, r_rel1_from DESC, r_rel2_from DESC, r_attr_from DESC, r_attr_val_from DESC
         WITH
             pfx,
             child,
-            av,
+            head(collect(av)) AS av,
             head(collect(is_active)) AS is_latest_active
         WHERE is_latest_active = TRUE
         """ % {

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1006,9 +1006,6 @@ class IPPrefixUtilizationResult:
     prefixlen: int
     """Prefix length of the child IP value."""
 
-    branch: str
-    """Branch name where this allocation exists."""
-
     @classmethod
     def from_db(cls, result: QueryResult) -> IPPrefixUtilizationResult:
         """Convert raw QueryResult to typed dataclass."""
@@ -1022,98 +1019,84 @@ class IPPrefixUtilizationResult:
             child_labels=tuple(child.labels),
             ip_value=av.get("value"),
             prefixlen=av.get("prefixlen"),
-            branch=str(result.get("branch")),
         )
 
 
 class IPPrefixUtilization(Query):
+    """Counts child allocations of one or more parent prefixes from the perspective of a single branch."""
+
     name = "ipprefix_utilization_prefix"
     type = QueryType.READ
-    branch: Branch | None = None  # type: ignore[assignment]
 
-    def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str], **kwargs) -> None:
+    def __init__(self, ip_prefixes: list[Node], allocated_kinds: list[str], branch: Branch, **kwargs) -> None:
         self.ip_prefixes = ip_prefixes
-        self.allocated_kinds: list[str] = []
-        self.allocated_kinds_rel: list[str] = []
-
-        for kind in sorted(allocated_kinds):
-            self.allocated_kinds.append(f'"{kind}"')
-            self.allocated_kinds_rel.append(
-                {InfrahubKind.IPADDRESS: '"ip_prefix__ip_address"', InfrahubKind.IPPREFIX: '"parent__child"'}[kind]
-            )
-
-        super().__init__(**kwargs)
+        self.allocated_kinds = sorted(allocated_kinds)
+        self.allocated_kinds_rel = [
+            {InfrahubKind.IPADDRESS: "ip_prefix__ip_address", InfrahubKind.IPPREFIX: "parent__child"}[kind]
+            for kind in self.allocated_kinds
+        ]
+        super().__init__(branch=branch, **kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         self.params["ids"] = [p.get_id() for p in self.ip_prefixes]
+        self.params["allocated_kinds"] = self.allocated_kinds
+        self.params["allocated_kinds_rel"] = self.allocated_kinds_rel
 
-        branch = self.branch
-        if branch is not None and not self.branch_agnostic:
-            branches_times = branch.get_branches_and_times_to_query_global(at=self.at)
-            for idx, (branch_names, time_to_query) in enumerate(branches_times.items()):
-                self.params[f"util_branch{idx}"] = list(branch_names)
-                self.params[f"util_time{idx}"] = time_to_query
-            num_branches = len(branches_times)
+        def rel_filter(variable_name: str) -> str:
+            filter_str, filter_params = self.branch.get_query_filter_path(
+                at=self.at.to_string(),
+                branch_agnostic=self.branch_agnostic,
+                variable_name=variable_name,
+            )
+            self.params.update(filter_params)
+            return filter_str
 
-            def rel_filter(rel_name: str) -> str:
-                parts = [
-                    f"({rel_name}.branch IN $util_branch{idx} AND {rel_name}.from <= $util_time{idx} "
-                    f"AND ({rel_name}.to IS NULL OR {rel_name}.to >= $util_time{idx}))"
-                    for idx in range(num_branches)
-                ]
-                return " OR ".join(parts)
-        else:
-            self.params["time_at"] = self.at.to_string()
-
-            def rel_filter(rel_name: str) -> str:
-                return f"{rel_name}.from <= $time_at AND ({rel_name}.to IS NULL OR {rel_name}.to >= $time_at)"
-
-        query = f"""
+        query = """
         MATCH (pfx:Node)
         WHERE pfx.uuid IN $ids
-        CALL (pfx) {{
+        CALL (pfx) {
             MATCH (pfx)-[r_rel1:IS_RELATED]-(rl:Relationship)<-[r_rel2:IS_RELATED]-(child:Node)
-            WHERE rl.name IN [{", ".join(self.allocated_kinds_rel)}]
-            AND any(l IN labels(child) WHERE l IN [{", ".join(self.allocated_kinds)}])
-            AND ({rel_filter("r_rel1")})
-            AND ({rel_filter("r_rel2")})
+            WHERE rl.name IN $allocated_kinds_rel
+            AND any(l IN labels(child) WHERE l IN $allocated_kinds)
+            AND %(rel1_filter)s
+            AND %(rel2_filter)s
             RETURN r_rel1, rl, r_rel2, child
-        }}
+        }
         WITH pfx, r_rel1, rl, r_rel2, child
         MATCH path = (
             (pfx)-[r_1:IS_RELATED]-(rl:Relationship)-[r_2:IS_RELATED]-(child:Node)
             -[r_attr:HAS_ATTRIBUTE]->(attr:Attribute)
-            -[r_attr_val:HAS_VALUE]->(av:{PREFIX_ATTRIBUTE_LABEL}|{ADDRESS_ATTRIBUTE_LABEL})
+            -[r_attr_val:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
         )
-        WHERE %(id_func)s(r_1) = %(id_func)s(r_rel1)
-        AND %(id_func)s(r_2) = %(id_func)s(r_rel2)
-        AND ({rel_filter("r_attr")})
-        AND ({rel_filter("r_attr_val")})
+        WHERE elementId(r_1) = elementId(r_rel1)
+        AND elementId(r_2) = elementId(r_rel2)
+        AND %(attr_filter)s
+        AND %(attr_val_filter)s
         AND attr.name IN ["prefix", "address"]
         WITH
             path,
             pfx,
             child,
             av,
-            reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS sum_branch_level,
-            all(r in relationships(path) WHERE r.status = "active") AS is_active,
-            [r_attr_val.from, r_attr.from, r_2.from, r_1.from] AS from_times,
-            reduce(
-                b_details = [0, null], r in relationships(path) |
-                CASE WHEN r.branch_level > b_details[0] THEN [r.branch_level, r.branch] ELSE b_details END
-            ) as deepest_branch_details
+            reduce(br_lvl = 0, r IN relationships(path) | br_lvl + r.branch_level) AS sum_branch_level,
+            all(r IN relationships(path) WHERE r.status = "active") AS is_active,
+            [r_attr_val.from, r_attr.from, r_2.from, r_1.from] AS from_times
         ORDER BY pfx.uuid, child.uuid, av.uuid, sum_branch_level DESC, from_times[3] DESC, from_times[2] DESC, from_times[1] DESC, from_times[0] DESC
         WITH
             pfx,
             child,
             av,
-            head(collect(deepest_branch_details[1])) AS branch,
             head(collect(is_active)) AS is_latest_active
         WHERE is_latest_active = TRUE
         """ % {
-            "id_func": db.get_id_function_name(),
+            "rel1_filter": rel_filter("r_rel1"),
+            "rel2_filter": rel_filter("r_rel2"),
+            "attr_filter": rel_filter("r_attr"),
+            "attr_val_filter": rel_filter("r_attr_val"),
+            "prefix_label": PREFIX_ATTRIBUTE_LABEL,
+            "address_label": ADDRESS_ATTRIBUTE_LABEL,
         }
-        self.return_labels = ["pfx", "child", "av", "branch"]
+        self.return_labels = ["pfx", "child", "av"]
         self.add_to_query(query)
 
     def get_data(self) -> list[IPPrefixUtilizationResult]:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1082,12 +1082,8 @@ class IPPrefixUtilization(Query):
             child,
             av,
             r_rel1.branch_level + r_rel2.branch_level + r_attr.branch_level + r_attr_val.branch_level AS sum_branch_level,
-            all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active,
-            r_rel1.from AS r_rel1_from,
-            r_rel2.from AS r_rel2_from,
-            r_attr.from AS r_attr_from,
-            r_attr_val.from AS r_attr_val_from
-        ORDER BY pfx.uuid, child.uuid, sum_branch_level DESC, r_rel1_from DESC, r_rel2_from DESC, r_attr_from DESC, r_attr_val_from DESC
+            all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active
+        ORDER BY pfx.uuid, child.uuid, sum_branch_level DESC, r_rel1.from DESC, r_rel2.from DESC, r_attr.from DESC, r_attr_val.from DESC
         WITH
             pfx,
             child,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1035,6 +1035,16 @@ class IPPrefixUtilization(Query):
         MATCH (pfx:Node)
         WHERE pfx.uuid IN $ids
         CALL (pfx) {
+            MATCH (pfx)-[r:IS_PART_OF]-(:Root)
+            WHERE %(branch_filter)s
+            RETURN r AS pfx_root
+            ORDER BY r.branch_level DESC, r.from DESC
+            LIMIT 1
+        }
+        WITH pfx, pfx_root
+        WHERE pfx_root.status = "active"
+        WITH pfx
+        CALL (pfx) {
             MATCH (pfx)-[r:IS_RELATED]-(rl:Relationship)
             WHERE rl.name IN $allocated_kinds_rel
             AND %(branch_filter)s
@@ -1046,6 +1056,16 @@ class IPPrefixUtilization(Query):
             AND %(branch_filter)s
             RETURN r AS r_rel2, child
         }
+        CALL (child) {
+            MATCH (child)-[r:IS_PART_OF]-(:Root)
+            WHERE %(branch_filter)s
+            RETURN r AS child_root
+            ORDER BY r.branch_level DESC, r.from DESC
+            LIMIT 1
+        }
+        WITH pfx, r_rel1, rl, r_rel2, child, child_root
+        WHERE child_root.status = "active"
+        WITH pfx, r_rel1, rl, r_rel2, child
         CALL (child) {
             MATCH (child)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
             WHERE attr.name IN ["prefix", "address"]

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1063,7 +1063,7 @@ class IPPrefixUtilization(Query):
             pfx,
             child,
             av,
-            reduce(br_lvl = 0, r IN [r_rel1, r_rel2, r_attr, r_attr_val] | br_lvl + r.branch_level) AS sum_branch_level,
+            r_rel1.branch_level + r_rel2.branch_level + r_attr.branch_level + r_attr_val.branch_level AS sum_branch_level,
             all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active,
             r_rel1.from AS r_rel1_from,
             r_rel2.from AS r_rel2_from,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1042,45 +1042,45 @@ class IPPrefixUtilization(Query):
         self.params["allocated_kinds"] = self.allocated_kinds
         self.params["allocated_kinds_rel"] = self.allocated_kinds_rel
 
-        def rel_filter(variable_name: str) -> str:
-            filter_str, filter_params = self.branch.get_query_filter_path(
-                at=self.at.to_string(),
-                branch_agnostic=self.branch_agnostic,
-                variable_name=variable_name,
-            )
-            self.params.update(filter_params)
-            return filter_str
+        branch_filter, branch_params = self.branch.get_query_filter_path(
+            at=self.at.to_string(), branch_agnostic=self.branch_agnostic
+        )
+        self.params.update(branch_params)
 
         query = """
         MATCH (pfx:Node)
         WHERE pfx.uuid IN $ids
         CALL (pfx) {
-            MATCH (pfx)-[r_rel1:IS_RELATED]-(rl:Relationship)<-[r_rel2:IS_RELATED]-(child:Node)
+            MATCH (pfx)-[r:IS_RELATED]-(rl:Relationship)
             WHERE rl.name IN $allocated_kinds_rel
-            AND any(l IN labels(child) WHERE l IN $allocated_kinds)
-            AND %(rel1_filter)s
-            AND %(rel2_filter)s
-            RETURN r_rel1, rl, r_rel2, child
+            AND %(branch_filter)s
+            RETURN r AS r_rel1, rl
         }
-        WITH pfx, r_rel1, rl, r_rel2, child
-        MATCH path = (
-            (pfx)-[r_1:IS_RELATED]-(rl:Relationship)-[r_2:IS_RELATED]-(child:Node)
-            -[r_attr:HAS_ATTRIBUTE]->(attr:Attribute)
-            -[r_attr_val:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
-        )
-        WHERE elementId(r_1) = elementId(r_rel1)
-        AND elementId(r_2) = elementId(r_rel2)
-        AND %(attr_filter)s
-        AND %(attr_val_filter)s
-        AND attr.name IN ["prefix", "address"]
+        CALL (rl, r_rel1) {
+            MATCH (rl)<-[r:IS_RELATED]-(child:Node)
+            WHERE any(l IN labels(child) WHERE l IN $allocated_kinds)
+            AND elementId(r) <> elementId(r_rel1)
+            AND %(branch_filter)s
+            RETURN r AS r_rel2, child
+        }
+        CALL (child) {
+            MATCH (child)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
+            WHERE attr.name IN ["prefix", "address"]
+            AND %(branch_filter)s
+            RETURN r AS r_attr, attr
+        }
+        CALL (attr) {
+            MATCH (attr)-[r:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
+            WHERE %(branch_filter)s
+            RETURN r AS r_attr_val, av
+        }
         WITH
-            path,
             pfx,
             child,
             av,
-            reduce(br_lvl = 0, r IN relationships(path) | br_lvl + r.branch_level) AS sum_branch_level,
-            all(r IN relationships(path) WHERE r.status = "active") AS is_active,
-            [r_attr_val.from, r_attr.from, r_2.from, r_1.from] AS from_times
+            reduce(br_lvl = 0, r IN [r_rel1, r_rel2, r_attr, r_attr_val] | br_lvl + r.branch_level) AS sum_branch_level,
+            all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active,
+            [r_attr_val.from, r_attr.from, r_rel2.from, r_rel1.from] AS from_times
         ORDER BY pfx.uuid, child.uuid, av.uuid, sum_branch_level DESC, from_times[3] DESC, from_times[2] DESC, from_times[1] DESC, from_times[0] DESC
         WITH
             pfx,
@@ -1089,10 +1089,7 @@ class IPPrefixUtilization(Query):
             head(collect(is_active)) AS is_latest_active
         WHERE is_latest_active = TRUE
         """ % {
-            "rel1_filter": rel_filter("r_rel1"),
-            "rel2_filter": rel_filter("r_rel2"),
-            "attr_filter": rel_filter("r_attr"),
-            "attr_val_filter": rel_filter("r_attr_val"),
+            "branch_filter": branch_filter,
             "prefix_label": PREFIX_ATTRIBUTE_LABEL,
             "address_label": ADDRESS_ATTRIBUTE_LABEL,
         }

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1024,7 +1024,6 @@ class IPPrefixUtilization(Query):
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         self.params["ids"] = [p.get_id() for p in self.ip_prefixes]
-        self.params["allocated_kinds"] = self.allocated_kinds
         self.params["allocated_kinds_rel"] = self.allocated_kinds_rel
 
         branch_filter, branch_params = self.branch.get_query_filter_path(
@@ -1042,9 +1041,8 @@ class IPPrefixUtilization(Query):
             RETURN r AS r_rel1, rl
         }
         CALL (rl, pfx) {
-            MATCH (rl)<-[r:IS_RELATED]-(child:Node)
-            WHERE any(l IN labels(child) WHERE l IN $allocated_kinds)
-            AND child <> pfx
+            MATCH (rl)<-[r:IS_RELATED]-(child:%(allocated_labels)s)
+            WHERE child <> pfx
             AND %(branch_filter)s
             RETURN r AS r_rel2, child
         }
@@ -1078,6 +1076,7 @@ class IPPrefixUtilization(Query):
         WHERE is_latest_active = TRUE
         """ % {
             "branch_filter": branch_filter,
+            "allocated_labels": "|".join(self.allocated_kinds),
             "prefix_label": PREFIX_ATTRIBUTE_LABEL,
             "address_label": ADDRESS_ATTRIBUTE_LABEL,
         }

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1041,10 +1041,10 @@ class IPPrefixUtilization(Query):
             AND %(branch_filter)s
             RETURN r AS r_rel1, rl
         }
-        CALL (rl, r_rel1) {
+        CALL (rl, pfx) {
             MATCH (rl)<-[r:IS_RELATED]-(child:Node)
             WHERE any(l IN labels(child) WHERE l IN $allocated_kinds)
-            AND elementId(r) <> elementId(r_rel1)
+            AND child <> pfx
             AND %(branch_filter)s
             RETURN r AS r_rel2, child
         }

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -14,6 +14,7 @@ from infrahub.core.utils import convert_ip_to_binary_str
 if TYPE_CHECKING:
     from uuid import UUID
 
+    from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
 
@@ -1028,6 +1029,7 @@ class IPPrefixUtilizationResult:
 class IPPrefixUtilization(Query):
     name = "ipprefix_utilization_prefix"
     type = QueryType.READ
+    branch: Branch | None = None  # type: ignore[assignment]
 
     def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str], **kwargs) -> None:
         self.ip_prefixes = ip_prefixes
@@ -1044,10 +1046,27 @@ class IPPrefixUtilization(Query):
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
         self.params["ids"] = [p.get_id() for p in self.ip_prefixes]
-        self.params["time_at"] = self.at.to_string()
 
-        def rel_filter(rel_name: str) -> str:
-            return f"{rel_name}.from <= $time_at AND ({rel_name}.to IS NULL OR {rel_name}.to >= $time_at)"
+        branch = self.branch
+        if branch is not None and not self.branch_agnostic:
+            branches_times = branch.get_branches_and_times_to_query_global(at=self.at)
+            for idx, (branch_names, time_to_query) in enumerate(branches_times.items()):
+                self.params[f"util_branch{idx}"] = list(branch_names)
+                self.params[f"util_time{idx}"] = time_to_query
+            num_branches = len(branches_times)
+
+            def rel_filter(rel_name: str) -> str:
+                parts = [
+                    f"({rel_name}.branch IN $util_branch{idx} AND {rel_name}.from <= $util_time{idx} "
+                    f"AND ({rel_name}.to IS NULL OR {rel_name}.to >= $util_time{idx}))"
+                    for idx in range(num_branches)
+                ]
+                return " OR ".join(parts)
+        else:
+            self.params["time_at"] = self.at.to_string()
+
+            def rel_filter(rel_name: str) -> str:
+                return f"{rel_name}.from <= $time_at AND ({rel_name}.to IS NULL OR {rel_name}.to >= $time_at)"
 
         query = f"""
         MATCH (pfx:Node)
@@ -1088,14 +1107,13 @@ class IPPrefixUtilization(Query):
             pfx,
             child,
             av,
-            deepest_branch_details[0] AS branch_level,
-            deepest_branch_details[1] AS branch,
+            head(collect(deepest_branch_details[1])) AS branch,
             head(collect(is_active)) AS is_latest_active
         WHERE is_latest_active = TRUE
         """ % {
             "id_func": db.get_id_function_name(),
         }
-        self.return_labels = ["pfx", "child", "av", "branch_level", "branch"]
+        self.return_labels = ["pfx", "child", "av", "branch"]
         self.add_to_query(query)
 
     def get_data(self) -> list[IPPrefixUtilizationResult]:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1089,7 +1089,7 @@ class IPPrefixUtilization(Query):
             child,
             head(collect(av)) AS av,
             head(collect(is_active)) AS is_latest_active
-        WHERE is_latest_active = TRUE
+        WHERE is_latest_active
         """ % {
             "branch_filter": branch_filter,
             "allocated_labels": "|".join(self.allocated_kinds),

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1065,8 +1065,11 @@ class IPPrefixUtilization(Query):
             av,
             reduce(br_lvl = 0, r IN [r_rel1, r_rel2, r_attr, r_attr_val] | br_lvl + r.branch_level) AS sum_branch_level,
             all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active,
-            [r_attr_val.from, r_attr.from, r_rel2.from, r_rel1.from] AS from_times
-        ORDER BY pfx.uuid, child.uuid, av.uuid, sum_branch_level DESC, from_times[3] DESC, from_times[2] DESC, from_times[1] DESC, from_times[0] DESC
+            r_rel1.from AS r_rel1_from,
+            r_rel2.from AS r_rel2_from,
+            r_attr.from AS r_attr_from,
+            r_attr_val.from AS r_attr_val_from
+        ORDER BY pfx.uuid, child.uuid, av.uuid, sum_branch_level DESC, r_rel1_from DESC, r_rel2_from DESC, r_attr_from DESC, r_attr_val_from DESC
         WITH
             pfx,
             child,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1045,16 +1045,25 @@ class IPPrefixUtilization(Query):
         WHERE pfx_root.status = "active"
         WITH pfx
         CALL (pfx) {
-            MATCH (pfx)-[r:IS_RELATED]-(rl:Relationship)
+            MATCH path = (pfx)
+                -[r_rel1:IS_RELATED]-(rl:Relationship)
+                <-[r_rel2:IS_RELATED]-(child:%(allocated_labels)s)
+                -[r_attr:HAS_ATTRIBUTE]->(attr:Attribute)
+                -[r_attr_val:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
             WHERE rl.name IN $allocated_kinds_rel
-            AND %(branch_filter)s
-            RETURN r AS r_rel1, rl
-        }
-        CALL (rl, pfx) {
-            MATCH (rl)<-[r:IS_RELATED]-(child:%(allocated_labels)s)
-            WHERE child <> pfx
-            AND %(branch_filter)s
-            RETURN r AS r_rel2, child
+            AND attr.name IN ["prefix", "address"]
+            AND child <> pfx
+            AND all(r IN relationships(path) WHERE %(branch_filter)s)
+            WITH
+                child,
+                av,
+                r_rel1.branch_level + r_rel2.branch_level + r_attr.branch_level + r_attr_val.branch_level AS sum_branch_level,
+                all(r IN relationships(path) WHERE r.status = "active") AS is_active,
+                r_rel1, r_rel2, r_attr, r_attr_val
+            ORDER BY child.uuid, sum_branch_level DESC, r_rel1.from DESC, r_rel2.from DESC, r_attr.from DESC, r_attr_val.from DESC
+            WITH child, head(collect(av)) AS av, head(collect(is_active)) AS is_latest_active
+            WHERE is_latest_active
+            RETURN child, av
         }
         CALL (child) {
             MATCH (child)-[r:IS_PART_OF]-(:Root)
@@ -1063,33 +1072,8 @@ class IPPrefixUtilization(Query):
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH pfx, r_rel1, rl, r_rel2, child, child_root
+        WITH pfx, child, av, child_root
         WHERE child_root.status = "active"
-        WITH pfx, r_rel1, rl, r_rel2, child
-        CALL (child) {
-            MATCH (child)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
-            WHERE attr.name IN ["prefix", "address"]
-            AND %(branch_filter)s
-            RETURN r AS r_attr, attr
-        }
-        CALL (attr) {
-            MATCH (attr)-[r:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
-            WHERE %(branch_filter)s
-            RETURN r AS r_attr_val, av
-        }
-        WITH
-            pfx,
-            child,
-            av,
-            r_rel1.branch_level + r_rel2.branch_level + r_attr.branch_level + r_attr_val.branch_level AS sum_branch_level,
-            all(r IN [r_rel1, r_rel2, r_attr, r_attr_val] WHERE r.status = "active") AS is_active
-        ORDER BY pfx.uuid, child.uuid, sum_branch_level DESC, r_rel1.from DESC, r_rel2.from DESC, r_attr.from DESC, r_attr_val.from DESC
-        WITH
-            pfx,
-            child,
-            head(collect(av)) AS av,
-            head(collect(is_active)) AS is_latest_active
-        WHERE is_latest_active
         """ % {
             "branch_filter": branch_filter,
             "allocated_labels": "|".join(self.allocated_kinds),

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -1043,37 +1043,47 @@ class IPPrefixUtilization(Query):
         }
         WITH pfx, pfx_root
         WHERE pfx_root.status = "active"
-        WITH pfx
-        CALL (pfx) {
-            MATCH path = (pfx)
-                -[r_rel1:IS_RELATED]-(rl:Relationship)
-                <-[r_rel2:IS_RELATED]-(child:%(allocated_labels)s)
-                -[r_attr:HAS_ATTRIBUTE]->(attr:Attribute)
-                -[r_attr_val:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
-            WHERE rl.name IN $allocated_kinds_rel
-            AND attr.name IN ["prefix", "address"]
-            AND child <> pfx
-            AND all(r IN relationships(path) WHERE %(branch_filter)s)
-            WITH
-                child,
-                av,
-                r_rel1.branch_level + r_rel2.branch_level + r_attr.branch_level + r_attr_val.branch_level AS sum_branch_level,
-                all(r IN relationships(path) WHERE r.status = "active") AS is_active,
-                r_rel1, r_rel2, r_attr, r_attr_val
-            ORDER BY child.uuid, sum_branch_level DESC, r_rel1.from DESC, r_rel2.from DESC, r_attr.from DESC, r_attr_val.from DESC
-            WITH child, head(collect(av)) AS av, head(collect(is_active)) AS is_latest_active
-            WHERE is_latest_active
-            RETURN child, av
-        }
-        CALL (child) {
-            MATCH (child)-[r:IS_PART_OF]-(:Root)
+        MATCH (pfx)-[:IS_RELATED]-(rl:Relationship)
+        WHERE rl.name IN $allocated_kinds_rel
+        WITH DISTINCT pfx, rl
+        CALL (pfx, rl) {
+            MATCH (pfx)-[r:IS_RELATED]-(rl)
             WHERE %(branch_filter)s
-            RETURN r AS child_root
-            ORDER BY r.branch_level DESC, r.from DESC
+            RETURN r AS r_rel1
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
             LIMIT 1
         }
-        WITH pfx, child, av, child_root
-        WHERE child_root.status = "active"
+        WITH pfx, rl, r_rel1
+        WHERE r_rel1.status = "active"
+        CALL (rl, pfx) {
+            MATCH (rl)<-[r:IS_RELATED]-(child:%(allocated_labels)s)
+            WHERE child <> pfx
+            AND %(branch_filter)s
+            RETURN r AS r_rel2, child
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+        WITH pfx, child, r_rel2
+        WHERE r_rel2.status = "active"
+        CALL (child) {
+            MATCH (child)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
+            WHERE attr.name IN ["prefix", "address"]
+            AND %(branch_filter)s
+            RETURN r AS r_attr, attr
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+        WITH pfx, child, attr, r_attr
+        WHERE r_attr.status = "active"
+        CALL (attr) {
+            MATCH (attr)-[r:HAS_VALUE]->(av:%(prefix_label)s|%(address_label)s)
+            WHERE %(branch_filter)s
+            RETURN r AS r_attr_val, av
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+        WITH pfx, child, av, r_attr_val
+        WHERE r_attr_val.status = "active"
         """ % {
             "branch_filter": branch_filter,
             "allocated_labels": "|".join(self.allocated_kinds),

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -207,6 +207,8 @@ class PoolUtilization(ObjectType):
         branch_getter = PrefixUtilizationGetter(
             db=db, ip_prefixes=resources, branch=graphql_context.branch, at=graphql_context.at
         )
+        # Reuse the single-branch query when the request is already on the default branch,
+        # otherwise the two getters cache independent result sets.
         default_branch_getter = (
             branch_getter
             if graphql_context.branch.name == default_branch.name
@@ -233,7 +235,9 @@ class PoolUtilization(ObjectType):
                 if default_branch_utilization is not None
                 else await default_branch_getter.get_use_percentage()
             )
-            response["utilization_branches"] = total_utilization - default_branch_utilization
+            # Clamp at 0: deletions on the branch can make its view smaller than the default
+            # branch's, but this field is exposed as a non-negative percentage.
+            response["utilization_branches"] = max(0.0, total_utilization - default_branch_utilization)
         if "edges" in fields:
             response["edges"] = []
             if "node" in fields["edges"]:
@@ -269,7 +273,7 @@ class PoolUtilization(ObjectType):
                             if default_branch_total is not None
                             else await default_branch_getter.get_use_percentage(ip_prefixes=[resource_node])
                         )
-                        node_response["utilization_branches"] = resource_total - default_branch_total
+                        node_response["utilization_branches"] = max(0.0, resource_total - default_branch_total)
                     response["edges"].append({"node": node_response})
 
         return response

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -115,6 +115,7 @@ class PoolAllocated(ObjectType):
         query = await IPPrefixUtilization.init(
             db=graphql_context.db,
             at=graphql_context.at,
+            branch=graphql_context.branch,
             ip_prefixes=[resource],
             allocated_kinds=allocated_kinds,
             offset=offset,
@@ -136,7 +137,7 @@ class PoolAllocated(ObjectType):
                         "node": {
                             "id": item.child_uuid,
                             "kind": item.child_kind,
-                            "branch": item.branch,
+                            "branch": graphql_context.branch.name,
                             "display_label": item.ip_value,
                         }
                     }
@@ -201,8 +202,15 @@ class PoolUtilization(ObjectType):
         with contextlib.suppress(SchemaNotFoundError):
             resources_map = await pool.resources.get_peers(db=db, branch_agnostic=True)  # type: ignore[attr-defined,union-attr]
 
-        utilization_getter = PrefixUtilizationGetter(
-            db=db, ip_prefixes=list(resources_map.values()), at=graphql_context.at
+        default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
+        resources = list(resources_map.values())
+        branch_getter = PrefixUtilizationGetter(
+            db=db, ip_prefixes=resources, branch=graphql_context.branch, at=graphql_context.at
+        )
+        default_branch_getter = (
+            branch_getter
+            if graphql_context.branch.name == default_branch.name
+            else PrefixUtilizationGetter(db=db, ip_prefixes=resources, branch=default_branch, at=graphql_context.at)
         )
         fields = extract_graphql_fields(info=info)
         response: dict[str, Any] = {}
@@ -211,19 +219,19 @@ class PoolUtilization(ObjectType):
         if "count" in fields:
             response["count"] = len(resources_map)
         if "utilization" in fields:
-            response["utilization"] = total_utilization = await utilization_getter.get_use_percentage()
+            response["utilization"] = total_utilization = await branch_getter.get_use_percentage()
         if "utilization_default_branch" in fields:
             response["utilization_default_branch"] = (
                 default_branch_utilization
-            ) = await utilization_getter.get_use_percentage(branch_names=[registry.default_branch])
+            ) = await default_branch_getter.get_use_percentage()
         if "utilization_branches" in fields:
             total_utilization = (
-                total_utilization if total_utilization is not None else await utilization_getter.get_use_percentage()
+                total_utilization if total_utilization is not None else await branch_getter.get_use_percentage()
             )
             default_branch_utilization = (
                 default_branch_utilization
                 if default_branch_utilization is not None
-                else await utilization_getter.get_use_percentage(branch_names=[registry.default_branch])
+                else await default_branch_getter.get_use_percentage()
             )
             response["utilization_branches"] = total_utilization - default_branch_utilization
         if "edges" in fields:
@@ -243,27 +251,23 @@ class PoolUtilization(ObjectType):
                     if "weight" in node_fields:
                         node_response["weight"] = await resource_node.get_resource_weight(db=db)  # type: ignore[attr-defined]
                     if "utilization" in node_fields:
-                        node_response["utilization"] = resource_total = await utilization_getter.get_use_percentage(
+                        node_response["utilization"] = resource_total = await branch_getter.get_use_percentage(
                             ip_prefixes=[resource_node]
                         )
                     if "utilization_default_branch" in node_fields:
                         node_response["utilization_default_branch"] = (
                             default_branch_total
-                        ) = await utilization_getter.get_use_percentage(
-                            ip_prefixes=[resource_node], branch_names=[registry.default_branch]
-                        )
+                        ) = await default_branch_getter.get_use_percentage(ip_prefixes=[resource_node])
                     if "utilization_branches" in node_fields:
                         resource_total = (
                             resource_total
                             if resource_total is not None
-                            else await utilization_getter.get_use_percentage(ip_prefixes=[resource_node])
+                            else await branch_getter.get_use_percentage(ip_prefixes=[resource_node])
                         )
                         default_branch_total = (
                             default_branch_total
                             if default_branch_total is not None
-                            else await utilization_getter.get_use_percentage(
-                                ip_prefixes=[resource_node], branch_names=[registry.default_branch]
-                            )
+                            else await default_branch_getter.get_use_percentage(ip_prefixes=[resource_node])
                         )
                         node_response["utilization_branches"] = resource_total - default_branch_total
                     response["edges"].append({"node": node_response})

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -235,8 +235,8 @@ class PoolUtilization(ObjectType):
                 if default_branch_utilization is not None
                 else await default_branch_getter.get_use_percentage()
             )
-            # Clamp at 0: deletions on the branch can make its view smaller than the default
-            # branch's, but this field is exposed as a non-negative percentage.
+            # Deletions on the branch can make its view smaller than the default branch's;
+            # this field is exposed as a non-negative percentage.
             response["utilization_branches"] = max(0.0, total_utilization - default_branch_utilization)
         if "edges" in fields:
             response["edges"] = []

--- a/backend/tests/component/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/component/core/ipam/test_ipam_utilization.py
@@ -1,7 +1,12 @@
+from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_branch
 from infrahub.core.ipam.constants import PrefixMemberType
 from infrahub.core.ipam.utilization import PrefixUtilizationGetter
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.database import InfrahubDatabase
 
 
@@ -25,3 +30,23 @@ async def test_use_percentage_no_prefixes(db: InfrahubDatabase, default_branch: 
     percentage = await utilization.get_use_percentage()
 
     assert percentage == 0.0
+
+
+async def test_graphql_utilization_inherited_on_new_branch(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
+) -> None:
+    registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+    net143_id = ip_dataset_01["net143"].id
+
+    main_prefix = await NodeManager.get_one(db=db, branch=default_branch, id=net143_id)
+    assert isinstance(main_prefix, BuiltinIPPrefix)
+    main_response = await main_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert main_response["utilization"] == {"value": 3}
+
+    new_branch = await create_branch(db=db, branch_name="branch-utilization")
+
+    branch_prefix = await NodeManager.get_one(db=db, branch=new_branch, id=net143_id)
+    assert isinstance(branch_prefix, BuiltinIPPrefix)
+    branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
+
+    assert branch_response["utilization"] == main_response["utilization"]

--- a/backend/tests/component/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/component/core/ipam/test_ipam_utilization.py
@@ -50,3 +50,80 @@ async def test_graphql_utilization_inherited_on_new_branch(
     branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
 
     assert branch_response["utilization"] == main_response["utilization"]
+
+
+async def test_graphql_utilization_branch_addition(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
+) -> None:
+    registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+    net143_id = ip_dataset_01["net143"].id
+    ns1 = ip_dataset_01["ns1"]
+
+    new_branch = await create_branch(db=db, branch_name="branch-utilization-add")
+    address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=new_branch)
+
+    net143_on_branch = await NodeManager.get_one(db=db, branch=new_branch, id=net143_id)
+    new_address = await Node.init(db=db, branch=new_branch, schema=address_schema)
+    await new_address.new(db=db, address="10.10.1.2", ip_prefix=net143_on_branch, ip_namespace=ns1)
+    await new_address.save(db=db)
+
+    branch_prefix = await NodeManager.get_one(db=db, branch=new_branch, id=net143_id)
+    assert isinstance(branch_prefix, BuiltinIPPrefix)
+    branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
+    # net143 has 30 usable addresses, 1 from main + 1 added on branch = 2/30 -> int(6.66) = 6
+    assert branch_response["utilization"] == {"value": 6}
+
+    main_prefix = await NodeManager.get_one(db=db, branch=default_branch, id=net143_id)
+    assert isinstance(main_prefix, BuiltinIPPrefix)
+    main_response = await main_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert main_response["utilization"] == {"value": 3}
+
+
+async def test_graphql_utilization_branch_deletion(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
+) -> None:
+    registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+    net143_id = ip_dataset_01["net143"].id
+    address11_id = ip_dataset_01["address11"].id
+
+    new_branch = await create_branch(db=db, branch_name="branch-utilization-delete")
+
+    address_on_branch = await NodeManager.get_one(db=db, branch=new_branch, id=address11_id)
+    assert address_on_branch is not None
+    await address_on_branch.delete(db=db)
+
+    branch_prefix = await NodeManager.get_one(db=db, branch=new_branch, id=net143_id)
+    assert isinstance(branch_prefix, BuiltinIPPrefix)
+    branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert branch_response["utilization"] == {"value": 0}
+
+    main_prefix = await NodeManager.get_one(db=db, branch=default_branch, id=net143_id)
+    assert isinstance(main_prefix, BuiltinIPPrefix)
+    main_response = await main_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert main_response["utilization"] == {"value": 3}
+
+
+async def test_graphql_utilization_main_addition_after_branch_creation(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
+) -> None:
+    registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
+    net143_id = ip_dataset_01["net143"].id
+    ns1 = ip_dataset_01["ns1"]
+
+    new_branch = await create_branch(db=db, branch_name="branch-utilization-main-add")
+
+    address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
+    net143_on_main = await NodeManager.get_one(db=db, branch=default_branch, id=net143_id)
+    new_address = await Node.init(db=db, schema=address_schema)
+    await new_address.new(db=db, address="10.10.1.2", ip_prefix=net143_on_main, ip_namespace=ns1)
+    await new_address.save(db=db)
+
+    main_prefix = await NodeManager.get_one(db=db, branch=default_branch, id=net143_id)
+    assert isinstance(main_prefix, BuiltinIPPrefix)
+    main_response = await main_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert main_response["utilization"] == {"value": 6}
+
+    branch_prefix = await NodeManager.get_one(db=db, branch=new_branch, id=net143_id)
+    assert isinstance(branch_prefix, BuiltinIPPrefix)
+    branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
+    assert branch_response["utilization"] == {"value": 3}

--- a/backend/tests/component/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/component/core/ipam/test_ipam_utilization.py
@@ -49,7 +49,7 @@ async def test_graphql_utilization_inherited_on_new_branch(
     assert isinstance(branch_prefix, BuiltinIPPrefix)
     branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
 
-    assert branch_response["utilization"] == main_response["utilization"]
+    assert branch_response["utilization"] == {"value": 3}
 
 
 async def test_graphql_utilization_branch_addition(

--- a/backend/tests/component/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/component/core/ipam/test_ipam_utilization.py
@@ -13,20 +13,20 @@ from infrahub.database import InfrahubDatabase
 async def test_use_percentage(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]) -> None:
     net240 = ip_dataset_01["net240"]
     net240.member_type.value = PrefixMemberType.ADDRESS.value
-    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net240])
+    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net240], branch=default_branch)
     percentage = await utilization.get_use_percentage()
 
     assert percentage == 0.0
 
     net240.member_type.value = PrefixMemberType.PREFIX.value
-    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net240])
+    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net240], branch=default_branch)
     percentage = await utilization.get_use_percentage()
 
     assert percentage == 0.2197265625
 
 
 async def test_use_percentage_no_prefixes(db: InfrahubDatabase, default_branch: Branch) -> None:
-    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[])
+    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[], branch=default_branch)
     percentage = await utilization.get_use_percentage()
 
     assert percentage == 0.0

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -580,9 +580,9 @@ class TestIpamUtilization(TestIpam):
         assert result.data
         pool_data = result.data["InfrahubResourcePoolUtilization"]
         assert pool_data["count"] == 2
-        # Pool space = 2 * 256 = 512. On branch2 (isolated) container shows prefix + prefix2
-        # (main's prefix2 deletion is invisible to the branch) plus prefix_branch alive on the
-        # branch, totalling 48/512. On main only prefix survives: 16/512.
+        # Pool space = 2 * 256 = 512. On branch2 container shows prefix + prefix2 (main's
+        # prefix2 deletion is invisible to the branch) plus prefix_branch alive on the branch,
+        # totalling 48/512. On main only prefix survives: 16/512.
         assert pool_data["utilization"] == (48 / 512) * 100
         assert pool_data["utilization_default_branch"] == (16 / 512) * 100
         assert pool_data["utilization_branches"] == (32 / 512) * 100

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -218,7 +218,7 @@ class TestIpamUtilization(TestIpam):
         container = initial_dataset["container"]
         prefix = initial_dataset["prefix"]
         prefix2 = initial_dataset["prefix2"]
-        getter = PrefixUtilizationGetter(db=db, ip_prefixes=[container, prefix, prefix2])
+        getter = PrefixUtilizationGetter(db=db, ip_prefixes=[container, prefix, prefix2], branch=default_branch)
 
         assert await getter.get_use_percentage(ip_prefixes=[container]) == 100 / 8
         assert await getter.get_use_percentage(ip_prefixes=[prefix2]) == 0
@@ -360,20 +360,18 @@ class TestIpamUtilization(TestIpam):
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
         prefix2_branch = step_02_dataset["prefix2_branch"]
-        getter = PrefixUtilizationGetter(db=db, ip_prefixes=[container, prefix, prefix_branch, prefix2_branch])
+        prefixes = [container, prefix, prefix_branch, prefix2_branch]
+        main_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=default_branch)
+        branch_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=branch2)
 
-        assert await getter.get_use_percentage(ip_prefixes=[container]) == 25.0
-        assert await getter.get_use_percentage(ip_prefixes=[container], branch_names=[branch2.name]) == 12.5
-        assert await getter.get_use_percentage(ip_prefixes=[container], branch_names=[default_branch.name]) == 12.5
-        assert await getter.get_use_percentage(ip_prefixes=[prefix2_branch]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix2_branch], branch_names=[branch2.name]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix2_branch], branch_names=[default_branch.name]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 100.0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix_branch], branch_names=[branch2.name]) == 100.0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix_branch], branch_names=[default_branch.name]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix]) == 100.0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix], branch_names=[branch2.name]) == 50.0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix], branch_names=[default_branch.name]) == 50.0
+        assert await branch_getter.get_use_percentage(ip_prefixes=[container]) == 25.0
+        assert await main_getter.get_use_percentage(ip_prefixes=[container]) == 12.5
+        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix2_branch]) == 0
+        assert await main_getter.get_use_percentage(ip_prefixes=[prefix2_branch]) == 0
+        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 100.0
+        assert await main_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 0
+        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix]) == 100.0
+        assert await main_getter.get_use_percentage(ip_prefixes=[prefix]) == 50.0
 
     async def test_step02_graphql_prefix_pool_branch_utilization(
         self,
@@ -386,8 +384,8 @@ class TestIpamUtilization(TestIpam):
         container = initial_dataset["container"]
         container_branch = step_02_dataset["container_branch"]
         prefix_pool = initial_dataset["prefix_pool"]
-        default_branch.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -426,8 +424,6 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        branch2.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -465,8 +461,8 @@ class TestIpamUtilization(TestIpam):
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
         address_pool = initial_dataset["address_pool"]
-        default_branch.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -505,8 +501,6 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        branch2.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -545,21 +539,21 @@ class TestIpamUtilization(TestIpam):
         container = initial_dataset["container"]
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
-        getter = PrefixUtilizationGetter(db=db, ip_prefixes=[container, prefix, prefix_branch])
+        prefixes = [container, prefix, prefix_branch]
+        main_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=default_branch)
+        branch_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=branch2)
 
-        assert await getter.get_use_percentage(ip_prefixes=[container]) == 12.5
-        assert await getter.get_use_percentage(ip_prefixes=[container], branch_names=[branch2.name]) == 100 / 16
-        assert await getter.get_use_percentage(ip_prefixes=[container], branch_names=[default_branch.name]) == 100 / 16
-        assert await getter.get_use_percentage(ip_prefixes=[prefix_branch]) == (13 / 14) * 100
-        assert (
-            await getter.get_use_percentage(ip_prefixes=[prefix_branch], branch_names=[branch2.name]) == (13 / 14) * 100
-        )
-        assert await getter.get_use_percentage(ip_prefixes=[prefix_branch], branch_names=[default_branch.name]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix]) == (12 / 14) * 100
-        assert await getter.get_use_percentage(ip_prefixes=[prefix], branch_names=[branch2.name]) == (6 / 14) * 100
-        assert (
-            await getter.get_use_percentage(ip_prefixes=[prefix], branch_names=[default_branch.name]) == (6 / 14) * 100
-        )
+        # main now sees only prefix under container; main's prefix2 deletion is invisible to the
+        # isolated branch, which still counts prefix + prefix2 plus its own live prefix_branch.
+        assert await main_getter.get_use_percentage(ip_prefixes=[container]) == 100 / 16
+        assert await branch_getter.get_use_percentage(ip_prefixes=[container]) == 18.75
+        # prefix_branch only exists on branch2; one of its 14 addresses was deleted on branch2.
+        assert await main_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 0
+        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == (13 / 14) * 100
+        # prefix on main lost one of its 7 addresses; branch2 still sees those 7 (isolation)
+        # plus its own 7 minus the one deleted on branch2.
+        assert await main_getter.get_use_percentage(ip_prefixes=[prefix]) == (6 / 14) * 100
+        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix]) == (13 / 14) * 100
 
     async def test_step03_graphql_prefix_pool_delete_utilization(
         self,
@@ -573,8 +567,8 @@ class TestIpamUtilization(TestIpam):
         container = initial_dataset["container"]
         container_branch = step_02_dataset["container_branch"]
         prefix_pool = initial_dataset["prefix_pool"]
-        default_branch.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -586,18 +580,21 @@ class TestIpamUtilization(TestIpam):
         assert result.data
         pool_data = result.data["InfrahubResourcePoolUtilization"]
         assert pool_data["count"] == 2
-        assert pool_data["utilization"] == 100 / 16
-        assert pool_data["utilization_default_branch"] == 100 / 32
-        assert pool_data["utilization_branches"] == 100 / 32
+        # Pool space = 2 * 256 = 512. On branch2 (isolated) container shows prefix + prefix2
+        # (main's prefix2 deletion is invisible to the branch) plus prefix_branch alive on the
+        # branch, totalling 48/512. On main only prefix survives: 16/512.
+        assert pool_data["utilization"] == (48 / 512) * 100
+        assert pool_data["utilization_default_branch"] == (16 / 512) * 100
+        assert pool_data["utilization_branches"] == (32 / 512) * 100
         prefix_details_list = pool_data["edges"]
         assert {
             "node": {
                 "display_label": await container.get_display_label(db=db),
                 "id": container.id,
                 "kind": "IpamIPPrefix",
-                "utilization": 12.5,
+                "utilization": 18.75,
                 "utilization_default_branch": 100 / 16,
-                "utilization_branches": 100 / 16,
+                "utilization_branches": 12.5,
                 "weight": 256,
             }
         } in prefix_details_list
@@ -613,8 +610,6 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        branch2.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -653,8 +648,8 @@ class TestIpamUtilization(TestIpam):
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
         address_pool = initial_dataset["address_pool"]
-        default_branch.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -666,18 +661,21 @@ class TestIpamUtilization(TestIpam):
         assert result.data
         pool_data = result.data["InfrahubResourcePoolUtilization"]
         assert pool_data["count"] == 2
-        assert pool_data["utilization"] == (25 / 28) * 100
+        # On branch2 prefix sees 13 addresses (the 7 originally on main, untouched by main's
+        # later deletion thanks to isolation, plus 7 from branch2 minus the one removed there);
+        # prefix_branch sees 13 of its 14. Total 26 over a 28-address pool.
+        assert pool_data["utilization"] == (26 / 28) * 100
         assert pool_data["utilization_default_branch"] == (6 / 28) * 100
-        assert pool_data["utilization_branches"] == (19 / 28) * 100
+        assert pool_data["utilization_branches"] == (20 / 28) * 100
         prefix_details_list = pool_data["edges"]
         assert {
             "node": {
                 "display_label": await prefix.get_display_label(db=db),
                 "id": prefix.id,
                 "kind": "IpamIPPrefix",
-                "utilization": (12 / 14) * 100,
+                "utilization": (13 / 14) * 100,
                 "utilization_default_branch": (6 / 14) * 100,
-                "utilization_branches": (6 / 14) * 100,
+                "utilization_branches": (13 / 14) * 100 - (6 / 14) * 100,
                 "weight": 14,
             }
         } in prefix_details_list
@@ -693,8 +691,6 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        branch2.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -629,7 +629,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": container.id,
-                "utilization": {"value": 12},
+                "utilization": {"value": 18},
                 "prefix": {"value": container.prefix.value},
             }
         } in prefix_details_list
@@ -709,7 +709,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": prefix.id,
-                "utilization": {"value": int(12 / 14 * 100)},
+                "utilization": {"value": int(13 / 14 * 100)},
                 "prefix": {"value": prefix.prefix.value},
             }
         } in prefix_details_list

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -442,7 +442,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": container.id,
-                "utilization": {"value": 12},
+                "utilization": {"value": 25},
                 "prefix": {"value": container.prefix.value},
             }
         } in prefix_details_list
@@ -521,7 +521,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": prefix.id,
-                "utilization": {"value": 50},
+                "utilization": {"value": 100},
                 "prefix": {"value": prefix.prefix.value},
             }
         } in prefix_details_list
@@ -629,7 +629,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": container.id,
-                "utilization": {"value": 6},
+                "utilization": {"value": 12},
                 "prefix": {"value": container.prefix.value},
             }
         } in prefix_details_list
@@ -709,7 +709,7 @@ class TestIpamUtilization(TestIpam):
         assert {
             "node": {
                 "id": prefix.id,
-                "utilization": {"value": int(6 / 14 * 100)},
+                "utilization": {"value": int(12 / 14 * 100)},
                 "prefix": {"value": prefix.prefix.value},
             }
         } in prefix_details_list

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -6,7 +6,6 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch, create_ipam_namespace, get_default_ipnamespace
-from infrahub.core.ipam.utilization import PrefixUtilizationGetter
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -212,18 +211,6 @@ class TestIpamUtilization(TestIpam):
         assert isinstance(step2_branch_addresses, list)
         await step2_branch_addresses[0].delete(db=db)
 
-    async def test_step01_main_utilization(
-        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: InitialDatasetType
-    ) -> None:
-        container = initial_dataset["container"]
-        prefix = initial_dataset["prefix"]
-        prefix2 = initial_dataset["prefix2"]
-        getter = PrefixUtilizationGetter(db=db, ip_prefixes=[container, prefix, prefix2], branch=default_branch)
-
-        assert await getter.get_use_percentage(ip_prefixes=[container]) == 100 / 8
-        assert await getter.get_use_percentage(ip_prefixes=[prefix2]) == 0
-        assert await getter.get_use_percentage(ip_prefixes=[prefix]) == 50.0
-
     async def test_step01_graphql_prefix_pool_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: InitialDatasetType
     ) -> None:
@@ -347,31 +334,6 @@ class TestIpamUtilization(TestIpam):
                 ],
             }
         }
-
-    async def test_step02_branch_utilization(
-        self,
-        db: InfrahubDatabase,
-        default_branch: Branch,
-        branch2: Branch,
-        initial_dataset: InitialDatasetType,
-        step_02_dataset: Step02DatasetType,
-    ) -> None:
-        container = initial_dataset["container"]
-        prefix = initial_dataset["prefix"]
-        prefix_branch = step_02_dataset["prefix_branch"]
-        prefix2_branch = step_02_dataset["prefix2_branch"]
-        prefixes = [container, prefix, prefix_branch, prefix2_branch]
-        main_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=default_branch)
-        branch_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=branch2)
-
-        assert await branch_getter.get_use_percentage(ip_prefixes=[container]) == 25.0
-        assert await main_getter.get_use_percentage(ip_prefixes=[container]) == 12.5
-        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix2_branch]) == 0
-        assert await main_getter.get_use_percentage(ip_prefixes=[prefix2_branch]) == 0
-        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 100.0
-        assert await main_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 0
-        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix]) == 100.0
-        assert await main_getter.get_use_percentage(ip_prefixes=[prefix]) == 50.0
 
     async def test_step02_graphql_prefix_pool_branch_utilization(
         self,
@@ -526,34 +488,6 @@ class TestIpamUtilization(TestIpam):
                 "prefix": {"value": prefix_branch.prefix.value},
             }
         } in prefix_details_list
-
-    async def test_step03_utilization_with_deletes(
-        self,
-        db: InfrahubDatabase,
-        default_branch: Branch,
-        branch2: Branch,
-        initial_dataset: InitialDatasetType,
-        step_02_dataset: Step02DatasetType,
-        step_03_dataset: None,
-    ) -> None:
-        container = initial_dataset["container"]
-        prefix = initial_dataset["prefix"]
-        prefix_branch = step_02_dataset["prefix_branch"]
-        prefixes = [container, prefix, prefix_branch]
-        main_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=default_branch)
-        branch_getter = PrefixUtilizationGetter(db=db, ip_prefixes=prefixes, branch=branch2)
-
-        # main now sees only prefix under container; main's prefix2 deletion is invisible to the
-        # isolated branch, which still counts prefix + prefix2 plus its own live prefix_branch.
-        assert await main_getter.get_use_percentage(ip_prefixes=[container]) == 100 / 16
-        assert await branch_getter.get_use_percentage(ip_prefixes=[container]) == 18.75
-        # prefix_branch only exists on branch2; one of its 14 addresses was deleted on branch2.
-        assert await main_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == 0
-        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix_branch]) == (13 / 14) * 100
-        # prefix on main lost one of its 7 addresses; branch2 still sees those 7 (isolation)
-        # plus its own 7 minus the one deleted on branch2.
-        assert await main_getter.get_use_percentage(ip_prefixes=[prefix]) == (6 / 14) * 100
-        assert await branch_getter.get_use_percentage(ip_prefixes=[prefix]) == (13 / 14) * 100
 
     async def test_step03_graphql_prefix_pool_delete_utilization(
         self,

--- a/changelog/9220.fixed.md
+++ b/changelog/9220.fixed.md
@@ -1,0 +1,1 @@
+Preserve `IPPrefix.utilization` on a newly created branch. The per-branch utilization resolver now considers the branch's full inheritance scope, so prefixes show the same value as their origin branch until data is modified.


### PR DESCRIPTION
## Why & What

`IpamIPPrefix.utilization` returned wrong values on every non-default branch:

1. A freshly created branch reported `0` for every prefix that had non-zero utilisation on its origin (the issue this PR was opened for).
2. Deleting an address on a branch zeroed out the same prefix on the origin branch as well.
3. Changes made on the origin branch after a feature branch was created leaked into the branch's view, even when the branch was isolated.

The cause was that prefix utilisation had its own bespoke way of reading the graph that did not match how the rest of the platform handles branches. Both per-branch visibility and cross-branch attribution were squeezed into a single query, which mixed the two semantics and routinely produced wrong results when modifications existed on both sides.

Utilisation now reads from one branch at a time using the same branch scoping that powers every other read in Infrahub: an isolated branch sees its origin frozen at its creation point and adds its own changes on top. The pool view, which still needs both the current branch view and the default branch view, derives them by asking the same question twice and subtracting.

Closes #9220

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
