### PR TITLE
Relationship cardinality declared on a concrete subtype is not enforced when the peer is a generic schema

### DIFF
--- a/backend/infrahub/core/node/lock_utils.py
+++ b/backend/infrahub/core/node/lock_utils.py
@@ -52,6 +52,19 @@ def _hash(value: str) -> str:
     return hashlib.sha256(value.encode()).hexdigest()
 
 
+def _any_subtype_has_count_constraint(
+    schema_branch: SchemaBranch, generic_schema: GenericSchema, identifier: str
+) -> bool:
+    """Return True if any concrete subtype of ``generic_schema`` declares a relationship
+    with the given ``identifier`` and a count constraint (cardinality=one, max_count, or
+    min_count)."""
+    return any(
+        rel.cardinality == RelationshipCardinality.ONE or rel.max_count or rel.min_count
+        for subtype_kind in generic_schema.used_by
+        for rel in schema_branch.get(name=subtype_kind, duplicate=False).get_relationships_by_identifier(id=identifier)
+    )
+
+
 def get_lock_names_on_object_mutation(node: Node, schema_branch: SchemaBranch) -> list[str]:
     """Return lock names for object on which we want to avoid concurrent mutation (create/update).
     Lock names include kind, some generic kinds, resource pool ids, peer ids for cardinality one relationships,
@@ -88,6 +101,18 @@ def get_lock_names_on_object_mutation(node: Node, schema_branch: SchemaBranch) -
             if peer_rel and (
                 peer_rel.cardinality == RelationshipCardinality.ONE or peer_rel.max_count or peer_rel.min_count
             ):
+                lock_names.add(f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.{rel.schema.identifier}.{peer_id}")
+            elif (
+                peer_rel is None
+                and isinstance(peer_schema, GenericSchema)
+                and _any_subtype_has_count_constraint(
+                    schema_branch=schema_branch, generic_schema=peer_schema, identifier=rel.schema.identifier
+                )
+            ):
+                # The relationship is declared on a concrete subtype rather than on the
+                # generic peer. Acquire the lock conservatively if any subtype carries
+                # a count constraint for this identifier: this never under-locks; it
+                # may over-lock when the actual peer's concrete kind has no constraint.
                 lock_names.add(f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.{rel.schema.identifier}.{peer_id}")
 
     lock_kinds = _get_kinds_to_lock_on_object_mutation(node.get_kind(), schema_branch)

--- a/backend/infrahub/core/relationship/constraints/count.py
+++ b/backend/infrahub/core/relationship/constraints/count.py
@@ -1,11 +1,15 @@
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import RelationshipDirection
 from infrahub.core.node import Node
+from infrahub.core.query.node import NodeGetKindQuery
 from infrahub.core.query.relationship import RelationshipCountPerNodeQuery
 from infrahub.core.schema import MainSchemaTypes
+from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 
@@ -16,7 +20,6 @@ from .interface import RelationshipManagerConstraintInterface
 @dataclass
 class NodeToValidate:
     uuid: str
-    cardinality: RelationshipCardinality
     min_count: int | None = None
     max_count: int | None = None
 
@@ -33,34 +36,41 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
         # but if the validation fails we'll end up with some allocated resources that are not being used
         await relm.resolve(db=self.db)
 
-        nodes_to_validate: list[NodeToValidate] = []
-
         # peer_ids_present_local_only:
         #    new relationship, need to check if the schema on the other side has a max_count defined
         # peer_ids_present_database_only:
         #    relationship to be deleted, need to check if the schema on the other side has a min_count defined
-        # TODO see how to manage Generic node
         peer_schema = registry.schema.get(name=relm.schema.peer, branch=branch, duplicate=False)
         peer_rels = peer_schema.get_relationships_by_identifier(id=relm.schema.get_identifier())
-        if not peer_rels:
+        update_details = await relm.fetch_relationship_ids(db=self.db, force_refresh=False)
+        local_ids = set(update_details.peer_ids_present_local_only)
+        db_ids = set(update_details.peer_ids_present_database_only)
+        candidate_peer_ids = local_ids | db_ids
+
+        if peer_rels:
+            nodes_to_validate = self._build_validation_targets(
+                relm=relm,
+                peer_rels=peer_rels,
+                candidate_peer_ids=candidate_peer_ids,
+                local_ids=local_ids,
+                db_ids=db_ids,
+            )
+        elif isinstance(peer_schema, GenericSchema):
+            # The relationship is declared on a concrete subtype rather than on the
+            # generic peer itself. Resolve each peer's concrete kind and use its
+            # schema to find the applicable cardinality constraint.
+            nodes_to_validate = await self._build_validation_targets_from_concrete(
+                relm=relm,
+                branch=branch,
+                candidate_peer_ids=candidate_peer_ids,
+                local_ids=local_ids,
+                db_ids=db_ids,
+            )
+        else:
             return
 
-        update_details = await relm.fetch_relationship_ids(db=self.db, force_refresh=False)
-        for peer_rel in peer_rels:
-            # If a relationship is directional and both have the same direction they can't work together
-            if relm.schema.direction == peer_rel.direction and peer_rel.direction != RelationshipDirection.BIDIR:
-                continue
-
-            for peer_id in update_details.peer_ids_present_local_only + update_details.peer_ids_present_database_only:
-                if peer_rel.max_count and peer_id in update_details.peer_ids_present_local_only:
-                    nodes_to_validate.append(
-                        NodeToValidate(uuid=peer_id, max_count=peer_rel.max_count, cardinality=peer_rel.cardinality)
-                    )
-
-                if peer_rel.min_count and peer_id in update_details.peer_ids_present_database_only:
-                    nodes_to_validate.append(
-                        NodeToValidate(uuid=peer_id, min_count=peer_rel.min_count, cardinality=peer_rel.cardinality)
-                    )
+        if not nodes_to_validate:
+            return
 
         query = await RelationshipCountPerNodeQuery.init(
             db=self.db,
@@ -86,3 +96,88 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
                     f"Node {node_to_validate.uuid} has {count_per_peer[node_to_validate.uuid] - 1} peers "
                     f"for {relm.schema.identifier}, no fewer than {node_to_validate.min_count} allowed",
                 )
+
+    def _build_validation_targets(
+        self,
+        relm: RelationshipManager,
+        peer_rels: list[RelationshipSchema],
+        candidate_peer_ids: set[str],
+        local_ids: set[str],
+        db_ids: set[str],
+    ) -> list[NodeToValidate]:
+        """Build validation targets when the peer schema directly declares the relevant
+        relationships. The same ``peer_rels`` apply to every candidate peer."""
+        return [
+            target
+            for peer_id in candidate_peer_ids
+            for target in self._targets_for_peer(
+                peer_id=peer_id, peer_rels=peer_rels, relm=relm, local_ids=local_ids, db_ids=db_ids
+            )
+        ]
+
+    async def _build_validation_targets_from_concrete(
+        self,
+        relm: RelationshipManager,
+        branch: Branch,
+        candidate_peer_ids: set[str],
+        local_ids: set[str],
+        db_ids: set[str],
+    ) -> list[NodeToValidate]:
+        """Build validation targets when the declared peer is a generic that does not
+        carry the relationship. Each peer's concrete kind is resolved from the database,
+        and the applicable ``peer_rels`` may differ between peers (e.g. one subtype
+        carries cardinality=one while a sibling carries cardinality=many)."""
+        if not candidate_peer_ids:
+            return []
+
+        kind_query = await NodeGetKindQuery.init(db=self.db, ids=list(candidate_peer_ids), branch=branch)
+        await kind_query.execute(db=self.db)
+        kind_per_peer = await kind_query.get_node_kind_map()
+
+        rels_by_kind: dict[str, list[RelationshipSchema]] = {}
+        identifier = relm.schema.get_identifier()
+
+        targets: list[NodeToValidate] = []
+        for peer_id in candidate_peer_ids:
+            concrete_kind = kind_per_peer.get(peer_id)
+            if concrete_kind is None:
+                continue
+            if concrete_kind not in rels_by_kind:
+                concrete_schema = registry.schema.get(name=concrete_kind, branch=branch, duplicate=False)
+                rels_by_kind[concrete_kind] = concrete_schema.get_relationships_by_identifier(id=identifier)
+            targets.extend(
+                self._targets_for_peer(
+                    peer_id=peer_id,
+                    peer_rels=rels_by_kind[concrete_kind],
+                    relm=relm,
+                    local_ids=local_ids,
+                    db_ids=db_ids,
+                )
+            )
+        return targets
+
+    @staticmethod
+    def _targets_for_peer(
+        peer_id: str,
+        peer_rels: list[RelationshipSchema],
+        relm: RelationshipManager,
+        local_ids: set[str],
+        db_ids: set[str],
+    ) -> Iterator[NodeToValidate]:
+        """Yield validation targets for ``peer_id`` — zero, one, or more depending on
+        how many of ``peer_rels`` carry an applicable constraint. ``local_ids`` and
+        ``db_ids`` are disjoint by construction, so a peer is at most one of an add or
+        a remove."""
+        for peer_rel in peer_rels:
+            if not _direction_is_compatible(relm=relm, peer_rel=peer_rel):
+                continue
+            if peer_rel.max_count and peer_id in local_ids:
+                yield NodeToValidate(uuid=peer_id, max_count=peer_rel.max_count)
+            elif peer_rel.min_count and peer_id in db_ids:
+                yield NodeToValidate(uuid=peer_id, min_count=peer_rel.min_count)
+
+
+def _direction_is_compatible(relm: RelationshipManager, peer_rel: RelationshipSchema) -> bool:
+    # A directional relationship and its peer cannot both face the same way
+    # (only bidirectional pairs can share a direction).
+    return relm.schema.direction != peer_rel.direction or peer_rel.direction == RelationshipDirection.BIDIR

--- a/backend/infrahub/core/relationship/constraints/count.py
+++ b/backend/infrahub/core/relationship/constraints/count.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 from infrahub.core import registry
@@ -43,28 +43,19 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
         peer_schema = registry.schema.get(name=relm.schema.peer, branch=branch, duplicate=False)
         peer_rels = peer_schema.get_relationships_by_identifier(id=relm.schema.get_identifier())
         update_details = await relm.fetch_relationship_ids(db=self.db, force_refresh=False)
-        local_ids = set(update_details.peer_ids_present_local_only)
-        db_ids = set(update_details.peer_ids_present_database_only)
-        candidate_peer_ids = local_ids | db_ids
+        added_peer_ids = update_details.peer_ids_present_local_only
+        removed_peer_ids = update_details.peer_ids_present_database_only
 
         if peer_rels:
             nodes_to_validate = self._build_validation_targets(
-                relm=relm,
-                peer_rels=peer_rels,
-                candidate_peer_ids=candidate_peer_ids,
-                local_ids=local_ids,
-                db_ids=db_ids,
+                relm=relm, peer_rels=peer_rels, added_peer_ids=added_peer_ids, removed_peer_ids=removed_peer_ids
             )
         elif isinstance(peer_schema, GenericSchema):
             # The relationship is declared on a concrete subtype rather than on the
             # generic peer itself. Resolve each peer's concrete kind and use its
             # schema to find the applicable cardinality constraint.
             nodes_to_validate = await self._build_validation_targets_from_concrete(
-                relm=relm,
-                branch=branch,
-                candidate_peer_ids=candidate_peer_ids,
-                local_ids=local_ids,
-                db_ids=db_ids,
+                relm=relm, branch=branch, added_peer_ids=added_peer_ids, removed_peer_ids=removed_peer_ids
             )
         else:
             return
@@ -101,79 +92,76 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
         self,
         relm: RelationshipManager,
         peer_rels: list[RelationshipSchema],
-        candidate_peer_ids: set[str],
-        local_ids: set[str],
-        db_ids: set[str],
+        added_peer_ids: Iterable[str],
+        removed_peer_ids: Iterable[str],
     ) -> list[NodeToValidate]:
         """Build validation targets when the peer schema directly declares the relevant
-        relationships. The same ``peer_rels`` apply to every candidate peer."""
-        return [
-            target
-            for peer_id in candidate_peer_ids
-            for target in self._targets_for_peer(
-                peer_id=peer_id, peer_rels=peer_rels, relm=relm, local_ids=local_ids, db_ids=db_ids
-            )
-        ]
+        relationships. The same ``peer_rels`` apply to every changed peer."""
+        targets: list[NodeToValidate] = []
+        for peer_id in added_peer_ids:
+            targets.extend(self._targets_for_added(peer_id=peer_id, peer_rels=peer_rels, relm=relm))
+        for peer_id in removed_peer_ids:
+            targets.extend(self._targets_for_removed(peer_id=peer_id, peer_rels=peer_rels, relm=relm))
+        return targets
 
     async def _build_validation_targets_from_concrete(
         self,
         relm: RelationshipManager,
         branch: Branch,
-        candidate_peer_ids: set[str],
-        local_ids: set[str],
-        db_ids: set[str],
+        added_peer_ids: Iterable[str],
+        removed_peer_ids: Iterable[str],
     ) -> list[NodeToValidate]:
         """Build validation targets when the declared peer is a generic that does not
         carry the relationship. Each peer's concrete kind is resolved from the database,
         and the applicable ``peer_rels`` may differ between peers (e.g. one subtype
         carries cardinality=one while a sibling carries cardinality=many)."""
-        if not candidate_peer_ids:
+        all_changed = [*added_peer_ids, *removed_peer_ids]
+        if not all_changed:
             return []
 
-        kind_query = await NodeGetKindQuery.init(db=self.db, ids=list(candidate_peer_ids), branch=branch)
+        kind_query = await NodeGetKindQuery.init(db=self.db, ids=all_changed, branch=branch)
         await kind_query.execute(db=self.db)
         kind_per_peer = await kind_query.get_node_kind_map()
 
         rels_by_kind: dict[str, list[RelationshipSchema]] = {}
         identifier = relm.schema.get_identifier()
 
+        def rels_for(peer_id: str) -> list[RelationshipSchema]:
+            kind = kind_per_peer.get(peer_id)
+            if kind is None:
+                return []
+            if kind not in rels_by_kind:
+                concrete_schema = registry.schema.get(name=kind, branch=branch, duplicate=False)
+                rels_by_kind[kind] = concrete_schema.get_relationships_by_identifier(id=identifier)
+            return rels_by_kind[kind]
+
         targets: list[NodeToValidate] = []
-        for peer_id in candidate_peer_ids:
-            concrete_kind = kind_per_peer.get(peer_id)
-            if concrete_kind is None:
-                continue
-            if concrete_kind not in rels_by_kind:
-                concrete_schema = registry.schema.get(name=concrete_kind, branch=branch, duplicate=False)
-                rels_by_kind[concrete_kind] = concrete_schema.get_relationships_by_identifier(id=identifier)
-            targets.extend(
-                self._targets_for_peer(
-                    peer_id=peer_id,
-                    peer_rels=rels_by_kind[concrete_kind],
-                    relm=relm,
-                    local_ids=local_ids,
-                    db_ids=db_ids,
-                )
-            )
+        for peer_id in added_peer_ids:
+            targets.extend(self._targets_for_added(peer_id=peer_id, peer_rels=rels_for(peer_id), relm=relm))
+        for peer_id in removed_peer_ids:
+            targets.extend(self._targets_for_removed(peer_id=peer_id, peer_rels=rels_for(peer_id), relm=relm))
         return targets
 
     @staticmethod
-    def _targets_for_peer(
-        peer_id: str,
-        peer_rels: list[RelationshipSchema],
-        relm: RelationshipManager,
-        local_ids: set[str],
-        db_ids: set[str],
+    def _targets_for_added(
+        peer_id: str, peer_rels: list[RelationshipSchema], relm: RelationshipManager
     ) -> Iterator[NodeToValidate]:
-        """Yield validation targets for ``peer_id`` — zero, one, or more depending on
-        how many of ``peer_rels`` carry an applicable constraint. ``local_ids`` and
-        ``db_ids`` are disjoint by construction, so a peer is at most one of an add or
-        a remove."""
+        """Yield max_count targets for a peer that is being added."""
         for peer_rel in peer_rels:
             if not _direction_is_compatible(relm=relm, peer_rel=peer_rel):
                 continue
-            if peer_rel.max_count and peer_id in local_ids:
+            if peer_rel.max_count:
                 yield NodeToValidate(uuid=peer_id, max_count=peer_rel.max_count)
-            elif peer_rel.min_count and peer_id in db_ids:
+
+    @staticmethod
+    def _targets_for_removed(
+        peer_id: str, peer_rels: list[RelationshipSchema], relm: RelationshipManager
+    ) -> Iterator[NodeToValidate]:
+        """Yield min_count targets for a peer that is being removed."""
+        for peer_rel in peer_rels:
+            if not _direction_is_compatible(relm=relm, peer_rel=peer_rel):
+                continue
+            if peer_rel.min_count:
                 yield NodeToValidate(uuid=peer_id, min_count=peer_rel.min_count)
 
 

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -1,8 +1,10 @@
 import pytest
 
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.relationship.constraints.count import RelationshipCountConstraint
+from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 
@@ -26,3 +28,73 @@ async def test_node_validate_constraint_relationship_count_success(
     constraint = RelationshipCountConstraint(db=db, branch=default_branch)
 
     await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema(), node=person_john_main)
+
+
+async def test_node_validate_constraint_relationship_count_failure_generic_peer(
+    db: InfrahubDatabase, default_branch: Branch
+) -> None:
+    """When the declared peer is a generic but cardinality=one is declared on a concrete subtype,
+    the count constraint must still raise ValidationError on the over-quota peer."""
+    schema = SchemaRoot(
+        generics=[
+            {
+                "name": "Thing",
+                "namespace": "Test",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+            },
+        ],
+        nodes=[
+            {
+                "name": "ExclusiveThing",
+                "namespace": "Test",
+                "inherit_from": ["TestThing"],
+                "relationships": [
+                    {
+                        "name": "owner",
+                        "peer": "TestPerson",
+                        "identifier": "person__thing",
+                        "cardinality": "one",
+                        "optional": True,
+                        "direction": "inbound",
+                    },
+                ],
+            },
+            {
+                "name": "Person",
+                "namespace": "Test",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+                "relationships": [
+                    {
+                        "name": "things",
+                        "peer": "TestThing",
+                        "identifier": "person__thing",
+                        "cardinality": "many",
+                        "optional": True,
+                        "direction": "outbound",
+                    },
+                ],
+            },
+        ],
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+    widget = await Node.init(db=db, schema="TestExclusiveThing", branch=default_branch)
+    await widget.new(db=db, name="widget")
+    await widget.save(db=db)
+
+    alice = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await alice.new(db=db, name="alice", things=[widget.id])
+    await alice.save(db=db)
+
+    bob = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await bob.new(db=db, name="bob", things=[widget.id])
+
+    constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+    with pytest.raises(ValidationError) as exc:
+        await constraint.check(relm=bob.things, node_schema=bob.get_schema(), node=bob)
+
+    assert "has 2 peers for person__thing, maximum of 1 allowed" in exc.value.message

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -4,9 +4,22 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.relationship.constraints.count import RelationshipCountConstraint
-from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
+from tests.helpers.schema.room import build_room_schema
+
+
+async def _make_person(db: InfrahubDatabase, branch: Branch, name: str, room_ids: list[str]) -> Node:
+    person = await Node.init(db=db, schema="TestPerson", branch=branch)
+    await person.new(db=db, name=name, rooms=room_ids)
+    return person
+
+
+async def _make_room(db: InfrahubDatabase, branch: Branch, kind: str, name: str) -> Node:
+    room = await Node.init(db=db, schema=kind, branch=branch)
+    await room.new(db=db, name=name)
+    await room.save(db=db)
+    return room
 
 
 async def test_node_validate_constraint_relationship_count_failure(
@@ -30,71 +43,210 @@ async def test_node_validate_constraint_relationship_count_success(
     await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema(), node=person_john_main)
 
 
-async def test_node_validate_constraint_relationship_count_failure_generic_peer(
-    db: InfrahubDatabase, default_branch: Branch
-) -> None:
-    """When the declared peer is a generic but cardinality=one is declared on a concrete subtype,
-    the count constraint must still raise ValidationError on the over-quota peer."""
-    schema = SchemaRoot(
-        generics=[
-            {
-                "name": "Thing",
-                "namespace": "Test",
-                "attributes": [
-                    {"name": "name", "kind": "Text", "unique": True},
-                ],
-            },
-        ],
-        nodes=[
-            {
-                "name": "ExclusiveThing",
-                "namespace": "Test",
-                "inherit_from": ["TestThing"],
-                "relationships": [
-                    {
-                        "name": "owner",
-                        "peer": "TestPerson",
-                        "identifier": "person__thing",
-                        "cardinality": "one",
-                        "optional": True,
-                        "direction": "inbound",
-                    },
-                ],
-            },
-            {
-                "name": "Person",
-                "namespace": "Test",
-                "attributes": [
-                    {"name": "name", "kind": "Text", "unique": True},
-                ],
-                "relationships": [
-                    {
-                        "name": "things",
-                        "peer": "TestThing",
-                        "identifier": "person__thing",
-                        "cardinality": "many",
-                        "optional": True,
-                        "direction": "outbound",
-                    },
-                ],
-            },
-        ],
-    )
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+class TestCountGenericPeerCardinalityOne:
+    """Cardinality=one declared only on a concrete subtype while the relationship's
+    declared peer is the parent generic."""
 
-    widget = await Node.init(db=db, schema="TestExclusiveThing", branch=default_branch)
-    await widget.new(db=db, name="widget")
-    await widget.save(db=db)
+    @pytest.fixture(autouse=True)
+    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        registry.schema.register_schema(schema=build_room_schema(), branch=default_branch.name)
 
-    alice = await Node.init(db=db, schema="TestPerson", branch=default_branch)
-    await alice.new(db=db, name="alice", things=[widget.id])
-    await alice.save(db=db)
+    async def test_failure_when_concrete_peer_at_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id])
 
-    bob = await Node.init(db=db, schema="TestPerson", branch=default_branch)
-    await bob.new(db=db, name="bob", things=[widget.id])
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-    constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-    with pytest.raises(ValidationError) as exc:
-        await constraint.check(relm=bob.things, node_schema=bob.get_schema(), node=bob)
+        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
-    assert "has 2 peers for person__thing, maximum of 1 allowed" in exc.value.message
+    async def test_success_when_concrete_peer_has_no_owner(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+
+    async def test_success_when_resaving_same_peer(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+
+        await alice.rooms.update(db=db, data=[single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+
+
+class TestCountGenericPeerWithGenericRel:
+    """Cardinality=one declared on the generic itself."""
+
+    @pytest.fixture(autouse=True)
+    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        registry.schema.register_schema(schema=build_room_schema(generic_has_rel=True), branch=default_branch.name)
+
+    async def test_failure_when_peer_at_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+
+        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
+
+    async def test_success_when_under_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+
+
+class TestCountGenericPeerMixedSubtypes:
+    """Generic with two concrete subtypes that declare different cardinalities for
+    the same identifier."""
+
+    @pytest.fixture(autouse=True)
+    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        registry.schema.register_schema(schema=build_room_schema(include_dorm_subtype=True), branch=default_branch.name)
+
+    async def test_failure_when_exclusive_subtype_over_limit(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+
+        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
+
+    async def test_success_when_shared_subtype_over_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
+        alice = await _make_person(db, default_branch, "alice", [dorm.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [dorm.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+
+    async def test_failure_when_mixed_peers_only_exclusive_violates(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id, dorm.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+
+        assert single.id in exc.value.message
+        assert "maximum of 1 allowed" in exc.value.message
+
+
+class TestCountGenericPeerMaxCount:
+    """max_count > 1 declared on a concrete subtype only."""
+
+    @pytest.fixture(autouse=True)
+    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(single_room_cardinality="many", single_room_max_count=3),
+            branch=default_branch.name,
+        )
+
+    async def test_failure_when_max_count_exceeded(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        for name in ("p1", "p2", "p3"):
+            person = await _make_person(db, default_branch, name, [single.id])
+            await person.save(db=db)
+        extra = await _make_person(db, default_branch, "extra", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
+
+        assert "maximum of 3 allowed" in exc.value.message
+
+    async def test_success_when_max_count_not_reached(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        for name in ("p1", "p2"):
+            person = await _make_person(db, default_branch, name, [single.id])
+            await person.save(db=db)
+        extra = await _make_person(db, default_branch, "extra", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
+
+
+class TestCountGenericPeerMinCount:
+    """min_count declared on a concrete subtype only."""
+
+    @pytest.fixture(autouse=True)
+    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(single_room_cardinality="many", single_room_min_count=1),
+            branch=default_branch.name,
+        )
+
+    async def test_failure_when_removing_drops_below_min(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+
+        await alice.rooms.update(db=db, data=[])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+
+        assert "no fewer than 1 allowed" in exc.value.message
+
+    async def test_success_when_removing_stays_above_min(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id])
+        await bob.save(db=db)
+
+        await alice.rooms.update(db=db, data=[])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+
+
+class TestCountGenericPeerDirection:
+    """Direction variations on a generic-peer relationship."""
+
+    async def test_failure_when_bidirectional_concrete_at_limit(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(
+                single_room_direction="bidirectional",
+                person_direction="bidirectional",
+            ),
+            branch=default_branch.name,
+        )
+
+        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        alice = await _make_person(db, default_branch, "alice", [single.id])
+        await alice.save(db=db)
+        bob = await _make_person(db, default_branch, "bob", [single.id])
+
+        constraint = RelationshipCountConstraint(db=db, branch=default_branch)
+        with pytest.raises(ValidationError) as exc:
+            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+
+        assert "maximum of 1 allowed" in exc.value.message

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -33,7 +33,7 @@ async def test_node_validate_constraint_relationship_count_failure(
     with pytest.raises(ValidationError) as exc:
         await constraint.check(relm=person.cars, node_schema=person.get_schema(), node=person)
 
-    assert "has 2 peers for testcar__testperson, maximum of 1 allowed" in exc.value.message
+    assert f"Node {car_accord_main.id} has 2 peers for testcar__testperson, maximum of 1 allowed" in exc.value.message
 
 
 async def test_node_validate_constraint_relationship_count_success(
@@ -62,7 +62,7 @@ class TestCountGenericPeerCardinalityOne:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
+        assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
     async def test_success_when_concrete_peer_has_no_owner(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         single = await _make_room(db, default_branch, "TestSingleRoom", "single")
@@ -103,7 +103,7 @@ class TestCountGenericPeerWithGenericRel:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
+        assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
     async def test_success_when_under_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         single = await _make_room(db, default_branch, "TestSingleRoom", "single")
@@ -135,7 +135,7 @@ class TestCountGenericPeerMixedSubtypes:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-        assert "has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
+        assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
     async def test_success_when_shared_subtype_over_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
@@ -183,7 +183,7 @@ class TestCountGenericPeerMaxCount:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
 
-        assert "maximum of 3 allowed" in exc.value.message
+        assert f"Node {dorm.id} has 4 peers for person__room, maximum of 3 allowed" in exc.value.message
 
     async def test_success_when_max_count_not_reached(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
@@ -220,7 +220,7 @@ class TestCountGenericPeerMinCount:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
 
-        assert "no fewer than 1 allowed" in exc.value.message
+        assert f"Node {dorm.id} has 0 peers for person__room, no fewer than 1 allowed" in exc.value.message
 
     async def test_success_when_removing_stays_above_min(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
@@ -267,7 +267,7 @@ class TestCountGenericPeerDirection:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-        assert "maximum of 1 allowed" in exc.value.message
+        assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
     async def test_schema_rejects_same_direction_same_identifier(
         self, db: InfrahubDatabase, default_branch: Branch

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -49,7 +49,7 @@ class TestCountGenericPeerCardinalityOne:
     declared peer is the parent generic."""
 
     @pytest.fixture(autouse=True)
-    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+    async def _register_one_subtype_has_relationship_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         registry.schema.register_schema(schema=build_room_schema(), branch=default_branch.name)
 
     async def test_failure_when_concrete_peer_at_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
@@ -90,7 +90,7 @@ class TestCountGenericPeerWithGenericRel:
     """Cardinality=one declared on the generic itself."""
 
     @pytest.fixture(autouse=True)
-    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+    async def _register_generic_has_relationship_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         registry.schema.register_schema(schema=build_room_schema(generic_has_rel=True), branch=default_branch.name)
 
     async def test_failure_when_peer_at_limit(self, db: InfrahubDatabase, default_branch: Branch) -> None:
@@ -118,7 +118,9 @@ class TestCountGenericPeerMixedSubtypes:
     the same identifier."""
 
     @pytest.fixture(autouse=True)
-    async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+    async def _register_two_subtypes_with_relationship_schema(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
         registry.schema.register_schema(schema=build_room_schema(include_dorm_subtype=True), branch=default_branch.name)
 
     async def test_failure_when_exclusive_subtype_over_limit(
@@ -157,8 +159,7 @@ class TestCountGenericPeerMixedSubtypes:
         with pytest.raises(ValidationError) as exc:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
-        assert single.id in exc.value.message
-        assert "maximum of 1 allowed" in exc.value.message
+        assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
 
 class TestCountGenericPeerMaxCount:
@@ -167,16 +168,16 @@ class TestCountGenericPeerMaxCount:
     @pytest.fixture(autouse=True)
     async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         registry.schema.register_schema(
-            schema=build_room_schema(single_room_cardinality="many", single_room_max_count=3),
+            schema=build_room_schema(include_dorm_subtype=True, dorm_max_count=3),
             branch=default_branch.name,
         )
 
     async def test_failure_when_max_count_exceeded(self, db: InfrahubDatabase, default_branch: Branch) -> None:
-        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
         for name in ("p1", "p2", "p3"):
-            person = await _make_person(db, default_branch, name, [single.id])
+            person = await _make_person(db, default_branch, name, [dorm.id])
             await person.save(db=db)
-        extra = await _make_person(db, default_branch, "extra", [single.id])
+        extra = await _make_person(db, default_branch, "extra", [dorm.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
@@ -185,11 +186,11 @@ class TestCountGenericPeerMaxCount:
         assert "maximum of 3 allowed" in exc.value.message
 
     async def test_success_when_max_count_not_reached(self, db: InfrahubDatabase, default_branch: Branch) -> None:
-        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
         for name in ("p1", "p2"):
-            person = await _make_person(db, default_branch, name, [single.id])
+            person = await _make_person(db, default_branch, name, [dorm.id])
             await person.save(db=db)
-        extra = await _make_person(db, default_branch, "extra", [single.id])
+        extra = await _make_person(db, default_branch, "extra", [dorm.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
@@ -201,13 +202,13 @@ class TestCountGenericPeerMinCount:
     @pytest.fixture(autouse=True)
     async def _register(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         registry.schema.register_schema(
-            schema=build_room_schema(single_room_cardinality="many", single_room_min_count=1),
+            schema=build_room_schema(include_dorm_subtype=True, dorm_min_count=1),
             branch=default_branch.name,
         )
 
     async def test_failure_when_removing_drops_below_min(self, db: InfrahubDatabase, default_branch: Branch) -> None:
-        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
-        alice = await _make_person(db, default_branch, "alice", [single.id])
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
+        alice = await _make_person(db, default_branch, "alice", [dorm.id])
         await alice.save(db=db)
 
         # Re-load alice so the RelationshipManager observes the post-save state.
@@ -222,10 +223,10 @@ class TestCountGenericPeerMinCount:
         assert "no fewer than 1 allowed" in exc.value.message
 
     async def test_success_when_removing_stays_above_min(self, db: InfrahubDatabase, default_branch: Branch) -> None:
-        single = await _make_room(db, default_branch, "TestSingleRoom", "single")
-        alice = await _make_person(db, default_branch, "alice", [single.id])
+        dorm = await _make_room(db, default_branch, "TestDorm", "dorm")
+        alice = await _make_person(db, default_branch, "alice", [dorm.id])
         await alice.save(db=db)
-        bob = await _make_person(db, default_branch, "bob", [single.id])
+        bob = await _make_person(db, default_branch, "bob", [dorm.id])
         await bob.save(db=db)
 
         alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
@@ -237,15 +238,22 @@ class TestCountGenericPeerMinCount:
 
 
 class TestCountGenericPeerDirection:
-    """Direction variations on a generic-peer relationship."""
+    """Direction variations on a generic-peer relationship.
+
+    The bidirectional case is exercised end-to-end against the constraint. The
+    same-direction case is checked at the schema layer instead: the schema
+    validator rejects two relationships that share an identifier and a
+    non-bidirectional direction, so the corresponding branch in the constraint
+    code is unreachable in practice. The default outbound/inbound pair is
+    implicitly covered by every other test in this file."""
 
     async def test_failure_when_bidirectional_concrete_at_limit(
         self, db: InfrahubDatabase, default_branch: Branch
     ) -> None:
         registry.schema.register_schema(
             schema=build_room_schema(
-                single_room_direction="bidirectional",
-                person_direction="bidirectional",
+                occupant_direction="bidirectional",
+                rooms_direction="bidirectional",
             ),
             branch=default_branch.name,
         )
@@ -260,3 +268,15 @@ class TestCountGenericPeerDirection:
             await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
 
         assert "maximum of 1 allowed" in exc.value.message
+
+    async def test_schema_rejects_same_direction_same_identifier(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        with pytest.raises(ValueError, match=r"Incompatible direction"):
+            registry.schema.register_schema(
+                schema=build_room_schema(
+                    occupant_direction="outbound",
+                    rooms_direction="outbound",
+                ),
+                branch=default_branch.name,
+            )

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -270,15 +270,3 @@ class TestCountGenericPeerDirection:
             await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
-
-    async def test_schema_rejects_same_direction_same_identifier(
-        self, db: InfrahubDatabase, default_branch: Branch
-    ) -> None:
-        with pytest.raises(ValueError, match=r"Incompatible direction"):
-            registry.schema.register_schema(
-                schema=build_room_schema(
-                    occupant_direction="outbound",
-                    rooms_direction="outbound",
-                ),
-                branch=default_branch.name,
-            )

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -31,7 +31,7 @@ async def test_node_validate_constraint_relationship_count_failure(
     await person.new(db=db, name="Alfred", height=160, cars=[car_accord_main.id])
 
     with pytest.raises(ValidationError) as exc:
-        await constraint.check(relm=person.cars, node_schema=person.get_schema(), node=person)
+        await constraint.check(relm=person.get_relationship("cars"), node_schema=person.get_schema(), node=person)
 
     assert f"Node {car_accord_main.id} has 2 peers for testcar__testperson, maximum of 1 allowed" in exc.value.message
 
@@ -41,7 +41,9 @@ async def test_node_validate_constraint_relationship_count_success(
 ) -> None:
     constraint = RelationshipCountConstraint(db=db, branch=default_branch)
 
-    await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema(), node=person_john_main)
+    await constraint.check(
+        relm=person_john_main.get_relationship("cars"), node_schema=person_john_main.get_schema(), node=person_john_main
+    )
 
 
 class TestCountGenericPeerCardinalityOne:
@@ -60,7 +62,7 @@ class TestCountGenericPeerCardinalityOne:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+            await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
@@ -69,7 +71,7 @@ class TestCountGenericPeerCardinalityOne:
         alice = await _make_person(db, default_branch, "alice", [single.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+        await constraint.check(relm=alice.get_relationship("rooms"), node_schema=alice.get_schema(), node=alice)
 
     async def test_success_when_resaving_same_peer(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         single = await _make_room(db, default_branch, "TestSingleRoom", "single")
@@ -79,11 +81,11 @@ class TestCountGenericPeerCardinalityOne:
         # Re-load alice so the RelationshipManager observes the post-save state,
         # then re-assert the same peer. The constraint must treat this as a no-op.
         alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
-        await alice.rooms.get_relationships(db=db)
-        await alice.rooms.update(db=db, data=[single.id])
+        await alice.get_relationship("rooms").get_relationships(db=db)
+        await alice.get_relationship("rooms").update(db=db, data=[single.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+        await constraint.check(relm=alice.get_relationship("rooms"), node_schema=alice.get_schema(), node=alice)
 
 
 class TestCountGenericPeerWithGenericRel:
@@ -101,7 +103,7 @@ class TestCountGenericPeerWithGenericRel:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+            await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
@@ -110,7 +112,7 @@ class TestCountGenericPeerWithGenericRel:
         alice = await _make_person(db, default_branch, "alice", [single.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+        await constraint.check(relm=alice.get_relationship("rooms"), node_schema=alice.get_schema(), node=alice)
 
 
 class TestCountGenericPeerMixedSubtypes:
@@ -133,7 +135,7 @@ class TestCountGenericPeerMixedSubtypes:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+            await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
@@ -144,7 +146,7 @@ class TestCountGenericPeerMixedSubtypes:
         bob = await _make_person(db, default_branch, "bob", [dorm.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+        await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
     async def test_failure_when_mixed_peers_only_exclusive_violates(
         self, db: InfrahubDatabase, default_branch: Branch
@@ -157,7 +159,7 @@ class TestCountGenericPeerMixedSubtypes:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+            await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 
@@ -181,7 +183,7 @@ class TestCountGenericPeerMaxCount:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
+            await constraint.check(relm=extra.get_relationship("rooms"), node_schema=extra.get_schema(), node=extra)
 
         assert f"Node {dorm.id} has 4 peers for person__room, maximum of 3 allowed" in exc.value.message
 
@@ -193,7 +195,7 @@ class TestCountGenericPeerMaxCount:
         extra = await _make_person(db, default_branch, "extra", [dorm.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=extra.rooms, node_schema=extra.get_schema(), node=extra)
+        await constraint.check(relm=extra.get_relationship("rooms"), node_schema=extra.get_schema(), node=extra)
 
 
 class TestCountGenericPeerMinCount:
@@ -213,12 +215,12 @@ class TestCountGenericPeerMinCount:
 
         # Re-load alice so the RelationshipManager observes the post-save state.
         alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
-        await alice.rooms.get_relationships(db=db)
-        await alice.rooms.update(db=db, data=[])
+        await alice.get_relationship("rooms").get_relationships(db=db)
+        await alice.get_relationship("rooms").update(db=db, data=[])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+            await constraint.check(relm=alice.get_relationship("rooms"), node_schema=alice.get_schema(), node=alice)
 
         assert f"Node {dorm.id} has 0 peers for person__room, no fewer than 1 allowed" in exc.value.message
 
@@ -230,11 +232,11 @@ class TestCountGenericPeerMinCount:
         await bob.save(db=db)
 
         alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
-        await alice.rooms.get_relationships(db=db)
-        await alice.rooms.update(db=db, data=[])
+        await alice.get_relationship("rooms").get_relationships(db=db)
+        await alice.get_relationship("rooms").update(db=db, data=[])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
-        await constraint.check(relm=alice.rooms, node_schema=alice.get_schema(), node=alice)
+        await constraint.check(relm=alice.get_relationship("rooms"), node_schema=alice.get_schema(), node=alice)
 
 
 class TestCountGenericPeerDirection:
@@ -265,7 +267,7 @@ class TestCountGenericPeerDirection:
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=bob.rooms, node_schema=bob.get_schema(), node=bob)
+            await constraint.check(relm=bob.get_relationship("rooms"), node_schema=bob.get_schema(), node=bob)
 
         assert f"Node {single.id} has 2 peers for person__room, maximum of 1 allowed" in exc.value.message
 

--- a/backend/tests/component/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_manager.py
@@ -2,6 +2,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.relationship.constraints.count import RelationshipCountConstraint
 from infrahub.database import InfrahubDatabase
@@ -75,6 +76,10 @@ class TestCountGenericPeerCardinalityOne:
         alice = await _make_person(db, default_branch, "alice", [single.id])
         await alice.save(db=db)
 
+        # Re-load alice so the RelationshipManager observes the post-save state,
+        # then re-assert the same peer. The constraint must treat this as a no-op.
+        alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
+        await alice.rooms.get_relationships(db=db)
         await alice.rooms.update(db=db, data=[single.id])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
@@ -205,6 +210,9 @@ class TestCountGenericPeerMinCount:
         alice = await _make_person(db, default_branch, "alice", [single.id])
         await alice.save(db=db)
 
+        # Re-load alice so the RelationshipManager observes the post-save state.
+        alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
+        await alice.rooms.get_relationships(db=db)
         await alice.rooms.update(db=db, data=[])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)
@@ -220,6 +228,8 @@ class TestCountGenericPeerMinCount:
         bob = await _make_person(db, default_branch, "bob", [single.id])
         await bob.save(db=db)
 
+        alice = await NodeManager.get_one(db=db, id=alice.id, branch=default_branch)
+        await alice.rooms.get_relationships(db=db)
         await alice.rooms.update(db=db, data=[])
 
         constraint = RelationshipCountConstraint(db=db, branch=default_branch)

--- a/backend/tests/component/core/test_get_kinds_lock.py
+++ b/backend/tests/component/core/test_get_kinds_lock.py
@@ -402,51 +402,35 @@ class TestLockGenericPeerConcreteConstraint(TestInfrahubApp):
         self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
     ) -> None:
         registry.schema.register_schema(
-            schema=build_room_schema(single_room_cardinality="many", single_room_max_count=3),
+            schema=build_room_schema(include_dorm_subtype=True, dorm_max_count=3),
             branch=default_branch.name,
         )
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
-        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
-        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+        dorm = await create_and_save(db=db, schema="TestDorm", name="dorm")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[dorm])
 
         lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
 
-        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{dorm.id}"
         assert expected_lock in lock_names
 
     async def test_lock_acquired_when_concrete_min_count(
         self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
     ) -> None:
         registry.schema.register_schema(
-            schema=build_room_schema(single_room_cardinality="many", single_room_min_count=1),
+            schema=build_room_schema(include_dorm_subtype=True, dorm_min_count=1),
             branch=default_branch.name,
         )
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
-        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
-        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+        dorm = await create_and_save(db=db, schema="TestDorm", name="dorm")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[dorm])
 
         lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
 
-        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{dorm.id}"
         assert expected_lock in lock_names
-
-    async def test_no_lock_when_no_concrete_constraint(
-        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
-    ) -> None:
-        registry.schema.register_schema(
-            schema=build_room_schema(single_room_cardinality="many"), branch=default_branch.name
-        )
-        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-
-        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
-        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
-
-        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
-
-        unexpected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
-        assert unexpected_lock not in lock_names
 
     async def test_lock_acquired_with_mixed_subtypes_one_constrained(
         self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient

--- a/backend/tests/component/core/test_get_kinds_lock.py
+++ b/backend/tests/component/core/test_get_kinds_lock.py
@@ -17,6 +17,7 @@ from infrahub.core.node.lock_utils import (
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+from tests.helpers.schema.room import build_room_schema
 from tests.helpers.test_app import TestInfrahubApp
 from tests.node_creation import create_and_save
 
@@ -376,4 +377,110 @@ class TestGetKindsLock(TestInfrahubApp):
         lock_names = get_lock_names_on_object_mutation(car, schema_branch=schema_branch)
 
         expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.testcar__testperson.{car.id}"
+        assert expected_lock in lock_names
+
+
+class TestLockGenericPeerConcreteConstraint(TestInfrahubApp):
+    """Lock acquisition when the declared peer is a generic but the count
+    constraint lives on a concrete subtype."""
+
+    async def test_lock_acquired_when_concrete_cardinality_one(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(schema=build_room_schema(), branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        assert expected_lock in lock_names
+
+    async def test_lock_acquired_when_concrete_max_count(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(single_room_cardinality="many", single_room_max_count=3),
+            branch=default_branch.name,
+        )
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        assert expected_lock in lock_names
+
+    async def test_lock_acquired_when_concrete_min_count(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(single_room_cardinality="many", single_room_min_count=1),
+            branch=default_branch.name,
+        )
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        assert expected_lock in lock_names
+
+    async def test_no_lock_when_no_concrete_constraint(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(
+            schema=build_room_schema(single_room_cardinality="many"), branch=default_branch.name
+        )
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        unexpected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
+        assert unexpected_lock not in lock_names
+
+    async def test_lock_acquired_with_mixed_subtypes_one_constrained(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(schema=build_room_schema(include_dorm_subtype=True), branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        # Peer is a TestDorm whose own occupant relationship is cardinality=many.
+        # A sibling concrete subtype under the same generic declares cardinality=one
+        # for the same identifier, so the conservative lock must still fire on the
+        # peer's ID.
+        dorm = await create_and_save(db=db, schema="TestDorm", name="dorm")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[dorm])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{dorm.id}"
+        assert expected_lock in lock_names
+
+
+class TestLockGenericPeerGenericRel(TestInfrahubApp):
+    """Lock acquisition when the cardinality constraint is declared on the generic
+    itself."""
+
+    async def test_lock_acquired_when_generic_cardinality_one(
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient
+    ) -> None:
+        registry.schema.register_schema(schema=build_room_schema(generic_has_rel=True), branch=default_branch.name)
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        single = await create_and_save(db=db, schema="TestSingleRoom", name="single")
+        alice = await create_and_save(db=db, schema="TestPerson", name="alice", rooms=[single])
+
+        lock_names = get_lock_names_on_object_mutation(alice, schema_branch=schema_branch)
+
+        expected_lock = f"{RELATIONSHIP_COUNT_LOCK_NAMESPACE}.person__room.{single.id}"
         assert expected_lock in lock_names

--- a/backend/tests/helpers/schema/room.py
+++ b/backend/tests/helpers/schema/room.py
@@ -2,13 +2,14 @@
 
 A ``TestRoom`` generic exposes two concrete subtypes:
 
-- ``TestSingleRoom`` — each room holds at most one occupant (cardinality=one).
-- ``TestDorm`` — a dorm may hold many occupants (cardinality=many).
+- ``TestSingleRoom`` — always cardinality=one (a single room holds one occupant).
+- ``TestDorm`` — always cardinality=many; an optional ``max_count`` / ``min_count``
+  can be set to bound the number of occupants.
 
 ``TestPerson`` declares a ``rooms`` relationship whose peer is the generic
-``TestRoom``. Builder parameters control whether the cardinality constraint
-sits on the generic or only on the concrete subtype, the constraint type
-(cardinality, max_count, min_count), and the relationship directions.
+``TestRoom``. Builder parameters control whether the cardinality constraints
+sit on the generic or only on the concrete subtypes, and the relationship
+directions.
 """
 
 from typing import Any
@@ -48,21 +49,17 @@ def _occupant_rel(
 def build_room_schema(
     *,
     generic_has_rel: bool = False,
-    single_room_cardinality: str = "one",
-    single_room_max_count: int | None = None,
-    single_room_min_count: int | None = None,
     include_dorm_subtype: bool = False,
-    single_room_direction: str = "inbound",
-    person_direction: str = "outbound",
+    dorm_max_count: int | None = None,
+    dorm_min_count: int | None = None,
+    occupant_direction: str = "inbound",
+    rooms_direction: str = "outbound",
 ) -> SchemaRoot:
-    direction = RelationshipDirection(single_room_direction)
-    single_occupant = _occupant_rel(
-        cardinality=RelationshipCardinality(single_room_cardinality),
-        direction=direction,
-        max_count=single_room_max_count,
-        min_count=single_room_min_count,
-    )
+    direction = RelationshipDirection(occupant_direction)
+    single_occupant = _occupant_rel(cardinality=RelationshipCardinality.ONE, direction=direction)
 
+    # The generic carries the ``cardinality=one`` declaration only when explicitly
+    # asked (``generic_has_rel=True``); otherwise the rel lives solely on the subtypes.
     room = GenericSchema(
         name="Room",
         namespace="Test",
@@ -83,6 +80,8 @@ def build_room_schema(
         dorm_occupant = _occupant_rel(
             cardinality=RelationshipCardinality.MANY,
             direction=direction,
+            max_count=dorm_max_count,
+            min_count=dorm_min_count,
         )
         nodes.append(
             NodeSchema(
@@ -105,7 +104,7 @@ def build_room_schema(
                     identifier="person__room",
                     cardinality=RelationshipCardinality.MANY,
                     optional=True,
-                    direction=RelationshipDirection(person_direction),
+                    direction=RelationshipDirection(rooms_direction),
                 )
             ],
         )

--- a/backend/tests/helpers/schema/room.py
+++ b/backend/tests/helpers/schema/room.py
@@ -12,8 +12,6 @@ sit on the generic or only on the concrete subtypes, and the relationship
 directions.
 """
 
-from typing import Any
-
 from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
 from infrahub.core.schema import (
     AttributeSchema,
@@ -31,19 +29,16 @@ def _occupant_rel(
     max_count: int | None = None,
     min_count: int | None = None,
 ) -> RelationshipSchema:
-    kwargs: dict[str, Any] = {
-        "name": "occupant",
-        "peer": "TestPerson",
-        "identifier": "person__room",
-        "cardinality": cardinality,
-        "optional": True,
-        "direction": direction,
-    }
-    if max_count is not None:
-        kwargs["max_count"] = max_count
-    if min_count is not None:
-        kwargs["min_count"] = min_count
-    return RelationshipSchema(**kwargs)
+    return RelationshipSchema(
+        name="occupant",
+        peer="TestPerson",
+        identifier="person__room",
+        cardinality=cardinality,
+        optional=True,
+        direction=direction,
+        max_count=max_count or 0,
+        min_count=min_count or 0,
+    )
 
 
 def build_room_schema(

--- a/backend/tests/helpers/schema/room.py
+++ b/backend/tests/helpers/schema/room.py
@@ -1,0 +1,114 @@
+"""Schema builder for relationships whose declared peer is a generic.
+
+A ``TestRoom`` generic exposes two concrete subtypes:
+
+- ``TestSingleRoom`` — each room holds at most one occupant (cardinality=one).
+- ``TestDorm`` — a dorm may hold many occupants (cardinality=many).
+
+``TestPerson`` declares a ``rooms`` relationship whose peer is the generic
+``TestRoom``. Builder parameters control whether the cardinality constraint
+sits on the generic or only on the concrete subtype, the constraint type
+(cardinality, max_count, min_count), and the relationship directions.
+"""
+
+from typing import Any
+
+from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.schema import (
+    AttributeSchema,
+    GenericSchema,
+    NodeSchema,
+    RelationshipSchema,
+    SchemaRoot,
+)
+
+
+def _occupant_rel(
+    *,
+    cardinality: RelationshipCardinality,
+    direction: RelationshipDirection,
+    max_count: int | None = None,
+    min_count: int | None = None,
+) -> RelationshipSchema:
+    kwargs: dict[str, Any] = {
+        "name": "occupant",
+        "peer": "TestPerson",
+        "identifier": "person__room",
+        "cardinality": cardinality,
+        "optional": True,
+        "direction": direction,
+    }
+    if max_count is not None:
+        kwargs["max_count"] = max_count
+    if min_count is not None:
+        kwargs["min_count"] = min_count
+    return RelationshipSchema(**kwargs)
+
+
+def build_room_schema(
+    *,
+    generic_has_rel: bool = False,
+    single_room_cardinality: str = "one",
+    single_room_max_count: int | None = None,
+    single_room_min_count: int | None = None,
+    include_dorm_subtype: bool = False,
+    single_room_direction: str = "inbound",
+    person_direction: str = "outbound",
+) -> SchemaRoot:
+    direction = RelationshipDirection(single_room_direction)
+    single_occupant = _occupant_rel(
+        cardinality=RelationshipCardinality(single_room_cardinality),
+        direction=direction,
+        max_count=single_room_max_count,
+        min_count=single_room_min_count,
+    )
+
+    room = GenericSchema(
+        name="Room",
+        namespace="Test",
+        attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+        relationships=[single_occupant] if generic_has_rel else [],
+    )
+
+    nodes: list[NodeSchema] = [
+        NodeSchema(
+            name="SingleRoom",
+            namespace="Test",
+            inherit_from=["TestRoom"],
+            relationships=[] if generic_has_rel else [single_occupant],
+        )
+    ]
+
+    if include_dorm_subtype:
+        dorm_occupant = _occupant_rel(
+            cardinality=RelationshipCardinality.MANY,
+            direction=direction,
+        )
+        nodes.append(
+            NodeSchema(
+                name="Dorm",
+                namespace="Test",
+                inherit_from=["TestRoom"],
+                relationships=[] if generic_has_rel else [dorm_occupant],
+            )
+        )
+
+    nodes.append(
+        NodeSchema(
+            name="Person",
+            namespace="Test",
+            attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            relationships=[
+                RelationshipSchema(
+                    name="rooms",
+                    peer="TestRoom",
+                    identifier="person__room",
+                    cardinality=RelationshipCardinality.MANY,
+                    optional=True,
+                    direction=RelationshipDirection(person_direction),
+                )
+            ],
+        )
+    )
+
+    return SchemaRoot(generics=[room], nodes=nodes)

--- a/changelog/8953.fixed.md
+++ b/changelog/8953.fixed.md
@@ -1,1 +1,1 @@
-Cardinality constraints declared on a concrete subtype are now enforced when the relationship's declared peer is a parent generic.
+Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there.

--- a/changelog/8953.fixed.md
+++ b/changelog/8953.fixed.md
@@ -1,0 +1,1 @@
+Cardinality constraints declared on a concrete subtype are now enforced when the relationship's declared peer is a parent generic.


### PR DESCRIPTION
## Why 

When a relationship's declared peer is a generic schema, but the cardinality constraint sits on a concrete subtype of that generic (not on the generic itself), the constraint check is silently skipped. The violation only surfaces later, on read, as `ValueError: At most, one relationship expected.`

Closes [#8953](https://github.com/opsmill/infrahub/issues/8953) / [IFC-2470](https://opsmill.atlassian.net/browse/IFC-2470)

### Example

Using the schema described in the issue 
```
---
# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
version: "1.0"

nodes:
  - name: UnicastIPAddress
    namespace: Network
    inherit_from:
      - BuiltinIPAddress
    relationships:
      - name: layer3
        peer: InterfaceLayer3
        kind: Generic
        optional: true
        cardinality: one
        identifier: ip__l3interface
        direction: inbound

  - name: AnycastIPAddress
    namespace: Network
    inherit_from:
      - BuiltinIPAddress
    relationships:
      - name: layer3
        peer: InterfaceLayer3
        kind: Generic
        optional: true
        cardinality: many
        identifier: ip__l3interface
        direction: inbound

  - name: Layer3
    namespace: Interface
    attributes:
      - name: name
        kind: Text
        unique: true
    relationships:
      - name: ip_addresses
        peer: BuiltinIPAddress
        kind: Attribute
        optional: true
        cardinality: many
        identifier: ip__l3interface
        direction: outbound

```

 #### Scenario
Create a second Layer3 whose ip_addresses already point at a UnicastIPAddress that has a Layer3 peer -> This is silently accepted. The violation only surfaces later, at read time.

### What this PR does

- `RelationshipCountConstraint`: when the relationship's declared peer is a generic with no matching rel, falls back to resolving each peer's concrete kind and applying that subtype's cardinality / max_count / min_count.
- lock_utils: when the declared peer is a generic, conservatively acquires the lock if any concrete
subtype carries a count constraint

### How to test

```
INFRAHUB_USE_TEST_CONTAINERS=true uv run pytest \
    backend/tests/component/core/constraint_validators/test_relationship_manager.py \
    backend/tests/component/core/test_get_kinds_lock.py::TestLockGenericPeerConcreteConstraint \
    backend/tests/component/core/test_get_kinds_lock.py::TestLockGenericPeerGenericRel -v
```

[IFC-2470]: https://opsmill.atlassian.net/browse/IFC-2470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing count enforcement when a relationship’s peer is generic and the constraint is declared on a concrete subtype. Constraints now run on mutation and locks cover these cases, closing #8953 / IFC-2470.

- **Bug Fixes**
  - RelationshipCountConstraint: if the generic peer has no matching rel, resolve each changed peer’s concrete kind via `NodeGetKindQuery` and enforce that subtype’s `cardinality`/`max_count`/`min_count` (respects direction; supports mixed subtypes and generic-vs-concrete declarations).
  - lock_utils: when the declared peer is generic, acquire the count lock if any concrete subtype defines a count constraint for the same identifier (conservative; prevents under-locking).
  - Tests/docs: added `tests.helpers.schema.room` and expanded matrix for generic peers, max/min, mixed subtypes, and bidirectional cases; use the public relationship getter; removed a redundant same-direction test; clarified the changelog entry.

<sup>Written for commit 473756f039926ce3e4da689ead31c9141eb2d9e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

