### PR TITLE
prep release 1.9.4

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -106,6 +106,7 @@ inlining
 Instruqt
 IPAddress
 IPHost
+IPNetwork
 IPs
 Jinja
 Jinja2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.4) - 2026-05-12
+
+### Added
+
+- Add a `rebase_branch` global permission so administrators can grant non-admin users the ability to rebase branches without requiring `super_admin`. ([#8050](https://github.com/opsmill/infrahub/issues/8050))
+
+### Fixed
+
+- Fixed inconsistent IPHost and IPNetwork attribute representations across HFID, display labels, and API responses by normalizing values at input time. Added a migration that recomputes HFID/display labels for nodes whose schema references an IPHost, IPNetwork, or MacAddress attribute. ([#8896](https://github.com/opsmill/infrahub/issues/8896))
+- Standardized stored MacAddress attribute values to colon-separated EUI-48 form (`AA:BB:CC:DD:EE:FF`) and rebuilt HFIDs / display labels for nodes referencing MAC attributes. ([#9015](https://github.com/opsmill/infrahub/issues/9015))
+- Prevent users from deleting their own account through the `CoreAccountDelete` mutation. ([#9138](https://github.com/opsmill/infrahub/issues/9138))
+- Remove the unresolvable `is_inherited` field from `AttributeInterface` and all concrete attribute types in the GraphQL schema. The field had no resolver, so any query selecting it failed with `'<AttributeKind>' object has no attribute 'is_inherited'`. ([#9146](https://github.com/opsmill/infrahub/issues/9146))
+- Skip artifacts whose `object` peer can no longer be resolved when validating artifact generation in a Proposed Change. A single orphan row no longer prevents `CheckArtifactCreate` from being dispatched for the rest of the group. ([#9188](https://github.com/opsmill/infrahub/issues/9188))
+- Fix diff calculation logic to correctly include updates to branch-aware attributes of branch-agnostic schemas. ([#9221](https://github.com/opsmill/infrahub/issues/9221))
+- Diff calculation between branches no longer scales with the total size of the database. Diffs now complete in a time proportional to the number of changes on the branch. ([#9224](https://github.com/opsmill/infrahub/issues/9224))
+- Reset a Proposed Change's status to "open" following a merge failure that raises an unexpected error.
+
 ## [Infrahub - v1.9.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.3) - 2026-05-05
 
 ### Fixed

--- a/changelog/+53a1cf44.fixed.md
+++ b/changelog/+53a1cf44.fixed.md
@@ -1,1 +1,0 @@
-Reset a Proposed Change's status to "open" following a merge failure that raises an unexpected error.

--- a/changelog/8050.added.md
+++ b/changelog/8050.added.md
@@ -1,1 +1,0 @@
-Add a `rebase_branch` global permission so administrators can grant non-admin users the ability to rebase branches without requiring `super_admin`.

--- a/changelog/8896.fixed.md
+++ b/changelog/8896.fixed.md
@@ -1,1 +1,0 @@
-Fixed inconsistent IPHost and IPNetwork attribute representations across HFID, display labels, and API responses by normalizing values at input time. Added a migration that recomputes HFID/display labels for nodes whose schema references an IPHost, IPNetwork, or MacAddress attribute.

--- a/changelog/9015.fixed.md
+++ b/changelog/9015.fixed.md
@@ -1,1 +1,0 @@
-Standardized stored MacAddress attribute values to colon-separated EUI-48 form (`AA:BB:CC:DD:EE:FF`) and rebuilt HFIDs / display labels for nodes referencing MAC attributes.

--- a/changelog/9138.fixed.md
+++ b/changelog/9138.fixed.md
@@ -1,1 +1,0 @@
-Prevent users from deleting their own account through the `CoreAccountDelete` mutation.

--- a/changelog/9146.fixed.md
+++ b/changelog/9146.fixed.md
@@ -1,1 +1,0 @@
-Remove the unresolvable `is_inherited` field from `AttributeInterface` and all concrete attribute types in the GraphQL schema. The field had no resolver, so any query selecting it failed with `'<AttributeKind>' object has no attribute 'is_inherited'`.

--- a/changelog/9188.fixed.md
+++ b/changelog/9188.fixed.md
@@ -1,1 +1,0 @@
-Skip artifacts whose `object` peer can no longer be resolved when validating artifact generation in a Proposed Change. A single orphan row no longer prevents `CheckArtifactCreate` from being dispatched for the rest of the group.

--- a/changelog/9221.fixed.md
+++ b/changelog/9221.fixed.md
@@ -1,1 +1,0 @@
-Fix diff calculation logic to correctly include updates to branch-aware attributes of branch-agnostic schemas.

--- a/changelog/9224.fixed.md
+++ b/changelog/9224.fixed.md
@@ -1,1 +1,0 @@
-Diff calculation between branches no longer scales with the total size of the database. Diffs now complete in a time proportional to the number of changes on the branch.

--- a/docs/docs/release-notes/infrahub/release-1_9_4.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_4.mdx
@@ -1,0 +1,34 @@
+---
+title: Release 1.9.4
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 13th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.4](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- Add a `rebase_branch` global permission so administrators can grant non-admin users the ability to rebase branches without requiring `super_admin`. ([#8050](https://github.com/opsmill/infrahub/issues/8050))
+
+### Fixed
+
+- Fixed inconsistent IPHost and IPNetwork attribute representations across HFID, display labels, and API responses by normalizing values at input time. Added a migration that recomputes HFID/display labels for nodes whose schema references an IPHost, IPNetwork, or MacAddress attribute. ([#8896](https://github.com/opsmill/infrahub/issues/8896))
+- Standardized stored MacAddress attribute values to colon-separated EUI-48 form (`AA:BB:CC:DD:EE:FF`) and rebuilt HFIDs / display labels for nodes referencing MAC attributes. ([#9015](https://github.com/opsmill/infrahub/issues/9015))
+- Prevent users from deleting their own account through the `CoreAccountDelete` mutation. ([#9138](https://github.com/opsmill/infrahub/issues/9138))
+- Remove the unresolvable `is_inherited` field from `AttributeInterface` and all concrete attribute types in the GraphQL schema. The field had no resolver, so any query selecting it failed with `'<AttributeKind>' object has no attribute 'is_inherited'`. ([#9146](https://github.com/opsmill/infrahub/issues/9146))
+- Skip artifacts whose `object` peer can no longer be resolved when validating artifact generation in a Proposed Change. A single orphan row no longer prevents `CheckArtifactCreate` from being dispatched for the rest of the group. ([#9188](https://github.com/opsmill/infrahub/issues/9188))
+- Fix diff calculation logic to correctly include updates to branch-aware attributes of branch-agnostic schemas. ([#9221](https://github.com/opsmill/infrahub/issues/9221))
+- Diff calculation between branches no longer scales with the total size of the database. Diffs now complete in a time proportional to the number of changes on the branch. ([#9224](https://github.com/opsmill/infrahub/issues/9224))
+- Reset a Proposed Change's status to "open" following a merge failure that raises an unexpected error.

--- a/docs/docs/schema/create-and-load.mdx
+++ b/docs/docs/schema/create-and-load.mdx
@@ -145,4 +145,4 @@ This issue commonly appears in:
 - [Schema extensions](./extensions) — Add attributes and relationships to existing nodes
 - [Schema migration](./migration) — How Infrahub handles schema updates and data migrations
 - [Schema validation](../reference/schema-validation) — Editor validation for schema YAML files
-- [Build your first schema](../../academy/tutorials/build-your-first-schema) — Step-by-step tutorial for creating a schema from scratch
+- [Build your first schema](../academy/tutorials/build-your-first-schema) — Step-by-step tutorial for creating a schema from scratch

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -639,6 +639,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_4',
                 'release-notes/infrahub/release-1_9_3',
                 'release-notes/infrahub/release-1_9_2',
                 'release-notes/infrahub/release-1_9_1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.3"
+version = "1.9.4"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.3"
+version = "1.9.4"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.3"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.3"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares the Infrahub 1.9.4 release by bumping versions for `infrahub-server` and `infrahub-testcontainers`, updating locks, publishing changelog and release notes, and adding a Vale spelling exception for “IPNetwork”. Also fixes a broken docs link.

- **New Features**
  - New `rebase_branch` global permission to let admins grant rebasing to non-admin users.

- **Bug Fixes**
  - Normalize IPHost/IPNetwork/MacAddress values; rebuild HFIDs/display labels where needed.
  - Remove unresolvable `is_inherited` from GraphQL `AttributeInterface` and concrete types.
  - Diff: include updates to branch-aware attributes; branch diffs now scale with number of changes.
  - Reliability: prevent self-account deletion, skip orphaned artifacts during validation, reset Proposed Change to “open” after unexpected merge failures.
  - Docs: fix broken link in the schema “Create and load” guide.

<sup>Written for commit ee0480b0968495958c0af83d9460a54bebe1810d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

