### PR TITLE
fix: clean broken link

### DIFF
--- a/docs/docs/schema/create-and-load.mdx
+++ b/docs/docs/schema/create-and-load.mdx
@@ -145,4 +145,4 @@ This issue commonly appears in:
 - [Schema extensions](./extensions) — Add attributes and relationships to existing nodes
 - [Schema migration](./migration) — How Infrahub handles schema updates and data migrations
 - [Schema validation](../reference/schema-validation) — Editor validation for schema YAML files
-- [Build your first schema](../../academy/tutorials/build-your-first-schema) — Step-by-step tutorial for creating a schema from scratch
+- [Build your first schema](../academy/tutorials/build-your-first-schema) — Step-by-step tutorial for creating a schema from scratch


### PR DESCRIPTION
Summary: DOCS_IN_APP=1 is set in development/Dockerfile:60, which changes baseUrl from / to /docs/. With baseUrl=/, the ../../ link resolves to /academy/tutorials/… — a valid path. With baseUrl=/docs/, the same link still resolves to /academy/tutorials/… but the actual content lives at /docs/academy/tutorials/…, so the link is one prefix short. Local docs.build uses baseUrl=/ and passes; the Docker build uses baseUrl=/docs/ and breaks.