### PR TITLE
fix(frontend): copy to clipboard fails over HTTP (non-secure context)

### DIFF
--- a/changelog/8857.fixed.md
+++ b/changelog/8857.fixed.md
@@ -1,0 +1,1 @@
+Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context).

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
@@ -7,7 +6,11 @@ import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 function CopyButton({ value }: { value: string }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   return (
-    <button data-testid="copy-btn" data-copied={String(isCopied)} onClick={() => copyToClipboard(value)}>
+    <button
+      data-testid="copy-btn"
+      data-copied={String(isCopied)}
+      onClick={() => copyToClipboard(value)}
+    >
       {isCopied ? "copied" : "copy"}
     </button>
   );

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+
+function CopyButton({ value }: { value: string }) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  return (
+    <button data-testid="copy-btn" data-copied={String(isCopied)} onClick={() => copyToClipboard(value)}>
+      {isCopied ? "copied" : "copy"}
+    </button>
+  );
+}
+
+describe("useCopyToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses navigator.clipboard.writeText in a secure context", async () => {
+    // GIVEN
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(writeText).toHaveBeenCalledWith("test-value");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when not in a secure context", async () => {
+    // GIVEN
+    vi.stubGlobal("isSecureContext", false);
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when navigator.clipboard is unavailable", async () => {
+    // GIVEN
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when navigator.clipboard.writeText rejects", async () => {
+    // GIVEN
+    const writeText = vi.fn().mockRejectedValue(new Error("Permission denied"));
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+});

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.ts
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.ts
@@ -20,7 +20,7 @@ const COPIED_FEEDBACK_DURATION = 2000;
 export function useCopyToClipboard() {
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const copyToClipboard = React.useCallback((value: string) => {
+  const copyToClipboard = React.useCallback(async (value: string) => {
     function confirmCopied() {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), COPIED_FEEDBACK_DURATION);
@@ -32,13 +32,13 @@ export function useCopyToClipboard() {
       return;
     }
 
-    navigator.clipboard
-      .writeText(value)
-      .then(confirmCopied)
-      .catch(() => {
-        oldSchoolCopy(value);
-        confirmCopied();
-      });
+    try {
+      await navigator.clipboard.writeText(value);
+      confirmCopied();
+    } catch {
+      oldSchoolCopy(value);
+      confirmCopied();
+    }
   }, []);
 
   return { isCopied, copyToClipboard };

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.ts
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.ts
@@ -1,12 +1,18 @@
 import React from "react";
 
 function oldSchoolCopy(text: string) {
-  const tempTextArea = document.createElement("textarea");
-  tempTextArea.value = text;
-  document.body.appendChild(tempTextArea);
-  tempTextArea.select();
-  document.execCommand("copy");
-  document.body.removeChild(tempTextArea);
+  const textNode = document.createTextNode(text);
+  document.body.appendChild(textNode);
+  const range = document.createRange();
+  range.selectNode(textNode);
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand("copy");
+    selection.removeAllRanges();
+  }
+  document.body.removeChild(textNode);
 }
 
 const COPIED_FEEDBACK_DURATION = 2000;
@@ -14,19 +20,25 @@ const COPIED_FEEDBACK_DURATION = 2000;
 export function useCopyToClipboard() {
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const copyToClipboard = React.useCallback(async (value: string) => {
+  const copyToClipboard = React.useCallback((value: string) => {
     function confirmCopied() {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), COPIED_FEEDBACK_DURATION);
     }
 
-    try {
-      await navigator.clipboard.writeText(value);
-      confirmCopied();
-    } catch {
+    if (!window.isSecureContext || !navigator.clipboard) {
       oldSchoolCopy(value);
       confirmCopied();
+      return;
     }
+
+    navigator.clipboard
+      .writeText(value)
+      .then(confirmCopied)
+      .catch(() => {
+        oldSchoolCopy(value);
+        confirmCopied();
+      });
   }, []);
 
   return { isCopied, copyToClipboard };


### PR DESCRIPTION
## Summary

- `navigator.clipboard` is unavailable in non-secure contexts (HTTP, non-localhost); previous code attempted it unconditionally, causing silent failures.
- Added an explicit `window.isSecureContext` guard: when the Clipboard API is unavailable, a synchronous `document.createRange()` + `window.getSelection()` + `execCommand("copy")` fallback is used instead.
- Replaced the previous `textarea`-based fallback, which was broken by React Aria's Popover focus trap — the textarea could not receive focus while the menu was open, so `execCommand("copy")` had no selection to act on.

Fixes #8857

## Test plan

- [ ] Open Infrahub over HTTP (non-localhost IP)
- [ ] Navigate to any object detail page → Actions → **Copy ID**: verify clipboard contains the UUID
- [ ] Actions → **Copy HFID**: verify clipboard contains the human-friendly ID
- [ ] Profile → Tokens → create a new token → click copy: verify clipboard contains the token value
- [ ] Verify all three copy actions still work over HTTPS / localhost (secure context, Clipboard API path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes copy actions over HTTP so users can copy IDs and tokens in non-secure contexts, without breaking HTTPS behavior. Restores the async contract of `useCopyToClipboard` to preserve await ordering. Fixes #8857.

- **Bug Fixes**
  - Guard on `window.isSecureContext` and `navigator.clipboard`; fall back to selection-based `document.createRange()` + `window.getSelection()` + `document.execCommand("copy")` compatible with the React Aria popover focus trap.
  - Make `copyToClipboard` async; add tests for secure/non-secure, missing clipboard, and rejected writes; fix Biome lint errors in the tests.

<sup>Written for commit 399e42855e17c1aca8541326a56b2f88f1273430. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9242?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

