### PR TITLE
fix: data-only proposed change spuriously triggers schema-migration validators

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -675,9 +675,12 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
 
         super().update(other=other)
 
-        # Allow to specify empty string to remove existing fields values
+        # Allow to specify empty string to remove existing fields values.
+        # Only clear when self actually has a value to clear — otherwise we synthesize a
+        # phantom diff (e.g. "" → None) when both sides start identical, which falsely
+        # triggers schema migration validation in the proposed-change integrity flow.
         for field_name in OPTIONAL_TEXT_FIELDS:
-            if getattr(other, field_name, None) == "":  # noqa: PLC1901
+            if getattr(other, field_name, None) == "" and getattr(self, field_name, None) not in (None, ""):  # noqa: PLC1901
                 setattr(self, field_name, None)
 
         return self

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2432,15 +2432,22 @@ class SchemaBranch:
             ):
                 continue
 
+            # Synthetic, deterministic id so diff matching is stable across processed schemas.
+            # See _diff_element in basenode_schema.py: two synthetic relationships with id=None
+            # on either side are reported as `added` even when structurally identical.
+            synthetic_id = f"__virtual__/{node_name}/{PROFILES_RELATIONSHIP_NAME}"
+
             # Add relationship between node and profile
             if PROFILES_RELATIONSHIP_NAME not in node.relationship_names:
                 node_schema = self.get(name=node_name, duplicate=True)
 
-                node_schema.relationships.append(RelationshipSchema(**profiles_rel_settings))
+                node_schema.relationships.append(RelationshipSchema(id=synthetic_id, **profiles_rel_settings))
                 self.set(name=node_name, schema=node_schema)
             else:
                 has_changes: bool = False
                 rel_profiles = node.get_relationship(name=PROFILES_RELATIONSHIP_NAME)
+                if rel_profiles.id != synthetic_id:
+                    has_changes = True
                 for name, value in profiles_rel_settings.items():
                     if getattr(rel_profiles, name) != value:
                         has_changes = True
@@ -2450,6 +2457,8 @@ class SchemaBranch:
 
                 node_schema = self.get(name=node_name, duplicate=True)
                 rel_profiles = node_schema.get_relationship(name=PROFILES_RELATIONSHIP_NAME)
+                if rel_profiles.id != synthetic_id:
+                    rel_profiles.id = synthetic_id
                 for name, value in profiles_rel_settings.items():
                     if getattr(rel_profiles, name) != value:
                         setattr(rel_profiles, name, value)
@@ -2550,16 +2559,19 @@ class SchemaBranch:
                 "max_count": 1,
                 "min_count": 0,
             }
+            synthetic_id = f"__virtual__/{node_name}/{OBJECT_TEMPLATE_RELATIONSHIP_NAME}"
 
             # Add relationship between node and template
             if OBJECT_TEMPLATE_RELATIONSHIP_NAME not in node.relationship_names:
                 node_schema = self.get(name=node_name, duplicate=True)
 
-                node_schema.relationships.append(RelationshipSchema(**template_rel_settings))
+                node_schema.relationships.append(RelationshipSchema(id=synthetic_id, **template_rel_settings))
                 self.set(name=node_name, schema=node_schema)
             else:
                 has_changes: bool = False
                 rel_template = node.get_relationship(name=OBJECT_TEMPLATE_RELATIONSHIP_NAME)
+                if rel_template.id != synthetic_id:
+                    has_changes = True
                 for name, value in template_rel_settings.items():
                     if getattr(rel_template, name) != value:
                         has_changes = True
@@ -2569,6 +2581,8 @@ class SchemaBranch:
 
                 node_schema = self.get(name=node_name, duplicate=True)
                 rel_template = node_schema.get_relationship(name=OBJECT_TEMPLATE_RELATIONSHIP_NAME)
+                if rel_template.id != synthetic_id:
+                    rel_template.id = synthetic_id
                 for name, value in template_rel_settings.items():
                     if getattr(rel_template, name) != value:
                         setattr(rel_template, name, value)
@@ -2746,7 +2760,8 @@ class SchemaBranch:
             if PROFILES_RELATIONSHIP_NAME not in [r.name for r in template_schema.relationships]:
                 settings = dict(profiles_rel_settings)
                 settings["identifier"] = PROFILE_TEMPLATE_RELATIONSHIP_IDENTIFIER
-                template_schema.relationships.append(RelationshipSchema(**settings))
+                synthetic_id = f"__virtual__/{template_schema.kind}/{PROFILES_RELATIONSHIP_NAME}"
+                template_schema.relationships.append(RelationshipSchema(id=synthetic_id, **settings))
 
         self.set(name=template_schema.kind, schema=template_schema)
 

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -83,16 +83,17 @@ class ConstraintValidatorDeterminer:
 
     async def _get_all_property_constraints(self) -> list[SchemaUpdateConstraintInfo]:
         constraints: list[SchemaUpdateConstraintInfo] = []
-        schemas = list(self.schema_branch.get_all(duplicate=False).values())
+        # Scope to kinds with actual data diffs — otherwise we revalidate node-level
+        # constraints (uniqueness, hierarchy, inherit_from, generate_profile) for every
+        # schema in the branch even when only one kind's data changed.
+        schemas = [
+            schema for schema in self.schema_branch.get_all(duplicate=False).values() if schema.kind in self._node_kinds
+        ]
         # added here to check their uniqueness constraints
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaNode", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaGeneric", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaAttribute", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaRelationship", duplicate=False))
+        for schema_kind in ("SchemaNode", "SchemaGeneric", "SchemaAttribute", "SchemaRelationship"):
+            if schema_kind in self._node_kinds:
+                with contextlib.suppress(SchemaNotFoundError):
+                    schemas.append(self.schema_branch.get_node(name=schema_kind, duplicate=False))
         for schema in schemas:
             constraints.extend(await self._get_property_constraints_for_one_schema(schema=schema))
         return constraints

--- a/backend/tests/component/core/constraint_validators/test_determiner.py
+++ b/backend/tests/component/core/constraint_validators/test_determiner.py
@@ -55,15 +55,6 @@ def person_name_node_diff(
                 property_name="inherit_from",
             ),
         ),
-        SchemaUpdateConstraintInfo(
-            constraint_name="node.inherit_from.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestCar",
-                field_name="inherit_from",
-                property_name="inherit_from",
-            ),
-        ),
     }
     return node_diff, schema_updated_constraint_infos
 
@@ -192,15 +183,6 @@ class TestConstraintDeterminer:
                 property_name="uniqueness_constraints",
             ),
         )
-        car_uniqueness_constraint_info = SchemaUpdateConstraintInfo(
-            constraint_name="node.uniqueness_constraints.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestCar",
-                field_name="uniqueness_constraints",
-                property_name="uniqueness_constraints",
-            ),
-        )
         max_length_param_constraint_info = SchemaUpdateConstraintInfo(
             constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MAX_LENGTH_UPDATE.value,
             path=SchemaPath(
@@ -211,7 +193,6 @@ class TestConstraintDeterminer:
             ),
         )
         constraint_info_set.add(person_uniqueness_constraint_info)
-        constraint_info_set.add(car_uniqueness_constraint_info)
         constraint_info_set.add(max_length_param_constraint_info)
 
         constraints = await determiner.get_constraints(node_diffs=[node_diff])

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -134,9 +134,8 @@ async def test_get_proposed_change_schema_integrity_constraints(
         schema=schema, diff_summary=branch_diff_01_summary
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
-    # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 248
-    assert len(non_generate_profile_constraints) == 151
+    assert len(constraints) == 14
+    assert len(non_generate_profile_constraints) == 13
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",
@@ -228,46 +227,10 @@ async def test_get_proposed_change_schema_integrity_constraints(
             "schema_kind": "TestPerson",
         },
     } in dumped_constraints
-    assert {
-        "constraint_name": "node.parent.update",
-        "path": {
-            "field_name": "parent",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "parent",
-            "schema_id": None,
-            "schema_kind": "CoreStandardGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.children.update",
-        "path": {
-            "field_name": "children",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "children",
-            "schema_id": None,
-            "schema_kind": "CoreStandardGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.parent.update",
-        "path": {
-            "field_name": "parent",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "parent",
-            "schema_id": None,
-            "schema_kind": "CoreGraphQLQueryGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.children.update",
-        "path": {
-            "field_name": "children",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "children",
-            "schema_id": None,
-            "schema_kind": "CoreGraphQLQueryGroup",
-        },
-    } in dumped_constraints
+    # Constraints are scoped to kinds with actual data diffs in branch_diff_01_summary
+    # (TestPerson only) — kinds like CoreStandardGroup or CoreGraphQLQueryGroup are not
+    # revalidated despite having property-level update constraints.
+    assert all(c.path.schema_kind == "TestPerson" for c in constraints)
 
 
 async def test_schema_integrity(


### PR DESCRIPTION
## Summary

Fixes #9246.

A data-only Proposed Change was running `schema_validate_migrations` over a large set of constraints — including full-DB uniqueness scans for kinds with no actual data diff. Root cause was a chain of three issues that combined to produce a non-empty schema diff and an over-broad constraint set:

- **Virtual relationships had no id.** `manage_profile_relationships` and `manage_object_template_relationships` appended `RelationshipSchema(...)` without an `id`. The diff logic in `_diff_element` then flagged these as `added` on every node when comparing two identical processed schemas. Fix: assign a stable per-node id `__virtual__/<kind>/<rel_name>` at injection time. The persistence layer already filters virtual relationships by name, so the synthetic id never reaches the DB.

- **`BaseNodeSchema.update()` over-cleared empty-string fields.** Empty-string sentinels in YAML (e.g. `LocationContinent.parent: ""`, `LocationRack.children: ""`) got unconditionally converted to `None` on the candidate schema during `update()` — even when the local already held `""`. That produced a phantom `changed={'parent': None}` against dest_schema. Fix: only clear when local actually has a value to clear.

- **Constraint determiner was over-broad.** `ConstraintValidatorDeterminer._get_all_property_constraints` iterated every schema in the branch and emitted node-level update constraints (uniqueness, hierarchy, inherit_from, generate_profile) for kinds with no data diff. Fix: scope to schemas whose kind appears in `self._node_kinds`. The fixture-count assertions in `test_determiner` and `test_proposed_change` were updated to match the now-scoped behaviour (e.g. the `_get_proposed_change_schema_integrity_constraints` test drops from 248 to 14 constraints — unrelated kinds are no longer revalidated).

Result: on a data-only PC, the schema diff is now empty and `constraints_from_data_diff` only contains constraints for kinds that actually changed.

## Test plan

- [x] `backend/tests/component/core/constraint_validators/test_determiner.py` (4 tests)
- [x] `backend/tests/component/core/schema_manager/` (177 tests)
- [x] `backend/tests/component/message_bus/operations/requests/test_proposed_change.py` (3 tests)
- [x] `backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py` (2 tests)
- [ ] Manual: reproduce on a branch with only data changes — `schema diff:` log should print `added={} changed={} removed={}` and `constraints_from_data_diff` should be scoped to changed kinds only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents schema-migration validators from running on data-only Proposed Changes by eliminating phantom schema diffs and scoping integrity checks to changed kinds. Data-only PCs now show an empty schema diff and avoid costly full-DB uniqueness scans.

- **Bug Fixes**
  - Assign deterministic ids to virtual relationships (`__virtual__/<kind>/<rel_name>`) so identical processed schemas don’t diff as added; persistence ignores these by name.
  - In `BaseNodeSchema.update()`, only clear optional text fields when the local value is set, avoiding "" → None phantom changes.
  - Scope `ConstraintValidatorDeterminer._get_all_property_constraints` to kinds present in the data diff (including `Schema*` kinds only when they’re in the diff).

<sup>Written for commit d846e73287537fdb23866858e51001fb539a8644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

