### PR TITLE
Add SpecKit specification for enriched GraphQL errors

### DIFF
--- a/dev/specs/infp-468-graphql-error-catalogue/checklists/requirements.md
+++ b/dev/specs/infp-468-graphql-error-catalogue/checklists/requirements.md
@@ -1,0 +1,70 @@
+# Specification Quality Checklist: Enriched GraphQL Error Catalogue
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Last reviewed**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+**Companion**: [discovery.md](../discovery.md)
+**Code-reference baseline (spec + discovery)**: `76395fd1c` (`stable` branch tip, 2026-05-13).
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [ ] All acceptance scenarios are defined — *US1 scenario 4 still needs to specify that each failing field carries its own sub-code (`ATTRIBUTE_REQUIRED` / `ATTRIBUTE_INVALID_TYPE` / `ATTRIBUTE_CONSTRAINT_VIOLATION`). Pending Q-D1.*
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded — *Transport scope reaffirmed as GraphQL-only on the wire (2026-05-15). REST keeps current shape; OpenAPI long-term direction captured in the new Future Direction section. CI scope further narrowed (2026-05-15) to frontend bindings only — SDK lives in the `python_sdk/` submodule and its binding sync is enforced by the SDK repository's own CI.*
+- [ ] Dependencies and assumptions identified — *Assumptions now reflect: GraphQL-only wire-format scope; shared Python catalogue; CI covers frontend bindings only (SDK external); cross-repo workflow uses the catalogue's machine-readable schema (FR-012) as the contract that crosses the repo boundary. Still missing FRs from discovery §9 (per-error explosion, `path` requirement, telemetry/logging, `data` evolution rules) — pending Q-D5.*
+
+## Feature Readiness
+
+- [ ] All functional requirements have clear acceptance criteria — *Current FRs are clear, including the new FR-015 `UNDEFINED_ERROR` requirement. Four additional FRs proposed in discovery §9 are pending Q-D5.*
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria — *SC-008 added (2026-05-15) for `extensions.code` always-present invariant on GraphQL responses.*
+- [x] No implementation details leak into specification
+
+## Pending decisions (block final sign-off)
+
+These remain open in discovery §10:
+
+- **Q-D1** — adopt the v1 catalogue (9 codes incl. auth split and validation split)?
+- **Q-D4** — adopt the worked example shapes in §8 as canonical?
+- **Q-D5** — promote the four "Belongs in the spec" items from discovery §9?
+
+Resolved:
+
+- **Q-D2** *(resolved 2026-05-15)*: REST keeps current wire format; the catalogue is GraphQL-only on the wire, with the Python catalogue shared across transports and OpenAPI as the long-term REST documentation surface.
+- **Q-D3** *(partially applied 2026-05-15)*: Breaking Changes reframe, Transport assumption, `UNDEFINED_ERROR` (FR-015 + Edge Cases), SC-008, the new Future Direction section, and the CI-scope narrowing (FR-009/US4/SC-005/CI-scope assumption — frontend-only) are applied. Outstanding pieces gated on Q-D1 and Q-D5.
+
+## Pending spec amendments (gated on remaining decisions)
+
+Once Q-D1, Q-D4, and Q-D5 are answered:
+
+1. **FR-005**: replace the analysis-driven phrasing with the agreed v1 list.
+2. **US1 acceptance scenario 4**: tighten to require per-field sub-codes.
+3. **Add new FRs** (Q-D5 default = all four):
+   - Per-error explosion for bundled validation errors.
+   - GraphQL `path` MUST point at the failing field for catalogued field-level errors.
+   - Structured logs and telemetry include the catalogue `code`.
+   - `data` schema evolution rules (additive non-breaking; remove/rename follows deprecation policy).
+4. **Worked examples**: confirm the §8 shapes as canonical so generators target them (Q-D4).
+
+## Notes
+
+- All three of the original `[NEEDS CLARIFICATION]` markers (FR-005 initial scope, FR-011 HTTP-status placement, FR-012 discoverability format) were resolved on 2026-05-13.
+- Discovery work (2026-05-13 → 2026-05-15) produced [discovery.md](../discovery.md): cross-transport error inventory, recommended v1 catalogue (9 codes), worked examples for `NODE_NOT_FOUND` and the `VALIDATION_ERROR` family, the boundary between Infrahub-validated errors and graphql-core-rejected errors, and the principle that `extensions.data` carries only what the consumer doesn't already know from their request.
+- The 2026-05-15 reviewer feedback narrowed the wire-format scope to GraphQL only and added a Future Direction section pointing at OpenAPI as the long-term home for REST error documentation.
+- A subsequent 2026-05-15 review further narrowed the CI scope: FR-009 covers frontend bindings only; the Python SDK (a git submodule = separate repo) has its own CI that consumes the catalogue's published machine-readable schema (FR-012) as an external input. The catalogue schema is therefore the cross-repo contract. US4 and SC-005 were tightened to match; a new US4 acceptance scenario 4 asserts the SDK submodule is not inspected by the in-repo CI.
+- Both `spec.md` and `discovery.md` now carry a "Code-reference baseline: `76395fd1c`" header so any `file:line` references can be re-located against that commit if drift occurs before implementation lands.
+- The spec uses GraphQL terminology (`errors`, `extensions`, `code`, `data`) because the feature is *defined* in those terms by the user and by INFP-468. This is treated as domain language, not as a leaked implementation detail.
+- "Python SDK" and "TypeScript bindings" are referenced as concrete consumers (named in the user input); the spec stays implementation-agnostic about *how* those bindings are produced.
+- Verified blast radius: 2 frontend files (`graphqlClientApollo.tsx`, `pages/login.tsx`), 0 SDK files. Both frontend sites read GraphQL-bound responses (auth-short-circuit case) so the migration sits within the GraphQL scope.

--- a/dev/specs/infp-468-graphql-error-catalogue/discovery.md
+++ b/dev/specs/infp-468-graphql-error-catalogue/discovery.md
@@ -1,0 +1,393 @@
+# Discovery: Enriched GraphQL Error Catalogue (INFP-468)
+
+**Created**: 2026-05-13
+**Companion to**: [spec.md](./spec.md)
+**Status**: Findings — pending review before spec update and `/speckit-plan`.
+**Code-reference baseline**: `76395fd1c` (`stable` branch tip at the time of writing, 2026-05-13). All `file:line` references in this document were verified against that commit. If implementation lands later and lines have drifted, treat the file path as the authoritative anchor and re-locate the referenced code by symbol/content rather than by line number.
+
+This document captures the cross-transport error inventory used to (a) decide which error codes belong in the v1 catalogue and (b) confirm/adjust the spec's assumptions about REST. Three parallel audits were run: backend (Infrahub), SDK (Python SDK), REST API.
+
+---
+
+## 1. Key architectural revelations
+
+These finding(s) materially affect the spec and should be reconciled before planning.
+
+### 1a. The integer `extensions.code` is REST-only today, not GraphQL
+
+The GraphQL app uses `graphql-core`'s default `format_error`, which produces `{"message": "...", "extensions": {...}}` **but does not populate `extensions.code` at all** from an internal exception. The integer code currently observed at `extensions.code` is set by the central FastAPI exception handler:
+
+> `backend/infrahub/api/exception_handlers.py:17-35` — `generic_api_exception_handler` constructs `{"data": null, "errors": [{"message": ..., "extensions": {"code": <HTTP_CODE int>}}]}` and the same shape is registered against `Error` and `ForwardableError` in `server.py:213-216`.
+
+**Consequence**: when the Infrahub frontend reads `graphQLError.extensions?.code` (Apollo's `onError` link at `graphqlClientApollo.tsx:66`) and sees an integer like `401` or `403`, that response actually came from FastAPI's exception handler short-circuiting the GraphQL request (e.g. auth rejected before the GraphQL execution step). Apollo's `onError` receives both true GraphQL errors and HTTP-level errors and they're being conflated in the existing code.
+
+**Spec impact**: the Breaking Changes section currently describes the change as repurposing a GraphQL field. It is actually more accurate to say: **REST error responses are reshaped** (existing integer at `extensions.code` moves to `extensions.http_status`, and the new string `code` is added), and **GraphQL error responses are *enriched*** (gaining `extensions.code` and `extensions.data` where they had nothing before). This is a smaller breaking change than the spec currently implies.
+
+### 1b. REST and GraphQL share the same backend exception hierarchy — but should keep distinct wire formats
+
+Every error condition surfaced by REST is a subclass of `backend/infrahub/exceptions.py::Error`, which carries an `HTTP_CODE` class attribute. The same classes are raised inside GraphQL resolvers. There is no "GraphQL-only" or "REST-only" subset of error *conditions* — but the appropriate *wire format* differs per transport.
+
+**Revised position** (after reviewer feedback): the Python catalogue is the shared source of truth, but only GraphQL responses get `extensions.code` + `extensions.data` on the wire. REST keeps its current body shape; REST consumers discover the possible errors per endpoint via the OpenAPI schema, which is the idiomatic REST discovery surface. The long-term direction is for the OpenAPI schema to enumerate possible error responses per endpoint, referencing catalogue codes by name — captured as Future Direction in the spec.
+
+**Spec impact**: the Transport assumption stays GraphQL-only on the wire, with explicit acknowledgment that (a) the Python catalogue is shared and (b) REST's discovery surface is OpenAPI, which is the long-term home for REST error documentation.
+
+### 1c. SDK has concrete message-string parsing that the catalogue eliminates
+
+Eight call sites in the SDK string-match against `error["message"]` text — exactly the brittleness the Jira ticket describes:
+
+| File:Line | Pattern | Replaceable by |
+|-----------|---------|----------------|
+| `client.py:90`, `client.py:104` | `"Expired Signature" in [error.get("message") ...]` (relogin decorator) | `TOKEN_EXPIRED` (or similar auth code) |
+| `query_groups.py:115` | `"Unable to find the node" not in exc.message` (suppress cascade-delete races) | `NODE_NOT_FOUND` |
+| `file_handler.py:112`, `object_store.py:55,77,99,143,165,187` | Extract messages to raise `AuthenticationError` | `AUTHENTICATION_REQUIRED` / `PERMISSION_DENIED` |
+
+These are deterministic adoption sites: each one becomes shorter and correct once the catalogue exists.
+
+---
+
+## 2. Backend exception inventory (grouped)
+
+Only classes whose conditions are at least somewhat externally observable are listed. Counts are approximate raise-site frequency in `backend/infrahub/`.
+
+### High-frequency / high-impact
+
+- **`ValidationError`** — 194 sites. Attribute schema violations (mandatory fields, type mismatches, regex/length). Already carries structured `input_value: {field_name: error_message}` dict.
+- **`NodeNotFoundError`** — 35 sites. Node lookups by ID/HFID. Captures `node_type`, `identifier`, `branch_name`.
+- **`AuthorizationError`** (HTTP 401) — 15 sites. Auth missing/invalid.
+- **`RepositoryError`** + family (`RepositoryConnectionError`, `RepositoryCredentialsError`, `RepositoryInvalidBranchError`, `RepositoryFileNotFoundError`, etc.) — 13 sites combined.
+- **`ProcessingError`** (HTTP 400) — 12 sites. Generic "operation blocked by state".
+- **`SchemaNotFoundError`** — 10 sites. Schema lookup failures.
+
+### Medium
+
+- **`ResourceNotFoundError`** — 7 sites. Generic 404 for REST.
+- **`PermissionDeniedError`** (HTTP 403) — 5 sites. Authenticated user lacks permission.
+- **`BranchStatusError`** + subclasses (`BranchAlreadyMergedError`, `BranchNeedsRebaseError`) — 5 sites.
+
+### Rare / specialised
+
+- **`HFIDViolatedError`** — 1 site, but already carries rich data (`matching_nodes_ids` set).
+- **`BranchNotFoundError`** — 3 sites.
+- **`QueryValidationError`** — 1 site.
+- **`DiffError`** + subclasses — ~3 sites.
+
+### Infrastructure (lower priority for v1)
+
+`TransformError`, `CheckError`, `HTTPServerError` family, `DatabaseError`, `RPCError`, `LockError`, `QueryError`. These are mostly 5xx-class and integrators are unlikely to need fine-grained control.
+
+### Where the integer `code` is set today
+
+`backend/infrahub/api/exception_handlers.py:32`:
+
+```python
+error_dict: dict[str, Any] = {
+    "data": None,
+    "errors": [{"message": message, "extensions": {"code": http_code}} for message in messages],
+}
+```
+
+This is the single migration point for REST.
+
+---
+
+## 3. SDK error landscape
+
+29 concrete exception classes in `python_sdk/infrahub_sdk/exceptions.py`. Most are SDK-internal (raised by the SDK from its own logic). The interesting subset:
+
+- **`GraphQLError`** — raised at four call sites in `client.py` (1008, 1073, 1915, 1980) whenever a GraphQL response contains an `errors` key. This is the handoff point: with the catalogue, these sites can dispatch on `extensions.code` and raise typed SDK errors instead of the generic wrapper.
+- **`AuthenticationError`** — currently raised after extracting `error.get("message")` from the errors array (7 sites: `file_handler.py`, `object_store.py` x6).
+- **`NodeNotFoundError`**, **`BranchNotFoundError`**, **`SchemaNotFoundError`** — SDK-internal but each corresponds 1:1 to a backend condition. With the catalogue, the SDK can raise these from the GraphQL/REST response directly rather than guessing.
+
+The SDK already has typed exceptions for the most common backend conditions; the catalogue lets them be raised reliably instead of via message parsing.
+
+---
+
+## 4. REST API parity
+
+REST routers and their relevant exception conditions:
+
+| Router | Condition currently surfaced | Backend class | Today's HTTP |
+|--------|------------------------------|---------------|--------------|
+| `auth` | Missing/invalid credentials | `AuthorizationError` | 401 |
+| `artifact`, `query`, `transformation` | Target not found | `NodeNotFoundError` | 404 |
+| `artifact`, `query` | User not allowed | `PermissionDeniedError` | 403 |
+| `schema` | Schema upload invalid | `ValidationError` | 422 |
+| `schema`, `artifact` | Branch state blocks op | `BranchStatusError` | 422 |
+| `file` | Commit not found | `CommitNotFoundError` | 400 |
+| `*` catch-all | Generic 404 | `ResourceNotFoundError` | 404 |
+
+**Implications** *(revised after reviewer feedback)*:
+
+- Every REST error condition has a backend exception class that GraphQL also surfaces. **No REST-only codes required**, and equally no need to duplicate the catalogue's string `code` into REST response bodies.
+- **REST wire format is unchanged**: `/api/...` responses keep their current body shape; REST consumers discover possible errors per endpoint via the OpenAPI schema. The Python catalogue is the shared source-of-truth for both transports, but each transport keeps idiomatic surface conventions.
+- **Auth-short-circuit case is the seam**: the central handler at `backend/infrahub/api/exception_handlers.py:32` serves both `/api/...` routes and `/graphql` when FastAPI middleware short-circuits a request (e.g. auth). It must detect that the caller is the GraphQL route and emit GraphQL-shaped errors with the string `code` for that case, while continuing to emit today's shape for REST routes. This is the single implementation seam.
+- **Blast radius unchanged**: the two frontend integer-reading sites consume GraphQL-bound responses (the auth-short-circuit path). REST consumers are not impacted.
+- **Long-term direction**: the OpenAPI schema should eventually enumerate possible error responses per endpoint, referencing catalogue codes by name and ideally including the structured `data` shape for each. This becomes the authoritative discovery surface for REST consumers, analogous to the catalogue docs for GraphQL. Captured as Future Direction in `spec.md`; out of scope for v1.
+
+---
+
+## 5. Recommended v1 catalogue
+
+Selection principle (per user's direction): "right and useful over many". Each code below either (a) eliminates message-string parsing in the SDK, (b) is required to migrate the 401/403 integer cases the frontend already handles, or (c) unlocks the form-validation UX explicitly named in the spec's US2.
+
+### Codes proposed for v1
+
+| Code | Backend class | `data` payload | Justification |
+|------|---------------|----------------|---------------|
+| `NODE_NOT_FOUND` | `NodeNotFoundError` | `{node_kind: str, identifier: str \| dict}` | 35 raise sites; SDK already parses message text for it (`query_groups.py:115`); REST 404 already returns it. **The single highest-value code.** |
+| `AUTHENTICATION_REQUIRED` | `AuthorizationError` | `{}` (initially empty — no useful payload identified yet) | Migrates the 401 path that the frontend's `graphqlClientApollo.tsx:67-97` already branches on for token refresh. SDK has 7 sites parsing for "Expired Signature" — fold into this code or split out `TOKEN_EXPIRED` (see open question 1 below). |
+| `PERMISSION_DENIED` | `PermissionDeniedError` | `{action?: str, resource?: str}` (or `{}` initially) | Migrates the 403 path that `graphqlClientApollo.tsx:98+` already branches on. Lets frontend route to permission dialog vs. toast. SA integrations benefit. |
+| `VALIDATION_ERROR` | `ValidationError` | `{field_name: str, kind: str, reason: str}` — one error entry per failing field | 194 raise sites; **the primary driver of US2 (per-field form highlighting)**. Backend already carries `input_value: {field: reason}` structure; just needs to be serialised one-per-field into the GraphQL `errors` array. |
+| `BRANCH_NOT_FOUND` | `BranchNotFoundError` | `{branch_name: str}` | SDK currently detects this by checking empty arrays or HTTP 400; small payload but eliminates SDK guesswork; common in branch-aware integrations. |
+| `SCHEMA_NOT_FOUND` | `SchemaNotFoundError` | `{kind: str}` | SDK relies on KeyError + message; useful for SDK schema-cache logic and frontend schema-validation feedback. |
+
+### Codes deferred to a follow-up release (rationale alongside)
+
+- `REPOSITORY_*` family — high value for SA integrations but a whole family; better as its own iteration once the v1 contract is stable.
+- `BRANCH_STATUS_*` (merged / needs-rebase) — only 5 sites; valuable but not blocking US1/US2.
+- `PROCESSING_ERROR` — too generic; would need splitting into sub-codes first.
+- `HFID_VIOLATED` — single raise site; rich data already captured; adopt when we touch the validation domain in a follow-up.
+- `RESOURCE_NOT_FOUND` (REST catch-all) — keep until we know whether to merge into `NODE_NOT_FOUND` or keep distinct for non-node resources.
+- All 5xx-class codes — out of scope for v1.
+
+### Coverage analysis
+
+The v1 batch above:
+
+- Eliminates **every** message-string parsing site currently in the SDK (8/8).
+- Migrates **both** integer-code branches in the frontend (401 → `AUTHENTICATION_REQUIRED`, 403 → `PERMISSION_DENIED`).
+- Delivers the per-field form-validation payload required by US2.
+- Covers the two codes the Jira ticket names explicitly (`NODE_NOT_FOUND`, `PERMISSION_DENIED`) plus the attribute-validation family.
+- Six codes total — small enough to land cleanly in one release, large enough that the catalogue is genuinely useful on day one.
+
+---
+
+## 6. Open questions surfaced by discovery
+
+1. **Auth code split**: should the auth domain be one code (`AUTHENTICATION_REQUIRED`) or two (`AUTHENTICATION_REQUIRED` for missing/invalid + `TOKEN_EXPIRED` for expired-signature)? The frontend's token-refresh path benefits from `TOKEN_EXPIRED` being distinguishable (don't show login redirect if a silent refresh succeeds), and the SDK has explicit `"Expired Signature"` detection. Recommendation: **split into two codes** — minimal extra effort, removes ambiguity for the most-handled error path.
+
+2. **`VALIDATION_ERROR` granularity**: keep it as one code with `data` describing the failing field, or split into `ATTRIBUTE_REQUIRED`, `ATTRIBUTE_INVALID_TYPE`, `ATTRIBUTE_CONSTRAINT_VIOLATION`? Splitting matches Bilal's initial frontend draft and aligns with US2's acceptance scenarios. Recommendation: **split into the three sub-codes** — frontend can branch on the specific failure kind without parsing `reason`.
+
+3. **`extensions.data` shape across transports** *(superseded by reviewer feedback)*: original recommendation was for REST to mirror GraphQL's `data`. Revised: REST wire format is unchanged; only GraphQL carries `extensions.code` / `extensions.data`. REST consumers discover errors per endpoint via OpenAPI (Future Direction). No cross-transport wire decision is required for v1.
+
+If both recommendations above are taken (auth split + validation split), the v1 catalogue is **9 codes**:
+
+`NODE_NOT_FOUND`, `AUTHENTICATION_REQUIRED`, `TOKEN_EXPIRED`, `PERMISSION_DENIED`, `ATTRIBUTE_REQUIRED`, `ATTRIBUTE_INVALID_TYPE`, `ATTRIBUTE_CONSTRAINT_VIOLATION`, `BRANCH_NOT_FOUND`, `SCHEMA_NOT_FOUND`.
+
+If neither split is adopted, the count falls back to the 6 codes proposed in §5. With only the validation split, 8 codes. With only the auth split, 7 codes. Adopting both is the recommended position.
+
+---
+
+## 7. Required spec updates *(applied 2026-05-15)*
+
+The following changes have been applied to `spec.md` after reviewer feedback. This section is kept for traceability.
+
+1. **Breaking Changes section reframed** — clarified that the wire-format change is scoped to GraphQL only. The integer at `extensions.code` exists today in responses produced by FastAPI's exception handler at the `/graphql` route (auth-short-circuit case); only those responses change shape. REST endpoint bodies under `/api/...` are unchanged. The verified blast radius (2 frontend files, 0 SDK files) is unchanged.
+2. **Transport assumption** — kept GraphQL-only on the wire, with explicit notes that (a) the Python catalogue is the shared source of truth across both transports, and (b) REST consumers discover errors per endpoint via the OpenAPI schema (Future Direction).
+3. **FR-005** — replaced the abstract analysis-driven phrasing with a pointer to the v1 list in §5+§6 of this document. (Final list pending Q-D1 sign-off.)
+4. **US1 / US2 acceptance scenarios** — pending tightening to require per-field sub-codes (`ATTRIBUTE_REQUIRED` / `ATTRIBUTE_INVALID_TYPE` / `ATTRIBUTE_CONSTRAINT_VIOLATION`).
+5. **`UNDEFINED_ERROR` catch-all** — added to FR-015 and Edge Cases as the always-present GraphQL fallback identifier.
+6. **`SC-008`** — added to require 100% `extensions.code` coverage on GraphQL responses, with `UNDEFINED_ERROR` observability driving catalogue growth.
+7. **Future Direction section** — added a new section in `spec.md` capturing long-term REST OpenAPI error enrichment, third-party schema export, and catalogue coverage growth.
+
+Pending FRs to add (driven by discovery §9; awaiting Q-D5):
+
+- Per-error explosion for bundled validation errors.
+- GraphQL `path` MUST point at the failing field for catalogued field-level errors.
+- Structured logs and telemetry include the catalogue `code`.
+- `data` schema evolution rules (additive non-breaking; remove/rename follows deprecation policy).
+
+---
+
+## 8. Worked examples
+
+Concrete end-to-end payloads for two representative codes, to make the shape unambiguous before planning.
+
+### 8a. `NODE_NOT_FOUND` — single-target mutation
+
+**Triggering request** (GraphQL update mutation targeting a missing node):
+
+```graphql
+mutation {
+  BuiltinTagUpdate(
+    data: { id: "17a90b4e-0000-0000-0000-deadbeef0000", description: { value: "renamed" } }
+  ) {
+    ok
+  }
+}
+```
+
+**Response (GraphQL)**:
+
+```json
+{
+  "data": { "BuiltinTagUpdate": null },
+  "errors": [
+    {
+      "message": "Unable to find the node 17a90b4e-0000-0000-0000-deadbeef0000 / BuiltinTag in the database.",
+      "locations": [{ "line": 2, "column": 3 }],
+      "path": ["BuiltinTagUpdate"],
+      "extensions": {
+        "code": "NODE_NOT_FOUND",
+        "http_status": 404,
+        "data": {
+          "node_kind": "BuiltinTag",
+          "identifier": "17a90b4e-0000-0000-0000-deadbeef0000"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Response (REST, same condition surfaced through `/api/.../{id}`)** — **unchanged by this work**. The REST exception handler at `backend/infrahub/api/exception_handlers.py:32` continues to emit today's shape, with the integer HTTP status at `extensions.code`:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Unable to find the node 17a90b4e-0000-0000-0000-deadbeef0000 / BuiltinTag in the database.",
+      "extensions": {
+        "code": 404
+      }
+    }
+  ]
+}
+```
+
+This is what REST consumers see today and what they will keep seeing after this feature ships. REST consumers learn about possible errors per endpoint via the OpenAPI schema, not via a wire-level string identifier; enriching the OpenAPI schema with catalogue codes is the Future Direction captured in `spec.md`. The HTTP transport status itself remains `404` regardless.
+
+**Principle for `data` field selection** (GraphQL): include only fields the consumer doesn't already know from the request. `branch` is omitted because the caller chose it. `node_kind` is included on `NODE_NOT_FOUND` because some lookup paths (e.g. generic ID-based queries, polymorphic resolvers) don't carry the kind in the request and the SDK/frontend benefits from the disambiguation. Future additions to `data` follow the same rule: it must enable the consumer to do something they couldn't do by introspecting their own request.
+
+**What the SDK does today** (`python_sdk/infrahub_sdk/query_groups.py:115`):
+
+```python
+except GraphQLError as exc:
+    if not exc.message or "Unable to find the node" not in exc.message:
+        raise
+```
+
+**What the SDK does with the catalogue**:
+
+```python
+except NodeNotFoundError:
+    pass  # cascade-delete race; ignore
+```
+
+### 8b. `VALIDATION_ERROR` family — multi-field form submission
+
+**Triggering request** (create with two simultaneous failures):
+
+```graphql
+mutation {
+  BuiltinTagCreate(data: { description: { value: 42 } }) {
+    ok
+  }
+}
+```
+
+**Response (GraphQL)** — one `errors` entry **per failing field**, not one combined entry:
+
+```json
+{
+  "data": { "BuiltinTagCreate": null },
+  "errors": [
+    {
+      "message": "name is mandatory for BuiltinTag",
+      "path": ["BuiltinTagCreate", "data", "name"],
+      "extensions": {
+        "code": "ATTRIBUTE_REQUIRED",
+        "http_status": 422,
+        "data": {
+          "node_kind": "BuiltinTag",
+          "field_name": "name"
+        }
+      }
+    },
+    {
+      "message": "description must be of type Text for BuiltinTag",
+      "path": ["BuiltinTagCreate", "data", "description", "value"],
+      "extensions": {
+        "code": "ATTRIBUTE_INVALID_TYPE",
+        "http_status": 422,
+        "data": {
+          "node_kind": "BuiltinTag",
+          "field_name": "description",
+          "expected_type": "Text",
+          "received_type": "Int"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Where the type check happens** — and why the backend can fill both `expected_type` and `received_type`:
+
+Attribute input `value` fields are typed `GenericScalar` in the GraphQL schema (`backend/infrahub/graphql/mutations/attribute.py:84-100`), which makes Graphene pass any JSON value straight through to Python without rejection. The real type check is `backend/infrahub/core/attribute.py:762`:
+
+```python
+if value_to_check.__class__ != cls.type:
+    raise ValidationError({name: f"{value} is not a valid {schema.kind}"})
+```
+
+At that point the backend has both `cls.type` (the expected Python type, e.g. `int`, `str`, `bool`) and `value.__class__` (what actually arrived). Both can be serialised into `data` as strings (the current message text already embeds both implicitly). **So `received_type` is something the backend determines, not something Graphene rejects on our behalf.**
+
+**Boundary**: this is true for attribute *values* because they use `GenericScalar`. It is *not* true for GraphQL operation shape errors (unknown field names, wrong argument scalars on non-`GenericScalar` inputs, malformed queries). Those are rejected by graphql-core / Graphene before any Infrahub code runs and surface as `GraphQLError`s with no `extensions.code` today. Bringing those into the catalogue is out of scope for v1 — they're a separate problem (would require a custom error formatter that re-classifies graphql-core's own errors).
+
+**Frontend consumer (with generated bindings)**:
+
+```ts
+const fieldErrors = response.errors
+  .filter(e => e.extensions.code === "ATTRIBUTE_REQUIRED"
+            || e.extensions.code === "ATTRIBUTE_INVALID_TYPE"
+            || e.extensions.code === "ATTRIBUTE_CONSTRAINT_VIOLATION")
+  .map(e => ({ field: e.extensions.data.field_name, message: e.message }));
+
+fieldErrors.forEach(({ field, message }) => form.setFieldError(field, message));
+```
+
+Both `extensions.data.field_name` and the GraphQL `path` carry the field identity — `data.field_name` is the canonical machine identifier; `path` lets sophisticated consumers walk the GraphQL operation tree if they want.
+
+---
+
+## 9. Other gaps the discovery surfaced
+
+Not blocking spec sign-off, but each is something we should not lose track of.
+
+### Belongs in the spec (proposed additions)
+
+- **`data` schema evolution rules**: FR-014 covers stability of `code` values but not what counts as a breaking change to a `data` payload. Recommendation — additive changes (adding new optional fields to an existing code's `data`) are non-breaking; removing or renaming an existing `data` field, or making an optional field required, is breaking and follows the same deprecation policy as removing a code.
+- **Per-error explosion of bundled validation errors**: today `ValidationError` carries an `input_value: {field_name: error_message}` dict (1 backend exception, N fields). The catalogue contract requires N entries in `errors` (one per field). This belongs as an explicit functional requirement so it isn't lost.
+- **GraphQL `path` requirement**: the spec already says `path` is preserved (FR-002) but doesn't explicitly require it to point at the failing field for catalogued field-level errors. Worth tightening — consumers like form validators rely on this.
+- **Telemetry / logging integration**: when an error is raised, the backend's structured logs and telemetry should include the catalogue `code` so on-call and analytics get the same identity. Cheap to add at the formatter, easy to forget if not stated.
+
+### Belongs in the plan (implementation notes to carry forward)
+
+- **GraphQL custom error formatter**: graphql-core's default `format_error` does not populate `extensions.code`/`data`. A custom formatter must be installed in `backend/infrahub/graphql/app.py` (around the place identified by the backend audit). This is also where exceptions wrapped via `GraphQLError(original_error=exc)` get their `extensions` field rendered.
+- **GraphQL/auth-short-circuit handler split**: the central handler at `backend/infrahub/api/exception_handlers.py:32` currently serves both `/api/...` and `/graphql` routes. It must detect when the caller is the `/graphql` route and emit GraphQL-shaped errors with the string `code` for that case (replacing the integer at `extensions.code` with the string identifier from the catalogue, and adding `http_status` + `data`). For `/api/...` routes the handler keeps its current shape — REST wire format is unchanged.
+- **Apollo `errorLink` migration**: `frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx:66` switches on `extensions?.code` as integer — must be rewritten to switch on the string code (`AUTHENTICATION_REQUIRED` / `TOKEN_EXPIRED` for refresh, `PERMISSION_DENIED` for the silent path) with `http_status` consulted only as a tie-breaker if needed. Same release as the backend formatter.
+- **Catalogue source-of-truth file**: open question — where in `backend/infrahub/` does the catalogue live? (`backend/infrahub/errors/catalogue.py`, alongside `exceptions.py`, or a new package?). Affects how generators discover it.
+- **Binding generators**: two generators are needed — frontend TypeScript (lives in this repo) and SDK Python (lives in the `python_sdk/` submodule = separate repo). The frontend generator runs in this repo's CI as `regenerate && git diff --exit-code` (the FR-009 sync check). The SDK generator runs in the SDK repository's own CI against the catalogue's published machine-readable schema (FR-012) — Infrahub's CI cannot enforce SDK freshness because submodule contents are managed by the submodule's repo, not the parent.
+- **Schema export**: the machine-readable schema file (FR-012) should be a build artefact, not a source file — same source as the bindings, just rendered to a third output (e.g. JSON Schema).
+- **Backward-compat shim consideration**: if we want a soft migration window for the GraphQL endpoint, the formatter could temporarily emit *both* `extensions.code` (string) AND a legacy `extensions.legacy_code` (int) for one release. Probably not worth it given the verified small blast radius (2 frontend files, both in this repo); flag for explicit decision.
+- **OpenAPI enrichment (Future Direction, out of scope for v1)**: scaffolding for per-endpoint error documentation in the OpenAPI schema. Each REST route would declare its possible error responses with catalogue code names. The catalogue source-of-truth file structure should be designed so this layering is straightforward later, even though no code in this release produces or consumes the enriched OpenAPI.
+
+### Belongs in the rollout plan / release notes
+
+- **Same-release coupling**: backend catalogue + GraphQL error formatter + auth-short-circuit GraphQL emission + frontend binding + Apollo errorLink migration MUST land in the same release (or the frontend will break on the auth path). REST endpoint bodies are not part of this coupling because their wire format is unchanged.
+- **SDK release coupling**: SDK bindings live in a separate repository (the `python_sdk/` submodule) with its own release cadence. Backend-side catalogue changes can land independently; the SDK repository pulls the catalogue's published schema and regenerates its bindings on its own schedule. The typed-exception adoption inside the SDK (the 8 message-string sites) is a discrete piece of work in the SDK repo that follows once its bindings are generated — coordinating release notes across the two repos is worth doing but the SDK is not blocked by Infrahub's CI and Infrahub is not blocked by the SDK's binding work.
+- **Documentation**: the docs page (FR-012) must list every v1 code with a worked example like §8a/§8b so integrators have a copy-pasteable starting point.
+
+---
+
+## 10. Decisions needed from reviewer
+
+Please confirm or revise:
+
+- **Q-D1**: Adopt the v1 catalogue list as proposed in §5 + §6 (9 codes, including auth split and validation split)?
+- **Q-D2** *(resolved 2026-05-15)*: ~~Adopt REST + GraphQL as a unified wire-format catalogue.~~ **Resolved**: REST keeps its current wire format; only GraphQL responses gain `extensions.code` + `extensions.data`. The Python catalogue is the shared source of truth across both transports, and OpenAPI is the long-term home for REST error documentation (captured as Future Direction in `spec.md`).
+- **Q-D3** *(partially applied 2026-05-15)*: Spec updates listed in §7 — Breaking Changes reframe, Transport assumption, `UNDEFINED_ERROR` catch-all (FR-015 + Edge Cases), `SC-008`, Future Direction section are **applied**. Outstanding: FR-005 final list (pending Q-D1), US1/US2 sub-code tightening (pending Q-D1), and the four FRs from Q-D5.
+- **Q-D4**: Adopt the worked example shapes in §8 as the canonical reference shape (acknowledging field names like `node_kind`, `field_name`, `expected_type` may still be refined during planning)?
+- **Q-D5**: Of the "Belongs in the spec" items in §9, which should be promoted into `spec.md` now (data evolution rules, per-error explosion, `path` requirement, telemetry/logging)? Default: all four.

--- a/dev/specs/infp-468-graphql-error-catalogue/spec.md
+++ b/dev/specs/infp-468-graphql-error-catalogue/spec.md
@@ -1,0 +1,211 @@
+# Feature Specification: Enriched GraphQL Error Catalogue
+
+**Feature Branch**: `graphql-error-catalogue-infp-468`
+**Created**: 2026-05-13
+**Status**: Draft
+**Jira Issue**: INFP-468
+**Linked Epic**: IFC-2279
+**Code-reference baseline**: `76395fd1c` (`stable` branch tip at the time of writing, 2026-05-13). All `file:line` references in this spec — and in the companion [discovery.md](./discovery.md) — were verified against that commit. If implementation lands later and lines have drifted, treat the file path as the authoritative anchor and re-locate the referenced code by symbol/content rather than by line number.
+**Input**: "Enrich GraphQL errors raised by Infrahub with a structured error code and a typed data payload exposed via the GraphQL `extensions` field, backed by an authoritative error catalogue used to generate bindings for the frontend and the Python SDK, with a CI check enforcing that those bindings stay in sync with the backend."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Structured Error Codes and Data in GraphQL Responses (Priority: P1)
+
+When a GraphQL query or mutation fails inside Infrahub, the response includes — for every error in the `errors` array — an `extensions` object containing a stable machine-readable `code` (such as `NODE_NOT_FOUND` or `PERMISSION_DENIED`) and a `data` object carrying the contextual information that is specific to that error kind (e.g. which node identifier was missing, which attribute violated which rule). The existing human-readable `message` is preserved unchanged so logs and ad-hoc tooling keep working.
+
+**Why this priority**: This is the foundation. Without a stable backend contract, no downstream consumer (frontend, SDK, integrations) can move off text parsing. Once this is in place, every other consumer story can be unblocked independently and incrementally. It also unlocks the multi-release rollout described in the Jira ticket, where additional error sites can opt into the catalogue over time.
+
+**Independent Test**: Can be fully tested by issuing a GraphQL request that triggers each error in the initial catalogue and asserting that the response includes `errors[*].extensions.code` matching the documented value and `errors[*].extensions.data` matching the documented shape for that code. No frontend or SDK changes are needed to verify this slice.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node ID that does not exist in the database, **When** a client issues an update or delete mutation targeting that ID, **Then** the response contains an entry in `errors` whose `extensions.code` equals `NODE_NOT_FOUND` and whose `extensions.data` identifies which kind and which identifier were searched for. (Note: GraphQL list queries for missing nodes return an empty array rather than an error — `NODE_NOT_FOUND` is surfaced by operations that require a specific node, e.g. update/delete mutations or single-node lookups.)
+2. **Given** a user without permission on a target node, **When** the user mutates that node, **Then** the response contains an entry in `errors` whose `extensions.code` equals `PERMISSION_DENIED` and whose `extensions.data` identifies the action and target sufficient for an integrator to log or message about it.
+3. **Given** a create or update mutation that omits a mandatory attribute, **When** the mutation is executed, **Then** an `errors` entry has `extensions.code` equal to a documented attribute-validation code and `extensions.data` includes the attribute name and node kind.
+4. **Given** a mutation that fails multiple field validations at once, **When** the mutation is executed, **Then** the response contains one entry in `errors` per failing field (rather than a single combined message), each with its own `code` and `data`.
+5. **Given** any error that is not yet covered by the catalogue, **When** that error is raised, **Then** the response still returns a well-formed GraphQL error (with `message`) so that uncovered errors degrade gracefully rather than breaking clients that already opted into structured handling.
+
+---
+
+### User Story 2 - Frontend Type-Safe Error Handling (Priority: P2)
+
+Frontend developers can import generated bindings that map each error `code` to the precise TypeScript type of its `data` payload, so the UI can branch on `code` and consume `data` with full type-safety — enabling field-level form validation (highlighting every invalid field in one pass) and reliable code-based control flow (e.g. permission dialogs vs. toast).
+
+**Why this priority**: Form-level validation and reliable control flow are the two most concrete UX wins called out by the frontend team in INFP-468 (Bilal's comment). Delivering this slice is what makes the catalogue user-visible in the product. It depends on US1 but is otherwise self-contained.
+
+**Independent Test**: Can be fully tested by generating the frontend bindings from the backend catalogue, writing a small consumer that switches on `code` and reads `data`, and confirming the consumer compiles with strict typing against each documented error. Form-validation use can be demonstrated by submitting a mutation with multiple invalid fields and verifying the UI highlights all of them simultaneously based solely on the structured response.
+
+**Acceptance Scenarios**:
+
+1. **Given** the generated frontend bindings, **When** a developer writes a handler that switches on the error `code`, **Then** the corresponding `data` payload is statically typed without manual casts and unknown codes are surfaced as a typed fallback branch.
+2. **Given** a form for creating a node, **When** the user submits with multiple invalid fields and the mutation returns multiple structured errors, **Then** the UI displays per-field error indicators on every offending field in a single round-trip.
+3. **Given** an error with `code` `PERMISSION_DENIED`, **When** the frontend receives the response, **Then** the UI routes the error through the permission-handling path (not the generic toast) based on `code` alone.
+
+---
+
+### User Story 3 - Python SDK Typed Errors (Priority: P3)
+
+Python SDK users receive errors from the SDK in a typed form (rather than parsing strings), aligned to the same catalogue, so SDK callers and SA-team integrations (Ansible, Nornir) can branch on a stable identifier and access the structured `data` per error.
+
+**Why this priority**: The SDK is the second-largest consumer of GraphQL errors after the frontend, and SDK consumers (including SA integrations) currently screen-scrape error text — a fragility called out in the Jira ticket. Like US2, this is self-contained on top of US1.
+
+**Independent Test**: Can be fully tested by invoking each catalogue error through the SDK, asserting the caller can branch on the typed identifier and read structured fields without parsing `message`, and confirming SDK behaviour does not depend on the wording of any error string.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Python script using the SDK, **When** the script makes a call that triggers `NODE_NOT_FOUND`, **Then** the caller can detect that condition by inspecting a typed identifier (not by string-matching the message) and read the missing identifier from a typed `data` field.
+2. **Given** a script that currently checks for "unable to find the node" in `message`, **When** rewritten to use the catalogue, **Then** it no longer depends on message wording and remains correct if the message is later rephrased.
+3. **Given** any error in the initial catalogue, **When** raised through the SDK, **Then** the SDK exposes the same `code` and the same `data` structure as the GraphQL response, with no information loss.
+
+---
+
+### User Story 4 - CI Enforcement of Frontend Binding Sync (Priority: P3)
+
+The Infrahub repository's CI fails any pull request in which the committed frontend bindings are out of date with the backend's authoritative error catalogue — preventing the catalogue from drifting silently between releases. SDK binding freshness is enforced by the SDK repository's own CI (since the SDK is a separate repo brought in here as a submodule) and is therefore out of scope for this user story.
+
+**Why this priority**: Without this, US2 will rot the first time a contributor adds, removes, or changes an error in the backend without regenerating the frontend bindings. It is cheap to add once US2 exists, and high-leverage for long-term maintainability. SDK sync is the SDK repo's responsibility against the catalogue's published schema (FR-012).
+
+**Independent Test**: Can be fully tested by intentionally modifying the backend catalogue without regenerating the frontend bindings, opening a pull request, and confirming CI fails with a clear message pointing the contributor at the regeneration command. Conversely, regenerating the bindings makes CI pass again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request that adds a new error code to the backend catalogue without updating the frontend bindings, **When** CI runs, **Then** CI fails and the failure message names the missing/outdated artefact and the command to regenerate it.
+2. **Given** a pull request that changes the shape of an existing error's `data` without regenerating frontend bindings, **When** CI runs, **Then** CI fails for the same reason.
+3. **Given** a pull request that updates both the catalogue and the regenerated frontend bindings consistently, **When** CI runs, **Then** the sync check passes.
+4. **Given** a pull request that touches only the backend catalogue, **When** CI runs, **Then** the SDK submodule is not inspected by this check (its sync is enforced upstream in the SDK repository).
+
+---
+
+### User Story 5 - Public Error Schema for Third-Party Consumers (Priority: P4)
+
+Operators and third-party integrators (outside the Infrahub repository) can obtain a machine-readable description of the error catalogue — every `code` and the shape of its `data` payload — so they can generate their own bindings or validate responses without copying source code from Infrahub.
+
+**Why this priority**: This is explicitly described in the Jira ticket as a "looking ahead" benefit. It is valuable but not on the critical path to fixing internal pain. Doing it as a separate slice avoids coupling community-facing surface to internal binding mechanics.
+
+**Independent Test**: Can be fully tested by fetching/exporting the published schema from a built Infrahub artefact and feeding it into a separate (non-Infrahub) code generator or validator that successfully reproduces typed bindings or validates a captured GraphQL response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a released Infrahub version, **When** an external consumer obtains the error catalogue schema, **Then** the schema lists every supported `code` and the structural definition of its `data` payload.
+2. **Given** an updated catalogue in a later Infrahub release, **When** the consumer pulls the new schema, **Then** changes (added, removed, modified codes) are detectable by diffing the schema between versions.
+
+---
+
+### Edge Cases
+
+- **Uncovered errors**: every **GraphQL** error response carries `extensions.code` without exception. When an internal error is raised that has not yet been adopted into the catalogue, the response carries `code = UNDEFINED_ERROR`. `UNDEFINED_ERROR` is a contract-level signal that the backend has a catalogue gap — its occurrence is treated as a bug to be triaged and either classified into a proper code or explicitly accepted as out-of-scope. GraphQL consumers can always rely on `extensions.code` being present, and their typed-fallback branch is the `UNDEFINED_ERROR` case rather than a "code missing" case.
+- **Multiple errors per response**: when a single request produces several distinct catalogue errors (e.g. multiple invalid form fields), all of them must appear in the `errors` array independently, each with their own `code` and `data`. Combining them into one error is not acceptable for the form-validation use case.
+- **Errors raised from nested resolvers** vs. top-level mutations: structured errors must be produced regardless of where in resolution they originate, and the GraphQL `path` continues to point at the offending field.
+- **Backward compatibility for text-based consumers**: existing scripts and dashboards that read `message` must continue to function; the catalogue adds structured information without removing or altering the existing `message` field's intent.
+- **Sensitive data in `data` payloads**: structured payloads must not leak information that the requesting user would not otherwise be entitled to see (e.g. existence of objects they have no permission on, internal IDs in security-sensitive contexts).
+- **Partial mutation success**: when a mutation that touches multiple records partially fails, the structured errors must allow a caller to identify which record(s) failed without re-querying.
+- **Catalogue change without binding regeneration**: see US4 — must fail CI rather than producing a silently broken release.
+- **REST API errors raised by the same backend code paths**: the underlying backend exception classes are shared (a single Python catalogue is the source of truth), but REST response bodies under `/api/...` continue to behave as today — the wire-format change in this feature is scoped to GraphQL. REST's discovery surface for consumers is the OpenAPI schema; the long-term direction is for that schema to enumerate the possible error responses per endpoint, referencing catalogue codes by name. Carrying out that OpenAPI enrichment is out of scope for v1 (see Future Direction).
+- **Apollo client compatibility**: the chosen `extensions` shape must be consumable by Apollo Client without custom link middleware beyond what is already in use (named out as a verification requirement in the Jira ticket).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST emit, on every GraphQL error that originates from a catalogued condition, an `extensions` object containing a `code` field (a stable string identifier) and a `data` field (a structured object whose shape is defined by the catalogue for that `code`).
+- **FR-002**: System MUST preserve the existing GraphQL `message`, `locations`, and `path` fields on every error in the response, so that consumers that have not adopted the catalogue continue to work.
+- **FR-003**: System MUST return one entry in the GraphQL `errors` array per distinct catalogued failure within a single request (e.g. multiple invalid fields produce multiple entries, not one combined entry).
+- **FR-004**: System MUST maintain a single authoritative definition of each catalogue error inside the Infrahub backend codebase, with the `data` shape declared as a strongly-typed Python structure (i.e. not free-form dictionaries), so the catalogue cannot drift from what the backend actually emits.
+- **FR-005**: System MUST determine the initial set of catalogued error codes through an explicit analysis of currently-raised errors in the backend, prioritising codes whose structured `data` payload would be materially useful to consumers (frontend and SDK). A code MAY be admitted to the initial catalogue with an empty `data` object (`{}`) when no useful payload has yet been identified, provided the code itself enables programmatic handling. The principle is "right and useful over many". The analysis output (codes + payloads + rationale) becomes part of the planning artefacts for this feature.
+- **FR-006**: System MUST provide a machine-consumable description of the catalogue (every `code` and the schema of its `data`) suitable for code generation, distinct from the GraphQL schema (which cannot natively represent the dynamic per-code shape of `data`).
+- **FR-007**: System MUST generate type-safe frontend bindings from the authoritative catalogue such that frontend code branching on `code` receives a precisely typed `data` payload, with a typed fallback for unknown codes.
+- **FR-008**: System MUST generate Python SDK bindings from the same authoritative catalogue, exposing the same identifiers and `data` shapes to SDK consumers without forcing them to parse the GraphQL `message` text.
+- **FR-009**: The Infrahub repository's CI MUST include a check that fails when the committed **frontend** bindings do not match what would be regenerated from the current backend catalogue. The failure message MUST point at the regeneration command. SDK bindings live in the `python_sdk/` submodule and are out of scope for the Infrahub repository's CI — keeping the SDK in sync is the responsibility of the SDK repository's own CI, which consumes the catalogue's machine-readable schema (FR-012) as an external input.
+- **FR-010**: System MUST clearly state in user-facing documentation which `code` values, and which fields of `data`, are part of the stable contract, and which (if any) are still considered evolving — so integrators know what they can rely on across releases.
+- **FR-011**: System MUST place the string error identifier at `extensions.code` (aligning with Apollo / GraphQL ecosystem convention) and MUST move the HTTP status integer — currently carried at `extensions.code` — to a dedicated `extensions.http_status` field, so the two pieces of information no longer collide on the same key.
+- **FR-012**: System MUST expose the error catalogue through **both** of the following surfaces: (a) a human-browsable documentation page generated from the catalogue source so developers and integrators can review every code, its `data` shape, its description, and its stability status; and (b) a machine-readable schema file shipped with each build so code generators (internal and third-party) can consume the catalogue without scraping the docs.
+- **FR-013**: System MUST not include in `extensions.data` any information about an object that the requesting user is not entitled to see (e.g. confirming a node exists when permission is denied).
+- **FR-014**: System MUST keep `code` values stable across releases once published — adding new codes is allowed at any time, removing or renaming a published code constitutes a breaking change and MUST follow Infrahub's existing deprecation policy.
+- **FR-015**: System MUST surface uncovered (not-yet-catalogued) errors raised through the **GraphQL** response with `extensions.code = "UNDEFINED_ERROR"` so every GraphQL error response carries a `code` without exception. `UNDEFINED_ERROR` is reserved as the always-present fallback identifier and its occurrence is treated as a bug (the catalogue has a gap that should be filled or explicitly accepted as out-of-scope). The human-readable `message` continues to be populated, and the rollout can be incremental across multiple releases — uncovered errors degrade gracefully into `UNDEFINED_ERROR` rather than breaking the contract.
+
+### Key Entities
+
+- **Error Catalogue**: The single authoritative list of error definitions inside the Infrahub backend. Each entry has a stable `code` (string identifier), a structured `data` schema, a human-readable description, and stability metadata (stable vs. evolving).
+- **Error Code**: A stable string identifier such as `NODE_NOT_FOUND` or `PERMISSION_DENIED`. Uppercase snake_case, namespaceable if future growth warrants it.
+- **Error Data Payload**: The structured object specific to one error code, carrying the contextual information a consumer needs to react (e.g. which attribute name was missing, which kind was searched). Defined alongside the code in the catalogue.
+- **Error Binding**: A generated artefact in a consumer codebase (frontend TypeScript types; Python SDK types/exceptions) that mirrors the catalogue and allows that consumer to handle errors in a type-safe way.
+- **Catalogue Schema**: The machine-readable description of the whole catalogue (every code + every data shape) used to generate bindings and, in the future, consumed by third parties.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of catalogued errors returned by the backend carry both `extensions.code` and `extensions.data` matching the published schema for that code, verified by an end-to-end test that triggers each catalogued error.
+- **SC-002**: Frontend handlers can branch on every catalogue error using `code` alone, with zero string parsing of `message` in product code — measurable by static-analysis count of `message`-string-matching call sites in the frontend (target: 0 net new, and a reduction in pre-existing ones for the catalogued errors).
+- **SC-003**: Python SDK callers can match every catalogue error without parsing `message`, demonstrated by removing all existing message-string checks for the catalogued errors from the SDK and replacing them with typed checks.
+- **SC-004**: When a user submits a form with N invalid fields, the UI displays an error indicator on every one of the N fields after a single submit (no fix-submit-fix-submit cycle), verified by an end-to-end test.
+- **SC-005**: Any pull request to the Infrahub repository that changes the backend catalogue without regenerating the frontend bindings fails CI with a self-explanatory message — verified by an intentional sync-break test in CI. (SDK sync is enforced by the SDK repository's own CI against the catalogue's published schema.)
+- **SC-006**: For every catalogued error, a developer (or integrator) reading the catalogue documentation can determine the `code`, the exact shape of `data`, and whether the contract is stable, in under one minute without reading backend source code.
+- **SC-007**: Adoption is incrementally measurable: at every release, the count of catalogued error codes is published, so we can track coverage growth over the multi-release rollout described in the Jira ticket.
+- **SC-008**: 100% of GraphQL error responses carry `extensions.code` — verified by an integration test that triggers every catalogued error plus a synthetic uncovered exception, asserting `UNDEFINED_ERROR` for the synthetic case and the specific code for each catalogued case. The occurrence rate of `UNDEFINED_ERROR` in production is observable so it can be driven toward zero over successive releases.
+
+## Breaking Changes
+
+This feature includes one intentional breaking change, scoped to the **GraphQL** error contract. REST endpoint response bodies under `/api/...` are not affected by this work. The change is small in scope but must be called out explicitly and surfaced in release notes.
+
+### What changes
+
+In **GraphQL error responses**, the `extensions.code` field is being repurposed:
+
+| Before                                            | After                                                  |
+|---------------------------------------------------|--------------------------------------------------------|
+| `extensions.code` is an integer HTTP status       | `extensions.code` is a string error identifier         |
+| (e.g. `401`, `403`)                               | (e.g. `NODE_NOT_FOUND`, `PERMISSION_DENIED`)           |
+| HTTP status is **not** otherwise represented in the error payload | HTTP status moves to a new `extensions.http_status` field (integer) |
+| `extensions.data` does not exist                  | `extensions.data` carries a typed payload defined by the catalogue for that `code` |
+
+### Why
+
+`extensions.code` carrying a string error identifier is the GraphQL ecosystem convention (Apollo Server's default; widely expected by GraphQL tooling and third-party integrators). The integer at `extensions.code` is actually emitted today by Infrahub's REST exception handler when a request to the `/graphql` endpoint is short-circuited by FastAPI middleware (e.g. auth rejection before GraphQL execution runs). Aligning the GraphQL wire format with the ecosystem convention now — before the catalogue is published — avoids permanently diverging from how GraphQL consumers expect the field to behave, and prevents Infrahub from needing a second non-standard error-identifier field forever.
+
+### Out of scope for this breaking change
+
+- **REST endpoints under `/api/...`**: response bodies keep their current behaviour. The OpenAPI schema is the discovery surface for REST consumers (see Future Direction).
+- **Frontend's other Apollo paths**: unchanged unless they currently read `extensions.code` as an integer.
+
+### Blast radius (verified)
+
+- **Frontend**: two call sites in the Infrahub frontend currently read `extensions.code` as an integer (`graphqlClientApollo.tsx:66`, `pages/login.tsx:27-29`). Both consume GraphQL-bound error responses (auth-short-circuit case). Both must be migrated in the same release that introduces the new contract.
+- **Python SDK** (this repo's `python_sdk/` submodule): the SDK's `GraphQLError` exception class bundles the raw `errors` array but does not itself introspect `extensions.code`. No SDK code change is forced by this rename — adopting the new typed `code` is pure addition.
+- **External GraphQL integrations**: SA-team integrations (Ansible, Nornir) and any third-party GraphQL consumer that today reads `extensions.code` from a GraphQL response as an integer will need to update. The probability is assessed as low (the prior integer convention is non-standard and lightly used at the GraphQL endpoint) but cannot be guaranteed for code outside this repository.
+
+### Release-notes requirement
+
+The release containing this feature MUST include, in the user-facing release notes, an entry that:
+
+1. Calls out that GraphQL `extensions.code` has changed from integer (HTTP status) to string (error identifier), and that REST `/api/...` response bodies are unaffected.
+2. Names the new `extensions.http_status` field on GraphQL responses.
+3. Points to the new error catalogue documentation (FR-012).
+4. Provides a short migration snippet for the most likely consumer pattern (`if (extensions.code === 401)` → `if (extensions.http_status === 401)` or, preferably, switching on the string identifier).
+
+## Assumptions
+
+- **Transport**: The wire-format contract introduced by this feature is GraphQL-only. The Python error catalogue is a shared source of truth (the same backend exception classes are raised regardless of which transport surfaced them), but the `extensions.code` / `extensions.data` shape is added to GraphQL responses only. REST API response bodies under `/api/...` continue to behave as today. REST consumers discover possible errors per endpoint via the OpenAPI schema (see Future Direction for the long-term plan to enrich that schema).
+- **Catalogue location**: The authoritative catalogue lives in the Infrahub backend repository. Frontend and SDK consumers receive generated, checked-in artefacts so that consumers can build without running the backend.
+- **CI scope**: The Infrahub repository's CI sync check covers frontend bindings only. The Python SDK is a Git submodule with its own repository and its own CI — Infrahub's CI cannot enforce the SDK's binding freshness, and the SDK's contents are not modified by PRs against this repository. Keeping the SDK bindings in sync is the SDK repository's responsibility, using the catalogue's machine-readable schema (FR-012) as an external input (likely fetched from a tagged Infrahub release artefact). This is a cross-repo workflow, not a within-repo CI check.
+- **Rollout shape**: Per the Jira ticket, the catalogue grows over multiple releases. The first release establishes the contract and the tooling (catalogue, bindings, CI), and includes a small initial set of high-value error codes. Subsequent releases adopt additional error sites without breaking the contract.
+- **Message stability**: The human-readable `message` field is preserved but is explicitly not part of the stable contract. Consumers that want stability must move to `code` + `data`.
+- **Naming convention**: `code` values use uppercase snake_case (e.g. `NODE_NOT_FOUND`) for consistency with the examples in the Jira ticket.
+- **Initial-coverage method**: rather than pre-committing a numeric count of error codes for v1, the planning phase produces an analysis of currently-raised errors and selects those whose programmatic handling delivers concrete consumer value (form validation, control flow, permission UX). Codes whose `data` payload is not yet useful are still allowed to ship with `data: {}`. See FR-005.
+- **`code` field semantics**: the string error identifier lives at `extensions.code` (Apollo / GraphQL convention). The integer HTTP status that previously occupied `extensions.code` moves to `extensions.http_status`. See Breaking Changes.
+- **Catalogue surfaces**: both a generated documentation page and a machine-readable schema file are produced from the same authoritative source.
+- **Apollo compatibility**: The chosen extensions shape works with Apollo Client out of the box (no exotic transport configuration on the consumer side). This is called out as a verification item from the Jira ticket.
+- **Public schema timing**: User Story 5 (third-party schema export) is "looking ahead" and may land in a follow-up release; it is not blocking for the internal-pain-point fix that motivates this work.
+
+## Future Direction *(out of scope for v1, captured to keep the long-term shape coherent)*
+
+- **REST API error documentation via OpenAPI**: REST endpoints under `/api/...` should eventually have their possible error responses enumerated directly in the OpenAPI schema, per endpoint, referencing catalogue codes by name (e.g. `"This endpoint may raise NODE_NOT_FOUND, PERMISSION_DENIED."`) and ideally including the structured `data` shape for each. This makes the OpenAPI schema the authoritative discovery surface for REST consumers — analogous to what the catalogue documentation does for GraphQL — and removes any need for a duplicated string `code` in REST response bodies. Carrying this out is a separate piece of work; this v1 spec only requires that the catalogue source-of-truth in Python is structured so that the OpenAPI enrichment can be layered on later without rewriting it.
+- **Third-party GraphQL schema export**: User Story 5 captures this; the machine-readable catalogue schema can be consumed by external integrators to generate their own bindings.
+- **Catalogue coverage growth**: the Jira ticket frames this work as multi-release. Subsequent releases adopt additional backend exception classes into the catalogue, reducing the occurrence rate of `UNDEFINED_ERROR` toward zero.
+
+## Dependencies
+
+- INFP-468 (this work) blocks INFP-393 ("Improve repository synchronization logs"), which expects more granular error reporting.
+- Linked Epic IFC-2279 ("[Spike] Enrich GraphQL errors raise by Infrahub") provides the prior discovery context referenced throughout this spec.
+- Historical/related items providing context (not blockers): IFC-551, IFC-2026, IHS-98, community GitHub issue #143.


### PR DESCRIPTION
# Why

Adds specifications for INFP-468

## What changed

* Speckit markdown files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SpecKit spec for a structured GraphQL error catalogue that replaces message parsing with stable codes and typed data, enabling type-safe handling in the frontend and SDK per INFP-468. The spec scopes the wire-format change to GraphQL, moves the HTTP integer to `extensions.http_status`, and defines `UNDEFINED_ERROR` as a fallback.

- **New Features**
  - Added `spec.md`, `discovery.md`, and a quality checklist under `dev/specs/infp-468-graphql-error-catalogue/`.
  - Defines GraphQL error shape: `extensions.code` (string), `extensions.data` (typed), `extensions.http_status` (int); preserves `message`.
  - GraphQL-only on the wire; REST unchanged. OpenAPI is the long-term surface for REST error docs (Future Direction added).
  - Proposes an initial catalogue with worked examples (e.g., `NODE_NOT_FOUND`, validation sub-codes), plus `UNDEFINED_ERROR` and a “code-always-present” invariant.
  - Requires a machine-readable schema and generated bindings; CI enforces frontend bindings stay in sync (SDK sync handled in its own repo).
  - Captures open decisions (v1 code list, canonical shapes, additional FRs) and verifies a small blast radius (two frontend sites).

<sup>Written for commit 9fc28a33ee3120436601669da06c907394f0f48b. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9260?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

