### PR TITLE
Add exclude_path configuration to lychee.toml

### DIFF
--- a/dev/lychee.toml
+++ b/dev/lychee.toml
@@ -1,1 +1,5 @@
 offline = true
+exclude_path = [
+  "dev/specs",
+  "specs",
+]


### PR DESCRIPTION
skip specs in the link checker

specs can refer to files that do not exist yet, so I think they should be excluded from the link checker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip link checking in spec directories to avoid false positives from WIP references. Adds `exclude_path` in `lychee.toml` to exclude `dev/specs` and `specs`.

<sup>Written for commit 72c1e5a3ada9dde7ae11d170dd6bcf2fe95978c9. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

