### PR TITLE
Fix bug-fixing commands

### DIFF
--- a/dev/bug-pipeline/fix-implementation.md
+++ b/dev/bug-pipeline/fix-implementation.md
@@ -1,0 +1,134 @@
+# Fix implementation steps
+
+These are the shared steps for implementing a bug fix.
+Read this file when directed by your main prompt.
+
+Before starting, you should already have:
+- The root cause analysis (root cause, affected files, fix strategy)
+- The PR with the failing test
+- The working branch checked out
+
+## Step 1: Read fix strategy
+
+Read the analyst's fix strategy. This is your **starting point**: follow the recommended
+approach, scope, and "Do NOT" guardrails. If you believe the strategy is wrong after reading
+the code, explain why before deviating -- do not silently ignore it.
+
+## Step 2: Read failing test
+
+Read the failing test in the PR diff. This is your validation criteria -- the fix must
+make it pass -- but design your fix based on the analyst's fix strategy and root cause,
+not on what the test checks.
+
+## Step 3: Reason about the fix
+
+Before writing any code, reason explicitly about the fix:
+- Is the root cause a shallow symptom (null check, off-by-one) or a deeper design issue?
+- If shallow: a targeted fix is appropriate.
+- If deeper: a proper fix may require refactoring the affected component.
+  In that case, do it: do NOT paper over a design flaw with a guard clause.
+
+## Step 4: Implement the fix
+
+- Fix the actual root cause, not just the symptom.
+- Do NOT change the test the test-writer wrote.
+- Do NOT refactor code unrelated to the root cause.
+- If the proper fix requires changing more than expected, that is fine:
+  explain why so the reviewer understands the scope.
+- Stage files by name (`git add path/to/file`) -- never use `git add .` or `git add -A`,
+  as unrelated files in the working tree will be committed by mistake.
+- Commit the fix with an explicit commit message.
+
+## Step 5: Verify replication test passes
+
+Run the specific test the test-writer wrote using the same runner they used:
+- Backend: `uv run pytest path/to/test_file.py::TestClass::test_name -x -v`
+- Frontend unit/component: `cd frontend/app && npm run test path/to/test`
+- Frontend E2E: `cd frontend/app && npx playwright test path/to/test`
+- If the test still FAILS, revisit your fix. Do NOT proceed until it passes.
+- Before continuing, verify `git diff` shows no changes to the test file(s) from the
+  test-writer's PR. If you accidentally modified a test file, revert those changes.
+
+## Step 6: Pre-CI checks
+
+Run pre-CI checks before pushing. Fix any issues they surface and commit the fixes
+separately (do NOT amend previous commits).
+
+**Phase 1 -- Auto-fix formatting (sequential, in this order):**
+```bash
+uv run invoke format
+uv run invoke docs.format
+(cd frontend/app && npx biome check --write .)
+```
+
+If Phase 1 changed any source files, you must re-run from Phase 2.
+
+**Phase 2a -- Regenerate schemas (run in parallel):**
+- `uv run invoke backend.generate`
+- `uv run invoke schema.generate-graphqlschema`
+- `uv run invoke schema.generate-jsonschema`
+- `uv run invoke docs.generate`
+
+**Phase 2b -- Lint & frontend codegen (run in parallel, after 2a completes):**
+- `uv run invoke main.lint`
+- `uv run invoke backend.lint`
+- `uv run invoke docs.lint`
+- `(cd frontend/app && npm run codegen:graphql)`
+- `(cd frontend/app && npm run codegen:openapi)`
+- `(cd frontend/app && npx betterer --update)`
+
+Stage any files changed by generation or betterer by name (`git add path/to/file`)
+-- never use `git add .` or `git add -A`.
+
+**Phase 3 -- Unit tests:**
+```bash
+uv run invoke backend.test-unit
+```
+If the fix touches frontend code, also run:
+```bash
+cd frontend/app && npm run test
+```
+
+If any check fails, fix the issue and re-run that check before proceeding.
+
+**Phase 4 -- Changelog entry:**
+Create a changelog fragment for this bug fix. Use the issue number and the `fixed` type:
+```bash
+uv run towncrier create -c "<user-facing description of what was fixed>" <issue_number>.fixed.md
+```
+Write the message from the user's perspective, in past tense, one sentence, no technical
+jargon (see `dev/guidelines/changelog.md`). Commit the generated file.
+
+## Step 7: Scope check
+
+If the fix requires changes to more than ~10 files or fundamentally alters a public API
+contract, **STOP** and escalate as described in your main prompt.
+
+## Step 8: Update the PR
+
+- Update the PR title to: `fix: <short description> (closes #<issue number>)`
+- Update the PR body: read the file `.github/pull_request_template.md` from the
+  repository and fill in every section using the context from this task.
+  Do not skip or remove any section from the template. For sections where you have
+  nothing meaningful to add (e.g., Screenshots), write "N/A" rather than inventing content.
+- Make sure the hidden marker `<!-- AGENT_FIX_COMPLETE -->` appears
+  somewhere in the PR body: it is used by downstream automation to detect this PR.
+- Use `gh pr edit` to update the title and body.
+
+## Step 9: Push
+
+**Push your fix commits to the PR branch LAST** (after the PR body update):
+```bash
+git push -u origin <branch>
+```
+
+Post a comment on the issue linking to the updated PR.
+
+## When to stop
+
+If at any point you determine that:
+- The analyst's root cause is incorrect and the real cause is substantially different,
+- The test cannot be made to pass with a correct fix (i.e., it tests the wrong behavior),
+- The fix is beyond the scope an automated agent should handle,
+
+then **STOP** and escalate as described in your main prompt. Do NOT push to the PR.

--- a/dev/bug-pipeline/fix-implementation.md
+++ b/dev/bug-pipeline/fix-implementation.md
@@ -43,8 +43,8 @@ Before writing any code, reason explicitly about the fix:
 
 Run the specific test the test-writer wrote using the same runner they used:
 - Backend: `uv run pytest path/to/test_file.py::TestClass::test_name -x -v`
-- Frontend unit/component: `cd frontend/app && npm run test path/to/test`
-- Frontend E2E: `cd frontend/app && npx playwright test path/to/test`
+- Frontend unit/component: `cd frontend/app && pnpm run test path/to/test`
+- Frontend E2E: `cd frontend/app && pnpm exec playwright test path/to/test`
 - If the test still FAILS, revisit your fix. Do NOT proceed until it passes.
 - Before continuing, verify `git diff` shows no changes to the test file(s) from the
   test-writer's PR. If you accidentally modified a test file, revert those changes.
@@ -58,7 +58,7 @@ separately (do NOT amend previous commits).
 ```bash
 uv run invoke format
 uv run invoke docs.format
-(cd frontend/app && npx biome check --write .)
+(cd frontend/app && pnpm exec biome check --write .)
 ```
 
 If Phase 1 changed any source files, you must re-run from Phase 2.
@@ -73,9 +73,9 @@ If Phase 1 changed any source files, you must re-run from Phase 2.
 - `uv run invoke main.lint`
 - `uv run invoke backend.lint`
 - `uv run invoke docs.lint`
-- `(cd frontend/app && npm run codegen:graphql)`
-- `(cd frontend/app && npm run codegen:openapi)`
-- `(cd frontend/app && npx betterer --update)`
+- `(cd frontend/app && pnpm run codegen:graphql)`
+- `(cd frontend/app && pnpm run codegen:openapi)`
+- `(cd frontend/app && pnpm exec betterer --update)`
 
 Stage any files changed by generation or betterer by name (`git add path/to/file`)
 -- never use `git add .` or `git add -A`.
@@ -86,7 +86,7 @@ uv run invoke backend.test-unit
 ```
 If the fix touches frontend code, also run:
 ```bash
-cd frontend/app && npm run test
+cd frontend/app && pnpm run test
 ```
 
 If any check fails, fix the issue and re-run that check before proceeding.

--- a/dev/bug-pipeline/investigation.md
+++ b/dev/bug-pipeline/investigation.md
@@ -1,0 +1,74 @@
+# Investigation
+
+These are the shared investigation steps for bug analysis.
+Read this file when directed by your main prompt.
+
+## Issue clarity check
+
+Verify the issue has enough information to work with:
+
+| Required | Description |
+|----------|-------------|
+| **Clear problem statement** | Can you understand what the bug actually is? |
+| **Reproduction path** | Are there steps to reproduce, OR can you infer them from the description? |
+| **Expected vs actual** | Is it clear what should happen vs what happens? |
+
+Rate the clarity:
+- **CLEAR**: intent, reproduction scenario, and expected behavior are understandable (even if some details like affected release are missing).
+- **UNCLEAR**: the intent and reproduction scenario are not understandable.
+
+If the bug is UNCLEAR, **STOP** here and escalate as described in your main prompt.
+
+## Investigate the codebase
+
+1. Read root `AGENTS.md` and `dev/documentation-architecture.md` in order to determine which code packages are related to the issue. Then:
+   - If you can determine the code package related to the bug, rate the code identification step as RESOLVED.
+   - If you cannot determine the code package related to the bug, rate the code identification step as EXPLORATION REQUIRED, and explore the code base.
+
+2. Read the relevant source files in the affected area to understand the current behavior.
+
+3. Identify the most likely root cause(s) -- point to specific files and lines.
+   - If you **cannot** identify a root cause after exploration, **STOP** and escalate
+     as described in your main prompt.
+
+4. Formulate a fix strategy. This is NOT the exact code -- it is the recommended approach:
+   - **Approach:** What should the fixer do and where? Reference existing functions/methods
+     that should be reused rather than reimplemented.
+   - **Scope:** Which files/functions need changes? How large should the change be?
+   - **Do NOT:** List common wrong approaches (e.g., adding a guard clause when the real
+     fix is a missing validation, creating new abstractions when an existing one should be reused).
+
+## Analysis template
+
+Write the analysis output using this structure (replace all `<placeholders>`):
+
+````markdown
+## Root cause analysis for #<issue_number>
+
+**Issue:** <issue title>
+**Based on:** `<commit SHA of origin/stable>`
+**Bug clarity:** CLEAR
+**Code identification:** RESOLVED | EXPLORATION REQUIRED
+
+### Root cause
+<one-sentence summary>
+
+### Affected files
+- `path/to/file.ext` -- line X: <why this is the culprit>
+
+### Explanation
+<detailed reasoning>
+
+## Fix strategy
+
+**Approach:** <recommended fix approach -- explain WHAT to do and WHERE, not the exact code>
+
+**Scope:** <which files/functions should need changes, and roughly how large the change should be>
+
+**Do NOT:**
+- <guardrail 1 -- common wrong approach to avoid>
+- <guardrail 2 -- unnecessary refactoring to avoid>
+
+## Notes for downstream steps
+<edge cases, risks, or constraints the test-writer and fixer should know about>
+````

--- a/dev/bug-pipeline/test-writing.md
+++ b/dev/bug-pipeline/test-writing.md
@@ -1,0 +1,184 @@
+# Test-writing steps
+
+These are the shared steps for writing a failing test that reproduces a confirmed bug.
+Read this file when directed by your main prompt.
+
+Before starting, you should already have:
+- The root cause analysis (root cause, affected files, fix strategy)
+
+## Step 0: Create working branch
+
+Create a working branch from `origin/stable`:
+
+```bash
+git fetch origin stable
+git checkout -b ai-bug-pipeline-<issue_number>-<short-slug> origin/stable
+```
+
+- Name: `ai-bug-pipeline-<issue_number>-<short-slug>` (lowercase, hyphens only, max 50 chars total).
+- If the branch already exists, check it out instead of creating a new one.
+
+## Step 1: Read testing documentation
+
+Read root `AGENTS.md` and `dev/documentation-architecture.md` to understand the project
+structure and determine which code packages are related to the bug. Then read the testing
+guidelines relevant to the bug:
+- Backend bugs -- read BOTH of these:
+  - `dev/knowledge/backend/testing.md` (test infrastructure, fixtures, test types)
+  - `dev/guidelines/backend/testing.md` (testing standards, patterns, best practices)
+- Frontend bugs -- read ALL of these:
+  - `dev/guides/frontend/writing-unit-tests.md`
+  - `dev/guides/frontend/writing-component-tests.md`
+  - `dev/guides/frontend/writing-e2e-tests.md`
+
+## Step 2: Read conftest files
+
+Read the `conftest.py` files in the target test directory AND its parent directories
+(up to `backend/tests/conftest.py`) to understand available fixtures, their scopes,
+and setup/teardown patterns. Do NOT reinvent setup logic that already exists as a fixture.
+
+## Step 3: Check reusable utilities
+
+Check `backend/tests/helpers/` and `backend/tests/adapters/` for reusable utilities:
+- `helpers/test_app.py` -- base test classes (`TestInfrahub`, `TestInfrahubApp`)
+- `helpers/graphql.py`, `helpers/events.py`, `helpers/db_validation.py` -- domain helpers
+- `adapters/` -- `BusRecorder`, `BusSimulator`, `MemoryCache`, `FakeLogger`
+Use these instead of writing your own test infrastructure.
+
+## Step 4: Read existing tests
+
+Read 2--3 existing tests in the target test directory to understand naming conventions,
+class structure, and import patterns before writing your own test.
+
+## Step 5: Choose the test type
+
+Use the "When to use" / "When NOT to use" guidance in
+`dev/knowledge/backend/testing.md` and the testing standards in
+`dev/guidelines/backend/testing.md` to pick the right test level.
+- **Backend:** pytest. Types: unit (`backend/tests/unit/`), component (`backend/tests/component/`),
+  functional (`backend/tests/functional/`), integration docker (`backend/tests/integration_docker/`).
+  Use existing schema fixtures and helpers when available.
+- **Frontend:** Vitest for unit/component tests (colocated with source as `.test.ts`),
+  Playwright for E2E (`frontend/app/tests/e2e/`).
+  Use BDD GIVEN/WHEN/THEN structure. Use factories from `tests/fake/`.
+
+## Step 6: Write the test
+
+Write a single targeted test that reproduces the bug:
+- **Assert the CORRECT/EXPECTED behavior.** The test fails because the bug prevents the
+  expected behavior from happening. Do NOT assert that the buggy behavior succeeds.
+  For example: if the bug is "duplicate branches can be created," assert that the second
+  creation raises an error or that only one branch exists. This assertion will FAIL on
+  buggy code (because the error is not raised / duplicates exist) and PASS once fixed.
+- The test MUST exercise the **actual production code path**, not a reimplementation of it.
+  Call the real functions/classes from the source code. Do NOT copy production logic
+  into the test file.
+- Test **observable behavior**, not internal implementation details. For example, test that
+  an API returns wrong data or that a constraint is violated -- do NOT test that a specific
+  constructor receives specific kwargs.
+- **Test the affected code path.** The test should exercise the code identified
+  in the analyst's "Affected files" section, not a lower-level abstraction.
+  If the analyst identified a bug in a workflow function, test that function -- do not
+  test the raw database operation it calls internally. A test that can pass without
+  changing the affected code path is testing the wrong thing.
+- Place it in the correct test folder following project conventions.
+  Test files mirror source structure: `infrahub/core/foo.py` -> `tests/unit/core/test_foo.py`
+- If adding to an existing test file is more appropriate than creating a new one, do that.
+
+## Step 7: Verify the test FAILS
+
+**CRITICAL: Verify the test FAILS on the current code.** Run it:
+- Backend: `uv run pytest path/to/test_file.py::TestClass::test_name -x -v`
+- Frontend unit/component: `cd frontend/app && npm run test path/to/test`
+- Frontend E2E: `cd frontend/app && npx playwright test path/to/test`
+- If a test run takes more than 5 minutes, kill it and investigate why.
+- The test must fail with an **assertion error that directly relates to the root cause**
+  described by the analyst. For example, if the root cause is "no uniqueness enforcement,"
+  the failure should be something like `AssertionError: Expected ValidationError but none
+  was raised` or `assert 2 == 1` (found 2 duplicates when expecting 1).
+- If the test **PASSES**, your assertions are wrong -- you are likely asserting buggy
+  behavior instead of correct behavior. Flip your assertions to assert what SHOULD happen.
+- If the test fails for the **wrong reason** (import error, fixture missing, syntax error),
+  fix those issues and re-run until it fails for the reason described in the root cause.
+
+## Step 8: Format and lint
+
+Run formatting and linting on the test file(s). Fix any issues before committing.
+
+**Format** Python code:
+```bash
+uv run invoke format
+```
+
+**Lint** (YAML, Ruff, ty, mypy, markdownlint, vale):
+```bash
+uv run invoke lint
+```
+
+**Frontend** (if applicable):
+```bash
+cd frontend/app && npx biome check --write .
+```
+
+## Step 9: Commit test files
+
+Commit ONLY the test file(s). Do NOT touch production code.
+Stage files by name (`git add path/to/test_file.py`) -- never use `git add .` or
+`git add -A`, as unrelated files in the working tree will be committed by mistake.
+Use commit message: `test: add failing test for #<issue_number>`
+
+## Step 10: Open draft PR
+
+Push the branch and open a **draft Pull Request**:
+
+```bash
+git push -u origin <branch>
+gh pr create --draft --base stable --title "<title>" --body-file .agent-tmp/gh-body.md
+```
+
+Write the PR body to `.agent-tmp/gh-body.md` first (using the Write tool), then pass it
+via `--body-file`.
+
+- Title: `test: failing test for #<issue_number> -- <short description>`
+- Target branch: `stable`
+- PR body with this exact structure:
+
+````markdown
+## Analyst's findings (summary)
+
+> **Root cause:** <copied from analysis>
+> **Affected files:**
+> <copied from analysis>
+
+## Replication test
+
+**Test file:** `path/to/test_file.ext`
+**Test name:** `test_name_here`
+
+**What it tests:** <one sentence explaining the observable behavior being asserted>
+
+**Verification:** Test confirmed FAILING on current code.
+**Failure reason:** <one sentence explaining HOW the test fails and why that proves the bug>
+
+<details><summary>Failure output (last 20 lines)</summary>
+
+```
+<paste the relevant failure output>
+```
+
+</details>
+
+## Test expectations
+
+<what the test asserts and any edge cases it covers -- NOT how to fix the bug>
+
+<!-- AGENT_TEST_COMPLETE -->
+````
+
+Post a short comment on the issue linking to the draft PR.
+
+## Failure handling
+
+If the test cannot be made to fail for the right reason after 3 attempts, **STOP**
+and escalate as described in your main prompt. Do NOT open a PR or include the
+`AGENT_TEST_COMPLETE` marker.

--- a/dev/bug-pipeline/test-writing.md
+++ b/dev/bug-pipeline/test-writing.md
@@ -89,8 +89,8 @@ Write a single targeted test that reproduces the bug:
 
 **CRITICAL: Verify the test FAILS on the current code.** Run it:
 - Backend: `uv run pytest path/to/test_file.py::TestClass::test_name -x -v`
-- Frontend unit/component: `cd frontend/app && npm run test path/to/test`
-- Frontend E2E: `cd frontend/app && npx playwright test path/to/test`
+- Frontend unit/component: `cd frontend/app && pnpm run test path/to/test`
+- Frontend E2E: `cd frontend/app && pnpm exec playwright test path/to/test`
 - If a test run takes more than 5 minutes, kill it and investigate why.
 - The test must fail with an **assertion error that directly relates to the root cause**
   described by the analyst. For example, if the root cause is "no uniqueness enforcement,"
@@ -117,7 +117,7 @@ uv run invoke lint
 
 **Frontend** (if applicable):
 ```bash
-cd frontend/app && npx biome check --write .
+cd frontend/app && pnpm exec biome check --write .
 ```
 
 ## Step 9: Commit test files

--- a/dev/commands/bug-analyze.md
+++ b/dev/commands/bug-analyze.md
@@ -30,7 +30,7 @@ If `$ARGUMENTS` is empty or the issue cannot be fetched, inform the developer an
 
 ## Instructions
 
-Read `.github/bug-agent-pipeline/shared/investigation.md` and follow all sections in order.
+Read `dev/bug-pipeline/investigation.md` and follow all sections in order.
 
 ### Escalation
 

--- a/dev/commands/bug-fix.md
+++ b/dev/commands/bug-fix.md
@@ -50,7 +50,7 @@ Read the PR diff to understand the failing test.
 
 ## Implement the fix
 
-Read `.github/bug-agent-pipeline/shared/fix-implementation.md` and follow all steps (1 through 9).
+Read `dev/bug-pipeline/fix-implementation.md` and follow all steps (1 through 9).
 
 ### Escalation
 

--- a/dev/commands/bug-tdd.md
+++ b/dev/commands/bug-tdd.md
@@ -35,7 +35,7 @@ Read the full analysis to understand the root cause and affected files.
 
 ## Write the test
 
-Read `.github/bug-agent-pipeline/shared/test-writing.md` and follow steps **0 through 9**.
+Read `dev/bug-pipeline/test-writing.md` and follow steps **0 through 9**.
 
 **Step 10 (draft PR) is only executed if `OPEN_PR=true`.**
 If `OPEN_PR=false`, push the branch (`git push -u origin <branch>`) and stop after step 9.


### PR DESCRIPTION
# Why

The `/bug-analyze`, `/bug-tdd`, and `/bug-fix` slash commands in `dev/commands/` were broken — they referenced `.github/bug-agent-pipeline/shared/{investigation,test-writing,fix-implementation}.md`, which was deleted when the bug agent pipeline was converted to gh-aw workflows (https://github.com/opsmill/infrahub/pull/9043). The shared instructions got inlined into the gh-aw workflow files but the slash commands were never updated.

## What changed

- Restored the three shared instruction files into `dev/bug-pipeline/`. Placed outside `dev/commands/` so they aren't auto-registered as user-invocable Claude Code skills.
- Adapted the existing commands.

## How to test

End-to-end: run `/bug-analyze <issue>` in a fresh Claude Code session and confirm it reads the investigation file and writes `.bug-analysis-<n>.md`.

## Checklist

- [x] Internal .md docs updated
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the broken `/bug-analyze`, `/bug-tdd`, and `/bug-fix` dev commands by re-adding shared instruction docs and updating paths to the new `dev/bug-pipeline/` location. Internal tooling only; no user-facing or runtime impact.

- **Bug Fixes**
  - Added shared docs: `dev/bug-pipeline/investigation.md`, `dev/bug-pipeline/test-writing.md`, `dev/bug-pipeline/fix-implementation.md`.
  - Updated `dev/commands/bug-analyze.md`, `dev/commands/bug-tdd.md`, and `dev/commands/bug-fix.md` to read from the new path.
  - `.github/workflows/bug-agent-*.md` remains unchanged.

<sup>Written for commit 5344b347732a218f828e14b27bd2fa0ae7d0345b. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9263?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

