### PR TITLE
fix: add labels to NodeNotFoundError for clearer messaging

### DIFF
--- a/changelog/5514.fixed.md
+++ b/changelog/5514.fixed.md
@@ -1,0 +1,1 @@
+Better error message when node cannot be found — added branch, kind, and identifier labels for clarity.


### PR DESCRIPTION
The error message now shows Branch:, Kind:, and Identifier: labels
instead of raw pipe-separated values, helping users understand
which branch the lookup failed on.

**Before:**
```
        Unable to find the node in the database.
        main | InfraDevice | {'name__value': 'bad-device404'}
```

**After:**
```
        Unable to find the node in the database.
        Branch: main | Kind: InfraDevice | Identifier: {'name__value': 'bad-device404'}
```

### Changes
- `python_sdk` submodule updated with the fix
- Changelog entry added

### Related
- SDK PR: opsmill/infrahub-sdk-python#1030
- Fixes #5514

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved NodeNotFoundError messaging by adding labels for Branch, Kind, and Identifier, replacing the ambiguous pipe-separated string. Pulls in the fix via the `python_sdk` submodule update and adds a changelog entry; fixes #5514.

<sup>Written for commit 3f2118896adf10e0f7ce2af76df25265cd7cb2de. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9266?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

