### PR TITLE
ci: skip bug-agent-review conclusion job on fork PRs

### DIFF
--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -1008,8 +1008,16 @@ jobs:
       - agent
       - detection
       - safe_outputs
+    # MANUAL PATCH: cross-repo (fork) PRs can't access GH_AW_APP_ID/PRIVATE_KEY
+    # secrets, which makes the create-github-app-token step in this job fail.
+    # `pre_activation`/`activation` already gate on cross-repo, but gh-aw does
+    # not propagate that gate to the `conclusion` job, so it ran and failed.
+    # The added clause below mirrors that gate. `gh aw compile` will strip
+    # this patch — re-apply it after any re-compile. Remove once
+    # https://github.com/github/gh-aw/issues/32991 is fixed.
     if: >
-      always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
+      always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id) &&
+      (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -1,4 +1,9 @@
 ---
+# IMPORTANT: bug-agent-review.lock.yml carries a hand patch that adds a
+# cross-repo gate to the `conclusion` job's `if:`. Running `gh aw compile`
+# will strip it — re-apply the patch from the lock file comment after any
+# re-compile. Remove the workaround once
+# https://github.com/github/gh-aw/issues/32991 is fixed.
 description: Review bug pipeline test and fix PRs (triggered on PR open/synchronize)
 on:
   pull_request:


### PR DESCRIPTION
## Context

A red ❌ has been showing up on some external-contributor PRs on the `Bug reviewer agent / conclusion` check (e.g. PR #9242, [failed job](https://github.com/opsmill/infrahub/actions/runs/25793836171/job/76472898570?pr=9242)). The error — `Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.` — comes from a `Generate GitHub App token` step inside the auto-generated `conclusion` job and is a false negative: nothing about the PR itself is wrong.

## When it occurs

Specifically: a **first contribution from an external contributor**, where GitHub's first-time-contributor approval gate holds the workflow as `action_required`, and **multiple events queue up** while waiting (e.g. the PR is opened, then a review bot edits the body — both events trigger the workflow). When a maintainer eventually approves, both queued runs fire at once, `cancel-in-progress: true` on the shared concurrency group cancels one, and the `conclusion` job (which is designed to run via `always()` to report failures) then trips on `create-github-app-token` because fork PRs aren't passed repo/org secrets.

**Workaround for affected PRs:** re-trigger the workflow run (a fresh sync, push, or rerun). Without a second event queuing behind the approval, there is no concurrency cancellation, all upstream jobs cleanly skip, and `conclusion` skips with them.

## What this PR changes

- `.github/workflows/bug-agent-review.lock.yml` — add the cross-repo gate gh-aw already applies to `pre_activation`/`activation` to the `conclusion` job's `if:`. On fork PRs, `conclusion` is now skipped instead of failing.
- `.github/workflows/bug-agent-review.md` — header note that the lock file carries a manual patch that `gh aw compile` will strip.

Stop-gap until upstream gh-aw fixes https://github.com/github/gh-aw/issues/32991.