### PR TITLE
IFC-2025: Fix artifact diff migrated kind

### DIFF
--- a/backend/changelog/7490.fixed.md
+++ b/backend/changelog/7490.fixed.md
@@ -1,0 +1,1 @@
+ArtifactDiffCalculator no longer produces false-positive diff entries for artifacts whose target node was re-keyed by a node kind migration (schema name or namespace change).

--- a/backend/changelog/7490.fixed.md
+++ b/backend/changelog/7490.fixed.md
@@ -1,1 +1,1 @@
-ArtifactDiffCalculator no longer produces false-positive diff entries for artifacts whose target node was re-keyed by a node kind migration (schema name or namespace change).
+Artifact diffs no longer show spurious changes for artifacts whose schema kind was renamed or moved to a different namespace on a branch.

--- a/backend/infrahub/core/diff/artifacts/calculator.py
+++ b/backend/infrahub/core/diff/artifacts/calculator.py
@@ -55,6 +55,8 @@ class ArtifactDiffCalculator:
                     storage_id=target_storage_id,
                     checksum=target_checksum,
                 )
+            if new_storage and old_storage and new_storage == old_storage:
+                continue
             artifact_diffs.append(
                 BranchDiffArtifact(
                     branch=source_branch.name,

--- a/backend/infrahub/core/diff/query/artifact.py
+++ b/backend/infrahub/core/diff/query/artifact.py
@@ -138,9 +138,10 @@ CALL (target_node, definition_node){
     // get the corresponding artifact on the target branch, if it exists
     // -----------------------
     CALL (target_node, definition_node) {
-        OPTIONAL MATCH path = (target_node)-[trel1:IS_RELATED]-(trel_node:Relationship)-[trel2:IS_RELATED]-
+        OPTIONAL MATCH path = (tn_target:Node)-[trel1:IS_RELATED]-(trel_node:Relationship)-[trel2:IS_RELATED]-
         (target_artifact:%(artifact_kind)s)-[drel1:IS_RELATED]-(drel_node:Relationship)-[drel2:IS_RELATED]-(definition_node)
-        WHERE trel_node.name = $target_rel_identifier
+        WHERE tn_target.uuid = target_node.uuid
+        AND trel_node.name = $target_rel_identifier
         AND drel_node.name = $definition_rel_identifier
         AND all(
             r IN relationships(path)

--- a/backend/tests/component/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/component/core/diff/test_calculate_artifact_diff.py
@@ -2,13 +2,17 @@ from uuid import uuid4
 
 import pytest
 
+from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.constants import DiffAction, InfrahubKind, SchemaPathType
 from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
 from infrahub.core.diff.model.diff import ArtifactTarget, BranchDiffArtifact, BranchDiffArtifactStorage
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.database import InfrahubDatabase
 
 
@@ -289,3 +293,186 @@ async def test_calculate_artifact_diff(
     assert diffs_by_id[art2_branch.id] == expected_artifact_diff_2
     assert diffs_by_id[art3_branch.id] == expected_artifact_diff_3
     assert diffs_by_id[art6_branch.id] == expected_artifact_diff_6
+
+
+@pytest.fixture
+async def artifact_diff_kind_migration_data(
+    db: InfrahubDatabase, default_branch: Branch, car_person_data_generic: dict[str, Node]
+) -> dict[str, Node | Branch]:
+    """One artifact on main for a TestElectricCar node; a branch where only a kind migration ran."""
+    g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g1.new(db=db, name="group_migration", members=[car_person_data_generic["c1"]])
+    await g1.save(db=db)
+
+    t1 = await Node.init(db=db, schema="CoreTransformPython")
+    await t1.new(
+        db=db,
+        name="transform_migration",
+        query=car_person_data_generic["q1"].id,
+        repository=car_person_data_generic["r1"].id,
+        file_path="transform_migration.py",
+        class_name="TransformMigration",
+    )
+    await t1.save(db=db)
+
+    ad1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await ad1.new(
+        db=db,
+        name="artifactdef_migration",
+        targets=g1,
+        transformation=t1,
+        content_type="application/json",
+        artifact_name="migration_artifact",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await ad1.save(db=db)
+
+    art_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await art_main.new(
+        db=db,
+        name="art_migration_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="aaaaaaaa-0000-4173-aa4b-f50e1309f03c",
+        checksum="aabbccdd11223344556677889900aabb",
+        content_type="application/json",
+    )
+    await art_main.save(db=db)
+
+    branch = await create_branch(branch_name="branch-kind-migration", db=db)
+
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    new_ecar_schema = schema_branch.get(name="TestElectricCar")
+    new_ecar_schema.name = "ElectricCarV2"
+    registry.schema.set(name="TestElectricCarV2", schema=new_ecar_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="TestElectricCar"),
+        new_node_schema=new_ecar_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestElectricCarV2", field_name="name"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
+    assert not execution_result.errors
+
+    return {
+        "branch": branch,
+        "art_main": art_main,
+        "c1": car_person_data_generic["c1"],
+    }
+
+
+async def test_calculate_artifact_diff_migrated_kind(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    artifact_diff_kind_migration_data: dict[str, Node | Branch],
+) -> None:
+    branch = artifact_diff_kind_migration_data["branch"]
+
+    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+
+    assert artifact_diffs == []
+
+
+async def test_calculate_artifact_diff_migrated_kind_with_genuine_change(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    artifact_diff_kind_migration_data: dict[str, Node | Branch],
+) -> None:
+    branch = artifact_diff_kind_migration_data["branch"]
+    art_main = artifact_diff_kind_migration_data["art_main"]
+
+    art_branch = await NodeManager.get_one(db=db, branch=branch, id=art_main.id)
+    art_branch.checksum.value = "new_checksum_after_genuine_content_change"
+    art_branch.storage_id.value = "bbbbbbbb-1111-4173-aa4b-f50e1309f03c"
+    await art_branch.save(db=db)
+
+    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+
+    assert len(artifact_diffs) == 1
+    assert artifact_diffs[0].action == DiffAction.UPDATED
+    assert artifact_diffs[0].item_new is not None
+    assert artifact_diffs[0].item_new.checksum == "new_checksum_after_genuine_content_change"
+    assert artifact_diffs[0].item_previous is not None
+    assert artifact_diffs[0].item_previous.checksum == "aabbccdd11223344556677889900aabb"
+
+
+async def test_calculate_artifact_diff_main_side_migration(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_data_generic: dict[str, Node],
+) -> None:
+    g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g1.new(db=db, name="group_main_migration", members=[car_person_data_generic["c1"]])
+    await g1.save(db=db)
+
+    t1 = await Node.init(db=db, schema="CoreTransformPython")
+    await t1.new(
+        db=db,
+        name="transform_main_migration",
+        query=car_person_data_generic["q1"].id,
+        repository=car_person_data_generic["r1"].id,
+        file_path="transform_main_migration.py",
+        class_name="TransformMainMigration",
+    )
+    await t1.save(db=db)
+
+    ad1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await ad1.new(
+        db=db,
+        name="artifactdef_main_migration",
+        targets=g1,
+        transformation=t1,
+        content_type="application/json",
+        artifact_name="main_migration_artifact",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await ad1.save(db=db)
+
+    art_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await art_main.new(
+        db=db,
+        name="art_main_migration_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="cccccccc-2222-4173-aa4b-f50e1309f03c",
+        checksum="ccddee001122334455667788aabbccdd",
+        content_type="application/json",
+    )
+    await art_main.save(db=db)
+
+    branch = await create_branch(branch_name="branch-pre-main-migration", db=db)
+
+    art_branch = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=branch)
+    await art_branch.new(
+        db=db,
+        name="art_main_migration_branch",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="cccccccc-2222-4173-aa4b-f50e1309f03c",
+        checksum="ccddee001122334455667788aabbccdd",
+        content_type="application/json",
+    )
+    await art_branch.save(db=db)
+
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    new_ecar_schema = schema_branch.get(name="TestElectricCar")
+    new_ecar_schema.name = "ElectricCarMainV2"
+    registry.schema.set(name="TestElectricCarMainV2", schema=new_ecar_schema, branch=default_branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="TestElectricCar"),
+        new_node_schema=new_ecar_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestElectricCarMainV2", field_name="name"
+        ),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+
+    assert artifact_diffs == []

--- a/backend/tests/component/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/component/core/diff/test_calculate_artifact_diff.py
@@ -367,29 +367,18 @@ async def test_calculate_artifact_diff_migrated_kind(
     artifact_diff_kind_migration_data: dict[str, Node | Branch],
 ) -> None:
     branch = artifact_diff_kind_migration_data["branch"]
+    art_main = artifact_diff_kind_migration_data["art_main"]
 
     artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
-
     assert artifact_diffs == []
-
-
-async def test_calculate_artifact_diff_migrated_kind_with_genuine_change(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    artifact_diff_kind_migration_data: dict[str, Node | Branch],
-) -> None:
-    branch = artifact_diff_kind_migration_data["branch"]
-    art_main = artifact_diff_kind_migration_data["art_main"]
 
     art_branch = await NodeManager.get_one(db=db, branch=branch, id=art_main.id)
     art_branch.checksum.value = "new_checksum_after_genuine_content_change"
     art_branch.storage_id.value = "bbbbbbbb-1111-4173-aa4b-f50e1309f03c"
     await art_branch.save(db=db)
 
-    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
-
     assert len(artifact_diffs) == 1
     assert artifact_diffs[0].action == DiffAction.UPDATED
     assert artifact_diffs[0].item_new is not None
@@ -474,5 +463,16 @@ async def test_calculate_artifact_diff_main_side_migration(
 
     artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
-
     assert artifact_diffs == []
+
+    art_branch.checksum.value = "new_checksum_main_side_genuine_change"
+    art_branch.storage_id.value = "dddddddd-3333-4173-aa4b-f50e1309f03c"
+    await art_branch.save(db=db)
+
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+    assert len(artifact_diffs) == 1
+    assert artifact_diffs[0].action == DiffAction.UPDATED
+    assert artifact_diffs[0].item_new is not None
+    assert artifact_diffs[0].item_new.checksum == "new_checksum_main_side_genuine_change"
+    assert artifact_diffs[0].item_previous is not None
+    assert artifact_diffs[0].item_previous.checksum == "ccddee001122334455667788aabbccdd"


### PR DESCRIPTION
# Why

`ArtifactDiffQuery` anchors its target-branch artifact lookup on the Neo4j node identity of `target_node`. After `NodeKindUpdateMigration` runs, two physical Neo4j nodes share the same UUID — the original (soft-deleted on the migration branch) and the new-kind duplicate (active). The query starts from the new-kind node, which has no `IS_RELATED` edges on the target branch, so the OPTIONAL MATCH returns NULL and the artifact appears as `ADDED`.


Closes https://github.com/opsmill/infrahub/issues/7490


## How to test

```bash
uv run pytest backend/tests/component/core/diff/test_calculate_artifact_diff.py -v
```

## Impact & rollout

- **Backward compatibility:** no breaking changes; the fix only suppresses false positives. Operators who were working around the bug by ignoring ADDED entries in schema-rename scenarios will now see correct empty diffs.
- **Performance:** the UUID-based OPTIONAL MATCH (`WHERE tn_target.uuid = target_node.uuid`) relies on the existing `uuid` index on `:Node`; no regression expected.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`backend/changelog/7490.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes artifact diffs for nodes re-keyed by a kind migration so we don’t show false ADDED/UPDATED entries. Aligns with IFC-2025 by matching migrated targets by UUID and only reporting real content changes.

- **Bug Fixes**
  - Cypher now matches the target by UUID (`tn_target.uuid = target_node.uuid`) to find the correct artifact across migrated nodes.
  - Diff calculator skips entries when the artifact storage is unchanged (same `storage_id` and `checksum`).
  - Tests cover branch-side migration, main-side migration, and a genuine content change after migration.

<sup>Written for commit 5d1b2ec7f92747fef2f0d1eb370b7198d62dba40. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

