### PR TITLE
Prep for release 1.9.5

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -232,6 +232,8 @@ untrusted
 updated_at
 updated_by
 upsert
+upserting
+Upserting
 userinfo
 Userinfo
 username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.5) - 2026-05-18
+
+### Fixed
+
+- Upserting a CoreNumberPool with allow_upsert=True no longer raises an error when node and node_attribute are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
+- Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments. ([#7474](https://github.com/opsmill/infrahub/issues/7474))
+- Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing profile and template objects. ([#8894](https://github.com/opsmill/infrahub/issues/8894))
+- Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there. ([#8953](https://github.com/opsmill/infrahub/issues/8953))
+
 ## [Infrahub - v1.9.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.4) - 2026-05-12
 
 ### Added

--- a/changelog/5636.fixed.md
+++ b/changelog/5636.fixed.md
@@ -1,1 +1,0 @@
-Upserting a CoreNumberPool with allow_upsert=True no longer raises an error when node and node_attribute are unchanged.

--- a/changelog/7474.fixed.md
+++ b/changelog/7474.fixed.md
@@ -1,1 +1,0 @@
-Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments.

--- a/changelog/8894.fixed.md
+++ b/changelog/8894.fixed.md
@@ -1,1 +1,0 @@
-Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing profile and template objects.

--- a/changelog/8953.fixed.md
+++ b/changelog/8953.fixed.md
@@ -1,1 +1,0 @@
-Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there.

--- a/docs/docs/release-notes/infrahub/release-1_9_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_5.mdx
@@ -20,7 +20,7 @@ title: Release 1.9.5
 
 ### Fixed
 
-- Upserting a CoreNumberPool with allow_upsert=True no longer raises an error when node and node_attribute are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
+- Creating or updating a `CoreNumberPool` with `allow_upsert=True` no longer raises an error when `node` and `node_attribute` are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
 - Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments. ([#7474](https://github.com/opsmill/infrahub/issues/7474))
-- Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing profile and template objects. ([#8894](https://github.com/opsmill/infrahub/issues/8894))
+- Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing Profile and Template objects. ([#8894](https://github.com/opsmill/infrahub/issues/8894))
 - Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there. ([#8953](https://github.com/opsmill/infrahub/issues/8953))

--- a/docs/docs/release-notes/infrahub/release-1_9_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_5.mdx
@@ -1,0 +1,26 @@
+---
+title: Release 1.9.5
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 18th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.5](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Upserting a CoreNumberPool with allow_upsert=True no longer raises an error when node and node_attribute are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
+- Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments. ([#7474](https://github.com/opsmill/infrahub/issues/7474))
+- Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing profile and template objects. ([#8894](https://github.com/opsmill/infrahub/issues/8894))
+- Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there. ([#8953](https://github.com/opsmill/infrahub/issues/8953))

--- a/docs/docs/release-notes/infrahub/release-1_9_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_5.mdx
@@ -20,7 +20,7 @@ title: Release 1.9.5
 
 ### Fixed
 
-- Creating or updating a `CoreNumberPool` with `allow_upsert=True` no longer raises an error when `node` and `node_attribute` are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
+- Upserting a `CoreNumberPool` with `allow_upsert=True` no longer raises an error when `node` and `node_attribute` are unchanged. ([#5636](https://github.com/opsmill/infrahub/issues/5636))
 - Fixed the standard resolver for schema-based objects returning an unhelpful database error when negative values were provided for limit or offset query arguments. ([#7474](https://github.com/opsmill/infrahub/issues/7474))
 - Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing Profile and Template objects. ([#8894](https://github.com/opsmill/infrahub/issues/8894))
 - Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) were silently skipped when the relationship being updated declared its peer as a generic and the constraint was defined on a concrete subtype of that generic, letting data violate the schema. The constraint check and lock path now resolve each peer's concrete kind and enforce the constraint declared there. ([#8953](https://github.com/opsmill/infrahub/issues/8953))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -639,6 +639,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_5',
                 'release-notes/infrahub/release-1_9_4',
                 'release-notes/infrahub/release-1_9_3',
                 'release-notes/infrahub/release-1_9_2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.4"
+version = "1.9.5"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.4"
+version = "1.9.5"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.4"
+version = "1.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.4"
+version = "1.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
## Why

Preparation PR for release 1.9.5. 

### What has changed

Additional spelling exception regarding `Upsert` & `Upserting` words.

## Changelog (1.9.5)
### Fixed
- Upserting a CoreNumberPool with `allow_upsert=True` no longer raises an error when node and node_attribute are unchanged. (#5636)
- Standard resolver for schema-based objects no longer returns an unhelpful database error when negative `limit`/`offset` are provided. (#7474)
- Changing `unique` to `False` on a schema attribute now correctly triggers a migration that adds the attribute to existing profile and template objects. (#8894)
- Cardinality constraints (`cardinality: one`, `min_count`, `max_count`) declared on a concrete subtype are now enforced when the relationship's declared peer is a generic. (#8953)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare release 1.9.5. Bumps `infrahub-server` and `infrahub-testcontainers`, rolls changelog fragments into `CHANGELOG.md`, adds a docs release notes page with a sidebar entry, and fixes Vale style issues by adding “upserting” to the dictionary.

- **Bug Fixes**
  - CoreNumberPool upsert no longer errors when node and attribute are unchanged (`allow_upsert=True`). (#5636)
  - Schema resolver now returns a clear error for negative limit/offset. (#7474)
  - Switching an attribute from unique to non-unique now migrates existing Profile/Template. (#8894)
  - Enforces cardinality constraints on concrete subtypes when the peer is generic. (#8953)

<sup>Written for commit e87b6fadf93660928e9ed399a89dbdfa21cb0970. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9274?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

