### PR TITLE
Scope schema-constraint validators to diffed nodes

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -105,6 +105,7 @@ class NodeDiffFieldSummary:
     kind: str
     attribute_names: set[str] = field(default_factory=set)
     relationship_names: set[str] = field(default_factory=set)
+    node_uuids: set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -156,6 +156,7 @@ class SchemaUpdateConstraintInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
     path: SchemaPath
     constraint_name: str
+    node_uuids: set[str] | None = None
 
     @property
     def routing_key(self) -> str:
@@ -163,6 +164,13 @@ class SchemaUpdateConstraintInfo(BaseModel):
 
     def __hash__(self) -> int:
         return hash((type(self),) + tuple(self.constraint_name + self.path.get_path()))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SchemaUpdateConstraintInfo):
+            return NotImplemented
+        # node_uuids is an optional scoping payload — not part of identity.
+        # Dedup must match __hash__ which only considers constraint_name + path.
+        return self.constraint_name == other.constraint_name and self.path == other.path
 
 
 class SchemaUpdateValidationResult(BaseModel):

--- a/backend/infrahub/core/validators/attribute/choices.py
+++ b/backend/infrahub/core/validators/attribute/choices.py
@@ -38,10 +38,12 @@ class AttributeChoicesUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["allowed_values"] = [choice.name for choice in self.attribute_schema.choices]
         self.params["null_value"] = NULL_VALUE
         self.params["excluded_kinds"] = self.excluded_kinds
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kind)s)
-        WHERE size($excluded_kinds) = 0 OR NOT n.kind IN $excluded_kinds
+        WHERE (size($excluded_kinds) = 0 OR NOT n.kind IN $excluded_kinds)
+          AND ($node_uuids IS NULL OR n.uuid IN $node_uuids)
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -121,6 +123,7 @@ class AttributeChoicesChecker(ConstraintCheckerInterface):
                 node_schema=request.node_schema,
                 schema_path=request.schema_path,
                 excluded_kinds=excluded_kinds,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/attribute/enum.py
+++ b/backend/infrahub/core/validators/attribute/enum.py
@@ -28,8 +28,10 @@ class AttributeEnumUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["attr_name"] = self.attribute_schema.name
         self.params["allowed_values"] = self.attribute_schema.enum
         self.params["null_value"] = NULL_VALUE
+        self.params["node_uuids"] = self.node_uuids
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -94,7 +96,11 @@ class AttributeEnumChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
 
             await query.execute(db=self.db)

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -34,9 +34,11 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 
         self.params["attr_name"] = self.attribute_schema.name
         self.params["null_value"] = NULL_VALUE
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kinds)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -108,7 +110,11 @@ class AttributeKindChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
 
             await query.execute(db=self.db)

--- a/backend/infrahub/core/validators/attribute/length.py
+++ b/backend/infrahub/core/validators/attribute/length.py
@@ -26,9 +26,11 @@ class AttributeLengthUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["attr_name"] = self.attribute_schema.name
         self.params["min_length"] = self.attribute_schema.get_min_length()
         self.params["max_length"] = self.attribute_schema.get_max_length()
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -98,7 +100,11 @@ class AttributeLengthChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/attribute/min_max.py
+++ b/backend/infrahub/core/validators/attribute/min_max.py
@@ -33,9 +33,11 @@ class AttributeNumberUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["max_value"] = self.attribute_schema.parameters.max_value
         self.params["excluded_values"] = self.attribute_schema.parameters.get_excluded_single_values()
         self.params["excluded_ranges"] = self.attribute_schema.parameters.get_excluded_ranges()
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -116,7 +118,11 @@ class AttributeNumberChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/attribute/number_pool.py
+++ b/backend/infrahub/core/validators/attribute/number_pool.py
@@ -30,9 +30,11 @@ class AttributeNumberPoolUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["attr_name"] = self.attribute_schema.name
         self.params["start_range"] = self.attribute_schema.parameters.start_range
         self.params["end_range"] = self.attribute_schema.parameters.end_range
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -99,7 +101,11 @@ class AttributeNumberPoolChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/attribute/optional.py
+++ b/backend/infrahub/core/validators/attribute/optional.py
@@ -24,9 +24,11 @@ class AttributeOptionalUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 
         self.params["attr_name"] = self.attribute_schema.name
         self.params["null_value"] = NULL_VALUE
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -85,7 +87,11 @@ class AttributeOptionalChecker(ConstraintCheckerInterface):
 
         for query_class in self.query_classes:
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/attribute/regex.py
+++ b/backend/infrahub/core/validators/attribute/regex.py
@@ -26,8 +26,10 @@ class AttributeRegexUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["attr_name"] = self.attribute_schema.name
         self.params["attr_value_regex"] = self.attribute_schema.get_regex()
         self.params["null_value"] = NULL_VALUE
+        self.params["node_uuids"] = self.node_uuids
         query = """
         MATCH p = (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -91,7 +93,11 @@ class AttributeRegexChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -26,6 +26,7 @@ class ConstraintValidatorDeterminer:
         self._node_kinds: set[str] = set()
         self._attribute_element_map: dict[str, set[str]] = {}
         self._relationship_element_map: dict[str, set[str]] = {}
+        self._node_uuid_map: dict[str, set[str]] = {}
 
     def _index_node_diffs(self, node_diffs: list[NodeDiffFieldSummary]) -> None:
         for node_diff in node_diffs:
@@ -38,6 +39,23 @@ class ConstraintValidatorDeterminer:
                 self._relationship_element_map[node_diff.kind] = set()
             for relationship_name in node_diff.relationship_names:
                 self._relationship_element_map[node_diff.kind].add(relationship_name)
+            if node_diff.kind not in self._node_uuid_map:
+                self._node_uuid_map[node_diff.kind] = set()
+            self._node_uuid_map[node_diff.kind].update(node_diff.node_uuids)
+
+    def _node_uuids_for(self, kind: str) -> set[str] | None:
+        # A generic schema's constraints apply to its derived node kinds; the
+        # diff carries the concrete kind, so we union across any inheriting
+        # kinds the determiner has seen. Returns None when no UUIDs are known
+        # (forces a full scan, preserving correctness for schema-diff origins).
+        node_schema = self.schema_branch.get(name=kind, duplicate=False)
+        derived_kinds = {kind}
+        if hasattr(node_schema, "used_by") and node_schema.used_by:
+            derived_kinds.update(node_schema.used_by)
+        uuids: set[str] = set()
+        for derived in derived_kinds:
+            uuids.update(self._node_uuid_map.get(derived, set()))
+        return uuids or None
 
     def _has_attribute_diff(self, kind: str, name: str) -> bool:
         return name in self._attribute_element_map.get(kind, set())
@@ -135,7 +153,13 @@ class ConstraintValidatorDeterminer:
             if not do_constraint_validation:
                 continue
 
-            constraints.append(SchemaUpdateConstraintInfo(constraint_name=constraint_name, path=schema_path))
+            constraints.append(
+                SchemaUpdateConstraintInfo(
+                    constraint_name=constraint_name,
+                    path=schema_path,
+                    node_uuids=self._node_uuids_for(schema.kind),
+                )
+            )
         return constraints
 
     async def _get_attribute_constraints_for_one_schema(
@@ -208,5 +232,11 @@ class ConstraintValidatorDeterminer:
                 property_name=prop_name,
             )
 
-            constraints.append(SchemaUpdateConstraintInfo(constraint_name=constraint_name, path=schema_path))
+            constraints.append(
+                SchemaUpdateConstraintInfo(
+                    constraint_name=constraint_name,
+                    path=schema_path,
+                    node_uuids=self._node_uuids_for(schema.kind),
+                )
+            )
         return constraints

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -48,14 +48,54 @@ class ConstraintValidatorDeterminer:
         # diff carries the concrete kind, so we union across any inheriting
         # kinds the determiner has seen. Returns None when no UUIDs are known
         # (forces a full scan, preserving correctness for schema-diff origins).
-        node_schema = self.schema_branch.get(name=kind, duplicate=False)
-        derived_kinds = {kind}
-        if hasattr(node_schema, "used_by") and node_schema.used_by:
-            derived_kinds.update(node_schema.used_by)
+        derived_kinds = self._derived_kinds(kind)
         uuids: set[str] = set()
         for derived in derived_kinds:
             uuids.update(self._node_uuid_map.get(derived, set()))
         return uuids or None
+
+    def _derived_kinds(self, kind: str) -> set[str]:
+        node_schema = self.schema_branch.get(name=kind, duplicate=False)
+        derived_kinds = {kind}
+        if hasattr(node_schema, "used_by") and node_schema.used_by:
+            derived_kinds.update(node_schema.used_by)
+        return derived_kinds
+
+    def find_cross_kind_uniqueness_dependents(self) -> dict[tuple[str, str], set[str]]:
+        """Identify uniqueness constraints whose values depend on a diffed peer attribute.
+
+        A path like ``device__name`` in kind S's uniqueness constraint means S's
+        constraint value depends on the peer kind's ``name`` attribute. If the
+        peer's ``name`` is in the diff, S's uniqueness must be re-checked even
+        though S itself has no entry in the diff.
+
+        Returns a dict keyed by (dependent_kind, rel_name) → diffed peer UUIDs
+        for the cases where the peer kind's referenced attribute is in the diff.
+        """
+        dependents: dict[tuple[str, str], set[str]] = {}
+        for schema in self.schema_branch.get_all(duplicate=False).values():
+            uniqueness_constraints = getattr(schema, "uniqueness_constraints", None)
+            if not uniqueness_constraints:
+                continue
+            for uniqueness_constraint in uniqueness_constraints:
+                for path in uniqueness_constraint:
+                    if "__" not in path:
+                        continue
+                    name, property_name = path.split("__", 1)
+                    rel_schema = schema.get_relationship_or_none(name=name)
+                    if rel_schema is None or not property_name:
+                        continue
+                    peer_concrete_kinds = self._derived_kinds(rel_schema.peer)
+                    diffed_peer_uuids: set[str] = set()
+                    for peer_kind in peer_concrete_kinds:
+                        if property_name not in self._attribute_element_map.get(peer_kind, set()):
+                            continue
+                        diffed_peer_uuids.update(self._node_uuid_map.get(peer_kind, set()))
+                    if not diffed_peer_uuids:
+                        continue
+                    key = (schema.kind, rel_schema.name)
+                    dependents.setdefault(key, set()).update(diffed_peer_uuids)
+        return dependents
 
     def _has_attribute_diff(self, kind: str, name: str) -> bool:
         return name in self._attribute_element_map.get(kind, set())

--- a/backend/infrahub/core/validators/model.py
+++ b/backend/infrahub/core/validators/model.py
@@ -16,6 +16,16 @@ class SchemaConstraintValidatorRequest(BaseModel):
     node_schema: NodeSchema | GenericSchema = Field(..., description="Schema of Node or Generic to validate")
     schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to validate")
     schema_branch: SchemaBranch = Field(..., description="SchemaBranch of the element to validate")
+    node_uuids: set[str] | None = Field(
+        default=None,
+        description=(
+            "Optional set of node UUIDs to scope the validation to. When provided, "
+            "checkers may pre-fetch current values for these nodes and run a "
+            "narrowed query instead of scanning every node of the kind. None means "
+            "fall back to the full-scan path (required for schema-diff-driven "
+            "constraint changes)."
+        ),
+    )
 
     @model_serializer()
     def serialize_model(self) -> dict[str, Any]:
@@ -25,6 +35,7 @@ class SchemaConstraintValidatorRequest(BaseModel):
             "node_schema": self.node_schema.model_dump(),
             "schema_path": self.schema_path.model_dump(),
             "schema_branch": self.schema_branch.to_dict_schema_object(),
+            "node_uuids": list(self.node_uuids) if self.node_uuids is not None else None,
         }
 
     @field_validator("schema_branch", mode="before")

--- a/backend/infrahub/core/validators/relationship/count.py
+++ b/backend/infrahub/core/validators/relationship/count.py
@@ -45,11 +45,13 @@ class RelationshipCountUpdateValidatorQuery(RelationshipSchemaValidatorQuery):
         if max_count == 0:
             max_count = None
         self.params["max_count"] = max_count
+        self.params["node_uuids"] = self.node_uuids
 
         # ruff: noqa: E501
         query = """
         // get the nodes on these branches nodes
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rroot:IS_PART_OF]-(n)
             WHERE all(r in relationships(path) WHERE %(branch_filter)s)
@@ -184,6 +186,7 @@ class RelationshipCountChecker(ConstraintCheckerInterface):
                 schema_path=request.schema_path,
                 min_count_override=min_count_override,
                 max_count_override=max_count_override,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/relationship/optional.py
+++ b/backend/infrahub/core/validators/relationship/optional.py
@@ -25,11 +25,13 @@ class RelationshipOptionalUpdateValidatorQuery(RelationshipSchemaValidatorQuery)
         self.params.update(branch_params)
 
         self.params["relationship_id"] = self.relationship_schema.identifier
+        self.params["node_uuids"] = self.node_uuids
 
         query = """
         // Query all Active Nodes of type
         // and store their UUID in uuids_active_node
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH (root:Root)<-[r:IS_PART_OF]-(n)
             WHERE %(branch_filter)s
@@ -43,6 +45,7 @@ class RelationshipOptionalUpdateValidatorQuery(RelationshipSchemaValidatorQuery)
         // identifier all nodes with at least one active member for this relationship
         // and store their UUID in uuids_with_rel
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n, uuids_active_node) {
             MATCH path = (n)-[r:IS_RELATED]-(:Relationship { name: $relationship_id })
             WHERE %(branch_filter)s
@@ -54,7 +57,8 @@ class RelationshipOptionalUpdateValidatorQuery(RelationshipSchemaValidatorQuery)
         WHERE r.status = "active"
         WITH COLLECT(node_with_rel.uuid) AS uuids_with_rel, uuids_active_node
         MATCH (n:%(node_kind)s)-[r:IS_PART_OF]->(:Root)
-        WHERE n.uuid IN uuids_active_node
+        WHERE ($node_uuids IS NULL OR n.uuid IN $node_uuids)
+          AND n.uuid IN uuids_active_node
           AND not n.uuid IN uuids_with_rel
           AND NOT exists((n)-[:IS_RELATED]-(:Relationship { name: $relationship_id }))
         """ % {"branch_filter": branch_filter, "node_kind": self.node_schema.kind}
@@ -102,7 +106,11 @@ class RelationshipOptionalChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/relationship/peer.py
+++ b/backend/infrahub/core/validators/relationship/peer.py
@@ -32,10 +32,12 @@ class RelationshipPeerUpdateValidatorQuery(RelationshipSchemaValidatorQuery):
 
         self.params["relationship_id"] = self.relationship_schema.identifier
         self.params["allowed_peer_kinds"] = allowed_peer_kinds
+        self.params["node_uuids"] = self.node_uuids
 
         # ruff: noqa: E501
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[rroot:IS_PART_OF]-(n)
             WHERE all(r in relationships(path) WHERE %(branch_filter)s)
@@ -120,7 +122,11 @@ class RelationshipPeerChecker(ConstraintCheckerInterface):
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())
@@ -149,6 +155,7 @@ class RelationshipPeerParentValidatorQuery(RelationshipSchemaValidatorQuery):
         self.params["peer_relationship_id"] = self.relationship.identifier
         self.params["parent_relationship_id"] = self.parent_relationship.identifier
         self.params["peer_parent_relationship_id"] = self.peer_parent_relationship.identifier
+        self.params["node_uuids"] = self.node_uuids
 
         parent_arrows = self.parent_relationship.get_query_arrows()
         parent_match = (
@@ -185,6 +192,7 @@ class RelationshipPeerParentValidatorQuery(RelationshipSchemaValidatorQuery):
 
         query = """
         MATCH (n:%(node_kind)s)
+        WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids
         CALL (n) {
             MATCH path = (root:Root)<-[r:IS_PART_OF]-(n)
             WHERE %(branch_filter)s
@@ -290,6 +298,7 @@ class RelationshipPeerParentChecker(ConstraintCheckerInterface):
                 relationship=relationship,
                 parent_relationship=parent_relationship,
                 peer_parent_relationship=peer_parent_relationship,
+                node_uuids=request.node_uuids,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/infrahub/core/validators/shared.py
+++ b/backend/infrahub/core/validators/shared.py
@@ -14,10 +14,16 @@ class SchemaValidatorQuery(Query):
         self,
         node_schema: NodeSchema | GenericSchema,
         schema_path: SchemaPath,
+        node_uuids: set[str] | None = None,
         **kwargs: Any,
     ) -> None:
         self.node_schema = node_schema
         self.schema_path = schema_path
+        # Optional scope for data-diff-driven constraint runs. Subclasses that
+        # opt in stamp this on $node_uuids and gate their initial MATCH with
+        # `WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids`, falling back to
+        # a full kind scan when None (the schema-diff-origin case).
+        self.node_uuids: list[str] | None = list(node_uuids) if node_uuids else None
         super().__init__(**kwargs)
 
     async def get_paths(self) -> GroupedDataPaths:

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -47,6 +47,7 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
             schema_path=constraint.path,
             schema_branch=message.schema_branch,
             database=await get_database(),
+            node_uuids=constraint.node_uuids,
         )
 
     results = [result async for _, result in batch.execute()]
@@ -67,6 +68,7 @@ async def schema_path_validate(
     schema_path: SchemaPath,
     schema_branch: SchemaBranch,
     database: InfrahubDatabase,
+    node_uuids: set[str] | None = None,
 ) -> SchemaValidatorPathResponseData:
     async with database.start_session(read_only=True) as db:
         constraint_request = SchemaConstraintValidatorRequest(
@@ -75,6 +77,7 @@ async def schema_path_validate(
             node_schema=node_schema,
             schema_path=schema_path,
             schema_branch=schema_branch,
+            node_uuids=node_uuids,
         )
 
         component_registry = get_component_registry()

--- a/backend/infrahub/core/validators/uniqueness/checker.py
+++ b/backend/infrahub/core/validators/uniqueness/checker.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.path import DataPath, GroupedDataPaths
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
 from infrahub.core.validators.uniqueness.index import UniquenessQueryResultsIndex
@@ -22,6 +23,7 @@ from .model import (
 from .query import NodeUniqueAttributeConstraintQuery
 
 if TYPE_CHECKING:
+    from infrahub.core.node import Node
     from infrahub.core.query import QueryResult
     from infrahub.database import InfrahubDatabase
 
@@ -66,7 +68,9 @@ class UniquenessChecker(ConstraintCheckerInterface):
 
     async def check(self, request: SchemaConstraintValidatorRequest) -> list[GroupedDataPaths]:
         schema_objects = [request.node_schema]
-        non_unique_nodes_lists = await asyncio.gather(*[self.check_one_schema(schema) for schema in schema_objects])
+        non_unique_nodes_lists = await asyncio.gather(
+            *[self.check_one_schema(schema, node_uuids=request.node_uuids) for schema in schema_objects]
+        )
 
         grouped_data_paths = GroupedDataPaths()
         for non_unique_node in chain(*non_unique_nodes_lists):
@@ -112,8 +116,12 @@ class UniquenessChecker(ConstraintCheckerInterface):
     async def check_one_schema(
         self,
         schema: MainSchemaTypes,
+        node_uuids: set[str] | None = None,
     ) -> list[NonUniqueNode]:
-        query_request = await self.build_query_request(schema)
+        if node_uuids:
+            query_request = await self.build_scoped_query_request(schema=schema, node_uuids=node_uuids)
+        else:
+            query_request = await self.build_query_request(schema)
 
         if not query_request:
             return []
@@ -126,6 +134,154 @@ class UniquenessChecker(ConstraintCheckerInterface):
                 query_results = await query.execute(db=db)
 
         return await self._parse_results(schema=schema, query_results=query_results.results)
+
+    async def build_scoped_query_request(
+        self, schema: MainSchemaTypes, node_uuids: set[str]
+    ) -> NodeUniquenessQueryRequest:
+        """Build a value-anchored query request for a known set of node UUIDs.
+
+        Pre-fetches the current values of every attribute/relationship referenced
+        by any uniqueness constraint on the schema, then emits
+        QueryAttributePath/QueryRelationshipAttributePath entries with `value`
+        set. The existing query routes these through its `_with_value` subqueries,
+        which can use the :AttributeValueIndexed(value) index instead of doing a
+        kind-wide label scan.
+
+        Why pre-fetch every constraint field (not just the diffed ones): a
+        constraint like (name, location) requires both values even if only `name`
+        diffed. We must look up `location` so the resulting valued query can find
+        peers sharing the full (name, location) tuple.
+        """
+        attr_schemas_in_constraints: dict[str, tuple[AttributeSchema, str | None]] = {}
+        rel_paths_in_constraints: list[tuple[RelationshipSchema, str | None]] = []
+
+        for attr_schema in schema.unique_attributes:
+            attr_schemas_in_constraints[f"{attr_schema.name}|value"] = (attr_schema, "value")
+
+        if schema.uniqueness_constraints:
+            for uniqueness_constraint in schema.uniqueness_constraints:
+                for path in uniqueness_constraint:
+                    sub_schema, property_name = get_attribute_path_from_string(path, schema)
+                    if isinstance(sub_schema, AttributeSchema):
+                        key = f"{sub_schema.name}|{property_name or 'value'}"
+                        attr_schemas_in_constraints[key] = (sub_schema, property_name)
+                    elif isinstance(sub_schema, RelationshipSchema):
+                        rel_paths_in_constraints.append((sub_schema, property_name))
+
+        if not attr_schemas_in_constraints and not rel_paths_in_constraints:
+            return NodeUniquenessQueryRequest(kind=schema.kind)
+
+        fields_filter: dict[str, dict] = {}
+        for attr_schema, _ in attr_schemas_in_constraints.values():
+            fields_filter[attr_schema.name] = {}
+        for rel_schema, _ in rel_paths_in_constraints:
+            fields_filter[rel_schema.name] = {}
+
+        branch = await self.get_branch()
+        nodes = await NodeManager.get_many(
+            db=self.db,
+            ids=list(node_uuids),
+            fields=fields_filter,
+            branch=branch,
+        )
+
+        unique_attr_paths: set[QueryAttributePath] = set()
+        relationship_attr_paths: set[QueryRelationshipAttributePath] = set()
+
+        for node in nodes.values():
+            for attr_schema, property_name in attr_schemas_in_constraints.values():
+                self._extract_attribute_path(
+                    node=node,
+                    attr_schema=attr_schema,
+                    property_name=property_name,
+                    paths=unique_attr_paths,
+                )
+            for rel_schema, property_name in rel_paths_in_constraints:
+                await self._extract_relationship_path(
+                    node=node,
+                    rel_schema=rel_schema,
+                    property_name=property_name,
+                    paths=relationship_attr_paths,
+                )
+
+        return NodeUniquenessQueryRequest(
+            kind=schema.kind,
+            unique_attribute_paths=unique_attr_paths,
+            relationship_attribute_paths=relationship_attr_paths,
+        )
+
+    @staticmethod
+    def _extract_attribute_path(
+        node: Node,
+        attr_schema: AttributeSchema,
+        property_name: str | None,
+        paths: set[QueryAttributePath],
+    ) -> None:
+        attr = getattr(node, attr_schema.name, None)
+        if attr is None:
+            return
+        attr_value = getattr(attr, property_name or "value", None)
+        if attr_value is None:
+            return
+        paths.add(
+            QueryAttributePath(
+                attribute_name=attr_schema.name,
+                attribute_kind=attr_schema.kind,
+                property_name=property_name,
+                value=attr_value,
+            )
+        )
+
+    async def _extract_relationship_path(
+        self,
+        node: Node,
+        rel_schema: RelationshipSchema,
+        property_name: str | None,
+        paths: set[QueryRelationshipAttributePath],
+    ) -> None:
+        rel_manager = getattr(node, rel_schema.name, None)
+        if rel_manager is None or rel_schema.cardinality != "one":
+            # Cardinality-many relationships in uniqueness constraints are
+            # uncommon and don't translate cleanly to a single peer value —
+            # emit an unvalued path so the existing query still exercises the
+            # constraint (it just won't be value-scoped).
+            paths.add(
+                QueryRelationshipAttributePath(
+                    identifier=rel_schema.get_identifier(),
+                    attribute_name=property_name,
+                )
+            )
+            return
+        relationships = await rel_manager.get_relationships(db=self.db)
+        if not relationships:
+            return
+        peer_id = relationships[0].peer_id
+        if peer_id is None:
+            return
+        if property_name is None:
+            # Relationship-only path: value is the peer UUID.
+            paths.add(
+                QueryRelationshipAttributePath(
+                    identifier=rel_schema.get_identifier(),
+                    attribute_name=None,
+                    value=peer_id,
+                )
+            )
+            return
+        # Relationship + peer-attribute path: value is the peer's attribute value.
+        peer = await rel_manager.get_peer(db=self.db)
+        if peer is None:
+            return
+        peer_attr = getattr(peer, property_name, None)
+        if peer_attr is None or peer_attr.value is None:
+            return
+        paths.add(
+            QueryRelationshipAttributePath(
+                identifier=rel_schema.get_identifier(),
+                attribute_name=property_name,
+                value=peer_attr.value,
+            )
+        )
 
     async def _parse_results(self, schema: MainSchemaTypes, query_results: list[QueryResult]) -> list[NonUniqueNode]:
         relationship_schema_by_identifier = {rel.identifier: rel for rel in schema.relationships}

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -55,7 +55,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
             if is_large_attribute_type(attr_path.attribute_kind):
                 attrs_include_large_type = True
             attribute_names.add(attr_path.attribute_name)
-            if attr_path.value:
+            if attr_path.value is not None:
                 attr_paths_with_value.append((attr_path.attribute_name, property_rel_name, attr_path.value))
                 attr_values.append(attr_path.value)
             else:
@@ -74,7 +74,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
         relationship_attr_paths_with_value = []
         for rel_path in self.query_request.relationship_attribute_paths:
             relationship_names.add(rel_path.identifier)
-            if rel_path.attribute_name and rel_path.value:
+            if rel_path.attribute_name and rel_path.value is not None:
                 relationship_attr_paths_with_value.append(
                     (rel_path.identifier, rel_path.attribute_name, rel_path.value)
                 )
@@ -83,7 +83,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
                 relationship_attr_paths.append((rel_path.identifier, rel_path.attribute_name))
             else:
                 relationship_only_attr_paths.append(rel_path.identifier)
-                if rel_path.value:
+                if rel_path.value is not None:
                     relationship_only_attr_values.append(rel_path.value)
 
         if (

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -38,6 +38,7 @@ from infrahub.core.constants import (
     GeneratorInstanceStatus,
     InfrahubKind,
     RepositoryInternalStatus,
+    SchemaPathType,
     ValidatorConclusion,
 )
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -45,6 +46,8 @@ from infrahub.core.diff.model.diff import DiffElementType, SchemaConflict
 from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
 from infrahub.core.manager import NodeManager
+from infrahub.core.models import SchemaUpdateConstraintInfo
+from infrahub.core.path import SchemaPath
 from infrahub.core.protocols import CoreDataCheck, CoreValidator
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.timestamp import Timestamp
@@ -52,6 +55,11 @@ from infrahub.core.validators.checks_runner import run_checks_and_update_validat
 from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
+from infrahub.core.validators.uniqueness.model import (
+    NodeUniquenessQueryRequest,
+    QueryRelationshipAttributePath,
+)
+from infrahub.core.validators.uniqueness.query import NodeUniqueAttributeConstraintQuery
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events import EventMeta, ProposedChangeMergedEvent
 from infrahub.exceptions import MergeFailedError, SchemaNotFoundError, ValidationError
@@ -117,7 +125,6 @@ if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
-    from infrahub.core.models import SchemaUpdateConstraintInfo
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
 
@@ -478,9 +485,12 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     validation_result = dest_schema.validate_update(other=candidate_schema, diff=schema_diff)
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    constraints_from_data_diff = await _get_proposed_change_schema_integrity_constraints(
-        schema=candidate_schema, diff_summary=diff_summary
-    )
+    source_branch = registry.get_branch_from_registry(branch=model.source_branch)
+    database = await get_database()
+    async with database.start_session(read_only=True) as db:
+        constraints_from_data_diff = await _get_proposed_change_schema_integrity_constraints(
+            schema=candidate_schema, diff_summary=diff_summary, db=db, branch=source_branch
+        )
     constraints_from_schema_diff = validation_result.constraints
     # Order matters for dedup: SchemaUpdateConstraintInfo.__eq__ compares only
     # (constraint_name, path). Add schema-diff constraints first so that, when
@@ -495,7 +505,6 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     # ----------------------------------------------------------
     # Validate if the new schema is valid with the content of the database
     # ----------------------------------------------------------
-    source_branch = registry.get_branch_from_registry(branch=model.source_branch)
     responses = await schema_validate_migrations(
         message=SchemaValidateMigrationData(
             branch=source_branch, schema_branch=candidate_schema, constraints=list(constraints)
@@ -532,7 +541,10 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
 
 
 async def _get_proposed_change_schema_integrity_constraints(
-    schema: SchemaBranch, diff_summary: list[NodeDiff]
+    schema: SchemaBranch,
+    diff_summary: list[NodeDiff],
+    db: InfrahubDatabase,
+    branch: Branch,
 ) -> list[SchemaUpdateConstraintInfo]:
     node_diff_field_summary_map: dict[str, NodeDiffFieldSummary] = {}
 
@@ -554,7 +566,104 @@ async def _get_proposed_change_schema_integrity_constraints(
                 field_summary.attribute_names.add(element_name)
 
     determiner = ConstraintValidatorDeterminer(schema_branch=schema)
-    return await determiner.get_constraints(node_diffs=list(node_diff_field_summary_map.values()))
+    constraints = await determiner.get_constraints(node_diffs=list(node_diff_field_summary_map.values()))
+
+    # Close the cross-kind uniqueness gap: when a diffed peer attribute is
+    # referenced by another kind's `rel__peer_attr` uniqueness path, the
+    # dependent kind needs re-validation even though it has no entry in the
+    # data diff.
+    cross_kind_dependents = determiner.find_cross_kind_uniqueness_dependents()
+    for (dependent_kind, rel_name), peer_uuids in cross_kind_dependents.items():
+        affected_uuids = await _resolve_cross_kind_dependent_uuids(
+            db=db,
+            branch=branch,
+            schema=schema,
+            dependent_kind=dependent_kind,
+            rel_name=rel_name,
+            peer_uuids=peer_uuids,
+        )
+        if not affected_uuids:
+            continue
+        _merge_uniqueness_constraint(
+            constraints=constraints,
+            dependent_kind=dependent_kind,
+            extra_node_uuids=affected_uuids,
+        )
+
+    return constraints
+
+
+async def _resolve_cross_kind_dependent_uuids(
+    db: InfrahubDatabase,
+    branch: Branch,
+    schema: SchemaBranch,
+    dependent_kind: str,
+    rel_name: str,
+    peer_uuids: set[str],
+) -> set[str]:
+    """Return UUIDs of `dependent_kind` nodes whose `rel_name` peer is in `peer_uuids`.
+
+    Reuses ``NodeUniqueAttributeConstraintQuery`` with ``min_count_required=0`` so
+    the existing ``relationship_only_attr_paths_subquery`` (which already does
+    ``related_n.uuid IN $relationship_only_attr_values``) returns every matching
+    dependent node, not only those already in a collision group.
+    """
+    dependent_schema = schema.get(name=dependent_kind, duplicate=False)
+    rel_schema = dependent_schema.get_relationship(name=rel_name)
+    request = NodeUniquenessQueryRequest(
+        kind=dependent_kind,
+        relationship_attribute_paths={
+            QueryRelationshipAttributePath(
+                identifier=rel_schema.get_identifier(),
+                attribute_name=None,
+                value=peer_uuid,
+            )
+            for peer_uuid in peer_uuids
+        },
+    )
+    query = await NodeUniqueAttributeConstraintQuery.init(
+        db=db,
+        branch=branch,
+        query_request=request,
+        min_count_required=0,
+    )
+    await query.execute(db=db)
+    return {str(result.get("node_id")) for result in query.results}
+
+
+def _merge_uniqueness_constraint(
+    constraints: list[SchemaUpdateConstraintInfo],
+    dependent_kind: str,
+    extra_node_uuids: set[str],
+) -> None:
+    """Add or merge a `node.uniqueness_constraints.update` constraint for `dependent_kind`.
+
+    If a matching constraint already exists with `node_uuids=None`, leave it
+    alone (full scan already covers the cross-kind scope). Otherwise union the
+    UUIDs, or append a new constraint if none exists yet.
+    """
+    schema_path = SchemaPath(
+        schema_kind=dependent_kind,
+        path_type=SchemaPathType.NODE,
+        field_name="uniqueness_constraints",
+        property_name="uniqueness_constraints",
+    )
+    for existing in constraints:
+        if (
+            existing.constraint_name == "node.uniqueness_constraints.update"
+            and existing.path == schema_path
+        ):
+            if existing.node_uuids is None:
+                return
+            existing.node_uuids |= extra_node_uuids
+            return
+    constraints.append(
+        SchemaUpdateConstraintInfo(
+            constraint_name="node.uniqueness_constraints.update",
+            path=schema_path,
+            node_uuids=extra_node_uuids,
+        )
+    )
 
 
 @flow(name="proposed-changed-repository-checks", flow_run_name="Process user defined checks")

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -482,7 +482,12 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
         schema=candidate_schema, diff_summary=diff_summary
     )
     constraints_from_schema_diff = validation_result.constraints
-    constraints = set(constraints_from_data_diff + constraints_from_schema_diff)
+    # Order matters for dedup: SchemaUpdateConstraintInfo.__eq__ compares only
+    # (constraint_name, path). Add schema-diff constraints first so that, when
+    # the same constraint is also data-diff-derived, the schema-diff version
+    # (node_uuids=None → full scan) wins. A schema change that adds/widens a
+    # uniqueness constraint must scan every node of the kind.
+    constraints = set(constraints_from_schema_diff + constraints_from_data_diff)
 
     if not constraints:
         return
@@ -536,6 +541,7 @@ async def _get_proposed_change_schema_integrity_constraints(
         if node_kind not in node_diff_field_summary_map:
             node_diff_field_summary_map[node_kind] = NodeDiffFieldSummary(kind=node_kind)
         field_summary = node_diff_field_summary_map[node_kind]
+        field_summary.node_uuids.add(node_diff["id"])
         for element in node_diff["elements"]:
             element_name = element["name"]
             element_type = element["element_type"]


### PR DESCRIPTION
## Summary

Stacked on top of `fac-fix-pc-validators` (which scoped property-constraint *selection* to diffed kinds via `d846e73`). This branch narrows the *scan within* each touched kind, and closes one cross-kind correctness gap surfaced along the way.

Four commits:

- `86eafcd6` **scope uniqueness query to diffed node values** — pre-fetch diffed nodes' uniqueness-relevant values via `NodeManager.get_many` and route through the existing `_with_value` Cypher subqueries. No new Cypher. Value-anchored, so collisions with untouched peers still surface.
- `691e6dc1` **scope attribute checkers to diffed node uuids** — plumb `node_uuids` through `SchemaConstraintValidatorRequest` and the shared `SchemaValidatorQuery` base; gate each `MATCH (n:Kind)` with `WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids` across kind, regex, length, min_max, optional, enum, choices, number_pool.
- `90927aa0` **trigger uniqueness re-check on cross-kind peer changes** — when a `rel__peer_attr` path's peer attribute changes, the dependent kind itself isn't in the diff. New `ConstraintValidatorDeterminer.find_cross_kind_uniqueness_dependents` plus a `min_count_required=0` reuse of the existing query resolves affected dependent UUIDs and merges them into the constraint.
- `62696cb7` **scope relationship checkers to diffed node uuids** — same UUID-scoping pattern for `relationship.optional`, `relationship.count`, `relationship.peer`, `relationship.common_parent`.

## Why

On a 400k-node kind, opening a PC that changes one attribute on one node previously triggered kind-wide label scans across every constraint validator that fired for the kind. With this stack the scan is bounded by the diffed node set (or, for the cross-kind case, the set of dependent nodes pointing to diffed peers). Schema-diff-origin constraints (e.g. flipping `optional` or adding `unique`) keep `node_uuids=None` and continue to full-scan — correctness is preserved.

## Test plan

- [x] `uv run pytest backend/tests/component/core/constraint_validators/` — 320 passed, 6 pre-existing skips (verified after each commit).
- [x] `uv run ruff check` and `uv run mypy` — clean on every modified file.
- [ ] End-to-end on the 400k-`DcimInterfaceL2` DB: open a PC that touches one `name`; capture the executed Cypher and `PROFILE` it to confirm the planner anchors on `:AttributeValueIndexed(value)` instead of a kind label scan. Time the validator — target sub-second.
- [ ] End-to-end cross-kind: rename a `DcimDevice` referenced by a `DcimInterface` `rel__peer_attr` uniqueness constraint; verify the PC reports any resulting collision.

## Out of scope (follow-ups)

- `attribute.unique.update` — group-by-value query; needs the same value pre-fetch as the main uniqueness checker.
- Cross-kind `relationship.common_parent.update` — when a peer's parent changes, the start kind isn't in the diff. Same shape as the uniqueness gap closed in `90927aa0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all schema-constraint validators to only the nodes changed in a proposed change and fixes cross-kind uniqueness rechecks. This removes kind-wide scans on large datasets while preserving full scans when the schema itself changes.

- **Refactors**
  - Added optional node UUID scoping to validator requests and queries; gated each initial MATCH with WHERE $node_uuids IS NULL OR n.uuid IN $node_uuids across attribute and relationship validators.
  - Uniqueness checker now prefetches constraint-relevant values for diffed nodes and issues value-anchored queries to surface collisions with untouched peers.

- **Bug Fixes**
  - Re-check uniqueness on peer attribute changes across kinds (e.g., rel__peer_attr paths) by resolving affected dependent node UUIDs and merging them into the constraint scope; schema-diff constraints still full-scan.
  - Fixed value checks so falsy-but-set values (0, "", false) are treated as set in value-scoped queries.

<sup>Written for commit 62696cb7e5153ef5ac9e62bb18121d70f9c07101. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9276?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

