### PR TITLE
Refine path results sidebar and node styling

### DIFF
--- a/dev/guidelines/frontend/page-architecture.md
+++ b/dev/guidelines/frontend/page-architecture.md
@@ -74,7 +74,8 @@ Examples of helpers that should live in `utils.ts`:
 Move these out of the page component the moment you write them:
 
 - Pure formatters → `utils.ts`
-- Clipboard / `navigator.*` helpers → `utils.ts` (or a small hook if stateful)
+- Pure clipboard / text-formatting helpers (`copyAllAsText`, `formatAsText`) → `utils.ts`
+- Reading from / writing to the clipboard at runtime → reuse `useCopyToClipboard` (`shared/hooks/useCopyToClipboard.ts`); do **not** call `navigator.clipboard.*` directly or reinvent the "Copied!" feedback state
 - API mappers → `domain/`
 - React Query hooks → `ui/queries/`
 - Subtree-specific UI when modes diverge → separate component (`<PathMode />`, `<ImpactMode />`)

--- a/dev/knowledge/frontend/shared-components.md
+++ b/dev/knowledge/frontend/shared-components.md
@@ -131,7 +131,7 @@ The `tab` argument on each helper is a string-literal union (e.g. `BranchDetails
 | Debounced value | `useDebounce` | `shared/hooks/useDebounce.ts` |
 | Pagination state | `usePagination` | `shared/hooks/usePagination.ts` |
 | Local-storage state | `useLocalStorage` | `shared/hooks/useLocalStorage.ts` |
-| Copy to clipboard | `useCopyToClipboard` | `shared/hooks/useCopyToClipboard.ts` |
+| Copy to clipboard (incl. "Copied!" feedback) | `useCopyToClipboard` — never call `navigator.clipboard.*` directly | `shared/hooks/useCopyToClipboard.ts` |
 | Detect truncation | `useIsTruncated` | `shared/hooks/useIsTruncated.ts` |
 | Previous value | `usePrevious` | `shared/hooks/usePrevious.ts` |
 | Search input state | `useSearch` | `shared/hooks/useSearch.ts` |

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -2,6 +2,12 @@ import type { UseFormReturn } from "react-hook-form";
 
 import { KindMultiSelect } from "@/shared/components/inputs/kind-multi-select";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/shared/components/ui/accordion";
+import {
   Form,
   FormField,
   FormInput,
@@ -64,34 +70,41 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
         )}
       />
 
-      <FormField
-        name="maxDepth"
-        rules={{
-          required: "Max depth is required",
-          min: { value: 1, message: "Must be ≥ 1" },
-          max: { value: 20, message: "Must be ≤ 20" },
-        }}
-        render={({ field }) => (
-          <div className="space-y-1">
-            <FormLabel>Max Depth</FormLabel>
-            <FormInput>
-              <Input
-                type="number"
-                min={1}
-                max={20}
-                value={(field.value as number) ?? ""}
-                onChange={(e) => {
-                  const value = e.target.valueAsNumber;
-                  field.onChange(isNaN(value) ? null : value);
-                }}
-              />
-            </FormInput>
-            <FormMessage />
-          </div>
-        )}
-      />
+      <Accordion type="single" collapsible>
+        <AccordionItem value="advanced">
+          <AccordionTrigger>Search options</AccordionTrigger>
+          <AccordionContent className="space-y-3">
+            <FormField
+              name="maxDepth"
+              rules={{
+                required: "Max depth is required",
+                min: { value: 1, message: "Must be ≥ 1" },
+                max: { value: 20, message: "Must be ≤ 20" },
+              }}
+              render={({ field }) => (
+                <div className="space-y-1">
+                  <FormLabel>Max Depth</FormLabel>
+                  <FormInput>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={20}
+                      value={(field.value as number) ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.valueAsNumber;
+                        field.onChange(isNaN(value) ? null : value);
+                      }}
+                    />
+                  </FormInput>
+                  <FormMessage />
+                </div>
+              )}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
 
-      <FormSubmit isPending={isPending} className="w-full bg-amber-600 hover:bg-amber-700">
+      <FormSubmit isPending={isPending} className="w-full">
         Find Dependencies
       </FormSubmit>
     </Form>

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
@@ -1,7 +1,8 @@
 import { useForm } from "react-hook-form";
 
+import { copyEntriesAsText, formatPathHopsAsText } from "../format-paths";
+import { PathResultsList } from "../path-results-list";
 import { useGetReachableNodes } from "../queries/get-reachable-nodes.query";
-import { getKindColor } from "../utils";
 import { DependenciesModeForm } from "./dependencies-mode-form";
 import {
   type DependenciesModeFormValues,
@@ -29,6 +30,7 @@ export function DependenciesModeSidebar() {
   );
 
   const data = query.data;
+  const paths = data?.dependencies.map((dep) => dep.path) ?? [];
 
   return (
     <div className="flex h-full flex-col">
@@ -39,38 +41,21 @@ export function DependenciesModeSidebar() {
       />
 
       {data && (
-        <div className="border-gray-200 border-t p-4">
-          <div className="mb-2 rounded-md border border-amber-200 bg-amber-50 p-2">
-            <div className="font-medium text-amber-800 text-xs">
-              {data.count} dependenc{data.count === 1 ? "y" : "ies"} found
-            </div>
-          </div>
-          <div className="space-y-1">
-            {data.dependencies.map((dep, index) => (
-              <button
-                key={`${dep.node.id}-${index}`}
-                type="button"
-                onClick={() => setParams({ selectedIndex: index })}
-                className={`flex w-full items-center gap-2 rounded-md border p-2 text-left text-xs transition-colors ${
-                  params.selectedIndex === index
-                    ? "border-amber-300 bg-amber-50"
-                    : "border-transparent hover:border-gray-200 hover:bg-gray-50"
-                }`}
-              >
-                <div
-                  className="size-2 flex-shrink-0 rounded-full"
-                  style={{ backgroundColor: getKindColor(dep.node.kind) }}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate font-medium">{dep.node.display_label}</div>
-                  <div className="truncate text-[10px] text-gray-400">
-                    {dep.node.kind} · {dep.depth} hop{dep.depth !== 1 ? "s" : ""}
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
+        <PathResultsList
+          paths={paths}
+          countLabel={`${data.count} dependenc${data.count === 1 ? "y" : "ies"} found`}
+          selectedIndex={params.selectedIndex}
+          onSelect={(index) => setParams({ selectedIndex: index })}
+          variant="amber"
+          getItemTitle={(_, index) => data.dependencies[index]?.node.display_label ?? ""}
+          getItemSubtitle={(_, index) => data.dependencies[index]?.node.kind}
+          emptyMessage="No dependencies found"
+          copyAllText={() =>
+            copyEntriesAsText(paths, (_, i) => data.dependencies[i]?.node.display_label ?? "")
+          }
+          copyItemText={(index) => formatPathHopsAsText(paths[index]!)}
+          ariaLabel="Dependency results"
+        />
       )}
     </div>
   );

--- a/frontend/app/src/entities/path-traversal/ui/format-paths.test.ts
+++ b/frontend/app/src/entities/path-traversal/ui/format-paths.test.ts
@@ -6,7 +6,7 @@ import type {
   PathResult,
   PathTraversalResponse,
 } from "../domain/path-traversal.types";
-import { copyAllPathsAsText, formatPathAsText, getKindCounts, pathPreview } from "./format-paths";
+import { copyAllPathsAsText, formatPathAsText } from "./format-paths";
 
 const node = (id: string, kind: string, label: string): PathNode => ({
   id,
@@ -83,38 +83,5 @@ describe("copyAllPathsAsText", () => {
 
   test("returns empty string for zero paths", () => {
     expect(copyAllPathsAsText({ ...response, paths: [], count: 0 })).toBe("");
-  });
-});
-
-describe("pathPreview", () => {
-  test("returns the full chain when nodes fit under the limit", () => {
-    expect(pathPreview(path, 5)).toBe("router-1 -> Ethernet1 -> router-2");
-  });
-
-  test("returns first -> ... -> last when nodes exceed the limit", () => {
-    const longPath: PathResult = {
-      ...path,
-      hops: [
-        hop(a),
-        hop(b, rel("interfaces", "device")),
-        hop(c, rel("device", "interfaces")),
-        hop(node("d", "InfraDevice", "router-3"), rel("link", "link")),
-      ],
-    };
-    expect(pathPreview(longPath, 3)).toBe("router-1 -> ... -> router-3");
-  });
-
-  test("uses default limit of 3", () => {
-    expect(pathPreview(path)).toBe("router-1 -> Ethernet1 -> router-2");
-  });
-});
-
-describe("getKindCounts", () => {
-  test("counts and labels each kind on the path", () => {
-    expect(getKindCounts(path)).toBe("2x InfraDevice, 1x InfraInterface");
-  });
-
-  test("returns an empty string for a path with no hops", () => {
-    expect(getKindCounts({ ...path, hops: [] })).toBe("");
   });
 });

--- a/frontend/app/src/entities/path-traversal/ui/format-paths.ts
+++ b/frontend/app/src/entities/path-traversal/ui/format-paths.ts
@@ -1,4 +1,4 @@
-import type { PathResult, PathTraversalResponse } from "../domain/path-traversal.types";
+import type { PathTraversalResponse } from "../domain/path-traversal.types";
 
 export function formatPathAsText(data: PathTraversalResponse, pathIndex: number): string {
   const path = data.paths[pathIndex];
@@ -20,20 +20,4 @@ export function copyAllPathsAsText(data: PathTraversalResponse): string {
       (path, i) => `Path ${i + 1}: ${path.hops.map((hop) => hop.node.display_label).join(" → ")}`
     )
     .join("\n");
-}
-
-export function pathPreview(path: PathResult, maxHops = 3): string {
-  const names = path.hops.map((hop) => hop.node.display_label);
-  if (names.length <= maxHops) return names.join(" -> ");
-  return `${names[0]} -> ... -> ${names.at(-1)}`;
-}
-
-export function getKindCounts(path: PathResult): string {
-  const counts = new Map<string, number>();
-  for (const hop of path.hops) {
-    counts.set(hop.node.kind, (counts.get(hop.node.kind) ?? 0) + 1);
-  }
-  return Array.from(counts.entries())
-    .map(([kind, count]) => `${count}x ${kind}`)
-    .join(", ");
 }

--- a/frontend/app/src/entities/path-traversal/ui/format-paths.ts
+++ b/frontend/app/src/entities/path-traversal/ui/format-paths.ts
@@ -1,9 +1,21 @@
-import type { PathTraversalResponse } from "../domain/path-traversal.types";
+import type { PathResult, PathTraversalResponse } from "../domain/path-traversal.types";
 
 export function formatPathAsText(data: PathTraversalResponse, pathIndex: number): string {
   const path = data.paths[pathIndex];
   if (!path) return "";
 
+  return formatPathHopsAsText(path);
+}
+
+export function copyAllPathsAsText(data: PathTraversalResponse): string {
+  return data.paths
+    .map(
+      (path, i) => `Path ${i + 1}: ${path.hops.map((hop) => hop.node.display_label).join(" → ")}`
+    )
+    .join("\n");
+}
+
+export function formatPathHopsAsText(path: PathResult): string {
   return path.hops
     .map((hop, index) => {
       const label = hop.node.display_label;
@@ -14,10 +26,14 @@ export function formatPathAsText(data: PathTraversalResponse, pathIndex: number)
     .join(" ");
 }
 
-export function copyAllPathsAsText(data: PathTraversalResponse): string {
-  return data.paths
+export function copyEntriesAsText(
+  paths: PathResult[],
+  labelFor: (path: PathResult, index: number) => string
+): string {
+  return paths
     .map(
-      (path, i) => `Path ${i + 1}: ${path.hops.map((hop) => hop.node.display_label).join(" → ")}`
+      (path, i) =>
+        `${labelFor(path, i)}: ${path.hops.map((hop) => hop.node.display_label).join(" → ")}`
     )
     .join("\n");
 }

--- a/frontend/app/src/entities/path-traversal/ui/infra-node.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/infra-node.tsx
@@ -35,39 +35,36 @@ export function InfraNode({ data }: NodeProps) {
     navigate(url);
   }
 
-  let borderColor = "border-gray-300";
-  let bgColor = "bg-white";
-  const showKindStripe = !isSource && !isDestination && !nodeData.highlighted;
   const kindColor = getKindColor(nodeData.kind);
+  const isEndpoint = isSource || isDestination;
+
+  let borderClass = "";
+  let bgClass = "bg-white";
+  let borderStyle: string | undefined;
 
   if (isSource) {
-    borderColor = "border-emerald-500";
-    bgColor = "bg-emerald-50";
+    borderClass = "border-emerald-500";
+    bgClass = "bg-emerald-50";
   } else if (isDestination) {
-    borderColor = "border-orange-500";
-    bgColor = "bg-orange-50";
-  } else if (nodeData.highlighted) {
-    borderColor = "border-blue-400";
-    bgColor = "bg-blue-50";
+    borderClass = "border-orange-500";
+    bgClass = "bg-orange-50";
+  } else {
+    borderStyle = kindColor;
+    if (nodeData.highlighted) bgClass = "bg-blue-50";
   }
 
-  const dimmed = !nodeData.highlighted && !isSource && !isDestination;
+  const dimmed = !nodeData.highlighted && !isEndpoint;
 
   return (
     <div
-      className={`relative min-w-[150px] max-w-[220px] cursor-pointer rounded-lg border-2 px-3 py-2 text-center shadow-sm transition-all hover:shadow-md ${borderColor} ${bgColor}
+      className={`relative min-w-[150px] max-w-[220px] cursor-pointer rounded-lg border-2 px-3 py-2 text-center shadow-sm transition-all hover:shadow-md ${borderClass} ${bgClass}
         ${dimmed ? "opacity-40" : ""}
       `}
+      style={borderStyle ? { borderColor: borderStyle } : undefined}
       onClick={handleClick}
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
-      {showKindStripe && (
-        <div
-          className="absolute top-0 left-0 h-full w-1 rounded-l-lg"
-          style={{ backgroundColor: kindColor }}
-        />
-      )}
       <Handle type="target" position={targetPosition} className="!bg-gray-400" />
 
       {/* Endpoint badge */}

--- a/frontend/app/src/entities/path-traversal/ui/path-flow-graph.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-flow-graph.tsx
@@ -13,6 +13,7 @@ import { type ReactNode, useState } from "react";
 import "@xyflow/react/dist/style.css";
 
 import { constructPath } from "@/shared/api/rest/fetch";
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 
 import type { PathResult } from "../domain/path-traversal.types";
 import { BottomToolbar, type LayoutDirection } from "./bottom-toolbar";
@@ -95,8 +96,10 @@ function NodeContextMenu({
   onClose: () => void;
   onExcludeKind?: (kind: string) => void;
 }) {
+  const { copyToClipboard } = useCopyToClipboard();
+
   function handleCopyId() {
-    navigator.clipboard.writeText(menu.nodeId);
+    copyToClipboard(menu.nodeId);
     onClose();
   }
 

--- a/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-sidebar.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-sidebar.tsx
@@ -1,10 +1,8 @@
-import { Command } from "cmdk";
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { copyAllPathsAsText, formatPathAsText } from "../format-paths";
+import { PathResultsList } from "../path-results-list";
 import { useGetPathTraversal } from "../queries/get-path-traversal.query";
-import { getKindColor } from "../utils";
 import { PathModeForm } from "./path-mode-form";
 import {
   formValuesToParams,
@@ -16,7 +14,6 @@ import {
 export function PathModeSidebar() {
   const [params, setParams] = usePathModeParams();
   const formValues = paramsToFormValues(params);
-  const [copyFeedback, setCopyFeedback] = useState("");
 
   const form = useForm<PathModeFormValues>({
     defaultValues: formValues,
@@ -35,14 +32,7 @@ export function PathModeSidebar() {
     { enabled: !!params.source && !!params.destination }
   );
 
-  async function handleCopy(text: string) {
-    await navigator.clipboard.writeText(text);
-    setCopyFeedback("Copied!");
-    setTimeout(() => setCopyFeedback(""), 2000);
-  }
-
   const data = query.data;
-  const selectedPath = params.selectedPath;
 
   return (
     <div className="flex h-full flex-col">
@@ -53,92 +43,18 @@ export function PathModeSidebar() {
       />
 
       {data && (
-        <div className="border-gray-200 border-t p-4">
-          <div className="mb-3 flex items-center justify-between">
-            <h3 className="font-medium text-gray-700 text-sm">
-              {data.count} path{data.count !== 1 ? "s" : ""} found
-            </h3>
-            {data.paths.length > 0 && (
-              <button
-                type="button"
-                onClick={() => handleCopy(copyAllPathsAsText(data))}
-                className="rounded px-2 py-0.5 text-blue-600 text-xs hover:bg-blue-50"
-                title="Copy all paths to clipboard"
-              >
-                {copyFeedback || "Copy all"}
-              </button>
-            )}
-          </div>
-
-          {data.paths.length > 0 ? (
-            <Command
-              shouldFilter={false}
-              loop
-              disablePointerSelection
-              value={String(selectedPath)}
-              onValueChange={(value) => setParams({ selectedPath: Number(value) })}
-              label="Path results"
-            >
-              <Command.List className="space-y-1">
-                {data.paths.map((path, index) => {
-                  const isExpanded = selectedPath === index;
-                  return (
-                    <Command.Item
-                      key={index}
-                      value={String(index)}
-                      onSelect={() => setParams({ selectedPath: index })}
-                      className="group block cursor-pointer rounded-md border border-transparent transition-colors hover:border-gray-200 hover:bg-gray-50 data-[selected=true]:border-blue-300 data-[selected=true]:bg-blue-50"
-                    >
-                      <div className="flex items-center gap-1 p-2">
-                        <div className="flex min-w-0 flex-1 items-center gap-2">
-                          <span
-                            className={`font-medium text-xs ${
-                              isExpanded ? "text-blue-700" : "text-gray-600"
-                            }`}
-                          >
-                            Path {index + 1}
-                          </span>
-                          <span className="rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-500">
-                            {path.depth} hop{path.depth !== 1 ? "s" : ""}
-                          </span>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleCopy(formatPathAsText(data, index));
-                          }}
-                          className="shrink-0 rounded p-0.5 text-gray-300 opacity-0 transition-opacity hover:text-gray-500 focus-visible:opacity-100 group-hover:opacity-100"
-                          title="Copy this path"
-                        >
-                          copy
-                        </button>
-                      </div>
-                      {isExpanded && (
-                        <ul className="space-y-1 px-3 pb-2">
-                          {path.hops.map((hop, hopIndex) => (
-                            <li
-                              key={`${hop.node.id}-${hopIndex}`}
-                              className="flex items-center gap-2 text-[11px] text-gray-700"
-                            >
-                              <span
-                                className="size-1.5 shrink-0 rounded-full"
-                                style={{ backgroundColor: getKindColor(hop.node.kind) }}
-                              />
-                              <span className="truncate">{hop.node.display_label}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </Command.Item>
-                  );
-                })}
-              </Command.List>
-            </Command>
-          ) : (
-            <div className="text-center text-gray-400 text-sm">No paths found</div>
-          )}
-        </div>
+        <PathResultsList
+          paths={data.paths}
+          countLabel={`${data.count} path${data.count !== 1 ? "s" : ""} found`}
+          selectedIndex={params.selectedPath}
+          onSelect={(index) => setParams({ selectedPath: index })}
+          variant="blue"
+          getItemTitle={(_, index) => `Path ${index + 1}`}
+          emptyMessage="No paths found"
+          copyAllText={() => copyAllPathsAsText(data)}
+          copyItemText={(index) => formatPathAsText(data, index)}
+          ariaLabel="Path results"
+        />
       )}
     </div>
   );

--- a/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-sidebar.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-mode/path-mode-sidebar.tsx
@@ -1,8 +1,10 @@
+import { Command } from "cmdk";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { copyAllPathsAsText, formatPathAsText, getKindCounts, pathPreview } from "../format-paths";
+import { copyAllPathsAsText, formatPathAsText } from "../format-paths";
 import { useGetPathTraversal } from "../queries/get-path-traversal.query";
+import { getKindColor } from "../utils";
 import { PathModeForm } from "./path-mode-form";
 import {
   formValuesToParams,
@@ -69,59 +71,72 @@ export function PathModeSidebar() {
           </div>
 
           {data.paths.length > 0 ? (
-            <div className="space-y-1">
-              {data.paths.map((path, index) => (
-                <div
-                  key={index}
-                  className={`group flex items-start gap-1 rounded-md border p-2 transition-colors ${
-                    selectedPath === index
-                      ? "border-blue-300 bg-blue-50"
-                      : "border-transparent hover:border-gray-200 hover:bg-gray-50"
-                  }`}
-                >
-                  <button
-                    type="button"
-                    onClick={() => setParams({ selectedPath: index })}
-                    className="min-w-0 flex-1 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={`font-medium text-xs ${
-                          selectedPath === index ? "text-blue-700" : "text-gray-600"
-                        }`}
-                      >
-                        Path {index + 1}
-                      </span>
-                      <span className="rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-500">
-                        {path.depth} hop{path.depth !== 1 ? "s" : ""}
-                      </span>
-                    </div>
-                    <div className="mt-0.5 truncate text-[11px] text-gray-400">
-                      {pathPreview(path)}
-                    </div>
-                    <div className="mt-0.5 truncate text-[10px] text-gray-300">
-                      {getKindCounts(path)}
-                    </div>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleCopy(formatPathAsText(data, index))}
-                    className="mt-0.5 flex-shrink-0 rounded p-0.5 text-gray-300 opacity-0 transition-opacity hover:text-gray-500 group-hover:opacity-100"
-                    title="Copy this path"
-                  >
-                    copy
-                  </button>
-                </div>
-              ))}
-            </div>
+            <Command
+              shouldFilter={false}
+              loop
+              disablePointerSelection
+              value={String(selectedPath)}
+              onValueChange={(value) => setParams({ selectedPath: Number(value) })}
+              label="Path results"
+            >
+              <Command.List className="space-y-1">
+                {data.paths.map((path, index) => {
+                  const isExpanded = selectedPath === index;
+                  return (
+                    <Command.Item
+                      key={index}
+                      value={String(index)}
+                      onSelect={() => setParams({ selectedPath: index })}
+                      className="group block cursor-pointer rounded-md border border-transparent transition-colors hover:border-gray-200 hover:bg-gray-50 data-[selected=true]:border-blue-300 data-[selected=true]:bg-blue-50"
+                    >
+                      <div className="flex items-center gap-1 p-2">
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
+                          <span
+                            className={`font-medium text-xs ${
+                              isExpanded ? "text-blue-700" : "text-gray-600"
+                            }`}
+                          >
+                            Path {index + 1}
+                          </span>
+                          <span className="rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-500">
+                            {path.depth} hop{path.depth !== 1 ? "s" : ""}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleCopy(formatPathAsText(data, index));
+                          }}
+                          className="shrink-0 rounded p-0.5 text-gray-300 opacity-0 transition-opacity hover:text-gray-500 focus-visible:opacity-100 group-hover:opacity-100"
+                          title="Copy this path"
+                        >
+                          copy
+                        </button>
+                      </div>
+                      {isExpanded && (
+                        <ul className="space-y-1 px-3 pb-2">
+                          {path.hops.map((hop, hopIndex) => (
+                            <li
+                              key={`${hop.node.id}-${hopIndex}`}
+                              className="flex items-center gap-2 text-[11px] text-gray-700"
+                            >
+                              <span
+                                className="size-1.5 shrink-0 rounded-full"
+                                style={{ backgroundColor: getKindColor(hop.node.kind) }}
+                              />
+                              <span className="truncate">{hop.node.display_label}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </Command.Item>
+                  );
+                })}
+              </Command.List>
+            </Command>
           ) : (
             <div className="text-center text-gray-400 text-sm">No paths found</div>
-          )}
-
-          {data.paths[selectedPath] && (
-            <div className="mt-3 rounded-md border border-gray-100 bg-gray-50 p-2 text-[11px] text-gray-600 leading-relaxed">
-              {formatPathAsText(data, selectedPath)}
-            </div>
           )}
         </div>
       )}

--- a/frontend/app/src/entities/path-traversal/ui/path-results-list.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-results-list.tsx
@@ -1,0 +1,166 @@
+import { Command } from "cmdk";
+import { useState } from "react";
+
+import { classNames } from "@/shared/utils/common";
+
+import type { PathResult } from "../domain/path-traversal.types";
+import { getKindColor } from "./utils";
+
+type Variant = "blue" | "amber";
+
+const VARIANT_CLASSES: Record<
+  Variant,
+  {
+    headerBanner: string;
+    headerText: string;
+    selected: string;
+    selectedTitle: string;
+  }
+> = {
+  blue: {
+    headerBanner: "",
+    headerText: "text-gray-700",
+    selected: "data-[selected=true]:border-blue-300 data-[selected=true]:bg-blue-50",
+    selectedTitle: "text-blue-700",
+  },
+  amber: {
+    headerBanner: "mb-2 rounded-md border border-amber-200 bg-amber-50 p-2",
+    headerText: "font-medium text-amber-800 text-xs",
+    selected: "data-[selected=true]:border-amber-300 data-[selected=true]:bg-amber-50",
+    selectedTitle: "text-amber-700",
+  },
+};
+
+type PathResultsListProps = {
+  paths: PathResult[];
+  countLabel: string;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  variant: Variant;
+  getItemTitle: (path: PathResult, index: number) => string;
+  getItemSubtitle?: (path: PathResult, index: number) => string | undefined;
+  emptyMessage?: string;
+  copyAllText?: () => string;
+  copyItemText?: (index: number) => string;
+  ariaLabel?: string;
+};
+
+export function PathResultsList({
+  paths,
+  countLabel,
+  selectedIndex,
+  onSelect,
+  variant,
+  getItemTitle,
+  getItemSubtitle,
+  emptyMessage = "No results found",
+  copyAllText,
+  copyItemText,
+  ariaLabel = "Path results",
+}: PathResultsListProps) {
+  const v = VARIANT_CLASSES[variant];
+  const [copyFeedback, setCopyFeedback] = useState("");
+
+  async function handleCopy(text: string) {
+    await navigator.clipboard.writeText(text);
+    setCopyFeedback("Copied!");
+    setTimeout(() => setCopyFeedback(""), 2000);
+  }
+
+  return (
+    <div className="border-gray-200 border-t p-4">
+      <div className={classNames("mb-3 flex items-center justify-between", v.headerBanner)}>
+        <h3 className={classNames("font-medium text-sm", v.headerText)}>{countLabel}</h3>
+        {paths.length > 0 && copyAllText && (
+          <button
+            type="button"
+            onClick={() => handleCopy(copyAllText())}
+            className="rounded px-2 py-0.5 text-blue-600 text-xs hover:bg-blue-50"
+            title="Copy all to clipboard"
+          >
+            {copyFeedback || "Copy all"}
+          </button>
+        )}
+      </div>
+
+      {paths.length > 0 ? (
+        <Command
+          shouldFilter={false}
+          loop
+          disablePointerSelection
+          value={String(selectedIndex)}
+          onValueChange={(value) => onSelect(Number(value))}
+          label={ariaLabel}
+        >
+          <Command.List className="space-y-1">
+            {paths.map((path, index) => {
+              const isExpanded = selectedIndex === index;
+              const subtitle = getItemSubtitle?.(path, index);
+              return (
+                <Command.Item
+                  key={index}
+                  value={String(index)}
+                  onSelect={() => onSelect(index)}
+                  className={classNames(
+                    "group block cursor-pointer rounded-md border border-transparent transition-colors hover:border-gray-200 hover:bg-gray-50",
+                    v.selected
+                  )}
+                >
+                  <div className="flex items-center gap-1 p-2">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <span
+                        className={classNames(
+                          "truncate font-medium text-xs",
+                          isExpanded ? v.selectedTitle : "text-gray-600"
+                        )}
+                      >
+                        {getItemTitle(path, index)}
+                      </span>
+                      <span className="shrink-0 rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-500">
+                        {path.depth} hop{path.depth !== 1 ? "s" : ""}
+                      </span>
+                    </div>
+                    {copyItemText && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleCopy(copyItemText(index));
+                        }}
+                        className="shrink-0 rounded p-0.5 text-gray-300 opacity-0 transition-opacity hover:text-gray-500 focus-visible:opacity-100 group-hover:opacity-100"
+                        title="Copy this entry"
+                      >
+                        copy
+                      </button>
+                    )}
+                  </div>
+                  {subtitle && !isExpanded && (
+                    <div className="truncate px-3 pb-2 text-[10px] text-gray-400">{subtitle}</div>
+                  )}
+                  {isExpanded && (
+                    <ul className="space-y-1 px-3 pb-2">
+                      {path.hops.map((hop, hopIndex) => (
+                        <li
+                          key={`${hop.node.id}-${hopIndex}`}
+                          className="flex items-center gap-2 text-[11px] text-gray-700"
+                        >
+                          <span
+                            className="size-1.5 shrink-0 rounded-full"
+                            style={{ backgroundColor: getKindColor(hop.node.kind) }}
+                          />
+                          <span className="truncate">{hop.node.display_label}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </Command.Item>
+              );
+            })}
+          </Command.List>
+        </Command>
+      ) : (
+        <div className="text-center text-gray-400 text-sm">{emptyMessage}</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/src/entities/path-traversal/ui/path-results-list.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/path-results-list.tsx
@@ -1,6 +1,6 @@
 import { Command } from "cmdk";
-import { useState } from "react";
 
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { classNames } from "@/shared/utils/common";
 
 import type { PathResult } from "../domain/path-traversal.types";
@@ -59,13 +59,7 @@ export function PathResultsList({
   ariaLabel = "Path results",
 }: PathResultsListProps) {
   const v = VARIANT_CLASSES[variant];
-  const [copyFeedback, setCopyFeedback] = useState("");
-
-  async function handleCopy(text: string) {
-    await navigator.clipboard.writeText(text);
-    setCopyFeedback("Copied!");
-    setTimeout(() => setCopyFeedback(""), 2000);
-  }
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
 
   return (
     <div className="border-gray-200 border-t p-4">
@@ -74,11 +68,11 @@ export function PathResultsList({
         {paths.length > 0 && copyAllText && (
           <button
             type="button"
-            onClick={() => handleCopy(copyAllText())}
+            onClick={() => copyToClipboard(copyAllText())}
             className="rounded px-2 py-0.5 text-blue-600 text-xs hover:bg-blue-50"
             title="Copy all to clipboard"
           >
-            {copyFeedback || "Copy all"}
+            {isCopied ? "Copied!" : "Copy all"}
           </button>
         )}
       </div>
@@ -125,7 +119,7 @@ export function PathResultsList({
                         type="button"
                         onClick={(e) => {
                           e.stopPropagation();
-                          handleCopy(copyItemText(index));
+                          copyToClipboard(copyItemText(index));
                         }}
                         className="shrink-0 rounded p-0.5 text-gray-300 opacity-0 transition-opacity hover:text-gray-500 focus-visible:opacity-100 group-hover:opacity-100"
                         title="Copy this entry"


### PR DESCRIPTION

<img width="1555" height="991" alt="image" src="https://github.com/user-attachments/assets/d41d2ce4-2d37-411c-8024-6b7623af70e1" />

<img width="1555" height="991" alt="Capture d’écran 2026-05-18 à 19 15 38" src="https://github.com/user-attachments/assets/12cb5320-e7ac-40b8-b567-92a1f2c439b4" />

<img width="1555" height="991" alt="Capture d’écran 2026-05-18 à 19 15 50" src="https://github.com/user-attachments/assets/99678505-88a9-4b3d-af18-f2b232f1917f" />

## Summary

  - Switch path results list to a `cmdk` `Command` for keyboard navigation; the selected path now expands inline to show every hop (with a kind-colored dot),
  replacing the previous `pathPreview` + kind-counts summary lines.
  - Drop the unused `pathPreview` / `getKindCounts` helpers (and their tests) now that the sidebar renders the full hop list directly.
  - Simplify `InfraNode` styling: non-endpoint nodes use the kind color as their border instead of a separate left stripe; endpoint (source/destination) styling and
  the highlight/dim behavior are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies path and dependency results into a shared, keyboard-friendly list with inline hop details, simplifies graph node styling with kind-colored borders, and standardizes clipboard copy behavior across the UI.

- **New Features**
  - Both sidebars use `cmdk` `Command` via a new `PathResultsList`: arrow-key selection, selected row expands to show all hops with kind-colored dots, plus per-item and “Copy all” actions.
  - Dependencies form: moved “Max Depth” into a collapsible “Search options” accordion.

- **Refactors**
  - Dropped `pathPreview` and `getKindCounts` (and tests); added `formatPathHopsAsText` and `copyEntriesAsText` for consistent copy text.
  - Centralized clipboard usage with `useCopyToClipboard` in sidebars and the graph; updated docs to “never call `navigator.clipboard.*` directly”.
  - `InfraNode`: non-endpoint nodes color the border by kind; removed the left stripe. Endpoint and highlight/dim behavior unchanged.

<sup>Written for commit c7ade84785a9ee15551c617b4f8c59bce58ff1d1. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9280?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



