### PR TITLE
fix(backend): Exclude cascade deleted nodes from deletion validation error

### DIFF
--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -169,8 +169,8 @@ class NodeDeleteValidator:
         if not missing_delete_ids:
             return node_ids_to_delete
         missing_delete_peers_data = []
-        for peers_data_list in dependent_node_details_map.values():
-            missing_delete_peers_data.extend(peers_data_list)
+        for peer_id in missing_delete_ids:
+            missing_delete_peers_data.extend(dependent_node_details_map[peer_id])
         validation_error = self._build_validation_error(missing_delete_peers_data=missing_delete_peers_data)
         raise validation_error
 

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -528,9 +528,7 @@ async def test_confusing_error_does_not_include_cascade_deleted_nodes(
         await NodeManager.delete(db=db, branch=default_branch, nodes=[person_jane_main])
 
     error_msg = str(exc.value)
-    assert "TestCar" not in error_msg, (
-        f"TestCar should NOT appear (cascade-deleted), but got: {error_msg}"
-    )
+    assert "TestCar" not in error_msg, f"TestCar should NOT appear (cascade-deleted), but got: {error_msg}"
 
 
 async def test_delete_cascade_artifacts(

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -494,7 +494,7 @@ async def test_delete_branch_aware_node_with_agnostic_relationship(
     )
 
 
-async def test_confusing_error_does_not_include_cascade_deleted_nodes(
+async def test_error_only_includes_violation_node_during_cascade_delete(
     db: InfrahubDatabase,
     default_branch: Branch,
     car_person_schema: SchemaBranch,
@@ -528,7 +528,11 @@ async def test_confusing_error_does_not_include_cascade_deleted_nodes(
         await NodeManager.delete(db=db, branch=default_branch, nodes=[person_jane_main])
 
     error_msg = str(exc.value)
-    assert "TestCar" not in error_msg, f"TestCar should NOT appear (cascade-deleted), but got: {error_msg}"
+    expected_msg = (
+        f"Cannot delete TestPerson '{person_jane_main.id}'. "
+        f"It is linked to mandatory relationship manager on node TestPerson '{person_albert_main.id}' at TestPerson.manager"
+    )
+    assert error_msg == expected_msg
 
 
 async def test_delete_cascade_artifacts(

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -494,6 +494,45 @@ async def test_delete_branch_aware_node_with_agnostic_relationship(
     )
 
 
+async def test_confusing_error_does_not_include_cascade_deleted_nodes(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+    person_jane_main: Node,
+    person_albert_main: Node,
+    car_camry_main: Node,
+) -> None:
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+    person_schema = schema_branch.get(name="TestPerson", duplicate=False)
+    person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
+
+    person_schema.relationships.append(
+        RelationshipSchema(
+            name="manager",
+            kind="Attribute",
+            optional=False,
+            peer="TestPerson",
+            cardinality="one",
+            identifier="person__manager",
+            on_delete=RelationshipDeleteBehavior.NO_ACTION,
+            branch=BranchSupportType.AWARE,
+        )
+    )
+
+    albert = await NodeManager.get_one(db=db, id=person_albert_main.id)
+    await albert.manager.update(db=db, data=person_jane_main.id)
+    await albert.save(db=db)
+
+    with pytest.raises(ValidationError) as exc:
+        await NodeManager.delete(db=db, branch=default_branch, nodes=[person_jane_main])
+
+    error_msg = str(exc.value)
+    assert "TestCar" not in error_msg, (
+        f"TestCar should NOT appear (cascade-deleted), but got: {error_msg}"
+    )
+
+
 async def test_delete_cascade_artifacts(
     db: InfrahubDatabase,
     default_branch: Branch,


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

Deletion errors include cascade deleted nodes (interfaces, artifacts) alongside blocking nodes, making the output noisy and confusing.

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

Closes #6495

## What changed

<!-- Group changes by intent, not by file. -->

<!-- Behavioral changes: what users/systems will observe differently -->
- Fix in `delete_validator.py`: iterate `missing_delete_ids` instead of all `dependent_node_details_map.values()`.

<!-- Implementation notes: key design choices, tradeoffs, notable refactors -->

<!-- What stayed the same: especially useful if you touched sensitive areas -->
<!-- e.g., "No schema changes", "API contract unchanged", "Only affects branch X" -->

<!-- If the diff is large, add a suggested review order:
### Suggested review order
1. Start with ...
2. Then ...
3. Tests are ...
-->

## How to test

<!-- Make it runnable and specific -->

```bash
uv run pytest backend/tests/component/core/test_node_manager_delete.py::test_confusing_error_does_not_include_cascade_deleted_nodes
```

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes cascade-deleted nodes from deletion validation errors so only real blockers are listed. This clarifies delete errors and addresses #6495.

- **Bug Fixes**
  - Build the error list from `missing_delete_ids` in `backend/infrahub/core/node/delete_validator.py`.
  - Add test `test_error_only_includes_violation_node_during_cascade_delete` to ensure only the violating node is mentioned and cascade peers are omitted.

<sup>Written for commit a3d531bdbea000e2404d985630584481b633ea39. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

