### PR TITLE
fix merge with delete of migrated kind object

### DIFF
--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -867,7 +867,7 @@ CALL (n) {
 // --------------------
 CALL (n, is_part_of_e) {
     WITH n, is_part_of_e
-    WHERE n.updated_at IS NULL OR n.updated_at <> $at)
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
     WITH n, is_part_of_e, CASE
         WHEN is_part_of_e.from = $at THEN is_part_of_e.from_user_id
         WHEN is_part_of_e.to = $at THEN is_part_of_e.to_user_id

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -65,14 +65,24 @@ CALL (node_diff_map, node_db_id) {
     ORDER BY n_is_part_of.branch_level DESC, n_is_part_of.from DESC, n_is_part_of.status ASC
     LIMIT 1
 }
-WITH n, node_diff_map, is_node_kind_migration
-CALL (n, node_diff_map, is_node_kind_migration) {
+// ------------------------------
+// Resolve the currently-active target-branch Node vertex for this UUID, if it exists
+// ------------------------------
+CALL (n) {
+    OPTIONAL MATCH (tgt_candidate:Node {uuid: n.uuid})-[tgt_ipo:IS_PART_OF {branch: $target_branch, status: "active"}]->(:Root)
+    WHERE tgt_ipo.to IS NULL
+    RETURN tgt_candidate
+    ORDER BY tgt_ipo.from DESC
+    LIMIT 1
+}
+WITH n, COALESCE(tgt_candidate, n) AS tgt_n, node_diff_map, is_node_kind_migration
+CALL (n, tgt_n, node_diff_map, is_node_kind_migration) {
     WITH CASE
         WHEN node_diff_map.action = "ADDED" THEN "active"
         WHEN node_diff_map.action = "REMOVED" THEN "deleted"
         ELSE NULL
     END AS node_rel_status
-    CALL (n, node_diff_map, is_node_kind_migration, node_rel_status) {
+    CALL (n, tgt_n, node_diff_map, is_node_kind_migration, node_rel_status) {
         // ------------------------------
         // only make IS_PART_OF updates if node is ADDED or REMOVED
         // ------------------------------
@@ -95,9 +105,9 @@ CALL (n, node_diff_map, is_node_kind_migration) {
         // ------------------------------
         // set IS_PART_OF.to, optionally, target branch
         // ------------------------------
-        WITH root, n, node_rel_status, source_from_user_id
-        CALL (root, n, node_rel_status, source_from_user_id) {
-            OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(n)
+        WITH root, n, tgt_n, node_rel_status, source_from_user_id
+        CALL (root, tgt_n, node_rel_status, source_from_user_id) {
+            OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(tgt_n)
             WHERE node_rel_status = "deleted"
             AND target_r_root.from <= $at AND target_r_root.to IS NULL
             SET target_r_root.to = $at, target_r_root.to_user_id = source_from_user_id
@@ -105,6 +115,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
         // ------------------------------
         // create new IS_PART_OF relationship on target_branch
         // also set created_at/created_by on Node vertex when adding
+        // (uses ``n``, `tgt_n` cannot exist for ADDED Nodes)
         // ------------------------------
         WITH root, n, node_rel_status, source_from_user_id
         CALL (root, n, node_rel_status, source_from_user_id) {
@@ -122,21 +133,23 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             SET n.created_at = $at, n.created_by = source_from_user_id
         }
         // ------------------------------
-        // shortcut to delete all attributes and relationships for this node if the node is deleted
+        // shortcut to delete all attributes and relationships for this node if the node is deleted.
+        // Walks from ``tgt_n`` so the cascade closes the post-migration vertex's edges when a
+        // migration happened on target.
         // ------------------------------
-        CALL (n, node_rel_status, source_from_user_id) {
-            WITH n, node_rel_status, source_from_user_id
+        CALL (tgt_n, node_rel_status, source_from_user_id) {
+            WITH tgt_n, node_rel_status, source_from_user_id
             WHERE node_rel_status = "deleted"
-            CALL (n) {
-                OPTIONAL MATCH (n)-[rel1:IS_RELATED]-(attr_rel:Relationship)-[rel2]-(p)
-                WHERE (p.uuid IS NULL OR n.uuid <> p.uuid)
+            CALL (tgt_n) {
+                OPTIONAL MATCH (tgt_n)-[rel1:IS_RELATED]-(attr_rel:Relationship)-[rel2]-(p)
+                WHERE (p.uuid IS NULL OR tgt_n.uuid <> p.uuid)
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
                 AND rel1.status = "active"
                 AND rel2.status = "active"
                 RETURN rel1, rel2, attr_rel
                 UNION
-                OPTIONAL MATCH (n)-[rel1:HAS_ATTRIBUTE]->(attr_rel:Attribute)-[rel2]->()
+                OPTIONAL MATCH (tgt_n)-[rel1:HAS_ATTRIBUTE]->(attr_rel:Attribute)-[rel2]->()
                 WHERE type(rel2) <> "HAS_ATTRIBUTE"
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
@@ -154,17 +167,17 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             // ------------------------------
             // and delete HAS_OWNER and HAS_SOURCE edges to this node if the node is deleted
             // ------------------------------
-            WITH n, source_from_user_id
-            CALL (n, source_from_user_id) {
-                CALL (n) {
-                    MATCH (n)<-[rel:HAS_OWNER]-()
+            WITH tgt_n, source_from_user_id
+            CALL (tgt_n, source_from_user_id) {
+                CALL (tgt_n) {
+                    MATCH (tgt_n)<-[rel:HAS_OWNER]-()
                     WHERE rel.branch = $target_branch
                     AND rel.status = "active"
                     AND rel.from <= $at
                     AND rel.to IS NULL
                     RETURN rel
                     UNION
-                    MATCH (n)<-[rel:HAS_SOURCE]-()
+                    MATCH (tgt_n)<-[rel:HAS_SOURCE]-()
                     WHERE rel.branch = $target_branch
                     AND rel.status = "active"
                     AND rel.from <= $at
@@ -814,32 +827,59 @@ class DiffMergeMetadataQuery(Query):
         # ruff: noqa: E501
         query = """
 // --------------------
-// Match all affected nodes, accounting for nodes with migrated kind
-// for each UUID, get the latest Node that was active on this branch
+// Match all affected Node vertices for each UUID, including post-migration
+// siblings created by a target-branch migration after the source branch was
+// forked. A UUID can map to more than one Node vertex when migrated, and the
+// merge can have touched edges on more than one of those vertices; we want
+// to refresh metadata on each. For each Node, pick its "best" IS_PART_OF
+// (latest ``from``, prefer active before deleted) to anchor the
+// updated_at/by fallback for newly-created vertices.
 // --------------------
 UNWIND $node_uuids AS node_uuid
-CALL (node_uuid) {
-    MATCH (n:Node {uuid: node_uuid})-[e:IS_PART_OF]->(:Root)
+MATCH (n:Node {uuid: node_uuid})
+// --------------------
+// Exclude Node vertices on the target branch that have previously been deleted
+// as part of a node kind/inheritance migration
+// --------------------
+WHERE NOT EXISTS {
+    MATCH (n)-[migrated_out:IS_PART_OF {branch: $target_branch, status: "deleted"}]->(:Root)
+    WHERE migrated_out.from < $at AND migrated_out.to IS NULL
+}
+CALL (n) {
+    MATCH (n)-[e:IS_PART_OF]->(:Root)
     WHERE e.branch IN [$target_branch, $global_branch]
     AND (
-        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at))
+        // pre-fork edge, edge created by the merge, or edge closed by the merge
+        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
         OR (e.branch = $global_branch AND e.from <= $at)
     )
-    RETURN n, e AS is_part_of_e
+    RETURN e AS is_part_of_e
     ORDER BY e.from DESC, e.status ASC
     LIMIT 1
 }
 // --------------------
-// Special handling for the new version of a migrated kind/inheritance Node
-// set updated_at/by to the time/user that created the new version of the Node
+// Node-level metadata refresh for added and deleted Node vertices
+//   - ADDED - ``updated_at``/``by`` on freshly-created Node vertices that the
+//     merge just inserted (their IS_PART_OF has ``from = $at``).
+//   - DELETED - ``updated_at``/``by`` on Node vertices whose IS_PART_OF was
+//     closed by the merge (``to = $at``). This is required to cover Nodes with
+//     their kind/inheritance migrated on the target branch then deleted in the merge
 // --------------------
 CALL (n, is_part_of_e) {
     WITH n, is_part_of_e
-    WHERE n.updated_at IS NULL
-    SET n.updated_at = is_part_of_e.from, n.updated_by = is_part_of_e.from_user_id
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at)
+    WITH n, is_part_of_e, CASE
+        WHEN is_part_of_e.from = $at THEN is_part_of_e.from_user_id
+        WHEN is_part_of_e.to = $at THEN is_part_of_e.to_user_id
+        ELSE NULL
+    END AS ipo_user_id
+    WHERE ipo_user_id IS NOT NULL
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+    SET n.updated_at = $at, n.updated_by = ipo_user_id
 }
 // --------------------
-// Get all the Attributes and Relationships for this Node that were active on this branch at some point
+// Get all the Attributes and Relationships for this Node that were active on
+// this branch at some point
 // --------------------
 MATCH (n)-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
 WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
@@ -904,11 +944,18 @@ ORDER BY change_time DESC, is_system ASC
 WITH n, collect(change_user_id)[0] AS node_updated_by
 
 // ------------------------------------
-// Update Node metadata with latest change across all its fields
+// Update Node metadata with latest change across all its fields.
+// Skip setting ``previous_updated_at`` if the IS_PART_OF-driven refresh
+// above already moved ``updated_at`` to ``$at`` — otherwise we'd clobber
+// the real ``previous_updated_at`` it captured.
 // ------------------------------------
 WITH n, node_updated_by
 WHERE node_updated_by IS NOT NULL
-SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+CALL (n) {
+    WITH n
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+}
 SET n.updated_at = $at, n.updated_by = node_updated_by
         """
         self.add_to_query(query=query)

--- a/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
+++ b/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
@@ -1,0 +1,187 @@
+"""Merging a delete from a user branch when the same UUID was kind-migrated on
+the target branch *after* the user branch was forked must propagate the delete
+(and its metadata) to the post-migration Node vertex on the target branch.
+"""
+
+from unittest.mock import AsyncMock
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+async def _get_diff_coordinator(db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+    return diff_coordinator
+
+
+async def _get_diff_merger(db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+    component_registry = get_component_registry()
+    return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+
+async def _migrate_testcar_to_test2newcar_on_default(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+) -> Timestamp:
+    main_schema = registry.schema.get_schema_branch(name=default_branch.name)
+    original_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema.name = "NewCar"
+    new_car_schema.namespace = "Test2"
+    assert new_car_schema.kind == "Test2NewCar"
+    main_schema.set(name="Test2NewCar", schema=new_car_schema)
+    person_schema = main_schema.get(name="TestPerson", duplicate=True)
+    person_schema.get_relationship("cars").peer = "Test2NewCar"
+    person_schema.get_relationship("cars_driven").peer = "Test2NewCar"
+    main_schema.set(name="TestPerson", schema=person_schema)
+    main_schema.delete(name="TestCar")
+    main_schema.process()
+    await registry.schema.update_schema_branch(
+        db=db,
+        branch=default_branch,
+        schema=main_schema,
+        limit=["TestCar", "Test2NewCar", "TestPerson"],
+        update_db=True,
+    )
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+    migration_at = Timestamp()
+    result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"),
+        branch=default_branch,
+    )
+    assert not result.errors
+    return migration_at
+
+
+async def test_target_branch_migration_after_fork_delete_propagates_to_post_migration_vertex(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    car_person_schema: SchemaBranch,
+    person_jane_main: Node,
+    car_camry_main: Node,
+) -> None:
+    """Post-migration ``Test2NewCar`` vertex must be fully deleted by the merge:
+    its active ``IS_PART_OF`` and child edges closed at ``merge_at``, and its
+    node-level ``updated_at`` / ``updated_by`` refreshed to reflect the delete.
+    """
+    branch_user = "branch-deleted-node-user"
+
+    # Fork the diff branch while the schema is still TestCar, then migrate
+    # TestCar -> Test2NewCar on default, then delete on the branch.
+    branch = await create_branch(db=db, branch_name="tgt-migration-after-fork")
+    migration_at = await _migrate_testcar_to_test2newcar_on_default(db=db, default_branch=default_branch)
+
+    branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
+    assert branch_car is not None
+    await branch_car.delete(db=db, user_id=branch_user)
+
+    coordinator = await _get_diff_coordinator(db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    merger = await _get_diff_merger(db=db, branch=branch)
+    merge_at = Timestamp()
+    await merger.merge_graph(at=merge_at)
+
+    # Dump every IS_PART_OF on the default branch for the deleted UUID so the
+    # failure is self-describing.
+    ipo_rows = await db.execute_query(
+        query="""
+        MATCH (n:Node {uuid: $uuid})-[ipo:IS_PART_OF {branch: $target_branch}]->(:Root)
+        RETURN labels(n) AS labels,
+               n.updated_at AS node_updated_at,
+               n.updated_by AS node_updated_by,
+               ipo.status AS status,
+               ipo.from AS ipo_from,
+               ipo.to AS ipo_to,
+               ipo.to_user_id AS ipo_to_user_id
+        ORDER BY ipo_from, status
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    diag = (
+        f"\nmigration_at = {migration_at.to_string()}"
+        f"\nmerge_at     = {merge_at.to_string()}"
+        f"\nIS_PART_OF rows on {default_branch.name!r} for {car_camry_main.id}:\n"
+        + "\n".join("  " + repr(r) for r in ipo_rows)
+    )
+
+    new_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" in r["labels"]]
+    old_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" not in r["labels"] and "TestCar" in r["labels"]]
+    assert old_vertex_ipos, f"expected a pre-migration TestCar IS_PART_OF{diag}"
+    assert new_vertex_ipos, f"expected a post-migration Test2NewCar IS_PART_OF{diag}"
+
+    # The active IS_PART_OF on the post-migration vertex must be closed at
+    # merge_at, attributed to the branch user.
+    new_active_ipo = [r for r in new_vertex_ipos if r["status"] == "active"]
+    assert len(new_active_ipo) == 1, f"expected exactly one active IS_PART_OF on the post-migration vertex{diag}"
+    assert new_active_ipo[0]["ipo_to"] == merge_at.to_string(), (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the merge "
+        f"(expected ipo.to == merge_at, got {new_active_ipo[0]['ipo_to']!r}){diag}"
+    )
+    assert new_active_ipo[0]["ipo_to_user_id"] == branch_user, (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the branch user "
+        f"(expected ipo.to_user_id == {branch_user!r}, got {new_active_ipo[0]['ipo_to_user_id']!r}){diag}"
+    )
+
+    # Child edges (HAS_ATTRIBUTE/IS_RELATED) on the post-migration vertex must
+    # also be closed.
+    open_child_edges = await db.execute_query(
+        query="""
+        MATCH (n:Test2NewCar {uuid: $uuid})-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+        WHERE e.branch = $target_branch
+        AND e.status = "active"
+        AND e.to IS NULL
+        RETURN type(e) AS edge_type, labels(field) AS field_labels, e.from AS e_from
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    assert not open_child_edges, (
+        "post-migration Test2NewCar vertex still has active target-branch HAS_ATTRIBUTE/IS_RELATED "
+        f"edges after a delete-merge: {open_child_edges!r}{diag}"
+    )
+
+    # Node-level metadata on the post-migration vertex must reflect the merge,
+    # not the prior migration.
+    new_node_updated_at = new_active_ipo[0]["node_updated_at"]
+    new_node_updated_by = new_active_ipo[0]["node_updated_by"]
+    assert new_node_updated_at == merge_at.to_string(), (
+        "post-migration Test2NewCar n.updated_at not refreshed by the merge "
+        f"(expected {merge_at.to_string()}, got {new_node_updated_at!r}){diag}"
+    )
+    assert new_node_updated_by == branch_user, (
+        "post-migration Test2NewCar n.updated_by not refreshed by the merge "
+        f"(expected {branch_user!r}, got {new_node_updated_by!r}){diag}"
+    )
+
+    # Conversely, the pre-migration ``TestCar`` vertex must NOT have its
+    # node-level metadata clobbered by the merge
+    old_node_updated_at = old_vertex_ipos[0]["node_updated_at"]
+    old_node_updated_by = old_vertex_ipos[0]["node_updated_by"]
+    assert old_node_updated_at != merge_at.to_string(), (
+        "pre-migration TestCar n.updated_at was clobbered to merge_at by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )
+    assert old_node_updated_by != branch_user, (
+        "pre-migration TestCar n.updated_by was clobbered to the branch user by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )

--- a/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
+++ b/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
@@ -1,6 +1,9 @@
-"""Merging a delete from a user branch when the same UUID was kind-migrated on
-the target branch *after* the user branch was forked must propagate the delete
-(and its metadata) to the post-migration Node vertex on the target branch.
+"""Delete-merge propagation across a post-fork target-branch kind migration.
+
+When the same UUID was kind-migrated on the target branch *after* the user
+branch was forked, merging a delete from the user branch must propagate the
+delete (and its metadata) to the post-migration Node vertex on the target
+branch.
 """
 
 from unittest.mock import AsyncMock
@@ -81,9 +84,11 @@ async def test_target_branch_migration_after_fork_delete_propagates_to_post_migr
     person_jane_main: Node,
     car_camry_main: Node,
 ) -> None:
-    """Post-migration ``Test2NewCar`` vertex must be fully deleted by the merge:
-    its active ``IS_PART_OF`` and child edges closed at ``merge_at``, and its
-    node-level ``updated_at`` / ``updated_by`` refreshed to reflect the delete.
+    """Post-migration ``Test2NewCar`` vertex must be fully deleted by the merge.
+
+    Its active ``IS_PART_OF`` and child edges must be closed at ``merge_at``,
+    and its node-level ``updated_at`` / ``updated_by`` refreshed to reflect
+    the delete.
     """
     branch_user = "branch-deleted-node-user"
 

--- a/changelog/9283.fixed.md
+++ b/changelog/9283.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked.


### PR DESCRIPTION
closes #9283 

Fix a couple of bugs in the merge logic related to object that their kind/inheritance migrated on the default branch and then are deleted on the feature branch. The order of operations to produce the bug(s) has to be

1. create user branch
2. updated name, namepace, or inheritance of schema on the default branch
3. delete an instance of the schema from step 2 on the user branch
4. merge the user branch

the two bugs are 
1. object with their kind/inheritance migrated on the default branch and a delete merged on the user branch were not actually deleted
2. the updated_at/by metadata of an object "deleted" using the reproduction steps was not correctly updated. this is not really visible to the user in any way today once the object is deleted, but it could be important for auditing in the future so should be correct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes merge behavior so a delete from a feature branch actually removes an object when its kind/inheritance was migrated on the default branch after the branch fork. Also fixes `updated_at`/`updated_by` so deletes reflect the branch user and time.

- **Bug Fixes**
  - Resolve the active target-branch node (`tgt_n`) for migrated UUIDs and run the delete cascade from it (`IS_PART_OF`, `HAS_ATTRIBUTE`, `IS_RELATED`, `HAS_OWNER`, `HAS_SOURCE`).
  - Refresh node metadata on adds/deletes using `IS_PART_OF.from_user_id`/`to_user_id`, keep `previous_updated_*`, and avoid touching pre-migration vertices.
  - Skip metadata updates for target-branch nodes already deleted by a migration.
  - Add a component test for fork → migrate-on-target → delete-on-branch that verifies full cascade and correct metadata.

<sup>Written for commit ee45105c7a756ddf4275403d37dcfdf5d64e5a7d. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

