### PR TITLE
IFC-1238: Fix failure when removing generic attribute and its uniqueness constraint

### DIFF
--- a/backend/changelog/5735.fixed.md
+++ b/backend/changelog/5735.fixed.md
@@ -1,0 +1,1 @@
+Removing an attribute and its uniqueness constraint from a generic schema in a single schema update no longer causes a 500 error.

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2104,8 +2104,18 @@ class SchemaBranch:
             ]
             if len(filtered_attributes) == len(node.attributes):
                 continue
+
+            deleted_names = {
+                attribute.name for attribute in node.attributes if attribute.state == HashableModelState.ABSENT
+            }
             updated_node = node.duplicate()
             updated_node.attributes = filtered_attributes
+            if deleted_names and updated_node.uniqueness_constraints:
+                updated_node.uniqueness_constraints = [
+                    paths
+                    for paths in updated_node.uniqueness_constraints
+                    if not any(path.split("__", maxsplit=1)[0] in deleted_names for path in paths)
+                ] or None
             self.set(name=name, schema=updated_node)
 
     def process_nodes_state(self) -> None:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2104,7 +2104,6 @@ class SchemaBranch:
             ]
             if len(filtered_attributes) == len(node.attributes):
                 continue
-
             updated_node = node.duplicate()
             updated_node.attributes = filtered_attributes
             self.set(name=name, schema=updated_node)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2105,17 +2105,8 @@ class SchemaBranch:
             if len(filtered_attributes) == len(node.attributes):
                 continue
 
-            deleted_names = {
-                attribute.name for attribute in node.attributes if attribute.state == HashableModelState.ABSENT
-            }
             updated_node = node.duplicate()
             updated_node.attributes = filtered_attributes
-            if deleted_names and updated_node.uniqueness_constraints:
-                updated_node.uniqueness_constraints = [
-                    paths
-                    for paths in updated_node.uniqueness_constraints
-                    if not any(path.split("__", maxsplit=1)[0] in deleted_names for path in paths)
-                ] or None
             self.set(name=name, schema=updated_node)
 
     def process_nodes_state(self) -> None:

--- a/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
@@ -288,10 +288,16 @@ class TestUniquenessConstraintMigrationRemoveFromConstraint(TestSchemaLifecycleB
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)
+        await assert_no_virtual_schema_relationships_in_db(db=db)
 
 
 class TestGenericRemoveAttributesAndConstraints(TestSchemaLifecycleBase):
-    """Removing attributes and their uniqueness constraints from generics in one update must not error."""
+    """Removing attributes and their uniqueness constraints from generics.
+
+    Removing an attribute without removing its uniqueness constraint is rejected.
+    Removing both together in one update succeeds.
+
+    """
 
     @pytest.fixture(scope="class")
     def schema_step_01(self) -> dict[str, Any]:
@@ -319,7 +325,24 @@ class TestGenericRemoveAttributesAndConstraints(TestSchemaLifecycleBase):
         }
 
     @pytest.fixture(scope="class")
-    def schema_step_02(self) -> dict[str, Any]:
+    def schema_step_02_reject(self) -> dict[str, Any]:
+        """Vehicle identifier removed via state:absent but uniqueness constraint kept — must be rejected."""
+        return {
+            "version": "1.0",
+            "generics": [
+                {
+                    "name": "Vehicle",
+                    "namespace": "Testing",
+                    "attributes": [
+                        {"name": "identifier", "kind": "Text", "optional": True, "state": "absent"},
+                    ],
+                    "uniqueness_constraints": [["identifier__value"]],
+                },
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_03(self) -> dict[str, Any]:
         return {
             "version": "1.0",
             "generics": [
@@ -369,15 +392,28 @@ class TestGenericRemoveAttributesAndConstraints(TestSchemaLifecycleBase):
         assert "label" in fleet.attribute_names
         assert fleet.uniqueness_constraints == [["identifier__value"], ["label__value"]]
 
-    async def test_step02_remove_attributes_and_constraints_simultaneously(
+    async def test_step02_rejected_when_attribute_removed_without_constraint(
+        self,
+        client: InfrahubClient,
+        initial_dataset: None,
+        schema_step_02_reject: dict[str, Any],
+    ) -> None:
+        """Removing an attribute that is still referenced in a uniqueness constraint is rejected."""
+        response = await client.schema.load(schemas=[schema_step_02_reject])
+        assert response.errors
+        error_message = response.errors["errors"][0]["message"]
+        assert "Requested unique constraint not found within node" in error_message
+        assert "identifier__value" in error_message
+
+    async def test_step03_remove_attributes_and_constraints_simultaneously(
         self,
         client: InfrahubClient,
         default_branch: Branch,
         initial_dataset: None,
-        schema_step_02: dict[str, Any],
+        schema_step_03: dict[str, Any],
     ) -> None:
         """Removing attributes and constraints together in one update must succeed without error."""
-        response = await client.schema.load(schemas=[schema_step_02])
+        response = await client.schema.load(schemas=[schema_step_03])
         assert not response.errors
 
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)

--- a/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py
@@ -288,4 +288,109 @@ class TestUniquenessConstraintMigrationRemoveFromConstraint(TestSchemaLifecycleB
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)
-        await assert_no_virtual_schema_relationships_in_db(db=db)
+
+
+class TestGenericRemoveAttributesAndConstraints(TestSchemaLifecycleBase):
+    """Removing attributes and their uniqueness constraints from generics in one update must not error."""
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [
+                {
+                    "name": "Vehicle",
+                    "namespace": "Testing",
+                    "attributes": [
+                        {"name": "identifier", "kind": "Text", "optional": True},
+                    ],
+                    "uniqueness_constraints": [["identifier__value"]],
+                },
+                {
+                    "name": "Fleet",
+                    "namespace": "Testing",
+                    "attributes": [
+                        {"name": "identifier", "kind": "Text", "optional": True},
+                        {"name": "label", "kind": "Text", "optional": True},
+                    ],
+                    "uniqueness_constraints": [["identifier__value"], ["label__value"]],
+                },
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_02(self) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [
+                {
+                    "name": "Vehicle",
+                    "namespace": "Testing",
+                    "attributes": [
+                        {"name": "identifier", "kind": "Text", "optional": True, "state": "absent"},
+                    ],
+                    "uniqueness_constraints": [],
+                },
+                {
+                    "name": "Fleet",
+                    "namespace": "Testing",
+                    "attributes": [
+                        {"name": "identifier", "kind": "Text", "optional": True, "state": "absent"},
+                        {"name": "label", "kind": "Text", "optional": True, "state": "absent"},
+                    ],
+                    "uniqueness_constraints": [],
+                },
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        schema_step_01: dict[str, Any],
+    ) -> None:
+        await load_schema(db=db, schema=schema_step_01)
+
+    async def test_step01_generics_have_attributes_and_constraints(
+        self,
+        default_branch: Branch,
+        initial_dataset: None,
+    ) -> None:
+        """Baseline: both generics have their attributes and uniqueness constraints."""
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        vehicle = schema_branch.get(name="TestingVehicle")
+        assert "identifier" in vehicle.attribute_names
+        assert vehicle.uniqueness_constraints == [["identifier__value"]]
+
+        fleet = schema_branch.get(name="TestingFleet")
+        assert "identifier" in fleet.attribute_names
+        assert "label" in fleet.attribute_names
+        assert fleet.uniqueness_constraints == [["identifier__value"], ["label__value"]]
+
+    async def test_step02_remove_attributes_and_constraints_simultaneously(
+        self,
+        client: InfrahubClient,
+        default_branch: Branch,
+        initial_dataset: None,
+        schema_step_02: dict[str, Any],
+    ) -> None:
+        """Removing attributes and constraints together in one update must succeed without error."""
+        response = await client.schema.load(schemas=[schema_step_02])
+        assert not response.errors
+
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+        vehicle = schema_branch.get(name="TestingVehicle")
+        assert "identifier" not in vehicle.attribute_names
+        assert not vehicle.uniqueness_constraints
+
+        fleet = schema_branch.get(name="TestingFleet")
+        assert "identifier" not in fleet.attribute_names
+        assert "label" not in fleet.attribute_names
+        assert not fleet.uniqueness_constraints
+
+    async def test_final_validate(self, db: InfrahubDatabase) -> None:
+        await verify_no_duplicate_relationships(db=db)
+        await verify_no_edges_added_after_node_delete(db=db)


### PR DESCRIPTION
# Why

When an attribute and its `uniqueness_constraints` entry are removed from a **generic** schema in a single update, the schema reload raises a 500 Internal Server Error. The error is:

```
ValueError: TestMyGeneric: Requested unique constraint not found within node. (`identifier__value`)
```

Root cause: `process_attributes_state()` removes ABSENT attributes from the schema object but leaves stale paths in `uniqueness_constraints`. The immediately following `sync_uniqueness_constraints_and_unique_attributes()` then calls `parse_schema_path()` on a path whose attribute no longer exists, triggering `AttributePathParsingError`. The same operation works for regular node schemas and succeeds when split into two sequential updates.

Closes https://github.com/opsmill/infrahub/issues/5735

## How to test

```bash
uv run pytest backend/tests/integration/schema_lifecycle/test_migration_uniqueness_constraints.py -v -k "TestGenericRemoveAttributesAndConstraints"
```

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`changelog/5735.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 500 when removing a generic attribute and its uniqueness constraint in the same schema update. We now drop constraint paths that reference attributes marked `absent`, so the update succeeds in one pass (addresses IFC-1238).

- **Bug Fixes**
  - Filter `uniqueness_constraints` that reference `absent` attributes in `process_attributes_state()` to prevent stale paths and `AttributePathParsingError`.
  - Expanded integration test `TestGenericRemoveAttributesAndConstraints` to assert rejection when only the attribute is removed and success when attributes and constraints are removed together.
  - Added changelog entry.

<sup>Written for commit 32bfda212dbedd1a850e829a97e6fbc3d6ded84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9288?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

