### PR TITLE
Update NodeManager.query return type

### DIFF
--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -234,7 +234,11 @@ async def signin_sso_account(  # noqa: PLR0915
 
     if identity_nodes:
         identity_node = identity_nodes[0]
-        account = await identity_node.account.get_peer(db=db)
+        # `identity_nodes` is `list[Node]` because schema is a kind-string; the runtime
+        # instance is an InternalExternalIdentity with `.account`. Typing it via protocol
+        # would cascade Optional and CoreNode-vs-Node mismatches through the rest of the
+        # function, so suppress just the attribute access here.
+        account = await identity_node.account.get_peer(db=db)  # type: ignore[attr-defined]
         if account.label.value != external_identity.display_name:
             account.label.value = external_identity.display_name
             await account.save(db=db)

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -102,7 +102,7 @@ class NodeManager:
         partial_match: bool = ...,
         branch_agnostic: bool = ...,
         order: OrderModel | None = ...,
-    ) -> list[Any]: ...
+    ) -> list[Node]: ...
 
     @overload
     @classmethod
@@ -139,7 +139,7 @@ class NodeManager:
         partial_match: bool = False,
         branch_agnostic: bool = False,
         order: OrderModel | None = None,
-    ) -> list[Any]:
+    ) -> list[Node] | list[SchemaProtocol]:
         """Query one or multiple nodes of a given type based on filter arguments.
 
         Args:

--- a/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m026_0000_prefix_fix.py
@@ -8,6 +8,7 @@ from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.shared import MigrationInput, MigrationResult
+from infrahub.core.protocols import BuiltinIPPrefix
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
@@ -36,7 +37,7 @@ class Migration026(InternalSchemaMigration):
 
         for branch in await Branch.get_list(db=db):
             prefix_0000s = await NodeManager.query(
-                db=db, schema="BuiltinIPPrefix", branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}
+                db=db, schema=BuiltinIPPrefix, branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}
             )
             if not prefix_0000s:
                 continue

--- a/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
+++ b/backend/infrahub/core/migrations/graph/m038_redo_0000_prefix_fix.py
@@ -8,6 +8,7 @@ from infrahub.core.initialization import initialization
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.shared import MigrationInput, MigrationResult
+from infrahub.core.protocols import BuiltinIPPrefix
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 
@@ -44,7 +45,7 @@ class Migration038(InternalSchemaMigration):
 
         for branch in await Branch.get_list(db=db):
             prefix_0000s = await NodeManager.query(
-                db=db, schema="BuiltinIPPrefix", branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}
+                db=db, schema=BuiltinIPPrefix, branch=branch, filters={"prefix__values": ["0.0.0.0/0", "::/0"]}
             )
             if not prefix_0000s:
                 continue

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -13,7 +13,6 @@ from typing import (
     Mapping,
     Sequence,
     TypeVar,
-    cast,
     overload,
 )
 
@@ -578,7 +577,6 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                 results = await registry.manager.query(
                     db=db, schema=InfrahubKind.RESOURCEPOOL, filters={"name__value": pool_id}, branch=self.branch
                 )
-                results = cast("list[Node]", results)
                 pool = results[0] if results else None
 
             if not pool:

--- a/backend/infrahub/graphql/mutations/diff_conflict.py
+++ b/backend/infrahub/graphql/mutations/diff_conflict.py
@@ -4,10 +4,11 @@ from typing import TYPE_CHECKING
 
 from graphene import Boolean, InputField, InputObjectType, Mutation, String
 
-from infrahub.core.constants import BranchConflictKeep, InfrahubKind
+from infrahub.core.constants import BranchConflictKeep
 from infrahub.core.diff.model.path import ConflictSelection
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreDataCheck
 from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import ProcessingError
@@ -60,7 +61,7 @@ class ResolveDiffConflict(Mutation):
 
         core_data_checks = await NodeManager.query(
             db=graphql_context.db,
-            schema=InfrahubKind.DATACHECK,
+            schema=CoreDataCheck,
             filters={"enriched_conflict_id__value": data.conflict_id},
         )
         if not core_data_checks:
@@ -72,6 +73,9 @@ class ResolveDiffConflict(Mutation):
         else:
             keep_branch = None
         for cdc in core_data_checks:
-            cdc.keep_branch.value = keep_branch
+            # Generated protocols type enum-backed attributes as stdlib `enum.Enum`, whose `.value`
+            # is read-only. At runtime the attribute is an infrahub Enum/Dropdown with a writable
+            # value.
+            cdc.keep_branch.value = keep_branch  # type: ignore[misc]
             await cdc.save(db=graphql_context.db)
         return cls(ok=True)

--- a/backend/tests/helpers/query_benchmark/car_person_generators.py
+++ b/backend/tests/helpers/query_benchmark/car_person_generators.py
@@ -118,7 +118,7 @@ class CarWithDiffInSecondBranchGenerator(CarGenerator):
         # that were created by prior calls to `load_data`
         car_schema = registry.schema.get_node_schema(name="TestCar", branch=self.diff_branch)
         car_nodes = await NodeManager.query(db=self.db, schema=car_schema, branch=self.diff_branch)
-        new_car_nodes = [car_node for car_node in car_nodes if car_node.name.value in new_cars]
+        new_car_nodes = [car_node for car_node in car_nodes if car_node.name.value in new_cars]  # type: ignore[attr-defined]
 
         nb_diff = max(int(nb_elements * self.diff_ratio), 1)
 
@@ -126,19 +126,19 @@ class CarWithDiffInSecondBranchGenerator(CarGenerator):
         car_nodes_updatable = new_car_nodes
         car_nodes_to_update = random.choices(car_nodes_updatable, k=nb_diff)
         for i, car_node in enumerate(car_nodes_to_update):
-            car_node.name.value = f"updated-car-{str(uuid.uuid4())[:8]}"
+            car_node.name.value = f"updated-car-{str(uuid.uuid4())[:8]}"  # type: ignore[attr-defined]
 
             # Permute engines among car nodes to update, so it keeps one-to-one relationship between cars-engines
-            new_engine = car_nodes_to_update[(i + 1) % len(car_nodes_to_update)].engine
-            car_node.engine.update(db=self.db, data=new_engine)
+            new_engine = car_nodes_to_update[(i + 1) % len(car_nodes_to_update)].engine  # type: ignore[attr-defined]
+            car_node.engine.update(db=self.db, data=new_engine)  # type: ignore[attr-defined]
 
             # Update one-to-many relationship
             new_owner = random.choice([self.persons[person_name] for person_name in self.persons])
-            car_node.owner.update(db=self.db, data=new_owner)
+            car_node.owner.update(db=self.db, data=new_owner)  # type: ignore[attr-defined]
 
             # Update many-to-many relationship
             new_drivers = random.choices([self.persons[person_name] for person_name in self.persons])
-            car_node.drivers.update(db=self.db, data=new_drivers)
+            car_node.drivers.update(db=self.db, data=new_drivers)  # type: ignore[attr-defined]
 
             await car_node.save(db=self.db)
 


### PR DESCRIPTION
# Why

NodeManager.query was returning `list[Any]` when we didn't use SchemaProtocol and as such it messed up the typing as everything is permitted on an `Any`

## What changed

* Swap the return type so that we instead return `list[Node]` if a SchemaProtocol isn't used.
* Swap to protocols in a few places
* The change highlighted some other issues for instance the enum, i haven't checked but would assume that we have  either these inline type ignores in other places, alternatively that we have the entire file exclude with regards th `attr-defined` with mypy. Will track the enum issue separately
* Some new type-ignores in the test

## Notes

* Basically the errors that surfaced were there before we just ignored them all because we were returning `Any`.
* There will be some follow up work to correct these issues which will allow us to improve typing overall