### PR TITLE
Stable to develop

### DIFF
--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -78,16 +78,18 @@ WHERE NOT EXISTS {
     WHERE migrated_out.from < $at AND migrated_out.to IS NULL
 }
 CALL (n) {
-    MATCH (n)-[e:IS_PART_OF]->(:Root)
+    // get add or delete IS_PART_OF edge if it exists
+    OPTIONAL MATCH (n)-[e:IS_PART_OF]->(:Root)
     WHERE e.branch IN [$target_branch, $global_branch]
     AND (
         // pre-fork edge, edge created by the merge, or edge closed by the merge
         (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
         OR (e.branch = $global_branch AND e.from <= $at)
     )
-    RETURN e AS is_part_of_e
+    WITH e
     ORDER BY e.from DESC, e.status ASC
     LIMIT 1
+    RETURN e AS is_part_of_e
 }
 // --------------------
 // Node-level metadata refresh for added and deleted Node vertices
@@ -118,6 +120,10 @@ WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
 AND (
     (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
     OR (e.branch IN [$source_branch, $global_branch] AND e.from <= $at)
+    // include any fields updated as part of this merge to cover the case where
+    // a Node had its kind migrated on the default branch after the user branch forked
+    OR exists((field)-[{branch: $target_branch, from: $at}]-())
+    OR exists((field)-[{branch: $target_branch, to: $at}]-())
 )
 
 // --------------------

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -59,37 +59,64 @@ class DiffMergeMetadataQuery(Query):
         }
         query = """
 // --------------------
-// Match all affected nodes, accounting for nodes with migrated kind
-// for each UUID, get the latest Node that was active on this branch
+// Match all affected Node vertices for each UUID, including post-migration
+// siblings created by a target-branch migration after the source branch was
+// forked. A UUID can map to more than one Node vertex when migrated, and the
+// merge can have touched edges on more than one of those vertices; we want
+// to refresh metadata on each. For each Node, pick its "best" IS_PART_OF
+// (latest ``from``, prefer active before deleted) to anchor the
+// updated_at/by fallback for newly-created vertices.
 // --------------------
 UNWIND $node_uuids AS node_uuid
-CALL (node_uuid) {
-    MATCH (n:Node {uuid: node_uuid})-[e:IS_PART_OF]->(:Root)
+MATCH (n:Node {uuid: node_uuid})
+// --------------------
+// Exclude Node vertices on the target branch that have previously been deleted
+// as part of a node kind/inheritance migration
+// --------------------
+WHERE NOT EXISTS {
+    MATCH (n)-[migrated_out:IS_PART_OF {branch: $target_branch, status: "deleted"}]->(:Root)
+    WHERE migrated_out.from < $at AND migrated_out.to IS NULL
+}
+CALL (n) {
+    MATCH (n)-[e:IS_PART_OF]->(:Root)
     WHERE e.branch IN [$target_branch, $global_branch]
     AND (
-        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at))
+        // pre-fork edge, edge created by the merge, or edge closed by the merge
+        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
         OR (e.branch = $global_branch AND e.from <= $at)
     )
-    RETURN n, e AS is_part_of_e
+    RETURN e AS is_part_of_e
     ORDER BY e.from DESC, e.status ASC
     LIMIT 1
 }
 // --------------------
-// Special handling for the new version of a migrated kind/inheritance Node
-// set updated_at/by to the time/user that created the new version of the Node
+// Node-level metadata refresh for added and deleted Node vertices
+//   - ADDED - ``updated_at``/``by`` on freshly-created Node vertices that the
+//     merge just inserted (their IS_PART_OF has ``from = $at``).
+//   - DELETED - ``updated_at``/``by`` on Node vertices whose IS_PART_OF was
+//     closed by the merge (``to = $at``). This is required to cover Nodes with
+//     their kind/inheritance migrated on the target branch then deleted in the merge
 // --------------------
 CALL (n, is_part_of_e) {
     WITH n, is_part_of_e
-    WHERE n.updated_at IS NULL
-    SET n.updated_at = is_part_of_e.from, n.updated_by = is_part_of_e.from_user_id
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
+    WITH n, is_part_of_e, CASE
+        WHEN is_part_of_e.from = $at THEN is_part_of_e.from_user_id
+        WHEN is_part_of_e.to = $at THEN is_part_of_e.to_user_id
+        ELSE NULL
+    END AS ipo_user_id
+    WHERE ipo_user_id IS NOT NULL
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+    SET n.updated_at = $at, n.updated_by = ipo_user_id
 }
 // --------------------
-// Get all the Attributes and Relationships for this Node that were active on this branch at some point
+// Get all the Attributes and Relationships for this Node that were active on
+// this branch at some point
 // --------------------
 MATCH (n)-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
 WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
 AND (
-    (e.branch = $target_branch AND e.from <= $branched_from)
+    (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
     OR (e.branch IN [$source_branch, $global_branch] AND e.from <= $at)
 )
 
@@ -149,11 +176,18 @@ ORDER BY change_time DESC, is_system ASC
 WITH n, collect(change_user_id)[0] AS node_updated_by
 
 // ------------------------------------
-// Update Node metadata with latest change across all its fields
+// Update Node metadata with latest change across all its fields.
+// Skip setting ``previous_updated_at`` if the IS_PART_OF-driven refresh
+// above already moved ``updated_at`` to ``$at`` — otherwise we'd clobber
+// the real ``previous_updated_at`` it captured.
 // ------------------------------------
 WITH n, node_updated_by
 WHERE node_updated_by IS NOT NULL
-SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+CALL (n) {
+    WITH n
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+}
 SET n.updated_at = $at, n.updated_by = node_updated_by
         """
         self.add_to_query(query=query)

--- a/backend/infrahub/core/metadata/query/node_metadata.py
+++ b/backend/infrahub/core/metadata/query/node_metadata.py
@@ -109,8 +109,9 @@ class NodeMetadataDefaultBranchQuery(Query):
     type = QueryType.READ
     insert_return = False
 
-    def __init__(self, node_uuids: list[str], **kwargs: Any) -> None:
+    def __init__(self, node_uuids: list[str], allowed_kinds: list[str] | None = None, **kwargs: Any) -> None:
         self.node_uuids = node_uuids
+        self.allowed_kinds = allowed_kinds
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
@@ -118,6 +119,7 @@ class NodeMetadataDefaultBranchQuery(Query):
             raise ValueError("NodeMetadataQuery only runs on the default branch")
 
         self.params["node_uuids"] = self.node_uuids
+        self.params["allowed_kinds"] = self.allowed_kinds
         self.params["branch"] = self.branch.name
 
         # Query nodes with their metadata and deletion status
@@ -130,6 +132,7 @@ UNWIND $node_uuids AS node_uuid
 CALL (node_uuid) {
     MATCH (n:Node {uuid: node_uuid})-[r_ipo:IS_PART_OF]->(root:Root)
     WHERE r_ipo.branch = $branch
+    AND ($allowed_kinds is NULL OR any(l in labels(n) WHERE l IN $allowed_kinds))
     RETURN n, r_ipo
     ORDER BY r_ipo.from DESC
     LIMIT 1

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -99,7 +99,6 @@ class NodeDuplicateQuery(Query):
                 SET deleted_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
                 SET deleted_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
-        subquery.append("RETURN peer_node as p2")
         return "\n".join(subquery)
 
     @classmethod
@@ -166,63 +165,68 @@ class NodeDuplicateQuery(Query):
         CALL (node) {
             MATCH (root:Root)<-[r:IS_PART_OF]-(node)
             WHERE %(branch_filter)s
-            RETURN node as n1, r as r1
+            RETURN node as active_node, r.status = "active" AS is_active
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH n1 as active_node, r1 as rb
-        WHERE rb.status = "active"
+        WITH active_node
+        WHERE is_active = TRUE
         CREATE (new_node:Node:%(labels)s { uuid: active_node.uuid, kind: $new_node.kind, namespace: $new_node.namespace, branch_support: $new_node.branch_support })
         WITH active_node, new_node
         // Set metadata on new Node vertex
         CALL (active_node, new_node) {
             // always pass created_by/at from active node
             SET new_node.created_at = active_node.created_at, new_node.created_by = active_node.created_by
-            WITH new_node
+            WITH active_node, new_node
             // set updated_by/at if we're on the default/global branch
             WHERE $set_metadata
+            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
             SET new_node.updated_at = $current_time, new_node.updated_by = $user_id
         }
 
         // Process Outbound Relationship
-        MATCH (active_node)-[]->(peer)
-        WITH DISTINCT active_node, new_node, peer
-        CALL (active_node, peer) {
-            MATCH (active_node)-[r]->(peer)
+        MATCH (active_node)-[]->(peer_node)
+        WITH DISTINCT active_node, new_node, peer_node
+        CALL (active_node, peer_node) {
+            MATCH (active_node)-[r]->(peer_node)
             WHERE %(branch_filter)s
-            RETURN active_node as n1, r as rel_outband1, peer as p1
+            RETURN r as rel_outband
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH n1 as active_node, rel_outband1 as rel_outband, p1 as peer_node, new_node
+        WITH active_node, rel_outband, peer_node, new_node
         WHERE rel_outband.status = "active" AND rel_outband.to IS NULL
         CALL (%(sub_query_out_args)s) {
             %(sub_query_out)s
         }
-        WITH p2 as peer_node, rel_outband, active_node, new_node
-        FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
+        WITH peer_node, rel_outband, active_node, new_node
+        CALL (rel_outband) {
+            WITH rel_outband
+            WHERE rel_outband.branch IN ["-global-", $branch]
             SET rel_outband.to = $current_time, rel_outband.to_user_id = $user_id
-        )
+        }
         WITH DISTINCT active_node, new_node
         // Process Inbound Relationship
-        MATCH (active_node)<-[]-(peer)
-        WITH DISTINCT active_node, new_node, peer
-        CALL (active_node, peer) {
-            MATCH (active_node)<-[r]-(peer)
+        MATCH (active_node)<-[]-(peer_node)
+        WITH DISTINCT active_node, new_node, peer_node
+        CALL (active_node, peer_node) {
+            MATCH (active_node)<-[r]-(peer_node)
             WHERE %(branch_filter)s
-            RETURN active_node as n1, r as rel_inband1, peer as p1
+            RETURN r as rel_inband
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH n1 as active_node, rel_inband1 as rel_inband, p1 as peer_node, new_node
+        WITH active_node, rel_inband, peer_node, new_node
         WHERE rel_inband.status = "active" AND rel_inband.to IS NULL
         CALL (%(sub_query_in_args)s) {
             %(sub_query_in)s
         }
-        WITH p2 as peer_node, rel_inband, active_node, new_node
-        FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
+        WITH peer_node, rel_inband, active_node, new_node
+        CALL (rel_inband) {
+            WITH rel_inband
+            WHERE rel_inband.branch IN ["-global-", $branch]
             SET rel_inband.to = $current_time, rel_inband.to_user_id = $user_id
-        )
+        }
         RETURN DISTINCT new_node
         """ % {
             "branch_filter": branch_filter,

--- a/backend/tests/component/core/diff/merge/_validators.py
+++ b/backend/tests/component/core/diff/merge/_validators.py
@@ -116,7 +116,9 @@ async def validate_deleted_node(db: InfrahubDatabase, branch: Branch, ctx: Delet
     with pytest.raises(NodeNotFoundError):
         await NodeManager.get_one(db=db, branch=branch, id=ctx.node_id, raise_on_error=True)
 
-    node_metadata_query = await NodeMetadataDefaultBranchQuery.init(db=db, branch=branch, node_uuids=[ctx.node_id])
+    node_metadata_query = await NodeMetadataDefaultBranchQuery.init(
+        db=db, branch=branch, node_uuids=[ctx.node_id], allowed_kinds=[ctx.expected_kind]
+    )
     await node_metadata_query.execute(db=db)
     metadatas = node_metadata_query.get_metadatas()
     assert len(metadatas) == 1

--- a/backend/tests/component/core/diff/merge/test_source_branch_migration.py
+++ b/backend/tests/component/core/diff/merge/test_source_branch_migration.py
@@ -83,11 +83,12 @@ async def test_source_branch_migration(
         car_tagged=car_tagged_main,
         added_node_kind="Test2NewCar",
     )
-    # Post-merge, every car kind on main becomes Test2NewCar.
+    # Post-merge, active TestCars on main becomes Test2NewCars
     assert contexts.added_node
     contexts.added_node.expected_kind = "Test2NewCar"
+    # Test2NewCars deleted on the source, cause the corresponding TestCar to be deleted on main
     assert contexts.deleted_node
-    contexts.deleted_node.expected_kind = "Test2NewCar"
+    contexts.deleted_node.expected_kind = "TestCar"
 
     coordinator = await get_diff_coordinator(db=db, branch=branch)
     enriched_diff = await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)

--- a/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
+++ b/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
@@ -1,0 +1,192 @@
+"""Delete-merge propagation across a post-fork target-branch kind migration.
+
+When the same UUID was kind-migrated on the target branch *after* the user
+branch was forked, merging a delete from the user branch must propagate the
+delete (and its metadata) to the post-migration Node vertex on the target
+branch.
+"""
+
+from unittest.mock import AsyncMock
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+async def _get_diff_coordinator(db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+    return diff_coordinator
+
+
+async def _get_diff_merger(db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+    component_registry = get_component_registry()
+    return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+
+async def _migrate_testcar_to_test2newcar_on_default(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+) -> Timestamp:
+    main_schema = registry.schema.get_schema_branch(name=default_branch.name)
+    original_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema.name = "NewCar"
+    new_car_schema.namespace = "Test2"
+    assert new_car_schema.kind == "Test2NewCar"
+    main_schema.set(name="Test2NewCar", schema=new_car_schema)
+    person_schema = main_schema.get(name="TestPerson", duplicate=True)
+    person_schema.get_relationship("cars").peer = "Test2NewCar"
+    person_schema.get_relationship("cars_driven").peer = "Test2NewCar"
+    main_schema.set(name="TestPerson", schema=person_schema)
+    main_schema.delete(name="TestCar")
+    main_schema.process()
+    await registry.schema.update_schema_branch(
+        db=db,
+        branch=default_branch,
+        schema=main_schema,
+        limit=["TestCar", "Test2NewCar", "TestPerson"],
+        update_db=True,
+    )
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+    migration_at = Timestamp()
+    result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"),
+        branch=default_branch,
+    )
+    assert not result.errors
+    return migration_at
+
+
+async def test_target_branch_migration_after_fork_delete_propagates_to_post_migration_vertex(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    car_person_schema: SchemaBranch,
+    person_jane_main: Node,
+    car_camry_main: Node,
+) -> None:
+    """Post-migration ``Test2NewCar`` vertex must be fully deleted by the merge.
+
+    Its active ``IS_PART_OF`` and child edges must be closed at ``merge_at``,
+    and its node-level ``updated_at`` / ``updated_by`` refreshed to reflect
+    the delete.
+    """
+    branch_user = "branch-deleted-node-user"
+
+    # Fork the diff branch while the schema is still TestCar, then migrate
+    # TestCar -> Test2NewCar on default, then delete on the branch.
+    branch = await create_branch(db=db, branch_name="tgt-migration-after-fork")
+    migration_at = await _migrate_testcar_to_test2newcar_on_default(db=db, default_branch=default_branch)
+
+    branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
+    assert branch_car is not None
+    await branch_car.delete(db=db, user_id=branch_user)
+
+    coordinator = await _get_diff_coordinator(db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    merger = await _get_diff_merger(db=db, branch=branch)
+    merge_at = Timestamp()
+    await merger.merge_graph(at=merge_at)
+
+    # Dump every IS_PART_OF on the default branch for the deleted UUID so the
+    # failure is self-describing.
+    ipo_rows = await db.execute_query(
+        query="""
+        MATCH (n:Node {uuid: $uuid})-[ipo:IS_PART_OF {branch: $target_branch}]->(:Root)
+        RETURN labels(n) AS labels,
+               n.updated_at AS node_updated_at,
+               n.updated_by AS node_updated_by,
+               ipo.status AS status,
+               ipo.from AS ipo_from,
+               ipo.to AS ipo_to,
+               ipo.to_user_id AS ipo_to_user_id
+        ORDER BY ipo_from, status
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    diag = (
+        f"\nmigration_at = {migration_at.to_string()}"
+        f"\nmerge_at     = {merge_at.to_string()}"
+        f"\nIS_PART_OF rows on {default_branch.name!r} for {car_camry_main.id}:\n"
+        + "\n".join("  " + repr(r) for r in ipo_rows)
+    )
+
+    new_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" in r["labels"]]
+    old_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" not in r["labels"] and "TestCar" in r["labels"]]
+    assert old_vertex_ipos, f"expected a pre-migration TestCar IS_PART_OF{diag}"
+    assert new_vertex_ipos, f"expected a post-migration Test2NewCar IS_PART_OF{diag}"
+
+    # The active IS_PART_OF on the post-migration vertex must be closed at
+    # merge_at, attributed to the branch user.
+    new_active_ipo = [r for r in new_vertex_ipos if r["status"] == "active"]
+    assert len(new_active_ipo) == 1, f"expected exactly one active IS_PART_OF on the post-migration vertex{diag}"
+    assert new_active_ipo[0]["ipo_to"] == merge_at.to_string(), (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the merge "
+        f"(expected ipo.to == merge_at, got {new_active_ipo[0]['ipo_to']!r}){diag}"
+    )
+    assert new_active_ipo[0]["ipo_to_user_id"] == branch_user, (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the branch user "
+        f"(expected ipo.to_user_id == {branch_user!r}, got {new_active_ipo[0]['ipo_to_user_id']!r}){diag}"
+    )
+
+    # Child edges (HAS_ATTRIBUTE/IS_RELATED) on the post-migration vertex must
+    # also be closed.
+    open_child_edges = await db.execute_query(
+        query="""
+        MATCH (n:Test2NewCar {uuid: $uuid})-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+        WHERE e.branch = $target_branch
+        AND e.status = "active"
+        AND e.to IS NULL
+        RETURN type(e) AS edge_type, labels(field) AS field_labels, e.from AS e_from
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    assert not open_child_edges, (
+        "post-migration Test2NewCar vertex still has active target-branch HAS_ATTRIBUTE/IS_RELATED "
+        f"edges after a delete-merge: {open_child_edges!r}{diag}"
+    )
+
+    # Node-level metadata on the post-migration vertex must reflect the merge,
+    # not the prior migration.
+    new_node_updated_at = new_active_ipo[0]["node_updated_at"]
+    new_node_updated_by = new_active_ipo[0]["node_updated_by"]
+    assert new_node_updated_at == merge_at.to_string(), (
+        "post-migration Test2NewCar n.updated_at not refreshed by the merge "
+        f"(expected {merge_at.to_string()}, got {new_node_updated_at!r}){diag}"
+    )
+    assert new_node_updated_by == branch_user, (
+        "post-migration Test2NewCar n.updated_by not refreshed by the merge "
+        f"(expected {branch_user!r}, got {new_node_updated_by!r}){diag}"
+    )
+
+    # Conversely, the pre-migration ``TestCar`` vertex must NOT have its
+    # node-level metadata clobbered by the merge
+    old_node_updated_at = old_vertex_ipos[0]["node_updated_at"]
+    old_node_updated_by = old_vertex_ipos[0]["node_updated_by"]
+    assert old_node_updated_at != merge_at.to_string(), (
+        "pre-migration TestCar n.updated_at was clobbered to merge_at by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )
+    assert old_node_updated_by != branch_user, (
+        "pre-migration TestCar n.updated_by was clobbered to the branch user by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )

--- a/changelog/9283.fixed.md
+++ b/changelog/9283.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked.


### PR DESCRIPTION
merge stable to develop with a few extra updates see the second and later commits for the individual updates

- clean up the `NodeDuplicateQuery` to set the `updated_by/at` metadata on Node vertices being deleted on the default/global branch. also generally update to be in the more modern style
- updates to the `DiffMergeMetadataQuery` to cover a fix from `stable`. The diff merge logic has been completely rewritten between `stable` and `develop`, so `develop` required a different update to actually be fixed.


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes merge behavior so deletes from a branch propagate to the correct node when the target branch migrated its kind/inheritance after the fork. The post‑migration vertex (and its child edges) is closed at merge time and node metadata is updated to the merge user/time.

- **Bug Fixes**
  - Merge query now handles post‑fork target‑branch migrations: includes migrated siblings, closes `IS_PART_OF` and child edges at `$at`, and refreshes `updated_at/updated_by` without clobbering `previous_updated_*`.
  - Includes fields added/closed at `$at` and skips vertices already deleted on the target branch.
  - `NodeMetadataDefaultBranchQuery` accepts `allowed_kinds` to filter returned nodes.
  - Added tests for delete propagation to post‑migration vertices and updated validators; changelog entry added.

- **Refactors**
  - Simplified `NodeDuplicateQuery`: streamlined subqueries and consistently close existing edges on branch/global while stamping `to_user_id`; set metadata when duplicating on default/global.

<sup>Written for commit b941db0902b5c5bd42bef550c93aae3b519dc7d3. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9295?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

