### PR TITLE
Activate RET lint rules

### DIFF
--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -76,5 +76,4 @@ async def get_diff_artifacts(
     artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     target_branch = await registry.get_branch(db=db, branch=registry.default_branch)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=target_branch)
-    response = {art_diff.id: art_diff for art_diff in artifact_diffs}
-    return response
+    return {art_diff.id: art_diff for art_diff in artifact_diffs}

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -354,8 +354,7 @@ def generate_access_token(account_id: str, session_id: uuid.UUID) -> str:
         "type": "access",
         "session_id": str(session_id),
     }
-    access_token = jwt.encode(access_data, config.SETTINGS.security.secret_key, algorithm="HS256")
-    return access_token
+    return jwt.encode(access_data, config.SETTINGS.security.secret_key, algorithm="HS256")
 
 
 def generate_refresh_token(account_id: str, session_id: uuid.UUID, expiration: datetime) -> str:
@@ -370,8 +369,7 @@ def generate_refresh_token(account_id: str, session_id: uuid.UUID, expiration: d
         "type": "refresh",
         "session_id": str(session_id),
     }
-    refresh_token = jwt.encode(refresh_data, config.SETTINGS.security.secret_key, algorithm="HS256")
-    return refresh_token
+    return jwt.encode(refresh_data, config.SETTINGS.security.secret_key, algorithm="HS256")
 
 
 async def authentication_token(

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -207,7 +207,6 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
         )
 
 
-
 class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
     type: TriggerType = TriggerType.COMPUTED_ATTR_PYTHON
     computed_attribute: PythonTransformComputedAttribute
@@ -272,7 +271,6 @@ class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
         )
 
 
-
 class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
     type: TriggerType = TriggerType.COMPUTED_ATTR_PYTHON_QUERY
 
@@ -331,7 +329,6 @@ class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
                 ),
             ],
         )
-
 
 
 class ComputedAttrJinja2GraphQLResponse(BaseModel):

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -196,7 +196,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
             },
         )
 
-        definition = cls(
+        return cls(
             name=f"{computed_attribute.key_name}{NAME_SEPARATOR}kind{NAME_SEPARATOR}{trigger_node.kind}",
             template_hash=template_hash,
             trigger_kind=trigger_node.kind,
@@ -206,7 +206,6 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
             actions=[workflow],
         )
 
-        return definition
 
 
 class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
@@ -246,7 +245,7 @@ class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
             # attribute query
             event_trigger.match_related["infrahub.field.name"] = update_fields
 
-        definition = cls(
+        return cls(
             name=computed_attribute.computed_attribute.key_name,
             branch=branch,
             computed_attribute=computed_attribute,
@@ -272,7 +271,6 @@ class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
             ],
         )
 
-        return definition
 
 
 class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
@@ -311,7 +309,7 @@ class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
         elif not branches_out_of_scope and branch != registry.default_branch:
             event_trigger.match["infrahub.branch.name"] = branch
 
-        definition = cls(
+        return cls(
             name=f"{computed_attribute.computed_attribute.key_name}{NAME_SEPARATOR}kind{NAME_SEPARATOR}{kind}",
             branch=branch,
             trigger=event_trigger,
@@ -334,7 +332,6 @@ class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
             ],
         )
 
-        return definition
 
 
 class ComputedAttrJinja2GraphQLResponse(BaseModel):

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -135,7 +135,6 @@ class BranchMerger:
         diff_destination = initial_source_schema.diff(other=self.destination_schema)
         return diff_source + diff_destination
 
-
     async def calculate_migrations(self, target_schema: SchemaBranch) -> list[SchemaUpdateMigrationInfo]:
         diff_3way = await self.get_3ways_diff_schema()
         validation = SchemaUpdateValidationResult.init(diff=diff_3way, schema=target_schema)

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -133,9 +133,8 @@ class BranchMerger:
 
         diff_source = initial_source_schema.diff(other=self.source_schema)
         diff_destination = initial_source_schema.diff(other=self.destination_schema)
-        diff_both = diff_source + diff_destination
+        return diff_source + diff_destination
 
-        return diff_both
 
     async def calculate_migrations(self, target_schema: SchemaBranch) -> list[SchemaUpdateMigrationInfo]:
         diff_3way = await self.get_3ways_diff_schema()

--- a/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
+++ b/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
@@ -31,6 +31,5 @@ class Migration002(GraphMigration):
     minimum_version: int = 1
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
+++ b/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
@@ -32,4 +32,3 @@ class Migration002(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
+++ b/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
@@ -50,4 +50,3 @@ class Migration003(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
+++ b/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
@@ -49,6 +49,5 @@ class Migration003(GraphMigration):
     minimum_version: int = 2
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/graph/m004_add_attr_documentation.py
+++ b/backend/infrahub/core/migrations/graph/m004_add_attr_documentation.py
@@ -44,5 +44,4 @@ class Migration004(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m005_add_rel_read_only.py
+++ b/backend/infrahub/core/migrations/graph/m005_add_rel_read_only.py
@@ -36,5 +36,4 @@ class Migration005(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m006_add_rel_on_delete.py
+++ b/backend/infrahub/core/migrations/graph/m006_add_rel_on_delete.py
@@ -36,5 +36,4 @@ class Migration006(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m007_add_rel_allow_override.py
+++ b/backend/infrahub/core/migrations/graph/m007_add_rel_allow_override.py
@@ -44,5 +44,4 @@ class Migration007(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m008_add_human_friendly_id.py
+++ b/backend/infrahub/core/migrations/graph/m008_add_human_friendly_id.py
@@ -44,5 +44,4 @@ class Migration008(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m009_add_generate_profile_attr.py
+++ b/backend/infrahub/core/migrations/graph/m009_add_generate_profile_attr.py
@@ -36,5 +36,4 @@ class Migration009(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m010_add_generate_profile_attr_generic.py
+++ b/backend/infrahub/core/migrations/graph/m010_add_generate_profile_attr_generic.py
@@ -36,5 +36,4 @@ class Migration010(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
+++ b/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
@@ -44,4 +44,3 @@ class Migration011(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
+++ b/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
@@ -43,6 +43,5 @@ class Migration011(GraphMigration):
     minimum_version: int = 10
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -60,7 +60,7 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
         super().__init__(new_attr=new_attr, previous_attr=previous_attr, branch=global_branch, **kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         CALL () {
             MATCH (node:%(node_kind)s)
@@ -76,7 +76,6 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
         WITH node
         """ % {"node_kind": self.previous_attr.node_kind}
 
-        return query
 
 
 class Migration012AddLabelData(NodeDuplicateQuery):
@@ -118,13 +117,12 @@ class Migration012AddLabelData(NodeDuplicateQuery):
         super().__init__(new_node=new_node, previous_node=previous_node, branch=branch, **kwargs)
 
     def render_match(self) -> str:
-        query = f"""
+        return f"""
         // Find all the active nodes
         MATCH (node:{self.previous_node.kind})
         WHERE NOT "CoreGenericAccount" IN LABELS(node)
         """
 
-        return query
 
 
 class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):
@@ -341,6 +339,5 @@ class Migration012(GraphMigration):
     minimum_version: int = 11
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -77,7 +77,6 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
         """ % {"node_kind": self.previous_attr.node_kind}
 
 
-
 class Migration012AddLabelData(NodeDuplicateQuery):
     name = "migration_012_add_labels"
     type = QueryType.WRITE
@@ -122,7 +121,6 @@ class Migration012AddLabelData(NodeDuplicateQuery):
         MATCH (node:{self.previous_node.kind})
         WHERE NOT "CoreGenericAccount" IN LABELS(node)
         """
-
 
 
 class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):
@@ -340,4 +338,3 @@ class Migration012(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
+++ b/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
@@ -305,4 +305,3 @@ class Migration013(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
+++ b/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
@@ -304,6 +304,5 @@ class Migration013(GraphMigration):
     minimum_version: int = 12
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
+++ b/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
@@ -42,5 +42,4 @@ class Migration014(GraphMigration):
         return result
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -21,9 +21,8 @@ class Migration015(ArbitraryMigration):
     minimum_version: int = 14
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -23,7 +23,6 @@ class Migration015(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db
         default_branch = registry.get_branch_from_registry()

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -23,7 +23,6 @@ class Migration016(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db
         default_branch = registry.get_branch_from_registry()

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -21,9 +21,8 @@ class Migration016(ArbitraryMigration):
     minimum_version: int = 15
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -24,7 +24,6 @@ class Migration017(InternalSchemaMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Load CoreProfile schema node in db."""
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -22,9 +22,8 @@ class Migration017(InternalSchemaMigration):
     migrations: Sequence[SchemaMigration] = []
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Load CoreProfile schema node in db."""

--- a/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
+++ b/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
@@ -232,5 +232,4 @@ class Migration019(GraphMigration):
     queries: Sequence[type[Query]] = [FixBranchAwareEdgesQuery, SetMissingToTimeQuery, DeleteNodesRelsQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
+++ b/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
@@ -147,5 +147,4 @@ class Migration020(GraphMigration):
         return await self.do_execute(migration_input=migration_input)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
+++ b/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
@@ -47,5 +47,4 @@ class Migration021(GraphMigration):
     queries: Sequence[type[Query]] = [SetMissingHierarchyQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m022_add_generate_template_attr.py
+++ b/backend/infrahub/core/migrations/graph/m022_add_generate_template_attr.py
@@ -44,5 +44,4 @@ class Migration022(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
@@ -92,5 +92,4 @@ class Migration023(GraphMigration):
     queries: Sequence[type[Query]] = [DedupCardinalityOneRelsQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
+++ b/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
@@ -65,5 +65,4 @@ class Migration024(GraphMigration):
     queries: Sequence[type[Query]] = [BackfillMissingHierarchyQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
+++ b/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
@@ -47,5 +47,4 @@ class Migration027(GraphMigration):
     queries: Sequence[type[Query]] = [DeleteIsolatedNodesQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -23,9 +23,8 @@ class Migration028(ArbitraryMigration):
     minimum_version: int = 27
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -25,7 +25,6 @@ class Migration028(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db
         default_branch = registry.get_branch_from_registry()

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -58,7 +58,7 @@ class CleanUpDuplicatedUuidVertices(Query):
             l_arrow = ""
             r_arrow = ">"
 
-        query = """
+        return """
     CALL (vertex_to_keep, edge_type, branch, peer, earliest_active_time, latest_deleted_time, all_edges_deleted, edge_to_copy) {
         // ------------
         // get or create the active %(edge_type)s edge
@@ -82,7 +82,6 @@ class CleanUpDuplicatedUuidVertices(Query):
             "l_arrow": l_arrow,
             "r_arrow": r_arrow,
         }
-        return query
 
     def _add_deleted_edge_subquery(
         self,
@@ -95,7 +94,7 @@ class CleanUpDuplicatedUuidVertices(Query):
         else:
             l_arrow = ""
             r_arrow = ">"
-        subquery = """
+        return """
     CALL (vertex_to_keep, edge_type, branch, peer, latest_deleted_time, edge_to_copy) {
         // ------------
         // create the deleted %(edge_type)s edge
@@ -112,7 +111,6 @@ class CleanUpDuplicatedUuidVertices(Query):
         SET deleted_edge.hierarchy = edge_to_copy.hierarchy
     }
         """ % {"edge_type": edge_type.value, "l_arrow": l_arrow, "r_arrow": r_arrow}
-        return subquery
 
     def _build_directed_edges_subquery(
         self,
@@ -139,7 +137,7 @@ class CleanUpDuplicatedUuidVertices(Query):
         active_edge_subqueries = "\n".join(active_subqueries)
         deleted_edge_subqueries = "\n".join(delete_subqueries)
 
-        edges_query = """
+        return """
 //------------
 // Get every %(direction)s branch, edge_type, peer element_id combinations touching vertices with this uuid/labels combination
 //------------
@@ -257,7 +255,6 @@ CALL (n_uuid, vertex_element_ids, element_id_to_keep) {
             "deleted_edge_subqueries": deleted_edge_subqueries,
             "vertex_label": self.vertex_label,
         }
-        return edges_query
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params["limit"] = self.limit or 1000
@@ -572,9 +569,8 @@ class Migration029(ArbitraryMigration):
     limit: int = 100
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         migration_result = MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -571,7 +571,6 @@ class Migration029(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         migration_result = MigrationResult()
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
+++ b/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
@@ -76,5 +76,4 @@ class Migration030(GraphMigration):
     queries: Sequence[type[Query]] = [DeletePosthumousEdges]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -101,5 +101,4 @@ class Migration031(InternalSchemaMigration):
         return MigrationResult(errors=[error_str] + errors_messages)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
+++ b/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
@@ -96,5 +96,4 @@ class Migration033(GraphMigration):
     queries: Sequence[type[Query]] = [DeduplicateRelationshipVerticesQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
+++ b/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
@@ -42,5 +42,4 @@ class Migration036(GraphMigration):
         return result
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -460,7 +460,6 @@ class Migration037(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:  # noqa: PLR0915
         console = get_migration_console()
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -458,9 +458,8 @@ class Migration037(ArbitraryMigration):
     minimum_version: int = 36
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:  # noqa: PLR0915
         console = get_migration_console()

--- a/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
+++ b/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
@@ -136,9 +136,8 @@ class Migration041(ArbitraryMigration):
     minimum_version: int = 40
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
+++ b/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
@@ -138,7 +138,6 @@ class Migration041(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db
         root_node = await get_root_node(db=db)

--- a/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
+++ b/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
@@ -82,4 +82,3 @@ class Migration055(GraphMigration):
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
-

--- a/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
+++ b/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
@@ -81,6 +81,5 @@ class Migration055(GraphMigration):
     minimum_version: int = 54
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
+        return MigrationResult()
 
-        return result

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -35,7 +35,7 @@ class AttributeRenameQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         CALL () {
             MATCH (node:%(node_kind)s)
@@ -53,7 +53,6 @@ class AttributeRenameQuery(Query):
         WITH node
         """ % {"node_kind": self.previous_attr.node_kind}
 
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type_update_active(rel_type: str, rel_def: FieldInfo) -> str:

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -53,7 +53,6 @@ class AttributeRenameQuery(Query):
         WITH node
         """ % {"node_kind": self.previous_attr.node_kind}
 
-
     @staticmethod
     def _render_sub_query_per_rel_type_update_active(rel_type: str, rel_def: FieldInfo) -> str:
         subquery = [

--- a/backend/infrahub/core/migrations/query/delete_element_in_schema.py
+++ b/backend/infrahub/core/migrations/query/delete_element_in_schema.py
@@ -30,11 +30,10 @@ class DeleteElementInSchemaQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         MATCH path = (attr_node:Node)-[:HAS_ATTRIBUTE]->(attr:Attribute)
         MATCH (attr_node)-[:HAS_ATTRIBUTE]->(attr_name:Attribute)-[:HAS_VALUE]->(attr_value:AttributeValue)
         """
-        return query
 
     def render_where(self) -> str:
         at = self.at or Timestamp()
@@ -42,7 +41,7 @@ class DeleteElementInSchemaQuery(Query):
         self.params.update(params)
 
         # ruff: noqa: E501
-        query = """
+        return """
         WHERE ( "SchemaAttribute" in LABELS(attr_node) OR "SchemaRelationship" IN LABELS(attr_node))
             AND exists( (attr_node)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(:Node)-[:HAS_ATTRIBUTE]->(:Attribute { name: "name"})-[:HAS_VALUE]->(:AttributeValue { value: $node_name }) )
             AND exists( (attr_node)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(:Node)-[:HAS_ATTRIBUTE]->(:Attribute { name: "namespace"})-[:HAS_VALUE]->(:AttributeValue  { value: $node_namespace }) )
@@ -50,7 +49,6 @@ class DeleteElementInSchemaQuery(Query):
             AND all(r IN relationships(path) WHERE ( %(filters)s ))
         """ % {"filters": filters}
 
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/delete_element_in_schema.py
+++ b/backend/infrahub/core/migrations/query/delete_element_in_schema.py
@@ -49,7 +49,6 @@ class DeleteElementInSchemaQuery(Query):
             AND all(r IN relationships(path) WHERE ( %(filters)s ))
         """ % {"filters": filters}
 
-
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:
         subquery = [

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -44,7 +44,7 @@ class NodeDuplicateQuery(Query):
 
     def render_match(self) -> str:
         labels_str = ":".join(self.previous_node.labels)
-        query = """
+        return """
         // Find all the active nodes
         MATCH (node:%(labels_str)s)
         WITH DISTINCT node
@@ -65,7 +65,6 @@ class NodeDuplicateQuery(Query):
         WITH node WHERE already_migrated = FALSE
         """ % {"labels_str": labels_str}
 
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -65,7 +65,6 @@ class NodeDuplicateQuery(Query):
         WITH node WHERE already_migrated = FALSE
         """ % {"labels_str": labels_str}
 
-
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:
         subquery = [

--- a/backend/infrahub/core/migrations/query/relationship_duplicate.py
+++ b/backend/infrahub/core/migrations/query/relationship_duplicate.py
@@ -36,13 +36,12 @@ class RelationshipDuplicateQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         MATCH (source:%(src_peer)s)-[:IS_RELATED]-(rel:Relationship { name: $previous_rel.name })-[:IS_RELATED]-(destination:%(dst_peer)s)
         WHERE source <> destination
         """ % {"src_peer": self.previous_rel.src_peer, "dst_peer": self.previous_rel.dst_peer}
 
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/relationship_duplicate.py
+++ b/backend/infrahub/core/migrations/query/relationship_duplicate.py
@@ -42,7 +42,6 @@ class RelationshipDuplicateQuery(Query):
         WHERE source <> destination
         """ % {"src_peer": self.previous_rel.src_peer, "dst_peer": self.previous_rel.dst_peer}
 
-
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:
         subquery = [

--- a/backend/infrahub/core/migrations/query/schema_attribute_update.py
+++ b/backend/infrahub/core/migrations/query/schema_attribute_update.py
@@ -38,17 +38,15 @@ class SchemaAttributeUpdateQuery(Query):
 
     def _render_match_schema_node(self) -> str:
         # ruff: noqa: E501
-        query = """
+        return """
         MATCH path = (node:SchemaNode)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[rel:HAS_VALUE]->(av:AttributeValue)
         """
-        return query
 
     def _render_match_schema_attribute(self) -> str:
         # ruff: noqa: E501
-        query = """
+        return """
         MATCH path = (node:SchemaNode)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(attr_node:SchemaAttribute)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[rel:HAS_VALUE]->(av:AttributeValue)
         """
-        return query
 
     def render_where(self) -> str:
         at = self.at or Timestamp()

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -275,9 +275,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             attr = getattr(node, schema_path.attribute_schema.name)
             return getattr(attr, schema_path.attribute_property_name)
 
-        raise ValueError(
-            f"Unable to retrieve value for unsupported schema path type {path!r} on {self.get_kind()!r}"
-        )
+        raise ValueError(f"Unable to retrieve value for unsupported schema path type {path!r} on {self.get_kind()!r}")
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind.

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -275,6 +275,10 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             attr = getattr(node, schema_path.attribute_schema.name)
             return getattr(attr, schema_path.attribute_property_name)
 
+        raise ValueError(
+            f"Unable to retrieve value for unsupported schema path type {path!r} on {self.get_kind()!r}"
+        )
+
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind.
 
@@ -292,8 +296,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             return labels
 
         if isinstance(self._schema, ProfileSchema | TemplateSchema):
-            labels = [self.get_kind()] + self._schema.inherit_from
-            return labels
+            return [self.get_kind()] + self._schema.inherit_from
 
         return [self.get_kind()]
 
@@ -901,7 +904,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         data: Any,
         db: InfrahubDatabase,
     ) -> RelationshipManager:
-        rm = await RelationshipManager.init(
+        return await RelationshipManager.init(
             db=db,
             data=data,
             schema=schema,
@@ -909,8 +912,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             at=self._at,
             node=self,
         )
-
-        return rm
 
     async def _generate_attribute_default(
         self,

--- a/backend/infrahub/core/node/base.py
+++ b/backend/infrahub/core/node/base.py
@@ -63,22 +63,4 @@ class ObjectNodeMeta(BaseNodeMeta):
         class InterObjectNode:
             pass
 
-        base_cls = super().__new__(mcs, name_, (InterObjectNode,) + bases, namespace, **options)
-        # if base_cls._meta:
-        #     fields = [
-        #         (
-        #             key,
-        #             "typing.Any",
-        #             field(
-        #                 default=field_value.default_value
-        #                 if isinstance(field_value, Field)
-        #                 else None
-        #             ),
-        #         )
-        #         for key, field_value in base_cls._meta.fields.items()
-        #     ]
-        #     dataclass = make_dataclass(name_, fields, bases=())
-        #     InterObjectType.__init__ = dataclass.__init__
-        #     InterObjectType.__eq__ = dataclass.__eq__
-        #     InterObjectType.__repr__ = dataclass.__repr__
-        return base_cls
+        return super().__new__(mcs, name_, (InterObjectNode,) + bases, namespace, **options)

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -36,8 +36,7 @@ class CoreNumberPool(Node):
         for start_range, end_range in excluded_ranges:
             sum_excluded_values += end_range - start_range + 1
 
-        res = len(attribute.parameters.get_excluded_single_values()) + sum_excluded_values
-        return res
+        return len(attribute.parameters.get_excluded_single_values()) + sum_excluded_values
 
     async def get_used(
         self,

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1030,8 +1030,7 @@ class RelationshipManager:
         if not rels and raise_on_error:
             raise LookupError("Unable to find the peer")
 
-        peer = await rels[0].get_peer(db=db)
-        return peer
+        return await rels[0].get_peer(db=db)
 
     @overload
     async def get_peers(
@@ -1060,14 +1059,13 @@ class RelationshipManager:
     ) -> Mapping[str, Node | PeerType]:
         rels = await self.get_relationships(db=db, branch_agnostic=branch_agnostic)
         peer_ids = [rel.peer_id for rel in rels if rel.peer_id]
-        nodes = await registry.manager.get_many(
+        return await registry.manager.get_many(
             db=db,
             ids=peer_ids,
             branch=self.branch,
             branch_agnostic=branch_agnostic,
             include_metadata=include_metadata,
         )
-        return nodes
 
     def get_branch_based_on_support_type(self) -> Branch:
         """If the attribute is branch aware, return the Branch object associated with this attribute.

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -149,8 +149,7 @@ class NumberAttributeParameters(AttributeParameters):
         if not self.excluded_values:
             return []
 
-        results = [int(value) for value in self.excluded_values.split(",") if "-" not in value]
-        return results
+        return [int(value) for value in self.excluded_values.split(",") if "-" not in value]
 
     def get_excluded_ranges(self) -> list[tuple[int, int]]:
         if not self.excluded_values:

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -49,8 +49,7 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
             database=await get_database(),
         )
 
-    results = [result async for _, result in batch.execute()]
-    return results
+    return [result async for _, result in batch.execute()]
 
 
 @task(  # type: ignore[arg-type]

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -180,8 +180,7 @@ class InfrahubEvent(BaseModel):
     @final
     def get_event_payload(self) -> dict[str, Any]:
         """This method should be used when emitting the event to the event broker."""
-        event_payload = {"data": self.get_payload(), "context": self.meta.context.to_event()}
-        return event_payload
+        return {"data": self.get_payload(), "context": self.meta.context.to_event()}
 
     def get_message_meta(self) -> Meta:
         meta = Meta()

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -998,7 +998,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         changed_files = git_status.splitlines()
         return [filename[3:] for filename in changed_files if filename.startswith("UU ")]
 
-
     async def find_files(
         self,
         extension: str | list[str],

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -996,9 +996,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 repo.git.merge("--abort")
 
         changed_files = git_status.splitlines()
-        conflict_files = [filename[3:] for filename in changed_files if filename.startswith("UU ")]
+        return [filename[3:] for filename in changed_files if filename.startswith("UU ")]
 
-        return conflict_files
 
     async def find_files(
         self,

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -206,9 +206,8 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         After the rebase we need to resync the data
         """
-        response = await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
+        return await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
 
-        return response
 
 
 class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -209,7 +209,6 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         return await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
 
 
-
 class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
     """Repository with only read-only access to the remote repo."""
 

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -699,9 +699,7 @@ async def git_repository_diff_names_only(model: GitDiffNamesOnly) -> GitDiffName
     else:
         files_added = await repo.list_all_files(commit=model.first_commit)
 
-    return GitDiffNamesOnlyResponse(
-        files_added=files_added, files_changed=files_changed, files_removed=files_removed
-    )
+    return GitDiffNamesOnlyResponse(files_added=files_added, files_changed=files_changed, files_removed=files_removed)
 
 
 @flow(

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -699,10 +699,9 @@ async def git_repository_diff_names_only(model: GitDiffNamesOnly) -> GitDiffName
     else:
         files_added = await repo.list_all_files(commit=model.first_commit)
 
-    response = GitDiffNamesOnlyResponse(
+    return GitDiffNamesOnlyResponse(
         files_added=files_added, files_changed=files_changed, files_removed=files_removed
     )
-    return response
 
 
 @flow(

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -137,10 +137,9 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         )
 
         reconciler = IpamReconciler(db=db, branch=branch)
-        reconciled_address = await reconciler.reconcile(
+        return await reconciler.reconcile(
             ip_value=ip_address, namespace=namespace_id, node_uuid=address.get_id()
         )
-        return reconciled_address
 
     @classmethod
     @retry_db_transaction(name="ipaddress_create")
@@ -179,10 +178,9 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         address = await cls.mutate_update_object(db=db, info=info, data=data, branch=branch, obj=address)
         reconciler = IpamReconciler(db=db, branch=branch)
         ip_address = ipaddress.ip_interface(address.address.value)
-        reconciled_address = await reconciler.reconcile(
+        return await reconciler.reconcile(
             ip_value=ip_address, node_uuid=address.get_id(), namespace=namespace_id
         )
-        return reconciled_address
 
     @classmethod
     @retry_db_transaction(name="ipaddress_update")
@@ -427,10 +425,9 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     ) -> Node:
         reconciler = IpamReconciler(db=db, branch=branch)
         ip_network = ipaddress.ip_network(prefix.prefix.value)
-        reconciled_prefix = await reconciler.reconcile(
+        return await reconciler.reconcile(
             ip_value=ip_network, node_uuid=prefix.get_id(), namespace=namespace_id, is_delete=is_delete
         )
-        return reconciled_prefix
 
     @classmethod
     @retry_db_transaction(name="ipprefix_delete")

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -137,9 +137,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         )
 
         reconciler = IpamReconciler(db=db, branch=branch)
-        return await reconciler.reconcile(
-            ip_value=ip_address, namespace=namespace_id, node_uuid=address.get_id()
-        )
+        return await reconciler.reconcile(ip_value=ip_address, namespace=namespace_id, node_uuid=address.get_id())
 
     @classmethod
     @retry_db_transaction(name="ipaddress_create")
@@ -178,9 +176,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         address = await cls.mutate_update_object(db=db, info=info, data=data, branch=branch, obj=address)
         reconciler = IpamReconciler(db=db, branch=branch)
         ip_address = ipaddress.ip_interface(address.address.value)
-        return await reconciler.reconcile(
-            ip_value=ip_address, node_uuid=address.get_id(), namespace=namespace_id
-        )
+        return await reconciler.reconcile(ip_value=ip_address, node_uuid=address.get_id(), namespace=namespace_id)
 
     @classmethod
     @retry_db_transaction(name="ipaddress_update")

--- a/backend/infrahub/graphql/order.py
+++ b/backend/infrahub/graphql/order.py
@@ -10,5 +10,4 @@ def deserialize_order_input(input_data: dict[str, Any] | None) -> OrderModel | N
     if not input_data:
         return None
 
-    order_model = OrderModel(**input_data)
-    return order_model
+    return OrderModel(**input_data)

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -44,8 +44,7 @@ async def account_resolver(
             order=OrderModel(disable=True),
         )
         if results:
-            account_profile = await results[0].to_graphql(db=db, fields=fields)
-            return account_profile
+            return await results[0].to_graphql(db=db, fields=fields)
 
         raise NodeNotFoundError(
             node_type=InfrahubKind.GENERICACCOUNT, identifier=graphql_context.account_session.account_id

--- a/backend/infrahub/pools/prefix.py
+++ b/backend/infrahub/pools/prefix.py
@@ -35,7 +35,6 @@ def get_next_available_prefix(
             return cidr
 
         if cidr.prefixlen <= prefix_length:
-            next_available = ipaddress.ip_network(f"{cidr.network}/{prefix_length}")
-            return next_available
+            return ipaddress.ip_network(f"{cidr.network}/{prefix_length}")
 
     raise ValueError("No available subnets in pool")

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -164,8 +164,7 @@ async def logging_middleware(request: Request, call_next: Callable[[Request], Aw
     if trace_id:
         set_log_data(key="trace_id", value=trace_id)
 
-    response = await call_next(request)
-    return response
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -249,7 +249,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
     @staticmethod
     def format_message(message: InfrahubMessage) -> aio_pika.Message:
-        pika_message = aio_pika.Message(
+        return aio_pika.Message(
             body=message.body,
             content_type="application/json",
             content_encoding="utf-8",
@@ -259,4 +259,3 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             headers=message.meta.headers,
             expiration=message.meta.expiration,
         )
-        return pika_message

--- a/backend/infrahub/telemetry/task_manager.py
+++ b/backend/infrahub/telemetry/task_manager.py
@@ -69,10 +69,9 @@ async def gather_prefect_automations(client: PrefectClient) -> dict[str, Any]:
 @task(name="telemetry-gather-prefect-information", task_run_name="Gather Prefect Information", cache_policy=NONE)
 async def gather_prefect_information() -> TelemetryPrefectData:
     async with get_client(sync_client=False) as client:
-        data = TelemetryPrefectData(
+        return TelemetryPrefectData(
             work_pools=await gather_prefect_work_pools(client=client),
             events=await gather_prefect_events(client=client),
             automations=await gather_prefect_automations(client=client),
         )
 
-        return data

--- a/backend/infrahub/telemetry/task_manager.py
+++ b/backend/infrahub/telemetry/task_manager.py
@@ -74,4 +74,3 @@ async def gather_prefect_information() -> TelemetryPrefectData:
             events=await gather_prefect_events(client=client),
             automations=await gather_prefect_automations(client=client),
         )
-

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -36,7 +36,6 @@ async def transform_python(message: TransformPythonData) -> Any:
     )  # type: ignore[call-overload]
 
 
-
 @flow(name="transform_render_jinja2_template", flow_run_name="Render transform Jinja2", persist_result=True)
 async def transform_render_jinja2_template(message: TransformJinjaTemplateData) -> str:
     await add_branch_tag(branch_name=message.branch)
@@ -54,4 +53,3 @@ async def transform_render_jinja2_template(message: TransformJinjaTemplateData) 
     return await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
         commit=message.commit, location=message.template_location, data={"data": message.data}
     )  # type: ignore[call-overload]
-

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -26,7 +26,7 @@ async def transform_python(message: TransformPythonData) -> Any:
         commit=message.commit,
     )
 
-    transformed_data = await repo.execute_python_transform.with_options(timeout_seconds=message.timeout)(
+    return await repo.execute_python_transform.with_options(timeout_seconds=message.timeout)(
         client=client,
         branch_name=message.branch,
         commit=message.commit,
@@ -35,7 +35,6 @@ async def transform_python(message: TransformPythonData) -> Any:
         convert_query_response=message.convert_query_response,
     )  # type: ignore[call-overload]
 
-    return transformed_data
 
 
 @flow(name="transform_render_jinja2_template", flow_run_name="Render transform Jinja2", persist_result=True)
@@ -52,8 +51,7 @@ async def transform_render_jinja2_template(message: TransformJinjaTemplateData) 
         commit=message.commit,
     )
 
-    rendered_template = await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
+    return await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
         commit=message.commit, location=message.template_location, data={"data": message.data}
     )  # type: ignore[call-overload]
 
-    return rendered_template

--- a/backend/infrahub/webhook/gather.py
+++ b/backend/infrahub/webhook/gather.py
@@ -13,5 +13,4 @@ from .models import WebhookTriggerDefinition
 @task(name="gather-trigger-webhook", task_run_name="Gather webhook triggers", cache_policy=NONE)
 async def gather_trigger_webhook(db: InfrahubDatabase) -> list[WebhookTriggerDefinition]:
     webhooks = await NodeManager.query(db=db, schema=CoreWebhook)
-    triggers = [WebhookTriggerDefinition.from_object(webhook) for webhook in webhooks if webhook.active.value]
-    return triggers
+    return [WebhookTriggerDefinition.from_object(webhook) for webhook in webhooks if webhook.active.value]

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -69,7 +69,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
         if obj.node_kind.value and event_type in get_all_infrahub_node_kind_events():
             event_trigger.match = {"infrahub.node.kind": obj.node_kind.value}
 
-        definition = cls(
+        return cls(
             id=obj.id,
             name=obj.name.value,
             trigger=event_trigger,
@@ -93,7 +93,6 @@ class WebhookTriggerDefinition(TriggerDefinition):
             ],
         )
 
-        return definition
 
 
 class EventContext(BaseModel):

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -94,7 +94,6 @@ class WebhookTriggerDefinition(TriggerDefinition):
         )
 
 
-
 class EventContext(BaseModel):
     id: str = Field(..., description="The internal id of the event")
     branch: str | None = Field(None, description="The branch associated with the event")

--- a/backend/tests/benchmark/test_nodemanager_peers.py
+++ b/backend/tests/benchmark/test_nodemanager_peers.py
@@ -29,11 +29,10 @@ async def relm(
     model = registry.schema.get(name="CoreAccount")
     rel_schema = model.get_relationship("member_of_groups")
 
-    relm = await RelationshipManager.init(
+    return await RelationshipManager.init(
         db=db, schema=rel_schema, branch=default_branch, at=Timestamp(), node=test_account
     )
 
-    return relm
 
 
 def test_nodemanager_querypeers(

--- a/backend/tests/benchmark/test_nodemanager_peers.py
+++ b/backend/tests/benchmark/test_nodemanager_peers.py
@@ -34,7 +34,6 @@ async def relm(
     )
 
 
-
 def test_nodemanager_querypeers(
     aio_benchmark: Callable[..., Any], db: InfrahubDatabase, default_branch: Branch, test_account: Node
 ) -> None:

--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -222,7 +222,7 @@ async def car_person_data_generic_diff(
     # Time After the changes
     time30 = Timestamp()
 
-    params = {
+    return {
         "branch": branch2,
         "time0": time0,
         "time10": time10,
@@ -242,7 +242,6 @@ async def car_person_data_generic_diff(
         "r1": repo01.id,
     }
 
-    return params
 
 
 @pytest.fixture
@@ -428,7 +427,7 @@ async def data_diff_attribute(
     # Time After the changes
     time30 = Timestamp()
 
-    params = {
+    return {
         "branch": branch2,
         "time0": time0,
         "time12": time12,
@@ -445,4 +444,3 @@ async def data_diff_attribute(
         "r1": repo01.id,
     }
 
-    return params

--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -243,7 +243,6 @@ async def car_person_data_generic_diff(
     }
 
 
-
 @pytest.fixture
 async def car_person_data_artifact_diff(
     db: InfrahubDatabase, default_branch: Branch, car_person_data_generic_diff: dict[str, Any]
@@ -443,4 +442,3 @@ async def data_diff_attribute(
         "p2": persons["Jane"].id,
         "r1": repo01.id,
     }
-

--- a/backend/tests/component/api/test_15_diff.py
+++ b/backend/tests/component/api/test_15_diff.py
@@ -107,7 +107,7 @@ async def test_get_display_labels_with_branch(
 async def r1_update_01(data_diff_attribute: dict[str, Any]) -> dict[str, Any]:
     r1 = data_diff_attribute["r1"]
 
-    expected_response = {
+    return {
         "kind": InfrahubKind.REPOSITORY,
         "id": r1,
         "path": f"data/{r1}",
@@ -142,7 +142,6 @@ async def r1_update_01(data_diff_attribute: dict[str, Any]) -> dict[str, Any]:
         "action": {"branch2": "updated"},
         "display_label": {"branch2": "repo01"},
     }
-    return expected_response
 
 
 async def test_diff_artifact(

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -1395,7 +1395,6 @@ async def car_person_generics_data(db: InfrahubDatabase, car_person_schema_gener
     }
 
 
-
 @pytest.fixture
 async def person_tag_schema(
     db: InfrahubDatabase, default_branch: Branch, data_schema: None, register_core_models_schema: SchemaBranch

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -1386,7 +1386,7 @@ async def car_person_generics_data(db: InfrahubDatabase, car_person_schema_gener
     await c3.new(db=db, name="nolt", nbr_seats=4, mpg=25, owner=p2)
     await c3.save(db=db)
 
-    nodes = {
+    return {
         "p1": p1,
         "p2": p2,
         "c1": c1,
@@ -1394,7 +1394,6 @@ async def car_person_generics_data(db: InfrahubDatabase, car_person_schema_gener
         "c3": c3,
     }
 
-    return nodes
 
 
 @pytest.fixture
@@ -2593,8 +2592,7 @@ async def create_test_admin(db: InfrahubDatabase, register_core_models_schema: S
 
 @pytest.fixture
 async def session_admin(db: InfrahubDatabase, create_test_admin: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=create_test_admin.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=create_test_admin.id)
 
 
 @pytest.fixture
@@ -2621,8 +2619,7 @@ async def first_account(
 
 @pytest.fixture
 async def session_first_account(db: InfrahubDatabase, first_account: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=first_account.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=first_account.id)
 
 
 @pytest.fixture
@@ -2637,8 +2634,7 @@ async def second_account(
 
 @pytest.fixture
 async def session_second_account(db: InfrahubDatabase, second_account: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=second_account.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=second_account.id)
 
 
 @pytest.fixture
@@ -2782,7 +2778,7 @@ async def ip_dataset_01(
     await net242.new(db=db, prefix="10.10.4.0/27", parent=net240, ip_namespace=ns2)
     await net242.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "ns2": ns2,
         "net161": net161,
@@ -2799,7 +2795,6 @@ async def ip_dataset_01(
         "net241": net241,
         "net242": net242,
     }
-    return data
 
 
 @pytest.fixture
@@ -2862,7 +2857,7 @@ async def ip_dataset_prefix_v4(
     await ip2_net147.new(db=db, address="10.200.0.2/30", ip_prefix=net147, ip_namespace=ns1)
     await ip2_net147.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "net140": net140,
         "net141": net141,
@@ -2873,7 +2868,6 @@ async def ip_dataset_prefix_v4(
         "net146": net146,
         "net147": net147,
     }
-    return data
 
 
 @pytest.fixture

--- a/backend/tests/component/core/constraint_validators/conftest.py
+++ b/backend/tests/component/core/constraint_validators/conftest.py
@@ -118,7 +118,6 @@ async def car_person_generics_data_simple(
     }
 
 
-
 @pytest.fixture
 async def car_person_schema_hfid(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
     SCHEMA = {

--- a/backend/tests/component/core/constraint_validators/conftest.py
+++ b/backend/tests/component/core/constraint_validators/conftest.py
@@ -109,7 +109,7 @@ async def car_person_generics_data_simple(
     await c3.new(db=db, name="nolt", nbr_seats=4, mpg=25, owner=p2)
     await c3.save(db=db)
 
-    nodes = {
+    return {
         "p1": p1,
         "p2": p2,
         "c1": c1,
@@ -117,7 +117,6 @@ async def car_person_generics_data_simple(
         "c3": c3,
     }
 
-    return nodes
 
 
 @pytest.fixture

--- a/backend/tests/component/core/ipam/conftest.py
+++ b/backend/tests/component/core/ipam/conftest.py
@@ -155,7 +155,7 @@ async def ip_dataset_01_load(
     await net242.new(db=db, prefix="10.10.4.0/27", parent=net240, ip_namespace=ns2)
     await net242.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "ns2": ns2,
         "net161": net161,
@@ -172,7 +172,6 @@ async def ip_dataset_01_load(
         "net241": net241,
         "net242": net242,
     }
-    return data
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -59,8 +59,7 @@ async def schema_aware() -> NodeSchema:
         ],
     }
 
-    node = NodeSchema(**SCHEMA)
-    return node
+    return NodeSchema(**SCHEMA)
 
 
 @pytest.fixture

--- a/backend/tests/component/core/schema_manager/conftest.py
+++ b/backend/tests/component/core/schema_manager/conftest.py
@@ -89,7 +89,6 @@ async def animal_person_schema_dict() -> dict:
     }
 
 
-
 @pytest.fixture
 def schema_all_in_one() -> dict[str, Any]:
     return {
@@ -236,7 +235,6 @@ def schema_all_in_one() -> dict[str, Any]:
             },
         ],
     }
-
 
 
 @pytest.fixture

--- a/backend/tests/component/core/schema_manager/conftest.py
+++ b/backend/tests/component/core/schema_manager/conftest.py
@@ -16,7 +16,7 @@ def _get_schema_by_kind(full_schema: dict[str, Any], kind: str) -> dict[str, Any
 
 @pytest.fixture
 async def animal_person_schema_dict() -> dict:
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "Animal",
@@ -88,12 +88,11 @@ async def animal_person_schema_dict() -> dict:
         ],
     }
 
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_all_in_one() -> dict[str, Any]:
-    FULL_SCHEMA = {
+    return {
         "nodes": [
             {
                 "name": "Criticality",
@@ -238,12 +237,11 @@ def schema_all_in_one() -> dict[str, Any]:
         ],
     }
 
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_criticality_tag() -> dict[str, Any]:
-    FULL_SCHEMA = {
+    return {
         "nodes": [
             {
                 "name": "Criticality",
@@ -286,12 +284,11 @@ def schema_criticality_tag() -> dict[str, Any]:
             },
         ]
     }
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_parent_component() -> dict:
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "ComponentGenericOne",
@@ -351,13 +348,12 @@ def schema_parent_component() -> dict:
             },
         ],
     }
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_diff_attr_inheritance_types() -> dict[str, Any]:
     """Two generics with the same attribute but different types and a single node implementation."""
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "Adapter",
@@ -387,4 +383,3 @@ def schema_diff_attr_inheritance_types() -> dict[str, Any]:
             }
         ],
     }
-    return FULL_SCHEMA

--- a/backend/tests/component/core/test_branch_diff.py
+++ b/backend/tests/component/core/test_branch_diff.py
@@ -108,12 +108,11 @@ async def test_diff_get_files_repository(
     db: InfrahubDatabase, repos_in_main: dict[str, Node], base_dataset_02: dict
 ) -> None:
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
-        model = GitDiffNamesOnlyResponse(
+        return GitDiffNamesOnlyResponse(
             files_changed=["readme.md", "mydir/myfile.py"],
             files_removed=["notthere.md"],
             files_added=["newandshiny.md"],
         )
-        return model
 
     service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (
@@ -152,12 +151,11 @@ async def test_diff_get_files_repositories_for_branch_case01(
     """
 
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
-        model = GitDiffNamesOnlyResponse(
+        return GitDiffNamesOnlyResponse(
             files_changed=["readme.md", "mydir/myfile.py"],
             files_removed=[],
             files_added=[],
         )
-        return model
 
     service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -125,14 +125,13 @@ async def git_repo_01(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_01 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
-    return repo
 
 
 @pytest.fixture
@@ -140,7 +139,7 @@ async def git_repo_01_read_only(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubReadOnlyRepository:
     """Git Repository with git_upstream_repo_01 as remote."""
-    repo = await InfrahubReadOnlyRepository.new(
+    return await InfrahubReadOnlyRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
@@ -149,7 +148,6 @@ async def git_repo_01_read_only(
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
-    return repo
 
 
 @pytest.fixture
@@ -162,14 +160,13 @@ async def git_repo_01_w_client(git_repo_01: InfrahubRepository, client: Infrahub
 @pytest.fixture
 async def git_repo_02(git_upstream_repo_02: dict[str, str | Path], git_repos_dir: Path) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_02 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
-    return repo
 
 
 @pytest.fixture
@@ -177,14 +174,13 @@ async def git_repo_03(
     client: InfrahubClient, git_upstream_repo_03: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_03 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_03["name"],
         location=str(git_upstream_repo_03["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
-    return repo
 
 
 @pytest.fixture
@@ -410,13 +406,12 @@ async def git_repo_checks(
 
     upstream.index.commit("Add 2 checks files")
 
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-    return repo
 
 
 @pytest.fixture
@@ -441,13 +436,12 @@ async def git_repo_transforms(
 
     upstream.index.commit("Add 2 Transforms files")
 
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-    return repo
 
 
 @pytest.fixture
@@ -573,7 +567,7 @@ async def mock_gql_query_my_query(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def gql_query_data_01() -> dict:
-    data = {
+    return {
         "node": {
             "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
             "display_label": "MyQuery",
@@ -587,12 +581,11 @@ async def gql_query_data_01() -> dict:
             },
         }
     }
-    return data
 
 
 @pytest.fixture
 async def gql_query_data_02() -> dict:
-    data = {
+    return {
         "node": {
             "id": "mmmmmmmm-nnnn-bbbb-vvvv-cccccccccccc",
             "display_label": "MyOtherQuery",
@@ -606,7 +599,6 @@ async def gql_query_data_02() -> dict:
             },
         }
     }
-    return data
 
 
 @pytest.fixture
@@ -647,7 +639,7 @@ async def mock_check_create(helper: TestHelper, httpx_mock: HTTPXMock) -> HTTPXM
 
 @pytest.fixture
 async def check_definition_data_01() -> dict:
-    data = {
+    return {
         "node": {
             "id": "d32f30f8-1d1e-4dfb-96d9-91234a9ffbe1",
             "display_label": "Check01",
@@ -734,7 +726,6 @@ async def check_definition_data_01() -> dict:
         },
     }
 
-    return data
 
 
 @pytest.fixture
@@ -763,7 +754,7 @@ async def gql_query_data_03() -> dict[str, Any]:
     }
     """
 
-    data = {
+    return {
         "id": "42665742-002b-4f98-b2e0-1ae716c1efbe",
         "type": InfrahubKind.GRAPHQLQUERY,
         "name": {
@@ -792,7 +783,6 @@ async def gql_query_data_03() -> dict[str, Any]:
         "__typename": InfrahubKind.GRAPHQLQUERY,
         "display_label": "query01",
     }
-    return data
 
 
 @pytest.fixture
@@ -806,8 +796,7 @@ async def schema_02(client: InfrahubClient, helper: TestHelper, car_data_01: dic
 async def gql_query_node_03(client: InfrahubClient, gql_query_data_03: dict[str, Any]) -> InfrahubNode:
     backend_schema = [model for model in SchemaRoot(**core_models).nodes if model.kind == InfrahubKind.GRAPHQLQUERY][0]
     schema = NodeSchemaAPI(**backend_schema.model_dump())
-    node = InfrahubNode(client=client, schema=schema, data=gql_query_data_03)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=gql_query_data_03)
 
 
 @pytest.fixture
@@ -839,7 +828,7 @@ async def mock_upload_content(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def artifact_definition_data_01() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
         "name": {
@@ -869,7 +858,6 @@ async def artifact_definition_data_01() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACTDEFINITION,
         "display_label": "artifactdef01",
     }
-    return data
 
 
 @pytest.fixture
@@ -877,13 +865,12 @@ async def artifact_definition_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_definition_data_01: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACTDEFINITION][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_definition_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_definition_data_01)
 
 
 @pytest.fixture
 async def artifact_definition_data_02() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
         "name": {
@@ -913,7 +900,6 @@ async def artifact_definition_data_02() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACTDEFINITION,
         "display_label": "artifactdef02",
     }
-    return data
 
 
 @pytest.fixture
@@ -921,13 +907,12 @@ async def artifact_definition_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_definition_data_02: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACTDEFINITION][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_definition_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_definition_data_02)
 
 
 @pytest.fixture
 async def artifact_data_01() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": "CoreArtifact",
         "name": {
@@ -948,7 +933,6 @@ async def artifact_data_01() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACT,
         "display_label": "artifact01",
     }
-    return data
 
 
 @pytest.fixture
@@ -956,13 +940,12 @@ async def artifact_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_data_01: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACT][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_data_01)
 
 
 @pytest.fixture
 async def artifact_data_02() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACT,
         "name": {
@@ -985,7 +968,6 @@ async def artifact_data_02() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACT,
         "display_label": "artifact01",
     }
-    return data
 
 
 @pytest.fixture
@@ -993,13 +975,12 @@ async def artifact_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_data_02: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACT][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_data_02)
 
 
 @pytest.fixture
 async def transformation_data_01() -> dict:
-    data = {
+    return {
         "id": "a0d4c22a-5f60-4bf9-a53f-f9a335420492",
         "type": "CoreTransformPython",
         "file_path": {
@@ -1068,7 +1049,6 @@ async def transformation_data_01() -> dict:
         "__typename": "CoreTransformPython",
         "display_label": "transform01",
     }
-    return data
 
 
 @pytest.fixture
@@ -1076,13 +1056,12 @@ async def transformation_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, transformation_data_01: dict
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == "CoreTransformPython"][0]
-    node = InfrahubNode(client=client, schema=schema, data=transformation_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=transformation_data_01)
 
 
 @pytest.fixture
 async def transformation_data_02() -> dict:
-    data = {
+    return {
         "id": "70a58c98-6185-4004-b4bf-713baccfdc87",
         "display_label": "device_startup",
         "template_path": {"value": "template01.tpl.j2", "__typename": "TextAttribute"},
@@ -1108,7 +1087,6 @@ async def transformation_data_02() -> dict:
         },
         "__typename": InfrahubKind.TRANSFORMJINJA2,
     }
-    return data
 
 
 @pytest.fixture
@@ -1116,13 +1094,12 @@ async def transformation_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, transformation_data_02: dict
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.TRANSFORMJINJA2][0]
-    node = InfrahubNode(client=client, schema=schema, data=transformation_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=transformation_data_02)
 
 
 @pytest.fixture
 async def car_data_01() -> dict:
-    data = {
+    return {
         "id": "b663d7a4-5f95-48dd-b04d-e03169e7fcf3",
         "type": "TestElectricCar",
         "nbr_engine": {
@@ -1160,14 +1137,12 @@ async def car_data_01() -> dict:
         "__typename": "TestElectricCar",
         "display_label": "TestElectricCar(ID: b663d7a4-5f95-48dd-b04d-e03169e7fcf3)",
     }
-    return data
 
 
 @pytest.fixture
 async def car_node_01(client: InfrahubClient, schema_02: ClientSchemaRoot, car_data_01: dict) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.name == "ElectricCar"][0]
-    node = InfrahubNode(client=client, schema=schema, data=car_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=car_data_01)
 
 
 @pytest.fixture

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -133,7 +133,6 @@ async def git_repo_01(
     )
 
 
-
 @pytest.fixture
 async def git_repo_01_read_only(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
@@ -147,7 +146,6 @@ async def git_repo_01_read_only(
         infrahub_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
 
 
 @pytest.fixture
@@ -168,7 +166,6 @@ async def git_repo_02(git_upstream_repo_02: dict[str, str | Path], git_repos_dir
     )
 
 
-
 @pytest.fixture
 async def git_repo_03(
     client: InfrahubClient, git_upstream_repo_03: dict[str, str | Path], git_repos_dir: Path
@@ -180,7 +177,6 @@ async def git_repo_03(
         location=str(git_upstream_repo_03["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
 
 
 @pytest.fixture
@@ -725,7 +721,6 @@ async def check_definition_data_01() -> dict:
             "__typename": "Check",
         },
     }
-
 
 
 @pytest.fixture

--- a/backend/tests/component/git/test_repository_config.py
+++ b/backend/tests/component/git/test_repository_config.py
@@ -45,13 +45,12 @@ class TestGetRepositoryConfig:
             cloned_repo.index.remove([".infrahub.yml"])
             cloned_repo.index.commit("Remove .infrahub.yml config file for testing")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_invalid_yaml(
@@ -85,13 +84,12 @@ schemas:
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add invalid YAML config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_invalid_format(
@@ -123,13 +121,12 @@ schemas: "should be a list, not a string"
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add invalid format config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_valid_config(
@@ -161,13 +158,12 @@ schemas: []
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add valid .infrahub.yml config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     async def test_missing_config_file_raises_error(
         self, repo_without_config: InfrahubRepository, prefect_test_fixture: None

--- a/backend/tests/component/graphql/conftest.py
+++ b/backend/tests/component/graphql/conftest.py
@@ -214,7 +214,6 @@ def query_05() -> str:
     """
 
 
-
 @pytest.fixture
 def query_06() -> str:
     """Simple query with variables."""

--- a/backend/tests/component/graphql/conftest.py
+++ b/backend/tests/component/graphql/conftest.py
@@ -56,7 +56,7 @@ def permissions_helper() -> PermissionsHelper:
 @pytest.fixture
 def query_01() -> str:
     """Simple query with one document."""
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -78,12 +78,11 @@ def query_01() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_02() -> str:
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -124,13 +123,12 @@ def query_02() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_03() -> str:
     """Advanced Query with 2 documents."""
-    query = """
+    return """
     query FirstQuery {
         TestPerson {
             edges {
@@ -164,13 +162,12 @@ def query_03() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_04() -> str:
     """Simple query with variables."""
-    query = """
+    return """
     query ($person: String!){
         TestPerson(name__value: $person) {
             edges {
@@ -183,12 +180,11 @@ def query_04() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_05() -> str:
-    query = """
+    return """
     query MyQuery {
         CoreRepository {
             edges {
@@ -217,13 +213,12 @@ def query_05() -> str:
     }
     """
 
-    return query
 
 
 @pytest.fixture
 def query_06() -> str:
     """Simple query with variables."""
-    query = """
+    return """
     query (
         $str1: String,
         $str2: String = "default2",
@@ -246,12 +241,11 @@ def query_06() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def bad_query_01() -> str:
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -271,12 +265,11 @@ def bad_query_01() -> str:
                 }
             }
     """
-    return query
 
 
 @pytest.fixture
 def query_introspection() -> str:
-    query = """
+    return """
         query IntrospectionQuery {
             __schema {
                 queryType {
@@ -377,7 +370,6 @@ def query_introspection() -> str:
             }
         }
     """
-    return query
 
 
 @pytest.fixture

--- a/backend/tests/component/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_query.py
@@ -238,8 +238,7 @@ async def diff_branch(db: InfrahubDatabase, default_branch: Branch) -> Branch:
 @pytest.fixture
 async def diff_repository(db: InfrahubDatabase, diff_branch: Branch) -> DiffRepository:
     component_registry = get_component_registry()
-    repository = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
-    return repository
+    return await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
 
 
 @pytest.fixture

--- a/backend/tests/component/graphql/queries/test_ipam.py
+++ b/backend/tests/component/graphql/queries/test_ipam.py
@@ -56,7 +56,7 @@ async def ip_dataset_01(
     await net145.new(db=db, prefix="10.10.3.0/27", parent=net140, ip_namespace=ns1)
     await net145.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         # "ns2": ns2,
         # "net161": net161,
@@ -73,7 +73,6 @@ async def ip_dataset_01(
         # "net241": net241,
         # "net242": net242,
     }
-    return data
 
 
 @pytest.fixture
@@ -102,11 +101,10 @@ async def ip_dataset_02(
     await net1_ip1.new(db=db, address="10.200.30.1/27", ip_namespace=ns, ip_prefix=net1)
     await net1_ip1.save(db=db)
 
-    data = {
+    return {
         "ns": ns,
         "net1": net1,
     }
-    return data
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/component/graphql/test_query.py
+++ b/backend/tests/component/graphql/test_query.py
@@ -60,7 +60,6 @@ async def execute_query(
     )
 
 
-
 async def test_execute_query(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:

--- a/backend/tests/component/graphql/test_query.py
+++ b/backend/tests/component/graphql/test_query.py
@@ -51,7 +51,7 @@ async def execute_query(
         at=at,
     )
 
-    result = await graphql(
+    return await graphql(
         schema=gql_params.schema,
         source=graphql_query.query.value,
         context_value=gql_params.context,
@@ -59,7 +59,6 @@ async def execute_query(
         variable_values=params or {},
     )
 
-    return result
 
 
 async def test_execute_query(

--- a/backend/tests/component/message_bus/operations/event/test_branch.py
+++ b/backend/tests/component/message_bus/operations/event/test_branch.py
@@ -30,8 +30,7 @@ async def init_service() -> InfrahubServices:
     recorder = BusRecorder()
     database = MagicMock()
     workflow = WorkflowLocalExecution()
-    service = await InfrahubServices.new(message_bus=recorder, database=database, workflow=workflow)
-    return service
+    return await InfrahubServices.new(message_bus=recorder, database=database, workflow=workflow)
 
 
 @pytest.fixture

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -42,13 +42,12 @@ async def mock_schema_query_02(helper: TestHelper, httpx_mock: HTTPXMock) -> HTT
 
 @pytest.fixture
 def branch_diff_01() -> ProposedChangeBranchDiff:
-    diff = ProposedChangeBranchDiff(
+    return ProposedChangeBranchDiff(
         pipeline_id=uuid4(),
         repositories=[],
         subscribers=[],
     )
 
-    return diff
 
 
 @pytest.fixture

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -49,7 +49,6 @@ def branch_diff_01() -> ProposedChangeBranchDiff:
     )
 
 
-
 @pytest.fixture
 def branch_diff_01_summary() -> list[NodeDiff]:
     return [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -754,7 +754,7 @@ async def car_person_schema(
 
 @pytest.fixture
 async def car_person_schema_branch_local_root(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
-    schema = SchemaRoot(
+    return SchemaRoot(
         nodes=[
             NodeSchema(
                 name="Car",
@@ -799,7 +799,6 @@ async def car_person_schema_branch_local_root(db: InfrahubDatabase, default_bran
             ),
         ],
     )
-    return schema
 
 
 @pytest.fixture

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/car_spec_markdown.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/car_spec_markdown.py
@@ -8,11 +8,10 @@ class CarSpecMarkdown(InfrahubTransform):
     timeout = 10
 
     async def transform(self, data: dict[str, Any]) -> str:
-        markdown = """
+        return """
         ## Car Specification
 
         **blue** Sedan
         Make: **Toyota**
         Model: **Camry**
         """
-        return markdown

--- a/backend/tests/functional/pools/test_numberpool_branch.py
+++ b/backend/tests/functional/pools/test_numberpool_branch.py
@@ -60,11 +60,10 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
-        schema = SchemaRoot(
+        return SchemaRoot(
             version="1.0",
             nodes=[INCIDENT, REQUEST],
         )
-        return schema
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -65,12 +65,11 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
-        schema = SchemaRoot(
+        return SchemaRoot(
             version="1.0",
             generics=[SNOW_TASK],
             nodes=[node_schema_definition, SNOW_INCIDENT, SNOW_REQUEST],
         )
-        return schema
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -233,8 +233,7 @@ class TestInfrahubAppBase(TestInfrahub):
             schema_converge_timeout=5,
         )
 
-        sdk_client = InfrahubClient(config=config)
-        return sdk_client
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def admin_account(

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -130,7 +130,6 @@ class TestInfrahubClient:
             client=client,
         )
 
-
     async def test_import_schema_files(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
     ) -> None:

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -123,14 +123,13 @@ class TestInfrahubClient:
         await obj.save(db=db)
 
         # Initialize the repository on the file system
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=obj.id,
             name=git_repo_infrahub_demo_edge_integration.name,
             location=git_repo_infrahub_demo_edge_integration.path,
             client=client,
         )
 
-        return repo
 
     async def test_import_schema_files(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -267,8 +267,7 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
                 "destination_branch": default_branch.name,
             },
         )
-        proposed_change_id = result["CoreProposedChangeCreate"]["object"]["id"]
-        return proposed_change_id
+        return result["CoreProposedChangeCreate"]["object"]["id"]
 
     def _get_diff_node_attribute_values(self, diff_node: dict[str, Any]) -> dict[str, Any]:
         diff_attribute_values_by_name = {}

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -208,7 +208,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         await deleted_specific_three.save(db=db)
         await deleted_specific_three.delete(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "thing_three": thing_three,
@@ -216,7 +216,6 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
             "specific_two": specific_two,
             "specific_three": specific_three,
         }
-        return objs
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -158,7 +158,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_step02(
         self,

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -139,7 +139,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "deleted_bob": deleted_bob.id,
             "jane": jane.id,
@@ -158,7 +158,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step02(

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -252,7 +252,6 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             "template_thing": template_thing,
         }
 
-
     async def test_step01_baseline(
         self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch
     ) -> None:

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -245,14 +245,13 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         )
         await template_thing.save(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "profile_thing": profile_thing,
             "template_thing": template_thing,
         }
 
-        return objs
 
     async def test_step01_baseline(
         self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch

--- a/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
@@ -59,7 +59,6 @@ class TestSchemaLifecycleGenericRenaming(TestSchemaLifecycleBase):
 
         return {"first_device": first_device.id, "second_device": second_device.id}
 
-
     async def test_step01_baseline(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         devices = await registry.manager.query(db=db, schema=DEVICE_KIND)
         assert len(devices) == 2

--- a/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
@@ -57,9 +57,8 @@ class TestSchemaLifecycleGenericRenaming(TestSchemaLifecycleBase):
         await deleted_device.save(db=db)
         await deleted_device.delete(db=db)
 
-        objs = {"first_device": first_device.id, "second_device": second_device.id}
+        return {"first_device": first_device.id, "second_device": second_device.id}
 
-        return objs
 
     async def test_step01_baseline(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         devices = await registry.manager.query(db=db, schema=DEVICE_KIND)

--- a/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
@@ -119,13 +119,12 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         await deleted_specific_one.save(db=db)
         await deleted_specific_one.delete(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "thing_three": thing_three,
             "specific_one": specific_one,
         }
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_specific_one_new_kind(self) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -148,7 +148,6 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_person_tag(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:
         schema_person_base["relationships"] = [

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -131,7 +131,7 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "richard": richard.id,
@@ -148,7 +148,6 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_person_tag(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
@@ -65,8 +65,7 @@ class TestNumberPoolSingleInstanceAcrossBranches(TestInfrahubApp):
         self,
         db: InfrahubDatabase,
     ) -> Branch:
-        branch = await create_branch(db=db, branch_name="numberpool-single-instance-branch")
-        return branch
+        return await create_branch(db=db, branch_name="numberpool-single-instance-branch")
 
     @pytest.fixture(scope="class")
     async def load_schema_on_default(

--- a/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
@@ -85,7 +85,7 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "renault": renault.id,
             "megane": megane.id,
@@ -93,7 +93,6 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
@@ -93,7 +93,6 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_step01(
         self,

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -145,7 +145,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db, user_id="blue-creator")
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "richard": richard.id,
@@ -162,7 +162,6 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-        return objs
 
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -162,7 +162,6 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
             "green": green.id,
         }
 
-
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)
         assert len(persons) == 2

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -86,7 +86,6 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)
         assert len(persons) == 2

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -74,7 +74,7 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -86,7 +86,6 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-        return objs
 
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -169,7 +169,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await deleted_cylon.save(db=db)
         await deleted_cylon.delete(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "president": president.id,
             "gaius": gaius.id,
@@ -178,7 +178,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "caprica": caprica.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step_01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -178,7 +178,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "caprica": caprica.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_step_01(
         self,

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -162,7 +162,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "megane": megane.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_step_01(
         self,

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -150,7 +150,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await megane.new(db=db, name="Megane", description="Renault Megane", color="#c93420", owner=starbuck)
         await megane.save(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "president": president.id,
             "gaius": gaius.id,
@@ -162,7 +162,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "megane": megane.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step_01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -133,7 +133,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await megane.new(db=db, name="Megane", description="Renault Megane", color="#c93420", owner=starbuck)
         await megane.save(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "gaius": gaius.id,
             "boomer": boomer.id,
@@ -141,7 +141,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "megane": megane.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_01_cylon_robot(self, schema_cylon_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -141,7 +141,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "megane": megane.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_01_cylon_robot(self, schema_cylon_base: dict[str, Any]) -> dict[str, Any]:
         schema_cylon_base["inherit_from"] = ["TestingHumanoid", "TestingRobot"]

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -78,7 +78,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -90,7 +90,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_01_person_name_regex_failure(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -90,7 +90,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_01_person_name_regex_failure(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:
         """Add regex to TestPerson.name that does not fit existing data."""

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -75,7 +75,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -87,7 +87,6 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     async def branch_2(self, db: InfrahubDatabase) -> Branch:

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -87,7 +87,6 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             "red": red.id,
         }
 
-
     @pytest.fixture(scope="class")
     async def branch_2(self, db: InfrahubDatabase) -> Branch:
         return await create_branch(db=db, branch_name="branch_2")

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -74,7 +74,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "clio": clio.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_generic_01(self) -> dict[str, Any]:
         return {

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -66,7 +66,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         )
         await deleted_car.delete(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "deleted_bob": deleted_bob.id,
             "renault": renault.id,
@@ -74,7 +74,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "clio": clio.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_generic_01(self) -> dict[str, Any]:

--- a/backend/tests/integration/sdk/test_node_create_constraint.py
+++ b/backend/tests/integration/sdk/test_node_create_constraint.py
@@ -164,7 +164,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
         )
         await megane.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -174,7 +174,6 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
             "megane": megane.id,
         }
 
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_02_car_uniqueness_constraint(self, schema_car_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/sdk/test_node_create_constraint.py
+++ b/backend/tests/integration/sdk/test_node_create_constraint.py
@@ -174,7 +174,6 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
             "megane": megane.id,
         }
 
-
     @pytest.fixture(scope="class")
     def schema_02_car_uniqueness_constraint(self, schema_car_base: dict[str, Any]) -> dict[str, Any]:
         schema_car_base["uniqueness_constraints"] = [["owner", "color__value"]]

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -89,11 +89,10 @@ class TestTransforms(TestInfrahubApp):
         await obj.save(db=db)
 
         # Initialize the repository on the file system
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=obj.id, name=git_repo_car_dealership.name, location=git_repo_car_dealership.path, client=client
         )
 
-        return repo
 
     async def test_transform_jinja(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset: None

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -93,7 +93,6 @@ class TestTransforms(TestInfrahubApp):
             id=obj.id, name=git_repo_car_dealership.name, location=git_repo_car_dealership.path, client=client
         )
 
-
     async def test_transform_jinja(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset: None
     ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -619,7 +619,6 @@ allow-dunder-method-names = [
     "PLR6301",  # Method could be a function, class method, or static method
     "PLW0603",  # Using the global statement is discouraged
     "PLW1514",  # `pathlib.Path(...).open` without explicit `encoding` argument
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
@@ -671,7 +670,6 @@ allow-dunder-method-names = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
     ##################################################################################################
-    "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
 ]
 
 "backend/infrahub/core/node/standard.py" = [
@@ -775,7 +773,6 @@ allow-dunder-method-names = [
     "PLR0914",  # Too many local variables
     "PLR6301",  # Method could be a function, class method, or static method
     "PT021",    # Use `yield` instead of `request.addfinalizer`
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "SIM108",   # Use ternary operator instead of `if`-`else`-block
@@ -802,7 +799,6 @@ allow-dunder-method-names = [
     "PLR0913",  # Too many arguments in function definition
     "PLR0917",  # Too many positional arguments
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
 ]
 
@@ -827,7 +823,6 @@ allow-dunder-method-names = [
     "PLR0917",  # Too many positional arguments
     "PLR2004",  # Magic value used in comparison
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "S311",     # Standard pseudo-random generators are not suitable for crypto
@@ -869,7 +864,6 @@ allow-dunder-method-names = [
     "PLR6301",  # Method could be a function, class method, or static method
     "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
@@ -903,7 +897,6 @@ allow-dunder-method-names = [
     "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
     "PT012",    # `pytest.raises()` block should contain a single simple statement
     "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
@@ -983,7 +976,6 @@ allow-dunder-method-names = [
     "PT007",    # Wrong values type in `pytest.mark.parametrize`
     "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
@@ -1062,7 +1054,6 @@ allow-dunder-method-names = [
     "PLR2004",  # Magic value used in comparison
     "PLR6201",  # Use a `set` literal when testing for membership
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "S101",     # Use of `assert` detected
@@ -1102,7 +1093,6 @@ allow-dunder-method-names = [
     "PERF203",  # `try`-`except` within a loop incurs performance overhead
     "PLR0912",  # Too many branches
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "S101",     # Use of `assert` detected
 ]
@@ -1126,7 +1116,6 @@ allow-dunder-method-names = [
     "PLR0917",  # Too many positional arguments
     "PLR6201",  # Use a `set` literal when testing for membership
     "PT028",    # Test function parameter has default argument (these are not tests)
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "S701",     # Jinja2 sets `autoescape` to `False`
     "SIM108",   # Use ternary operator instead of `if`-`else`-block

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -118,5 +118,4 @@ def get_yamllint_rules() -> dict:
     from ruamel.yaml import YAML
 
     yaml = YAML(typ="rt")
-    yamllint_rules = yaml.load(Path(".yamllint.yml"))
-    return yamllint_rules
+    return yaml.load(Path(".yamllint.yml"))


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

Enable all the disabled RET rules and fixed all the issues.

Closes #2192

## What changed

<!-- Group changes by intent, not by file. -->

<!-- Behavioral changes: what users/systems will observe differently -->
- Removed all the disabled RET related rules from the `pyproject.toml`. So, all the RET related checks are done with `ruff check`.

<!-- Implementation notes: key design choices, tradeoffs, notable refactors -->

<!-- What stayed the same: especially useful if you touched sensitive areas -->
<!-- e.g., "No schema changes", "API contract unchanged", "Only affects branch X" -->

<!-- If the diff is large, add a suggested review order:
### Suggested review order
1. Start with ...
2. Then ...
3. Tests are ...
-->

<!-- Expected outputs, screenshots, or links to CI results -->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates RET return rules in `ruff` and resolves RET504 violations by returning values directly across the codebase. No behavior changes expected; adds a clear error when `get_path_value` receives an unsupported schema path. Aligns with #2192.

- **Refactors**
  - Removed disabled RET rules in `pyproject.toml`; `ruff check` now enforces them.
  - Replaced temporary variables with direct returns across auth, migrations, nodes/relationships, Git, GraphQL, tasks, events, telemetry, message bus, webhooks, server, and tests.
  - Added a `ValueError` for unsupported schema paths in node `get_path_value`.
  - No API, schema, or runtime behavior changes; tests updated only for style.

<sup>Written for commit 16f2659b8862034afc30ce7d3126caa3c946b916. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

