### PR TITLE
IFC-2555: Fix prefix pool duplication

### DIFF
--- a/backend/infrahub/core/ipam/resource_allocator.py
+++ b/backend/infrahub/core/ipam/resource_allocator.py
@@ -53,7 +53,11 @@ class IPAMResourceAllocator:
         self.branch_agnostic = branch_agnostic
 
     async def _get_next_ipv4_prefix(
-        self, ip_prefix: IPNetworkType, target_prefix_length: int, at: Timestamp | str | None = None
+        self,
+        ip_prefix: IPNetworkType,
+        target_prefix_length: int,
+        at: Timestamp | str | None = None,
+        parent_uuid: str | None = None,
     ) -> IPNetworkType | None:
         """Get the next available free IPv4 prefix.
 
@@ -83,6 +87,7 @@ class IPAMResourceAllocator:
             namespace=self.namespace,
             at=at,
             branch_agnostic=self.branch_agnostic,
+            parent_uuid=parent_uuid,
         )
         await query.execute(db=self.db)
 
@@ -94,7 +99,11 @@ class IPAMResourceAllocator:
         return ipaddress.ip_network(f"{network_address}/{target_prefix_length}")
 
     async def _get_next_ipv6_prefix(
-        self, ip_prefix: IPNetworkType, target_prefix_length: int, at: Timestamp | str | None = None
+        self,
+        ip_prefix: IPNetworkType,
+        target_prefix_length: int,
+        at: Timestamp | str | None = None,
+        parent_uuid: str | None = None,
     ) -> IPNetworkType | None:
         """Get the next available free IPv6 prefix.
 
@@ -124,6 +133,7 @@ class IPAMResourceAllocator:
             namespace=self.namespace,
             at=at,
             branch_agnostic=self.branch_agnostic,
+            parent_uuid=parent_uuid,
         )
         await query.execute(db=self.db)
 
@@ -137,7 +147,11 @@ class IPAMResourceAllocator:
         return ipaddress.ip_network(f"{network_address}/{target_prefix_length}")
 
     async def get_next_prefix(
-        self, ip_prefix: IPNetworkType, target_prefix_length: int, at: Timestamp | str | None = None
+        self,
+        ip_prefix: IPNetworkType,
+        target_prefix_length: int,
+        at: Timestamp | str | None = None,
+        parent_uuid: str | None = None,
     ) -> IPNetworkType | None:
         """Get the next available free prefix of specified length within a parent prefix.
 
@@ -147,6 +161,7 @@ class IPAMResourceAllocator:
             ip_prefix: Parent prefix to allocate from.
             target_prefix_length: Desired prefix length for the new prefix.
             at: Optional timestamp for point-in-time queries.
+            parent_uuid: UUID of the pool-resource prefix node to exclude from occupied ranges.
 
         Returns:
             The next available prefix, or None if no space is available.
@@ -154,9 +169,11 @@ class IPAMResourceAllocator:
         """
         if ip_prefix.version == 4:
             return await self._get_next_ipv4_prefix(
-                ip_prefix=ip_prefix, target_prefix_length=target_prefix_length, at=at
+                ip_prefix=ip_prefix, target_prefix_length=target_prefix_length, at=at, parent_uuid=parent_uuid
             )
-        return await self._get_next_ipv6_prefix(ip_prefix=ip_prefix, target_prefix_length=target_prefix_length, at=at)
+        return await self._get_next_ipv6_prefix(
+            ip_prefix=ip_prefix, target_prefix_length=target_prefix_length, at=at, parent_uuid=parent_uuid
+        )
 
     async def get_next_address(
         self, ip_prefix: IPNetworkType, at: Timestamp | str | None = None, is_pool: bool = False

--- a/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
@@ -104,7 +104,9 @@ class CoreIPPrefixPool(Node):
 
         for resource in weighted_resources:
             resource_prefix = ipaddress.ip_network(resource.prefix.value)  # type: ignore[attr-defined]
-            next_available = await allocator.get_next_prefix(ip_prefix=resource_prefix, target_prefix_length=prefixlen)
+            next_available = await allocator.get_next_prefix(
+                ip_prefix=resource_prefix, target_prefix_length=prefixlen, parent_uuid=resource.id
+            )
             if next_available:
                 return next_available
 

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -333,8 +333,6 @@ class IPPrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
-        # obj is an IPNetworkType (Python network object); parent_uuid is the database UUID of
-        # the pool-resource node. They represent different things and cannot substitute each other.
         parent_uuid: str | None = None,
         **kwargs,
     ) -> None:
@@ -469,8 +467,6 @@ class IPv6PrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
-        # obj is an IPNetworkType (Python network object); parent_uuid is the database UUID of
-        # the pool-resource node. They represent different things and cannot substitute each other.
         parent_uuid: str | None = None,
         **kwargs,
     ) -> None:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -333,11 +333,13 @@ class IPPrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
+        parent_uuid: str | None = None,
         **kwargs,
     ) -> None:
         self.obj = obj
         self.target_prefixlen = target_prefixlen
         self.namespace_id = _get_namespace_id(namespace)
+        self.parent_uuid = parent_uuid
 
         super().__init__(**kwargs)
 
@@ -351,6 +353,7 @@ class IPPrefixSubnetFetchFree(Query):
         self.params["parent_start"] = int(self.obj.network_address)
         self.params["parent_end"] = int(self.obj.broadcast_address)
         self.params["block_size"] = 1 << (32 - self.target_prefixlen)
+        self.params["exclude_uuid"] = self.parent_uuid or ""
 
         branch_filter, branch_params = self.branch.get_query_filter_path(
             at=self.at.to_string(), branch_agnostic=self.branch_agnostic
@@ -375,7 +378,8 @@ class IPPrefixSubnetFetchFree(Query):
         OPTIONAL MATCH path2 = (ns)-[:IS_RELATED]-(ns_rel:Relationship)-[:IS_RELATED]-(pfx:%(node_label)s)-[:HAS_ATTRIBUTE]-(an:Attribute {name: "prefix"})-[:HAS_VALUE]-(av:AttributeIPNetwork)
         WHERE ns_rel.name = "ip_namespace__ip_prefix"
             AND av.binary_address STARTS WITH $prefix_binary
-            AND av.prefixlen > $maxprefixlen
+            AND av.prefixlen >= $maxprefixlen
+            AND pfx.uuid <> $exclude_uuid
             AND av.version = $ip_version
             AND all(r IN relationships(path2) WHERE (%(branch_filter)s) AND r.status = "active")
         WITH collect({binary: av.binary_address, prefixlen: av.prefixlen}) AS ranges_raw
@@ -460,11 +464,13 @@ class IPv6PrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
+        parent_uuid: str | None = None,
         **kwargs,
     ) -> None:
         self.obj = obj
         self.target_prefixlen = target_prefixlen
         self.namespace_id = _get_namespace_id(namespace)
+        self.parent_uuid = parent_uuid
 
         super().__init__(**kwargs)
 
@@ -479,6 +485,7 @@ class IPv6PrefixSubnetFetchFree(Query):
         # Binary representation of parent network and broadcast addresses
         self.params["parent_start_bin"] = convert_ip_to_binary_str(self.obj)
         self.params["parent_end_bin"] = format(int(self.obj.broadcast_address), "0128b")
+        self.params["exclude_uuid"] = self.parent_uuid or ""
 
         branch_filter, branch_params = self.branch.get_query_filter_path(
             at=self.at.to_string(), branch_agnostic=self.branch_agnostic
@@ -503,7 +510,8 @@ class IPv6PrefixSubnetFetchFree(Query):
         OPTIONAL MATCH path2 = (ns)-[:IS_RELATED]-(ns_rel:Relationship)-[:IS_RELATED]-(pfx:%(node_label)s)-[:HAS_ATTRIBUTE]-(an:Attribute {name: "prefix"})-[:HAS_VALUE]-(av:AttributeIPNetwork)
         WHERE ns_rel.name = "ip_namespace__ip_prefix"
             AND av.binary_address STARTS WITH $prefix_binary
-            AND av.prefixlen > $maxprefixlen
+            AND av.prefixlen >= $maxprefixlen
+            AND pfx.uuid <> $exclude_uuid
             AND av.version = $ip_version
             AND all(r IN relationships(path2) WHERE (%(branch_filter)s) AND r.status = "active")
         WITH collect({binary: av.binary_address, prefixlen: av.prefixlen}) AS ranges_raw

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -333,6 +333,8 @@ class IPPrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
+        # obj is an IPNetworkType (Python network object); parent_uuid is the database UUID of
+        # the pool-resource node. They represent different things and cannot substitute each other.
         parent_uuid: str | None = None,
         **kwargs,
     ) -> None:
@@ -379,6 +381,9 @@ class IPPrefixSubnetFetchFree(Query):
         WHERE ns_rel.name = "ip_namespace__ip_prefix"
             AND av.binary_address STARTS WITH $prefix_binary
             AND av.prefixlen >= $maxprefixlen
+            // Exclude the pool-resource prefix node itself: it appears in the DB at the same
+            // address as the parent, so without this filter it would be counted as occupied
+            // space and prevent allocating a prefix of the same length as the resource.
             AND pfx.uuid <> $exclude_uuid
             AND av.version = $ip_version
             AND all(r IN relationships(path2) WHERE (%(branch_filter)s) AND r.status = "active")
@@ -464,6 +469,8 @@ class IPv6PrefixSubnetFetchFree(Query):
         obj: IPNetworkType,
         target_prefixlen: int,
         namespace: Node | str | None = None,
+        # obj is an IPNetworkType (Python network object); parent_uuid is the database UUID of
+        # the pool-resource node. They represent different things and cannot substitute each other.
         parent_uuid: str | None = None,
         **kwargs,
     ) -> None:
@@ -511,6 +518,9 @@ class IPv6PrefixSubnetFetchFree(Query):
         WHERE ns_rel.name = "ip_namespace__ip_prefix"
             AND av.binary_address STARTS WITH $prefix_binary
             AND av.prefixlen >= $maxprefixlen
+            // Exclude the pool-resource prefix node itself: it appears in the DB at the same
+            // address as the parent, so without this filter it would be counted as occupied
+            // space and prevent allocating a prefix of the same length as the resource.
             AND pfx.uuid <> $exclude_uuid
             AND av.version = $ip_version
             AND all(r IN relationships(path2) WHERE (%(branch_filter)s) AND r.status = "active")

--- a/backend/tests/component/core/resource_manager/test_prefix_pool.py
+++ b/backend/tests/component/core/resource_manager/test_prefix_pool.py
@@ -467,6 +467,74 @@ async def test_ipv4_same_prefixlen_pool_exhaustion(
         )
 
 
+async def test_mixed_prefixlen_allocation_two_resources(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node, register_ipam_schema: SchemaBranch
+) -> None:
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+
+    ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ns.new(db=db, name="ns_mixed_prefixlen")
+    await ns.save(db=db)
+
+    resource_a = await Node.init(db=db, schema=prefix_schema)
+    await resource_a.new(db=db, prefix="192.168.0.0/30", ip_namespace=ns)
+    await resource_a.save(db=db)
+
+    resource_b = await Node.init(db=db, schema=prefix_schema)
+    await resource_b.new(db=db, prefix="192.168.0.4/30", ip_namespace=ns)
+    await resource_b.save(db=db)
+
+    prefix_pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPPREFIXPOOL, branch=default_branch)
+
+    pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db)
+    await pool.new(db=db, name="pool_mixed", resources=[resource_a, resource_b], ip_namespace=ns)
+    await pool.save(db=db)
+
+    # /31 from first /30 succeeds
+    first_31 = await pool.get_resource(
+        db=db,
+        prefixlen=31,
+        prefix_type="IpamIPPrefix",
+        member_type="prefix",
+        identifier="first_31",
+        branch=default_branch,
+    )
+    assert first_31.prefix.value == "192.168.0.0/31"
+
+    # /30 succeeds — first /30 is partially used so the allocator moves to the second /30
+    first_30 = await pool.get_resource(
+        db=db,
+        prefixlen=30,
+        prefix_type="IpamIPPrefix",
+        member_type="prefix",
+        identifier="first_30",
+        branch=default_branch,
+    )
+    assert first_30.prefix.value == "192.168.0.4/30"
+
+    # second /30 is exhausted, first /30 can't fit another /30 — fails
+    with pytest.raises(IndexError):
+        await pool.get_resource(
+            db=db,
+            prefixlen=30,
+            prefix_type="IpamIPPrefix",
+            member_type="prefix",
+            identifier="second_30",
+            branch=default_branch,
+        )
+
+    # /31 still fits in the remaining space of the first /30
+    second_31 = await pool.get_resource(
+        db=db,
+        prefixlen=31,
+        prefix_type="IpamIPPrefix",
+        member_type="prefix",
+        identifier="second_31",
+        branch=default_branch,
+    )
+    assert second_31.prefix.value == "192.168.0.2/31"
+
+
 async def test_ipv6_same_prefixlen_pool_exhaustion(
     db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node, register_ipam_schema: SchemaBranch
 ) -> None:

--- a/backend/tests/component/core/resource_manager/test_prefix_pool.py
+++ b/backend/tests/component/core/resource_manager/test_prefix_pool.py
@@ -420,3 +420,93 @@ async def test_ipv6_small_prefix_pool_full_allocation(
             identifier="v6_small_overflow",
             branch=default_branch,
         )
+
+
+async def test_ipv4_same_prefixlen_pool_exhaustion(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node, register_ipam_schema: SchemaBranch
+) -> None:
+    """Test that a pool whose resource prefix length equals the requested allocation length.
+
+    Allocates exactly one prefix and then signals exhaustion rather than returning duplicates.
+    A /30 parent has room for exactly one /30 allocation. The second request must raise IndexError.
+    """
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+
+    ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ns.new(db=db, name="ns_ipv4_same_prefixlen")
+    await ns.save(db=db)
+
+    parent = await Node.init(db=db, schema=prefix_schema)
+    await parent.new(db=db, prefix="172.16.0.0/30", ip_namespace=ns)
+    await parent.save(db=db)
+
+    prefix_pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPPREFIXPOOL, branch=default_branch)
+
+    pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db)
+    await pool.new(db=db, name="pool_ipv4_same_prefixlen", resources=[parent], ip_namespace=ns)
+    await pool.save(db=db)
+
+    first = await pool.get_resource(
+        db=db,
+        prefixlen=30,
+        prefix_type="IpamIPPrefix",
+        member_type="prefix",
+        identifier="v4_same_0",
+        branch=default_branch,
+    )
+    assert first.prefix.value == "172.16.0.0/30"
+
+    with pytest.raises(IndexError):
+        await pool.get_resource(
+            db=db,
+            prefixlen=30,
+            prefix_type="IpamIPPrefix",
+            member_type="prefix",
+            identifier="v4_same_1",
+            branch=default_branch,
+        )
+
+
+async def test_ipv6_same_prefixlen_pool_exhaustion(
+    db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node, register_ipam_schema: SchemaBranch
+) -> None:
+    """Test that a pool whose resource prefix length equals the requested allocation length.
+
+    Allocates exactly one prefix and then signals exhaustion rather than returning duplicates.
+    A /127 parent has room for exactly one /127 allocation. The second request must raise IndexError.
+    """
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+
+    ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ns.new(db=db, name="ns_ipv6_same_prefixlen")
+    await ns.save(db=db)
+
+    parent = await Node.init(db=db, schema=prefix_schema)
+    await parent.new(db=db, prefix="2001:db8::/127", ip_namespace=ns)
+    await parent.save(db=db)
+
+    prefix_pool_schema = registry.schema.get_node_schema(name=InfrahubKind.IPPREFIXPOOL, branch=default_branch)
+
+    pool = await CoreIPPrefixPool.init(schema=prefix_pool_schema, db=db)
+    await pool.new(db=db, name="pool_ipv6_same_prefixlen", resources=[parent], ip_namespace=ns)
+    await pool.save(db=db)
+
+    first = await pool.get_resource(
+        db=db,
+        prefixlen=127,
+        prefix_type="IpamIPPrefix",
+        member_type="prefix",
+        identifier="v6_same_0",
+        branch=default_branch,
+    )
+    assert first.prefix.value == "2001:db8::/127"
+
+    with pytest.raises(IndexError):
+        await pool.get_resource(
+            db=db,
+            prefixlen=127,
+            prefix_type="IpamIPPrefix",
+            member_type="prefix",
+            identifier="v6_same_1",
+            branch=default_branch,
+        )

--- a/changelog/981.fixed.md
+++ b/changelog/981.fixed.md
@@ -1,1 +1,0 @@
-Prefix pools no longer allocate the same prefix multiple times when the pool resource has the same prefix length as the requested allocation size.

--- a/changelog/981.fixed.md
+++ b/changelog/981.fixed.md
@@ -1,0 +1,1 @@
+Prefix pools no longer allocate the same prefix multiple times when the pool resource has the same prefix length as the requested allocation size.

--- a/changelog/prefix-resource-pool-duplication.fixed.md
+++ b/changelog/prefix-resource-pool-duplication.fixed.md
@@ -1,0 +1,1 @@
+Prefix pools no longer allocate the same prefix multiple times when the pool resource has the same prefix length as the requested allocation size. Prefix pools can now correctly allocate a prefix that uses an entire linked resource.


### PR DESCRIPTION
# Why

When a prefix pool's resource prefix has the same length as the requested allocation size (e.g., allocating `/30` subnets from a `/30` parent), the pool returns the same prefix on every request instead of signalling exhaustion. This causes generators to silently produce duplicate IP allocations, resulting in routing failures.

Root cause: `IPPrefixSubnetFetchFree` and `IPv6PrefixSubnetFetchFree` filter occupied child ranges with `av.prefixlen > $maxprefixlen` (strict greater-than). When the allocated child has `prefixlen == parent.prefixlen`, the condition `30 > 30` is false — the child is invisible to subsequent queries, which then return the same `free_start` again.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/981


## How to test

```bash
# New edge-case tests (reproduce the bug before the fix)
uv run pytest backend/tests/component/core/resource_manager/test_prefix_pool.py \
    -k "same_prefixlen" -v
```


## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`changelog/+fix-prefix-pool-dup.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate allocations from prefix pools when the resource prefix length equals the requested size. Pools now allocate once and then correctly signal exhaustion for IPv4 and IPv6, matching IFC-2555’s “no more resource available” expectation.

- **Bug Fixes**
  - Count occupied ranges as `prefixlen >= maxprefixlen` (was `>`), for IPv4 and IPv6.
  - Exclude the pool-resource prefix from occupied matches with `pfx.uuid <> $exclude_uuid`.
  - Pass `parent_uuid` from pool → allocator → IPAM queries to enable the exclusion.
  - Added tests for /30-from-/30, /127-from-/127, and mixed-resource allocation/exhaustion.

<sup>Written for commit d99bb24aeb9fe42a1711df8196f38d87aa492253. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

