### PR TITLE
Add LDAP enum values

### DIFF
--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -118,6 +118,7 @@ async def fetch_account_groups_and_roles(
 class ExternalAuthProtocol(StrEnum):
     OAUTH2 = "oauth2"
     OIDC = "oidc"
+    LDAP = "ldap"
 
 
 class ExternalIdentity(BaseModel):

--- a/backend/infrahub/events/account_action.py
+++ b/backend/infrahub/events/account_action.py
@@ -16,6 +16,7 @@ class AuthMethod(InfrahubStringEnum):
     PASSWORD = "password"
     OAUTH2 = "oauth2"
     OIDC = "oidc"
+    LDAP = "ldap"
 
 
 class AccountLoggedInEvent(InfrahubEvent):


### PR DESCRIPTION

# Why

Add LDAP enum values for use within the enterprise version

## What changed

* Add LDAP as values under ExternalAuthProtocol & AuthMethod

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `LDAP` to the `ExternalAuthProtocol` and `AuthMethod` enums to support enterprise LDAP integration and event logging. No behavior change; this enables LDAP-based login flows to be recognized by the backend.

<sup>Written for commit 3c84d228c24202453e5d3461888c2f0a0f92e564. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

