### PR TITLE
Fix return type of NodeManager.get_one_by_id_or_default_filter()

### DIFF
--- a/backend/infrahub/api/file.py
+++ b/backend/infrahub/api/file.py
@@ -6,14 +6,13 @@ from fastapi import APIRouter, Depends, Request
 from starlette.responses import PlainTextResponse
 
 from infrahub.api.dependencies import BranchParams, get_branch_params, get_current_user, get_db
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreGenericRepository
 from infrahub.database import InfrahubDatabase  # noqa: TC001
 from infrahub.exceptions import CommitNotFoundError, PropagatedFromWorkerError
 from infrahub.message_bus.messages import GitFileGet, GitFileGetResponse
 
 if TYPE_CHECKING:
-    from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
     from infrahub.services import InfrahubServices
 
 
@@ -39,15 +38,19 @@ async def get_file(
     """
     service: InfrahubServices = request.app.state.service
 
-    repo: CoreRepository | CoreReadOnlyRepository = await NodeManager.get_one_by_id_or_default_filter(
+    repo = await NodeManager.get_one_by_id_or_default_filter(
         db=db,
         id=repository_id,
-        kind=InfrahubKind.GENERICREPOSITORY,
+        kind=CoreGenericRepository,
         branch=branch_params.branch,
         at=branch_params.at,
     )
 
-    commit = commit or repo.commit.value
+    # `commit` is defined on CoreRepository/CoreReadOnlyRepository but not on
+    # CoreGenericRepository; arguably it belongs on the generic since every concrete
+    # repository kind carries one. Until that's lifted, the runtime kind here is always
+    # one of the subclasses, so the access is safe.
+    commit = commit or repo.commit.value  # type: ignore[attr-defined]
 
     if not commit:
         raise CommitNotFoundError(identifier=repository_id, commit="", message="No commits found on this repository")

--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -1,7 +1,7 @@
 from typing import Sequence, cast
 
 from infrahub import lock
-from infrahub.core.constants import InfrahubKind, ValidatorConclusion, ValidatorState
+from infrahub.core.constants import ValidatorConclusion, ValidatorState
 from infrahub.core.diff.model.diff import ObjectConflict
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -21,11 +21,10 @@ class ObjectConflictValidatorRecorder:
     async def record_conflicts(self, proposed_change_id: str, conflicts: Sequence[ObjectConflict]) -> list[Node]:
         try:
             proposed_change = await NodeManager.get_one_by_id_or_default_filter(
-                id=proposed_change_id, kind=InfrahubKind.PROPOSEDCHANGE, db=self.db
+                id=proposed_change_id, kind=CoreProposedChange, db=self.db
             )
         except NodeNotFoundError:
             return []
-        proposed_change = cast("CoreProposedChange", proposed_change)
         validator = await self.get_or_create_validator(proposed_change)
         await self.initialize_validator(validator)
 

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -829,7 +829,7 @@ class NodeManager:
         include_metadata: MetadataQueryOptions | MetadataOptions = ...,
         prefetch_relationships: bool = ...,
         branch_agnostic: bool = ...,
-    ) -> Any: ...
+    ) -> Node: ...
 
     @classmethod
     async def get_one_by_id_or_default_filter(
@@ -843,7 +843,7 @@ class NodeManager:
         include_metadata: MetadataQueryOptions | MetadataOptions = MetadataOptions.NONE,
         prefetch_relationships: bool = False,
         branch_agnostic: bool = False,
-    ) -> Any:
+    ) -> Node | SchemaProtocol:
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -18,6 +18,7 @@ from infrahub.core.constants import (
 )
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
@@ -46,7 +47,6 @@ if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
     from infrahub.core.node import Node
-    from infrahub.core.protocols import CoreProposedChange
     from infrahub.events.models import InfrahubEvent
 
     from ..initialization import GraphqlContext
@@ -313,7 +313,7 @@ class ProposedChangeReview(Mutation):
         async with InfrahubLock(name=lock_name, connection=lock.registry.connection):
             proposed_change = await NodeManager.get_one_by_id_or_default_filter(
                 id=pc_id,
-                kind=InfrahubKind.PROPOSEDCHANGE,
+                kind=CoreProposedChange,
                 db=graphql_context.db,
                 prefetch_relationships=True,
                 include_metadata=MetadataOptions.CREATED_BY,

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -9,6 +9,7 @@ from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.ipam.utilization import PrefixUtilizationGetter
 from infrahub.core.manager import NodeManager
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.query.ipam import IPPrefixUtilization
 from infrahub.core.query.resource_manager import (
     IPAddressPoolGetIdentifiers,
@@ -308,7 +309,7 @@ async def resolve_number_pool_utilization(
 
     The utilization is calculated as the percentage of the total number of values in the pool that are not excluded for the corresponding attribute.
     """
-    core_number_pool = await registry.manager.get_one_by_id_or_default_filter(db=db, id=pool.id, kind="CoreNumberPool")
+    core_number_pool = await registry.manager.get_one_by_id_or_default_filter(db=db, id=pool.id, kind=CoreNumberPool)
     number_pool = NumberUtilizationGetter(db=db, pool=core_number_pool, at=at, branch=branch)
     await number_pool.load_data()
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -45,7 +45,7 @@ from infrahub.core.diff.model.diff import DiffElementType, SchemaConflict
 from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
 from infrahub.core.manager import NodeManager
-from infrahub.core.protocols import CoreDataCheck, CoreValidator
+from infrahub.core.protocols import CoreDataCheck, CoreGenericAccount, CoreValidator
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.validators.checks_runner import run_checks_and_update_validator
@@ -258,7 +258,7 @@ async def merge_proposed_change(
         )
 
         current_user = await NodeManager.get_one_by_id_or_default_filter(
-            id=context.account.account_id, kind=InfrahubKind.GENERICACCOUNT, db=db
+            id=context.account.account_id, kind=CoreGenericAccount, db=db
         )
         event_service = await get_event_service()
         await event_service.send(


### PR DESCRIPTION
# Why

Fix return type for NodeManager.get_one_by_id_or_default_filter() so that it doesn't return an `Any`, final invalid method after #9290 was done.

## What changed

* Correct return format if a SchemaProtocol isn't defined
* Mainly small typing corrections
* One type ignore related to `.commit` on generic repositories. I think the follow up task there should be to just add a .commit attribute on the generic even if we let the node kinds override the branch status, the current approach where we don't have a commit attribute on the generic is a bit weird but outside the scope of this PR.
