### PR TITLE
prep release 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.6) - 2026-05-20
+
+### Fixed
+
+- Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context). ([#8857](https://github.com/opsmill/infrahub/issues/8857))
+- Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked. ([#9283](https://github.com/opsmill/infrahub/issues/9283))
+- Bump SDK version to 1.20.1 to include fix for retrieving branches in the MERGING status ([sdk#1036](https://github.com/opsmill/infrahub-sdk-python/pull/1036))
+
 ## [Infrahub - v1.9.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.5) - 2026-05-18
 
 ### Fixed

--- a/changelog/8857.fixed.md
+++ b/changelog/8857.fixed.md
@@ -1,1 +1,0 @@
-Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context).

--- a/changelog/9283.fixed.md
+++ b/changelog/9283.fixed.md
@@ -1,1 +1,0 @@
-Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked.

--- a/docs/docs/release-notes/infrahub/release-1_9_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_6.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.9.6
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 20th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.6](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context). ([#8857](https://github.com/opsmill/infrahub/issues/8857))
+- Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked. ([#9283](https://github.com/opsmill/infrahub/issues/9283))
+- Bump SDK version to 1.20.1 to include fix for retrieving branches in the MERGING status ([sdk#1036](https://github.com/opsmill/infrahub-sdk-python/pull/1036))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -639,6 +639,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_6',
                 'release-notes/infrahub/release-1_9_5',
                 'release-notes/infrahub/release-1_9_4',
                 'release-notes/infrahub/release-1_9_3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.5"
+version = "1.9.6"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.5"
+version = "1.9.6"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.5"
+version = "1.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.5"
+version = "1.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
prep release 1.9.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare Infrahub v1.9.6. Updates versions and docs, and ships fixes for copy actions over HTTP and merge deletion logic.

- **Bug Fixes**
  - Copy actions ("Copy ID", "Copy HFID", "Copy Token") now work over HTTP (non-secure context). (#8857)
  - Merge logic now correctly deletes objects after kind/inheritance changes on default branch post-fork. (#9283)

- **Dependencies**
  - Set `infrahub-server` and `infrahub-testcontainers` to 1.9.6 and update lockfiles; bump `infrahub-sdk-python` to 1.20.1 to support retrieving branches in MERGING status (sdk#1036).

<sup>Written for commit 583d901d67daf5a82fe40252d866d974da18c3dd. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

