### PR TITLE
wait for flaky test

### DIFF
--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from asyncio import sleep
+from asyncio import sleep, timeout
 from typing import TYPE_CHECKING
 
 import pytest
@@ -31,6 +31,27 @@ async def wait_for_all_tasks_to_be_completed(client: InfrahubClient) -> None:
         await client.task.count(filters=TaskFilter(state=[TaskState.PENDING, TaskState.RUNNING, TaskState.SCHEDULED]))
         > 0
     ):
+        await sleep(1)
+
+
+async def wait_for_display_label_backfill(client: InfrahubClient, node_id: str) -> None:
+    # The backfill is dispatched async: SchemaUpdatedEvent -> Prefect automation ->
+    # display-labels-setup-jinja2 -> trigger-update-display-labels -> per-node
+    # display-label-jinja2-update-value. With Redis-backed scaleout messaging that
+    # chain has non-trivial latency, so polling for an empty task queue can return
+    # before the backfill is even scheduled. Wait for the per-node update flow to
+    # reach a terminal state instead. Wrap in `asyncio.timeout()` to bound the wait.
+    terminal = [TaskState.COMPLETED, TaskState.FAILED, TaskState.CRASHED, TaskState.CANCELLED]
+    while True:
+        observed = await client.task.count(
+            filters=TaskFilter(
+                workflow=["display-label-jinja2-update-value"],
+                related_node__ids=[node_id],
+                state=terminal,
+            )
+        )
+        if observed:
+            return
         await sleep(1)
 
 
@@ -86,8 +107,12 @@ class TestDisplayLabelBackfillOnSchemaChange(TestInfrahubDockerClient):
         labels = await self._get_display_labels(client)
         assert labels[color_after] == "Blue"
 
-    async def test_backfill_updates_preexisting_node(self, client: InfrahubClient, color_after: str) -> None:
+    async def test_backfill_updates_preexisting_node(
+        self, client: InfrahubClient, color_before: str, color_after: str
+    ) -> None:
         """After the async backfill completes, all nodes should have correct display_labels."""
-        await wait_for_all_tasks_to_be_completed(client=client)
+        async with timeout(120):
+            await wait_for_display_label_backfill(client=client, node_id=color_before)
         labels = await self._get_display_labels(client)
-        assert set(labels.values()) == {"Red", "Blue"}
+        assert labels[color_before] == "Red"
+        assert labels[color_after] == "Blue"


### PR DESCRIPTION
this integration test is flaky on the enterprise repo, seemingly because multiple task and API workers run in that environment. waiting for the expected task to actually be done seems to unflake it. this update could probably be written in a more maintainable manner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes a flaky integration test by waiting for the per-node display label backfill to reach a terminal state, fixing race conditions in multi-worker environments.

- **Bug Fixes**
  - Added `wait_for_display_label_backfill(client, node_id)` to poll the `display-label-jinja2-update-value` workflow for terminal states via `TaskFilter`.
  - Bounded the wait with `asyncio.timeout(120)` and removed reliance on `wait_for_all_tasks_to_be_completed`.
  - Updated assertions to check the expected labels for the specific nodes.

<sup>Written for commit 56babf91f0c1ab717ce16a49f2b0baad78a834cf. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9315?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

