### PR TITLE
fix: emit one log line per user check log entry

### DIFF
--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -64,6 +64,21 @@ from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_init
 from .utils import fetch_artifact_definition_targets, fetch_check_definition_targets, get_repositories_commit_per_branch
 
 
+def format_check_log_entry(entry: dict[str, Any]) -> str:
+    """Render one user-check log record as a single line for the Prefect flow logger."""
+    parts = [f"[{entry['level']}] {entry['message']}"]
+    object_type = entry.get("object_type")
+    object_id = entry.get("object_id")
+    if object_type or object_id:
+        details = []
+        if object_type:
+            details.append(f"object_type={object_type}")
+        if object_id:
+            details.append(f"object_id={object_id}")
+        parts.append(f"({', '.join(details)})")
+    return " ".join(parts)
+
+
 @flow(
     name="git-repository-add-read-write",
     flow_run_name="Adding repository {model.repository_name} in branch {model.infrahub_branch_name}",
@@ -1047,8 +1062,8 @@ async def run_user_check(model: UserCheckData) -> ValidatorConclusion:
             log.info("The check passed")
         else:
             log.warning("The check reported failures")
-            for log_entry in check_run.log_entries:
-                log.warning(log_entry)
+            for entry in check_run.logs:
+                log.warning(format_check_log_entry(entry))
         log_entries = check_run.log_entries
     except CheckError as exc:
         log.warning("The check failed to run")

--- a/backend/tests/unit/git/test_tasks.py
+++ b/backend/tests/unit/git/test_tasks.py
@@ -1,0 +1,59 @@
+from infrahub.git.tasks import format_check_log_entry
+
+
+def test_format_check_log_entry_message_only() -> None:
+    entry = {"level": "ERROR", "message": "boom", "branch": "main"}
+
+    assert format_check_log_entry(entry) == "[ERROR] boom"
+
+
+def test_format_check_log_entry_with_object_type_and_id() -> None:
+    entry = {
+        "level": "ERROR",
+        "message": "Duplicate serial '12345' for manufacturer 'Acme'.",
+        "branch": "main",
+        "object_id": "abc-123",
+        "object_type": "DcimDeviceAsset",
+    }
+
+    assert format_check_log_entry(entry) == (
+        "[ERROR] Duplicate serial '12345' for manufacturer 'Acme'. (object_type=DcimDeviceAsset, object_id=abc-123)"
+    )
+
+
+def test_format_check_log_entry_with_object_id_only() -> None:
+    entry = {
+        "level": "INFO",
+        "message": "validated",
+        "branch": "main",
+        "object_id": "abc-123",
+    }
+
+    assert format_check_log_entry(entry) == "[INFO] validated (object_id=abc-123)"
+
+
+def test_format_check_log_entry_with_object_type_only() -> None:
+    entry = {
+        "level": "ERROR",
+        "message": "missing description",
+        "branch": "main",
+        "object_type": "TestingCar",
+    }
+
+    assert format_check_log_entry(entry) == "[ERROR] missing description (object_type=TestingCar)"
+
+
+def test_format_check_log_entry_produces_single_line_per_entry() -> None:
+    """Regression: the formatter must emit exactly one line per log record."""
+    entry = {
+        "level": "ERROR",
+        "message": "multi word message",
+        "branch": "main",
+        "object_id": "abc",
+        "object_type": "Foo",
+    }
+
+    rendered = format_check_log_entry(entry)
+
+    assert "\n" not in rendered
+    assert rendered.count("[ERROR]") == 1

--- a/changelog/8224.fixed.md
+++ b/changelog/8224.fixed.md
@@ -1,0 +1,1 @@
+Fix user-check failure logs being emitted one character per line in the proposed change task output — each log entry from `self.log_error(...)` is now rendered as a single warning line.


### PR DESCRIPTION
## Summary

- Fixes #8224
- `run_user_check` iterated over `check_run.log_entries`, which is a single formatted string rather than the structured list of log records. Iterating a string in Python yields one character at a time, so the Prefect flow logger received one warning event per character instead of one per log entry.
- The loop now iterates `check_run.logs` (the structured `list[dict[str, Any]]`) and renders each entry as a single line via a new `format_check_log_entry` helper. The string assignment to `check.message.value` (stored in Neo4j and shown in the check message panel) is unchanged.

## Scope

Backend only. The SDK property `log_entries` is left intact: even with its current naming, the calling code is wrong to iterate it as a list. Any SDK clarification (return type annotation, naming) is orthogonal and can be addressed separately if desired.

## Test plan

- [x] New unit tests in `backend/tests/unit/git/test_tasks.py` covering the formatter on five shapes of log entries, including a regression assertion that no `\n` is produced per record.
- [x] `uv run pytest backend/tests/unit/git/` runs 13/13 green locally.
- [x] `uv run invoke format` and `uv run invoke lint` (ruff, ty, mypy) all pass.
- [x] Manual reproduction on `stable` confirmed the bug end to end (a custom check repo plus a proposed change produced one `prefect.flow_runs warning` per character in `docker logs infrahub-task-worker-1`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user-check logs emitting one character per line; each check log record now logs as a single warning line. Fixes #8224.

- **Bug Fixes**
  - Iterate `check_run.logs` (structured list) instead of `check_run.log_entries` (string) and use `format_check_log_entry` to render one line per entry.
  - Added unit tests for the formatter, including a regression ensuring no newline per record.

<sup>Written for commit f8570d361401bb94a2882c5430799490c214ccd6. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

