### PR TITLE
Pass request to LDAP auth function

### DIFF
--- a/backend/infrahub/api/ldap.py
+++ b/backend/infrahub/api/ldap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Request, Response
 from pydantic import BaseModel, Field
 
 from infrahub import config, models
@@ -50,10 +50,12 @@ class LDAPAuthErrorResponse(BaseModel):
     },
 )
 async def login_ldap(
-    credentials: LDAPCredentials, response: Response, db: InfrahubDatabase = Depends(get_db)
+    credentials: LDAPCredentials, request: Request, response: Response, db: InfrahubDatabase = Depends(get_db)
 ) -> models.UserToken:
     ldap_service: LDAPAuthService = get_ldap_auth_service()
-    auth_result = await ldap_service.authenticate(db=db, username=credentials.username, password=credentials.password)
+    auth_result = await ldap_service.authenticate(
+        db=db, request=request, username=credentials.username, password=credentials.password
+    )
     response.set_cookie(
         "access_token",
         auth_result.token.access_token,

--- a/backend/infrahub/ldap_auth/service.py
+++ b/backend/infrahub/ldap_auth/service.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from infrahub.exceptions import EnterpriseRequiredError
 
 if TYPE_CHECKING:
+    from fastapi import Request
+
     from infrahub.auth import AuthResult
     from infrahub.database import InfrahubDatabase
 
@@ -17,12 +19,22 @@ class LDAPAuthService(ABC):
     """Abstract base for LDAP authentication."""
 
     @abstractmethod
-    async def authenticate(self, db: InfrahubDatabase, username: str, password: str) -> AuthResult:
+    async def authenticate(
+        self,
+        *,
+        db: InfrahubDatabase,
+        request: Request,
+        username: str,
+        password: str,
+    ) -> AuthResult:
         """Authenticate `username`/`password` against the configured directory.
 
         Returns an `AuthResult` on success - same shape as the local-login and
         OAuth2/OIDC flows so downstream consumers cannot distinguish the
         authentication method from the session alone.
+
+        The ``request`` argument lets concrete implementations attribute the
+        successful login event with the originating client's IP and user-agent.
 
         Raises:
             EnterpriseRequiredError: when invoked on a community deployment.
@@ -36,7 +48,9 @@ class LDAPAuthService(ABC):
 class LDAPAuthServiceCommunity(LDAPAuthService):
     async def authenticate(
         self,
+        *,
         db: InfrahubDatabase,  # noqa: ARG002
+        request: Request,  # noqa: ARG002
         username: str,  # noqa: ARG002
         password: str,  # noqa: ARG002
     ) -> AuthResult:

--- a/backend/tests/unit/api/test_ldap_endpoint.py
+++ b/backend/tests/unit/api/test_ldap_endpoint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from starlette.responses import Response
 
@@ -44,7 +44,12 @@ async def test_community_login_handler_raises_enterprise_required(
     Mapping to the HTTP envelope is the framework's job, not the route's.
     """
     with pytest.raises(EnterpriseRequiredError) as exc_info:
-        await login_ldap(credentials=credentials, response=fastapi_response, db=UnusableDatabase())
+        await login_ldap(
+            credentials=credentials,
+            request=Request(scope={"type": "http"}),
+            response=fastapi_response,
+            db=UnusableDatabase(),
+        )
     assert exc_info.value.feature == "ldap_auth"
 
 


### PR DESCRIPTION
# Why

The enterprise code needs to pass the request in order to create a login event. This is a workaround for now and might will probably change into an object that's disconnected from FastAPI. For now it just needs to be in place

## What changed

* Small change to pass along the request to the LDAP auth method
* Update test to pass this parameter



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `fastapi.Request` into the LDAP auth flow to enable login event logging (client IP and user-agent). `LDAPAuthService.authenticate` now requires a `request`, and the login endpoint receives and forwards it.

- **Migration**
  - Update any custom `LDAPAuthService` implementations to accept the new `request` kwarg.

<sup>Written for commit 56db2b3a402b156fbb5c989866e7b2ee9ff77c19. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



