### PR TITLE
fix: pass SchemaBranch when parsing constraint paths in HFID derivation

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1748,7 +1748,7 @@ class SchemaBranch:
                 continue
             constraint_path = constraint_paths[0]
             try:
-                schema_path = node.parse_schema_path(path=constraint_path, schema=node)
+                schema_path = node.parse_schema_path(path=constraint_path, schema=self)
             except AttributePathParsingError:
                 if raise_parsing_errors:
                     raise

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,0 +1,79 @@
+import pytest
+
+from infrahub.core.constants import (
+    BranchSupportType,
+    RelationshipCardinality,
+    RelationshipDirection,
+    RelationshipKind,
+)
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
+
+
+@pytest.fixture
+def car_person_schema_root() -> SchemaRoot:
+    car = NodeSchema(
+        name="Car",
+        namespace="Test",
+        default_filter="name__value",
+        display_label="{{ name__value }} {{ color__value }}",
+        uniqueness_constraints=[["name__value"]],
+        branch=BranchSupportType.AWARE,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="nbr_seats", kind="Number", optional=True),
+            AttributeSchema(name="color", kind="Text", default_value="#444444", max_length=7, optional=True),
+            AttributeSchema(name="is_electric", kind="Boolean", optional=True),
+            AttributeSchema(
+                name="transmission",
+                kind="Text",
+                optional=True,
+                enum=["manual", "automatic", "flintstone-feet"],
+            ),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="owner",
+                label="Commander of Car",
+                peer="TestPerson",
+                optional=False,
+                kind=RelationshipKind.PARENT,
+                cardinality=RelationshipCardinality.ONE,
+                direction=RelationshipDirection.OUTBOUND,
+            ),
+            RelationshipSchema(
+                name="driver",
+                label="Commander of Car",
+                peer="TestPerson",
+                optional=True,
+                cardinality=RelationshipCardinality.ONE,
+                identifier="cars_driven__driver",
+            ),
+        ],
+    )
+    person = NodeSchema(
+        name="Person",
+        namespace="Test",
+        default_filter="name__value",
+        display_label="name__value",
+        branch=BranchSupportType.AWARE,
+        uniqueness_constraints=[["name__value"]],
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="height", kind="Number", optional=True),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="cars",
+                peer="TestCar",
+                cardinality=RelationshipCardinality.MANY,
+                direction=RelationshipDirection.INBOUND,
+            ),
+            RelationshipSchema(
+                name="cars_driven",
+                peer="TestCar",
+                cardinality=RelationshipCardinality.MANY,
+                identifier="cars_driven__driver",
+            ),
+        ],
+    )
+    return SchemaRoot(nodes=[car, person])

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -4,54 +4,20 @@ from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, Sch
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
-class TestDeriveHumanFriendlyIdWithRelationshipOnlyConstraint:
-    """A single-element relationship-only uniqueness_constraint must not crash HFID derivation."""
+def test_single_relationship_uniqueness_constraint(car_person_schema_root: SchemaRoot) -> None:
+    """The HFID derivation must resolve a parent-only constraint without crashing."""
+    car_schema = next(n for n in car_person_schema_root.nodes if n.name == "Car")
+    car_schema.uniqueness_constraints = [["owner"]]
+    for attribute_schema in car_schema.attributes:
+        attribute_schema.unique = False
 
-    @pytest.fixture
-    def processed_branch(self) -> SchemaBranch:
-        schema_root = SchemaRoot(
-            generics=[
-                GenericSchema(
-                    name="Location",
-                    namespace="Testing",
-                    hierarchical=True,
-                    attributes=[
-                        AttributeSchema(name="name", kind="Text"),
-                    ],
-                ),
-            ],
-            nodes=[
-                NodeSchema(
-                    name="Country",
-                    namespace="Testing",
-                    inherit_from=["TestingLocation"],
-                    parent="",
-                    children="TestingSite",
-                ),
-                NodeSchema(
-                    name="Site",
-                    namespace="Testing",
-                    inherit_from=["TestingLocation"],
-                    parent="TestingCountry",
-                    children="",
-                    uniqueness_constraints=[["parent"]],
-                ),
-            ],
-        )
-        branch = SchemaBranch(cache={}, name="test")
-        branch.load_schema(schema=schema_root)
-        branch.process_inheritance()
-        branch.process_hierarchy()
-        branch.add_hierarchy_generic()
-        branch.add_hierarchy_node()
-        return branch
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=car_person_schema_root)
+    schema_branch.process()
 
-    def test_process_human_friendly_id_does_not_raise(self, processed_branch: SchemaBranch) -> None:
-        """The HFID derivation must resolve a parent-only constraint without crashing."""
-        processed_branch.process_human_friendly_id(raise_parsing_errors=True)
-
-        site = processed_branch.get(name="TestingSite", duplicate=False)
-        assert site.human_friendly_id is None
+    processed_car_schema = schema_branch.get(name="TestCar", duplicate=False)
+    assert processed_car_schema.uniqueness_constraints == [["owner"]]
+    assert processed_car_schema.human_friendly_id is None
 
 
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -4,6 +4,56 @@ from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, Sch
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
+class TestDeriveHumanFriendlyIdWithRelationshipOnlyConstraint:
+    """A single-element relationship-only uniqueness_constraint must not crash HFID derivation."""
+
+    @pytest.fixture
+    def processed_branch(self) -> SchemaBranch:
+        schema_root = SchemaRoot(
+            generics=[
+                GenericSchema(
+                    name="Location",
+                    namespace="Testing",
+                    hierarchical=True,
+                    attributes=[
+                        AttributeSchema(name="name", kind="Text"),
+                    ],
+                ),
+            ],
+            nodes=[
+                NodeSchema(
+                    name="Country",
+                    namespace="Testing",
+                    inherit_from=["TestingLocation"],
+                    parent="",
+                    children="TestingSite",
+                ),
+                NodeSchema(
+                    name="Site",
+                    namespace="Testing",
+                    inherit_from=["TestingLocation"],
+                    parent="TestingCountry",
+                    children="",
+                    uniqueness_constraints=[["parent"]],
+                ),
+            ],
+        )
+        branch = SchemaBranch(cache={}, name="test")
+        branch.load_schema(schema=schema_root)
+        branch.process_inheritance()
+        branch.process_hierarchy()
+        branch.add_hierarchy_generic()
+        branch.add_hierarchy_node()
+        return branch
+
+    def test_process_human_friendly_id_does_not_raise(self, processed_branch: SchemaBranch) -> None:
+        """The HFID derivation must resolve a parent-only constraint without crashing."""
+        processed_branch.process_human_friendly_id(raise_parsing_errors=True)
+
+        site = processed_branch.get(name="TestingSite", duplicate=False)
+        assert site.human_friendly_id is None
+
+
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:
     """Proves that schema processing produces the peer/hierarchical values in an expected manner."""
 

--- a/changelog/4483.fixed.md
+++ b/changelog/4483.fixed.md
@@ -1,0 +1,1 @@
+Fix schema processing crashing with `'NodeSchema' object has no attribute 'get'` when a node defines a single-element relationship-only `uniqueness_constraints` entry (e.g. `[["parent"]]`).


### PR DESCRIPTION
# Why

  Creating a node with a single-element relationship-only `uniqueness_constraints` entry (e.g. `[["parent"]]`) crashes schema processing with `AttributeError: 'NodeSchema' object has no attribute 'get'` and returns a 500. The docs list relationship-only constraints as supported syntax, so the implementation and docs disagree. The bug has been present since at
  least 0.16.1.

  **Goal:** Make relationship-only single-element uniqueness constraints process without crashing.

  **Non-goals:**
  - Auto-promoting a relationship-only constraint to an HFID (HFID logic only triggers when `schema_path.is_type_attribute` is true, which a pure relationship path is not — so the constraint correctly stays as a constraint and isn't lifted to HFID).
  - Reconciling whether relationship-only single-element constraints should be a first-class HFID source.

  Closes #4483

  ## What changed

  **Behavioral changes**
  - Schema processing no longer crashes when a node defines `uniqueness_constraints: [["<relationship>"]]` with no other entries.
  - Mixed constraints like `["parent", "name__value"]` were already working — that path skipped the broken branch via the `if len(constraint_paths) > 1: continue` filter, which is why the bug only surfaces for the single-element relationship case.

  **Implementation notes**
  - One-line fix in `_derive_human_friendly_id`: pass `schema=self` (the `SchemaBranch`) to `node.parse_schema_path` instead of `schema=node`. `parse_schema_path` treats its `schema` argument as a `SchemaBranch` and calls `.get(name=..., duplicate=True)` on it when resolving a relationship peer; passing the `NodeSchema` instead made that call raise.
  - The other two `parse_schema_path` call sites in the same file already pass `schema=self`, so this was a one-spot typo, not a systemic issue.

  **What stayed the same**
  - `parse_schema_path` is unchanged.
  - No API, GraphQL, or DB schema changes.
  - HFID derivation rules are unchanged — relationship-only constraints still do not auto-promote to HFID.

  ## How to review

  - `backend/infrahub/core/schema/schema_branch.py` — the one-line fix at the `_derive_human_friendly_id` call site.
  - `backend/tests/unit/core/schema/test_schema_branch.py` — new test class that builds a hierarchical schema with `uniqueness_constraints=[["parent"]]` and asserts `process_human_friendly_id` does not raise. The test fails on `stable` with the original `AttributeError`.

  No risky areas — the change strictly narrows the failure surface; mixed-constraint and attribute-only paths were already exercising the correct argument.

  ## How to test

  ```bash
  # Run the new unit test
  uv run pytest backend/tests/unit/core/schema/test_schema_branch.py::TestDeriveHumanFriendlyIdWithRelationshipOnlyConstraint -v

  # Full schema unit suite to confirm no regressions
  uv run pytest backend/tests/unit/core/schema/ backend/tests/unit/core/test_schema_defaults.py
  ```

  To reproduce on `stable` before the fix, load a schema like:

  ```yaml
  nodes:
    - name: Site
      namespace: Testing
      inherit_from: [TestingLocation]
      parent: TestingCountry
      uniqueness_constraints:
        - [parent]
  ```

  Schema processing raises `AttributeError: 'NodeSchema' object has no attribute 'get'` → HTTP 500. With this PR the same schema loads cleanly.

  ## Impact & rollout

  - **Backward compatibility:** None broken. Schemas that previously crashed now load; schemas that previously worked are unaffected.
  - **Performance:** None. Single attribute access change inside a path already taken on every schema reload.
  - **Config/env changes:** None.
  - **Deployment notes:** Safe to deploy. No migrations, no coordinated release needed.

  ## Checklist

  - [x] Tests added/updated
  - [x] Changelog entry added (`changelog/4483.fixed.md`)
  - [ ] External docs updated — N/A, docs already describe the intended (now-working) behavior
  - [ ] Internal .md docs updated — N/A
  - [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when a node uses a single-element relationship-only `uniqueness_constraints` (e.g., `[["parent"]]`) by passing the `SchemaBranch` to `parse_schema_path` during HFID derivation. Adds a fixture-based unit test that processes a simple Car/Person schema to verify the constraint resolves without error and does not promote to an HFID.

<sup>Written for commit 8e29c5ad399eca2c1ab9fd9f5f1cd2c819325bda. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

