### PR TITLE
fix: reject schema names containing '__' (closes #9209)

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -710,7 +710,6 @@ class SchemaBranch:
 
         self.validate_names()
         self.validate_python_keywords()
-        self.validate_no_double_underscores_in_names()
         self.validate_kinds()
         self.validate_restricted_namespaces_from_generic()
         self.validate_computed_attributes()
@@ -1219,11 +1218,21 @@ class SchemaBranch:
                     isinstance(node, GenericSchema) and attr.name in RESERVED_ATTR_GEN_NAMES
                 ):
                     raise ValueError(f"{node.kind}: {attr.name} isn't allowed as an attribute name.")
+                if "__" in attr.name:
+                    raise ValueError(
+                        f"{node.kind}: '{attr.name}' cannot be used as an attribute name because"
+                        " it contains '__', which is reserved as the schema path separator."
+                    )
             for rel in node.relationships:
                 if rel.name in RESERVED_ATTR_REL_NAMES or (
                     isinstance(node, GenericSchema) and rel.name in RESERVED_ATTR_GEN_NAMES
                 ):
                     raise ValueError(f"{node.kind}: {rel.name} isn't allowed as a relationship name.")
+                if "__" in rel.name:
+                    raise ValueError(
+                        f"{node.kind}: '{rel.name}' cannot be used as a relationship name"
+                        " because it contains '__', which is reserved as the schema path separator."
+                    )
 
     def validate_restricted_namespaces_from_generic(self) -> None:
         """Ensure that every node which inherit from a generic node containing restricted namespaces are following on.
@@ -1273,36 +1282,6 @@ class SchemaBranch:
                         raise ValueError(
                             f"Python keyword '{relationship.name}' cannot be used as a relationship name on '{node.kind}' when using strict mode"
                         )
-
-    def validate_no_double_underscores_in_names(self) -> None:
-        """Validate that attribute and relationship names do not contain '__'.
-
-        '__' is reserved as the schema path separator (e.g. ``name__value``,
-        ``rel__attr__property``); a name containing it cannot be addressed by
-        the path-splitting logic and must be rejected at load time.
-
-        Raises:
-            ValueError: When an attribute or relationship name contains '__'.
-
-        """
-        for name in self.all_names:
-            node = self.get(name=name, duplicate=False)
-
-            if node.kind in INTERNAL_SCHEMA_NODE_KINDS:
-                continue
-
-            for attribute in node.attributes:
-                if "__" in attribute.name:
-                    raise ValueError(
-                        f"{node.kind}: '{attribute.name}' cannot be used as an attribute name because"
-                        " it contains '__', which is reserved as the schema path separator."
-                    )
-            for relationship in node.relationships:
-                if "__" in relationship.name:
-                    raise ValueError(
-                        f"{node.kind}: '{relationship.name}' cannot be used as a relationship name"
-                        " because it contains '__', which is reserved as the schema path separator."
-                    )
 
     def _validate_common_parent(self, node: NodeSchema, rel: RelationshipSchema) -> None:
         if not rel.common_parent:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -710,6 +710,7 @@ class SchemaBranch:
 
         self.validate_names()
         self.validate_python_keywords()
+        self.validate_no_double_underscores_in_names()
         self.validate_kinds()
         self.validate_restricted_namespaces_from_generic()
         self.validate_computed_attributes()
@@ -1272,6 +1273,35 @@ class SchemaBranch:
                         raise ValueError(
                             f"Python keyword '{relationship.name}' cannot be used as a relationship name on '{node.kind}' when using strict mode"
                         )
+
+    def validate_no_double_underscores_in_names(self) -> None:
+        """Validate that attribute and relationship names do not contain '__'.
+
+        '__' is reserved as the schema path separator (e.g. ``name__value``,
+        ``rel__attr__property``); a name containing it cannot be addressed by
+        the path-splitting logic and must be rejected at load time.
+
+        Raises:
+            ValueError: When an attribute or relationship name contains '__'.
+        """
+        for name in self.all_names:
+            node = self.get(name=name, duplicate=False)
+
+            if node.kind in INTERNAL_SCHEMA_NODE_KINDS:
+                continue
+
+            for attribute in node.attributes:
+                if "__" in attribute.name:
+                    raise ValueError(
+                        f"{node.kind}: '{attribute.name}' cannot be used as an attribute name because"
+                        " it contains '__', which is reserved as the schema path separator."
+                    )
+            for relationship in node.relationships:
+                if "__" in relationship.name:
+                    raise ValueError(
+                        f"{node.kind}: '{relationship.name}' cannot be used as a relationship name"
+                        " because it contains '__', which is reserved as the schema path separator."
+                    )
 
     def _validate_common_parent(self, node: NodeSchema, rel: RelationshipSchema) -> None:
         if not rel.common_parent:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1283,6 +1283,7 @@ class SchemaBranch:
 
         Raises:
             ValueError: When an attribute or relationship name contains '__'.
+
         """
         for name in self.all_names:
             node = self.get(name=name, duplicate=False)

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 import pytest
 
 from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
@@ -22,22 +20,10 @@ def test_single_relationship_uniqueness_constraint(car_person_schema_root: Schem
     assert processed_car_schema.human_friendly_id is None
 
 
-@dataclass
-class DoubleUnderscoreNameCase:
-    name: str
-    """Descriptive name for the test scenario."""
-
-    schema_root: SchemaRoot
-    """Schema whose validation must reject a name containing the schema-path separator."""
-
-    offending_name: str
-    """The attribute or relationship name that contains '__' and should be rejected."""
-
-
-DOUBLE_UNDERSCORE_NAME_CASES: list[DoubleUnderscoreNameCase] = [
-    DoubleUnderscoreNameCase(
-        name="attribute_name_with_double_underscore_is_rejected",
-        schema_root=SchemaRoot(
+def test_validate_names_rejects_double_underscore_in_attribute_name() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
             nodes=[
                 NodeSchema(
                     name="Underscore",
@@ -49,44 +35,37 @@ DOUBLE_UNDERSCORE_NAME_CASES: list[DoubleUnderscoreNameCase] = [
                 ),
             ],
         ),
-        offending_name="name__asc",
-    ),
-    DoubleUnderscoreNameCase(
-        name="relationship_name_with_double_underscore_is_rejected",
-        schema_root=SchemaRoot(
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"TestingUnderscore: 'name__asc' cannot be used as an attribute name",
+    ):
+        schema.validate_names()
+
+
+def test_validate_names_rejects_double_underscore_in_relationship_name() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
             nodes=[
                 NodeSchema(
                     name="Underscore",
                     namespace="Testing",
-                    attributes=[
-                        AttributeSchema(name="name", kind="Text"),
-                    ],
+                    attributes=[AttributeSchema(name="name", kind="Text")],
                     relationships=[
                         RelationshipSchema(name="peer__link", peer="TestingUnderscore", optional=True),
                     ],
                 ),
             ],
         ),
-        offending_name="peer__link",
-    ),
-]
+    )
 
-
-@pytest.mark.parametrize(
-    "test_case",
-    [pytest.param(tc, id=tc.name) for tc in DOUBLE_UNDERSCORE_NAME_CASES],
-)
-def test_double_underscores_in_names_are_rejected(test_case: DoubleUnderscoreNameCase) -> None:
-    """Schema validation must reject attribute/relationship names containing '__'.
-
-    '__' is the schema path separator (e.g. ``name__value``), so any name that
-    contains it collides with the path-splitting logic and cannot be referenced.
-    """
-    schema = SchemaBranch(cache={}, name="test")
-    schema.load_schema(schema=test_case.schema_root)
-
-    with pytest.raises(ValueError, match=test_case.offending_name):
-        schema.process_validate()
+    with pytest.raises(
+        ValueError,
+        match=r"TestingUnderscore: 'peer__link' cannot be used as a relationship name",
+    ):
+        schema.validate_names()
 
 
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass
+
 import pytest
 
-from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
@@ -18,6 +20,73 @@ def test_single_relationship_uniqueness_constraint(car_person_schema_root: Schem
     processed_car_schema = schema_branch.get(name="TestCar", duplicate=False)
     assert processed_car_schema.uniqueness_constraints == [["owner"]]
     assert processed_car_schema.human_friendly_id is None
+
+
+@dataclass
+class DoubleUnderscoreNameCase:
+    name: str
+    """Descriptive name for the test scenario."""
+
+    schema_root: SchemaRoot
+    """Schema whose validation must reject a name containing the schema-path separator."""
+
+    offending_name: str
+    """The attribute or relationship name that contains '__' and should be rejected."""
+
+
+DOUBLE_UNDERSCORE_NAME_CASES: list[DoubleUnderscoreNameCase] = [
+    DoubleUnderscoreNameCase(
+        name="attribute_name_with_double_underscore_is_rejected",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Underscore",
+                    namespace="Testing",
+                    attributes=[
+                        AttributeSchema(name="name", kind="Text"),
+                        AttributeSchema(name="name__asc", kind="Text"),
+                    ],
+                ),
+            ],
+        ),
+        offending_name="name__asc",
+    ),
+    DoubleUnderscoreNameCase(
+        name="relationship_name_with_double_underscore_is_rejected",
+        schema_root=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Underscore",
+                    namespace="Testing",
+                    attributes=[
+                        AttributeSchema(name="name", kind="Text"),
+                    ],
+                    relationships=[
+                        RelationshipSchema(name="peer__link", peer="TestingUnderscore", optional=True),
+                    ],
+                ),
+            ],
+        ),
+        offending_name="peer__link",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in DOUBLE_UNDERSCORE_NAME_CASES],
+)
+def test_double_underscores_in_names_are_rejected(test_case: DoubleUnderscoreNameCase) -> None:
+    """Schema validation must reject attribute/relationship names containing '__'.
+
+    '__' is the schema path separator (e.g. ``name__value``), so any name that
+    contains it collides with the path-splitting logic and cannot be referenced.
+    """
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=test_case.schema_root)
+
+    with pytest.raises(ValueError, match=test_case.offending_name):
+        schema.process_validate()
 
 
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:

--- a/changelog/9209.fixed.md
+++ b/changelog/9209.fixed.md
@@ -1,1 +1,1 @@
-Schema attribute and relationship names containing '__' are now rejected at load time, since '__' is reserved as the schema path separator.
+Schema attribute and relationship names containing `__` are now rejected at load time, since `__` is reserved as the schema path separator. **Breaking change:** any existing schema using such names will fail to load after upgrading — rename the affected attributes or relationships in your schema files (and remove or rename the corresponding data) before upgrading.

--- a/changelog/9209.fixed.md
+++ b/changelog/9209.fixed.md
@@ -1,0 +1,1 @@
+Schema attribute and relationship names containing '__' are now rejected at load time, since '__' is reserved as the schema path separator.


### PR DESCRIPTION
# Why

`__` is reserved as the schema path separator (used to address attribute properties as `name__value`, relationship traversals as `rel__attr__property`, and elsewhere). Attribute and relationship names containing `__` were nevertheless accepted by the schema loader because the underlying `NAME_REGEX` (`^[a-z0-9\_]+$`) permits consecutive underscores. A schema with an attribute named `name__asc` loaded successfully but the attribute became unreachable: `parse_schema_path("name__asc__value")` splits on `__`, matches the `name` attribute, then errors on `asc` as if it were a property.

**Goal:** Reject such schemas at load time so the failure mode is a clear error instead of a silently-broken attribute or relationship.

**Non-goals:** Migrating pre-existing user schemas that already contain `__` in names. This PR is the load-time gate; affected users will see the new validation error when they next push the schema. Per the linked issue, this is an accepted breaking change for 1.10.

Closes #9209 and internal [IFC-2571](https://opsmill.atlassian.net/browse/IFC-2571)

## What changed

- `SchemaBranch.validate_names()` now also rejects attribute and relationship names containing `__`, with a `ValueError`.
- `Relationship.identifier` values (which legitimately contain `__`, e.g. `schema__node__attributes`, generated by `_generate_identifier_string`) are not affected — the validator targets `name` only.

## How to test

```bash
uv run pytest backend/tests/unit/core/schema/test_schema_branch.py -v
uv run invoke backend.test-unit
```

## Impact & rollout

- **Backward compatibility:** Breaking change. Users with attribute or relationship names containing `__` will see the new `ValueError` on schema load. The issue explicitly accepts this for 1.10; the changelog fragment is the user-facing entry and includes the migration step.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) — N/A; surfaced via load-time error and the changelog entry.
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) — N/A; no new architecture or workflow.
- [x] I have reviewed AI generated content

<!-- AGENT_FIX_COMPLETE -->


[IFC-2571]: https://opsmill.atlassian.net/browse/IFC-2571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ