### PR TITLE
docs: rename Automation & Outputs to Design & Integrate

### DIFF
--- a/docs/docs/release-notes/infrahub/docs-restructure.mdx
+++ b/docs/docs/release-notes/infrahub/docs-restructure.mdx
@@ -16,7 +16,7 @@ The three main feature sections map directly to the three core jobs Infrahub is 
 
 - **Schema & Data** — Infrahub as the unified source of truth for infrastructure data: modeling your schema, managing objects, IPAM, and resource allocation.
 - **Branches & Change Control** — Infrahub's Git-like versioning layer: branching, proposed changes, checks, validation, and Git repository integration.
-- **Automation & Outputs** — Infrahub as the design surface for your automation stack: generators, transformations, artifacts, events, webhooks, and integrations with tools like Ansible and Nornir.
+- **Design & Integrate** — Infrahub as the design surface for your automation stack: generators, transformations, artifacts, events, webhooks, and integrations with tools like Ansible and Nornir.
 
 The remaining sections support those three jobs:
 
@@ -134,7 +134,7 @@ All pages pre-existing and unchanged.
 
 ---
 
-### Automation & Outputs
+### Design & Integrate
 
 - **Generators** · `generators/` · from `topics/generator` — moved as hub
   - **Build a generator** · `generators/build` · net new — recipe-form how-to; replaces the 528-line tutorial moved to Academy

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -256,7 +256,7 @@ const sidebars: SidebarsConfig = {
 
     {
       type: 'category',
-      label: 'Automation & Outputs',
+      label: 'Design & Integrate',
       collapsible: false,
       collapsed: false,
       link: { type: 'generated-index', slug: 'automation-and-outputs' },


### PR DESCRIPTION
## Summary

Renames the "Automation & Outputs" sidebar section to **"Design & Integrate"**.

- `docs/sidebars.ts` — label updated
- `docs/docs/release-notes/infrahub/docs-restructure.mdx` — updated in 3 places (summary bullet, section heading, detailed listing)

## What didn't change

- No URLs changed
- No content changed — label only

🤖 Generated with [Claude Code](https://claude.com/claude-code)