### PR TITLE
Merge stable into develop with resolved conflicts

### DIFF
--- a/.github/workflows/bug-agent-analyst.lock.yml
+++ b/.github/workflows/bug-agent-analyst.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f36a30d653766cab803e455a96cc790e39b0eb5ef1a997119678de9fd43fc2e6","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27ff3fd52d290d17ebdfe693b5a77102181c0169b4b42d141bc6673eefa3eee4","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -36,7 +36,6 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -249,20 +248,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_21139dea0fd8c80c_EOF'
+          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
           <system>
-          GH_AW_PROMPT_21139dea0fd8c80c_EOF
+          GH_AW_PROMPT_bde3d329d612b3ac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_21139dea0fd8c80c_EOF'
+          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_21139dea0fd8c80c_EOF
+          GH_AW_PROMPT_bde3d329d612b3ac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_21139dea0fd8c80c_EOF'
+          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -294,15 +293,15 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_21139dea0fd8c80c_EOF
+          GH_AW_PROMPT_bde3d329d612b3ac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_21139dea0fd8c80c_EOF'
+          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-analyst.md}}
-          GH_AW_PROMPT_21139dea0fd8c80c_EOF
+          GH_AW_PROMPT_bde3d329d612b3ac_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -470,16 +469,14 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -498,9 +495,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_44ddec4909753287_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2157a195b6af823d_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_44ddec4909753287_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2157a195b6af823d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -682,8 +679,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -708,7 +703,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_edc17c78c1f30c28_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c38d960dab0e52f2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -721,8 +716,11 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": "all",
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -748,7 +746,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_edc17c78c1f30c28_EOF
+          GH_AW_MCP_CONFIG_c38d960dab0e52f2_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1007,6 +1005,8 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-analyst.md
+++ b/.github/workflows/bug-agent-analyst.md
@@ -16,6 +16,8 @@ permissions:
 tools:
   github:
     toolsets: [default]
+    min-integrity: approved
+    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-fix.lock.yml
+++ b/.github/workflows/bug-agent-fix.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f40d15a587ffea70033808298504fb25f6816e0db31b99580269136b020c0cf1","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7804fefb5b0e7b2ad1f6cef18cfa0d22a3d659d973df60bec30246ebedfc153f","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,7 +37,6 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -248,23 +247,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_fcfdd9f2599689d0_EOF'
+          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
           <system>
-          GH_AW_PROMPT_fcfdd9f2599689d0_EOF
+          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_fcfdd9f2599689d0_EOF'
+          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), update_pull_request(max:3), add_labels(max:2), push_to_pull_request_branch(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_fcfdd9f2599689d0_EOF
+          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_fcfdd9f2599689d0_EOF'
+          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_fcfdd9f2599689d0_EOF
+          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_fcfdd9f2599689d0_EOF'
+          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -296,7 +295,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_fcfdd9f2599689d0_EOF
+          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -304,10 +303,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_fcfdd9f2599689d0_EOF'
+          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-fix.md}}
-          GH_AW_PROMPT_fcfdd9f2599689d0_EOF
+          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -448,22 +447,98 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - env:
+      - name: Start DIFC Proxy
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
+          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
+        run: |
+          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
+      - name: "Gate check - require reviewer approval"
+        run: |
+          set -euo pipefail
+          fail() {
+            echo "::error::$1"
+            echo "### Gate failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "$1" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null || echo "")
+          if [ -z "$PR_JSON" ] || [ "$(echo "$PR_JSON" | jq -r '.number // empty')" = "" ]; then
+            fail "Cannot run /bug-fix here: must be invoked on a PR comment."
+          fi
+          PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+
+          if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
+            REQ=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+                and (.body | contains("AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED")))] | length')
+            if [ "$REQ" = "0" ]; then
+              fail "Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer."
+            fi
+            exit 0
+          fi
+
+          if [[ "$PR_BODY" != *"AGENT_TEST_COMPLETE"* ]]; then
+            fail "Cannot run /bug-fix: no AGENT_TEST_COMPLETE marker on PR body. Run /bug-tdd first."
+          fi
+
+          APPROVED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+              and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
+          if [ "$APPROVED" = "0" ]; then
+            fail "Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict."
+          fi
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-        name: "Gate check - require reviewer approval"
-        run: "set -euo pipefail\nfail() {\n  echo \"::error::$1\"\n  echo \"### Gate failed\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nPR_JSON=$(gh api \"repos/$REPO/pulls/$PR_NUMBER\" 2>/dev/null || echo \"\")\nif [ -z \"$PR_JSON\" ] || [ \"$(echo \"$PR_JSON\" | jq -r '.number // empty')\" = \"\" ]; then\n  fail \"Cannot run /bug-fix here: must be invoked on a PR comment.\"\nfi\nPR_BODY=$(echo \"$PR_JSON\" | jq -r '.body // \"\"')\n\nif [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n  REQ=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n    --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n      and (.body | contains(\"AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED\")))] | length')\n  if [ \"$REQ\" = \"0\" ]; then\n    fail \"Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer.\"\n  fi\n  exit 0\nfi\n\nif [[ \"$PR_BODY\" != *\"AGENT_TEST_COMPLETE\"* ]]; then\n  fail \"Cannot run /bug-fix: no AGENT_TEST_COMPLETE marker on PR body. Run /bug-tdd first.\"\nfi\n\nAPPROVED=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n  --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n    and (.body | contains(\"AGENT_REVIEW_VERDICT: TEST_APPROVED\")))] | length')\nif [ \"$APPROVED\" = \"0\" ]; then\n  fail \"Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict.\"\nfi\n"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: latest
       - run: uv sync --all-groups
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: 10
       - run: cd frontend/app && pnpm install --frozen-lockfile
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - run: cd frontend/app && pnpm exec playwright install chromium
-
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -500,16 +575,18 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+      - name: Stop DIFC Proxy
+        if: always()
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -528,9 +605,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a915d955eb5cb84b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9281cc759c87a58b_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":5,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{},"update_pull_request":{"allow_body":true,"allow_title":true,"max":3,"target":"*","update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a915d955eb5cb84b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9281cc759c87a58b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -771,8 +848,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -797,7 +872,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4c32d57d0fd3e8af_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dd344038df537c80_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -810,8 +885,11 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": "all",
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -837,7 +915,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4c32d57d0fd3e8af_EOF
+          GH_AW_MCP_CONFIG_dd344038df537c80_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1096,6 +1174,8 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-fix.md
+++ b/.github/workflows/bug-agent-fix.md
@@ -16,6 +16,8 @@ permissions:
 tools:
   github:
     toolsets: [default]
+    min-integrity: approved
+    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"77dbedcef54126670e8335e0466703da603eb79f1ced63ce5ac4ced29a1cb332","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"aca2da9e127d1d566ff0ec77e6a9bb699212fe0e0b365f1169200d765c58dbdc","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -36,7 +36,6 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -229,20 +228,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6c1a37b941b60316_EOF'
+          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
           <system>
-          GH_AW_PROMPT_6c1a37b941b60316_EOF
+          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1a37b941b60316_EOF'
+          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_6c1a37b941b60316_EOF
+          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1a37b941b60316_EOF'
+          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -274,12 +273,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_6c1a37b941b60316_EOF
+          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1a37b941b60316_EOF'
+          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-review.md}}
-          GH_AW_PROMPT_6c1a37b941b60316_EOF
+          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -407,14 +406,49 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - env:
+      - name: Start DIFC Proxy
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
+          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
+        run: |
+          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
+      - name: "Gate check - skip if current mode already approved"
+        run: |
+          set -euo pipefail
+          skip() {
+            echo "::notice::$1"
+            echo "### Reviewer skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "$1" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
+            MARKER="AGENT_REVIEW_VERDICT: FIX_APPROVED"
+            SKIP_MSG="Skipping reviewer: fix already FIX_APPROVED, pipeline complete."
+          else
+            MARKER="AGENT_REVIEW_VERDICT: TEST_APPROVED"
+            SKIP_MSG="Skipping reviewer: test already TEST_APPROVED, waiting for fix."
+          fi
+
+          COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
+              and (.body | contains(\"$MARKER\")))] | length")
+
+          if [ "$COUNT" -gt 0 ]; then
+            skip "$SKIP_MSG"
+          fi
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        name: "Gate check - skip if current mode already approved"
-        run: "set -euo pipefail\nskip() {\n  echo \"::notice::$1\"\n  echo \"### Reviewer skipped\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nif [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n  MARKER=\"AGENT_REVIEW_VERDICT: FIX_APPROVED\"\n  SKIP_MSG=\"Skipping reviewer: fix already FIX_APPROVED, pipeline complete.\"\nelse\n  MARKER=\"AGENT_REVIEW_VERDICT: TEST_APPROVED\"\n  SKIP_MSG=\"Skipping reviewer: test already TEST_APPROVED, waiting for fix.\"\nfi\n\nCOUNT=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n  --jq \"[.[] | select((.user.login == \\\"infrahub-bug-pipeline[bot]\\\" or .user.login == \\\"github-actions[bot]\\\" or .user.login == \\\"claude[bot]\\\")\n    and (.body | contains(\\\"$MARKER\\\")))] | length\")\n\nif [ \"$COUNT\" -gt 0 ]; then\n  skip \"$SKIP_MSG\"\nfi\n"
-
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -451,16 +485,18 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+      - name: Stop DIFC Proxy
+        if: always()
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -479,9 +515,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_acddac24c607322d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_83a52feeac775ecf_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_acddac24c607322d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_83a52feeac775ecf_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -663,8 +699,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -689,7 +723,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8f8b675b11a3d3aa_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0e96071aed38701d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -702,8 +736,11 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": "all",
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -729,7 +766,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8f8b675b11a3d3aa_EOF
+          GH_AW_MCP_CONFIG_0e96071aed38701d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -987,6 +1024,8 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -19,6 +19,8 @@ permissions:
 tools:
   github:
     toolsets: [default]
+    min-integrity: approved
+    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-test.lock.yml
+++ b/.github/workflows/bug-agent-test.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"68d5dc6771fcd70acba0d91459c1199d5ef9e221c98cfd39fa2c28e8817738b9","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4c9e1580c1f45ea14e1f6a8d0d506a9e0359cb210b839bbdea89408136b16dee","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,7 +37,6 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -248,24 +247,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9a65b2ffb16830f8_EOF'
+          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
           <system>
-          GH_AW_PROMPT_9a65b2ffb16830f8_EOF
+          GH_AW_PROMPT_e1d67eae4c16accb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9a65b2ffb16830f8_EOF'
+          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), create_pull_request, add_labels(max:2), push_to_pull_request_branch(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_9a65b2ffb16830f8_EOF
+          GH_AW_PROMPT_e1d67eae4c16accb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_9a65b2ffb16830f8_EOF'
+          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_9a65b2ffb16830f8_EOF
+          GH_AW_PROMPT_e1d67eae4c16accb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9a65b2ffb16830f8_EOF'
+          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -297,7 +296,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_9a65b2ffb16830f8_EOF
+          GH_AW_PROMPT_e1d67eae4c16accb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -305,10 +304,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_9a65b2ffb16830f8_EOF'
+          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-test.md}}
-          GH_AW_PROMPT_9a65b2ffb16830f8_EOF
+          GH_AW_PROMPT_e1d67eae4c16accb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -449,22 +448,100 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - env:
+      - name: Start DIFC Proxy
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
+          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
+        run: |
+          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
+      - name: "Gate check - require prior pipeline state"
+        run: |
+          set -euo pipefail
+          fail() {
+            echo "::error::$1"
+            echo "### Gate failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "$1" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          ISSUE_JSON=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER")
+          IS_PR=$(echo "$ISSUE_JSON" | jq -r 'if .pull_request then "true" else "false" end')
+
+          if [ "$IS_PR" = "true" ]; then
+            PR_BODY=$(gh api "repos/$REPO/pulls/$ISSUE_NUMBER" | jq -r '.body // ""')
+
+            if [[ "$PR_BODY" != *"AGENT_TEST_COMPLETE"* ]]; then
+              fail "Cannot run /bug-tdd here: PR has no AGENT_TEST_COMPLETE marker."
+            fi
+            if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
+              fail "Cannot run /bug-tdd: fix already applied (AGENT_FIX_COMPLETE present). Test revision after fix is unsupported."
+            fi
+
+            REQ=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
+              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+                and (.body | contains("AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED")))] | length')
+            if [ "$REQ" = "0" ]; then
+              fail "Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on."
+            fi
+            exit 0
+          fi
+
+          ANALYSIS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
+            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+              and (.body | contains("AGENT_ANALYSIS_COMPLETE")))] | length')
+          if [ "$ANALYSIS" = "0" ]; then
+            fail "Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first."
+          fi
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           REPO: ${{ github.repository }}
-        name: "Gate check - require prior pipeline state"
-        run: "set -euo pipefail\nfail() {\n  echo \"::error::$1\"\n  echo \"### Gate failed\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nISSUE_JSON=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER\")\nIS_PR=$(echo \"$ISSUE_JSON\" | jq -r 'if .pull_request then \"true\" else \"false\" end')\n\nif [ \"$IS_PR\" = \"true\" ]; then\n  PR_BODY=$(gh api \"repos/$REPO/pulls/$ISSUE_NUMBER\" | jq -r '.body // \"\"')\n\n  if [[ \"$PR_BODY\" != *\"AGENT_TEST_COMPLETE\"* ]]; then\n    fail \"Cannot run /bug-tdd here: PR has no AGENT_TEST_COMPLETE marker.\"\n  fi\n  if [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n    fail \"Cannot run /bug-tdd: fix already applied (AGENT_FIX_COMPLETE present). Test revision after fix is unsupported.\"\n  fi\n\n  REQ=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER/comments\" --paginate \\\n    --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n      and (.body | contains(\"AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED\")))] | length')\n  if [ \"$REQ\" = \"0\" ]; then\n    fail \"Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on.\"\n  fi\n  exit 0\nfi\n\nANALYSIS=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER/comments\" --paginate \\\n  --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n    and (.body | contains(\"AGENT_ANALYSIS_COMPLETE\")))] | length')\nif [ \"$ANALYSIS\" = \"0\" ]; then\n  fail \"Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first.\"\nfi\n"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: latest
       - run: uv sync --all-groups
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: 10
       - run: cd frontend/app && pnpm install --frozen-lockfile
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - run: cd frontend/app && pnpm exec playwright install chromium
-
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -501,16 +578,18 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+      - name: Stop DIFC Proxy
+        if: always()
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -529,9 +608,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3a18c233f6528f1_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_36a11782ac551623_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_pull_request":{"allowed_base_branches":["stable"],"base_branch":"stable","draft":true,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":3,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a3a18c233f6528f1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_36a11782ac551623_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -776,8 +855,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -802,7 +879,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1cf780a8c43df901_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_19b0d61fea8876a7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -815,8 +892,11 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": "all",
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -842,7 +922,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1cf780a8c43df901_EOF
+          GH_AW_MCP_CONFIG_19b0d61fea8876a7_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1101,6 +1181,8 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-test.md
+++ b/.github/workflows/bug-agent-test.md
@@ -16,6 +16,8 @@ permissions:
 tools:
   github:
     toolsets: [default]
+    min-integrity: approved
+    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.6) - 2026-05-20
+
+### Fixed
+
+- Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context). ([#8857](https://github.com/opsmill/infrahub/issues/8857))
+- Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked. ([#9283](https://github.com/opsmill/infrahub/issues/9283))
+- Bump SDK version to 1.20.1 to include fix for retrieving branches in the MERGING status ([sdk#1036](https://github.com/opsmill/infrahub-sdk-python/pull/1036))
+
 ## [Infrahub - v1.9.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.5) - 2026-05-18
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,60 @@ Please see our [Development Docs](https://docs.infrahub.app/development/) for a 
 
 We maintain a [list of issues that are appropriate to newcomers](https://github.com/opsmill/infrahub/issues?q=is:open+is:issue+label:type/newcomers) to the Infrahub development community. This is a great place to get started!
 
+## Bug pipeline slash commands
+
+Infrahub ships an AI-assisted bug-fixing pipeline built on [GitHub Agentic Workflows](https://github.github.com/gh-aw/). Contributors and maintainers drive it from GitHub by posting slash commands on issues and pull requests. Each command triggers one agent; agents pass state to each other through markers (`AGENT_ANALYSIS_COMPLETE`, `AGENT_TEST_COMPLETE`, `AGENT_FIX_COMPLETE`, `AGENT_REVIEW_VERDICT: …`) embedded in issue comments and PR bodies. The reviewer is **not** invoked via a slash command — it runs automatically when a pipeline PR is opened or updated.
+
+Pipeline flow:
+
+```text
+issue: /bug-analyze ──► analyst posts root cause (AGENT_ANALYSIS_COMPLETE)
+issue: /bug-tdd     ──► test-writer opens draft PR (AGENT_TEST_COMPLETE)
+PR opened/synced    ──► reviewer auto-runs → TEST_APPROVED | TEST_CHANGES_REQUESTED
+PR:    /bug-fix     ──► fixer pushes fix (AGENT_FIX_COMPLETE)
+PR synced           ──► reviewer auto-runs → FIX_APPROVED | FIX_CHANGES_REQUESTED
+```
+
+The pipeline uses a single PR throughout: `/bug-tdd` opens it, `/bug-fix` adds the fix to the same branch. To revise a rejected step, re-run the same command on that PR — `/bug-tdd` after `TEST_CHANGES_REQUESTED`, `/bug-fix` after `FIX_CHANGES_REQUESTED`.
+
+### Running the pipeline on community-reported issues
+
+Issues from outside contributors must be approved by an OpsMill maintainer before the pipeline can run on them. A maintainer applies the `state/ai-pipeline-ready` label after reviewing the report; once labeled, anyone can post `/bug-analyze`. The label must stay on for the duration of the pipeline. Maintainer-authored issues skip this step.
+
+### `/bug-analyze`
+
+- **Where to invoke:** comment on the bug **issue**.
+- **What it does:** reads the issue, explores the codebase, posts a root-cause analysis and fix strategy as a comment on the issue, ending with `AGENT_ANALYSIS_COMPLETE`. Does not write code or open a PR.
+- **Preconditions:** none beyond a bug issue with enough detail to investigate. If the issue is unclear, the agent labels it `state/need-more-info` and stops without the completion marker.
+- **Owning workflow:** [`.github/workflows/bug-agent-analyst.md`](./.github/workflows/bug-agent-analyst.md)
+
+### `/bug-tdd`
+
+- **Where to invoke:**
+  - On the bug **issue** (initial test mode) — opens a draft PR with a failing test.
+  - On the resulting test **PR** (revision mode) — reworks the test based on reviewer feedback.
+- **What it does:** writes a single failing test that reproduces the bug, verifies it fails for the right reason, opens (or updates) a draft PR against `stable` from a branch named `ai-bug-pipeline-<issue_number>-<slug>`, and stamps `AGENT_TEST_COMPLETE` in the PR body. The branch prefix is what the reviewer keys off — do not rename the branch. Production code is never modified.
+- **Preconditions:**
+  - Initial mode: a comment from the bug pipeline bot on the issue containing `AGENT_ANALYSIS_COMPLETE`.
+  - Revision mode: PR body contains `AGENT_TEST_COMPLETE`, does **not** contain `AGENT_FIX_COMPLETE`, and a prior reviewer comment with `AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED` exists.
+- **Owning workflow:** [`.github/workflows/bug-agent-test.md`](./.github/workflows/bug-agent-test.md)
+
+### `/bug-fix`
+
+- **Where to invoke:** comment on the pipeline **PR** opened by `/bug-tdd`.
+- **What it does:** implements the fix on the PR branch, verifies the replication test now passes, runs format/lint/codegen/unit tests, adds a changelog fragment, updates the PR title/body from the project template, and stamps `AGENT_FIX_COMPLETE`. In revision mode it applies the reviewer's requested changes.
+- **Preconditions:**
+  - Initial mode: PR body contains `AGENT_TEST_COMPLETE` **and** a prior reviewer comment with `AGENT_REVIEW_VERDICT: TEST_APPROVED`. Must not already contain `AGENT_FIX_COMPLETE`.
+  - Revision mode: PR body contains `AGENT_FIX_COMPLETE` **and** a prior reviewer comment with `AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED`.
+- **Owning workflow:** [`.github/workflows/bug-agent-fix.md`](./.github/workflows/bug-agent-fix.md)
+
+### Bug reviewer (automatic)
+
+- **Where to invoke:** not invoked manually — runs automatically on `pull_request` events (`opened`, `synchronize`, `edited`, `reopened`) for PRs whose head branch starts with `ai-bug-pipeline-`.
+- **What it does:** picks test-review or fix-review mode based on the PR body markers, posts a verdict comment whose first line is one of `AGENT_REVIEW_VERDICT: TEST_APPROVED | TEST_CHANGES_REQUESTED | FIX_APPROVED | FIX_CHANGES_REQUESTED`. The verdict is the gate the downstream `/bug-tdd` or `/bug-fix` run reads.
+- **Preconditions:** PR head branch matches `ai-bug-pipeline-*` and the PR body contains either `AGENT_TEST_COMPLETE` or `AGENT_FIX_COMPLETE`. The reviewer self-skips if the current mode is already approved or after three iterations of the same mode (labels the PR `state/needs-human-fix`).
+- **Owning workflow:** [`.github/workflows/bug-agent-review.md`](./.github/workflows/bug-agent-review.md)
+
 ## Code of Conduct
 
 [View our CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md) policy to find the latest information.

--- a/backend/changelog/7490.fixed.md
+++ b/backend/changelog/7490.fixed.md
@@ -1,0 +1,1 @@
+Artifact diffs no longer show spurious changes for artifacts whose schema kind was renamed or moved to a different namespace on a branch.

--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -76,5 +76,4 @@ async def get_diff_artifacts(
     artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     target_branch = await registry.get_branch(db=db, branch=registry.default_branch)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=target_branch)
-    response = {art_diff.id: art_diff for art_diff in artifact_diffs}
-    return response
+    return {art_diff.id: art_diff for art_diff in artifact_diffs}

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -354,8 +354,7 @@ def generate_access_token(account_id: str, session_id: uuid.UUID) -> str:
         "type": "access",
         "session_id": str(session_id),
     }
-    access_token = jwt.encode(access_data, config.SETTINGS.security.secret_key, algorithm="HS256")
-    return access_token
+    return jwt.encode(access_data, config.SETTINGS.security.secret_key, algorithm="HS256")
 
 
 def generate_refresh_token(account_id: str, session_id: uuid.UUID, expiration: datetime) -> str:
@@ -370,8 +369,7 @@ def generate_refresh_token(account_id: str, session_id: uuid.UUID, expiration: d
         "type": "refresh",
         "session_id": str(session_id),
     }
-    refresh_token = jwt.encode(refresh_data, config.SETTINGS.security.secret_key, algorithm="HS256")
-    return refresh_token
+    return jwt.encode(refresh_data, config.SETTINGS.security.secret_key, algorithm="HS256")
 
 
 async def authentication_token(

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -196,7 +196,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
             },
         )
 
-        definition = cls(
+        return cls(
             name=f"{computed_attribute.key_name}{NAME_SEPARATOR}kind{NAME_SEPARATOR}{trigger_node.kind}",
             template_hash=template_hash,
             trigger_kind=trigger_node.kind,
@@ -205,8 +205,6 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
             trigger=event_trigger,
             actions=[workflow],
         )
-
-        return definition
 
 
 class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
@@ -246,7 +244,7 @@ class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
             # attribute query
             event_trigger.match_related["infrahub.field.name"] = update_fields
 
-        definition = cls(
+        return cls(
             name=computed_attribute.computed_attribute.key_name,
             branch=branch,
             computed_attribute=computed_attribute,
@@ -271,8 +269,6 @@ class ComputedAttrPythonTriggerDefinition(TriggerBranchDefinition):
                 ),
             ],
         )
-
-        return definition
 
 
 class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
@@ -311,7 +307,7 @@ class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
         elif not branches_out_of_scope and branch != registry.default_branch:
             event_trigger.match["infrahub.branch.name"] = branch
 
-        definition = cls(
+        return cls(
             name=f"{computed_attribute.computed_attribute.key_name}{NAME_SEPARATOR}kind{NAME_SEPARATOR}{kind}",
             branch=branch,
             trigger=event_trigger,
@@ -333,8 +329,6 @@ class ComputedAttrPythonQueryTriggerDefinition(TriggerBranchDefinition):
                 ),
             ],
         )
-
-        return definition
 
 
 class ComputedAttrJinja2GraphQLResponse(BaseModel):

--- a/backend/infrahub/core/diff/artifacts/calculator.py
+++ b/backend/infrahub/core/diff/artifacts/calculator.py
@@ -55,6 +55,8 @@ class ArtifactDiffCalculator:
                     storage_id=target_storage_id,
                     checksum=target_checksum,
                 )
+            if new_storage and old_storage and new_storage == old_storage:
+                continue
             artifact_diffs.append(
                 BranchDiffArtifact(
                     branch=source_branch.name,

--- a/backend/infrahub/core/diff/query/artifact.py
+++ b/backend/infrahub/core/diff/query/artifact.py
@@ -138,9 +138,10 @@ CALL (target_node, definition_node){
     // get the corresponding artifact on the target branch, if it exists
     // -----------------------
     CALL (target_node, definition_node) {
-        OPTIONAL MATCH path = (target_node)-[trel1:IS_RELATED]-(trel_node:Relationship)-[trel2:IS_RELATED]-
+        OPTIONAL MATCH path = (tn_target:Node)-[trel1:IS_RELATED]-(trel_node:Relationship)-[trel2:IS_RELATED]-
         (target_artifact:%(artifact_kind)s)-[drel1:IS_RELATED]-(drel_node:Relationship)-[drel2:IS_RELATED]-(definition_node)
-        WHERE trel_node.name = $target_rel_identifier
+        WHERE tn_target.uuid = target_node.uuid
+        AND trel_node.name = $target_rel_identifier
         AND drel_node.name = $definition_rel_identifier
         AND all(
             r IN relationships(path)

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -65,14 +65,24 @@ CALL (node_diff_map, node_db_id) {
     ORDER BY n_is_part_of.branch_level DESC, n_is_part_of.from DESC, n_is_part_of.status ASC
     LIMIT 1
 }
-WITH n, node_diff_map, is_node_kind_migration
-CALL (n, node_diff_map, is_node_kind_migration) {
+// ------------------------------
+// Resolve the currently-active target-branch Node vertex for this UUID, if it exists
+// ------------------------------
+CALL (n) {
+    OPTIONAL MATCH (tgt_candidate:Node {uuid: n.uuid})-[tgt_ipo:IS_PART_OF {branch: $target_branch, status: "active"}]->(:Root)
+    WHERE tgt_ipo.to IS NULL
+    RETURN tgt_candidate
+    ORDER BY tgt_ipo.from DESC
+    LIMIT 1
+}
+WITH n, COALESCE(tgt_candidate, n) AS tgt_n, node_diff_map, is_node_kind_migration
+CALL (n, tgt_n, node_diff_map, is_node_kind_migration) {
     WITH CASE
         WHEN node_diff_map.action = "ADDED" THEN "active"
         WHEN node_diff_map.action = "REMOVED" THEN "deleted"
         ELSE NULL
     END AS node_rel_status
-    CALL (n, node_diff_map, is_node_kind_migration, node_rel_status) {
+    CALL (n, tgt_n, node_diff_map, is_node_kind_migration, node_rel_status) {
         // ------------------------------
         // only make IS_PART_OF updates if node is ADDED or REMOVED
         // ------------------------------
@@ -95,9 +105,9 @@ CALL (n, node_diff_map, is_node_kind_migration) {
         // ------------------------------
         // set IS_PART_OF.to, optionally, target branch
         // ------------------------------
-        WITH root, n, node_rel_status, source_from_user_id
-        CALL (root, n, node_rel_status, source_from_user_id) {
-            OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(n)
+        WITH root, n, tgt_n, node_rel_status, source_from_user_id
+        CALL (root, tgt_n, node_rel_status, source_from_user_id) {
+            OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(tgt_n)
             WHERE node_rel_status = "deleted"
             AND target_r_root.from <= $at AND target_r_root.to IS NULL
             SET target_r_root.to = $at, target_r_root.to_user_id = source_from_user_id
@@ -105,6 +115,7 @@ CALL (n, node_diff_map, is_node_kind_migration) {
         // ------------------------------
         // create new IS_PART_OF relationship on target_branch
         // also set created_at/created_by on Node vertex when adding
+        // (uses ``n``, `tgt_n` cannot exist for ADDED Nodes)
         // ------------------------------
         WITH root, n, node_rel_status, source_from_user_id
         CALL (root, n, node_rel_status, source_from_user_id) {
@@ -122,21 +133,23 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             SET n.created_at = $at, n.created_by = source_from_user_id
         }
         // ------------------------------
-        // shortcut to delete all attributes and relationships for this node if the node is deleted
+        // shortcut to delete all attributes and relationships for this node if the node is deleted.
+        // Walks from ``tgt_n`` so the cascade closes the post-migration vertex's edges when a
+        // migration happened on target.
         // ------------------------------
-        CALL (n, node_rel_status, source_from_user_id) {
-            WITH n, node_rel_status, source_from_user_id
+        CALL (tgt_n, node_rel_status, source_from_user_id) {
+            WITH tgt_n, node_rel_status, source_from_user_id
             WHERE node_rel_status = "deleted"
-            CALL (n) {
-                OPTIONAL MATCH (n)-[rel1:IS_RELATED]-(attr_rel:Relationship)-[rel2]-(p)
-                WHERE (p.uuid IS NULL OR n.uuid <> p.uuid)
+            CALL (tgt_n) {
+                OPTIONAL MATCH (tgt_n)-[rel1:IS_RELATED]-(attr_rel:Relationship)-[rel2]-(p)
+                WHERE (p.uuid IS NULL OR tgt_n.uuid <> p.uuid)
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
                 AND rel1.status = "active"
                 AND rel2.status = "active"
                 RETURN rel1, rel2, attr_rel
                 UNION
-                OPTIONAL MATCH (n)-[rel1:HAS_ATTRIBUTE]->(attr_rel:Attribute)-[rel2]->()
+                OPTIONAL MATCH (tgt_n)-[rel1:HAS_ATTRIBUTE]->(attr_rel:Attribute)-[rel2]->()
                 WHERE type(rel2) <> "HAS_ATTRIBUTE"
                 AND rel1.branch = $target_branch
                 AND rel2.branch = $target_branch
@@ -154,17 +167,17 @@ CALL (n, node_diff_map, is_node_kind_migration) {
             // ------------------------------
             // and delete HAS_OWNER and HAS_SOURCE edges to this node if the node is deleted
             // ------------------------------
-            WITH n, source_from_user_id
-            CALL (n, source_from_user_id) {
-                CALL (n) {
-                    MATCH (n)<-[rel:HAS_OWNER]-()
+            WITH tgt_n, source_from_user_id
+            CALL (tgt_n, source_from_user_id) {
+                CALL (tgt_n) {
+                    MATCH (tgt_n)<-[rel:HAS_OWNER]-()
                     WHERE rel.branch = $target_branch
                     AND rel.status = "active"
                     AND rel.from <= $at
                     AND rel.to IS NULL
                     RETURN rel
                     UNION
-                    MATCH (n)<-[rel:HAS_SOURCE]-()
+                    MATCH (tgt_n)<-[rel:HAS_SOURCE]-()
                     WHERE rel.branch = $target_branch
                     AND rel.status = "active"
                     AND rel.from <= $at
@@ -814,32 +827,59 @@ class DiffMergeMetadataQuery(Query):
         # ruff: noqa: E501
         query = """
 // --------------------
-// Match all affected nodes, accounting for nodes with migrated kind
-// for each UUID, get the latest Node that was active on this branch
+// Match all affected Node vertices for each UUID, including post-migration
+// siblings created by a target-branch migration after the source branch was
+// forked. A UUID can map to more than one Node vertex when migrated, and the
+// merge can have touched edges on more than one of those vertices; we want
+// to refresh metadata on each. For each Node, pick its "best" IS_PART_OF
+// (latest ``from``, prefer active before deleted) to anchor the
+// updated_at/by fallback for newly-created vertices.
 // --------------------
 UNWIND $node_uuids AS node_uuid
-CALL (node_uuid) {
-    MATCH (n:Node {uuid: node_uuid})-[e:IS_PART_OF]->(:Root)
+MATCH (n:Node {uuid: node_uuid})
+// --------------------
+// Exclude Node vertices on the target branch that have previously been deleted
+// as part of a node kind/inheritance migration
+// --------------------
+WHERE NOT EXISTS {
+    MATCH (n)-[migrated_out:IS_PART_OF {branch: $target_branch, status: "deleted"}]->(:Root)
+    WHERE migrated_out.from < $at AND migrated_out.to IS NULL
+}
+CALL (n) {
+    MATCH (n)-[e:IS_PART_OF]->(:Root)
     WHERE e.branch IN [$target_branch, $global_branch]
     AND (
-        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at))
+        // pre-fork edge, edge created by the merge, or edge closed by the merge
+        (e.branch = $target_branch AND (e.from <= $branched_from OR e.from = $at OR e.to = $at))
         OR (e.branch = $global_branch AND e.from <= $at)
     )
-    RETURN n, e AS is_part_of_e
+    RETURN e AS is_part_of_e
     ORDER BY e.from DESC, e.status ASC
     LIMIT 1
 }
 // --------------------
-// Special handling for the new version of a migrated kind/inheritance Node
-// set updated_at/by to the time/user that created the new version of the Node
+// Node-level metadata refresh for added and deleted Node vertices
+//   - ADDED - ``updated_at``/``by`` on freshly-created Node vertices that the
+//     merge just inserted (their IS_PART_OF has ``from = $at``).
+//   - DELETED - ``updated_at``/``by`` on Node vertices whose IS_PART_OF was
+//     closed by the merge (``to = $at``). This is required to cover Nodes with
+//     their kind/inheritance migrated on the target branch then deleted in the merge
 // --------------------
 CALL (n, is_part_of_e) {
     WITH n, is_part_of_e
-    WHERE n.updated_at IS NULL
-    SET n.updated_at = is_part_of_e.from, n.updated_by = is_part_of_e.from_user_id
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
+    WITH n, is_part_of_e, CASE
+        WHEN is_part_of_e.from = $at THEN is_part_of_e.from_user_id
+        WHEN is_part_of_e.to = $at THEN is_part_of_e.to_user_id
+        ELSE NULL
+    END AS ipo_user_id
+    WHERE ipo_user_id IS NOT NULL
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+    SET n.updated_at = $at, n.updated_by = ipo_user_id
 }
 // --------------------
-// Get all the Attributes and Relationships for this Node that were active on this branch at some point
+// Get all the Attributes and Relationships for this Node that were active on
+// this branch at some point
 // --------------------
 MATCH (n)-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
 WHERE e.branch IN [$source_branch, $target_branch, $global_branch]
@@ -904,11 +944,18 @@ ORDER BY change_time DESC, is_system ASC
 WITH n, collect(change_user_id)[0] AS node_updated_by
 
 // ------------------------------------
-// Update Node metadata with latest change across all its fields
+// Update Node metadata with latest change across all its fields.
+// Skip setting ``previous_updated_at`` if the IS_PART_OF-driven refresh
+// above already moved ``updated_at`` to ``$at`` — otherwise we'd clobber
+// the real ``previous_updated_at`` it captured.
 // ------------------------------------
 WITH n, node_updated_by
 WHERE node_updated_by IS NOT NULL
-SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+CALL (n) {
+    WITH n
+    WHERE n.updated_at IS NULL OR n.updated_at <> $at
+    SET n.previous_updated_at = n.updated_at, n.previous_updated_by = n.updated_by
+}
 SET n.updated_at = $at, n.updated_by = node_updated_by
         """
         self.add_to_query(query=query)

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -133,9 +133,7 @@ class BranchMerger:
 
         diff_source = initial_source_schema.diff(other=self.source_schema)
         diff_destination = initial_source_schema.diff(other=self.destination_schema)
-        diff_both = diff_source + diff_destination
-
-        return diff_both
+        return diff_source + diff_destination
 
     async def calculate_migrations(self, target_schema: SchemaBranch) -> list[SchemaUpdateMigrationInfo]:
         diff_3way = await self.get_3ways_diff_schema()

--- a/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
+++ b/backend/infrahub/core/migrations/graph/m002_attribute_is_default.py
@@ -31,6 +31,4 @@ class Migration002(GraphMigration):
     minimum_version: int = 1
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
+++ b/backend/infrahub/core/migrations/graph/m003_relationship_parent_optional.py
@@ -49,6 +49,4 @@ class Migration003(GraphMigration):
     minimum_version: int = 2
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m004_add_attr_documentation.py
+++ b/backend/infrahub/core/migrations/graph/m004_add_attr_documentation.py
@@ -44,5 +44,4 @@ class Migration004(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m005_add_rel_read_only.py
+++ b/backend/infrahub/core/migrations/graph/m005_add_rel_read_only.py
@@ -36,5 +36,4 @@ class Migration005(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m006_add_rel_on_delete.py
+++ b/backend/infrahub/core/migrations/graph/m006_add_rel_on_delete.py
@@ -36,5 +36,4 @@ class Migration006(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m007_add_rel_allow_override.py
+++ b/backend/infrahub/core/migrations/graph/m007_add_rel_allow_override.py
@@ -44,5 +44,4 @@ class Migration007(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m008_add_human_friendly_id.py
+++ b/backend/infrahub/core/migrations/graph/m008_add_human_friendly_id.py
@@ -44,5 +44,4 @@ class Migration008(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m009_add_generate_profile_attr.py
+++ b/backend/infrahub/core/migrations/graph/m009_add_generate_profile_attr.py
@@ -36,5 +36,4 @@ class Migration009(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m010_add_generate_profile_attr_generic.py
+++ b/backend/infrahub/core/migrations/graph/m010_add_generate_profile_attr_generic.py
@@ -36,5 +36,4 @@ class Migration010(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
+++ b/backend/infrahub/core/migrations/graph/m011_remove_profile_relationship_schema.py
@@ -43,6 +43,4 @@ class Migration011(GraphMigration):
     minimum_version: int = 10
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -60,7 +60,7 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
         super().__init__(new_attr=new_attr, previous_attr=previous_attr, branch=global_branch, **kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         CALL () {
             MATCH (node:%(node_kind)s)
@@ -75,8 +75,6 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
         }
         WITH node
         """ % {"node_kind": self.previous_attr.node_kind}
-
-        return query
 
 
 class Migration012AddLabelData(NodeDuplicateQuery):
@@ -118,13 +116,11 @@ class Migration012AddLabelData(NodeDuplicateQuery):
         super().__init__(new_node=new_node, previous_node=previous_node, branch=branch, **kwargs)
 
     def render_match(self) -> str:
-        query = f"""
+        return f"""
         // Find all the active nodes
         MATCH (node:{self.previous_node.kind})
         WHERE NOT "CoreGenericAccount" IN LABELS(node)
         """
-
-        return query
 
 
 class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):
@@ -341,6 +337,4 @@ class Migration012(GraphMigration):
     minimum_version: int = 11
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
+++ b/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
@@ -304,6 +304,4 @@ class Migration013(GraphMigration):
     minimum_version: int = 12
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
+++ b/backend/infrahub/core/migrations/graph/m014_remove_index_attr_value.py
@@ -42,5 +42,4 @@ class Migration014(GraphMigration):
         return result
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -21,9 +21,7 @@ class Migration015(ArbitraryMigration):
     minimum_version: int = 14
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -21,9 +21,7 @@ class Migration016(ArbitraryMigration):
     minimum_version: int = 15
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
+++ b/backend/infrahub/core/migrations/graph/m017_add_core_profile.py
@@ -22,9 +22,7 @@ class Migration017(InternalSchemaMigration):
     migrations: Sequence[SchemaMigration] = []
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         """Load CoreProfile schema node in db."""

--- a/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
+++ b/backend/infrahub/core/migrations/graph/m019_restore_rels_to_time.py
@@ -232,5 +232,4 @@ class Migration019(GraphMigration):
     queries: Sequence[type[Query]] = [FixBranchAwareEdgesQuery, SetMissingToTimeQuery, DeleteNodesRelsQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
+++ b/backend/infrahub/core/migrations/graph/m020_duplicate_edges.py
@@ -147,5 +147,4 @@ class Migration020(GraphMigration):
         return await self.do_execute(migration_input=migration_input)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
+++ b/backend/infrahub/core/migrations/graph/m021_missing_hierarchy_merge.py
@@ -47,5 +47,4 @@ class Migration021(GraphMigration):
     queries: Sequence[type[Query]] = [SetMissingHierarchyQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m022_add_generate_template_attr.py
+++ b/backend/infrahub/core/migrations/graph/m022_add_generate_template_attr.py
@@ -44,5 +44,4 @@ class Migration022(InternalSchemaMigration):
         return cls(migrations=migrations, **kwargs)  # type: ignore[arg-type]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
@@ -92,5 +92,4 @@ class Migration023(GraphMigration):
     queries: Sequence[type[Query]] = [DedupCardinalityOneRelsQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
+++ b/backend/infrahub/core/migrations/graph/m024_missing_hierarchy_backfill.py
@@ -65,5 +65,4 @@ class Migration024(GraphMigration):
     queries: Sequence[type[Query]] = [BackfillMissingHierarchyQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
+++ b/backend/infrahub/core/migrations/graph/m027_delete_isolated_nodes.py
@@ -47,5 +47,4 @@ class Migration027(GraphMigration):
     queries: Sequence[type[Query]] = [DeleteIsolatedNodesQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -23,9 +23,7 @@ class Migration028(ArbitraryMigration):
     minimum_version: int = 27
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -58,7 +58,7 @@ class CleanUpDuplicatedUuidVertices(Query):
             l_arrow = ""
             r_arrow = ">"
 
-        query = """
+        return """
     CALL (vertex_to_keep, edge_type, branch, peer, earliest_active_time, latest_deleted_time, all_edges_deleted, edge_to_copy) {
         // ------------
         // get or create the active %(edge_type)s edge
@@ -82,7 +82,6 @@ class CleanUpDuplicatedUuidVertices(Query):
             "l_arrow": l_arrow,
             "r_arrow": r_arrow,
         }
-        return query
 
     def _add_deleted_edge_subquery(
         self,
@@ -95,7 +94,7 @@ class CleanUpDuplicatedUuidVertices(Query):
         else:
             l_arrow = ""
             r_arrow = ">"
-        subquery = """
+        return """
     CALL (vertex_to_keep, edge_type, branch, peer, latest_deleted_time, edge_to_copy) {
         // ------------
         // create the deleted %(edge_type)s edge
@@ -112,7 +111,6 @@ class CleanUpDuplicatedUuidVertices(Query):
         SET deleted_edge.hierarchy = edge_to_copy.hierarchy
     }
         """ % {"edge_type": edge_type.value, "l_arrow": l_arrow, "r_arrow": r_arrow}
-        return subquery
 
     def _build_directed_edges_subquery(
         self,
@@ -139,7 +137,7 @@ class CleanUpDuplicatedUuidVertices(Query):
         active_edge_subqueries = "\n".join(active_subqueries)
         deleted_edge_subqueries = "\n".join(delete_subqueries)
 
-        edges_query = """
+        return """
 //------------
 // Get every %(direction)s branch, edge_type, peer element_id combinations touching vertices with this uuid/labels combination
 //------------
@@ -257,7 +255,6 @@ CALL (n_uuid, vertex_element_ids, element_id_to_keep) {
             "deleted_edge_subqueries": deleted_edge_subqueries,
             "vertex_label": self.vertex_label,
         }
-        return edges_query
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params["limit"] = self.limit or 1000
@@ -572,9 +569,7 @@ class Migration029(ArbitraryMigration):
     limit: int = 100
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         migration_result = MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
+++ b/backend/infrahub/core/migrations/graph/m030_illegal_edges.py
@@ -76,5 +76,4 @@ class Migration030(GraphMigration):
     queries: Sequence[type[Query]] = [DeletePosthumousEdges]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
+++ b/backend/infrahub/core/migrations/graph/m031_check_number_attributes.py
@@ -101,5 +101,4 @@ class Migration031(InternalSchemaMigration):
         return MigrationResult(errors=[error_str] + errors_messages)
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
+++ b/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
@@ -96,5 +96,4 @@ class Migration033(GraphMigration):
     queries: Sequence[type[Query]] = [DeduplicateRelationshipVerticesQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
+++ b/backend/infrahub/core/migrations/graph/m036_drop_attr_value_index.py
@@ -42,5 +42,4 @@ class Migration036(GraphMigration):
         return result
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
+++ b/backend/infrahub/core/migrations/graph/m037_index_attr_vals.py
@@ -458,9 +458,7 @@ class Migration037(ArbitraryMigration):
     minimum_version: int = 36
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:  # noqa: PLR0915
         console = get_migration_console()

--- a/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
+++ b/backend/infrahub/core/migrations/graph/m041_deleted_dup_edges.py
@@ -136,9 +136,7 @@ class Migration041(ArbitraryMigration):
     minimum_version: int = 40
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()
 
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         db = migration_input.db

--- a/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
+++ b/backend/infrahub/core/migrations/graph/m055_remove_webhook_validate_certificates_default.py
@@ -81,6 +81,4 @@ class Migration055(GraphMigration):
     minimum_version: int = 54
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
-        result = MigrationResult()
-
-        return result
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -35,7 +35,7 @@ class AttributeRenameQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         CALL () {
             MATCH (node:%(node_kind)s)
@@ -52,8 +52,6 @@ class AttributeRenameQuery(Query):
         }
         WITH node
         """ % {"node_kind": self.previous_attr.node_kind}
-
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type_update_active(rel_type: str, rel_def: FieldInfo) -> str:

--- a/backend/infrahub/core/migrations/query/delete_element_in_schema.py
+++ b/backend/infrahub/core/migrations/query/delete_element_in_schema.py
@@ -30,11 +30,10 @@ class DeleteElementInSchemaQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         MATCH path = (attr_node:Node)-[:HAS_ATTRIBUTE]->(attr:Attribute)
         MATCH (attr_node)-[:HAS_ATTRIBUTE]->(attr_name:Attribute)-[:HAS_VALUE]->(attr_value:AttributeValue)
         """
-        return query
 
     def render_where(self) -> str:
         at = self.at or Timestamp()
@@ -42,15 +41,13 @@ class DeleteElementInSchemaQuery(Query):
         self.params.update(params)
 
         # ruff: noqa: E501
-        query = """
+        return """
         WHERE ( "SchemaAttribute" in LABELS(attr_node) OR "SchemaRelationship" IN LABELS(attr_node))
             AND exists( (attr_node)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(:Node)-[:HAS_ATTRIBUTE]->(:Attribute { name: "name"})-[:HAS_VALUE]->(:AttributeValue { value: $node_name }) )
             AND exists( (attr_node)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(:Node)-[:HAS_ATTRIBUTE]->(:Attribute { name: "namespace"})-[:HAS_VALUE]->(:AttributeValue  { value: $node_namespace }) )
             AND ( attr_name.name = "name" AND attr_value.value IN $element_names)
             AND all(r IN relationships(path) WHERE ( %(filters)s ))
         """ % {"filters": filters}
-
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -44,7 +44,7 @@ class NodeDuplicateQuery(Query):
 
     def render_match(self) -> str:
         labels_str = ":".join(self.previous_node.labels)
-        query = """
+        return """
         // Find all the active nodes
         MATCH (node:%(labels_str)s)
         WITH DISTINCT node
@@ -64,8 +64,6 @@ class NodeDuplicateQuery(Query):
         }
         WITH node WHERE already_migrated = FALSE
         """ % {"labels_str": labels_str}
-
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/relationship_duplicate.py
+++ b/backend/infrahub/core/migrations/query/relationship_duplicate.py
@@ -36,13 +36,11 @@ class RelationshipDuplicateQuery(Query):
         super().__init__(**kwargs)
 
     def render_match(self) -> str:
-        query = """
+        return """
         // Find all the active nodes
         MATCH (source:%(src_peer)s)-[:IS_RELATED]-(rel:Relationship { name: $previous_rel.name })-[:IS_RELATED]-(destination:%(dst_peer)s)
         WHERE source <> destination
         """ % {"src_peer": self.previous_rel.src_peer, "dst_peer": self.previous_rel.dst_peer}
-
-        return query
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:

--- a/backend/infrahub/core/migrations/query/schema_attribute_update.py
+++ b/backend/infrahub/core/migrations/query/schema_attribute_update.py
@@ -38,17 +38,15 @@ class SchemaAttributeUpdateQuery(Query):
 
     def _render_match_schema_node(self) -> str:
         # ruff: noqa: E501
-        query = """
+        return """
         MATCH path = (node:SchemaNode)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[rel:HAS_VALUE]->(av:AttributeValue)
         """
-        return query
 
     def _render_match_schema_attribute(self) -> str:
         # ruff: noqa: E501
-        query = """
+        return """
         MATCH path = (node:SchemaNode)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(attr_node:SchemaAttribute)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[rel:HAS_VALUE]->(av:AttributeValue)
         """
-        return query
 
     def render_where(self) -> str:
         at = self.at or Timestamp()

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -275,6 +275,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             attr = getattr(node, schema_path.attribute_schema.name)
             return getattr(attr, schema_path.attribute_property_name)
 
+        raise ValueError(f"Unable to retrieve value for unsupported schema path type {path!r} on {self.get_kind()!r}")
+
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind.
 
@@ -292,8 +294,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             return labels
 
         if isinstance(self._schema, ProfileSchema | TemplateSchema):
-            labels = [self.get_kind()] + self._schema.inherit_from
-            return labels
+            return [self.get_kind()] + self._schema.inherit_from
 
         return [self.get_kind()]
 
@@ -901,7 +902,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         data: Any,
         db: InfrahubDatabase,
     ) -> RelationshipManager:
-        rm = await RelationshipManager.init(
+        return await RelationshipManager.init(
             db=db,
             data=data,
             schema=schema,
@@ -909,8 +910,6 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             at=self._at,
             node=self,
         )
-
-        return rm
 
     async def _generate_attribute_default(
         self,

--- a/backend/infrahub/core/node/base.py
+++ b/backend/infrahub/core/node/base.py
@@ -63,22 +63,4 @@ class ObjectNodeMeta(BaseNodeMeta):
         class InterObjectNode:
             pass
 
-        base_cls = super().__new__(mcs, name_, (InterObjectNode,) + bases, namespace, **options)
-        # if base_cls._meta:
-        #     fields = [
-        #         (
-        #             key,
-        #             "typing.Any",
-        #             field(
-        #                 default=field_value.default_value
-        #                 if isinstance(field_value, Field)
-        #                 else None
-        #             ),
-        #         )
-        #         for key, field_value in base_cls._meta.fields.items()
-        #     ]
-        #     dataclass = make_dataclass(name_, fields, bases=())
-        #     InterObjectType.__init__ = dataclass.__init__
-        #     InterObjectType.__eq__ = dataclass.__eq__
-        #     InterObjectType.__repr__ = dataclass.__repr__
-        return base_cls
+        return super().__new__(mcs, name_, (InterObjectNode,) + bases, namespace, **options)

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -36,8 +36,7 @@ class CoreNumberPool(Node):
         for start_range, end_range in excluded_ranges:
             sum_excluded_values += end_range - start_range + 1
 
-        res = len(attribute.parameters.get_excluded_single_values()) + sum_excluded_values
-        return res
+        return len(attribute.parameters.get_excluded_single_values()) + sum_excluded_values
 
     async def get_used(
         self,

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1030,8 +1030,7 @@ class RelationshipManager:
         if not rels and raise_on_error:
             raise LookupError("Unable to find the peer")
 
-        peer = await rels[0].get_peer(db=db)
-        return peer
+        return await rels[0].get_peer(db=db)
 
     @overload
     async def get_peers(
@@ -1060,14 +1059,13 @@ class RelationshipManager:
     ) -> Mapping[str, Node | PeerType]:
         rels = await self.get_relationships(db=db, branch_agnostic=branch_agnostic)
         peer_ids = [rel.peer_id for rel in rels if rel.peer_id]
-        nodes = await registry.manager.get_many(
+        return await registry.manager.get_many(
             db=db,
             ids=peer_ids,
             branch=self.branch,
             branch_agnostic=branch_agnostic,
             include_metadata=include_metadata,
         )
-        return nodes
 
     def get_branch_based_on_support_type(self) -> Branch:
         """If the attribute is branch aware, return the Branch object associated with this attribute.

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -149,8 +149,7 @@ class NumberAttributeParameters(AttributeParameters):
         if not self.excluded_values:
             return []
 
-        results = [int(value) for value in self.excluded_values.split(",") if "-" not in value]
-        return results
+        return [int(value) for value in self.excluded_values.split(",") if "-" not in value]
 
     def get_excluded_ranges(self) -> list[tuple[int, int]]:
         if not self.excluded_values:

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -49,8 +49,7 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
             database=await get_database(),
         )
 
-    results = [result async for _, result in batch.execute()]
-    return results
+    return [result async for _, result in batch.execute()]
 
 
 @task(  # type: ignore[arg-type]

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -180,8 +180,7 @@ class InfrahubEvent(BaseModel):
     @final
     def get_event_payload(self) -> dict[str, Any]:
         """This method should be used when emitting the event to the event broker."""
-        event_payload = {"data": self.get_payload(), "context": self.meta.context.to_event()}
-        return event_payload
+        return {"data": self.get_payload(), "context": self.meta.context.to_event()}
 
     def get_message_meta(self) -> Meta:
         meta = Meta()

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -996,9 +996,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 repo.git.merge("--abort")
 
         changed_files = git_status.splitlines()
-        conflict_files = [filename[3:] for filename in changed_files if filename.startswith("UU ")]
-
-        return conflict_files
+        return [filename[3:] for filename in changed_files if filename.startswith("UU ")]
 
     async def find_files(
         self,

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -206,9 +206,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         After the rebase we need to resync the data
         """
-        response = await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
-
-        return response
+        return await self.merge(dest_branch=branch_name, source_branch=source_branch, push_remote=push_remote)
 
 
 class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -64,6 +64,21 @@ from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_init
 from .utils import fetch_artifact_definition_targets, fetch_check_definition_targets, get_repositories_commit_per_branch
 
 
+def format_check_log_entry(entry: dict[str, Any]) -> str:
+    """Render one user-check log record as a single line for the Prefect flow logger."""
+    parts = [f"[{entry['level']}] {entry['message']}"]
+    object_type = entry.get("object_type")
+    object_id = entry.get("object_id")
+    if object_type or object_id:
+        details = []
+        if object_type:
+            details.append(f"object_type={object_type}")
+        if object_id:
+            details.append(f"object_id={object_id}")
+        parts.append(f"({', '.join(details)})")
+    return " ".join(parts)
+
+
 @flow(
     name="git-repository-add-read-write",
     flow_run_name="Adding repository {model.repository_name} in branch {model.infrahub_branch_name}",
@@ -1047,8 +1062,8 @@ async def run_user_check(model: UserCheckData) -> ValidatorConclusion:
             log.info("The check passed")
         else:
             log.warning("The check reported failures")
-            for log_entry in check_run.log_entries:
-                log.warning(log_entry)
+            for entry in check_run.logs:
+                log.warning(format_check_log_entry(entry))
         log_entries = check_run.log_entries
     except CheckError as exc:
         log.warning("The check failed to run")

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -714,10 +714,7 @@ async def git_repository_diff_names_only(model: GitDiffNamesOnly) -> GitDiffName
     else:
         files_added = await repo.list_all_files(commit=model.first_commit)
 
-    response = GitDiffNamesOnlyResponse(
-        files_added=files_added, files_changed=files_changed, files_removed=files_removed
-    )
-    return response
+    return GitDiffNamesOnlyResponse(files_added=files_added, files_changed=files_changed, files_removed=files_removed)
 
 
 @flow(

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -137,10 +137,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         )
 
         reconciler = IpamReconciler(db=db, branch=branch)
-        reconciled_address = await reconciler.reconcile(
-            ip_value=ip_address, namespace=namespace_id, node_uuid=address.get_id()
-        )
-        return reconciled_address
+        return await reconciler.reconcile(ip_value=ip_address, namespace=namespace_id, node_uuid=address.get_id())
 
     @classmethod
     @retry_db_transaction(name="ipaddress_create")
@@ -179,10 +176,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         address = await cls.mutate_update_object(db=db, info=info, data=data, branch=branch, obj=address)
         reconciler = IpamReconciler(db=db, branch=branch)
         ip_address = ipaddress.ip_interface(address.address.value)
-        reconciled_address = await reconciler.reconcile(
-            ip_value=ip_address, node_uuid=address.get_id(), namespace=namespace_id
-        )
-        return reconciled_address
+        return await reconciler.reconcile(ip_value=ip_address, node_uuid=address.get_id(), namespace=namespace_id)
 
     @classmethod
     @retry_db_transaction(name="ipaddress_update")
@@ -427,10 +421,9 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     ) -> Node:
         reconciler = IpamReconciler(db=db, branch=branch)
         ip_network = ipaddress.ip_network(prefix.prefix.value)
-        reconciled_prefix = await reconciler.reconcile(
+        return await reconciler.reconcile(
             ip_value=ip_network, node_uuid=prefix.get_id(), namespace=namespace_id, is_delete=is_delete
         )
-        return reconciled_prefix
 
     @classmethod
     @retry_db_transaction(name="ipprefix_delete")

--- a/backend/infrahub/graphql/order.py
+++ b/backend/infrahub/graphql/order.py
@@ -10,5 +10,4 @@ def deserialize_order_input(input_data: dict[str, Any] | None) -> OrderModel | N
     if not input_data:
         return None
 
-    order_model = OrderModel(**input_data)
-    return order_model
+    return OrderModel(**input_data)

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -44,8 +44,7 @@ async def account_resolver(
             order=OrderModel(disable=True),
         )
         if results:
-            account_profile = await results[0].to_graphql(db=db, fields=fields)
-            return account_profile
+            return await results[0].to_graphql(db=db, fields=fields)
 
         raise NodeNotFoundError(
             node_type=InfrahubKind.GENERICACCOUNT, identifier=graphql_context.account_session.account_id

--- a/backend/infrahub/pools/prefix.py
+++ b/backend/infrahub/pools/prefix.py
@@ -35,7 +35,6 @@ def get_next_available_prefix(
             return cidr
 
         if cidr.prefixlen <= prefix_length:
-            next_available = ipaddress.ip_network(f"{cidr.network}/{prefix_length}")
-            return next_available
+            return ipaddress.ip_network(f"{cidr.network}/{prefix_length}")
 
     raise ValueError("No available subnets in pool")

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -164,8 +164,7 @@ async def logging_middleware(request: Request, call_next: Callable[[Request], Aw
     if trace_id:
         set_log_data(key="trace_id", value=trace_id)
 
-    response = await call_next(request)
-    return response
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -249,7 +249,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
     @staticmethod
     def format_message(message: InfrahubMessage) -> aio_pika.Message:
-        pika_message = aio_pika.Message(
+        return aio_pika.Message(
             body=message.body,
             content_type="application/json",
             content_encoding="utf-8",
@@ -259,4 +259,3 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             headers=message.meta.headers,
             expiration=message.meta.expiration,
         )
-        return pika_message

--- a/backend/infrahub/telemetry/task_manager.py
+++ b/backend/infrahub/telemetry/task_manager.py
@@ -69,10 +69,8 @@ async def gather_prefect_automations(client: PrefectClient) -> dict[str, Any]:
 @task(name="telemetry-gather-prefect-information", task_run_name="Gather Prefect Information", cache_policy=NONE)
 async def gather_prefect_information() -> TelemetryPrefectData:
     async with get_client(sync_client=False) as client:
-        data = TelemetryPrefectData(
+        return TelemetryPrefectData(
             work_pools=await gather_prefect_work_pools(client=client),
             events=await gather_prefect_events(client=client),
             automations=await gather_prefect_automations(client=client),
         )
-
-        return data

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -26,7 +26,7 @@ async def transform_python(message: TransformPythonData) -> Any:
         commit=message.commit,
     )
 
-    transformed_data = await repo.execute_python_transform.with_options(timeout_seconds=message.timeout)(
+    return await repo.execute_python_transform.with_options(timeout_seconds=message.timeout)(
         client=client,
         branch_name=message.branch,
         commit=message.commit,
@@ -34,8 +34,6 @@ async def transform_python(message: TransformPythonData) -> Any:
         data=message.data,
         convert_query_response=message.convert_query_response,
     )  # type: ignore[call-overload]
-
-    return transformed_data
 
 
 @flow(name="transform_render_jinja2_template", flow_run_name="Render transform Jinja2", persist_result=True)
@@ -52,8 +50,6 @@ async def transform_render_jinja2_template(message: TransformJinjaTemplateData) 
         commit=message.commit,
     )
 
-    rendered_template = await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
+    return await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
         commit=message.commit, location=message.template_location, data={"data": message.data}
     )  # type: ignore[call-overload]
-
-    return rendered_template

--- a/backend/infrahub/webhook/gather.py
+++ b/backend/infrahub/webhook/gather.py
@@ -13,5 +13,4 @@ from .models import WebhookTriggerDefinition
 @task(name="gather-trigger-webhook", task_run_name="Gather webhook triggers", cache_policy=NONE)
 async def gather_trigger_webhook(db: InfrahubDatabase) -> list[WebhookTriggerDefinition]:
     webhooks = await NodeManager.query(db=db, schema=CoreWebhook)
-    triggers = [WebhookTriggerDefinition.from_object(webhook) for webhook in webhooks if webhook.active.value]
-    return triggers
+    return [WebhookTriggerDefinition.from_object(webhook) for webhook in webhooks if webhook.active.value]

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -69,7 +69,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
         if obj.node_kind.value and event_type in get_all_infrahub_node_kind_events():
             event_trigger.match = {"infrahub.node.kind": obj.node_kind.value}
 
-        definition = cls(
+        return cls(
             id=obj.id,
             name=obj.name.value,
             trigger=event_trigger,
@@ -92,8 +92,6 @@ class WebhookTriggerDefinition(TriggerDefinition):
                 ),
             ],
         )
-
-        return definition
 
 
 class EventContext(BaseModel):

--- a/backend/tests/benchmark/test_nodemanager_peers.py
+++ b/backend/tests/benchmark/test_nodemanager_peers.py
@@ -29,11 +29,9 @@ async def relm(
     model = registry.schema.get(name="CoreAccount")
     rel_schema = model.get_relationship("member_of_groups")
 
-    relm = await RelationshipManager.init(
+    return await RelationshipManager.init(
         db=db, schema=rel_schema, branch=default_branch, at=Timestamp(), node=test_account
     )
-
-    return relm
 
 
 def test_nodemanager_querypeers(

--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -222,7 +222,7 @@ async def car_person_data_generic_diff(
     # Time After the changes
     time30 = Timestamp()
 
-    params = {
+    return {
         "branch": branch2,
         "time0": time0,
         "time10": time10,
@@ -241,8 +241,6 @@ async def car_person_data_generic_diff(
         "p3": p3.id,
         "r1": repo01.id,
     }
-
-    return params
 
 
 @pytest.fixture
@@ -428,7 +426,7 @@ async def data_diff_attribute(
     # Time After the changes
     time30 = Timestamp()
 
-    params = {
+    return {
         "branch": branch2,
         "time0": time0,
         "time12": time12,
@@ -444,5 +442,3 @@ async def data_diff_attribute(
         "p2": persons["Jane"].id,
         "r1": repo01.id,
     }
-
-    return params

--- a/backend/tests/component/api/test_15_diff.py
+++ b/backend/tests/component/api/test_15_diff.py
@@ -107,7 +107,7 @@ async def test_get_display_labels_with_branch(
 async def r1_update_01(data_diff_attribute: dict[str, Any]) -> dict[str, Any]:
     r1 = data_diff_attribute["r1"]
 
-    expected_response = {
+    return {
         "kind": InfrahubKind.REPOSITORY,
         "id": r1,
         "path": f"data/{r1}",
@@ -142,7 +142,6 @@ async def r1_update_01(data_diff_attribute: dict[str, Any]) -> dict[str, Any]:
         "action": {"branch2": "updated"},
         "display_label": {"branch2": "repo01"},
     }
-    return expected_response
 
 
 async def test_diff_artifact(

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -1386,15 +1386,13 @@ async def car_person_generics_data(db: InfrahubDatabase, car_person_schema_gener
     await c3.new(db=db, name="nolt", nbr_seats=4, mpg=25, owner=p2)
     await c3.save(db=db)
 
-    nodes = {
+    return {
         "p1": p1,
         "p2": p2,
         "c1": c1,
         "c2": c2,
         "c3": c3,
     }
-
-    return nodes
 
 
 @pytest.fixture
@@ -2593,8 +2591,7 @@ async def create_test_admin(db: InfrahubDatabase, register_core_models_schema: S
 
 @pytest.fixture
 async def session_admin(db: InfrahubDatabase, create_test_admin: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=create_test_admin.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=create_test_admin.id)
 
 
 @pytest.fixture
@@ -2621,8 +2618,7 @@ async def first_account(
 
 @pytest.fixture
 async def session_first_account(db: InfrahubDatabase, first_account: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=first_account.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=first_account.id)
 
 
 @pytest.fixture
@@ -2637,8 +2633,7 @@ async def second_account(
 
 @pytest.fixture
 async def session_second_account(db: InfrahubDatabase, second_account: Node) -> AccountSession:
-    session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=second_account.id)
-    return session
+    return AccountSession(authenticated=True, auth_type=AuthType.API, account_id=second_account.id)
 
 
 @pytest.fixture
@@ -2782,7 +2777,7 @@ async def ip_dataset_01(
     await net242.new(db=db, prefix="10.10.4.0/27", parent=net240, ip_namespace=ns2)
     await net242.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "ns2": ns2,
         "net161": net161,
@@ -2799,7 +2794,6 @@ async def ip_dataset_01(
         "net241": net241,
         "net242": net242,
     }
-    return data
 
 
 @pytest.fixture
@@ -2862,7 +2856,7 @@ async def ip_dataset_prefix_v4(
     await ip2_net147.new(db=db, address="10.200.0.2/30", ip_prefix=net147, ip_namespace=ns1)
     await ip2_net147.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "net140": net140,
         "net141": net141,
@@ -2873,7 +2867,6 @@ async def ip_dataset_prefix_v4(
         "net146": net146,
         "net147": net147,
     }
-    return data
 
 
 @pytest.fixture

--- a/backend/tests/component/core/constraint_validators/conftest.py
+++ b/backend/tests/component/core/constraint_validators/conftest.py
@@ -109,15 +109,13 @@ async def car_person_generics_data_simple(
     await c3.new(db=db, name="nolt", nbr_seats=4, mpg=25, owner=p2)
     await c3.save(db=db)
 
-    nodes = {
+    return {
         "p1": p1,
         "p2": p2,
         "c1": c1,
         "c2": c2,
         "c3": c3,
     }
-
-    return nodes
 
 
 @pytest.fixture

--- a/backend/tests/component/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/component/core/diff/test_calculate_artifact_diff.py
@@ -2,13 +2,17 @@ from uuid import uuid4
 
 import pytest
 
+from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.constants import DiffAction, InfrahubKind, SchemaPathType
 from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
 from infrahub.core.diff.model.diff import ArtifactTarget, BranchDiffArtifact, BranchDiffArtifactStorage
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.database import InfrahubDatabase
 
 
@@ -289,3 +293,186 @@ async def test_calculate_artifact_diff(
     assert diffs_by_id[art2_branch.id] == expected_artifact_diff_2
     assert diffs_by_id[art3_branch.id] == expected_artifact_diff_3
     assert diffs_by_id[art6_branch.id] == expected_artifact_diff_6
+
+
+@pytest.fixture
+async def artifact_diff_kind_migration_data(
+    db: InfrahubDatabase, default_branch: Branch, car_person_data_generic: dict[str, Node]
+) -> dict[str, Node | Branch]:
+    """One artifact on main for a TestElectricCar node; a branch where only a kind migration ran."""
+    g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g1.new(db=db, name="group_migration", members=[car_person_data_generic["c1"]])
+    await g1.save(db=db)
+
+    t1 = await Node.init(db=db, schema="CoreTransformPython")
+    await t1.new(
+        db=db,
+        name="transform_migration",
+        query=car_person_data_generic["q1"].id,
+        repository=car_person_data_generic["r1"].id,
+        file_path="transform_migration.py",
+        class_name="TransformMigration",
+    )
+    await t1.save(db=db)
+
+    ad1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await ad1.new(
+        db=db,
+        name="artifactdef_migration",
+        targets=g1,
+        transformation=t1,
+        content_type="application/json",
+        artifact_name="migration_artifact",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await ad1.save(db=db)
+
+    art_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await art_main.new(
+        db=db,
+        name="art_migration_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="aaaaaaaa-0000-4173-aa4b-f50e1309f03c",
+        checksum="aabbccdd11223344556677889900aabb",
+        content_type="application/json",
+    )
+    await art_main.save(db=db)
+
+    branch = await create_branch(branch_name="branch-kind-migration", db=db)
+
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    new_ecar_schema = schema_branch.get(name="TestElectricCar")
+    new_ecar_schema.name = "ElectricCarV2"
+    registry.schema.set(name="TestElectricCarV2", schema=new_ecar_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="TestElectricCar"),
+        new_node_schema=new_ecar_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestElectricCarV2", field_name="name"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
+    assert not execution_result.errors
+
+    return {
+        "branch": branch,
+        "art_main": art_main,
+        "c1": car_person_data_generic["c1"],
+    }
+
+
+async def test_calculate_artifact_diff_migrated_kind(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    artifact_diff_kind_migration_data: dict[str, Node | Branch],
+) -> None:
+    branch = artifact_diff_kind_migration_data["branch"]
+    art_main = artifact_diff_kind_migration_data["art_main"]
+
+    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+    assert artifact_diffs == []
+
+    art_branch = await NodeManager.get_one(db=db, branch=branch, id=art_main.id)
+    art_branch.checksum.value = "new_checksum_after_genuine_content_change"
+    art_branch.storage_id.value = "bbbbbbbb-1111-4173-aa4b-f50e1309f03c"
+    await art_branch.save(db=db)
+
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+    assert len(artifact_diffs) == 1
+    assert artifact_diffs[0].action == DiffAction.UPDATED
+    assert artifact_diffs[0].item_new is not None
+    assert artifact_diffs[0].item_new.checksum == "new_checksum_after_genuine_content_change"
+    assert artifact_diffs[0].item_previous is not None
+    assert artifact_diffs[0].item_previous.checksum == "aabbccdd11223344556677889900aabb"
+
+
+async def test_calculate_artifact_diff_main_side_migration(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_data_generic: dict[str, Node],
+) -> None:
+    g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g1.new(db=db, name="group_main_migration", members=[car_person_data_generic["c1"]])
+    await g1.save(db=db)
+
+    t1 = await Node.init(db=db, schema="CoreTransformPython")
+    await t1.new(
+        db=db,
+        name="transform_main_migration",
+        query=car_person_data_generic["q1"].id,
+        repository=car_person_data_generic["r1"].id,
+        file_path="transform_main_migration.py",
+        class_name="TransformMainMigration",
+    )
+    await t1.save(db=db)
+
+    ad1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await ad1.new(
+        db=db,
+        name="artifactdef_main_migration",
+        targets=g1,
+        transformation=t1,
+        content_type="application/json",
+        artifact_name="main_migration_artifact",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await ad1.save(db=db)
+
+    art_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await art_main.new(
+        db=db,
+        name="art_main_migration_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="cccccccc-2222-4173-aa4b-f50e1309f03c",
+        checksum="ccddee001122334455667788aabbccdd",
+        content_type="application/json",
+    )
+    await art_main.save(db=db)
+
+    branch = await create_branch(branch_name="branch-pre-main-migration", db=db)
+
+    art_branch = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=branch)
+    await art_branch.new(
+        db=db,
+        name="art_main_migration_branch",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["c1"],
+        storage_id="cccccccc-2222-4173-aa4b-f50e1309f03c",
+        checksum="ccddee001122334455667788aabbccdd",
+        content_type="application/json",
+    )
+    await art_branch.save(db=db)
+
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    new_ecar_schema = schema_branch.get(name="TestElectricCar")
+    new_ecar_schema.name = "ElectricCarMainV2"
+    registry.schema.set(name="TestElectricCarMainV2", schema=new_ecar_schema, branch=default_branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="TestElectricCar"),
+        new_node_schema=new_ecar_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestElectricCarMainV2", field_name="name"
+        ),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+    assert not execution_result.errors
+
+    artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+    assert artifact_diffs == []
+
+    art_branch.checksum.value = "new_checksum_main_side_genuine_change"
+    art_branch.storage_id.value = "dddddddd-3333-4173-aa4b-f50e1309f03c"
+    await art_branch.save(db=db)
+
+    artifact_diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+    assert len(artifact_diffs) == 1
+    assert artifact_diffs[0].action == DiffAction.UPDATED
+    assert artifact_diffs[0].item_new is not None
+    assert artifact_diffs[0].item_new.checksum == "new_checksum_main_side_genuine_change"
+    assert artifact_diffs[0].item_previous is not None
+    assert artifact_diffs[0].item_previous.checksum == "ccddee001122334455667788aabbccdd"

--- a/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
+++ b/backend/tests/component/core/diff/test_target_branch_migration_after_fork.py
@@ -1,0 +1,192 @@
+"""Delete-merge propagation across a post-fork target-branch kind migration.
+
+When the same UUID was kind-migrated on the target branch *after* the user
+branch was forked, merging a delete from the user branch must propagate the
+delete (and its metadata) to the post-migration Node vertex on the target
+branch.
+"""
+
+from unittest.mock import AsyncMock
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+async def _get_diff_coordinator(db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    diff_coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+    return diff_coordinator
+
+
+async def _get_diff_merger(db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+    component_registry = get_component_registry()
+    return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+
+async def _migrate_testcar_to_test2newcar_on_default(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+) -> Timestamp:
+    main_schema = registry.schema.get_schema_branch(name=default_branch.name)
+    original_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema = main_schema.get(name="TestCar", duplicate=True)
+    new_car_schema.name = "NewCar"
+    new_car_schema.namespace = "Test2"
+    assert new_car_schema.kind == "Test2NewCar"
+    main_schema.set(name="Test2NewCar", schema=new_car_schema)
+    person_schema = main_schema.get(name="TestPerson", duplicate=True)
+    person_schema.get_relationship("cars").peer = "Test2NewCar"
+    person_schema.get_relationship("cars_driven").peer = "Test2NewCar"
+    main_schema.set(name="TestPerson", schema=person_schema)
+    main_schema.delete(name="TestCar")
+    main_schema.process()
+    await registry.schema.update_schema_branch(
+        db=db,
+        branch=default_branch,
+        schema=main_schema,
+        limit=["TestCar", "Test2NewCar", "TestPerson"],
+        update_db=True,
+    )
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+    migration_at = Timestamp()
+    result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_at, user_id="migration-user"),
+        branch=default_branch,
+    )
+    assert not result.errors
+    return migration_at
+
+
+async def test_target_branch_migration_after_fork_delete_propagates_to_post_migration_vertex(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    car_person_schema: SchemaBranch,
+    person_jane_main: Node,
+    car_camry_main: Node,
+) -> None:
+    """Post-migration ``Test2NewCar`` vertex must be fully deleted by the merge.
+
+    Its active ``IS_PART_OF`` and child edges must be closed at ``merge_at``,
+    and its node-level ``updated_at`` / ``updated_by`` refreshed to reflect
+    the delete.
+    """
+    branch_user = "branch-deleted-node-user"
+
+    # Fork the diff branch while the schema is still TestCar, then migrate
+    # TestCar -> Test2NewCar on default, then delete on the branch.
+    branch = await create_branch(db=db, branch_name="tgt-migration-after-fork")
+    migration_at = await _migrate_testcar_to_test2newcar_on_default(db=db, default_branch=default_branch)
+
+    branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
+    assert branch_car is not None
+    await branch_car.delete(db=db, user_id=branch_user)
+
+    coordinator = await _get_diff_coordinator(db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    merger = await _get_diff_merger(db=db, branch=branch)
+    merge_at = Timestamp()
+    await merger.merge_graph(at=merge_at)
+
+    # Dump every IS_PART_OF on the default branch for the deleted UUID so the
+    # failure is self-describing.
+    ipo_rows = await db.execute_query(
+        query="""
+        MATCH (n:Node {uuid: $uuid})-[ipo:IS_PART_OF {branch: $target_branch}]->(:Root)
+        RETURN labels(n) AS labels,
+               n.updated_at AS node_updated_at,
+               n.updated_by AS node_updated_by,
+               ipo.status AS status,
+               ipo.from AS ipo_from,
+               ipo.to AS ipo_to,
+               ipo.to_user_id AS ipo_to_user_id
+        ORDER BY ipo_from, status
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    diag = (
+        f"\nmigration_at = {migration_at.to_string()}"
+        f"\nmerge_at     = {merge_at.to_string()}"
+        f"\nIS_PART_OF rows on {default_branch.name!r} for {car_camry_main.id}:\n"
+        + "\n".join("  " + repr(r) for r in ipo_rows)
+    )
+
+    new_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" in r["labels"]]
+    old_vertex_ipos = [r for r in ipo_rows if "Test2NewCar" not in r["labels"] and "TestCar" in r["labels"]]
+    assert old_vertex_ipos, f"expected a pre-migration TestCar IS_PART_OF{diag}"
+    assert new_vertex_ipos, f"expected a post-migration Test2NewCar IS_PART_OF{diag}"
+
+    # The active IS_PART_OF on the post-migration vertex must be closed at
+    # merge_at, attributed to the branch user.
+    new_active_ipo = [r for r in new_vertex_ipos if r["status"] == "active"]
+    assert len(new_active_ipo) == 1, f"expected exactly one active IS_PART_OF on the post-migration vertex{diag}"
+    assert new_active_ipo[0]["ipo_to"] == merge_at.to_string(), (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the merge "
+        f"(expected ipo.to == merge_at, got {new_active_ipo[0]['ipo_to']!r}){diag}"
+    )
+    assert new_active_ipo[0]["ipo_to_user_id"] == branch_user, (
+        "post-migration Test2NewCar IS_PART_OF was not closed by the branch user "
+        f"(expected ipo.to_user_id == {branch_user!r}, got {new_active_ipo[0]['ipo_to_user_id']!r}){diag}"
+    )
+
+    # Child edges (HAS_ATTRIBUTE/IS_RELATED) on the post-migration vertex must
+    # also be closed.
+    open_child_edges = await db.execute_query(
+        query="""
+        MATCH (n:Test2NewCar {uuid: $uuid})-[e:HAS_ATTRIBUTE|IS_RELATED]-(field:Attribute|Relationship)
+        WHERE e.branch = $target_branch
+        AND e.status = "active"
+        AND e.to IS NULL
+        RETURN type(e) AS edge_type, labels(field) AS field_labels, e.from AS e_from
+        """,
+        params={"uuid": car_camry_main.id, "target_branch": default_branch.name},
+    )
+    assert not open_child_edges, (
+        "post-migration Test2NewCar vertex still has active target-branch HAS_ATTRIBUTE/IS_RELATED "
+        f"edges after a delete-merge: {open_child_edges!r}{diag}"
+    )
+
+    # Node-level metadata on the post-migration vertex must reflect the merge,
+    # not the prior migration.
+    new_node_updated_at = new_active_ipo[0]["node_updated_at"]
+    new_node_updated_by = new_active_ipo[0]["node_updated_by"]
+    assert new_node_updated_at == merge_at.to_string(), (
+        "post-migration Test2NewCar n.updated_at not refreshed by the merge "
+        f"(expected {merge_at.to_string()}, got {new_node_updated_at!r}){diag}"
+    )
+    assert new_node_updated_by == branch_user, (
+        "post-migration Test2NewCar n.updated_by not refreshed by the merge "
+        f"(expected {branch_user!r}, got {new_node_updated_by!r}){diag}"
+    )
+
+    # Conversely, the pre-migration ``TestCar`` vertex must NOT have its
+    # node-level metadata clobbered by the merge
+    old_node_updated_at = old_vertex_ipos[0]["node_updated_at"]
+    old_node_updated_by = old_vertex_ipos[0]["node_updated_by"]
+    assert old_node_updated_at != merge_at.to_string(), (
+        "pre-migration TestCar n.updated_at was clobbered to merge_at by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )
+    assert old_node_updated_by != branch_user, (
+        "pre-migration TestCar n.updated_by was clobbered to the branch user by the merge "
+        f"(merge did not add or close any edges on this vertex){diag}"
+    )

--- a/backend/tests/component/core/ipam/conftest.py
+++ b/backend/tests/component/core/ipam/conftest.py
@@ -155,7 +155,7 @@ async def ip_dataset_01_load(
     await net242.new(db=db, prefix="10.10.4.0/27", parent=net240, ip_namespace=ns2)
     await net242.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         "ns2": ns2,
         "net161": net161,
@@ -172,7 +172,6 @@ async def ip_dataset_01_load(
         "net241": net241,
         "net242": net242,
     }
-    return data
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -59,8 +59,7 @@ async def schema_aware() -> NodeSchema:
         ],
     }
 
-    node = NodeSchema(**SCHEMA)
-    return node
+    return NodeSchema(**SCHEMA)
 
 
 @pytest.fixture

--- a/backend/tests/component/core/schema_manager/conftest.py
+++ b/backend/tests/component/core/schema_manager/conftest.py
@@ -16,7 +16,7 @@ def _get_schema_by_kind(full_schema: dict[str, Any], kind: str) -> dict[str, Any
 
 @pytest.fixture
 async def animal_person_schema_dict() -> dict:
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "Animal",
@@ -88,12 +88,10 @@ async def animal_person_schema_dict() -> dict:
         ],
     }
 
-    return FULL_SCHEMA
-
 
 @pytest.fixture
 def schema_all_in_one() -> dict[str, Any]:
-    FULL_SCHEMA = {
+    return {
         "nodes": [
             {
                 "name": "Criticality",
@@ -238,12 +236,10 @@ def schema_all_in_one() -> dict[str, Any]:
         ],
     }
 
-    return FULL_SCHEMA
-
 
 @pytest.fixture
 def schema_criticality_tag() -> dict[str, Any]:
-    FULL_SCHEMA = {
+    return {
         "nodes": [
             {
                 "name": "Criticality",
@@ -286,12 +282,11 @@ def schema_criticality_tag() -> dict[str, Any]:
             },
         ]
     }
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_parent_component() -> dict:
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "ComponentGenericOne",
@@ -351,13 +346,12 @@ def schema_parent_component() -> dict:
             },
         ],
     }
-    return FULL_SCHEMA
 
 
 @pytest.fixture
 def schema_diff_attr_inheritance_types() -> dict[str, Any]:
     """Two generics with the same attribute but different types and a single node implementation."""
-    FULL_SCHEMA = {
+    return {
         "generics": [
             {
                 "name": "Adapter",
@@ -387,4 +381,3 @@ def schema_diff_attr_inheritance_types() -> dict[str, Any]:
             }
         ],
     }
-    return FULL_SCHEMA

--- a/backend/tests/component/core/test_branch_diff.py
+++ b/backend/tests/component/core/test_branch_diff.py
@@ -108,12 +108,11 @@ async def test_diff_get_files_repository(
     db: InfrahubDatabase, repos_in_main: dict[str, Node], base_dataset_02: dict
 ) -> None:
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
-        model = GitDiffNamesOnlyResponse(
+        return GitDiffNamesOnlyResponse(
             files_changed=["readme.md", "mydir/myfile.py"],
             files_removed=["notthere.md"],
             files_added=["newandshiny.md"],
         )
-        return model
 
     service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (
@@ -152,12 +151,11 @@ async def test_diff_get_files_repositories_for_branch_case01(
     """
 
     def execute_workflow_side_effect(workflow: WorkflowDefinition, parameters: dict[str, Any] | None):
-        model = GitDiffNamesOnlyResponse(
+        return GitDiffNamesOnlyResponse(
             files_changed=["readme.md", "mydir/myfile.py"],
             files_removed=[],
             files_added=[],
         )
-        return model
 
     service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -125,14 +125,12 @@ async def git_repo_01(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_01 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
-    return repo
 
 
 @pytest.fixture
@@ -140,7 +138,7 @@ async def git_repo_01_read_only(
     client: InfrahubClient, git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubReadOnlyRepository:
     """Git Repository with git_upstream_repo_01 as remote."""
-    repo = await InfrahubReadOnlyRepository.new(
+    return await InfrahubReadOnlyRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
@@ -148,8 +146,6 @@ async def git_repo_01_read_only(
         infrahub_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
-    return repo
 
 
 @pytest.fixture
@@ -162,14 +158,12 @@ async def git_repo_01_w_client(git_repo_01: InfrahubRepository, client: Infrahub
 @pytest.fixture
 async def git_repo_02(git_upstream_repo_02: dict[str, str | Path], git_repos_dir: Path) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_02 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
-    return repo
 
 
 @pytest.fixture
@@ -177,14 +171,12 @@ async def git_repo_03(
     client: InfrahubClient, git_upstream_repo_03: dict[str, str | Path], git_repos_dir: Path
 ) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_03 as remote."""
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_03["name"],
         location=str(git_upstream_repo_03["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-
-    return repo
 
 
 @pytest.fixture
@@ -410,13 +402,12 @@ async def git_repo_checks(
 
     upstream.index.commit("Add 2 checks files")
 
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-    return repo
 
 
 @pytest.fixture
@@ -441,13 +432,12 @@ async def git_repo_transforms(
 
     upstream.index.commit("Add 2 Transforms files")
 
-    repo = await InfrahubRepository.new(
+    return await InfrahubRepository.new(
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
-    return repo
 
 
 @pytest.fixture
@@ -573,7 +563,7 @@ async def mock_gql_query_my_query(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def gql_query_data_01() -> dict:
-    data = {
+    return {
         "node": {
             "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
             "display_label": "MyQuery",
@@ -587,12 +577,11 @@ async def gql_query_data_01() -> dict:
             },
         }
     }
-    return data
 
 
 @pytest.fixture
 async def gql_query_data_02() -> dict:
-    data = {
+    return {
         "node": {
             "id": "mmmmmmmm-nnnn-bbbb-vvvv-cccccccccccc",
             "display_label": "MyOtherQuery",
@@ -606,7 +595,6 @@ async def gql_query_data_02() -> dict:
             },
         }
     }
-    return data
 
 
 @pytest.fixture
@@ -647,7 +635,7 @@ async def mock_check_create(helper: TestHelper, httpx_mock: HTTPXMock) -> HTTPXM
 
 @pytest.fixture
 async def check_definition_data_01() -> dict:
-    data = {
+    return {
         "node": {
             "id": "d32f30f8-1d1e-4dfb-96d9-91234a9ffbe1",
             "display_label": "Check01",
@@ -734,8 +722,6 @@ async def check_definition_data_01() -> dict:
         },
     }
 
-    return data
-
 
 @pytest.fixture
 async def gql_query_data_03() -> dict[str, Any]:
@@ -763,7 +749,7 @@ async def gql_query_data_03() -> dict[str, Any]:
     }
     """
 
-    data = {
+    return {
         "id": "42665742-002b-4f98-b2e0-1ae716c1efbe",
         "type": InfrahubKind.GRAPHQLQUERY,
         "name": {
@@ -792,7 +778,6 @@ async def gql_query_data_03() -> dict[str, Any]:
         "__typename": InfrahubKind.GRAPHQLQUERY,
         "display_label": "query01",
     }
-    return data
 
 
 @pytest.fixture
@@ -806,8 +791,7 @@ async def schema_02(client: InfrahubClient, helper: TestHelper, car_data_01: dic
 async def gql_query_node_03(client: InfrahubClient, gql_query_data_03: dict[str, Any]) -> InfrahubNode:
     backend_schema = [model for model in SchemaRoot(**core_models).nodes if model.kind == InfrahubKind.GRAPHQLQUERY][0]
     schema = NodeSchemaAPI(**backend_schema.model_dump())
-    node = InfrahubNode(client=client, schema=schema, data=gql_query_data_03)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=gql_query_data_03)
 
 
 @pytest.fixture
@@ -839,7 +823,7 @@ async def mock_upload_content(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def artifact_definition_data_01() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
         "name": {
@@ -869,7 +853,6 @@ async def artifact_definition_data_01() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACTDEFINITION,
         "display_label": "artifactdef01",
     }
-    return data
 
 
 @pytest.fixture
@@ -877,13 +860,12 @@ async def artifact_definition_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_definition_data_01: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACTDEFINITION][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_definition_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_definition_data_01)
 
 
 @pytest.fixture
 async def artifact_definition_data_02() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACTDEFINITION,
         "name": {
@@ -913,7 +895,6 @@ async def artifact_definition_data_02() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACTDEFINITION,
         "display_label": "artifactdef02",
     }
-    return data
 
 
 @pytest.fixture
@@ -921,13 +902,12 @@ async def artifact_definition_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_definition_data_02: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACTDEFINITION][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_definition_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_definition_data_02)
 
 
 @pytest.fixture
 async def artifact_data_01() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": "CoreArtifact",
         "name": {
@@ -948,7 +928,6 @@ async def artifact_data_01() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACT,
         "display_label": "artifact01",
     }
-    return data
 
 
 @pytest.fixture
@@ -956,13 +935,12 @@ async def artifact_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_data_01: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACT][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_data_01)
 
 
 @pytest.fixture
 async def artifact_data_02() -> dict[str, Any]:
-    data = {
+    return {
         "id": "c4908d78-7b24-45e2-9252-96d0fb3e2c78",
         "type": InfrahubKind.ARTIFACT,
         "name": {
@@ -985,7 +963,6 @@ async def artifact_data_02() -> dict[str, Any]:
         "__typename": InfrahubKind.ARTIFACT,
         "display_label": "artifact01",
     }
-    return data
 
 
 @pytest.fixture
@@ -993,13 +970,12 @@ async def artifact_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, artifact_data_02: dict[str, Any]
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.ARTIFACT][0]
-    node = InfrahubNode(client=client, schema=schema, data=artifact_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=artifact_data_02)
 
 
 @pytest.fixture
 async def transformation_data_01() -> dict:
-    data = {
+    return {
         "id": "a0d4c22a-5f60-4bf9-a53f-f9a335420492",
         "type": "CoreTransformPython",
         "file_path": {
@@ -1068,7 +1044,6 @@ async def transformation_data_01() -> dict:
         "__typename": "CoreTransformPython",
         "display_label": "transform01",
     }
-    return data
 
 
 @pytest.fixture
@@ -1076,13 +1051,12 @@ async def transformation_node_01(
     client: InfrahubClient, schema_02: ClientSchemaRoot, transformation_data_01: dict
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == "CoreTransformPython"][0]
-    node = InfrahubNode(client=client, schema=schema, data=transformation_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=transformation_data_01)
 
 
 @pytest.fixture
 async def transformation_data_02() -> dict:
-    data = {
+    return {
         "id": "70a58c98-6185-4004-b4bf-713baccfdc87",
         "display_label": "device_startup",
         "template_path": {"value": "template01.tpl.j2", "__typename": "TextAttribute"},
@@ -1108,7 +1082,6 @@ async def transformation_data_02() -> dict:
         },
         "__typename": InfrahubKind.TRANSFORMJINJA2,
     }
-    return data
 
 
 @pytest.fixture
@@ -1116,13 +1089,12 @@ async def transformation_node_02(
     client: InfrahubClient, schema_02: ClientSchemaRoot, transformation_data_02: dict
 ) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.kind == InfrahubKind.TRANSFORMJINJA2][0]
-    node = InfrahubNode(client=client, schema=schema, data=transformation_data_02)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=transformation_data_02)
 
 
 @pytest.fixture
 async def car_data_01() -> dict:
-    data = {
+    return {
         "id": "b663d7a4-5f95-48dd-b04d-e03169e7fcf3",
         "type": "TestElectricCar",
         "nbr_engine": {
@@ -1160,14 +1132,12 @@ async def car_data_01() -> dict:
         "__typename": "TestElectricCar",
         "display_label": "TestElectricCar(ID: b663d7a4-5f95-48dd-b04d-e03169e7fcf3)",
     }
-    return data
 
 
 @pytest.fixture
 async def car_node_01(client: InfrahubClient, schema_02: ClientSchemaRoot, car_data_01: dict) -> InfrahubNode:
     schema = [model for model in schema_02.nodes if model.name == "ElectricCar"][0]
-    node = InfrahubNode(client=client, schema=schema, data=car_data_01)
-    return node
+    return InfrahubNode(client=client, schema=schema, data=car_data_01)
 
 
 @pytest.fixture

--- a/backend/tests/component/git/test_repository_config.py
+++ b/backend/tests/component/git/test_repository_config.py
@@ -45,13 +45,12 @@ class TestGetRepositoryConfig:
             cloned_repo.index.remove([".infrahub.yml"])
             cloned_repo.index.commit("Remove .infrahub.yml config file for testing")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_invalid_yaml(
@@ -85,13 +84,12 @@ schemas:
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add invalid YAML config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_invalid_format(
@@ -123,13 +121,12 @@ schemas: "should be a list, not a string"
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add invalid format config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     @pytest.fixture
     async def repo_with_valid_config(
@@ -161,13 +158,12 @@ schemas: []
         cloned_repo.index.add([".infrahub.yml"])
         cloned_repo.index.commit("Add valid .infrahub.yml config file")
 
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(clone_path),
             client=InfrahubClient(config=Config(requester=dummy_async_request)),
         )
-        return repo
 
     async def test_missing_config_file_raises_error(
         self, repo_without_config: InfrahubRepository, prefect_test_fixture: None

--- a/backend/tests/component/graphql/conftest.py
+++ b/backend/tests/component/graphql/conftest.py
@@ -56,7 +56,7 @@ def permissions_helper() -> PermissionsHelper:
 @pytest.fixture
 def query_01() -> str:
     """Simple query with one document."""
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -78,12 +78,11 @@ def query_01() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_02() -> str:
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -124,13 +123,12 @@ def query_02() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_03() -> str:
     """Advanced Query with 2 documents."""
-    query = """
+    return """
     query FirstQuery {
         TestPerson {
             edges {
@@ -164,13 +162,12 @@ def query_03() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_04() -> str:
     """Simple query with variables."""
-    query = """
+    return """
     query ($person: String!){
         TestPerson(name__value: $person) {
             edges {
@@ -183,12 +180,11 @@ def query_04() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def query_05() -> str:
-    query = """
+    return """
     query MyQuery {
         CoreRepository {
             edges {
@@ -217,13 +213,11 @@ def query_05() -> str:
     }
     """
 
-    return query
-
 
 @pytest.fixture
 def query_06() -> str:
     """Simple query with variables."""
-    query = """
+    return """
     query (
         $str1: String,
         $str2: String = "default2",
@@ -246,12 +240,11 @@ def query_06() -> str:
         }
     }
     """
-    return query
 
 
 @pytest.fixture
 def bad_query_01() -> str:
-    query = """
+    return """
     query {
         TestPerson {
             edges {
@@ -271,12 +264,11 @@ def bad_query_01() -> str:
                 }
             }
     """
-    return query
 
 
 @pytest.fixture
 def query_introspection() -> str:
-    query = """
+    return """
         query IntrospectionQuery {
             __schema {
                 queryType {
@@ -377,7 +369,6 @@ def query_introspection() -> str:
             }
         }
     """
-    return query
 
 
 @pytest.fixture

--- a/backend/tests/component/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/component/graphql/diff/test_diff_tree_query.py
@@ -238,8 +238,7 @@ async def diff_branch(db: InfrahubDatabase, default_branch: Branch) -> Branch:
 @pytest.fixture
 async def diff_repository(db: InfrahubDatabase, diff_branch: Branch) -> DiffRepository:
     component_registry = get_component_registry()
-    repository = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
-    return repository
+    return await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
 
 
 @pytest.fixture

--- a/backend/tests/component/graphql/queries/test_ipam.py
+++ b/backend/tests/component/graphql/queries/test_ipam.py
@@ -56,7 +56,7 @@ async def ip_dataset_01(
     await net145.new(db=db, prefix="10.10.3.0/27", parent=net140, ip_namespace=ns1)
     await net145.save(db=db)
 
-    data = {
+    return {
         "ns1": ns1,
         # "ns2": ns2,
         # "net161": net161,
@@ -73,7 +73,6 @@ async def ip_dataset_01(
         # "net241": net241,
         # "net242": net242,
     }
-    return data
 
 
 @pytest.fixture
@@ -102,11 +101,10 @@ async def ip_dataset_02(
     await net1_ip1.new(db=db, address="10.200.30.1/27", ip_namespace=ns, ip_prefix=net1)
     await net1_ip1.save(db=db)
 
-    data = {
+    return {
         "ns": ns,
         "net1": net1,
     }
-    return data
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/component/graphql/test_query.py
+++ b/backend/tests/component/graphql/test_query.py
@@ -51,15 +51,13 @@ async def execute_query(
         at=at,
     )
 
-    result = await graphql(
+    return await graphql(
         schema=gql_params.schema,
         source=graphql_query.query.value,
         context_value=gql_params.context,
         root_value=None,
         variable_values=params or {},
     )
-
-    return result
 
 
 async def test_execute_query(

--- a/backend/tests/component/message_bus/operations/event/test_branch.py
+++ b/backend/tests/component/message_bus/operations/event/test_branch.py
@@ -30,8 +30,7 @@ async def init_service() -> InfrahubServices:
     recorder = BusRecorder()
     database = MagicMock()
     workflow = WorkflowLocalExecution()
-    service = await InfrahubServices.new(message_bus=recorder, database=database, workflow=workflow)
-    return service
+    return await InfrahubServices.new(message_bus=recorder, database=database, workflow=workflow)
 
 
 @pytest.fixture

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -42,13 +42,11 @@ async def mock_schema_query_02(helper: TestHelper, httpx_mock: HTTPXMock) -> HTT
 
 @pytest.fixture
 def branch_diff_01() -> ProposedChangeBranchDiff:
-    diff = ProposedChangeBranchDiff(
+    return ProposedChangeBranchDiff(
         pipeline_id=uuid4(),
         repositories=[],
         subscribers=[],
     )
-
-    return diff
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -754,7 +754,7 @@ async def car_person_schema(
 
 @pytest.fixture
 async def car_person_schema_branch_local_root(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
-    schema = SchemaRoot(
+    return SchemaRoot(
         nodes=[
             NodeSchema(
                 name="Car",
@@ -799,7 +799,6 @@ async def car_person_schema_branch_local_root(db: InfrahubDatabase, default_bran
             ),
         ],
     )
-    return schema
 
 
 @pytest.fixture

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/car_spec_markdown.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/car_spec_markdown.py
@@ -8,11 +8,10 @@ class CarSpecMarkdown(InfrahubTransform):
     timeout = 10
 
     async def transform(self, data: dict[str, Any]) -> str:
-        markdown = """
+        return """
         ## Car Specification
 
         **blue** Sedan
         Make: **Toyota**
         Model: **Camry**
         """
-        return markdown

--- a/backend/tests/functional/pools/test_numberpool_branch.py
+++ b/backend/tests/functional/pools/test_numberpool_branch.py
@@ -60,11 +60,10 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
-        schema = SchemaRoot(
+        return SchemaRoot(
             version="1.0",
             nodes=[INCIDENT, REQUEST],
         )
-        return schema
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -65,12 +65,11 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     def initial_schema(self) -> SchemaRoot:
-        schema = SchemaRoot(
+        return SchemaRoot(
             version="1.0",
             generics=[SNOW_TASK],
             nodes=[node_schema_definition, SNOW_INCIDENT, SNOW_REQUEST],
         )
-        return schema
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -233,8 +233,7 @@ class TestInfrahubAppBase(TestInfrahub):
             schema_converge_timeout=5,
         )
 
-        sdk_client = InfrahubClient(config=config)
-        return sdk_client
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def admin_account(

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -123,14 +123,12 @@ class TestInfrahubClient:
         await obj.save(db=db)
 
         # Initialize the repository on the file system
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=obj.id,
             name=git_repo_infrahub_demo_edge_integration.name,
             location=git_repo_infrahub_demo_edge_integration.path,
             client=client,
         )
-
-        return repo
 
     async def test_import_schema_files(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -267,8 +267,7 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
                 "destination_branch": default_branch.name,
             },
         )
-        proposed_change_id = result["CoreProposedChangeCreate"]["object"]["id"]
-        return proposed_change_id
+        return result["CoreProposedChangeCreate"]["object"]["id"]
 
     def _get_diff_node_attribute_values(self, diff_node: dict[str, Any]) -> dict[str, Any]:
         diff_attribute_values_by_name = {}

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -208,7 +208,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
         await deleted_specific_three.save(db=db)
         await deleted_specific_three.delete(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "thing_three": thing_three,
@@ -216,7 +216,6 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
             "specific_two": specific_two,
             "specific_three": specific_three,
         }
-        return objs
 
     @pytest.fixture(scope="class")
     async def initial_dataset(

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -139,7 +139,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "deleted_bob": deleted_bob.id,
             "jane": jane.id,
@@ -157,8 +157,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "red": red.id,
             "green": green.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step02(

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -245,14 +245,12 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         )
         await template_thing.save(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "profile_thing": profile_thing,
             "template_thing": template_thing,
         }
-
-        return objs
 
     async def test_step01_baseline(
         self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch

--- a/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_generic_renaming.py
@@ -57,9 +57,7 @@ class TestSchemaLifecycleGenericRenaming(TestSchemaLifecycleBase):
         await deleted_device.save(db=db)
         await deleted_device.delete(db=db)
 
-        objs = {"first_device": first_device.id, "second_device": second_device.id}
-
-        return objs
+        return {"first_device": first_device.id, "second_device": second_device.id}
 
     async def test_step01_baseline(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         devices = await registry.manager.query(db=db, schema=DEVICE_KIND)

--- a/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
@@ -119,13 +119,12 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         await deleted_specific_one.save(db=db)
         await deleted_specific_one.delete(db=db)
 
-        objs = {
+        return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "thing_three": thing_three,
             "specific_one": specific_one,
         }
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_specific_one_new_kind(self) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -131,7 +131,7 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "richard": richard.id,
@@ -147,8 +147,6 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
             "red": red.id,
             "green": green.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_person_tag(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_number_pool_branch_merge.py
@@ -65,8 +65,7 @@ class TestNumberPoolSingleInstanceAcrossBranches(TestInfrahubApp):
         self,
         db: InfrahubDatabase,
     ) -> Branch:
-        branch = await create_branch(db=db, branch_name="numberpool-single-instance-branch")
-        return branch
+        return await create_branch(db=db, branch_name="numberpool-single-instance-branch")
 
     @pytest.fixture(scope="class")
     async def load_schema_on_default(

--- a/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
@@ -85,15 +85,13 @@ class TestSchemaLifecycleAttributeRemoveAddMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "renault": renault.id,
             "megane": megane.id,
             "clio": clio.id,
             "red": red.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -145,7 +145,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
         await blue.new(db=db, name="blue", cars=[accord, civic], persons=[jane])
         await blue.save(db=db, user_id="blue-creator")
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "richard": richard.id,
@@ -161,8 +161,6 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
             "red": red.id,
             "green": green.id,
         }
-
-        return objs
 
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=self.branch1)

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -74,7 +74,7 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -85,8 +85,6 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
             "blue": blue.id,
             "red": red.id,
         }
-
-        return objs
 
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset: dict[str, str]) -> None:
         persons = await registry.manager.query(db=db, schema=PERSON_KIND)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -169,7 +169,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await deleted_cylon.save(db=db)
         await deleted_cylon.delete(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "president": president.id,
             "gaius": gaius.id,
@@ -177,8 +177,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "athena": athena.id,
             "caprica": caprica.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step_01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -150,7 +150,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await megane.new(db=db, name="Megane", description="Renault Megane", color="#c93420", owner=starbuck)
         await megane.save(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "president": president.id,
             "gaius": gaius.id,
@@ -161,8 +161,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "civic": civic.id,
             "megane": megane.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_step_01(

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -133,15 +133,13 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await megane.new(db=db, name="Megane", description="Renault Megane", color="#c93420", owner=starbuck)
         await megane.save(db=db)
 
-        objs = {
+        return {
             "starbuck": starbuck.id,
             "gaius": gaius.id,
             "boomer": boomer.id,
             "caprica": caprica.id,
             "megane": megane.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_01_cylon_robot(self, schema_cylon_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -78,7 +78,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -89,8 +89,6 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
             "blue": blue.id,
             "red": red.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_01_person_name_regex_failure(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -75,7 +75,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
         await red.new(db=db, name="red", persons=[john])
         await red.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -86,8 +86,6 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             "blue": blue.id,
             "red": red.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     async def branch_2(self, db: InfrahubDatabase) -> Branch:

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -66,15 +66,13 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         )
         await deleted_car.delete(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "deleted_bob": deleted_bob.id,
             "renault": renault.id,
             "megane": megane.id,
             "clio": clio.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_generic_01(self) -> dict[str, Any]:

--- a/backend/tests/integration/sdk/test_node_create_constraint.py
+++ b/backend/tests/integration/sdk/test_node_create_constraint.py
@@ -164,7 +164,7 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
         )
         await megane.save(db=db)
 
-        objs = {
+        return {
             "john": john.id,
             "jane": jane.id,
             "honda": honda.id,
@@ -173,8 +173,6 @@ class TestSDKNodeCreateConstraints(TestInfrahubApp):
             "civic": civic.id,
             "megane": megane.id,
         }
-
-        return objs
 
     @pytest.fixture(scope="class")
     def schema_02_car_uniqueness_constraint(self, schema_car_base: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -89,11 +89,9 @@ class TestTransforms(TestInfrahubApp):
         await obj.save(db=db)
 
         # Initialize the repository on the file system
-        repo = await InfrahubRepository.new(
+        return await InfrahubRepository.new(
             id=obj.id, name=git_repo_car_dealership.name, location=git_repo_car_dealership.path, client=client
         )
-
-        return repo
 
     async def test_transform_jinja(
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, base_dataset: None

--- a/backend/tests/integration_docker/test_display_label_backfill.py
+++ b/backend/tests/integration_docker/test_display_label_backfill.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from asyncio import sleep
+from asyncio import sleep, timeout
 from typing import TYPE_CHECKING
 
 import pytest
@@ -31,6 +31,27 @@ async def wait_for_all_tasks_to_be_completed(client: InfrahubClient) -> None:
         await client.task.count(filters=TaskFilter(state=[TaskState.PENDING, TaskState.RUNNING, TaskState.SCHEDULED]))
         > 0
     ):
+        await sleep(1)
+
+
+async def wait_for_display_label_backfill(client: InfrahubClient, node_id: str) -> None:
+    # The backfill is dispatched async: SchemaUpdatedEvent -> Prefect automation ->
+    # display-labels-setup-jinja2 -> trigger-update-display-labels -> per-node
+    # display-label-jinja2-update-value. With Redis-backed scaleout messaging that
+    # chain has non-trivial latency, so polling for an empty task queue can return
+    # before the backfill is even scheduled. Wait for the per-node update flow to
+    # reach a terminal state instead. Wrap in `asyncio.timeout()` to bound the wait.
+    terminal = [TaskState.COMPLETED, TaskState.FAILED, TaskState.CRASHED, TaskState.CANCELLED]
+    while True:
+        observed = await client.task.count(
+            filters=TaskFilter(
+                workflow=["display-label-jinja2-update-value"],
+                related_node__ids=[node_id],
+                state=terminal,
+            )
+        )
+        if observed:
+            return
         await sleep(1)
 
 
@@ -86,8 +107,12 @@ class TestDisplayLabelBackfillOnSchemaChange(TestInfrahubDockerClient):
         labels = await self._get_display_labels(client)
         assert labels[color_after] == "Blue"
 
-    async def test_backfill_updates_preexisting_node(self, client: InfrahubClient, color_after: str) -> None:
+    async def test_backfill_updates_preexisting_node(
+        self, client: InfrahubClient, color_before: str, color_after: str
+    ) -> None:
         """After the async backfill completes, all nodes should have correct display_labels."""
-        await wait_for_all_tasks_to_be_completed(client=client)
+        async with timeout(120):
+            await wait_for_display_label_backfill(client=client, node_id=color_before)
         labels = await self._get_display_labels(client)
-        assert set(labels.values()) == {"Red", "Blue"}
+        assert labels[color_before] == "Red"
+        assert labels[color_after] == "Blue"

--- a/backend/tests/unit/git/test_tasks.py
+++ b/backend/tests/unit/git/test_tasks.py
@@ -1,0 +1,59 @@
+from infrahub.git.tasks import format_check_log_entry
+
+
+def test_format_check_log_entry_message_only() -> None:
+    entry = {"level": "ERROR", "message": "boom", "branch": "main"}
+
+    assert format_check_log_entry(entry) == "[ERROR] boom"
+
+
+def test_format_check_log_entry_with_object_type_and_id() -> None:
+    entry = {
+        "level": "ERROR",
+        "message": "Duplicate serial '12345' for manufacturer 'Acme'.",
+        "branch": "main",
+        "object_id": "abc-123",
+        "object_type": "DcimDeviceAsset",
+    }
+
+    assert format_check_log_entry(entry) == (
+        "[ERROR] Duplicate serial '12345' for manufacturer 'Acme'. (object_type=DcimDeviceAsset, object_id=abc-123)"
+    )
+
+
+def test_format_check_log_entry_with_object_id_only() -> None:
+    entry = {
+        "level": "INFO",
+        "message": "validated",
+        "branch": "main",
+        "object_id": "abc-123",
+    }
+
+    assert format_check_log_entry(entry) == "[INFO] validated (object_id=abc-123)"
+
+
+def test_format_check_log_entry_with_object_type_only() -> None:
+    entry = {
+        "level": "ERROR",
+        "message": "missing description",
+        "branch": "main",
+        "object_type": "TestingCar",
+    }
+
+    assert format_check_log_entry(entry) == "[ERROR] missing description (object_type=TestingCar)"
+
+
+def test_format_check_log_entry_produces_single_line_per_entry() -> None:
+    """Regression: the formatter must emit exactly one line per log record."""
+    entry = {
+        "level": "ERROR",
+        "message": "multi word message",
+        "branch": "main",
+        "object_id": "abc",
+        "object_type": "Foo",
+    }
+
+    rendered = format_check_log_entry(entry)
+
+    assert "\n" not in rendered
+    assert rendered.count("[ERROR]") == 1

--- a/changelog/8224.fixed.md
+++ b/changelog/8224.fixed.md
@@ -1,0 +1,1 @@
+Fix user-check failure logs being emitted one character per line in the proposed change task output — each log entry from `self.log_error(...)` is now rendered as a single warning line.

--- a/changelog/8857.fixed.md
+++ b/changelog/8857.fixed.md
@@ -1,1 +1,0 @@
-Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context).

--- a/changelog/8857.fixed.md
+++ b/changelog/8857.fixed.md
@@ -1,0 +1,1 @@
+Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context).

--- a/changelog/9283.fixed.md
+++ b/changelog/9283.fixed.md
@@ -1,1 +1,0 @@
-Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked.

--- a/changelog/9283.fixed.md
+++ b/changelog/9283.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       - 6362:6362
 
   task-manager:
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.5}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     command: uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect
     restart: unless-stopped
     depends_on:
@@ -246,7 +246,7 @@ services:
       retries: 5
 
   infrahub-server:
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.5}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     restart: unless-stopped
     command: >
       gunicorn --config backend/infrahub/serve/gunicorn_config.py
@@ -292,7 +292,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.5}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     command: prefect worker start --type infrahubasync --pool infrahub-worker --with-healthcheck
     restart: unless-stopped
     depends_on:

--- a/docs/docs/release-notes/infrahub/release-1_9_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_6.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.9.6
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 20th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.6](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fixed "Copy ID", "Copy HFID", and "Copy Token" actions not working when accessing Infrahub over HTTP (non-secure context). ([#8857](https://github.com/opsmill/infrahub/issues/8857))
+- Fix a bug in the merge logic that prevented the merge operation from deleting an object that had its kind or inheritance updated on the default branch after the branch being merged forked. ([#9283](https://github.com/opsmill/infrahub/issues/9283))
+- Bump SDK version to 1.20.1 to include fix for retrieving branches in the MERGING status ([sdk#1036](https://github.com/opsmill/infrahub-sdk-python/pull/1036))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -639,6 +639,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_6',
                 'release-notes/infrahub/release-1_9_5',
                 'release-notes/infrahub/release-1_9_4',
                 'release-notes/infrahub/release-1_9_3',

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
@@ -7,7 +6,11 @@ import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 function CopyButton({ value }: { value: string }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   return (
-    <button data-testid="copy-btn" data-copied={String(isCopied)} onClick={() => copyToClipboard(value)}>
+    <button
+      data-testid="copy-btn"
+      data-copied={String(isCopied)}
+      onClick={() => copyToClipboard(value)}
+    >
       {isCopied ? "copied" : "copy"}
     </button>
   );

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+
+function CopyButton({ value }: { value: string }) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  return (
+    <button data-testid="copy-btn" data-copied={String(isCopied)} onClick={() => copyToClipboard(value)}>
+      {isCopied ? "copied" : "copy"}
+    </button>
+  );
+}
+
+describe("useCopyToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses navigator.clipboard.writeText in a secure context", async () => {
+    // GIVEN
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(writeText).toHaveBeenCalledWith("test-value");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when not in a secure context", async () => {
+    // GIVEN
+    vi.stubGlobal("isSecureContext", false);
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when navigator.clipboard is unavailable", async () => {
+    // GIVEN
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+
+  it("falls back to selection-based copy when navigator.clipboard.writeText rejects", async () => {
+    // GIVEN
+    const writeText = vi.fn().mockRejectedValue(new Error("Permission denied"));
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const execCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+
+    const component = await render(<CopyButton value="test-value" />);
+
+    // WHEN
+    await component.getByTestId("copy-btn").click();
+
+    // THEN
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    await expect.element(component.getByText("copied")).toBeVisible();
+  });
+});

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.ts
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.ts
@@ -20,7 +20,7 @@ const COPIED_FEEDBACK_DURATION = 2000;
 export function useCopyToClipboard() {
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const copyToClipboard = React.useCallback((value: string) => {
+  const copyToClipboard = React.useCallback(async (value: string) => {
     function confirmCopied() {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), COPIED_FEEDBACK_DURATION);
@@ -32,13 +32,13 @@ export function useCopyToClipboard() {
       return;
     }
 
-    navigator.clipboard
-      .writeText(value)
-      .then(confirmCopied)
-      .catch(() => {
-        oldSchoolCopy(value);
-        confirmCopied();
-      });
+    try {
+      await navigator.clipboard.writeText(value);
+      confirmCopied();
+    } catch {
+      oldSchoolCopy(value);
+      confirmCopied();
+    }
   }, []);
 
   return { isCopied, copyToClipboard };

--- a/frontend/app/src/shared/hooks/useCopyToClipboard.ts
+++ b/frontend/app/src/shared/hooks/useCopyToClipboard.ts
@@ -1,12 +1,18 @@
 import React from "react";
 
 function oldSchoolCopy(text: string) {
-  const tempTextArea = document.createElement("textarea");
-  tempTextArea.value = text;
-  document.body.appendChild(tempTextArea);
-  tempTextArea.select();
-  document.execCommand("copy");
-  document.body.removeChild(tempTextArea);
+  const textNode = document.createTextNode(text);
+  document.body.appendChild(textNode);
+  const range = document.createRange();
+  range.selectNode(textNode);
+  const selection = window.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand("copy");
+    selection.removeAllRanges();
+  }
+  document.body.removeChild(textNode);
 }
 
 const COPIED_FEEDBACK_DURATION = 2000;
@@ -14,19 +20,25 @@ const COPIED_FEEDBACK_DURATION = 2000;
 export function useCopyToClipboard() {
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const copyToClipboard = React.useCallback(async (value: string) => {
+  const copyToClipboard = React.useCallback((value: string) => {
     function confirmCopied() {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), COPIED_FEEDBACK_DURATION);
     }
 
-    try {
-      await navigator.clipboard.writeText(value);
-      confirmCopied();
-    } catch {
+    if (!window.isSecureContext || !navigator.clipboard) {
       oldSchoolCopy(value);
       confirmCopied();
+      return;
     }
+
+    navigator.clipboard
+      .writeText(value)
+      .then(confirmCopied)
+      .catch(() => {
+        oldSchoolCopy(value);
+        confirmCopied();
+      });
   }, []);
 
   return { isCopied, copyToClipboard };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -619,7 +619,6 @@ allow-dunder-method-names = [
     "PLR6301",  # Method could be a function, class method, or static method
     "PLW0603",  # Using the global statement is discouraged
     "PLW1514",  # `pathlib.Path(...).open` without explicit `encoding` argument
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
@@ -671,7 +670,6 @@ allow-dunder-method-names = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
     ##################################################################################################
-    "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
 ]
 
 "backend/infrahub/core/node/standard.py" = [
@@ -775,7 +773,6 @@ allow-dunder-method-names = [
     "PLR0914",  # Too many local variables
     "PLR6301",  # Method could be a function, class method, or static method
     "PT021",    # Use `yield` instead of `request.addfinalizer`
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "SIM108",   # Use ternary operator instead of `if`-`else`-block
@@ -802,7 +799,6 @@ allow-dunder-method-names = [
     "PLR0913",  # Too many arguments in function definition
     "PLR0917",  # Too many positional arguments
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
 ]
 
@@ -827,7 +823,6 @@ allow-dunder-method-names = [
     "PLR0917",  # Too many positional arguments
     "PLR2004",  # Magic value used in comparison
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "S311",     # Standard pseudo-random generators are not suitable for crypto
@@ -869,7 +864,6 @@ allow-dunder-method-names = [
     "PLR6301",  # Method could be a function, class method, or static method
     "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
@@ -903,7 +897,6 @@ allow-dunder-method-names = [
     "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
     "PT012",    # `pytest.raises()` block should contain a single simple statement
     "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
@@ -983,7 +976,6 @@ allow-dunder-method-names = [
     "PT007",    # Wrong values type in `pytest.mark.parametrize`
     "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
@@ -1062,7 +1054,6 @@ allow-dunder-method-names = [
     "PLR2004",  # Magic value used in comparison
     "PLR6201",  # Use a `set` literal when testing for membership
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "S101",     # Use of `assert` detected
@@ -1102,7 +1093,6 @@ allow-dunder-method-names = [
     "PERF203",  # `try`-`except` within a loop incurs performance overhead
     "PLR0912",  # Too many branches
     "PLR6301",  # Method could be a function, class method, or static method
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "S101",     # Use of `assert` detected
 ]
@@ -1126,7 +1116,6 @@ allow-dunder-method-names = [
     "PLR0917",  # Too many positional arguments
     "PLR6201",  # Use a `set` literal when testing for membership
     "PT028",    # Test function parameter has default argument (these are not tests)
-    "RET504",   # Unnecessary assignment before `return` statement
     "RUF010",   # Use explicit conversion flag
     "S701",     # Jinja2 sets `autoescape` to `False`
     "SIM108",   # Use ternary operator instead of `if`-`else`-block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.5"
+version = "1.9.6"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.5"
+version = "1.9.6"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.5"
+version = "1.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -118,5 +118,4 @@ def get_yamllint_rules() -> dict:
     from ruamel.yaml import YAML
 
     yaml = YAML(typ="rt")
-    yamllint_rules = yaml.load(Path(".yamllint.yml"))
-    return yamllint_rules
+    return yaml.load(Path(".yamllint.yml"))

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.5"
+version = "1.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
# Why

Resolve merge conflicts between stable and develop

## What changed

* Everything in stable
* Resolved merge conflicts

 ## Merge conflict resolution

  Four files conflicted between `stable` and `develop`. In all four, stable's changes
  were the RET504 cleanup from #9297 (inline `return await ...`) plus the migrated-kind
  delete fix from #9285.

  - **`backend/infrahub/webhook/gather.py`**: took develop. PR #8862 refactored
    this file into a builder pattern with no `var = ...; return var` lines left for
    stable's RET504 cleanup to apply to.
  
  - **`backend/infrahub/webhook/models.py`**: took develop. Same as above:
    develop's builder/automation classes replaced the `from_object` classmethod
    that stable inlined.
  
  - **`backend/infrahub/core/diff/query/merge.py`**: took develop. PR #8847 moved
    `DiffMergeQuery` to the database level in `bulk_merge.py`, which already
    incorporates #9285's `tgt_n` / `migrated_out` logic (pulled in via the prior
    "merge stable" + follow-up cleanup). The two smaller conflicts in
    `DiffMergeMetadataQuery` are develop's deliberate refinement of the same
    Cypher pattern (`OPTIONAL MATCH … WITH e … LIMIT 1`), so develop's version is
    the correct one.

  - **`backend/tests/component/git/conftest.py`**: manual edit. Develop moved
    the `git_repo_01` fixture to the global `backend/tests/conftest.py`, so
    stable's local re-add was dropped. Stable's RET504 inlining was kept for
    `git_repo_01_read_only`, `git_repo_02`, and `git_repo_03`, since those
    fixtures still exist on develop and will be checked by the newly-active RET
    rules.

  The `python_sdk` submodule pointer was reset to develop's commit
  (`dec31010`) rather than taking stable's release-prep pointer (`98bb218b`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge stable into develop, bringing v1.9.6 fixes and workflow/doc updates with conflicts resolved. Improves artifact diff accuracy and merge-delete handling, restores clipboard copy over HTTP, corrects user‑check logging, and adds an approval‑gated bug pipeline for community issues.

- **Bug Fixes**
  - Artifact diffs: skip identical storage and match target artifacts by node UUID to prevent spurious diffs after schema kind rename/move.
  - Merge: allow deletion when an object’s kind or inheritance changed on the default branch after the fork.
  - Clipboard: add non‑secure context fallback for “Copy ID/HFID/Token”.
  - Check logs: emit one line per user‑check log entry via a new formatter.

- **Dependencies**
  - Bumped `infrahub-sdk-python` to 1.20.1 to fix retrieval of branches in MERGING status.

<sup>Written for commit 1cefef08c74f49e87cd71e092699eb98312ea11c. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

