### PR TITLE
docs: fix broken docs.infrahub.app links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ Three ways to try Infrahub:
 
 - **[Sandbox](https://sandbox.infrahub.app/)** — a hosted demo of the Infrahub UI with sample data — explore the interface without installing anything.
 - **[Getting Started Lab](https://opsmill.instruqt.com/pages/labs)** — a guided browser tutorial covering branches, schemas, and unified storage.
-- **[Quick Start guide](https://docs.infrahub.app/getting-started/quick-start)** — set up a local Infrahub instance and walk through the basics in your own environment.
+- **[Quick Start guide](https://docs.infrahub.app/overview/quickstart)** — set up a local Infrahub instance and walk through the basics in your own environment.
 
 For production deployments on Kubernetes, see [`opsmill/infrahub-helm`](https://github.com/opsmill/infrahub-helm) and the [installation guide](https://docs.infrahub.app/guides/installation).
 
 ## Documentation
 
 - [Documentation home](https://docs.infrahub.app/)
-- [Getting started](https://docs.infrahub.app/getting-started/overview)
-- [Core concepts](https://docs.infrahub.app/getting-started/concepts)
+- [Getting started](https://docs.infrahub.app/overview)
+- [Core concepts](https://docs.infrahub.app/overview/concepts)
 - [Release notes](https://docs.infrahub.app/release-notes)
 - [FAQ](https://docs.infrahub.app/faq/)
 


### PR DESCRIPTION
## Summary

- Three `docs.infrahub.app/getting-started/*` links in `README.md` returned **404**; they were moved under `/overview/*` in the docs site.
- Updated to the live paths:
  - `/getting-started/quick-start` → `/overview/quickstart`
  - `/getting-started/overview`    → `/overview`
  - `/getting-started/concepts`    → `/overview/concepts`

Closes #9339

## Test plan

- [x] `curl -sIL` against the three replacement URLs returns `200`.
- [x] `curl -sIL` against the three original URLs returns `404`.
- [ ] Visually verify rendered README on GitHub (links go to the right pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken docs links in `README.md` by updating three `docs.infrahub.app/getting-started/*` URLs to their new `/overview/*` paths. Fixes #9339.

<sup>Written for commit fc9024d4b9fe86b8dd91b973f05b78a40a5cb2b4. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9341?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

