### PR TITLE
remove arg-type exclusion from mypy rules on `schema_branch.py`

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2484,13 +2484,7 @@ class SchemaBranch:
 
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
-<<<<<<< HEAD
-            node = self.get(name=node_name, duplicate=False)
-            if not isinstance(node, NodeSchema | GenericSchema):
-                continue
-=======
             node = self.get_node_or_generic_schema(name=node_name, duplicate=False)
->>>>>>> d6ea36073 (add and use get_node_or_generic_schema())
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")
                 or not node.generate_profile

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2467,7 +2467,7 @@ class SchemaBranch:
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
             node = self.get(name=node_name, duplicate=False)
-            if not isinstance(node_schema, NodeSchema | GenericSchema):
+            if not isinstance(node, NodeSchema | GenericSchema):
                 continue
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -246,9 +246,7 @@ class SchemaBranch:
 
         # Process of the one that have been updated to identify the list of impacted fields
         for key in present_both:
-            local_node = self.get(name=key, duplicate=False)
-            other_node = other.get(name=key, duplicate=False)
-            diff_node = other_node.diff(other=local_node)
+            diff_node = self._diff_node_or_generic(other_schema_branch=other, local_key=key, other_key=key)
             if diff_node.has_diff:
                 schema_diff.changed[key] = diff_node
 
@@ -256,15 +254,30 @@ class SchemaBranch:
         reversed_map_other: dict[str | None, str] = {v: k for k, v in other_kind_id_map.items()}
 
         for shared_id in shared_ids:
-            local_node = self.get(name=reversed_map_local[shared_id], duplicate=False)
-            other_node = other.get(name=reversed_map_other[shared_id], duplicate=False)
-            diff_node = other_node.diff(other=local_node)
-            if other_node.state == HashableModelState.ABSENT:
-                schema_diff.removed[reversed_map_other[shared_id]] = None
+            local_key = reversed_map_local[shared_id]
+            other_key = reversed_map_other[shared_id]
+            diff_node = self._diff_node_or_generic(other_schema_branch=other, local_key=local_key, other_key=other_key)
+            if other.get(name=other_key, duplicate=False).state == HashableModelState.ABSENT:
+                schema_diff.removed[other_key] = None
             elif diff_node.has_diff:
-                schema_diff.changed[reversed_map_other[shared_id]] = diff_node
+                schema_diff.changed[other_key] = diff_node
 
         return schema_diff
+
+    def _diff_node_or_generic(
+        self, other_schema_branch: SchemaBranch, local_key: str, other_key: str
+    ) -> HashableModelDiff:
+        """Diff two schemas across branches, dispatching to the matching concrete subclass.
+
+        Callers must ensure both keys reference either nodes or generics (not profiles or templates).
+        """
+        if local_key in self.nodes:
+            local_node = self.get_node(name=local_key, duplicate=False)
+            other_node = other_schema_branch.get_node(name=other_key, duplicate=False)
+            return other_node.diff(other=local_node)
+        local_generic = self.get_generic(name=local_key, duplicate=False)
+        other_generic = other_schema_branch.get_generic(name=other_key, duplicate=False)
+        return other_generic.diff(other=local_generic)
 
     def update(self, schema: SchemaBranch) -> None:
         """Update another SchemaBranch into this one."""

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -233,7 +233,7 @@ class SchemaBranch:
 
                 cache[node_hash] = node
 
-        return cls(cache=cache, data=nodes, name=data.get("name", "Unknown"))
+        return cls(cache=cache, data=nodes, name=data["name"])
 
     def diff(self, other: SchemaBranch) -> SchemaDiff:
         # Identify the nodes or generics that have been added or removed

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1158,7 +1158,8 @@ class SchemaBranch:
         dependency_map: dict[str, set[str]] = defaultdict(set)
         for name in self.generic_names_without_templates + self.node_names:
             node_schema = self.get(name=name, duplicate=False)
-            assert isinstance(node_schema, NodeSchema | GenericSchema)
+            if not isinstance(node_schema, NodeSchema | GenericSchema):
+                continue
 
             parent_relationships: list[RelationshipSchema] = []
             component_relationships: list[RelationshipSchema] = []
@@ -2466,7 +2467,8 @@ class SchemaBranch:
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
             node = self.get(name=node_name, duplicate=False)
-            assert isinstance(node, NodeSchema | GenericSchema)
+            if not isinstance(node_schema, NodeSchema | GenericSchema):
+                continue
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")
                 or not node.generate_profile

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1145,6 +1145,7 @@ class SchemaBranch:
         dependency_map: dict[str, set[str]] = defaultdict(set)
         for name in self.generic_names_without_templates + self.node_names:
             node_schema = self.get(name=name, duplicate=False)
+            assert isinstance(node_schema, NodeSchema | GenericSchema)
 
             parent_relationships: list[RelationshipSchema] = []
             component_relationships: list[RelationshipSchema] = []
@@ -1549,7 +1550,7 @@ class SchemaBranch:
 
     def validate_inherited_relationships_fields(self) -> None:
         for name in self.node_names:
-            node_schema = self.get(name=name, duplicate=False)
+            node_schema = self.get_node(name=name, duplicate=False)
             if not node_schema.inherit_from:
                 continue
 
@@ -2452,6 +2453,7 @@ class SchemaBranch:
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
             node = self.get(name=node_name, duplicate=False)
+            assert isinstance(node, NodeSchema | GenericSchema)
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")
                 or not node.generate_profile
@@ -2537,7 +2539,7 @@ class SchemaBranch:
     def _get_profile_kind(self, node_kind: str) -> str:
         return f"Profile{node_kind}"
 
-    def generate_profile_from_node(self, node: NodeSchema) -> ProfileSchema:
+    def generate_profile_from_node(self, node: NodeSchema | GenericSchema) -> ProfileSchema:
         core_profile_schema = self.get(name=InfrahubKind.PROFILE, duplicate=False)
         core_name_attr = core_profile_schema.get_attribute(name="profile_name")
         name_attr_schema_class = get_attribute_schema_class_for_kind(kind=core_name_attr.kind)
@@ -2951,7 +2953,7 @@ class SchemaBranch:
                 ):
                     for used_by in peer_schema.used_by:
                         identified |= self.identify_required_object_templates(
-                            node_schema=self.get(name=used_by, duplicate=False), identified=identified
+                            node_schema=self.get_node(name=used_by, duplicate=False), identified=identified
                         )
 
             identified |= self.identify_required_object_templates(node_schema=peer_schema, identified=identified)
@@ -2963,7 +2965,7 @@ class SchemaBranch:
         template_schema_kinds: set[str] = set()
 
         for node_name in self.node_names:
-            node = self.get(name=node_name, duplicate=False)
+            node = self.get_node(name=node_name, duplicate=False)
 
             # Delete old object templates if schemas were removed
             if (
@@ -2973,7 +2975,7 @@ class SchemaBranch:
             ):
                 try:
                     if any(r.name == OBJECT_TEMPLATE_RELATIONSHIP_NAME for r in node.relationships):
-                        node = self.get(name=node_name, duplicate=True)
+                        node = self.get_node(name=node_name, duplicate=True)
                         node.relationships = [
                             r for r in node.relationships if r.name != OBJECT_TEMPLATE_RELATIONSHIP_NAME
                         ]

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2373,29 +2373,33 @@ class SchemaBranch:
             read_only = InfrahubKind.IPPREFIX in node.inherit_from
 
             parent_peer = node.parent or node.hierarchy
-            if "parent" not in node.relationship_names:
-                node.relationships.append(
-                    self._get_hierarchy_parent_rel(
-                        peer=parent_peer,
-                        hierarchical=node.hierarchy,
-                        read_only=read_only,
-                        optional=parent_peer in [node_name] + self.generic_names,
+            if parent_peer is not None:
+                if "parent" not in node.relationship_names:
+                    node.relationships.append(
+                        self._get_hierarchy_parent_rel(
+                            peer=parent_peer,
+                            hierarchical=node.hierarchy,
+                            read_only=read_only,
+                            optional=parent_peer in [node_name] + self.generic_names,
+                        )
                     )
-                )
-            else:
-                parent_rel = node.get_relationship(name="parent")
-                if parent_rel.peer != parent_peer:
-                    parent_rel.peer = parent_peer
+                else:
+                    parent_rel = node.get_relationship(name="parent")
+                    if parent_rel.peer != parent_peer:
+                        parent_rel.peer = parent_peer
 
             children_peer = node.children or node.hierarchy
-            if "children" not in node.relationship_names:
-                node.relationships.append(
-                    self._get_hierarchy_child_rel(peer=children_peer, hierarchical=node.hierarchy, read_only=read_only)
-                )
-            else:
-                children_rel = node.get_relationship(name="children")
-                if children_rel.peer != children_peer:
-                    children_rel.peer = children_peer
+            if children_peer is not None:
+                if "children" not in node.relationship_names:
+                    node.relationships.append(
+                        self._get_hierarchy_child_rel(
+                            peer=children_peer, hierarchical=node.hierarchy, read_only=read_only
+                        )
+                    )
+                else:
+                    children_rel = node.get_relationship(name="children")
+                    if children_rel.peer != children_peer:
+                        children_rel.peer = children_peer
 
             self.set(name=node_name, schema=node)
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -6,7 +6,7 @@ import hashlib
 import keyword
 from collections import defaultdict
 from itertools import chain, combinations
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from infrahub_sdk.template.exceptions import JinjaTemplateError, JinjaTemplateOperationViolationError
 from infrahub_sdk.template.filters import ExecutionContext
@@ -84,6 +84,14 @@ if TYPE_CHECKING:
     from infrahub.core.validators.schema_branch.interface import SchemaBranchValidator
 
 log = get_logger()
+
+
+class SchemaBranchDict(TypedDict):
+    name: str
+    nodes: dict[str, NodeSchema]
+    profiles: dict[str, ProfileSchema]
+    generics: dict[str, GenericSchema]
+    templates: dict[str, TemplateSchema]
 
 
 profiles_rel_settings: dict[str, Any] = {
@@ -188,13 +196,13 @@ class SchemaBranch:
     def to_dict(self) -> dict[str, Any]:
         return {"nodes": self.nodes, "generics": self.generics, "profiles": self.profiles, "templates": self.templates}
 
-    def to_dict_schema_object(self, duplicate: bool = False) -> dict[str, Any]:
+    def to_dict_schema_object(self, duplicate: bool = False) -> SchemaBranchDict:
         return {
             "name": self.name,
-            "nodes": {name: self.get(name, duplicate=duplicate) for name in self.nodes},
-            "profiles": {name: self.get(name, duplicate=duplicate) for name in self.profiles},
-            "generics": {name: self.get(name, duplicate=duplicate) for name in self.generics},
-            "templates": {name: self.get(name, duplicate=duplicate) for name in self.templates},
+            "nodes": {name: self.get_node(name, duplicate=duplicate) for name in self.nodes},
+            "profiles": {name: self.get_profile(name, duplicate=duplicate) for name in self.profiles},
+            "generics": {name: self.get_generic(name, duplicate=duplicate) for name in self.generics},
+            "templates": {name: self.get_template(name, duplicate=duplicate) for name in self.templates},
         }
 
     def to_dict_api_schema_object(self) -> dict[str, list[dict]]:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -101,14 +101,14 @@ class SchemaBranch:
     def __init__(
         self,
         cache: dict,
-        name: str | None = None,
+        name: str,
         data: dict[str, dict[str, str]] | None = None,
         computed_attributes: ComputedAttributes | None = None,
         display_labels: DisplayLabels | None = None,
         hfids: HFIDs | None = None,
     ) -> None:
         self._cache: dict[str, NodeSchema | GenericSchema] = cache
-        self.name: str | None = name
+        self.name: str = name
         self.nodes: dict[str, str] = {}
         self.generics: dict[str, str] = {}
         self.profiles: dict[str, str] = {}
@@ -188,8 +188,9 @@ class SchemaBranch:
     def to_dict(self) -> dict[str, Any]:
         return {"nodes": self.nodes, "generics": self.generics, "profiles": self.profiles, "templates": self.templates}
 
-    def to_dict_schema_object(self, duplicate: bool = False) -> dict[str, dict[str, MainSchemaTypes]]:
+    def to_dict_schema_object(self, duplicate: bool = False) -> dict[str, Any]:
         return {
+            "name": self.name,
             "nodes": {name: self.get(name, duplicate=duplicate) for name in self.nodes},
             "profiles": {name: self.get(name, duplicate=duplicate) for name in self.profiles},
             "generics": {name: self.get(name, duplicate=duplicate) for name in self.generics},
@@ -224,7 +225,7 @@ class SchemaBranch:
 
                 cache[node_hash] = node
 
-        return cls(cache=cache, data=nodes)
+        return cls(cache=cache, data=nodes, name=data.get("name", "Unknown"))
 
     def diff(self, other: SchemaBranch) -> SchemaDiff:
         # Identify the nodes or generics that have been added or removed
@@ -320,7 +321,7 @@ class SchemaBranch:
     def duplicate(self, name: str | None = None) -> SchemaBranch:
         """Duplicate the current object but conserve the same cache."""
         return self.__class__(
-            name=name,
+            name=name if name is not None else self.name,
             data=copy.deepcopy(self.to_dict()),
             cache=self._cache,
             computed_attributes=self.computed_attributes.duplicate(),

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -458,6 +458,18 @@ class SchemaBranch:
             raise ValueError(f"{name!r} is not of type TemplateSchema")
         return item
 
+    def get_node_or_generic_schema(self, name: str, duplicate: bool = True) -> NodeSchema | GenericSchema:
+        """Access a specific NodeSchema or GenericSchema, defined by its kind.
+
+        Raises:
+            ValueError: When the schema with the given name is neither a NodeSchema nor a GenericSchema.
+
+        """
+        item = self.get(name=name, duplicate=duplicate)
+        if not isinstance(item, NodeSchema | GenericSchema):
+            raise ValueError(f"{name!r} is not of type NodeSchema or GenericSchema")
+        return item
+
     def delete(self, name: str) -> None:
         if name in self.nodes:
             del self.nodes[name]
@@ -1165,9 +1177,7 @@ class SchemaBranch:
         # {parent_kind: {component_kind_1, component_kind_2, ...}}
         dependency_map: dict[str, set[str]] = defaultdict(set)
         for name in self.generic_names_without_templates + self.node_names:
-            node_schema = self.get(name=name, duplicate=False)
-            if not isinstance(node_schema, NodeSchema | GenericSchema):
-                continue
+            node_schema = self.get_node_or_generic_schema(name=name, duplicate=False)
 
             parent_relationships: list[RelationshipSchema] = []
             component_relationships: list[RelationshipSchema] = []
@@ -2474,9 +2484,13 @@ class SchemaBranch:
 
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
+<<<<<<< HEAD
             node = self.get(name=node_name, duplicate=False)
             if not isinstance(node, NodeSchema | GenericSchema):
                 continue
+=======
+            node = self.get_node_or_generic_schema(name=node_name, duplicate=False)
+>>>>>>> d6ea36073 (add and use get_node_or_generic_schema())
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")
                 or not node.generate_profile
@@ -2726,9 +2740,7 @@ class SchemaBranch:
             A RelationshipSchema for the resource pool relationship, or None if not applicable
 
         """
-        peer_schema = self.get(name=relationship.peer, duplicate=False)
-        if not isinstance(peer_schema, NodeSchema | GenericSchema):
-            return None
+        peer_schema = self.get_node_or_generic_schema(name=relationship.peer, duplicate=False)
 
         pool_peer = None
         if isinstance(peer_schema, GenericSchema):
@@ -2965,8 +2977,8 @@ class SchemaBranch:
             ):
                 continue
 
-            peer_schema = self.get(name=relationship.peer, duplicate=False)
-            if not isinstance(peer_schema, NodeSchema | GenericSchema) or peer_schema in identified:
+            peer_schema = self.get_node_or_generic_schema(name=relationship.peer, duplicate=False)
+            if peer_schema in identified:
                 continue
             # In a context of a generic, we won't be able to create objects out of it, so any kind of nodes implementing the generic is a valid
             # option, we therefore need to have a template for each of those nodes

--- a/backend/tests/component/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_choices_update.py
@@ -30,7 +30,7 @@ async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, cr
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
@@ -58,7 +58,7 @@ async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criti
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
@@ -96,7 +96,7 @@ async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticali
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -159,7 +159,7 @@ async def test_attribute_update_on_branch(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -221,7 +221,7 @@ async def test_node_delete_on_branch(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -281,7 +281,7 @@ async def test_validator(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_enum_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_enum_update.py
@@ -164,7 +164,7 @@ async def test_validator(
         constraint_name="attribute.enum.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeEnumChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_kind_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_kind_update.py
@@ -306,7 +306,7 @@ async def test_validator(
         constraint_name="attribute.kind.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeKindChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_length.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_length.py
@@ -227,7 +227,7 @@ async def test_validator(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_LENGTH_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeLengthChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_number_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_number_constraints.py
@@ -233,7 +233,7 @@ async def test_validator_min_max(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberChecker(db=db, branch=branch)
@@ -295,7 +295,7 @@ async def test_validator_excluded_values(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
@@ -155,7 +155,7 @@ async def test_validator_range(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=incident_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberPoolChecker(db=db, branch=branch)
@@ -173,7 +173,7 @@ async def test_validator_range(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=incident_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberPoolChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_optional.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_optional.py
@@ -166,7 +166,7 @@ async def test_validator(db: InfrahubDatabase, branch: Branch, person_john_main:
         constraint_name="attribute.optional.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeOptionalChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_regex_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_regex_update.py
@@ -171,7 +171,7 @@ async def test_validator(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_REGEX_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeRegexChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_unique_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_unique_update.py
@@ -184,7 +184,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeUniquenessChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_node_generate_profiles_update.py
+++ b/backend/tests/component/core/constraint_validators/test_node_generate_profiles_update.py
@@ -27,7 +27,7 @@ async def test_set_generate_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -48,7 +48,7 @@ async def test_set_generate_profile_success_generics(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -72,7 +72,7 @@ async def test_set_generate_profile_false_fail(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -100,7 +100,7 @@ async def test_set_generate_profile_false_fail_generic(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -130,7 +130,7 @@ async def test_set_generate_profile_false_branch_delete_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_node_hierarchy_update.py
+++ b/backend/tests/component/core/constraint_validators/test_node_hierarchy_update.py
@@ -381,7 +381,7 @@ async def test_validator_parents_failure(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -408,7 +408,7 @@ async def test_validator_parents_success(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -433,7 +433,7 @@ async def test_validator_children_failure(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -460,7 +460,7 @@ async def test_validator_children_success(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_relationship_count.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_count.py
@@ -460,7 +460,7 @@ async def test_validator(
         constraint_name="relationship.max_count.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)
@@ -502,7 +502,7 @@ async def test_validator_cardinality_failure(
         constraint_name="relationship.cardinality.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_relationship_optional_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_optional_update.py
@@ -62,7 +62,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipOptionalChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
@@ -450,7 +450,7 @@ async def test_validator(
         constraint_name="relationship.peer.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestCar", field_name="owner"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipPeerChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_uniqueness_checker.py
+++ b/backend/tests/component/core/constraint_validators/test_uniqueness_checker.py
@@ -23,7 +23,7 @@ class TestUniquenessChecker:
             constraint_name="node.uniqueness_constraints.update",
             node_schema=schema,
             schema_path=schema_path,
-            schema_branch=SchemaBranch(cache={}),
+            schema_branch=SchemaBranch(cache={}, name="test"),
         )
         return await checker.check(request)
 

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -103,7 +103,7 @@ def test_number_pool_optional() -> None:
     node_schema = NodeSchema(**node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it can't be optional"
@@ -130,7 +130,7 @@ def test_number_pool_read_only() -> None:
     node_schema = NodeSchema(**node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it has to be a read_only attribute"
@@ -174,7 +174,7 @@ def test_number_pool_override_generic() -> None:
     generic_schema = GenericSchema(**generic_node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema], generics=[generic_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError,
@@ -194,7 +194,7 @@ def test_number_pool_fail_on_multiple_generics() -> None:
 
     modified_incident.inherit_from.append("SnowOtherTask")
     schema = SchemaRoot(generics=[SNOW_TASK, alternate_base], nodes=[modified_incident])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"SnowIncident.number is a NumberPool inherited from more than one generic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,6 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "infrahub.core.schema.schema_branch"
 disable_error_code = [
-    "arg-type",
     "assignment",
     "attr-defined",
     "index",


### PR DESCRIPTION
 ## Summary

  Removes `arg-type` from the mypy override for `infrahub.core.schema.schema_branch` and fixes all 20 hidden type errors

  ## Changes

  ### `SchemaBranch.name` is now required
  - `__init__` signature changed from `name: str | None = None` to `name: str` — every production call site already passed a name; only test fixtures were relying on
  the default.
  - `to_dict_schema_object()` now carries `"name"` in the payload; `from_dict_schema_object()` reads it. This keeps round-tripping honest across the Pydantic
  validator/migration pipelines (`validators/model.py`, `validators/models/validate_migration.py`, `migrations/schema/models.py`).
  - `duplicate(name=None)` now falls back to `self.name` instead of producing a nameless copy.
  - 34 test instantiation sites across 16 files updated to pass `name="test"`.

  ### Type narrowing in `SchemaBranch` methods
  - Replaced overly broad `self.get()` calls with the existing typed helpers `get_node()` / `get_generic()` at 6 sites where the iteration source guarantees the kind.
  - Extracted `_diff_node_or_generic()` helper in `SchemaBranch.diff()` to dispatch by kind so each subclass's `diff(other: Self)` contract is satisfied without `cast`.
  - Added `assert isinstance(node, NodeSchema | GenericSchema)` at two loops that iterate `node_names + generic_names_without_templates` — the union return type was
  strictly wider than the iteration source.
  - Widened `generate_profile_from_node(node: NodeSchema)` to `NodeSchema | GenericSchema`. The body only touches `BaseNodeSchema` attributes, and the calling loop
  legitimately invokes it for both kinds (both have `generate_profile`).

  ### Guard against `None` in `add_hierarchy_node`
  Wrapped the parent- and children-relationship blocks in `if parent_peer is not None:` / `if children_peer is not None:` guards. Schema procession would make reaching this point impossible, but the typing does not make that clear. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `SchemaBranch.name` required and include it in schema serialization. Tightens typing across `schema_branch.py`, adds safe dispatch in `diff()`, and removes the `arg-type` mypy override.

- **Refactors**
  - `SchemaBranch.__init__` now requires `name: str`; tests updated to pass `name="test"`.
  - `to_dict_schema_object()` returns `SchemaBranchDict` and writes `"name"`; `from_dict_schema_object()` now requires it.
  - Introduced `SchemaBranchDict` `TypedDict`.
  - Added `get_node_or_generic_schema()`; replaced broad `get()` with typed getters (`get_node`/`get_generic`/`get_profile`/`get_template`) and `_diff_node_or_generic()` for type-safe `diff()`.
  - `generate_profile_from_node()` accepts `NodeSchema | GenericSchema`; replaced assertions with conditional checks.
  - `duplicate(name=None)` falls back to `self.name`; removed `arg-type` from mypy overrides in `pyproject.toml`.

- **Bug Fixes**
  - Guarded `add_hierarchy_node` to skip creating parent/children relationships when peers are `None`.

<sup>Written for commit 71b0f018196ce1cd0ffdaa0b81c14d2f9c37a085. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub/pull/9343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

