### PR TITLE
IFC-2113: Fix failure when removing a profile with a many relationship and overriding with same peers

### DIFF
--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1210,7 +1210,7 @@ class RelationshipManager:
                 return rel
         return None
 
-    async def update(
+    async def update(  # noqa: PLR0915
         self,
         data: list[str | Node | dict[str, Any] | PeerWithRelationshipMetadata]
         | dict[str, Any]
@@ -1251,7 +1251,11 @@ class RelationshipManager:
             if hasattr(item, "_schema"):
                 item_id = getattr(item, "id", None)
                 if item_id and item_id in previous_relationships:
-                    self._relationships.append(previous_relationships[str(item_id)])
+                    rel = previous_relationships[str(item_id)]
+                    if rel.is_from_profile:
+                        rel.is_from_profile = False
+                        rel.clear_source()
+                    self._relationships.append(rel)
                     continue
 
             if item is None:
@@ -1263,7 +1267,11 @@ class RelationshipManager:
                 continue
 
             if isinstance(item, str) and item in previous_relationships:
-                self._relationships.append(previous_relationships[item])
+                rel = previous_relationships[item]
+                if rel.is_from_profile:
+                    rel.is_from_profile = False
+                    rel.clear_source()
+                self._relationships.append(rel)
                 continue
 
             if isinstance(item, dict) and item.get("id", None) in previous_relationships:
@@ -1272,6 +1280,9 @@ class RelationshipManager:
                 rel.load(data=item, db=db)
                 if hash(rel) != hash_before:
                     changed = True
+                if rel.is_from_profile:
+                    rel.is_from_profile = False
+                    rel.clear_source()
                 self._relationships.append(rel)
                 continue
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1210,7 +1210,7 @@ class RelationshipManager:
                 return rel
         return None
 
-    async def update(  # noqa: PLR0915
+    async def update(
         self,
         data: list[str | Node | dict[str, Any] | PeerWithRelationshipMetadata]
         | dict[str, Any]
@@ -1243,60 +1243,14 @@ class RelationshipManager:
         changed = False
 
         for item in list_data:
-            if not isinstance(
-                item, self.rel_class | str | dict | type(None) | PeerWithRelationshipMetadata
-            ) and not hasattr(item, "_schema"):
-                raise ValidationError({self.name: f"Invalid data provided to form a relationship {item}"})
-
-            if hasattr(item, "_schema"):
-                item_id = getattr(item, "id", None)
-                if item_id and item_id in previous_relationships:
-                    rel = previous_relationships[str(item_id)]
-                    if rel.is_from_profile:
-                        rel.is_from_profile = False
-                        rel.clear_source()
-                    self._relationships.append(rel)
-                    continue
-
-            if item is None:
-                if previous_relationships:
-                    if process_delete:
-                        for rel in previous_relationships.values():
-                            await rel.delete(db=db, at=update_at, user_id=user_id)
-                    changed = True
-                continue
-
-            if isinstance(item, str) and item in previous_relationships:
-                rel = previous_relationships[item]
-                if rel.is_from_profile:
-                    rel.is_from_profile = False
-                    rel.clear_source()
-                self._relationships.append(rel)
-                continue
-
-            if isinstance(item, dict) and item.get("id", None) in previous_relationships:
-                rel = previous_relationships[item["id"]]
-                hash_before = hash(rel)
-                rel.load(data=item, db=db)
-                if hash(rel) != hash_before:
-                    changed = True
-                if rel.is_from_profile:
-                    rel.is_from_profile = False
-                    rel.clear_source()
-                self._relationships.append(rel)
-                continue
-
-            # If the item is not present in the previous list of relationship, we create a new one.
-            self._relationships.append(
-                await self.rel_class(
-                    schema=self.schema,
-                    branch=self.branch,
-                    source_kind=self.node.get_kind(),
-                    at=update_at,
-                    node=self.node,
-                ).new(db=db, data=item)
+            changed |= await self._process_update_item(
+                db=db,
+                item=item,
+                previous_relationships=previous_relationships,
+                update_at=update_at,
+                process_delete=process_delete,
+                user_id=user_id,
             )
-            changed = True
 
         # Check if some relationship got removed by checking if the previous list of relationship is a subset of the current list of not
         if set(previous_relationships.keys()) <= {rel.peer_id for rel in await self.get_relationships(db=db)}:
@@ -1306,6 +1260,77 @@ class RelationshipManager:
             self._relationships.validate()
 
         return changed
+
+    def _detach_profile_source(self, rel: Relationship) -> None:
+        """A peer explicitly provided by the user is no longer sourced from a profile."""
+        if rel.is_from_profile:
+            rel.is_from_profile = False
+            rel.clear_source()
+
+    async def _process_update_item(
+        self,
+        db: InfrahubDatabase,
+        item: str | Node | dict[str, Any] | PeerWithRelationshipMetadata | None,
+        previous_relationships: dict[str, Relationship],
+        update_at: Timestamp,
+        process_delete: bool,
+        user_id: str,
+    ) -> bool:
+        """Process a single item from update()'s input, appending to self._relationships as needed.
+
+        Returns True if the item represents a change to the relationship set.
+
+        Raises:
+            ValidationError: When the supplied data cannot form a valid relationship.
+
+        """
+        if not isinstance(
+            item, self.rel_class | str | dict | type(None) | PeerWithRelationshipMetadata
+        ) and not hasattr(item, "_schema"):
+            raise ValidationError({self.name: f"Invalid data provided to form a relationship {item}"})
+
+        if hasattr(item, "_schema"):
+            item_id = getattr(item, "id", None)
+            if item_id and item_id in previous_relationships:
+                rel = previous_relationships[str(item_id)]
+                self._detach_profile_source(rel)
+                self._relationships.append(rel)
+                return False
+
+        if item is None:
+            if previous_relationships:
+                if process_delete:
+                    for rel in previous_relationships.values():
+                        await rel.delete(db=db, at=update_at, user_id=user_id)
+                return True
+            return False
+
+        if isinstance(item, str) and item in previous_relationships:
+            rel = previous_relationships[item]
+            self._detach_profile_source(rel)
+            self._relationships.append(rel)
+            return False
+
+        if isinstance(item, dict) and item.get("id", None) in previous_relationships:
+            rel = previous_relationships[item["id"]]
+            hash_before = hash(rel)
+            rel.load(data=item, db=db)
+            changed = hash(rel) != hash_before
+            self._detach_profile_source(rel)
+            self._relationships.append(rel)
+            return changed
+
+        # If the item is not present in the previous list of relationship, we create a new one.
+        self._relationships.append(
+            await self.rel_class(
+                schema=self.schema,
+                branch=self.branch,
+                source_kind=self.node.get_kind(),
+                at=update_at,
+                node=self.node,
+            ).new(db=db, data=item)
+        )
+        return True
 
     async def add(self, data: dict[str, Any] | Node, db: InfrahubDatabase) -> bool:
         """Add a new relationship to the list of existing ones, avoid duplication.
@@ -1495,6 +1520,9 @@ class RelationshipManager:
         is_changed = False
         len_rels_to_remove = len(relationships_to_remove)
         len_rels_to_insert = len(relationships_to_insert)
+
+        if not len_rels_to_remove and not len_rels_to_insert:
+            return False
 
         if len_rels_to_remove and not len_rels_to_insert:
             for rel_to_remove in relationships_to_remove:

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -107,6 +107,7 @@ class RelationshipAdd(Mutation):
 
         async with graphql_context.db.start_transaction() as db:
             peers: list[EventNode] = []
+            relationship_modified = False
             for node_data in data.get("nodes"):
                 # Instantiate and resolve a relationship
                 # This will take care of allocating a node from a pool if needed
@@ -121,13 +122,21 @@ class RelationshipAdd(Mutation):
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.create_relationship(relationship=rel)
                     await rel.save(db=db, user_id=graphql_context.assigned_user_id)
+                    relationship_modified = True
 
-            if relationship_name == "profiles":
-                await _apply_profiles(node=source, db=db, branch=graphql_context.branch)
-
-            if source.get_schema().is_profile_schema and relationship_name == "related_nodes":
-                for node in nodes.values():
-                    await _apply_profiles(node=node, db=db, branch=graphql_context.branch)
+            # peers that need to have their profile source cleared
+            profile_sourced_peers = [peer for peer in existing_peers.values() if peer.is_from_profile]
+            await _apply_profiles_after_relationship_change(
+                db=db,
+                branch=graphql_context.branch,
+                source=source,
+                related_peers=nodes,
+                relationship_name=relationship_name,
+                rel_schema=rel_schema,
+                relationship_modified=relationship_modified,
+                profile_sourced_peers=profile_sourced_peers,
+                user_id=graphql_context.assigned_user_id,
+            )
 
         if (
             graphql_context.background
@@ -244,6 +253,8 @@ class RelationshipRemove(Mutation):
 
         async with graphql_context.db.start_transaction() as db:
             peers: list[EventNode] = []
+            relationship_modified = False
+            removed_peer_ids: set[str] = set()
 
             for node_data in data.get("nodes"):
                 if node_data.get("id") in existing_peers.keys():
@@ -258,13 +269,26 @@ class RelationshipRemove(Mutation):
                         peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.delete_relationship(relationship=rel)
                     await rel.delete(db=db, user_id=graphql_context.assigned_user_id)
+                    removed_peer_ids.add(str(node_data.get("id")))
+                    relationship_modified = True
 
-            if relationship_name == "profiles":
-                await _apply_profiles(node=source, db=db, branch=graphql_context.branch)
-
-            if source.get_schema().is_profile_schema and relationship_name == "related_nodes":
-                for node in nodes.values():
-                    await _apply_profiles(node=node, db=db, branch=graphql_context.branch)
+            # remaining peers that need to have their profile source cleared
+            profile_sourced_peers = [
+                peer
+                for peer_id, peer in existing_peers.items()
+                if peer.is_from_profile and peer_id not in removed_peer_ids
+            ]
+            await _apply_profiles_after_relationship_change(
+                db=db,
+                branch=graphql_context.branch,
+                source=source,
+                related_peers=nodes,
+                relationship_name=relationship_name,
+                rel_schema=rel_schema,
+                relationship_modified=relationship_modified,
+                profile_sourced_peers=profile_sourced_peers,
+                user_id=graphql_context.assigned_user_id,
+            )
 
         if (
             graphql_context.background
@@ -479,12 +503,14 @@ async def _collect_current_peers(
     rel_schema = source_node.get_schema().get_relationship(name=relationship_name)
 
     # The nodes that are already present in the db
+    # include SOURCE metadata for handling profile-sourcing updates if necessary
     query = await RelationshipGetPeerQuery.init(
         db=graphql_context.db,
         source=source_node,
         rel=Relationship(
             schema=rel_schema, branch=graphql_context.branch, source_kind=source_node.get_kind(), node=source_node
         ),
+        include_metadata=MetadataOptions.SOURCE,
     )
     await query.execute(db=graphql_context.db)
     return {str(peer.peer_id): peer for peer in query.get_peers()}
@@ -537,3 +563,54 @@ async def _apply_profiles(node: Node, db: InfrahubDatabase, branch: Branch) -> N
     updated_fields = await node_profiles_applier.apply_profiles(node=refreshed_node)
     if updated_fields:
         await refreshed_node.save(db=db, fields=updated_fields)
+
+
+async def _detach_relationship_from_profiles(
+    db: InfrahubDatabase,
+    branch: Branch,
+    source: Node,
+    rel_schema: RelationshipSchema,
+    profile_sourced_peers: list[RelationshipPeerData],
+    user_id: str,
+) -> None:
+    """Detach a relationship from its profile by clearing the source from its profile-sourced peers.
+
+    A relationship is either entirely profile-sourced or entirely user-defined. A user modification to a
+    profile-sourced relationship turns it into a user-defined one: the peers are kept and only their
+    profile source is cleared (the relationships are not deleted).
+
+    The peers are passed in already loaded (with source metadata) by the caller so the relationships are
+    not re-read.
+    """
+    for peer_data in profile_sourced_peers:
+        rel = Relationship(schema=rel_schema, branch=branch, source_kind=source.get_kind(), node=source)
+        rel.load(db=db, data=peer_data)
+        rel.clear_source()
+        await rel.update(db=db, properties_to_update=["source"], data=peer_data, user_id=user_id)
+
+
+async def _apply_profiles_after_relationship_change(
+    db: InfrahubDatabase,
+    branch: Branch,
+    source: Node,
+    related_peers: dict[str, Node],
+    relationship_name: str,
+    rel_schema: RelationshipSchema,
+    relationship_modified: bool,
+    profile_sourced_peers: list[RelationshipPeerData],
+    user_id: str,
+) -> None:
+    if relationship_name == "profiles":
+        await _apply_profiles(node=source, db=db, branch=branch)
+    elif source.get_schema().is_profile_schema and relationship_name == "related_nodes":
+        for node in related_peers.values():
+            await _apply_profiles(node=node, db=db, branch=branch)
+    elif relationship_modified and rel_schema.support_profiles:
+        await _detach_relationship_from_profiles(
+            db=db,
+            branch=branch,
+            source=source,
+            rel_schema=rel_schema,
+            profile_sourced_peers=profile_sourced_peers,
+            user_id=user_id,
+        )

--- a/backend/infrahub/profiles/node_applier.py
+++ b/backend/infrahub/profiles/node_applier.py
@@ -194,6 +194,16 @@ class NodeProfilesApplier:
         await relationship_manager.delete(db=self.db)
 
     async def apply_profiles(self, node: Node) -> list[str]:
+        """Reconcile a node's profile-sourced attributes and relationships with its assigned profiles.
+
+        For each attribute and relationship that supports profiles, the highest-priority profile value
+        is applied, or a previously profile-sourced value is reset when no assigned profile supplies
+        one. Values the user has set directly are left untouched and take precedence over profiles.
+
+        Returns the names of the attributes and relationships that this method modified. Fields the
+        caller changed before calling this method are not reported unless applying profiles changed
+        them further; an empty list means nothing was modified here.
+        """
         profile_ids = await self._get_profile_ids(node=node)
         attr_names_for_profiles = await self._get_attr_names_for_profiles(node=node)
         rel_names_for_profiles = await self._get_rel_names_for_profiles(node=node)

--- a/backend/tests/component/core/profiles/test_node_applier.py
+++ b/backend/tests/component/core/profiles/test_node_applier.py
@@ -634,7 +634,6 @@ async def test_get_many_with_profile_relationships_override(
     )
 
 
-@pytest.mark.xfail(reason="Depending on how we override the peers, it may or may not work")
 async def test_get_many_with_profile_relationships_partial_override(
     db: InfrahubDatabase, branch: Branch, child_and_thing_nodes: ChildThingFixtures
 ) -> None:
@@ -676,21 +675,12 @@ async def test_get_many_with_profile_relationships_partial_override(
         ],
     )
 
-    # Removing the peers from the profile before adding them will work
-    # for thing in {child_and_thing_nodes.thing_nodes[0], child_and_thing_nodes.thing_nodes[1]}:
-    #    await updated_child_one.things.remove_locally(db=db, peer_id=thing.id)
-
-    # Override with a peer that is also in the profile, by adding them won't work
-    # for thing in {child_and_thing_nodes.thing_nodes[1], child_and_thing_nodes.thing_nodes[2]}:
-    #    await updated_child_one.things.add(db=db, data=thing)
-
-    # Updating by replacing all peers will work
     await updated_child_one.things.update(
         db=db, data=[child_and_thing_nodes.thing_nodes[1], child_and_thing_nodes.thing_nodes[2]]
     )
 
     updated_field_names = await node_applier.apply_profiles(node=updated_child_one)
-    assert updated_field_names == ["things"]
+    assert updated_field_names == []
     await updated_child_one.save(db=db)
 
     node_map = await NodeManager.get_many(

--- a/backend/tests/component/core/profiles/test_node_applier.py
+++ b/backend/tests/component/core/profiles/test_node_applier.py
@@ -257,8 +257,10 @@ async def _validate_node_profile_relationships(
 
         if expected_profile_relationship:
             assert {p.id for p in updated_peers} == {p.id for p in expected_profile_relationship.peers}
-            if expected_profile_relationship.source_uuid or updated_source:
+            if expected_profile_relationship.source_uuid:
                 assert updated_source == {expected_profile_relationship.source_uuid}
+            else:
+                assert updated_source == set()
         else:
             assert {p.id for p in updated_peers} == {p.id for p in original_peers}
             assert updated_source == set()
@@ -647,7 +649,9 @@ async def test_get_many_with_profile_relationships_partial_override(
     )
     await augmented_child_profile.save(db=db)
 
-    await child_and_thing_nodes.child_nodes[0].profiles.update(db=db, data=[augmented_child_profile])
+    await (
+        child_and_thing_nodes.child_nodes[0].get_relationship("profiles").update(db=db, data=[augmented_child_profile])
+    )
     await child_and_thing_nodes.child_nodes[0].save(db=db)
 
     node_applier = NodeProfilesApplier(db=db, branch=branch)
@@ -675,11 +679,13 @@ async def test_get_many_with_profile_relationships_partial_override(
         ],
     )
 
-    await updated_child_one.things.update(
+    await updated_child_one.get_relationship("things").update(
         db=db, data=[child_and_thing_nodes.thing_nodes[1], child_and_thing_nodes.thing_nodes[2]]
     )
 
     updated_field_names = await node_applier.apply_profiles(node=updated_child_one)
+    # no profiles are applied: thing_nodes[1] is kept but de-sourced, thing_nodes[2] is added,
+    # and thing_nodes[0] is removed.
     assert updated_field_names == []
     await updated_child_one.save(db=db)
 

--- a/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
+++ b/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
@@ -1,0 +1,245 @@
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import MetadataOptions
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.core.schema import SchemaRoot
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.profiles.node_applier import NodeProfilesApplier
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from tests.helpers.graphql import graphql
+from tests.helpers.schema import CHILD, THING, load_schema
+
+# Object selection returning the `things` peers with their source and the assigned profiles. Used in
+# the mutation response so the source of each peer can be verified from the mutation itself.
+_OBJECT_WITH_SOURCES = """
+        object {
+            profiles { edges { node { id } } }
+            things {
+                edges {
+                    node { id }
+                    properties { source { id } }
+                }
+            }
+        }
+"""
+
+
+@dataclass
+class ThingsAndProfile:
+    profile_id: str
+    thing_ids: list[str]
+
+
+@dataclass
+class ChildState:
+    # Maps each `things` peer id to its source id, or None when the peer is not sourced from a profile.
+    thing_sources: dict[str, str | None]
+    profile_ids: set[str]
+
+
+async def _run_graphql(db: InfrahubDatabase, branch: Branch, query: str, variables: dict[str, Any]):
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    gql_params.context.service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
+    return await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values=variables,
+    )
+
+
+def _parse_child_state(node: dict[str, Any]) -> ChildState:
+    thing_sources = {
+        edge["node"]["id"]: (edge["properties"]["source"]["id"] if edge["properties"]["source"] else None)
+        for edge in node["things"]["edges"]
+    }
+    profile_ids = {edge["node"]["id"] for edge in node["profiles"]["edges"]}
+    return ChildState(thing_sources=thing_sources, profile_ids=profile_ids)
+
+
+async def _get_child_state_via_manager(db: InfrahubDatabase, branch: Branch, child_id: str) -> ChildState:
+    # prefetch_relationships loads the peers and their source metadata eagerly, so get_relationships()
+    # is served from cache and the source can be read from `source_id` without a per-peer query.
+    node = await NodeManager.get_one(
+        db=db,
+        branch=branch,
+        id=child_id,
+        include_metadata=MetadataOptions.SOURCE,
+        prefetch_relationships=True,
+    )
+    things_manager = node.get_relationship(name="things")
+    thing_sources: dict[str, str | None] = {}
+    for rel in await things_manager.get_relationships(db=db):
+        if not rel.peer_id:
+            continue
+        thing_sources[rel.peer_id] = str(rel.source_id) if rel.source_id else None
+    profiles_manager = node.get_relationship(name="profiles")
+    profile_ids = set((await profiles_manager.get_peers(db=db)).keys())
+    return ChildState(thing_sources=thing_sources, profile_ids=profile_ids)
+
+
+async def _verify_state(
+    db: InfrahubDatabase, branch: Branch, child_id: str, mutation_object: dict[str, Any], expected: ChildState
+) -> None:
+    # The mutation response carries the resulting peers and their sources.
+    assert _parse_child_state(mutation_object) == expected
+    # The database matches what the mutation reported.
+    assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == expected
+
+
+class TestProfileRelationshipOverride:
+    @pytest.fixture(scope="class")
+    async def things_and_profile(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        data_schema_scope_class: None,
+        register_core_models_schema_scope_class: None,
+    ) -> ThingsAndProfile:
+        branch = default_branch_scope_class
+        thing_copy = copy.deepcopy(THING)
+        thing_copy.relationships[0].optional = True
+        await load_schema(db=db, schema=SchemaRoot(nodes=[CHILD, thing_copy]), branch_name=branch.name)
+
+        thing_node_schema = registry.schema.get_node_schema(name=THING.kind, branch=branch, duplicate=False)
+        thing_ids: list[str] = []
+        for name, color in [("Eye cover", "black"), ("Cybernetic arms", "black"), ("Pearl necklace", "white")]:
+            thing = await Node.init(db=db, branch=branch, schema=thing_node_schema)
+            await thing.new(db=db, name=name, color=color)
+            await thing.save(db=db)
+            thing_ids.append(thing.id)
+
+        profile_schema = registry.schema.get_profile_schema(name=f"Profile{CHILD.kind}", branch=branch, duplicate=False)
+        profile = await Node.init(db=db, branch=branch, schema=profile_schema)
+        await profile.new(db=db, profile_name="augmented", things=[thing_ids[0], thing_ids[1]], profile_priority=100)
+        await profile.save(db=db)
+
+        return ThingsAndProfile(profile_id=profile.id, thing_ids=thing_ids)
+
+    @pytest.fixture
+    async def child_id(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, things_and_profile: ThingsAndProfile
+    ) -> str:
+        branch = default_branch_scope_class
+        child_node_schema = registry.schema.get_node_schema(name=CHILD.kind, branch=branch, duplicate=False)
+        child = await Node.init(db=db, branch=branch, schema=child_node_schema)
+        await child.new(db=db, name="adam", profiles=[things_and_profile.profile_id])
+        await child.save(db=db)
+        applier = NodeProfilesApplier(db=db, branch=branch)
+        await applier.apply_profiles(node=child)
+        await child.save(db=db)
+
+        # The profile sources both of its peers onto the new node
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child.id) == ChildState(
+            thing_sources={
+                things_and_profile.thing_ids[0]: things_and_profile.profile_id,
+                things_and_profile.thing_ids[1]: things_and_profile.profile_id,
+            },
+            profile_ids={things_and_profile.profile_id},
+        )
+
+        return child.id
+
+    async def test_update_remove_profile_and_readd_profile_sourced_peer(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        things_and_profile: ThingsAndProfile,
+        child_id: str,
+    ) -> None:
+        branch = default_branch_scope_class
+        kept_peer = things_and_profile.thing_ids[0]
+
+        # Remove the profile and explicitly set the relationship to a peer the profile used to source.
+        update = (
+            """
+        mutation UpdateChild($child_id: String!, $thing_id: String!) {
+            TestingChildUpdate(data: {
+                id: $child_id,
+                profiles: [],
+                things: [{ id: $thing_id }],
+            }) {
+                ok
+        """
+            + _OBJECT_WITH_SOURCES
+            + """
+            }
+        }
+        """
+        )
+        result = await _run_graphql(
+            db=db, branch=branch, query=update, variables={"child_id": child_id, "thing_id": kept_peer}
+        )
+        assert result.errors is None
+        assert result.data
+        assert result.data["TestingChildUpdate"]["ok"] is True
+
+        # The peer is retained (not deleted with the profile) and is now user-owned with no source.
+        await _verify_state(
+            db=db,
+            branch=branch,
+            child_id=child_id,
+            mutation_object=result.data["TestingChildUpdate"]["object"],
+            expected=ChildState(thing_sources={kept_peer: None}, profile_ids=set()),
+        )
+
+    async def test_update_relationships_mixed_keep_profile(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        things_and_profile: ThingsAndProfile,
+        child_id: str,
+    ) -> None:
+        branch = default_branch_scope_class
+        profile_peer = things_and_profile.thing_ids[0]
+        non_profile_peer = things_and_profile.thing_ids[2]
+
+        # Override the relationship with a mix of a profile-sourced peer and a new peer, leaving the
+        # profile assigned to the node.
+        update = (
+            """
+        mutation UpdateChild($child_id: String!, $profile_peer: String!, $non_profile_peer: String!) {
+            TestingChildUpdate(data: {
+                id: $child_id,
+                things: [{ id: $profile_peer }, { id: $non_profile_peer }],
+            }) {
+                ok
+        """
+            + _OBJECT_WITH_SOURCES
+            + """
+            }
+        }
+        """
+        )
+        result = await _run_graphql(
+            db=db,
+            branch=branch,
+            query=update,
+            variables={"child_id": child_id, "profile_peer": profile_peer, "non_profile_peer": non_profile_peer},
+        )
+        assert result.errors is None
+        assert result.data
+        assert result.data["TestingChildUpdate"]["ok"] is True
+
+        # The overlapping profile peer is kept (not removed) but loses its source; the whole relationship
+        # is now user-owned even though the profile remains assigned.
+        await _verify_state(
+            db=db,
+            branch=branch,
+            child_id=child_id,
+            mutation_object=result.data["TestingChildUpdate"]["object"],
+            expected=ChildState(
+                thing_sources={profile_peer: None, non_profile_peer: None}, profile_ids={things_and_profile.profile_id}
+            ),
+        )

--- a/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
+++ b/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
@@ -100,18 +100,29 @@ async def _verify_state(
 
 class TestProfileRelationshipOverride:
     @pytest.fixture(scope="class")
-    async def things_and_profile(
+    async def child_thing_schema(
         self,
         db: InfrahubDatabase,
         default_branch_scope_class: Branch,
         data_schema_scope_class: None,
         register_core_models_schema_scope_class: None,
-    ) -> ThingsAndProfile:
-        branch = default_branch_scope_class
+    ) -> None:
         thing_copy = copy.deepcopy(THING)
         thing_copy.relationships[0].optional = True
-        await load_schema(db=db, schema=SchemaRoot(nodes=[CHILD, thing_copy]), branch_name=branch.name)
+        await load_schema(
+            db=db, schema=SchemaRoot(nodes=[CHILD, thing_copy]), branch_name=default_branch_scope_class.name
+        )
 
+    @pytest.fixture
+    async def things_and_profile(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        child_thing_schema: None,
+    ) -> ThingsAndProfile:
+        # Fresh peers per test: `TestingThing.owner` is cardinality one, so a thing cannot be owned by
+        # more than one child across tests sharing the same database.
+        branch = default_branch_scope_class
         thing_node_schema = registry.schema.get_node_schema(name=THING.kind, branch=branch, duplicate=False)
         thing_ids: list[str] = []
         for name, color in [("Eye cover", "black"), ("Cybernetic arms", "black"), ("Pearl necklace", "white")]:
@@ -242,4 +253,121 @@ class TestProfileRelationshipOverride:
             expected=ChildState(
                 thing_sources={profile_peer: None, non_profile_peer: None}, profile_ids={things_and_profile.profile_id}
             ),
+        )
+
+    async def test_relationship_add_new_peer_keeps_existing_profile_sources(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        things_and_profile: ThingsAndProfile,
+        child_id: str,
+    ) -> None:
+        """Tests that adding a new peer via RelationshipAdd does not affect the sources of existing peers
+
+        This does not need to remain the case. It is codified in this test to prevent it from unexpectedly changing
+        """
+        branch = default_branch_scope_class
+        existing_profile_peers = [things_and_profile.thing_ids[0], things_and_profile.thing_ids[1]]
+        new_peer = things_and_profile.thing_ids[2]
+
+        # Add a single new peer to the profile-sourced relationship.
+        add = """
+        mutation AddThing($child_id: String!, $thing_id: String!) {
+            RelationshipAdd(data: {
+                id: $child_id,
+                name: "things",
+                nodes: [{ id: $thing_id }],
+            }) {
+                ok
+            }
+        }
+        """
+        result = await _run_graphql(
+            db=db, branch=branch, query=add, variables={"child_id": child_id, "thing_id": new_peer}
+        )
+        assert result.errors is None
+        assert result.data
+        assert result.data["RelationshipAdd"]["ok"] is True
+
+        # RelationshipAdd does not re-apply profiles for an ordinary relationship: the pre-existing peers
+        # keep their profile source and only the newly-added peer is user-owned.
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == ChildState(
+            thing_sources={
+                existing_profile_peers[0]: things_and_profile.profile_id,
+                existing_profile_peers[1]: things_and_profile.profile_id,
+                new_peer: None,
+            },
+            profile_ids={things_and_profile.profile_id},
+        )
+
+    @pytest.mark.xfail(reason="Profile changes are not propagated to a mixed relationship; see docstring.", strict=True)
+    async def test_profile_change_propagates_to_mixed_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        things_and_profile: ThingsAndProfile,
+        child_id: str,
+    ) -> None:
+        """Profile changes should propagate to the profile-sourced portion of a mixed relationship.
+
+        A mixed relationship holds both profile-sourced and user-owned peers. When the profile drops
+        one of its peers, that peer should be removed from the node while the still-sourced peer and
+        the user-owned peer remain.
+
+        This currently fails: NodeProfilesApplier._get_rel_names_for_profiles
+        (backend/infrahub/profiles/node_applier.py) gates on the relationship-manager-level
+        `is_from_profile`, which RelationshipManager.fetch_relationship_ids
+        (backend/infrahub/core/relationship/model.py) computes as `all(peer.is_from_profile ...)`. A
+        mixed relationship therefore reports is_from_profile=False and is excluded from reconciliation,
+        so its profile-sourced peers are frozen and never updated or removed when the profile changes.
+        Fixing it requires either
+        - reconciling the profile-sourced portion per-peer instead of treating the
+        relationship as all-or-nothing
+        - or ensuring that relationship are either all profile-sourced or none of them are
+        """
+        branch = default_branch_scope_class
+        # thing_ids[1] is the profile peer that gets dropped from the profile below.
+        kept_profile_peer = things_and_profile.thing_ids[0]
+        user_peer = things_and_profile.thing_ids[2]
+
+        # Produce a mixed relationship: profile sources thing0 + thing1, user adds thing2.
+        add = """
+        mutation AddThing($child_id: String!, $thing_id: String!) {
+            RelationshipAdd(data: { id: $child_id, name: "things", nodes: [{ id: $thing_id }] }) { ok }
+        }
+        """
+        result = await _run_graphql(
+            db=db, branch=branch, query=add, variables={"child_id": child_id, "thing_id": user_peer}
+        )
+        assert result.errors is None
+
+        # Change the profile so it no longer sources thing1.
+        profile_update = """
+        mutation UpdateProfile($profile_id: String!, $thing_id: String!) {
+            ProfileTestingChildUpdate(data: { id: $profile_id, things: [{ id: $thing_id }] }) { ok }
+        }
+        """
+        result = await _run_graphql(
+            db=db,
+            branch=branch,
+            query=profile_update,
+            variables={"profile_id": things_and_profile.profile_id, "thing_id": kept_profile_peer},
+        )
+        assert result.errors is None
+
+        # Re-apply the profiles to the child. In production a Prefect automation does this when the
+        # profile changes; that automation does not run in component tests, so trigger it explicitly.
+        refresh = """
+        mutation RefreshProfiles($child_id: String!) {
+            InfrahubProfilesRefresh(data: { id: $child_id }) { ok }
+        }
+        """
+        result = await _run_graphql(db=db, branch=branch, query=refresh, variables={"child_id": child_id})
+        assert result.errors is None
+
+        # Desired behavior: the profile-sourced peer the profile dropped (thing1) is removed, the still-
+        # sourced peer (thing0) stays profile-sourced, and the user peer (thing2) is untouched.
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == ChildState(
+            thing_sources={kept_profile_peer: things_and_profile.profile_id, user_peer: None},
+            profile_ids={things_and_profile.profile_id},
         )

--- a/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
+++ b/backend/tests/component/graphql/profiles/test_mutation_relationship_override.py
@@ -32,11 +32,29 @@ _OBJECT_WITH_SOURCES = """
         }
 """
 
+_ADD_THING_MUTATION = """
+mutation AddThing($child_id: String!, $thing_id: String!) {
+    RelationshipAdd(data: { id: $child_id, name: "things", nodes: [{ id: $thing_id }] }) { ok }
+}
+"""
+
+_REMOVE_THING_MUTATION = """
+mutation RemoveThing($child_id: String!, $thing_id: String!) {
+    RelationshipRemove(data: { id: $child_id, name: "things", nodes: [{ id: $thing_id }] }) { ok }
+}
+"""
+
 
 @dataclass
 class ThingsAndProfile:
     profile_id: str
     thing_ids: list[str]
+
+
+@dataclass
+class ChildWithProfile:
+    child_id: str
+    things_and_profile: ThingsAndProfile
 
 
 @dataclass
@@ -98,6 +116,40 @@ async def _verify_state(
     assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == expected
 
 
+async def _build_child_with_profile(db: InfrahubDatabase, branch: Branch, name: str) -> ChildWithProfile:
+    """Create three things objects, a profile sourcing the first two, and a child with that profile applied."""
+    thing_node_schema = registry.schema.get_node_schema(name=THING.kind, branch=branch, duplicate=False)
+    thing_ids: list[str] = []
+    for thing_name, color in [(f"{name}_eye_cover", "black"), (f"{name}_arms", "black"), (f"{name}_necklace", "white")]:
+        thing = await Node.init(db=db, branch=branch, schema=thing_node_schema)
+        await thing.new(db=db, name=thing_name, color=color)
+        await thing.save(db=db)
+        thing_ids.append(thing.id)
+
+    profile_schema = registry.schema.get_profile_schema(name=f"Profile{CHILD.kind}", branch=branch, duplicate=False)
+    profile = await Node.init(db=db, branch=branch, schema=profile_schema)
+    await profile.new(db=db, profile_name=name, things=[thing_ids[0], thing_ids[1]], profile_priority=100)
+    await profile.save(db=db)
+
+    child_node_schema = registry.schema.get_node_schema(name=CHILD.kind, branch=branch, duplicate=False)
+    child = await Node.init(db=db, branch=branch, schema=child_node_schema)
+    await child.new(db=db, name=name, profiles=[profile.id])
+    await child.save(db=db)
+    applier = NodeProfilesApplier(db=db, branch=branch)
+    await applier.apply_profiles(node=child)
+    await child.save(db=db)
+
+    # Sanity check: the profile sources both of its peers onto the new node.
+    assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child.id) == ChildState(
+        thing_sources={thing_ids[0]: profile.id, thing_ids[1]: profile.id},
+        profile_ids={profile.id},
+    )
+
+    return ChildWithProfile(
+        child_id=child.id, things_and_profile=ThingsAndProfile(profile_id=profile.id, thing_ids=thing_ids)
+    )
+
+
 class TestProfileRelationshipOverride:
     @pytest.fixture(scope="class")
     async def child_thing_schema(
@@ -114,45 +166,22 @@ class TestProfileRelationshipOverride:
         )
 
     @pytest.fixture
-    async def things_and_profile(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        child_thing_schema: None,
-    ) -> ThingsAndProfile:
-        # Fresh peers per test: `TestingThing.owner` is cardinality one, so a thing cannot be owned by
-        # more than one child across tests sharing the same database.
-        branch = default_branch_scope_class
-        thing_node_schema = registry.schema.get_node_schema(name=THING.kind, branch=branch, duplicate=False)
-        thing_ids: list[str] = []
-        for name, color in [("Eye cover", "black"), ("Cybernetic arms", "black"), ("Pearl necklace", "white")]:
-            thing = await Node.init(db=db, branch=branch, schema=thing_node_schema)
-            await thing.new(db=db, name=name, color=color)
-            await thing.save(db=db)
-            thing_ids.append(thing.id)
+    async def child_with_profile(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_thing_schema: None
+    ) -> ChildWithProfile:
+        # Fresh data per test for tests that modify the relationship. `TestingThing.owner` is cardinality
+        # one, so each test needs its own thing nodes.
+        return await _build_child_with_profile(db=db, branch=default_branch_scope_class, name="augmented")
 
-        profile_schema = registry.schema.get_profile_schema(name=f"Profile{CHILD.kind}", branch=branch, duplicate=False)
-        profile = await Node.init(db=db, branch=branch, schema=profile_schema)
-        await profile.new(db=db, profile_name="augmented", things=[thing_ids[0], thing_ids[1]], profile_priority=100)
-        await profile.save(db=db)
+    @pytest.fixture(scope="class")
+    async def base_child_with_profile(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_thing_schema: None
+    ) -> ChildWithProfile:
+        # Built once for the whole class and shared by tests that do not alter state.
+        return await _build_child_with_profile(db=db, branch=default_branch_scope_class, name="base")
 
-        return ThingsAndProfile(profile_id=profile.id, thing_ids=thing_ids)
-
-    @pytest.fixture
-    async def child_id(
-        self, db: InfrahubDatabase, default_branch_scope_class: Branch, things_and_profile: ThingsAndProfile
-    ) -> str:
-        branch = default_branch_scope_class
-        child_node_schema = registry.schema.get_node_schema(name=CHILD.kind, branch=branch, duplicate=False)
-        child = await Node.init(db=db, branch=branch, schema=child_node_schema)
-        await child.new(db=db, name="adam", profiles=[things_and_profile.profile_id])
-        await child.save(db=db)
-        applier = NodeProfilesApplier(db=db, branch=branch)
-        await applier.apply_profiles(node=child)
-        await child.save(db=db)
-
-        # The profile sources both of its peers onto the new node
-        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child.id) == ChildState(
+    def _fully_sourced_state(self, things_and_profile: ThingsAndProfile) -> ChildState:
+        return ChildState(
             thing_sources={
                 things_and_profile.thing_ids[0]: things_and_profile.profile_id,
                 things_and_profile.thing_ids[1]: things_and_profile.profile_id,
@@ -160,17 +189,12 @@ class TestProfileRelationshipOverride:
             profile_ids={things_and_profile.profile_id},
         )
 
-        return child.id
-
     async def test_update_remove_profile_and_readd_profile_sourced_peer(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        things_and_profile: ThingsAndProfile,
-        child_id: str,
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_with_profile: ChildWithProfile
     ) -> None:
         branch = default_branch_scope_class
-        kept_peer = things_and_profile.thing_ids[0]
+        child_id = child_with_profile.child_id
+        kept_peer = child_with_profile.things_and_profile.thing_ids[0]
 
         # Remove the profile and explicitly set the relationship to a peer the profile used to source.
         update = (
@@ -206,13 +230,11 @@ class TestProfileRelationshipOverride:
         )
 
     async def test_update_relationships_mixed_keep_profile(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        things_and_profile: ThingsAndProfile,
-        child_id: str,
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_with_profile: ChildWithProfile
     ) -> None:
         branch = default_branch_scope_class
+        child_id = child_with_profile.child_id
+        things_and_profile = child_with_profile.things_and_profile
         profile_peer = things_and_profile.thing_ids[0]
         non_profile_peer = things_and_profile.thing_ids[2]
 
@@ -255,119 +277,129 @@ class TestProfileRelationshipOverride:
             ),
         )
 
-    async def test_relationship_add_new_peer_keeps_existing_profile_sources(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        things_and_profile: ThingsAndProfile,
-        child_id: str,
+    async def test_relationship_add_clears_profile_source(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_with_profile: ChildWithProfile
     ) -> None:
-        """Tests that adding a new peer via RelationshipAdd does not affect the sources of existing peers
+        """Adding a peer to a profile-sourced relationship makes the whole relationship user-defined.
 
-        This does not need to remain the case. It is codified in this test to prevent it from unexpectedly changing
+        A relationship is either entirely profile-sourced or entirely user-defined; modifying it via
+        RelationshipAdd clears the source of every peer from the profile.
         """
         branch = default_branch_scope_class
-        existing_profile_peers = [things_and_profile.thing_ids[0], things_and_profile.thing_ids[1]]
+        child_id = child_with_profile.child_id
+        things_and_profile = child_with_profile.things_and_profile
+        profile_peers = [things_and_profile.thing_ids[0], things_and_profile.thing_ids[1]]
         new_peer = things_and_profile.thing_ids[2]
 
-        # Add a single new peer to the profile-sourced relationship.
-        add = """
-        mutation AddThing($child_id: String!, $thing_id: String!) {
-            RelationshipAdd(data: {
-                id: $child_id,
-                name: "things",
-                nodes: [{ id: $thing_id }],
-            }) {
-                ok
-            }
-        }
-        """
         result = await _run_graphql(
-            db=db, branch=branch, query=add, variables={"child_id": child_id, "thing_id": new_peer}
+            db=db, branch=branch, query=_ADD_THING_MUTATION, variables={"child_id": child_id, "thing_id": new_peer}
         )
         assert result.errors is None
         assert result.data
         assert result.data["RelationshipAdd"]["ok"] is True
 
-        # RelationshipAdd does not re-apply profiles for an ordinary relationship: the pre-existing peers
-        # keep their profile source and only the newly-added peer is user-owned.
+        # Every peer is now user-defined; the profile stays assigned but no longer sources the relationship.
         assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == ChildState(
-            thing_sources={
-                existing_profile_peers[0]: things_and_profile.profile_id,
-                existing_profile_peers[1]: things_and_profile.profile_id,
-                new_peer: None,
-            },
+            thing_sources={profile_peers[0]: None, profile_peers[1]: None, new_peer: None},
             profile_ids={things_and_profile.profile_id},
         )
 
-    @pytest.mark.xfail(reason="Profile changes are not propagated to a mixed relationship; see docstring.", strict=True)
-    async def test_profile_change_propagates_to_mixed_relationship(
-        self,
-        db: InfrahubDatabase,
-        default_branch_scope_class: Branch,
-        things_and_profile: ThingsAndProfile,
-        child_id: str,
+    async def test_relationship_remove_clears_profile_source(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, child_with_profile: ChildWithProfile
     ) -> None:
-        """Profile changes should propagate to the profile-sourced portion of a mixed relationship.
+        """Removing a peer from a profile-sourced relationship makes the remaining peers user-defined.
 
-        A mixed relationship holds both profile-sourced and user-owned peers. When the profile drops
-        one of its peers, that peer should be removed from the node while the still-sourced peer and
-        the user-owned peer remain.
-
-        This currently fails: NodeProfilesApplier._get_rel_names_for_profiles
-        (backend/infrahub/profiles/node_applier.py) gates on the relationship-manager-level
-        `is_from_profile`, which RelationshipManager.fetch_relationship_ids
-        (backend/infrahub/core/relationship/model.py) computes as `all(peer.is_from_profile ...)`. A
-        mixed relationship therefore reports is_from_profile=False and is excluded from reconciliation,
-        so its profile-sourced peers are frozen and never updated or removed when the profile changes.
-        Fixing it requires either
-        - reconciling the profile-sourced portion per-peer instead of treating the
-        relationship as all-or-nothing
-        - or ensuring that relationship are either all profile-sourced or none of them are
+        A relationship is either entirely profile-sourced or entirely user-defined; modifying it via
+        RelationshipRemove detaches the surviving peers from the profile.
         """
         branch = default_branch_scope_class
-        # thing_ids[1] is the profile peer that gets dropped from the profile below.
-        kept_profile_peer = things_and_profile.thing_ids[0]
-        user_peer = things_and_profile.thing_ids[2]
+        child_id = child_with_profile.child_id
+        things_and_profile = child_with_profile.things_and_profile
+        removed_peer = things_and_profile.thing_ids[0]
+        remaining_peer = things_and_profile.thing_ids[1]
 
-        # Produce a mixed relationship: profile sources thing0 + thing1, user adds thing2.
-        add = """
-        mutation AddThing($child_id: String!, $thing_id: String!) {
-            RelationshipAdd(data: { id: $child_id, name: "things", nodes: [{ id: $thing_id }] }) { ok }
-        }
-        """
-        result = await _run_graphql(
-            db=db, branch=branch, query=add, variables={"child_id": child_id, "thing_id": user_peer}
-        )
-        assert result.errors is None
-
-        # Change the profile so it no longer sources thing1.
-        profile_update = """
-        mutation UpdateProfile($profile_id: String!, $thing_id: String!) {
-            ProfileTestingChildUpdate(data: { id: $profile_id, things: [{ id: $thing_id }] }) { ok }
-        }
-        """
         result = await _run_graphql(
             db=db,
             branch=branch,
-            query=profile_update,
-            variables={"profile_id": things_and_profile.profile_id, "thing_id": kept_profile_peer},
+            query=_REMOVE_THING_MUTATION,
+            variables={"child_id": child_id, "thing_id": removed_peer},
         )
         assert result.errors is None
+        assert result.data
+        assert result.data["RelationshipRemove"]["ok"] is True
 
-        # Re-apply the profiles to the child. In production a Prefect automation does this when the
-        # profile changes; that automation does not run in component tests, so trigger it explicitly.
-        refresh = """
-        mutation RefreshProfiles($child_id: String!) {
-            InfrahubProfilesRefresh(data: { id: $child_id }) { ok }
-        }
-        """
-        result = await _run_graphql(db=db, branch=branch, query=refresh, variables={"child_id": child_id})
-        assert result.errors is None
-
-        # Desired behavior: the profile-sourced peer the profile dropped (thing1) is removed, the still-
-        # sourced peer (thing0) stays profile-sourced, and the user peer (thing2) is untouched.
+        # The removed peer is gone and the surviving peer is now user-defined.
         assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == ChildState(
-            thing_sources={kept_profile_peer: things_and_profile.profile_id, user_peer: None},
+            thing_sources={remaining_peer: None},
             profile_ids={things_and_profile.profile_id},
+        )
+
+    async def test_failed_relationship_add_does_not_clear_profile_source(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, base_child_with_profile: ChildWithProfile
+    ) -> None:
+        """A failed RelationshipAdd must not clear the profile source.
+
+        Detaching happens inside the mutation transaction and after validation, so a mutation that
+        fails leaves the profile-sourced peers untouched.
+        """
+        branch = default_branch_scope_class
+        child_id = base_child_with_profile.child_id
+
+        # Adding a non-existent peer fails the whole mutation.
+        result = await _run_graphql(
+            db=db,
+            branch=branch,
+            query=_ADD_THING_MUTATION,
+            variables={"child_id": child_id, "thing_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert result.errors is not None
+
+        # The relationship is unchanged: both peers remain sourced from the profile.
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == self._fully_sourced_state(
+            base_child_with_profile.things_and_profile
+        )
+
+    async def test_failed_relationship_remove_does_not_clear_profile_source(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, base_child_with_profile: ChildWithProfile
+    ) -> None:
+        """A failed RelationshipRemove must not clear the profile source."""
+        branch = default_branch_scope_class
+        child_id = base_child_with_profile.child_id
+
+        result = await _run_graphql(
+            db=db,
+            branch=branch,
+            query=_REMOVE_THING_MUTATION,
+            variables={"child_id": child_id, "thing_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert result.errors is not None
+
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == self._fully_sourced_state(
+            base_child_with_profile.things_and_profile
+        )
+
+    async def test_relationship_add_existing_peer_does_not_clear_profile_source(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, base_child_with_profile: ChildWithProfile
+    ) -> None:
+        """Re-adding a peer that is already present is a no-op and must not clear the profile source.
+
+        The source is only cleared when the relationship is actually modified.
+        """
+        branch = default_branch_scope_class
+        child_id = base_child_with_profile.child_id
+        existing_profile_peer = base_child_with_profile.things_and_profile.thing_ids[0]
+
+        result = await _run_graphql(
+            db=db,
+            branch=branch,
+            query=_ADD_THING_MUTATION,
+            variables={"child_id": child_id, "thing_id": existing_profile_peer},
+        )
+        assert result.errors is None
+        assert result.data
+        assert result.data["RelationshipAdd"]["ok"] is True
+
+        # Nothing was added, so the relationship still has both peers sourced from the profile.
+        assert await _get_child_state_via_manager(db=db, branch=branch, child_id=child_id) == self._fully_sourced_state(
+            base_child_with_profile.things_and_profile
         )

--- a/changelog/+ff501817.fixed.md
+++ b/changelog/+ff501817.fixed.md
@@ -1,0 +1,1 @@
+Update RelationshipAdd and RelationshipRemove GraphQL mutations so that they properly remove the profile sourcing of all peers on an updated relationship if that relationship is sourced from a profile.

--- a/changelog/+profile-many-relationship-override.fixed.md
+++ b/changelog/+profile-many-relationship-override.fixed.md
@@ -1,0 +1,1 @@
+Fixed overriding a node relationship that was set by a profile. Peers also provided by the profile are no longer removed when overriding the relationship; they are kept and become node-defined values.

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -93,9 +93,18 @@ When updating relationships, the manager compares new data against existing rela
 1. Fetch current relationships from DB -> `previous_relationships` dict (keyed by `peer_id`)
 2. Clear `_relationships` list
 3. For each new item:
-   - **UUID match** (string or dict with `"id"`): Reuse existing `Relationship` object from `previous_relationships`
+   - **UUID match** (string or dict with `"id"`): Reuse existing `Relationship` object from `previous_relationships`. If that peer was sourced from a Profile, its source is cleared (`is_from_profile = False`, `clear_source()`) — see "Profile-sourced relationships" below.
    - **No match** (HFID, default_filter, new UUID): Create new `Relationship` via `.new()`
 4. Mark as changed if the set of peers differs
+
+### Profile-sourced relationships
+
+A relationship's peers are all-or-nothing with respect to Profile sourcing: either every peer is sourced from a Profile or none are. Any user modification to a Profile-sourced relationship turns the whole relationship into a user-defined one, with the peers kept but their Profile source cleared:
+
+- `RelationshipManager.update()` clears the source from reused peers (above), so an object update detaches the relationship from its Profile.
+- The `RelationshipAdd` and `RelationshipRemove` GraphQL mutations call `_detach_relationship_from_profiles()` after a successful, modifying change to clear the source from the surviving peers. `_collect_current_peers()` requests `MetadataOptions.SOURCE` so those peers can be identified without re-reading the relationship. A failed or no-op mutation leaves the sourcing untouched (the detach runs inside the mutation transaction, after validation).
+
+`NodeProfilesApplier` then treats such a relationship as user-defined and does not re-apply Profile peers to it.
 
 ### UUID vs HFID References
 

--- a/docs/docs/profiles/override-values.mdx
+++ b/docs/docs/profiles/override-values.mdx
@@ -111,6 +111,74 @@ query {
 </TabItem>
 </Tabs>
 
+## Override a relationship
+
+Profiles can also source relationship values for both `one` and `many` cardinality relationships. Overriding a Profile-sourced relationship behaves differently from an attribute: a relationship is either **entirely** inherited from a Profile or **entirely** not. That is, all peers on a given relationship either share the same source Profile or none of the peers have a source Profile.
+
+As soon as you modify a Profile-sourced relationship on an object, by setting it explicitly or by adding or removing a peer, then all of the relationship's peers lose their Profile sourcing. Peers that the Profile also provided are kept (they are not deleted); only their Profile source is cleared. The Profile itself stays assigned to the object.
+
+<Tabs groupId="method" queryString>
+<TabItem value="web" label="Web interface">
+
+1. Open the object
+2. Click **Edit**
+3. Add or remove peers in the relationship field
+4. Click **Save**
+
+Every peer in the relationship is now object-defined; the Profile no longer sources it.
+
+</TabItem>
+<TabItem value="graphql" label="GraphQL">
+
+Set the relationship explicitly on the object to override it:
+
+```graphql
+mutation {
+  <Kind>Update(
+    data: {
+      hfid: ["<object-name>"]
+      <relationship>: [{ hfid: ["<peer-name>"] }]
+    }
+  ) {
+    ok
+  }
+}
+```
+
+Adding or removing a peer has the same effect, clearing the Profile-source from every peer:
+
+```graphql
+mutation {
+  RelationshipAdd(
+    data: { id: "<object-id>", name: "<relationship>", nodes: [{ id: "<peer-id>" }] }
+  ) {
+    ok
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+To confirm a relationship is no longer inherited, query the `source` metadata of its peers. An empty `source` means the peer is object-defined:
+
+```graphql
+query {
+  <Kind>(name__value: "<object-name>") {
+    edges {
+      node {
+        <relationship> {
+          edges {
+            node { id }
+            properties { source { id } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## How precedence works
 
 Explicit values on the object beat Profile values. When multiple Profiles also define the attribute, priority decides which Profile would have applied if no explicit value was set — see [Priority and inheritance](./priority-and-inheritance.mdx).

--- a/docs/docs/profiles/overview.mdx
+++ b/docs/docs/profiles/overview.mdx
@@ -133,7 +133,7 @@ Relationship inheritance in Profiles follows the same principles as attribute in
 
 2. **Priority-based resolution**: When multiple Profiles define the same relationship, the Profile with the highest priority (lowest priority number) takes precedence.
 
-3. **Override capability**: Like attributes, relationship values can be overridden on individual objects when exceptions are needed.
+3. **Override capability**: Like attributes, relationship peers can be overridden on individual objects when exceptions are needed. A relationship is overridden as a whole; modifying it on an object clears the Profile-source of every peer in the relationship (see [Override specific Profile values](./override-values.mdx)).
 
 4. **Metadata tracking**: Relationship values inherited from Profiles include metadata indicating their source, enabling full data lineage tracking.
 


### PR DESCRIPTION
# Why

### Issue 1

When a node's cardinality-many relationship is sourced from a profile (peers A, B, C) and the user saves an override containing a peer that also appears in the profile (e.g. [C, D, E]), peer C is silently dropped. Only D and E remain.

The root cause: `RelationshipManager.update()` reuses the existing `Relationship` object for C without clearing its `is_from_profile=True` flag. When `NodeProfilesApplier.apply_profiles()` runs immediately after (before `save()`), it sees C as profile-sourced and removes it because C is not in the set of user-set peers.

This PR clears `is_from_profile` and the source metadata on any reused relationship peer when the user explicitly includes it in their override.

### Issue 2

Updating a relationship via the `RelationshipAdd` or `RelationshipRemove` mutations left profile-sourcing untouched on the updated relationship. It was possible to add or remove a peer such that 
- the peers on the relationship no longer matched those defined on the profile
- some peers on the relationship had a source of a profile and some did not
both of these situations were unexpected

The fix is to update the two `RelationshipAdd/Remove` mutations so that they still add or remove a single peer AND also clear the profile sourcing on any remaining peers. This way we maintain both the invariants (Claude uses this word all the time and I think I am using it correctly here)
- either all peers on a given relationship have the same profile source or none of them have a profile source
- if any peer on a relationship has a profile source then the peers on the profile's relationship will match the peers on the local relationship

Closes IFC-2113 / IFC-2693

## What changed

### Issue 1 - overriding a profile-sourced relationship keeps the peers

- **`RelationshipManager.update()` now clears the profile source on reused peers.** When a peer from `previous_relationships` is included in the new override list, `is_from_profile` is set to `False` and `clear_source()` is called before it is re-appended to `_relationships` (applied in all reuse branches: node-object, string peer-ID, and dict). Previously the overlapping peer was wrongly removed; now it is kept and becomes a node-defined value. The per-item logic was extracted into `_process_update_item()` / `_detach_profile_source()` to keep `update()` readable.
- **`RelationshipManager.update_relationships()` returns early when there is nothing to add or remove**, so a no-op reconciliation no longer reports a spurious change.

### Issue 2 - `RelationshipAdd` / `RelationshipRemove` mutations

- **A user modification to a profile-sourced relationship now detaches the whole relationship from the profile.** `RelationshipAdd` and `RelationshipRemove` clear the profile source from every surviving peer when the relationship was profile-sourced and was actually modified. Peers are kept (not deleted) and the profile assignment itself is left in place; only the sourcing is removed. This makes the additive mutations consistent with the object `Update` override and preserves the invariant that a relationship's peers are either all profile-sourced or all user-defined.
- The detach runs **inside the mutation transaction and after validation**, so a failed or no-op mutation leaves the sourcing untouched.
- **`_collect_current_peers()` now requests `SOURCE` metadata** so callers can identify profile-sourced peers (and clear their source) from the already-loaded peer data, without re-reading the relationships.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [x] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content
