### PR TITLE
fix: prevent git task workers from diverging during sync fan-out (#9349)

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -969,6 +969,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
             repo = self.get_git_repo_worktree(identifier=branch_name)
             commit_after = str(repo.head.commit)
+            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
         else:
             raise ValueError(
                 f"Unable to identify the worktree for the branch : {branch_name} "

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -986,9 +986,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         else:
             raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}")
 
-        await self._update_commit_value_if_requested(
-            branch_name=branch_name, commit=commit_after, update_commit_value=update_commit_value
-        )
+        if update_commit_value:
+            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+            await self.update_commit_value(branch_name=infrahub_branch, commit=commit_after)
         return commit_after
 
     async def reset_to_commit(
@@ -998,7 +998,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         branch_id: str | None = None,
         create_if_missing: bool = False,
         update_commit_value: bool = True,
-    ) -> str:
+    ) -> None:
         """Hard-reset a branch worktree to a specific commit already present locally.
 
         The caller must have fetched the commit beforehand; this method does not
@@ -1008,9 +1008,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             ValueError: When no worktree exists for the branch and ``branch_id`` is not provided to create one.
 
         """
-        if not self.has_origin:
-            return commit
-
         repo = self._get_branch_worktree(branch_name)
         if repo is None:
             if not create_if_missing or not branch_id:
@@ -1026,10 +1023,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             await self._raise_enriched_error(error=exc, branch_name=branch_name)
 
         self.create_commit_worktree(commit=commit)
-        await self._update_commit_value_if_requested(
-            branch_name=branch_name, commit=commit, update_commit_value=update_commit_value
-        )
-        return commit
+
+        if update_commit_value:
+            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+            await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
 
     async def get_conflicts(self, source_branch: str, dest_branch: str) -> list[str]:
         repo = self.get_git_repo_worktree(identifier=dest_branch)

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -980,6 +980,54 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
         return commit_after
 
+    async def reset_to_commit(
+        self,
+        branch_name: str,
+        commit: str,
+        branch_id: str | None = None,
+        create_if_missing: bool = False,
+        update_commit_value: bool = True,
+    ) -> str:
+        """Hard-reset a branch worktree to a specific commit already present locally.
+
+        The caller must have fetched the commit beforehand; this method does not
+        contact the remote.
+
+        Raises:
+            ValueError: When no worktree exists for the branch and ``branch_id`` is not provided to create one.
+
+        """
+        if not self.has_origin:
+            return commit
+
+        identifier = branch_name
+        if branch_name == self.default_branch and branch_name != registry.default_branch:
+            identifier = "main"
+
+        try:
+            repo = self.get_git_repo_worktree(identifier=identifier)
+        except RepositoryError as exc:
+            if not create_if_missing or not branch_id:
+                raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}") from exc
+            await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
+            repo = self.get_git_repo_worktree(identifier=branch_name)
+
+        # Hard reset, not merge: the worktree is a disposable mirror of the remote, so we
+        # force it onto the requested commit and intentionally drop any local divergence.
+        # Convergence on this exact SHA is the goal; a fast-forward could land elsewhere.
+        try:
+            repo.git.reset("--hard", commit)
+        except GitCommandError as exc:
+            await self._raise_enriched_error(error=exc, branch_name=branch_name)
+
+        self.create_commit_worktree(commit=commit)
+        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+
+        if update_commit_value:
+            await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+
+        return commit
+
     async def get_conflicts(self, source_branch: str, dest_branch: str) -> list[str]:
         repo = self.get_git_repo_worktree(identifier=dest_branch)
         if not repo:

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -1133,6 +1133,15 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         if "error: pathspec" in error.stderr:
             raise RepositoryInvalidBranchError(identifier=name, branch_name=branch_name, location=location) from error
 
+        if "reset" in (error.command or []) and "Could not parse object" in error.stderr:
+            raise RepositoryError(
+                identifier=name,
+                message=(
+                    f"Commit not found in the local clone of repository {name}; "
+                    "it may have been force-pushed or pruned upstream."
+                ),
+            ) from error
+
         if "SSL certificate problem" in error.stderr or "server certificate verification failed" in error.stderr:
             raise RepositoryConnectionError(
                 identifier=name, message=f"SSL verification failed for {name}, please validate the certificate chain."

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -924,6 +924,31 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
         return True
 
+    def _resolve_worktree_identifier(self, branch_name: str) -> str:
+        """Map a branch name to the identifier used to locate its worktree on disk."""
+        if branch_name == self.default_branch and branch_name != registry.default_branch:
+            return "main"
+        return branch_name
+
+    def _get_branch_worktree(self, branch_name: str) -> Repo | None:
+        """Return the existing worktree for a branch, or None when it has none yet."""
+        identifier = self._resolve_worktree_identifier(branch_name)
+        try:
+            return self.get_git_repo_worktree(identifier=identifier)
+        except RepositoryError:
+            return None
+
+    async def _create_branch_worktree(self, branch_name: str, branch_id: str) -> Repo:
+        """Create the branch in git and return its freshly created worktree."""
+        await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
+        return self.get_git_repo_worktree(identifier=branch_name)
+
+    async def _update_commit_value_if_requested(self, branch_name: str, commit: str, update_commit_value: bool) -> None:
+        if not update_commit_value:
+            return
+        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+        await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+
     async def pull(
         self,
         branch_name: str,
@@ -939,18 +964,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """
         if not self.has_origin:
             return False
-        identifier = branch_name
-        if branch_name == self.default_branch and branch_name != registry.default_branch:
-            identifier = "main"
 
-        repo: Repo | None = None
-        try:
-            repo = self.get_git_repo_worktree(identifier=identifier)
-        except RepositoryError as exc:
-            if not create_if_missing:
-                raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}") from exc
-
-        if repo:
+        repo = self._get_branch_worktree(branch_name)
+        if repo is not None:
             try:
                 commit_before = str(repo.head.commit)
                 repo.remotes.origin.pull(branch_name)
@@ -958,27 +974,21 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 await self._raise_enriched_error(error=exc, branch_name=branch_name)
 
             commit_after = str(repo.head.commit)
-
             if commit_after == commit_before:
                 return True
 
             self.create_commit_worktree(commit=commit_after)
-            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
-
-        elif branch_id:
-            await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
-            repo = self.get_git_repo_worktree(identifier=branch_name)
+        elif create_if_missing and branch_id:
+            # create_branch_in_git already syncs any matching remote branch, and a local-only
+            # branch has no upstream ref to pull from, so skip the fast-forward here.
+            repo = await self._create_branch_worktree(branch_name, branch_id)
             commit_after = str(repo.head.commit)
-            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
         else:
-            raise ValueError(
-                f"Unable to identify the worktree for the branch : {branch_name} "
-                "and unable to pull the branch because the branch)id is missing"
-            )
+            raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}")
 
-        if update_commit_value:
-            await self.update_commit_value(branch_name=infrahub_branch, commit=commit_after)
-
+        await self._update_commit_value_if_requested(
+            branch_name=branch_name, commit=commit_after, update_commit_value=update_commit_value
+        )
         return commit_after
 
     async def reset_to_commit(
@@ -1001,17 +1011,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         if not self.has_origin:
             return commit
 
-        identifier = branch_name
-        if branch_name == self.default_branch and branch_name != registry.default_branch:
-            identifier = "main"
-
-        try:
-            repo = self.get_git_repo_worktree(identifier=identifier)
-        except RepositoryError as exc:
+        repo = self._get_branch_worktree(branch_name)
+        if repo is None:
             if not create_if_missing or not branch_id:
-                raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}") from exc
-            await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
-            repo = self.get_git_repo_worktree(identifier=branch_name)
+                raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}")
+            repo = await self._create_branch_worktree(branch_name, branch_id)
 
         # Hard reset, not merge: the worktree is a disposable mirror of the remote, so we
         # force it onto the requested commit and intentionally drop any local divergence.
@@ -1022,11 +1026,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             await self._raise_enriched_error(error=exc, branch_name=branch_name)
 
         self.create_commit_worktree(commit=commit)
-        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
-
-        if update_commit_value:
-            await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
-
+        await self._update_commit_value_if_requested(
+            branch_name=branch_name, commit=commit, update_commit_value=update_commit_value
+        )
         return commit
 
     async def get_conflicts(self, source_branch: str, dest_branch: str) -> list[str]:

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -943,12 +943,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
         return self.get_git_repo_worktree(identifier=branch_name)
 
-    async def _update_commit_value_if_requested(self, branch_name: str, commit: str, update_commit_value: bool) -> None:
-        if not update_commit_value:
-            return
-        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
-        await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
-
     async def pull(
         self,
         branch_name: str,

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -154,7 +154,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
                 location=model.location,
                 repository_id=model.repository_id,
                 repository_name=model.repository_name,
-                repository_kind=InfrahubKind.REPOSITORY,
+                repository_kind=InfrahubKind.READONLYREPOSITORY,
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
                 commit=pinned_commit,

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from git.exc import GitError
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.protocols import (
     CoreArtifact,
@@ -303,7 +304,13 @@ async def sync_remote_repositories() -> None:
                     staging_branch=staging_branch,
                     infrahub_branch=infrahub_branch,
                 )
-                # Tell workers to fetch to stay in sync
+                try:
+                    pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
+                except (ValueError, GitError) as exc:
+                    log.debug(f"Could not resolve pinned commit for {repo_name}, workers will fall back to pull: {exc}")
+                    pinned_commit = None
+                # Tell workers to fetch and check out the SHA pinned by this sync, so the whole
+                # pool converges on the same commit even if upstream advances during fan-out.
                 message = messages.RefreshGitFetch(
                     meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
                     location=repository.location.value,
@@ -312,6 +319,7 @@ async def sync_remote_repositories() -> None:
                     repository_kind=repository.get_kind(),
                     infrahub_branch_name=infrahub_branch,
                     infrahub_branch_id=branches[infrahub_branch].id,
+                    commit=pinned_commit,
                 )
                 message_bus = await get_message_bus()
                 await message_bus.send(message=message)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -587,10 +587,17 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
                 infrahub_branch_name=model.infrahub_branch_name,
             )
 
-        await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)  # type: ignore[call-overload]
-        await repo.sync_from_remote(commit=model.commit)
+        # Resolve the ref to a concrete commit once so the sync and the broadcast share the same
+        # SHA. model.commit may be None for a ref-only pull, in which case broadcasting it would
+        # leave workers to re-resolve the ref independently and diverge.
+        pinned_commit = model.commit
+        if pinned_commit is None and repo.ref:
+            pinned_commit = repo.get_commit_value(branch_name=repo.ref, remote=True)
 
-        # Tell workers to fetch to stay in sync
+        await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=pinned_commit)  # type: ignore[call-overload]
+        await repo.sync_from_remote(commit=pinned_commit)
+
+        # Tell workers to fetch and check out the resolved commit to stay in sync
         message = messages.RefreshGitFetch(
             meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
             location=model.location,
@@ -599,7 +606,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
             repository_kind=InfrahubKind.READONLYREPOSITORY,
             infrahub_branch_name=model.infrahub_branch_name,
             infrahub_branch_id=model.infrahub_branch_id,
-            commit=model.commit,
+            commit=pinned_commit,
         )
         message_bus = await get_message_bus()
         await message_bus.send(message=message)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from git.exc import GitError
+from git.exc import InvalidGitRepositoryError
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.protocols import (
     CoreArtifact,
@@ -105,7 +105,7 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
 
             try:
                 pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
-            except (ValueError, GitError):
+            except (ValueError, InvalidGitRepositoryError):
                 pinned_commit = None
             # Notify other workers they need to clone the repository and check out the SHA pinned
             # by this initial sync, so the whole pool converges even if upstream advances meanwhile.
@@ -312,7 +312,7 @@ async def sync_remote_repositories() -> None:
                 )
                 try:
                     pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
-                except (ValueError, GitError) as exc:
+                except (ValueError, InvalidGitRepositoryError) as exc:
                     log.debug(f"Could not resolve pinned commit for {repo_name}, workers will fall back to pull: {exc}")
                     pinned_commit = None
                 # Tell workers to fetch and check out the SHA pinned by this sync, so the whole

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -103,7 +103,12 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
         if model.internal_status == RepositoryInternalStatus.ACTIVE.value:
             await repo.sync()
 
-            # Notify other workers they need to clone the repository
+            try:
+                pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
+            except (ValueError, GitError):
+                pinned_commit = None
+            # Notify other workers they need to clone the repository and check out the SHA pinned
+            # by this initial sync, so the whole pool converges even if upstream advances meanwhile.
             notification = messages.RefreshGitFetch(
                 meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
                 location=model.location,
@@ -112,6 +117,7 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
                 repository_kind=InfrahubKind.REPOSITORY,
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
+                commit=pinned_commit,
             )
             message_bus = await get_message_bus()
             await message_bus.send(message=notification)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -587,6 +587,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
             repository_kind=InfrahubKind.READONLYREPOSITORY,
             infrahub_branch_name=model.infrahub_branch_name,
             infrahub_branch_id=model.infrahub_branch_id,
+            commit=model.commit,
         )
         message_bus = await get_message_bus()
         await message_bus.send(message=message)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -655,7 +655,14 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         async with lock.registry.get(name=model.repository_name, namespace="repository"):
             await repo.merge(source_branch=model.source_branch, dest_branch=model.destination_branch)
             if repo.location:
-                # Destination branch has changed and pushed remotely, tell workers to re-fetch
+                try:
+                    pinned_commit: str | None = repo.get_commit_value(
+                        branch_name=model.destination_branch, remote=False
+                    )
+                except (ValueError, InvalidGitRepositoryError):
+                    pinned_commit = None
+                # Destination branch has changed and pushed remotely, tell workers to re-fetch and
+                # check out the merge commit so the pool converges even if upstream advances meanwhile.
                 message = messages.RefreshGitFetch(
                     meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
                     location=repo.location,
@@ -664,6 +671,7 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
                     repository_kind=InfrahubKind.REPOSITORY,
                     infrahub_branch_name=model.destination_branch,
                     infrahub_branch_id=model.destination_branch_id,
+                    commit=pinned_commit,
                 )
                 message_bus = await get_message_bus()
                 await message_bus.send(message=message)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -141,9 +141,14 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
         )
         await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name)  # type: ignore[call-overload]
         if model.internal_status == RepositoryInternalStatus.ACTIVE.value:
-            await repo.sync_from_remote()
+            # Resolve the ref to a concrete commit once so the sync and the broadcast share the
+            # same SHA; broadcasting nothing would leave workers to re-resolve the ref and diverge.
+            pinned_commit: str | None = None
+            if repo.ref:
+                pinned_commit = repo.get_commit_value(branch_name=repo.ref, remote=True)
+            await repo.sync_from_remote(commit=pinned_commit)
 
-            # Notify other workers they need to clone the repository
+            # Notify other workers they need to clone the repository and check out the resolved commit
             notification = messages.RefreshGitFetch(
                 meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
                 location=model.location,
@@ -152,6 +157,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
                 repository_kind=InfrahubKind.REPOSITORY,
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
+                commit=pinned_commit,
             )
             message_bus = await get_message_bus()
             await message_bus.send(message=notification)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -355,7 +355,12 @@ async def git_branch_create(
     async with lock.registry.get(name=repository_name, namespace="repository"):
         await repo.create_branch_in_git(branch_name=branch, branch_id=branch_id, push_origin=True)
 
-        # New branch has been pushed remotely, tell workers to fetch it
+        try:
+            pinned_commit: str | None = repo.get_commit_value(branch_name=branch, remote=False)
+        except (ValueError, InvalidGitRepositoryError):
+            pinned_commit = None
+        # New branch has been pushed remotely, tell workers to fetch it and check out the SHA it
+        # was created at so the pool converges even if upstream advances during fan-out.
         message = messages.RefreshGitFetch(
             meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
             location=repo.get_location(),
@@ -364,6 +369,7 @@ async def git_branch_create(
             repository_kind=InfrahubKind.REPOSITORY,
             infrahub_branch_name=branch,
             infrahub_branch_id=branch_id,
+            commit=pinned_commit,
         )
         await message_bus.send(message=message)
         log.debug("Sent message to all workers to fetch the latest version of the repository (RefreshGitFetch)")

--- a/backend/infrahub/message_bus/messages/refresh_git_fetch.py
+++ b/backend/infrahub/message_bus/messages/refresh_git_fetch.py
@@ -12,3 +12,11 @@ class RefreshGitFetch(InfrahubMessage):
     repository_kind: str = Field(..., description="The type of repository")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
     infrahub_branch_id: str = Field(..., description="Id of the Infrahub branch on which to sync the remote repository")
+    commit: str | None = Field(
+        default=None,
+        description=(
+            "Commit SHA pinned by the sync orchestrator. When set, receiving workers check out this "
+            "exact commit instead of pulling whatever upstream HEAD currently is, ensuring all workers "
+            "in the pool converge on the same commit even if upstream advances during fan-out."
+        ),
+    )

--- a/backend/infrahub/message_bus/messages/refresh_git_fetch.py
+++ b/backend/infrahub/message_bus/messages/refresh_git_fetch.py
@@ -14,9 +14,5 @@ class RefreshGitFetch(InfrahubMessage):
     infrahub_branch_id: str = Field(..., description="Id of the Infrahub branch on which to sync the remote repository")
     commit: str | None = Field(
         default=None,
-        description=(
-            "Commit SHA pinned by the sync orchestrator. When set, receiving workers check out this "
-            "exact commit instead of pulling whatever upstream HEAD currently is, ensuring all workers "
-            "in the pool converge on the same commit even if upstream advances during fan-out."
-        ),
+        description="Commit SHA to check out, pinned by the sync orchestrator instead of pulling the latest upstream HEAD",
     )

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -1,5 +1,6 @@
 from prefect import flow
 
+from infrahub import lock
 from infrahub.exceptions import RepositoryError
 from infrahub.git.repository import InfrahubRepository, get_initialized_repo
 from infrahub.log import get_logger
@@ -46,12 +47,24 @@ async def fetch(message: messages.RefreshGitFetch) -> None:
     )
 
     await repo.fetch()
-    await repo.pull(
-        branch_name=message.infrahub_branch_name,
-        branch_id=message.infrahub_branch_id,
-        create_if_missing=True,
-        update_commit_value=False,
-    )
+    if message.commit:
+        # reset_to_commit hard-resets the worktree, which would silently discard a concurrent
+        # local change. Serialize it against the merges and syncs holding the same lock.
+        async with lock.registry.get(name=message.repository_name, namespace="repository"):
+            await repo.reset_to_commit(
+                branch_name=message.infrahub_branch_name,
+                commit=message.commit,
+                branch_id=message.infrahub_branch_id,
+                create_if_missing=True,
+                update_commit_value=False,
+            )
+    else:
+        await repo.pull(
+            branch_name=message.infrahub_branch_name,
+            branch_id=message.infrahub_branch_id,
+            create_if_missing=True,
+            update_commit_value=False,
+        )
 
 
 @flow(

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -48,8 +48,8 @@ async def fetch(message: messages.RefreshGitFetch) -> None:
 
     await repo.fetch()
     if message.commit:
-        # reset_to_commit hard-resets the worktree, which would silently discard a concurrent
-        # local change. Serialize it against the merges and syncs holding the same lock.
+        # Hold the repo lock so the hard reset doesn't interleave with other git
+        # operations on the same on-disk tree (merges, syncs, branch creation).
         async with lock.registry.get(name=message.repository_name, namespace="repository"):
             await repo.reset_to_commit(
                 branch_name=message.infrahub_branch_name,

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -46,11 +46,11 @@ async def fetch(message: messages.RefreshGitFetch) -> None:
         repository_kind=message.repository_kind,
     )
 
-    await repo.fetch()
-    if message.commit:
-        # Hold the repo lock so the hard reset doesn't interleave with other git
-        # operations on the same on-disk tree (merges, syncs, branch creation).
-        async with lock.registry.get(name=message.repository_name, namespace="repository"):
+    # Hold the repo lock so the hard reset doesn't interleave with other git
+    # operations on the same on-disk tree (merges, syncs, branch creation).
+    async with lock.registry.get(name=message.repository_name, namespace="repository"):
+        await repo.fetch()
+        if message.commit:
             await repo.reset_to_commit(
                 branch_name=message.infrahub_branch_name,
                 commit=message.commit,
@@ -58,13 +58,13 @@ async def fetch(message: messages.RefreshGitFetch) -> None:
                 create_if_missing=True,
                 update_commit_value=False,
             )
-    else:
-        await repo.pull(
-            branch_name=message.infrahub_branch_name,
-            branch_id=message.infrahub_branch_id,
-            create_if_missing=True,
-            update_commit_value=False,
-        )
+        else:
+            await repo.pull(
+                branch_name=message.infrahub_branch_name,
+                branch_id=message.infrahub_branch_id,
+                create_if_missing=True,
+                update_commit_value=False,
+            )
 
 
 @flow(

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -407,6 +407,23 @@ async def test_pull_new_branch(git_repo_01: InfrahubRepository) -> None:
     assert response is True
 
 
+async def test_pull_new_branch_updates_commit_value(git_repo_01: InfrahubRepository) -> None:
+    repo = git_repo_01
+    await repo.fetch()
+
+    branch_name = "branch02"
+
+    response = await repo.pull(
+        branch_name=branch_name,
+        branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
+        create_if_missing=True,
+        update_commit_value=True,
+    )
+
+    commit = repo.get_commit_value(branch_name=branch_name, remote=False)
+    assert response == commit
+
+
 async def test_pull_branch_conflict(git_repo_06: InfrahubRepository) -> None:
     repo = git_repo_06
     await repo.fetch()

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -270,7 +270,9 @@ class TestAddReadOnly:
         self.mock_repo.sync_from_remote.assert_awaited_once_with(commit="0123456789abcdef0123456789abcdef01234567")
 
         assert len(self.recorder.messages) > 0
-        assert isinstance(self.recorder.messages[0], RefreshGitFetch)
+        broadcast = self.recorder.messages[0]
+        assert isinstance(broadcast, RefreshGitFetch)
+        assert broadcast.repository_kind == InfrahubKind.READONLYREPOSITORY
 
 
 class TestPullReadOnly:

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -268,9 +268,7 @@ class TestAddReadOnly:
             infrahub_branch_name="read-only-branch",
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(infrahub_branch_name="read-only-branch")
-        self.mock_repo.sync_from_remote.assert_awaited_once_with(
-            commit="0123456789abcdef0123456789abcdef01234567"
-        )
+        self.mock_repo.sync_from_remote.assert_awaited_once_with(commit="0123456789abcdef0123456789abcdef01234567")
 
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -70,7 +70,6 @@ class TestAddRepository:
 
         with dependency_provider.scope(build_message_bus, lambda: self.recorder):
             self.mock_repo = AsyncMock(spec=InfrahubRepository)
-            self.mock_repo = AsyncMock(spec=InfrahubRepository)
             self.mock_repo.default_branch = self.default_branch_name
             self.mock_repo.infrahub_branch_name = self.default_branch_name
             self.mock_repo.internal_status = "active"

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -74,6 +74,7 @@ class TestAddRepository:
             self.mock_repo.default_branch = self.default_branch_name
             self.mock_repo.infrahub_branch_name = self.default_branch_name
             self.mock_repo.internal_status = "active"
+            self.mock_repo.get_commit_value.return_value = "0123456789abcdef0123456789abcdef01234567"
 
             yield
 
@@ -232,6 +233,8 @@ class TestAddReadOnly:
             repo_class_patcher = patch("infrahub.git.tasks.InfrahubReadOnlyRepository", spec=InfrahubReadOnlyRepository)
             self.mock_repo_class = repo_class_patcher.start()
             self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
+            self.mock_repo.ref = "branch01"
+            self.mock_repo.get_commit_value.return_value = "0123456789abcdef0123456789abcdef01234567"
             self.mock_repo_class.new.return_value = self.mock_repo
 
             yield
@@ -266,7 +269,9 @@ class TestAddReadOnly:
             infrahub_branch_name="read-only-branch",
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(infrahub_branch_name="read-only-branch")
-        self.mock_repo.sync_from_remote.assert_awaited_once_with()
+        self.mock_repo.sync_from_remote.assert_awaited_once_with(
+            commit="0123456789abcdef0123456789abcdef01234567"
+        )
 
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -74,7 +74,6 @@ class TestAddRepository:
             self.mock_repo.infrahub_branch_name = self.default_branch_name
             self.mock_repo.internal_status = "active"
             self.mock_repo.get_commit_value.return_value = "0123456789abcdef0123456789abcdef01234567"
-
             yield
 
             patch.stopall()

--- a/backend/tests/component/message_bus/operations/git/test_refresh_git_fetch.py
+++ b/backend/tests/component/message_bus/operations/git/test_refresh_git_fetch.py
@@ -7,6 +7,7 @@ from git import Repo
 from pytest_httpx import HTTPXMock
 
 from infrahub.core.constants import InfrahubKind
+from infrahub.exceptions import RepositoryError
 from infrahub.git import InfrahubRepository
 from infrahub.message_bus import messages
 from infrahub.message_bus.operations.git.repository import fetch
@@ -62,3 +63,44 @@ async def test_fan_out_pins_to_orchestrator_commit_when_upstream_advances(
 
     worktree = git_fixture_repo.get_git_repo_worktree(identifier=branch_name)
     assert str(worktree.head.commit) == pinned_sha
+
+
+@pytest.mark.httpx_mock(should_mock=lambda request: request.url.host == "mock")
+async def test_fan_out_raises_when_pinned_commit_unreachable(
+    git_fixture_repo: InfrahubRepository,
+    git_sources_dir: Path,
+    dependency_provider: Provider,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Worker must raise when the broadcasted SHA is not reachable after fetch."""
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"http://mock/graphql/.*"),
+        json={"data": {"CoreGenericRepositoryUpdate": {"ok": True}}},
+        is_reusable=True,
+        is_optional=True,
+    )
+
+    branch_name = "main"
+    branch_id = "8808dcea-f7b4-4f5a-b5e9-a0605d4c11ba"
+    unreachable_sha = "deadbeef" * 5
+
+    worktree_before = git_fixture_repo.get_git_repo_worktree(identifier=branch_name)
+    head_before = str(worktree_before.head.commit)
+
+    message = messages.RefreshGitFetch(
+        location=str(git_sources_dir / "test_base"),
+        repository_id=str(git_fixture_repo.id),
+        repository_name=git_fixture_repo.name,
+        repository_kind=InfrahubKind.REPOSITORY,
+        infrahub_branch_name=branch_name,
+        infrahub_branch_id=branch_id,
+        commit=unreachable_sha,
+    )
+
+    with dependency_provider.scope(build_client, lambda: git_fixture_repo.sdk):
+        with pytest.raises(RepositoryError, match=r"Commit not found in the local clone"):
+            await fetch.fn(message=message)
+
+    worktree_after = git_fixture_repo.get_git_repo_worktree(identifier=branch_name)
+    assert str(worktree_after.head.commit) == head_before

--- a/backend/tests/component/message_bus/operations/git/test_refresh_git_fetch.py
+++ b/backend/tests/component/message_bus/operations/git/test_refresh_git_fetch.py
@@ -1,0 +1,64 @@
+import re
+from pathlib import Path
+
+import pytest
+from fast_depends import Provider
+from git import Repo
+from pytest_httpx import HTTPXMock
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.git import InfrahubRepository
+from infrahub.message_bus import messages
+from infrahub.message_bus.operations.git.repository import fetch
+from infrahub.workers.dependencies import build_client
+
+
+@pytest.mark.httpx_mock(should_mock=lambda request: request.url.host == "mock")
+async def test_fan_out_pins_to_orchestrator_commit_when_upstream_advances(
+    git_fixture_repo: InfrahubRepository,
+    git_sources_dir: Path,
+    dependency_provider: Provider,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Fan-out workers must land on the SHA pinned by the sync orchestrator.
+
+    When upstream advances between the orchestrator pinning a SHA and a worker
+    processing the fan-out, the worker must check out the pinned SHA rather
+    than fast-forwarding to whatever upstream HEAD currently is.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"http://mock/graphql/.*"),
+        json={"data": {"CoreGenericRepositoryUpdate": {"ok": True}}},
+        is_reusable=True,
+        is_optional=True,
+    )
+
+    branch_name = "main"
+    branch_id = "8808dcea-f7b4-4f5a-b5e9-a0605d4c11ba"
+
+    upstream = Repo(str(git_sources_dir / "test_base"))
+    pinned_sha = str(upstream.head.commit)
+
+    new_file = git_sources_dir / "test_base" / "late_commit.txt"
+    new_file.write_text("upstream advanced after fan-out started", encoding="utf-8")
+    upstream.index.add(["late_commit.txt"])
+    upstream.index.commit("Upstream commit landed after fan-out started")
+    later_sha = str(upstream.head.commit)
+    assert pinned_sha != later_sha
+
+    message = messages.RefreshGitFetch(
+        location=str(git_sources_dir / "test_base"),
+        repository_id=str(git_fixture_repo.id),
+        repository_name=git_fixture_repo.name,
+        repository_kind=InfrahubKind.REPOSITORY,
+        infrahub_branch_name=branch_name,
+        infrahub_branch_id=branch_id,
+        commit=pinned_sha,
+    )
+
+    with dependency_provider.scope(build_client, lambda: git_fixture_repo.sdk):
+        await fetch.fn(message=message)
+
+    worktree = git_fixture_repo.get_git_repo_worktree(identifier=branch_name)
+    assert str(worktree.head.commit) == pinned_sha

--- a/changelog/+pull-new-branch-unbound-commit.fixed.md
+++ b/changelog/+pull-new-branch-unbound-commit.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash when pulling a git repository that had to create a missing local branch and record its commit value.

--- a/changelog/+readonly-repository-kind-broadcast.fixed.md
+++ b/changelog/+readonly-repository-kind-broadcast.fixed.md
@@ -1,0 +1,1 @@
+Fixed the read-only git repository add flow broadcasting the wrong repository kind, which caused peer workers to materialize the new repository as read-write instead of read-only.

--- a/changelog/9349.fixed.md
+++ b/changelog/9349.fixed.md
@@ -1,0 +1,1 @@
+Fixed git repository sync where multiple task workers could diverge on different commits if upstream advanced during fan-out.

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -79,6 +79,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **repository_kind** | The type of repository | string | None |
 | **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
 | **infrahub_branch_id** | Id of the Infrahub branch on which to sync the remote repository | string | None |
+| **commit** | Commit SHA to check out, pinned by the sync orchestrator instead of pulling the latest upstream HEAD | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event refresh.git.branch_deleted


### PR DESCRIPTION
## Why

In a multi-worker task pool, the git sync flow fans work out across workers. When a new upstream commit landed between the orchestrator resolving HEAD and the other workers running their own `git pull`, workers ended up on different commits for the same repo.

Goal: make every fan-out worker converge on the exact commit the orchestrator pinned, regardless of what lands upstream during fan-out.

This PR also carries a second, independent git fix (see below).

Closes #9349

## What changed

**Behavioral**

- The sync orchestrator now records the commit SHA it just synced and broadcasts it in `RefreshGitFetch`. Receiving workers check out that exact SHA instead of fast-forwarding to whatever upstream HEAD currently is.
- **Separate fix:** pulling a repository that had to create a *missing* local branch crashed when recording its commit value (an unbound `infrahub_branch`). The branch is now bound before the commit is written.

## How to review

A commit by commit approach would be relevant since there is:
- One commit for the initial bug fix 93e86ebfab0ef3b82b51be608cfe5c928a41b014 and one for the related test 7e2f13975564a1f6e54b4ef0a6f67f7965701eb7
- One commit for the collateral bug and related test 308110c5e8a738d7922a270214a4f2ee4bcbdba8
- One commit for the refactor 419ef910aa2e7c457d072416154a9f37955834a9

Following commits are unitary fix or similar issue using the new pinned commit, or documentation/lint/format matter.
Extra scrutiny welcome on the pin source per flow.

## How to test

```bash
# Divergence reproduction (fails before the fix, passes after)
uv run pytest backend/tests/component/message_bus/operations/git/test_refresh_git_fetch.py -x -v

# Missing-branch pull regression
uv run pytest backend/tests/component/git/test_git_repository.py -x -v
```

## Known follow-ups (intentionally out of scope)

- That read-only flow broadcasts `repository_kind=REPOSITORY` for a read-only repo. Worth confirming independently.

## Checklist

- [x] Tests added/updated
- [x] Changelog entries added (`9349.fixed.md`, `+pull-new-branch-unbound-commit.fixed.md`)
- [ ] External docs updated (no user-facing/ops-facing surface change)
- [ ] Internal .md docs updated (no knowledge-doc change needed)
- [x] I have reviewed AI generated content




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents git task workers from diverging during sync fan-out by pinning the orchestrator commit and hard-resetting to that SHA under the repo lock. Also fixes a crash when pulling a new branch, records commit values, broadcasts the correct kind for read-only adds, and improves errors when a pinned commit is unreachable; addresses IFC-2642.

- **Bug Fixes**
  - Added optional `commit` to `RefreshGitFetch`; workers fetch then hard-reset via `reset_to_commit` under the repo lock, falling back to pull when the pin is missing or can’t be resolved.
  - Applied pinning across periodic sync, repository add (read/write and read-only), branch create, merge, and read-only pull; ref-only read-only flows resolve a concrete SHA once and broadcast it.
  - Read-only add now broadcasts `repository_kind=READONLYREPOSITORY` so workers materialize the correct repo type.
  - Fixed missing-branch pull crash by binding the branch before writing its commit; commit value updates when a new local branch is created.
  - Clearer error when a pinned commit isn’t reachable after fetch; raises a descriptive `RepositoryError` and leaves the worktree unchanged; narrowed pin-resolution exceptions; added fan-out convergence and sad-path tests; updated RPC mocks and message-bus docs for the new `commit` field.

- **Refactors**
  - Removed unused `_update_commit_value_if_requested` helper.

<sup>Written for commit 472ad025467e1b18d7c14e4ee9f55781fd7729e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





