### PR TITLE
docs: add Infrahub Marketplace page

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -270,5 +270,8 @@ QRadar
 rsyslog
 sourcetype
 Splunk
+stderr
+stdin
+stdout
 syslog
 Syslog

--- a/docs/docs/deploy-manage/install-configure/install/community.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/community.mdx
@@ -307,3 +307,21 @@ kubectl get pods -l app=infrahub
 
 </TabItem>
 </Tabs>
+
+## Load a schema
+
+Infrahub ships with a minimal built-in schema. After installation, load a domain schema to model your infrastructure.
+
+:::tip Use the Marketplace for pre-built schemas
+
+The [Infrahub Marketplace](https://marketplace.infrahub.app) hosts ready-to-use schemas for common domains such as DCIM, IPAM, locations, and routing.
+Fetch a schema with `infrahubctl marketplace get opsmill/dcim`, then load it with `infrahubctl schema load schemas/dcim.yml`.
+See [Infrahub Marketplace](../../../schema/marketplace/) for the complete workflow.
+
+:::
+
+## Related resources
+
+- [Infrahub Marketplace](../../../schema/marketplace/) — Fetch and load pre-built schemas
+- [Database backup and restore](../../maintain-upgrade/database-backup/backup-and-restore) — Learn how to backup and restore your Infrahub database
+- [Production deployment](../production-deployment/overview) — Understand resilient deployment architectures

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -347,3 +347,21 @@ To learn more about bare metal deployment options and requirements, reach out to
 
 </TabItem>
 </Tabs>
+
+## Load a schema
+
+Infrahub ships with a minimal built-in schema. After installation, load a domain schema to model your infrastructure.
+
+:::tip Use the Marketplace for pre-built schemas
+
+The [Infrahub Marketplace](https://marketplace.infrahub.app) hosts ready-to-use schemas for common domains such as DCIM, IPAM, locations, and routing.
+Fetch a schema with `infrahubctl marketplace get opsmill/dcim`, then load it with `infrahubctl schema load schemas/dcim.yml`.
+See [Infrahub Marketplace](../../../schema/marketplace/) for the complete workflow.
+
+:::
+
+## Related resources
+
+- [Infrahub Marketplace](../../../schema/marketplace/) — Fetch and load pre-built schemas
+- [Database backup and restore](../../maintain-upgrade/database-backup/backup-and-restore) — Learn how to backup and restore your Infrahub database
+- [Production deployment](../production-deployment/overview) — Understand resilient deployment architectures

--- a/docs/docs/overview/concepts.mdx
+++ b/docs/docs/overview/concepts.mdx
@@ -14,7 +14,7 @@ The schema provides an abstraction layer to the graph database, and as such no k
 
 The schema is described in YAML format, and consists of nodes, attributes, relationships, and other descriptors. A new deployment of Infrahub will have no schema by default — it is up to the administrator to define and load the initial schema.
 
-Example schemas can be found in the [Schema Library](https://github.com/opsmill/schema-library), the most comprehensive collection currently maintained by the community and OpsMill.
+Example schemas can be found in the [Infrahub Marketplace](https://marketplace.infrahub.app), the catalog of schemas maintained by the community and OpsMill.
 
 The schema can be loaded using the [`infrahubctl schema load`]($(base_url)infrahubctl/infrahubctl-load) command for development, or via Infrahub Git integration for production deployments. Once loaded, it's stored and version controlled in the graph database. Changes to the schema can be made at any time, and it's best practice to make schema changes in a branch to allow for testing before implementation.
 

--- a/docs/docs/overview/next-steps.mdx
+++ b/docs/docs/overview/next-steps.mdx
@@ -10,7 +10,7 @@ If you completed the [Quick Start](./quickstart.mdx), you have a local Infrahub 
 
 The Quick Start used pre-built schemas from the Schema Library. For a POC, model a slice of your actual infrastructure — the devices, services, or resources that matter most to your team.
 
-Start with a focused scope. Pick one domain (for example: data center fabric, WAN sites, or firewall policies) and model it. You can always expand later. The [Schema Library](https://github.com/opsmill/schema-library) remains a good starting point to extend from.
+Start with a focused scope. Pick one domain (for example: data center fabric, WAN sites, or firewall policies) and model it. You can always expand later. The [Infrahub Marketplace](https://marketplace.infrahub.app) is a good starting point — browse it for schemas that match your domain and extend from there.
 
 <ReferenceLink title="Create a schema" url="../academy/tutorials/build-your-first-schema"/>
 

--- a/docs/docs/overview/quickstart.mdx
+++ b/docs/docs/overview/quickstart.mdx
@@ -80,31 +80,30 @@ You should see the Infrahub web interface with a navigation menu on the left sid
 
 A schema defines the structure of your infrastructure data in Infrahub — the types of objects, their attributes, and how they relate to each other. [Learn more about schemas](../schema/overview).
 
-Rather than writing a schema from scratch, use the [Schema Library](https://github.com/opsmill/schema-library), a community-maintained collection of reusable data models.
+Rather than writing a schema from scratch, use the [Infrahub Marketplace](https://marketplace.infrahub.app), a catalog of reusable schemas for common infrastructure domains maintained by the community and OpsMill.
 
-1. Download the schema library:
+1. Browse [marketplace.infrahub.app](https://marketplace.infrahub.app) and identify the schema you need (for example, `opsmill/dcim`).
+
+2. Fetch the schema to your project:
 
 ```bash
-uv run invoke schema-library-get
+infrahubctl marketplace get opsmill/dcim
 ```
 
-2. Explore the downloaded schema files in the `schema-library/` folder in your IDE.
+This downloads the schema YAML to `./schemas/`.
 
 :::info
 
-- The schema library is divided into a `base/` with core definitions and `extensions/` that build on top of the base. You need to load the base to add extensions.
-- Since you have access to the full schema code, you can explore and modify the schemas to fit your organization's needs.
+The Marketplace organizes schemas into base schemas (core definitions) and extensions that build on top of a base.
+You need to load the base before loading extensions.
+Browse the Marketplace to discover what is available and check each schema's dependencies.
 
 :::
 
 3. Load the schema into your project:
 
-:::info
-To keep things organized, put all schema files in a `schemas/` folder in your project and load them from there. Copy the files you need from the `schema-library/` folder into your project's `schemas/` folder.
-:::
-
 ```bash
-uv run infrahubctl schema load schemas/
+infrahubctl schema load schemas/
 ```
 
 :::success Verification

--- a/docs/docs/schema/extensions.mdx
+++ b/docs/docs/schema/extensions.mdx
@@ -61,7 +61,7 @@ If multiple extensions target the same node, all extensions are merged. Conflict
 
 The extension mechanism was designed to support modular schema composition. In large organizations, different teams often own different parts of the infrastructure model. Extensions allow teams to add their specific requirements to shared base schemas without coordinating changes to common files.
 
-This pattern is used extensively in the [OpsMill Schema Library](https://github.com/opsmill/schema-library), where the `extensions/` directory contains feature modules that augment base schemas:
+This pattern is used extensively in schemas published on the [Infrahub Marketplace](https://marketplace.infrahub.app), where extensions are feature modules that augment base schemas:
 
 - `extensions/lag/` adds LAG support to interface models
 - `extensions/contracts/` adds procurement tracking to organization models
@@ -155,4 +155,4 @@ Schema extensions interact with several other Infrahub concepts:
 
 - [Reference: Node extension](../reference/schema/node-extension) — Complete reference for extension properties
 - [Create and load schema](./create-and-load) — How to load schema files including extensions
-- [OpsMill Schema Library](https://github.com/opsmill/schema-library/tree/main/extensions) — Production examples of schema extensions
+- [Infrahub Marketplace](https://marketplace.infrahub.app) — Community and OpsMill schema catalog, including production examples of schema extensions

--- a/docs/docs/schema/marketplace/index.mdx
+++ b/docs/docs/schema/marketplace/index.mdx
@@ -1,0 +1,134 @@
+---
+title: Infrahub Marketplace
+---
+
+# Infrahub Marketplace
+
+The Infrahub Marketplace is a public catalog of pre-built schemas and schema collections that you can fetch and load into any Infrahub instance.
+It provides a curated starting point for common infrastructure domains — from physical device modeling to IP address management — so you can get a working data model without building one from scratch.
+
+## What the Marketplace contains
+
+The Marketplace hosts two types of content:
+
+- **Schemas** — versioned YAML files that define nodes, attributes, and relationships for a specific domain. A DCIM schema might define `Device`, `Interface`, and `Platform` nodes; an IPAM schema might define `IPAddress`, `Prefix`, and `VLAN`.
+- **Collections** — curated bundles of related schemas published together. A "network automation starter" collection might include DCIM, IPAM, location, and organization schemas in a single download.
+
+## How identifiers work
+
+Every item in the Marketplace is identified by a `namespace/name` reference, similar to Docker Hub image names or npm package scopes.
+
+- `opsmill/dcim` — the `dcim` schema published by the `opsmill` namespace
+- `opsmill/starter-pack` — the `starter-pack` collection published by `opsmill`
+
+Namespaces are tied to the account of the schema's author on the Marketplace.
+
+## Schemas and schema versions
+
+Marketplace schemas follow [semantic versioning](https://semver.org/). Each published schema has a version number (`MAJOR.MINOR.PATCH`). When you fetch a schema you can pin to a specific version or use the latest published release.
+
+Breaking changes — such as removing a node or changing a relationship cardinality — require a major version bump. Additive changes (new nodes, new optional attributes) use a minor or patch bump.
+
+## Relationship to an Infrahub instance
+
+The Marketplace is an external catalog — it stores schema definitions, not your infrastructure data. Fetching a schema from the Marketplace downloads its YAML to your local filesystem. You then load that YAML into your Infrahub instance using `infrahubctl schema load`. The Marketplace and your instance remain independent; updates to a schema on the Marketplace do not automatically change your loaded schema.
+
+## Fetch and load a schema
+
+### Prerequisites
+
+- A running Infrahub instance
+- `infrahubctl` installed and configured with your instance URL (see [installation guide](../../deploy-manage/install-configure/install/overview.mdx))
+
+### Find the schema
+
+Browse [marketplace.infrahub.app](https://marketplace.infrahub.app) and identify the schema or collection you want.
+Each item has an identifier in `namespace/name` format — for example, `opsmill/dcim`.
+Note this identifier; you will use it in the next step.
+
+### Fetch the schema
+
+Run `infrahubctl marketplace get` with the identifier:
+
+```shell
+infrahubctl marketplace get opsmill/dcim
+```
+
+The command downloads the schema YAML to `./schemas/` by default:
+
+```text
+Downloaded schema opsmill/dcim (version 1.4.2) → schemas/dcim.yml
+```
+
+#### Pin to a specific version
+
+Pin to a published version with `--version`:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --version 1.2.0
+```
+
+#### Save to a custom directory
+
+Use `--output-dir` to change where files are saved:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --output-dir ./infra/schemas
+```
+
+#### Inspect before loading
+
+Use `--stdout` to print the schema YAML to stdout without writing to disk:
+
+```shell
+infrahubctl marketplace get opsmill/dcim --stdout
+```
+
+This is useful for reviewing the schema or piping it into another tool before committing to disk.
+
+#### Collections
+
+The Marketplace also hosts collections — bundles of related schemas published together.
+The `get` command detects whether an identifier is a schema or a collection automatically.
+To force collection download when a name exists as both, add `--collection`:
+
+```shell
+infrahubctl marketplace get opsmill/starter-pack --collection
+```
+
+A collection download writes one file per schema in the bundle.
+
+### Load the schema into Infrahub
+
+Use `infrahubctl schema load` to apply the downloaded file to your instance:
+
+```shell
+infrahubctl schema load schemas/dcim.yml
+```
+
+For a collection, load all files at once:
+
+```shell
+infrahubctl schema load schemas/
+```
+
+Infrahub validates the schema, applies the changes, and restarts the relevant services.
+
+:::tip Verify the schema loaded
+
+After loading, browse to the [schema page](http://localhost:8000/schema) in the Infrahub UI.
+The new nodes should appear in the node list.
+
+:::
+
+## Version compatibility
+
+Marketplace schemas are versioned independently from Infrahub itself.
+If a schema uses features from a newer version of Infrahub than you are running, `infrahubctl schema load` reports a validation error.
+Check the schema's Marketplace page for the minimum supported Infrahub version before loading.
+
+## Related resources
+
+- [About Schema](../overview) — core schema concepts and how schemas govern data in Infrahub
+- [Create and load schema](../create-and-load) — create a schema from scratch and load it into Infrahub
+- [Schema extensions](../extensions) — add attributes and relationships to existing nodes using extension files

--- a/docs/docs/tutorials/getting-started/schema.mdx
+++ b/docs/docs/tutorials/getting-started/schema.mdx
@@ -54,6 +54,14 @@ Use the following command to load these new models into Infrahub
 invoke demo.load-infra-schema
 ```
 
+:::tip Find these schemas on the Marketplace
+
+The schemas loaded above (`dcim`, `ipam`, `location`, `organization`, `routing`) are also available on the [Infrahub Marketplace](https://marketplace.infrahub.app) as `opsmill/dcim`, `opsmill/ipam`, and so on.
+When starting a new Infrahub project outside of this demo, you can fetch them directly with `infrahubctl marketplace get opsmill/dcim` instead of using the demo command.
+See [Infrahub Marketplace](../../schema/marketplace/) for the full workflow.
+
+:::
+
 <details>
   <summary>Expected Results</summary>
   ```shell

--- a/docs/redirects-pending/README.md
+++ b/docs/redirects-pending/README.md
@@ -99,3 +99,4 @@ See [Docs Revamp — URL Migration & Redirects](https://opsmill.atlassian.net/wi
 | `integrations.yml` | Integrations | TBD |
 | `events.yml` | Events | TBD |
 | `generators.yml` | Generators | TBD |
+| `marketplace.yml` | Infrahub Marketplace (single-page merge, supersedes PR #9093) | TBD |

--- a/docs/redirects-pending/marketplace.yml
+++ b/docs/redirects-pending/marketplace.yml
@@ -1,0 +1,23 @@
+---
+feature: Infrahub Marketplace
+pr: TBD
+description: |
+  Merged topics/marketplace.mdx + guides/marketplace-install-schema.mdx (from PR #9093)
+  into a single page at schema/marketplace/index.mdx following the revamped single-page-merge
+  pattern. PR #9093 was authored before the docs revamp shipped; this PR supersedes it with
+  the content adapted to the new structure.
+
+# Legacy URLs that will redirect to new locations
+redirects:
+  - from: /topics/marketplace
+    to: /schema/marketplace/
+  - from: /guides/marketplace-install-schema
+    to: /schema/marketplace/
+
+# Net-new pages introduced by this migration
+new_pages:
+  - path: /schema/marketplace/
+    title: Infrahub Marketplace
+
+# Internal cross-link references in OTHER files that point at legacy paths
+cross_links_to_update: []

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -113,6 +113,7 @@ const sidebars: SidebarsConfig = {
           items: [
             { type: 'doc', id: 'schema/create-and-load', label: 'Create and load schema' },
             { type: 'doc', id: 'schema/migration', label: 'Schema migration' },
+            { type: 'doc', id: 'schema/marketplace/index', label: 'Marketplace' },
           ],
         },
         // ── Advanced schema features ──────────────────────────


### PR DESCRIPTION
## Summary

- Supersedes #9093 — original content by Alex Gao, adapted for the revamped docs structure
- New `schema/marketplace/index.mdx`: single-page merge of the original topic + how-to guide. Covers what the Marketplace is, namespace/name identifiers, semantic versioning, and the full fetch+load workflow (`infrahubctl marketplace get` → `infrahubctl schema load`) including version pinning, `--stdout`, and collection variants
- Sidebar: Marketplace added under **Schema & Data → Schema operations**
- Replaced all `github.com/opsmill/schema-library` references with Marketplace links: overview/concepts, overview/quickstart, overview/next-steps, schema/extensions, tutorials/getting-started/schema
- Added "Load a schema" section + Marketplace tip to community and enterprise install pages (the original `guides/installation.mdx` has since moved to these two files)
- Added `stderr`/`stdin`/`stdout` to Vale spelling exceptions
- Added `redirects-pending/marketplace.yml` for URL tracking (will be aggregated at cleanup)

## Why a new PR instead of merging #9093

PR #9093 was created before the docs revamp shipped. It adds content to `topics/` and `guides/` paths that no longer exist, and uses the old sidebar structure. This PR applies the same content to the correct new locations.

## Test plan

- [ ] Build passes: `cd docs && npm run build`
- [ ] Lint passes: `uv run invoke docs.lint`
- [ ] Browse to `/schema/marketplace/` — page renders with concept intro and full workflow
- [ ] Confirm Marketplace links work in quickstart, concepts, next-steps, schema extensions, getting-started tutorial
- [ ] Confirm install pages (community + enterprise) show the "Load a schema" Marketplace tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)