### PR TITLE
parser for new `order_by` grammar

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -25,6 +25,8 @@ DEFAULT_IP_NAMESPACE = "default"
 
 RESERVED_BRANCH_NAMES = [GLOBAL_BRANCH_NAME]
 
+NODE_METADATA_PREFIX = "node_metadata"
+
 RESERVED_ATTR_REL_NAMES = [
     "any",
     "attribute",
@@ -38,6 +40,7 @@ RESERVED_ATTR_REL_NAMES = [
     "save",
     "hfid",
     "process_pools",
+    NODE_METADATA_PREFIX,
 ]
 
 RESERVED_ATTR_REL_HIERARCHICAL_NAMES = [

--- a/backend/infrahub/core/schema/order_by.py
+++ b/backend/infrahub/core/schema/order_by.py
@@ -67,9 +67,7 @@ class ParsedMetadataOrderBy(_ParsedOrderByBase):
         return (self.kind.value, self.metadata_field.value)
 
 
-type ParsedOrderByEntry = (
-    ParsedAttributeOrderBy | ParsedRelationshipAttributeOrderBy | ParsedMetadataOrderBy
-)
+type ParsedOrderByEntry = ParsedAttributeOrderBy | ParsedRelationshipAttributeOrderBy | ParsedMetadataOrderBy
 
 
 def parse_order_by_entry(entry: str, node_schema: BaseNodeSchema) -> ParsedOrderByEntry:
@@ -91,12 +89,8 @@ def _consume_direction(entry: str, parts: list[str], path_length: int) -> OrderD
         token = parts[-1]
         if token in _DIRECTION_TOKENS:
             return OrderDirection(token.upper())
-        raise ValueError(
-            f"invalid direction (entry: {entry!r}). Direction must be 'asc' or 'desc'."
-        )
-    raise ValueError(
-        f"invalid entry (entry: {entry!r}). Unexpected number of segments."
-    )
+        raise ValueError(f"invalid direction (entry: {entry!r}). Direction must be 'asc' or 'desc'.")
+    raise ValueError(f"invalid entry (entry: {entry!r}). Unexpected number of segments.")
 
 
 def _parse_metadata(entry: str, parts: list[str]) -> ParsedMetadataOrderBy:
@@ -112,9 +106,7 @@ def _parse_metadata(entry: str, parts: list[str]) -> ParsedMetadataOrderBy:
         metadata_field = OrderByMetadataField(field_token)
     except ValueError as exc:
         supported = ", ".join(field.value for field in OrderByMetadataField)
-        raise ValueError(
-            f"unknown metadata field (entry: {entry!r}). Supported metadata fields: {supported}."
-        ) from exc
+        raise ValueError(f"unknown metadata field (entry: {entry!r}). Supported metadata fields: {supported}.") from exc
 
     direction = _consume_direction(entry=entry, parts=parts, path_length=2)
 
@@ -156,6 +148,4 @@ def _parse_path(
             property_name=parts[1],
         )
 
-    raise ValueError(
-        f"attribute {first!r} not defined on this schema (entry: {entry!r})."
-    )
+    raise ValueError(f"attribute {first!r} not defined on this schema (entry: {entry!r}).")

--- a/backend/infrahub/core/schema/order_by.py
+++ b/backend/infrahub/core/schema/order_by.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+from infrahub.constants.enums import OrderDirection
+from infrahub.core.constants import NODE_METADATA_PREFIX
+from infrahub.core.order import METADATA_CREATED_AT, METADATA_UPDATED_AT
+
+if TYPE_CHECKING:
+    from infrahub.core.schema.basenode_schema import BaseNodeSchema, SchemaAttributePath
+
+
+_DIRECTION_TOKENS = {direction.value.lower() for direction in OrderDirection}
+
+
+class OrderByTargetKind(StrEnum):
+    ATTRIBUTE = "attribute"
+    RELATIONSHIP_ATTRIBUTE = "relationship_attribute"
+    METADATA = "metadata"
+
+
+class OrderByMetadataField(StrEnum):
+    CREATED_AT = METADATA_CREATED_AT
+    UPDATED_AT = METADATA_UPDATED_AT
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedOrderByBase:
+    raw: str
+    direction: OrderDirection
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedAttributeOrderBy(_ParsedOrderByBase):
+    attribute_name: str
+    property_name: str
+    schema_path: SchemaAttributePath | None = None
+    kind: ClassVar[Literal[OrderByTargetKind.ATTRIBUTE]] = OrderByTargetKind.ATTRIBUTE
+
+    @property
+    def target_key(self) -> tuple[str, ...]:
+        return (self.kind.value, self.attribute_name, self.property_name)
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedRelationshipAttributeOrderBy(_ParsedOrderByBase):
+    relationship_name: str
+    attribute_name: str
+    property_name: str
+    schema_path: SchemaAttributePath | None = None
+    kind: ClassVar[Literal[OrderByTargetKind.RELATIONSHIP_ATTRIBUTE]] = OrderByTargetKind.RELATIONSHIP_ATTRIBUTE
+
+    @property
+    def target_key(self) -> tuple[str, ...]:
+        return (self.kind.value, self.relationship_name, self.attribute_name, self.property_name)
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedMetadataOrderBy(_ParsedOrderByBase):
+    metadata_field: OrderByMetadataField
+    kind: ClassVar[Literal[OrderByTargetKind.METADATA]] = OrderByTargetKind.METADATA
+
+    @property
+    def target_key(self) -> tuple[str, ...]:
+        return (self.kind.value, self.metadata_field.value)
+
+
+type ParsedOrderByEntry = (
+    ParsedAttributeOrderBy | ParsedRelationshipAttributeOrderBy | ParsedMetadataOrderBy
+)
+
+
+def parse_order_by_entry(entry: str, node_schema: BaseNodeSchema) -> ParsedOrderByEntry:
+    if not entry:
+        raise ValueError(f"order_by entries must be non-empty strings (entry: {entry!r}).")
+
+    parts = entry.split("__")
+
+    if parts[0] == NODE_METADATA_PREFIX:
+        return _parse_metadata(entry=entry, parts=parts)
+
+    return _parse_path(entry=entry, parts=parts, node_schema=node_schema)
+
+
+def _consume_direction(entry: str, parts: list[str], path_length: int) -> OrderDirection:
+    if len(parts) == path_length:
+        return OrderDirection.ASC
+    if len(parts) == path_length + 1:
+        token = parts[-1]
+        if token in _DIRECTION_TOKENS:
+            return OrderDirection(token.upper())
+        raise ValueError(
+            f"invalid direction (entry: {entry!r}). Direction must be 'asc' or 'desc'."
+        )
+    raise ValueError(
+        f"invalid entry (entry: {entry!r}). Unexpected number of segments."
+    )
+
+
+def _parse_metadata(entry: str, parts: list[str]) -> ParsedMetadataOrderBy:
+    if len(parts) < 2:
+        raise ValueError(
+            f"invalid {NODE_METADATA_PREFIX} entry (entry: {entry!r}). "
+            f"Expected '{NODE_METADATA_PREFIX}__<field>' "
+            f"or '{NODE_METADATA_PREFIX}__<field>__<direction>'."
+        )
+
+    field_token = parts[1]
+    try:
+        metadata_field = OrderByMetadataField(field_token)
+    except ValueError as exc:
+        supported = ", ".join(field.value for field in OrderByMetadataField)
+        raise ValueError(
+            f"unknown metadata field (entry: {entry!r}). Supported metadata fields: {supported}."
+        ) from exc
+
+    direction = _consume_direction(entry=entry, parts=parts, path_length=2)
+
+    return ParsedMetadataOrderBy(raw=entry, direction=direction, metadata_field=metadata_field)
+
+
+def _parse_path(
+    entry: str, parts: list[str], node_schema: BaseNodeSchema
+) -> ParsedAttributeOrderBy | ParsedRelationshipAttributeOrderBy:
+    first = parts[0]
+
+    if first in node_schema.relationship_names:
+        if len(parts) < 3:
+            raise ValueError(
+                f"invalid relationship path (entry: {entry!r}). "
+                f"Expected '<relationship>__<attribute>__<property>' "
+                f"with an optional direction suffix."
+            )
+        direction = _consume_direction(entry=entry, parts=parts, path_length=3)
+        return ParsedRelationshipAttributeOrderBy(
+            raw=entry,
+            direction=direction,
+            relationship_name=parts[0],
+            attribute_name=parts[1],
+            property_name=parts[2],
+        )
+
+    if first in node_schema.attribute_names:
+        if len(parts) < 2:
+            raise ValueError(
+                f"invalid attribute path (entry: {entry!r}). "
+                f"Expected '<attribute>__<property>' with an optional direction suffix."
+            )
+        direction = _consume_direction(entry=entry, parts=parts, path_length=2)
+        return ParsedAttributeOrderBy(
+            raw=entry,
+            direction=direction,
+            attribute_name=parts[0],
+            property_name=parts[1],
+        )
+
+    raise ValueError(
+        f"attribute {first!r} not defined on this schema (entry: {entry!r})."
+    )

--- a/backend/infrahub/core/schema/order_by.py
+++ b/backend/infrahub/core/schema/order_by.py
@@ -9,7 +9,7 @@ from infrahub.core.constants import NODE_METADATA_PREFIX
 from infrahub.core.order import METADATA_CREATED_AT, METADATA_UPDATED_AT
 
 if TYPE_CHECKING:
-    from infrahub.core.schema.basenode_schema import BaseNodeSchema, SchemaAttributePath
+    from infrahub.core.schema.basenode_schema import BaseNodeSchema
 
 
 _DIRECTION_TOKENS = {direction.value.lower() for direction in OrderDirection}
@@ -36,7 +36,6 @@ class _ParsedOrderByBase:
 class ParsedAttributeOrderBy(_ParsedOrderByBase):
     attribute_name: str
     property_name: str
-    schema_path: SchemaAttributePath | None = None
     kind: ClassVar[Literal[OrderByTargetKind.ATTRIBUTE]] = OrderByTargetKind.ATTRIBUTE
 
     @property
@@ -49,7 +48,6 @@ class ParsedRelationshipAttributeOrderBy(_ParsedOrderByBase):
     relationship_name: str
     attribute_name: str
     property_name: str
-    schema_path: SchemaAttributePath | None = None
     kind: ClassVar[Literal[OrderByTargetKind.RELATIONSHIP_ATTRIBUTE]] = OrderByTargetKind.RELATIONSHIP_ATTRIBUTE
 
     @property
@@ -75,6 +73,9 @@ def parse_order_by_entry(entry: str, node_schema: BaseNodeSchema) -> ParsedOrder
         raise ValueError(f"order_by entries must be non-empty strings (entry: {entry!r}).")
 
     parts = entry.split("__")
+
+    if any(not part for part in parts):
+        raise ValueError(f"invalid entry (entry: {entry!r}). Entry segments must be non-empty.")
 
     if parts[0] == NODE_METADATA_PREFIX:
         return _parse_metadata(entry=entry, parts=parts)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1166,12 +1166,18 @@ class SchemaBranch:
                 if attr.name in RESERVED_ATTR_REL_NAMES or (
                     isinstance(node, GenericSchema) and attr.name in RESERVED_ATTR_GEN_NAMES
                 ):
-                    raise ValueError(f"{node.kind}: {attr.name} isn't allowed as an attribute name.")
+                    raise ValueError(
+                        f"{node.kind}: {attr.name!r} is a reserved name (attribute: {attr.name!r}). "
+                        "Rename this attribute or relationship."
+                    )
             for rel in node.relationships:
                 if rel.name in RESERVED_ATTR_REL_NAMES or (
                     isinstance(node, GenericSchema) and rel.name in RESERVED_ATTR_GEN_NAMES
                 ):
-                    raise ValueError(f"{node.kind}: {rel.name} isn't allowed as a relationship name.")
+                    raise ValueError(
+                        f"{node.kind}: {rel.name!r} is a reserved name (relationship: {rel.name!r}). "
+                        "Rename this attribute or relationship."
+                    )
 
     def validate_restricted_namespaces_from_generic(self) -> None:
         """Ensure that every node which inherit from a generic node containing restricted namespaces are following on.

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -1086,8 +1086,7 @@ SCHEMA_BRANCH_VALIDATE_NAMES_TEST_CASES = [
             ]
         },
         expected_error=(
-            "TestCriticality: 'save' is a reserved name (relationship: 'save'). "
-            "Rename this attribute or relationship."
+            "TestCriticality: 'save' is a reserved name (relationship: 'save'). Rename this attribute or relationship."
         ),
     ),
     SchemaBranchValidateNamesTestCaseData(
@@ -1109,8 +1108,7 @@ SCHEMA_BRANCH_VALIDATE_NAMES_TEST_CASES = [
             ]
         },
         expected_error=(
-            "TestCriticality: 'save' is a reserved name (attribute: 'save'). "
-            "Rename this attribute or relationship."
+            "TestCriticality: 'save' is a reserved name (attribute: 'save'). Rename this attribute or relationship."
         ),
     ),
     SchemaBranchValidateNamesTestCaseData(

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -1085,7 +1085,10 @@ SCHEMA_BRANCH_VALIDATE_NAMES_TEST_CASES = [
                 }
             ]
         },
-        expected_error="TestCriticality: save isn't allowed as a relationship name.",
+        expected_error=(
+            "TestCriticality: 'save' is a reserved name (relationship: 'save'). "
+            "Rename this attribute or relationship."
+        ),
     ),
     SchemaBranchValidateNamesTestCaseData(
         name="attribute-reserved-names-test",
@@ -1105,7 +1108,54 @@ SCHEMA_BRANCH_VALIDATE_NAMES_TEST_CASES = [
                 }
             ]
         },
-        expected_error="TestCriticality: save isn't allowed as an attribute name.",
+        expected_error=(
+            "TestCriticality: 'save' is a reserved name (attribute: 'save'). "
+            "Rename this attribute or relationship."
+        ),
+    ),
+    SchemaBranchValidateNamesTestCaseData(
+        name="attribute-node-metadata-reserved",
+        schema={
+            "nodes": [
+                {
+                    "name": "Criticality",
+                    "namespace": "Test",
+                    "default_filter": "name__value",
+                    "branch": BranchSupportType.AWARE.value,
+                    "attributes": [
+                        {"name": "name", "kind": "Text"},
+                        {"name": "node_metadata", "kind": "Text"},
+                    ],
+                }
+            ]
+        },
+        expected_error=(
+            "TestCriticality: 'node_metadata' is a reserved name (attribute: 'node_metadata'). "
+            "Rename this attribute or relationship."
+        ),
+    ),
+    SchemaBranchValidateNamesTestCaseData(
+        name="relationship-node-metadata-reserved",
+        schema={
+            "nodes": [
+                {
+                    "name": "Criticality",
+                    "namespace": "Test",
+                    "default_filter": "name__value",
+                    "branch": BranchSupportType.AWARE.value,
+                    "attributes": [
+                        {"name": "name", "kind": "Text"},
+                    ],
+                    "relationships": [
+                        {"name": "node_metadata", "peer": "TestCriticality", "cardinality": "one"},
+                    ],
+                }
+            ]
+        },
+        expected_error=(
+            "TestCriticality: 'node_metadata' is a reserved name (relationship: 'node_metadata'). "
+            "Rename this attribute or relationship."
+        ),
     ),
 ]
 

--- a/backend/tests/unit/core/schema/test_order_by_parser.py
+++ b/backend/tests/unit/core/schema/test_order_by_parser.py
@@ -151,7 +151,17 @@ REJECTION_CASES = [
     RejectionCase(
         name="empty_direction_tail",
         entry="name__value__",
-        match=r"invalid direction.*Direction must be 'asc' or 'desc'",
+        match=r"Entry segments must be non-empty",
+    ),
+    RejectionCase(
+        name="empty_middle_segment",
+        entry="name____value",
+        match=r"Entry segments must be non-empty",
+    ),
+    RejectionCase(
+        name="empty_leading_segment",
+        entry="__value",
+        match=r"Entry segments must be non-empty",
     ),
     RejectionCase(
         name="unknown_attribute",

--- a/backend/tests/unit/core/schema/test_order_by_parser.py
+++ b/backend/tests/unit/core/schema/test_order_by_parser.py
@@ -1,0 +1,172 @@
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.constants.enums import OrderDirection
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
+from infrahub.core.schema.order_by import (
+    OrderByMetadataField,
+    OrderByTargetKind,
+    ParsedMetadataOrderBy,
+    parse_order_by_entry,
+)
+
+
+@pytest.fixture
+def node_schema() -> NodeSchema:
+    return NodeSchema(
+        name="Note",
+        namespace="Documentation",
+        attributes=[
+            AttributeSchema(name="name", kind="Text"),
+            AttributeSchema(name="status", kind="Text", optional=True),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="account",
+                kind=RelationshipKind.ATTRIBUTE,
+                peer="CoreAccount",
+                cardinality=RelationshipCardinality.ONE,
+                optional=False,
+            ),
+        ],
+    )
+
+
+@dataclass
+class ParserCase:
+    name: str
+    entry: str
+    expected_kind: OrderByTargetKind
+    expected_direction: OrderDirection
+    expected_target_key: tuple[str, ...]
+
+
+SUCCESS_CASES = [
+    ParserCase(
+        name="attribute_implicit_asc",
+        entry="name__value",
+        expected_kind=OrderByTargetKind.ATTRIBUTE,
+        expected_direction=OrderDirection.ASC,
+        expected_target_key=("attribute", "name", "value"),
+    ),
+    ParserCase(
+        name="attribute_explicit_asc",
+        entry="name__value__asc",
+        expected_kind=OrderByTargetKind.ATTRIBUTE,
+        expected_direction=OrderDirection.ASC,
+        expected_target_key=("attribute", "name", "value"),
+    ),
+    ParserCase(
+        name="attribute_desc",
+        entry="status__value__desc",
+        expected_kind=OrderByTargetKind.ATTRIBUTE,
+        expected_direction=OrderDirection.DESC,
+        expected_target_key=("attribute", "status", "value"),
+    ),
+    ParserCase(
+        name="relationship_attribute_implicit_asc",
+        entry="account__name__value",
+        expected_kind=OrderByTargetKind.RELATIONSHIP_ATTRIBUTE,
+        expected_direction=OrderDirection.ASC,
+        expected_target_key=("relationship_attribute", "account", "name", "value"),
+    ),
+    ParserCase(
+        name="relationship_attribute_desc",
+        entry="account__name__value__desc",
+        expected_kind=OrderByTargetKind.RELATIONSHIP_ATTRIBUTE,
+        expected_direction=OrderDirection.DESC,
+        expected_target_key=("relationship_attribute", "account", "name", "value"),
+    ),
+    ParserCase(
+        name="metadata_created_at_implicit_asc",
+        entry="node_metadata__created_at",
+        expected_kind=OrderByTargetKind.METADATA,
+        expected_direction=OrderDirection.ASC,
+        expected_target_key=("metadata", "created_at"),
+    ),
+    ParserCase(
+        name="metadata_updated_at_desc",
+        entry="node_metadata__updated_at__desc",
+        expected_kind=OrderByTargetKind.METADATA,
+        expected_direction=OrderDirection.DESC,
+        expected_target_key=("metadata", "updated_at"),
+    ),
+    ParserCase(
+        name="metadata_created_at_asc",
+        entry="node_metadata__created_at__asc",
+        expected_kind=OrderByTargetKind.METADATA,
+        expected_direction=OrderDirection.ASC,
+        expected_target_key=("metadata", "created_at"),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", SUCCESS_CASES, ids=lambda c: c.name)
+def test_parse_order_by_entry_success(case: ParserCase, node_schema: NodeSchema) -> None:
+    parsed = parse_order_by_entry(entry=case.entry, node_schema=node_schema)
+
+    assert parsed.kind is case.expected_kind
+    assert parsed.direction is case.expected_direction
+    assert parsed.target_key == case.expected_target_key
+    assert parsed.raw == case.entry
+
+
+def test_parse_order_by_metadata_field_populated(node_schema: NodeSchema) -> None:
+    parsed = parse_order_by_entry(entry="node_metadata__updated_at__desc", node_schema=node_schema)
+
+    assert isinstance(parsed, ParsedMetadataOrderBy)
+    assert parsed.metadata_field is OrderByMetadataField.UPDATED_AT
+
+
+@dataclass
+class RejectionCase:
+    name: str
+    entry: str
+    match: str
+
+
+REJECTION_CASES = [
+    RejectionCase(
+        name="empty_string",
+        entry="",
+        match=r"order_by entries must be non-empty strings",
+    ),
+    RejectionCase(
+        name="unsupported_metadata_field",
+        entry="node_metadata__created_by",
+        match=r"unknown metadata field.*Supported metadata fields: created_at, updated_at",
+    ),
+    RejectionCase(
+        name="malformed_direction_descending",
+        entry="name__value__descending",
+        match=r"invalid direction.*Direction must be 'asc' or 'desc'",
+    ),
+    RejectionCase(
+        name="malformed_direction_uppercase",
+        entry="name__value__ASC",
+        match=r"invalid direction.*Direction must be 'asc' or 'desc'",
+    ),
+    RejectionCase(
+        name="empty_direction_tail",
+        entry="name__value__",
+        match=r"invalid direction.*Direction must be 'asc' or 'desc'",
+    ),
+    RejectionCase(
+        name="unknown_attribute",
+        entry="nonexistent__value",
+        match=r"attribute 'nonexistent' not defined on this schema",
+    ),
+    RejectionCase(
+        name="metadata_malformed_direction",
+        entry="node_metadata__created_at__descending",
+        match=r"invalid direction",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", REJECTION_CASES, ids=lambda c: c.name)
+def test_parse_order_by_entry_rejection(case: RejectionCase, node_schema: NodeSchema) -> None:
+    with pytest.raises(ValueError, match=case.match):
+        parse_order_by_entry(entry=case.entry, node_schema=node_schema)

--- a/dev/specs/infp-530-order-by-metadata-direction/data-model.md
+++ b/dev/specs/infp-530-order-by-metadata-direction/data-model.md
@@ -29,30 +29,50 @@ New string enum, same module.
 
 The supported field set is identical to the GraphQL `InfrahubNodeMetadataOrder` input (FR-010): `created_at`, `updated_at`. No user-reference fields (`created_by`, `updated_by`).
 
-## Entity: `ParsedOrderByEntry` (frozen dataclass)
+## Entity: `ParsedOrderByEntry` (discriminated union of frozen dataclasses)
+
+`ParsedOrderByEntry` is a type alias for a three-variant union; each variant carries only the fields it actually needs. `kind` is a `ClassVar[Literal[...]]` so callers narrow via `isinstance` or `parsed.kind is OrderByTargetKind.<...>` without runtime assertions.
 
 ```python
 @dataclass(frozen=True, slots=True)
-class ParsedOrderByEntry:
+class _ParsedOrderByBase:
     raw: str                          # the original string from order_by
-    kind: OrderByTargetKind
-    direction: OrderDirection
-    # ATTRIBUTE / RELATIONSHIP_ATTRIBUTE only:
-    schema_path: SchemaAttributePath | None
-    # METADATA only:
-    metadata_field: OrderByMetadataField | None
+    direction: OrderDirection         # always set; defaults to ASC when no suffix
 
-    @property
-    def target_key(self) -> tuple[str, ...]:
-        """Stable tuple identifying the sortable target. Used for duplicate detection."""
+
+@dataclass(frozen=True, slots=True)
+class ParsedAttributeOrderBy(_ParsedOrderByBase):
+    attribute_name: str
+    property_name: str
+    kind: ClassVar[Literal[OrderByTargetKind.ATTRIBUTE]] = OrderByTargetKind.ATTRIBUTE
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedRelationshipAttributeOrderBy(_ParsedOrderByBase):
+    relationship_name: str
+    attribute_name: str
+    property_name: str
+    kind: ClassVar[Literal[OrderByTargetKind.RELATIONSHIP_ATTRIBUTE]] = OrderByTargetKind.RELATIONSHIP_ATTRIBUTE
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedMetadataOrderBy(_ParsedOrderByBase):
+    metadata_field: OrderByMetadataField
+    kind: ClassVar[Literal[OrderByTargetKind.METADATA]] = OrderByTargetKind.METADATA
+
+
+type ParsedOrderByEntry = (
+    ParsedAttributeOrderBy | ParsedRelationshipAttributeOrderBy | ParsedMetadataOrderBy
+)
 ```
 
-Invariants enforced by the parser/validator:
+Each variant exposes a `target_key` property used for duplicate detection (see below).
 
-- `kind == METADATA` ⇒ `metadata_field is not None` AND `schema_path is None`.
-- `kind in {ATTRIBUTE, RELATIONSHIP_ATTRIBUTE}` ⇒ `schema_path is not None` AND `metadata_field is None`.
+Invariants:
+
 - `direction` is always set (defaulted to `ASC` when no suffix is provided).
 - `raw` is preserved so error messages and `__repr__` can echo what the author wrote.
+- Path resolution (verifying that a relationship's peer schema actually has the named attribute, checking cardinality, etc.) is **not** the parser's job — it stays in `validate_schema_path` at schema-load time. The parser is a pure classifier + direction extractor and needs only `node_schema.attribute_names` / `node_schema.relationship_names` (no `SchemaBranch`).
 
 ### `target_key` rules
 

--- a/dev/specs/infp-530-order-by-metadata-direction/tasks.md
+++ b/dev/specs/infp-530-order-by-metadata-direction/tasks.md
@@ -29,7 +29,7 @@ description: "Task list for schema-level order_by for node metadata and directio
 
 **Purpose**: Confirm baseline before changes. No new project scaffolding required — feature lives entirely inside the existing backend.
 
-- [ ] T001 Run baseline unit + targeted component tests (`uv run invoke backend.test-unit` and `uv run pytest -x backend/tests/component/core/schema_manager/test_manager_schema.py backend/tests/component/core/test_node_get_list_query.py`); record any pre-existing failures so they aren't attributed to this branch.
+- [X] T001 Run baseline unit + targeted component tests (`uv run invoke backend.test-unit` and `uv run pytest -x backend/tests/component/core/schema_manager/test_manager_schema.py backend/tests/component/core/test_node_get_list_query.py`); record any pre-existing failures so they aren't attributed to this branch.
 
 ---
 
@@ -39,14 +39,14 @@ description: "Task list for schema-level order_by for node metadata and directio
 
 **⚠️ CRITICAL**: No user story work may begin until T002–T005 are complete.
 
-- [ ] T002 [P] Add the literal `"node_metadata"` to `RESERVED_ATTR_REL_NAMES` in `backend/infrahub/core/constants/__init__.py` (the list defined around lines 28–48). Do not modify `RESERVED_ATTR_GEN_NAMES`. No code comment referencing the spec or ticket.
-- [ ] T003 [P] Create new module `backend/infrahub/core/schema/order_by.py` that defines:
+- [X] T002 [P] Add the literal `"node_metadata"` to `RESERVED_ATTR_REL_NAMES` in `backend/infrahub/core/constants/__init__.py` (the list defined around lines 28–48). Do not modify `RESERVED_ATTR_GEN_NAMES`. No code comment referencing the spec or ticket.
+- [X] T003 [P] Create new module `backend/infrahub/core/schema/order_by.py` that defines:
   - Frozen dataclass `ParsedOrderByEntry` with fields `raw: str`, `kind: OrderByTargetKind`, `direction: OrderDirection`, `schema_path: SchemaAttributePath | None`, `metadata_field: OrderByMetadataField | None`, plus a `target_key` property (see `data-model.md`).
   - String enums `OrderByTargetKind` (`ATTRIBUTE`, `RELATIONSHIP_ATTRIBUTE`, `METADATA`) and `OrderByMetadataField` (`CREATED_AT="created_at"`, `UPDATED_AT="updated_at"`).
   - `parse_order_by_entry(entry: str, node_schema) -> ParsedOrderByEntry` that recognizes the six grammar shapes in `contracts/grammar.md`. Raise `ValueError` with messages matching the templates in `contracts/errors.md` on malformed input; resolve attribute / relationship-attribute paths via the existing `node_schema.parse_schema_path()` helper.
   - Reuse `OrderDirection` from `infrahub.core.constants` and `METADATA_CREATED_AT` / `METADATA_UPDATED_AT` literals where appropriate.
-- [ ] T004 [P] Create `backend/tests/unit/core/schema/test_order_by_parser.py` with parametrized cases covering: all six grammar shapes (with and without direction); implicit-ascending default; rejection of malformed direction tokens (`__descending`, `__ASC`, empty tail); rejection of unsupported metadata field (`node_metadata__created_by`); rejection of empty string. Each case asserts on `kind`, `direction`, and `target_key`.
-- [ ] T005 [P] Add a reserved-name component test to `backend/tests/component/core/schema_manager/test_manager_schema.py`: loading a schema whose `NodeSchema.attributes` or `NodeSchema.relationships` contains an item named `node_metadata` raises the standard `SchemaNotValidError` and the message includes the offending node kind plus the literal `'node_metadata'` and the word "reserved".
+- [X] T004 [P] Create `backend/tests/unit/core/schema/test_order_by_parser.py` with parametrized cases covering: all six grammar shapes (with and without direction); implicit-ascending default; rejection of malformed direction tokens (`__descending`, `__ASC`, empty tail); rejection of unsupported metadata field (`node_metadata__created_by`); rejection of empty string. Each case asserts on `kind`, `direction`, and `target_key`.
+- [X] T005 [P] Add a reserved-name component test to `backend/tests/component/core/schema_manager/test_manager_schema.py`: loading a schema whose `NodeSchema.attributes` or `NodeSchema.relationships` contains an item named `node_metadata` raises the standard `SchemaNotValidError` and the message includes the offending node kind plus the literal `'node_metadata'` and the word "reserved".
 
 **Checkpoint**: Parser and reserved name are in place. User-story phases can now proceed in parallel.
 


### PR DESCRIPTION
new parsing class and tests to support the new `order_by` options in the schema
- <attribute_name>[__<asc_or_desc>]
- <relationship_name>__<attribute_name>[__<asc_or_desc>]
- node_metadata__<created/updated__at>[__<asc_or_desc>]

existing logic in `SchemaBranch.validate_order_by` handles verifying that attributes on relationships actually exist in the schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new parser for schema `order_by` with support for metadata fields and explicit sort direction, addressing INFP-530. Also reserves `node_metadata` and tightens validation errors.

- **New Features**
  - Parse `order_by` entries:
    - `<attribute>__<property>[__asc|desc]`
    - `<relationship>__<attribute>__<property>[__asc|desc]`
    - `node_metadata__<created_at|updated_at>[__asc|desc]`
  - Defaults to ascending when direction is omitted.
  - Clear errors for unknown fields, bad direction tokens, undefined attributes, or empty segments.

- **Migration**
  - `node_metadata` is now a reserved name for attributes and relationships; rename if used.
  - Validation errors now state the reserved name and whether it was used on an attribute or relationship.

<sup>Written for commit 5e7025dac04f3039d2d065a0fd094997abbab738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9369?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

