### PR TITLE
Merge 'stable' into 'develop' with resolved conflicts

### DIFF
--- a/.github/workflows/bug-agent-analyst.lock.yml
+++ b/.github/workflows/bug-agent-analyst.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27ff3fd52d290d17ebdfe693b5a77102181c0169b4b42d141bc6673eefa3eee4","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"783846754bdc8890ff9f9dfb2b1d2535ba709bd620ddc8968a677f997fcf3cdc","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -248,20 +248,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
+          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
           <system>
-          GH_AW_PROMPT_bde3d329d612b3ac_EOF
+          GH_AW_PROMPT_dbc69ab7aea88407_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
+          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_bde3d329d612b3ac_EOF
+          GH_AW_PROMPT_dbc69ab7aea88407_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
+          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -293,15 +293,15 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_bde3d329d612b3ac_EOF
+          GH_AW_PROMPT_dbc69ab7aea88407_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_bde3d329d612b3ac_EOF'
+          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-analyst.md}}
-          GH_AW_PROMPT_bde3d329d612b3ac_EOF
+          GH_AW_PROMPT_dbc69ab7aea88407_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -495,9 +495,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2157a195b6af823d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_687634720ffc0aea_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2157a195b6af823d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_687634720ffc0aea_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -703,7 +703,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c38d960dab0e52f2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_460d12542e623f85_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -746,7 +746,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c38d960dab0e52f2_EOF
+          GH_AW_MCP_CONFIG_460d12542e623f85_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1165,7 +1165,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "40"

--- a/.github/workflows/bug-agent-analyst.lock.yml
+++ b/.github/workflows/bug-agent-analyst.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"783846754bdc8890ff9f9dfb2b1d2535ba709bd620ddc8968a677f997fcf3cdc","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"15abd92cfabee631f753e1ad09297669a7741b7b7eb9b1ab6dd29a6b1e7463fd","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -36,6 +36,7 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -248,20 +249,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
+          cat << 'GH_AW_PROMPT_0da32ae12e47d072_EOF'
           <system>
-          GH_AW_PROMPT_dbc69ab7aea88407_EOF
+          GH_AW_PROMPT_0da32ae12e47d072_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
+          cat << 'GH_AW_PROMPT_0da32ae12e47d072_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_dbc69ab7aea88407_EOF
+          GH_AW_PROMPT_0da32ae12e47d072_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
+          cat << 'GH_AW_PROMPT_0da32ae12e47d072_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -293,15 +294,15 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_dbc69ab7aea88407_EOF
+          GH_AW_PROMPT_0da32ae12e47d072_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_dbc69ab7aea88407_EOF'
+          cat << 'GH_AW_PROMPT_0da32ae12e47d072_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-analyst.md}}
-          GH_AW_PROMPT_dbc69ab7aea88407_EOF
+          GH_AW_PROMPT_0da32ae12e47d072_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -469,14 +470,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Parse integrity filter lists
-        id: parse-guard-vars
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
-          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
-          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -495,9 +498,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_687634720ffc0aea_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_81d37131338115bd_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_687634720ffc0aea_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_81d37131338115bd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -679,6 +682,8 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
+          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -703,7 +708,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_460d12542e623f85_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_91f9536ce175fe9d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -716,11 +721,8 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
-                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
-                    "repos": "all",
-                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
+                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
+                    "repos": "$GITHUB_MCP_GUARD_REPOS"
                   }
                 }
               },
@@ -746,7 +748,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_460d12542e623f85_EOF
+          GH_AW_MCP_CONFIG_91f9536ce175fe9d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1005,8 +1007,6 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
-            /tmp/gh-aw/proxy-logs/
-            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-analyst.md
+++ b/.github/workflows/bug-agent-analyst.md
@@ -16,8 +16,6 @@ permissions:
 tools:
   github:
     toolsets: [default]
-    min-integrity: approved
-    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-analyst.md
+++ b/.github/workflows/bug-agent-analyst.md
@@ -26,6 +26,7 @@ safe-outputs:
   github-app:
     client-id: ${{ secrets.GH_AW_APP_ID }}
     private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+  report-failure-as-issue: false
   add-comment:
     max: 3
     discussions: false

--- a/.github/workflows/bug-agent-fix.lock.yml
+++ b/.github/workflows/bug-agent-fix.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7804fefb5b0e7b2ad1f6cef18cfa0d22a3d659d973df60bec30246ebedfc153f","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3c2f0d3d97158cc4bae98e7b45cd24e8b5eb2514a9c2b344ed6e2e5193dc90be","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -247,23 +247,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
+          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
           <system>
-          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
+          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
+          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), update_pull_request(max:3), add_labels(max:2), push_to_pull_request_branch(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
+          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
+          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
+          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
+          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -295,7 +295,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
+          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -303,10 +303,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_c4c4e40c8d030fb9_EOF'
+          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-fix.md}}
-          GH_AW_PROMPT_c4c4e40c8d030fb9_EOF
+          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -605,9 +605,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9281cc759c87a58b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_52dfc26d9c5c8b22_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":5,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{},"update_pull_request":{"allow_body":true,"allow_title":true,"max":3,"target":"*","update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9281cc759c87a58b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_52dfc26d9c5c8b22_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -872,7 +872,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dd344038df537c80_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_70a3d5ac3a42e207_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -915,7 +915,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dd344038df537c80_EOF
+          GH_AW_MCP_CONFIG_70a3d5ac3a42e207_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1337,7 +1337,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "60"

--- a/.github/workflows/bug-agent-fix.lock.yml
+++ b/.github/workflows/bug-agent-fix.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3c2f0d3d97158cc4bae98e7b45cd24e8b5eb2514a9c2b344ed6e2e5193dc90be","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c00d0a4179e5214535789fd759b7df8c646eb5ebfaecccfc63ca6b6010ff6af","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,6 +37,7 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -247,23 +248,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
+          cat << 'GH_AW_PROMPT_dd51df99c68e65da_EOF'
           <system>
-          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
+          GH_AW_PROMPT_dd51df99c68e65da_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
+          cat << 'GH_AW_PROMPT_dd51df99c68e65da_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), update_pull_request(max:3), add_labels(max:2), push_to_pull_request_branch(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
+          GH_AW_PROMPT_dd51df99c68e65da_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
+          cat << 'GH_AW_PROMPT_dd51df99c68e65da_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
+          GH_AW_PROMPT_dd51df99c68e65da_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
+          cat << 'GH_AW_PROMPT_dd51df99c68e65da_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -295,7 +296,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
+          GH_AW_PROMPT_dd51df99c68e65da_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -303,10 +304,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_2521b5fc3bb6a68e_EOF'
+          cat << 'GH_AW_PROMPT_dd51df99c68e65da_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-fix.md}}
-          GH_AW_PROMPT_2521b5fc3bb6a68e_EOF
+          GH_AW_PROMPT_dd51df99c68e65da_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -447,98 +448,22 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Start DIFC Proxy
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
-          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
-        run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
-      - name: "Gate check - require reviewer approval"
-        run: |
-          set -euo pipefail
-          fail() {
-            echo "::error::$1"
-            echo "### Gate failed" >> "$GITHUB_STEP_SUMMARY"
-            echo "$1" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          }
-
-          PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null || echo "")
-          if [ -z "$PR_JSON" ] || [ "$(echo "$PR_JSON" | jq -r '.number // empty')" = "" ]; then
-            fail "Cannot run /bug-fix here: must be invoked on a PR comment."
-          fi
-          PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
-
-          if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
-            REQ=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
-                and (.body | contains("AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED")))] | length')
-            if [ "$REQ" = "0" ]; then
-              fail "Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer."
-            fi
-            exit 0
-          fi
-
-          if [[ "$PR_BODY" != *"AGENT_TEST_COMPLETE"* ]]; then
-            fail "Cannot run /bug-fix: no AGENT_TEST_COMPLETE marker on PR body. Run /bug-tdd first."
-          fi
-
-          APPROVED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
-              and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
-          if [ "$APPROVED" = "0" ]; then
-            fail "Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict."
-          fi
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
+      - env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+        name: "Gate check - require reviewer approval"
+        run: "set -euo pipefail\nfail() {\n  echo \"::error::$1\"\n  echo \"### Gate failed\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nPR_JSON=$(gh api \"repos/$REPO/pulls/$PR_NUMBER\" 2>/dev/null || echo \"\")\nif [ -z \"$PR_JSON\" ] || [ \"$(echo \"$PR_JSON\" | jq -r '.number // empty')\" = \"\" ]; then\n  fail \"Cannot run /bug-fix here: must be invoked on a PR comment.\"\nfi\nPR_BODY=$(echo \"$PR_JSON\" | jq -r '.body // \"\"')\n\nif [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n  REQ=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n    --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n      and (.body | contains(\"AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED\")))] | length')\n  if [ \"$REQ\" = \"0\" ]; then\n    fail \"Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer.\"\n  fi\n  exit 0\nfi\n\nif [[ \"$PR_BODY\" != *\"AGENT_TEST_COMPLETE\"* ]]; then\n  fail \"Cannot run /bug-fix: no AGENT_TEST_COMPLETE marker on PR body. Run /bug-tdd first.\"\nfi\n\nAPPROVED=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n  --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n    and (.body | contains(\"AGENT_REVIEW_VERDICT: TEST_APPROVED\")))] | length')\nif [ \"$APPROVED\" = \"0\" ]; then\n  fail \"Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict.\"\nfi\n"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: latest
       - run: uv sync --all-groups
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: 10
       - run: cd frontend/app && pnpm install --frozen-lockfile
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - run: cd frontend/app && pnpm exec playwright install chromium
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -575,18 +500,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Parse integrity filter lists
-        id: parse-guard-vars
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
-          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
-          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
-      - name: Stop DIFC Proxy
-        if: always()
-        continue-on-error: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -605,9 +528,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_52dfc26d9c5c8b22_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_099dcc380352bc4d_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":5,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{},"update_pull_request":{"allow_body":true,"allow_title":true,"max":3,"target":"*","update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_52dfc26d9c5c8b22_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_099dcc380352bc4d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -848,6 +771,8 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
+          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -872,7 +797,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_70a3d5ac3a42e207_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4f8bc026858f4b9e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -885,11 +810,8 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
-                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
-                    "repos": "all",
-                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
+                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
+                    "repos": "$GITHUB_MCP_GUARD_REPOS"
                   }
                 }
               },
@@ -915,7 +837,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_70a3d5ac3a42e207_EOF
+          GH_AW_MCP_CONFIG_4f8bc026858f4b9e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1174,8 +1096,6 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
-            /tmp/gh-aw/proxy-logs/
-            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-fix.md
+++ b/.github/workflows/bug-agent-fix.md
@@ -16,8 +16,6 @@ permissions:
 tools:
   github:
     toolsets: [default]
-    min-integrity: approved
-    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-fix.md
+++ b/.github/workflows/bug-agent-fix.md
@@ -82,6 +82,7 @@ safe-outputs:
   github-app:
     client-id: ${{ secrets.GH_AW_APP_ID }}
     private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+  report-failure-as-issue: false
   add-comment:
     max: 3
     discussions: false

--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8f2a5f68ce26cba2e0d0ec73e01f43727a784771449ae468da30813ee887be62","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0c04c3b6a88a631a3a3297c0ac6f01a1ae9f5ecbe56aba4fb32a784a71d5a3bc","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -36,6 +36,7 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -228,20 +229,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_6e756455d73539bf_EOF'
           <system>
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_6e756455d73539bf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_6e756455d73539bf_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_6e756455d73539bf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_6e756455d73539bf_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -273,12 +274,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_6e756455d73539bf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_6e756455d73539bf_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-review.md}}
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_6e756455d73539bf_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -406,49 +407,14 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Start DIFC Proxy
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
-          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
-        run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
-      - name: "Gate check - skip if current mode already approved"
-        run: |
-          set -euo pipefail
-          skip() {
-            echo "::notice::$1"
-            echo "### Reviewer skipped" >> "$GITHUB_STEP_SUMMARY"
-            echo "$1" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          }
-
-          if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
-            MARKER="AGENT_REVIEW_VERDICT: FIX_APPROVED"
-            SKIP_MSG="Skipping reviewer: fix already FIX_APPROVED, pipeline complete."
-          else
-            MARKER="AGENT_REVIEW_VERDICT: TEST_APPROVED"
-            SKIP_MSG="Skipping reviewer: test already TEST_APPROVED, waiting for fix."
-          fi
-
-          COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq "[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
-              and (.body | contains(\"$MARKER\")))] | length")
-
-          if [ "$COUNT" -gt 0 ]; then
-            skip "$SKIP_MSG"
-          fi
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
+      - env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+        name: "Gate check - skip if current mode already approved"
+        run: "set -euo pipefail\nskip() {\n  echo \"::notice::$1\"\n  echo \"### Reviewer skipped\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nif [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n  MARKER=\"AGENT_REVIEW_VERDICT: FIX_APPROVED\"\n  SKIP_MSG=\"Skipping reviewer: fix already FIX_APPROVED, pipeline complete.\"\nelse\n  MARKER=\"AGENT_REVIEW_VERDICT: TEST_APPROVED\"\n  SKIP_MSG=\"Skipping reviewer: test already TEST_APPROVED, waiting for fix.\"\nfi\n\nCOUNT=$(gh api \"repos/$REPO/issues/$PR_NUMBER/comments\" --paginate \\\n  --jq \"[.[] | select((.user.login == \\\"infrahub-bug-pipeline[bot]\\\" or .user.login == \\\"github-actions[bot]\\\" or .user.login == \\\"claude[bot]\\\")\n    and (.body | contains(\\\"$MARKER\\\")))] | length\")\n\nif [ \"$COUNT\" -gt 0 ]; then\n  skip \"$SKIP_MSG\"\nfi\n"
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -485,18 +451,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Parse integrity filter lists
-        id: parse-guard-vars
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
-          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
-          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
-      - name: Stop DIFC Proxy
-        if: always()
-        continue-on-error: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -515,9 +479,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8a9e92b6fead8f08_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8a9e92b6fead8f08_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -699,6 +663,8 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
+          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -723,7 +689,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a5ebf1ce7ba8594b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -736,11 +702,8 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
-                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
-                    "repos": "all",
-                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
+                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
+                    "repos": "$GITHUB_MCP_GUARD_REPOS"
                   }
                 }
               },
@@ -766,7 +729,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF
+          GH_AW_MCP_CONFIG_a5ebf1ce7ba8594b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1024,8 +987,6 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
-            /tmp/gh-aw/proxy-logs/
-            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"aca2da9e127d1d566ff0ec77e6a9bb699212fe0e0b365f1169200d765c58dbdc","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8f2a5f68ce26cba2e0d0ec73e01f43727a784771449ae468da30813ee887be62","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -228,20 +228,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
+          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
           <system>
-          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
+          GH_AW_PROMPT_a41bce5f7b2af731_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
+          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
+          GH_AW_PROMPT_a41bce5f7b2af731_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
+          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -273,12 +273,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
+          GH_AW_PROMPT_a41bce5f7b2af731_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b14c892a5b8eedf0_EOF'
+          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-review.md}}
-          GH_AW_PROMPT_b14c892a5b8eedf0_EOF
+          GH_AW_PROMPT_a41bce5f7b2af731_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -515,9 +515,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_83a52feeac775ecf_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_83a52feeac775ecf_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -723,7 +723,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_0e96071aed38701d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -766,7 +766,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0e96071aed38701d_EOF
+          GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1184,7 +1184,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "20"

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -19,8 +19,6 @@ permissions:
 tools:
   github:
     toolsets: [default]
-    min-integrity: approved
-    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -66,6 +66,7 @@ safe-outputs:
   github-app:
     client-id: ${{ secrets.GH_AW_APP_ID }}
     private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+  report-failure-as-issue: false
   add-comment:
     max: 3
     discussions: false

--- a/.github/workflows/bug-agent-test.lock.yml
+++ b/.github/workflows/bug-agent-test.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4c9e1580c1f45ea14e1f6a8d0d506a9e0359cb210b839bbdea89408136b16dee","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cf42f760986a1db57b513cc719db2ca6c6f55fb564b312ecc17b151d8aa6ad0c","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -247,24 +247,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
+          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
           <system>
-          GH_AW_PROMPT_e1d67eae4c16accb_EOF
+          GH_AW_PROMPT_fa3474d20b62f14a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
+          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), create_pull_request, add_labels(max:2), push_to_pull_request_branch(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_e1d67eae4c16accb_EOF
+          GH_AW_PROMPT_fa3474d20b62f14a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
+          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_e1d67eae4c16accb_EOF
+          GH_AW_PROMPT_fa3474d20b62f14a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
+          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -296,7 +296,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_e1d67eae4c16accb_EOF
+          GH_AW_PROMPT_fa3474d20b62f14a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -304,10 +304,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_e1d67eae4c16accb_EOF'
+          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-test.md}}
-          GH_AW_PROMPT_e1d67eae4c16accb_EOF
+          GH_AW_PROMPT_fa3474d20b62f14a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -608,9 +608,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_36a11782ac551623_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_867103ab103562d3_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_pull_request":{"allowed_base_branches":["stable"],"base_branch":"stable","draft":true,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":3,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_36a11782ac551623_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_867103ab103562d3_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -879,7 +879,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_19b0d61fea8876a7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3126fe28a44aa061_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -922,7 +922,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_19b0d61fea8876a7_EOF
+          GH_AW_MCP_CONFIG_3126fe28a44aa061_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1344,7 +1344,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "60"

--- a/.github/workflows/bug-agent-test.lock.yml
+++ b/.github/workflows/bug-agent-test.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cf42f760986a1db57b513cc719db2ca6c6f55fb564b312ecc17b151d8aa6ad0c","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"abb5013e51012a4b7c88e3bdb3197fc76a2f80873e09f721e082ad79deaca697","compiler_version":"v0.71.5","strict":true,"agent_id":"claude"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"94527f2e458b27549849d47d273a16bec83a01e9","version":"94527f2e458b27549849d47d273a16bec83a01e9"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"pnpm/action-setup","sha":"f40ffcd9367d9f12939873eb1018b921a783ffaa","version":"f40ffcd9367d9f12939873eb1018b921a783ffaa"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,6 +37,7 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -247,24 +248,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
+          cat << 'GH_AW_PROMPT_971eb51de8b941a5_EOF'
           <system>
-          GH_AW_PROMPT_fa3474d20b62f14a_EOF
+          GH_AW_PROMPT_971eb51de8b941a5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
+          cat << 'GH_AW_PROMPT_971eb51de8b941a5_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), create_pull_request, add_labels(max:2), push_to_pull_request_branch(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_fa3474d20b62f14a_EOF
+          GH_AW_PROMPT_971eb51de8b941a5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
+          cat << 'GH_AW_PROMPT_971eb51de8b941a5_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_fa3474d20b62f14a_EOF
+          GH_AW_PROMPT_971eb51de8b941a5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
+          cat << 'GH_AW_PROMPT_971eb51de8b941a5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -296,7 +297,7 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_fa3474d20b62f14a_EOF
+          GH_AW_PROMPT_971eb51de8b941a5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -304,10 +305,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_fa3474d20b62f14a_EOF'
+          cat << 'GH_AW_PROMPT_971eb51de8b941a5_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-test.md}}
-          GH_AW_PROMPT_fa3474d20b62f14a_EOF
+          GH_AW_PROMPT_971eb51de8b941a5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -448,100 +449,22 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Start DIFC Proxy
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"approved","repos":"all"}}'
-          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
-        run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
-      - name: "Gate check - require prior pipeline state"
-        run: |
-          set -euo pipefail
-          fail() {
-            echo "::error::$1"
-            echo "### Gate failed" >> "$GITHUB_STEP_SUMMARY"
-            echo "$1" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          }
-
-          ISSUE_JSON=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER")
-          IS_PR=$(echo "$ISSUE_JSON" | jq -r 'if .pull_request then "true" else "false" end')
-
-          if [ "$IS_PR" = "true" ]; then
-            PR_BODY=$(gh api "repos/$REPO/pulls/$ISSUE_NUMBER" | jq -r '.body // ""')
-
-            if [[ "$PR_BODY" != *"AGENT_TEST_COMPLETE"* ]]; then
-              fail "Cannot run /bug-tdd here: PR has no AGENT_TEST_COMPLETE marker."
-            fi
-            if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
-              fail "Cannot run /bug-tdd: fix already applied (AGENT_FIX_COMPLETE present). Test revision after fix is unsupported."
-            fi
-
-            REQ=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
-                and (.body | contains("AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED")))] | length')
-            if [ "$REQ" = "0" ]; then
-              fail "Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on."
-            fi
-            exit 0
-          fi
-
-          ANALYSIS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
-              and (.body | contains("AGENT_ANALYSIS_COMPLETE")))] | length')
-          if [ "$ANALYSIS" = "0" ]; then
-            fail "Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first."
-          fi
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
+      - env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
           REPO: ${{ github.repository }}
+        name: "Gate check - require prior pipeline state"
+        run: "set -euo pipefail\nfail() {\n  echo \"::error::$1\"\n  echo \"### Gate failed\" >> \"$GITHUB_STEP_SUMMARY\"\n  echo \"$1\" >> \"$GITHUB_STEP_SUMMARY\"\n  exit 1\n}\n\nISSUE_JSON=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER\")\nIS_PR=$(echo \"$ISSUE_JSON\" | jq -r 'if .pull_request then \"true\" else \"false\" end')\n\nif [ \"$IS_PR\" = \"true\" ]; then\n  PR_BODY=$(gh api \"repos/$REPO/pulls/$ISSUE_NUMBER\" | jq -r '.body // \"\"')\n\n  if [[ \"$PR_BODY\" != *\"AGENT_TEST_COMPLETE\"* ]]; then\n    fail \"Cannot run /bug-tdd here: PR has no AGENT_TEST_COMPLETE marker.\"\n  fi\n  if [[ \"$PR_BODY\" == *\"AGENT_FIX_COMPLETE\"* ]]; then\n    fail \"Cannot run /bug-tdd: fix already applied (AGENT_FIX_COMPLETE present). Test revision after fix is unsupported.\"\n  fi\n\n  REQ=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER/comments\" --paginate \\\n    --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n      and (.body | contains(\"AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED\")))] | length')\n  if [ \"$REQ\" = \"0\" ]; then\n    fail \"Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on.\"\n  fi\n  exit 0\nfi\n\nANALYSIS=$(gh api \"repos/$REPO/issues/$ISSUE_NUMBER/comments\" --paginate \\\n  --jq '[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")\n    and (.body | contains(\"AGENT_ANALYSIS_COMPLETE\")))] | length')\nif [ \"$ANALYSIS\" = \"0\" ]; then\n  fail \"Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first.\"\nfi\n"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: latest
       - run: uv sync --all-groups
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         with:
           version: 10
       - run: cd frontend/app && pnpm install --frozen-lockfile
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - run: cd frontend/app && pnpm exec playwright install chromium
-        env:
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -578,18 +501,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.126
-      - name: Parse integrity filter lists
-        id: parse-guard-vars
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
-          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_EXTRA: state/ai-pipeline-ready
-          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
-      - name: Stop DIFC Proxy
-        if: always()
-        continue-on-error: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -608,9 +529,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_867103ab103562d3_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_38ac04193f66b065_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_pull_request":{"allowed_base_branches":["stable"],"base_branch":"stable","draft":true,"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":3,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_867103ab103562d3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_38ac04193f66b065_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -855,6 +776,8 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
+          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -879,7 +802,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3126fe28a44aa061_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4bd008d40d9c3850_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -892,11 +815,8 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
-                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
-                    "repos": "all",
-                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
+                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
+                    "repos": "$GITHUB_MCP_GUARD_REPOS"
                   }
                 }
               },
@@ -922,7 +842,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3126fe28a44aa061_EOF
+          GH_AW_MCP_CONFIG_4bd008d40d9c3850_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1181,8 +1101,6 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
-            /tmp/gh-aw/proxy-logs/
-            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/pre-agent-audit.txt

--- a/.github/workflows/bug-agent-test.md
+++ b/.github/workflows/bug-agent-test.md
@@ -16,8 +16,6 @@ permissions:
 tools:
   github:
     toolsets: [default]
-    min-integrity: approved
-    approval-labels: [state/ai-pipeline-ready]
 network: defaults
 checkout:
   fetch-depth: 0

--- a/.github/workflows/bug-agent-test.md
+++ b/.github/workflows/bug-agent-test.md
@@ -84,6 +84,7 @@ safe-outputs:
   github-app:
     client-id: ${{ secrets.GH_AW_APP_ID }}
     private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+  report-failure-as-issue: false
   add-comment:
     max: 3
     discussions: false

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ Three ways to try Infrahub:
 
 - **[Sandbox](https://sandbox.infrahub.app/)** — a hosted demo of the Infrahub UI with sample data — explore the interface without installing anything.
 - **[Getting Started Lab](https://opsmill.instruqt.com/pages/labs)** — a guided browser tutorial covering branches, schemas, and unified storage.
-- **[Quick Start guide](https://docs.infrahub.app/getting-started/quick-start)** — set up a local Infrahub instance and walk through the basics in your own environment.
+- **[Quick Start guide](https://docs.infrahub.app/overview/quickstart)** — set up a local Infrahub instance and walk through the basics in your own environment.
 
 For production deployments on Kubernetes, see [`opsmill/infrahub-helm`](https://github.com/opsmill/infrahub-helm) and the [installation guide](https://docs.infrahub.app/guides/installation).
 
 ## Documentation
 
 - [Documentation home](https://docs.infrahub.app/)
-- [Getting started](https://docs.infrahub.app/getting-started/overview)
-- [Core concepts](https://docs.infrahub.app/getting-started/concepts)
+- [Getting started](https://docs.infrahub.app/overview)
+- [Core concepts](https://docs.infrahub.app/overview/concepts)
 - [Release notes](https://docs.infrahub.app/release-notes)
 - [FAQ](https://docs.infrahub.app/faq/)
 

--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -23,18 +23,27 @@ if TYPE_CHECKING:
     from infrahub.core.node import Node
     from infrahub.core.relationship.model import RelationshipManager
     from infrahub.core.schema import (
+        AttributeSchema,
         MainSchemaTypes,
         SchemaAttributePath,
     )
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
+    from .uniqueness_violation_message import UniquenessViolationMessageBuilder
+
 
 class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
-    def __init__(self, db: InfrahubDatabase, branch: Branch) -> None:
+    def __init__(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        message_builder: UniquenessViolationMessageBuilder,
+    ) -> None:
         self.db = db
         self.branch = branch
         self.schema_branch = registry.schema.get_schema_branch(branch.name)
+        self._message_builder = message_builder
 
     async def _get_unique_valued_paths(
         self,
@@ -178,7 +187,7 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
         for schema in schemas_to_check:
             schema_filters = list(filters) if filters is not None else []
             for attr_schema in schema.attributes:
-                if attr_schema.optional and attr_schema.unique and attr_schema.name not in schema_filters:
+                if self._should_implicitly_check_uniqueness(attr_schema=attr_schema, schema_filters=schema_filters):
                     schema_filters.append(attr_schema.name)
 
             schema_violations = await self._get_single_schema_violations(
@@ -208,9 +217,22 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                 ):
                     continue
 
-            error_msg = f"Violates uniqueness constraint '{'-'.join(violation.fields)}'"
+            error_msg = self._message_builder.build(node_schema=node.get_schema(), fields=violation.fields)
             raise ValidationError(error_msg)
 
         if hfid_violation:
-            error_msg = f"Violates uniqueness constraint '{'-'.join(hfid_violation.fields)}'"
+            error_msg = self._message_builder.build(node_schema=node.get_schema(), fields=hfid_violation.fields)
             raise HFIDViolatedError(error_msg, matching_nodes_ids=hfid_violation.nodes_ids)
+
+    def _should_implicitly_check_uniqueness(self, attr_schema: AttributeSchema, schema_filters: list[str]) -> bool:
+        """Decide whether an attribute must be validated for uniqueness despite being absent from the user-provided filters.
+
+        Optional attributes can carry a default value and computed attributes are populated after
+        the request is submitted, so neither appears in the user-provided filter list but both must
+        still be evaluated for uniqueness.
+        """
+        if attr_schema.name in schema_filters:
+            return False
+        if not attr_schema.unique:
+            return False
+        return bool(attr_schema.optional or attr_schema.computed_attribute)

--- a/backend/infrahub/core/node/constraints/uniqueness_violation_message.py
+++ b/backend/infrahub/core/node/constraints/uniqueness_violation_message.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.template.exceptions import JinjaTemplateError
+
+from infrahub.computed_attribute.jinja2 import InfrahubJinja2Template
+from infrahub.core.constants.schema import SchemaElementPathType
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.schema_branch import SchemaBranch
+
+_ALLOWED_INPUT_PATH_TYPES = (
+    SchemaElementPathType.ATTR_WITH_PROP
+    | SchemaElementPathType.REL_ONE_MANDATORY_ATTR_WITH_PROP
+    | SchemaElementPathType.REL_ONE_OPTIONAL_ATTR_WITH_PROP
+)
+
+
+class UniquenessViolationMessageBuilder:
+    """Format a uniqueness-violation message.
+
+    Names the input attributes that drive any computed field involved, so the user knows
+    which value to change.
+    """
+
+    def __init__(self, schema_branch: SchemaBranch) -> None:
+        self.schema_branch = schema_branch
+
+    def build(self, node_schema: MainSchemaTypes, fields: list[str]) -> str:
+        message = f"Violates uniqueness constraint '{'-'.join(fields)}'"
+        inputs = self._collect_computed_inputs(node_schema=node_schema, fields=fields)
+        if inputs:
+            message += f" (computed from: {', '.join(inputs)})"
+        return message
+
+    def _collect_computed_inputs(self, node_schema: MainSchemaTypes, fields: list[str]) -> list[str]:
+        """Return the deduplicated user-controllable inputs feeding the computed fields among `fields`."""
+        inputs: list[str] = []
+        for field in fields:
+            for input_name in self._inputs_for_field(node_schema=node_schema, field=field):
+                if input_name not in inputs:
+                    inputs.append(input_name)
+        return inputs
+
+    def _inputs_for_field(self, node_schema: MainSchemaTypes, field: str) -> list[str]:
+        """Resolve the input names a single field's Jinja2 template depends on, or empty if not computed."""
+        attr_schema = node_schema.get_attribute_or_none(name=field)
+        if attr_schema is None or attr_schema.computed_attribute is None:
+            return []
+        template = attr_schema.computed_attribute.jinja2_template
+        if not template:
+            return []
+        try:
+            variables = InfrahubJinja2Template(template=template).get_variables()
+        except JinjaTemplateError:
+            return []
+        names: list[str] = []
+        for variable in variables:
+            input_name = self._resolve_input_name(node_schema=node_schema, path=variable)
+            if input_name is not None:
+                names.append(input_name)
+        return names
+
+    def _resolve_input_name(self, node_schema: MainSchemaTypes, path: str) -> str | None:
+        """Map a Jinja2 path to a user-facing name: a bare attribute (`model`) or dotted relationship (`owner.name`)."""
+        try:
+            attribute_path = self.schema_branch.validate_schema_path(
+                node_schema=node_schema, path=path, allowed_path_types=_ALLOWED_INPUT_PATH_TYPES
+            )
+        except ValueError:
+            return None
+        if attribute_path.is_type_relationship:
+            return f"{attribute_path.active_relationship_schema.name}.{attribute_path.active_attribute_schema.name}"
+        if attribute_path.is_type_attribute:
+            return attribute_path.active_attribute_schema.name
+        return None

--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -169,8 +169,8 @@ class NodeDeleteValidator:
         if not missing_delete_ids:
             return node_ids_to_delete
         missing_delete_peers_data = []
-        for peers_data_list in dependent_node_details_map.values():
-            missing_delete_peers_data.extend(peers_data_list)
+        for peer_id in missing_delete_ids:
+            missing_delete_peers_data.extend(dependent_node_details_map[peer_id])
         validation_error = self._build_validation_error(missing_delete_peers_data=missing_delete_peers_data)
         raise validation_error
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1218,11 +1218,21 @@ class SchemaBranch:
                     isinstance(node, GenericSchema) and attr.name in RESERVED_ATTR_GEN_NAMES
                 ):
                     raise ValueError(f"{node.kind}: {attr.name} isn't allowed as an attribute name.")
+                if "__" in attr.name:
+                    raise ValueError(
+                        f"{node.kind}: '{attr.name}' cannot be used as an attribute name because"
+                        " it contains '__', which is reserved as the schema path separator."
+                    )
             for rel in node.relationships:
                 if rel.name in RESERVED_ATTR_REL_NAMES or (
                     isinstance(node, GenericSchema) and rel.name in RESERVED_ATTR_GEN_NAMES
                 ):
                     raise ValueError(f"{node.kind}: {rel.name} isn't allowed as a relationship name.")
+                if "__" in rel.name:
+                    raise ValueError(
+                        f"{node.kind}: '{rel.name}' cannot be used as a relationship name"
+                        " because it contains '__', which is reserved as the schema path separator."
+                    )
 
     def validate_restricted_namespaces_from_generic(self) -> None:
         """Ensure that every node which inherit from a generic node containing restricted namespaces are following on.

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -6,7 +6,7 @@ import hashlib
 import keyword
 from collections import defaultdict
 from itertools import chain, combinations
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from infrahub_sdk.template.exceptions import JinjaTemplateError, JinjaTemplateOperationViolationError
 from infrahub_sdk.template.filters import ExecutionContext
@@ -86,6 +86,14 @@ if TYPE_CHECKING:
 log = get_logger()
 
 
+class SchemaBranchDict(TypedDict):
+    name: str
+    nodes: dict[str, NodeSchema]
+    profiles: dict[str, ProfileSchema]
+    generics: dict[str, GenericSchema]
+    templates: dict[str, TemplateSchema]
+
+
 profiles_rel_settings: dict[str, Any] = {
     "name": PROFILES_RELATIONSHIP_NAME,
     "identifier": PROFILE_NODE_RELATIONSHIP_IDENTIFIER,
@@ -101,14 +109,14 @@ class SchemaBranch:
     def __init__(
         self,
         cache: dict,
-        name: str | None = None,
+        name: str,
         data: dict[str, dict[str, str]] | None = None,
         computed_attributes: ComputedAttributes | None = None,
         display_labels: DisplayLabels | None = None,
         hfids: HFIDs | None = None,
     ) -> None:
         self._cache: dict[str, NodeSchema | GenericSchema] = cache
-        self.name: str | None = name
+        self.name: str = name
         self.nodes: dict[str, str] = {}
         self.generics: dict[str, str] = {}
         self.profiles: dict[str, str] = {}
@@ -188,12 +196,13 @@ class SchemaBranch:
     def to_dict(self) -> dict[str, Any]:
         return {"nodes": self.nodes, "generics": self.generics, "profiles": self.profiles, "templates": self.templates}
 
-    def to_dict_schema_object(self, duplicate: bool = False) -> dict[str, dict[str, MainSchemaTypes]]:
+    def to_dict_schema_object(self, duplicate: bool = False) -> SchemaBranchDict:
         return {
-            "nodes": {name: self.get(name, duplicate=duplicate) for name in self.nodes},
-            "profiles": {name: self.get(name, duplicate=duplicate) for name in self.profiles},
-            "generics": {name: self.get(name, duplicate=duplicate) for name in self.generics},
-            "templates": {name: self.get(name, duplicate=duplicate) for name in self.templates},
+            "name": self.name,
+            "nodes": {name: self.get_node(name, duplicate=duplicate) for name in self.nodes},
+            "profiles": {name: self.get_profile(name, duplicate=duplicate) for name in self.profiles},
+            "generics": {name: self.get_generic(name, duplicate=duplicate) for name in self.generics},
+            "templates": {name: self.get_template(name, duplicate=duplicate) for name in self.templates},
         }
 
     def to_dict_api_schema_object(self) -> dict[str, list[dict]]:
@@ -224,7 +233,7 @@ class SchemaBranch:
 
                 cache[node_hash] = node
 
-        return cls(cache=cache, data=nodes)
+        return cls(cache=cache, data=nodes, name=data["name"])
 
     def diff(self, other: SchemaBranch) -> SchemaDiff:
         # Identify the nodes or generics that have been added or removed
@@ -245,9 +254,7 @@ class SchemaBranch:
 
         # Process of the one that have been updated to identify the list of impacted fields
         for key in present_both:
-            local_node = self.get(name=key, duplicate=False)
-            other_node = other.get(name=key, duplicate=False)
-            diff_node = other_node.diff(other=local_node)
+            diff_node = self._diff_node_or_generic(other_schema_branch=other, local_key=key, other_key=key)
             if diff_node.has_diff:
                 schema_diff.changed[key] = diff_node
 
@@ -255,15 +262,30 @@ class SchemaBranch:
         reversed_map_other: dict[str | None, str] = {v: k for k, v in other_kind_id_map.items()}
 
         for shared_id in shared_ids:
-            local_node = self.get(name=reversed_map_local[shared_id], duplicate=False)
-            other_node = other.get(name=reversed_map_other[shared_id], duplicate=False)
-            diff_node = other_node.diff(other=local_node)
-            if other_node.state == HashableModelState.ABSENT:
-                schema_diff.removed[reversed_map_other[shared_id]] = None
+            local_key = reversed_map_local[shared_id]
+            other_key = reversed_map_other[shared_id]
+            diff_node = self._diff_node_or_generic(other_schema_branch=other, local_key=local_key, other_key=other_key)
+            if other.get(name=other_key, duplicate=False).state == HashableModelState.ABSENT:
+                schema_diff.removed[other_key] = None
             elif diff_node.has_diff:
-                schema_diff.changed[reversed_map_other[shared_id]] = diff_node
+                schema_diff.changed[other_key] = diff_node
 
         return schema_diff
+
+    def _diff_node_or_generic(
+        self, other_schema_branch: SchemaBranch, local_key: str, other_key: str
+    ) -> HashableModelDiff:
+        """Diff two schemas across branches, dispatching to the matching concrete subclass.
+
+        Callers must ensure both keys reference either nodes or generics (not profiles or templates).
+        """
+        if local_key in self.nodes:
+            local_node = self.get_node(name=local_key, duplicate=False)
+            other_node = other_schema_branch.get_node(name=other_key, duplicate=False)
+            return other_node.diff(other=local_node)
+        local_generic = self.get_generic(name=local_key, duplicate=False)
+        other_generic = other_schema_branch.get_generic(name=other_key, duplicate=False)
+        return other_generic.diff(other=local_generic)
 
     def update(self, schema: SchemaBranch) -> None:
         """Update another SchemaBranch into this one."""
@@ -320,7 +342,7 @@ class SchemaBranch:
     def duplicate(self, name: str | None = None) -> SchemaBranch:
         """Duplicate the current object but conserve the same cache."""
         return self.__class__(
-            name=name,
+            name=name if name is not None else self.name,
             data=copy.deepcopy(self.to_dict()),
             cache=self._cache,
             computed_attributes=self.computed_attributes.duplicate(),
@@ -434,6 +456,18 @@ class SchemaBranch:
         item = self.get(name=name, duplicate=duplicate)
         if not isinstance(item, TemplateSchema):
             raise ValueError(f"{name!r} is not of type TemplateSchema")
+        return item
+
+    def get_node_or_generic_schema(self, name: str, duplicate: bool = True) -> NodeSchema | GenericSchema:
+        """Access a specific NodeSchema or GenericSchema, defined by its kind.
+
+        Raises:
+            ValueError: When the schema with the given name is neither a NodeSchema nor a GenericSchema.
+
+        """
+        item = self.get(name=name, duplicate=duplicate)
+        if not isinstance(item, NodeSchema | GenericSchema):
+            raise ValueError(f"{name!r} is not of type NodeSchema or GenericSchema")
         return item
 
     def delete(self, name: str) -> None:
@@ -1143,7 +1177,7 @@ class SchemaBranch:
         # {parent_kind: {component_kind_1, component_kind_2, ...}}
         dependency_map: dict[str, set[str]] = defaultdict(set)
         for name in self.generic_names_without_templates + self.node_names:
-            node_schema = self.get(name=name, duplicate=False)
+            node_schema = self.get_node_or_generic_schema(name=name, duplicate=False)
 
             parent_relationships: list[RelationshipSchema] = []
             component_relationships: list[RelationshipSchema] = []
@@ -1558,7 +1592,7 @@ class SchemaBranch:
 
     def validate_inherited_relationships_fields(self) -> None:
         for name in self.node_names:
-            node_schema = self.get(name=name, duplicate=False)
+            node_schema = self.get_node(name=name, duplicate=False)
             if not node_schema.inherit_from:
                 continue
 
@@ -2382,29 +2416,33 @@ class SchemaBranch:
             read_only = InfrahubKind.IPPREFIX in node.inherit_from
 
             parent_peer = node.parent or node.hierarchy
-            if "parent" not in node.relationship_names:
-                node.relationships.append(
-                    self._get_hierarchy_parent_rel(
-                        peer=parent_peer,
-                        hierarchical=node.hierarchy,
-                        read_only=read_only,
-                        optional=parent_peer in [node_name] + self.generic_names,
+            if parent_peer is not None:
+                if "parent" not in node.relationship_names:
+                    node.relationships.append(
+                        self._get_hierarchy_parent_rel(
+                            peer=parent_peer,
+                            hierarchical=node.hierarchy,
+                            read_only=read_only,
+                            optional=parent_peer in [node_name] + self.generic_names,
+                        )
                     )
-                )
-            else:
-                parent_rel = node.get_relationship(name="parent")
-                if parent_rel.peer != parent_peer:
-                    parent_rel.peer = parent_peer
+                else:
+                    parent_rel = node.get_relationship(name="parent")
+                    if parent_rel.peer != parent_peer:
+                        parent_rel.peer = parent_peer
 
             children_peer = node.children or node.hierarchy
-            if "children" not in node.relationship_names:
-                node.relationships.append(
-                    self._get_hierarchy_child_rel(peer=children_peer, hierarchical=node.hierarchy, read_only=read_only)
-                )
-            else:
-                children_rel = node.get_relationship(name="children")
-                if children_rel.peer != children_peer:
-                    children_rel.peer = children_peer
+            if children_peer is not None:
+                if "children" not in node.relationship_names:
+                    node.relationships.append(
+                        self._get_hierarchy_child_rel(
+                            peer=children_peer, hierarchical=node.hierarchy, read_only=read_only
+                        )
+                    )
+                else:
+                    children_rel = node.get_relationship(name="children")
+                    if children_rel.peer != children_peer:
+                        children_rel.peer = children_peer
 
             self.set(name=node_name, schema=node)
 
@@ -2456,7 +2494,7 @@ class SchemaBranch:
 
         profile_schema_kinds = set()
         for node_name in self.node_names + self.generic_names_without_templates:
-            node = self.get(name=node_name, duplicate=False)
+            node = self.get_node_or_generic_schema(name=node_name, duplicate=False)
             if (
                 (node.namespace in RESTRICTED_NAMESPACES and node.namespace != "Builtin")
                 or not node.generate_profile
@@ -2542,7 +2580,7 @@ class SchemaBranch:
     def _get_profile_kind(self, node_kind: str) -> str:
         return f"Profile{node_kind}"
 
-    def generate_profile_from_node(self, node: NodeSchema) -> ProfileSchema:
+    def generate_profile_from_node(self, node: NodeSchema | GenericSchema) -> ProfileSchema:
         core_profile_schema = self.get(name=InfrahubKind.PROFILE, duplicate=False)
         core_name_attr = core_profile_schema.get_attribute(name="profile_name")
         name_attr_schema_class = get_attribute_schema_class_for_kind(kind=core_name_attr.kind)
@@ -2706,9 +2744,7 @@ class SchemaBranch:
             A RelationshipSchema for the resource pool relationship, or None if not applicable
 
         """
-        peer_schema = self.get(name=relationship.peer, duplicate=False)
-        if not isinstance(peer_schema, NodeSchema | GenericSchema):
-            return None
+        peer_schema = self.get_node_or_generic_schema(name=relationship.peer, duplicate=False)
 
         pool_peer = None
         if isinstance(peer_schema, GenericSchema):
@@ -2945,8 +2981,8 @@ class SchemaBranch:
             ):
                 continue
 
-            peer_schema = self.get(name=relationship.peer, duplicate=False)
-            if not isinstance(peer_schema, NodeSchema | GenericSchema) or peer_schema in identified:
+            peer_schema = self.get_node_or_generic_schema(name=relationship.peer, duplicate=False)
+            if peer_schema in identified:
                 continue
             # In a context of a generic, we won't be able to create objects out of it, so any kind of nodes implementing the generic is a valid
             # option, we therefore need to have a template for each of those nodes
@@ -2956,7 +2992,7 @@ class SchemaBranch:
                 ):
                     for used_by in peer_schema.used_by:
                         identified |= self.identify_required_object_templates(
-                            node_schema=self.get(name=used_by, duplicate=False), identified=identified
+                            node_schema=self.get_node(name=used_by, duplicate=False), identified=identified
                         )
 
             identified |= self.identify_required_object_templates(node_schema=peer_schema, identified=identified)
@@ -2968,7 +3004,7 @@ class SchemaBranch:
         template_schema_kinds: set[str] = set()
 
         for node_name in self.node_names:
-            node = self.get(name=node_name, duplicate=False)
+            node = self.get_node(name=node_name, duplicate=False)
 
             # Delete old object templates if schemas were removed
             if (
@@ -2978,7 +3014,7 @@ class SchemaBranch:
             ):
                 try:
                     if any(r.name == OBJECT_TEMPLATE_RELATIONSHIP_NAME for r in node.relationships):
-                        node = self.get(name=node_name, duplicate=True)
+                        node = self.get_node(name=node_name, duplicate=True)
                         node.relationships = [
                             r for r in node.relationships if r.name != OBJECT_TEMPLATE_RELATIONSHIP_NAME
                         ]

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1748,7 +1748,7 @@ class SchemaBranch:
                 continue
             constraint_path = constraint_paths[0]
             try:
-                schema_path = node.parse_schema_path(path=constraint_path, schema=node)
+                schema_path = node.parse_schema_path(path=constraint_path, schema=self)
             except AttributePathParsingError:
                 if raise_parsing_errors:
                     raise

--- a/backend/infrahub/dependencies/builder/constraint/node/grouped_uniqueness.py
+++ b/backend/infrahub/dependencies/builder/constraint/node/grouped_uniqueness.py
@@ -1,8 +1,15 @@
+from infrahub.core import registry
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
+from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
 
 class NodeGroupedUniquenessConstraintDependency(DependencyBuilder[NodeGroupedUniquenessConstraint]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> NodeGroupedUniquenessConstraint:
-        return NodeGroupedUniquenessConstraint(db=context.db, branch=context.branch)
+        schema_branch = registry.schema.get_schema_branch(context.branch.name)
+        return NodeGroupedUniquenessConstraint(
+            db=context.db,
+            branch=context.branch,
+            message_builder=UniquenessViolationMessageBuilder(schema_branch=schema_branch),
+        )

--- a/backend/tests/component/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_choices_update.py
@@ -30,7 +30,7 @@ async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, cr
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
@@ -58,7 +58,7 @@ async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criti
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
@@ -96,7 +96,7 @@ async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticali
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -159,7 +159,7 @@ async def test_attribute_update_on_branch(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -221,7 +221,7 @@ async def test_node_delete_on_branch(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
@@ -281,7 +281,7 @@ async def test_validator(
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_enum_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_enum_update.py
@@ -164,7 +164,7 @@ async def test_validator(
         constraint_name="attribute.enum.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeEnumChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_kind_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_kind_update.py
@@ -306,7 +306,7 @@ async def test_validator(
         constraint_name="attribute.kind.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeKindChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_length.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_length.py
@@ -227,7 +227,7 @@ async def test_validator(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_LENGTH_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeLengthChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_number_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_number_constraints.py
@@ -233,7 +233,7 @@ async def test_validator_min_max(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberChecker(db=db, branch=branch)
@@ -295,7 +295,7 @@ async def test_validator_excluded_values(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
@@ -155,7 +155,7 @@ async def test_validator_range(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=incident_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberPoolChecker(db=db, branch=branch)
@@ -173,7 +173,7 @@ async def test_validator_range(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MIN_VALUE_UPDATE.value,
         node_schema=incident_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeNumberPoolChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_optional.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_optional.py
@@ -166,7 +166,7 @@ async def test_validator(db: InfrahubDatabase, branch: Branch, person_john_main:
         constraint_name="attribute.optional.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeOptionalChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_regex_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_regex_update.py
@@ -171,7 +171,7 @@ async def test_validator(
         constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_REGEX_UPDATE.value,
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeRegexChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_attribute_unique_update.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_unique_update.py
@@ -184,7 +184,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = AttributeUniquenessChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_node_generate_profiles_update.py
+++ b/backend/tests/component/core/constraint_validators/test_node_generate_profiles_update.py
@@ -27,7 +27,7 @@ async def test_set_generate_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -48,7 +48,7 @@ async def test_set_generate_profile_success_generics(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -72,7 +72,7 @@ async def test_set_generate_profile_false_fail(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -100,7 +100,7 @@ async def test_set_generate_profile_false_fail_generic(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -130,7 +130,7 @@ async def test_set_generate_profile_false_branch_delete_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/component/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -7,6 +7,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
+from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.validators.uniqueness.query import UniquenessValidationQuery
 from infrahub.database import InfrahubDatabase
@@ -18,7 +19,13 @@ class TestNodeGroupedUniquenessConstraint:
     async def __call_system_under_test(
         self, db: InfrahubDatabase, branch: Branch, node: Node, filters: list[str] | None = None
     ) -> None:
-        constraint = NodeGroupedUniquenessConstraint(db=db, branch=branch)
+        constraint = NodeGroupedUniquenessConstraint(
+            db=db,
+            branch=branch,
+            message_builder=UniquenessViolationMessageBuilder(
+                schema_branch=registry.schema.get_schema_branch(branch.name)
+            ),
+        )
         await constraint.check(node=node, filters=filters)
 
     async def test_no_uniqueness_constraint(

--- a/backend/tests/component/core/constraint_validators/test_node_hierarchy_update.py
+++ b/backend/tests/component/core/constraint_validators/test_node_hierarchy_update.py
@@ -381,7 +381,7 @@ async def test_validator_parents_failure(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -408,7 +408,7 @@ async def test_validator_parents_success(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -433,7 +433,7 @@ async def test_validator_children_failure(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -460,7 +460,7 @@ async def test_validator_children_success(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_node_uniqueness.py
+++ b/backend/tests/component/core/constraint_validators/test_node_uniqueness.py
@@ -4,6 +4,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
+from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
 from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
@@ -12,7 +13,13 @@ from infrahub.exceptions import ValidationError
 async def test_node_validate_constraint_node_uniqueness_failure(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main: Node
 ) -> None:
-    constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
+    constraint = NodeGroupedUniquenessConstraint(
+        db=db,
+        branch=default_branch,
+        message_builder=UniquenessViolationMessageBuilder(
+            schema_branch=registry.schema.get_schema_branch(default_branch.name)
+        ),
+    )
     new_john = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await new_john.new(db=db, name="John", height=160)
 
@@ -25,7 +32,13 @@ async def test_node_validate_constraint_node_uniqueness_failure(
 async def test_node_validate_constraint_node_uniqueness_success(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main: Node
 ) -> None:
-    constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
+    constraint = NodeGroupedUniquenessConstraint(
+        db=db,
+        branch=default_branch,
+        message_builder=UniquenessViolationMessageBuilder(
+            schema_branch=registry.schema.get_schema_branch(default_branch.name)
+        ),
+    )
     alfred = await Node.init(db=db, schema="TestPerson", branch=default_branch)
 
     await alfred.new(db=db, name="Alfred", height=160)
@@ -45,7 +58,13 @@ async def test_hierarchical_uniqueness_constraint(
     rack_schema.uniqueness_constraints = [["parent", "status__value"]]
 
     registry.schema.register_schema(schema=hierarchical_location_schema_simple_unregistered, branch=default_branch.name)
-    constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
+    constraint = NodeGroupedUniquenessConstraint(
+        db=db,
+        branch=default_branch,
+        message_builder=UniquenessViolationMessageBuilder(
+            schema_branch=registry.schema.get_schema_branch(default_branch.name)
+        ),
+    )
 
     eu = await Node.init(db=db, schema="LocationRegion", branch=default_branch)
     await eu.new(db=db, name="Europe")

--- a/backend/tests/component/core/constraint_validators/test_relationship_count.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_count.py
@@ -460,7 +460,7 @@ async def test_validator(
         constraint_name="relationship.max_count.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)
@@ -502,7 +502,7 @@ async def test_validator_cardinality_failure(
         constraint_name="relationship.cardinality.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)

--- a/backend/tests/component/core/constraint_validators/test_relationship_optional_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_optional_update.py
@@ -62,7 +62,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestPerson", field_name="cars"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipOptionalChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_peer_update.py
@@ -450,7 +450,7 @@ async def test_validator(
         constraint_name="relationship.peer.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestCar", field_name="owner"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=SchemaBranch(cache={}, name="test"),
     )
 
     constraint_checker = RelationshipPeerChecker(db=db, branch=default_branch)

--- a/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
+++ b/backend/tests/component/core/constraint_validators/test_template_resource_pool_exclusive.py
@@ -11,6 +11,7 @@ from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
+from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
 from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
@@ -445,7 +446,13 @@ class TestNodeConstraintRunnerPoolFilterExpansion:
         runner = NodeConstraintRunner(
             db=db,
             branch=default_branch_scope_class,
-            uniqueness_constraint=NodeGroupedUniquenessConstraint(db=db, branch=default_branch_scope_class),
+            uniqueness_constraint=NodeGroupedUniquenessConstraint(
+                db=db,
+                branch=default_branch_scope_class,
+                message_builder=UniquenessViolationMessageBuilder(
+                    schema_branch=registry.schema.get_schema_branch(default_branch_scope_class.name)
+                ),
+            ),
             relationship_manager_constraints=[constraint],
         )
 
@@ -482,7 +489,13 @@ class TestNodeConstraintRunnerPoolFilterExpansion:
         runner = NodeConstraintRunner(
             db=db,
             branch=default_branch_scope_class,
-            uniqueness_constraint=NodeGroupedUniquenessConstraint(db=db, branch=default_branch_scope_class),
+            uniqueness_constraint=NodeGroupedUniquenessConstraint(
+                db=db,
+                branch=default_branch_scope_class,
+                message_builder=UniquenessViolationMessageBuilder(
+                    schema_branch=registry.schema.get_schema_branch(default_branch_scope_class.name)
+                ),
+            ),
             relationship_manager_constraints=[constraint],
         )
 

--- a/backend/tests/component/core/constraint_validators/test_uniqueness_checker.py
+++ b/backend/tests/component/core/constraint_validators/test_uniqueness_checker.py
@@ -23,7 +23,7 @@ class TestUniquenessChecker:
             constraint_name="node.uniqueness_constraints.update",
             node_schema=schema,
             schema_path=schema_path,
-            schema_branch=SchemaBranch(cache={}),
+            schema_branch=SchemaBranch(cache={}, name="test"),
         )
         return await checker.check(request)
 

--- a/backend/tests/component/core/node/test_create_node_computed_uniqueness.py
+++ b/backend/tests/component/core/node/test_create_node_computed_uniqueness.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.node.create import create_node
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
+from infrahub.exceptions import HFIDViolatedError, ValidationError
+from tests.helpers.schema_builders import computed_jinja2_attr
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+@pytest.fixture
+async def stuff_schema_computed_hfid(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+    """Schema where the human-friendly id is a required computed attribute derived from a local attribute."""
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Stuff",
+                namespace="Random",
+                human_friendly_id=["name__value"],
+                attributes=[
+                    computed_jinja2_attr(name="name", template="{{ description__value | upper }}-STUFF"),
+                    AttributeSchema(name="description", kind="Text"),
+                ],
+            ),
+        ],
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    return schema
+
+
+@pytest.fixture
+async def stuff_schema_computed_from_relationship(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+    """Schema where the unique computed attribute is derived from an attribute on a peer relationship."""
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Stuff",
+                namespace="Random",
+                human_friendly_id=["name__value"],
+                attributes=[computed_jinja2_attr(name="name", template="{{ owner__name__value | upper }}")],
+                relationships=[
+                    RelationshipSchema(name="owner", peer="RandomOwner", optional=False, cardinality="one"),
+                ],
+            ),
+            NodeSchema(
+                name="Owner",
+                namespace="Random",
+                attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            ),
+        ],
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    return schema
+
+
+@pytest.fixture
+async def stuff_schema_computed_secondary_unique(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+    """Schema where a unique computed attribute exists alongside a separate, non-computed human-friendly id."""
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="Stuff",
+                namespace="Random",
+                human_friendly_id=["name__value"],
+                attributes=[
+                    AttributeSchema(name="name", kind="Text", unique=True),
+                    computed_jinja2_attr(name="code", template="{{ description__value | upper }}"),
+                    AttributeSchema(name="description", kind="Text"),
+                ],
+            ),
+        ],
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    return schema
+
+
+async def test_create_node_rejects_duplicate_computed_hfid(
+    db: InfrahubDatabase, default_branch: Branch, stuff_schema_computed_hfid: SchemaRoot
+) -> None:
+    stuff_schema = registry.schema.get_node_schema(name="RandomStuff", branch=default_branch)
+
+    first = await create_node(data={"description": "widget"}, db=db, branch=default_branch, schema=stuff_schema)
+    assert first.name.value == "WIDGET-STUFF"
+
+    with pytest.raises(
+        HFIDViolatedError, match=r"Violates uniqueness constraint 'name' \(computed from: description\)"
+    ):
+        await create_node(data={"description": "widget"}, db=db, branch=default_branch, schema=stuff_schema)
+
+
+async def test_violation_message_lists_relationship_peer_attribute(
+    db: InfrahubDatabase, default_branch: Branch, stuff_schema_computed_from_relationship: SchemaRoot
+) -> None:
+    stuff_schema = registry.schema.get_node_schema(name="RandomStuff", branch=default_branch)
+    owner_schema = registry.schema.get_node_schema(name="RandomOwner", branch=default_branch)
+
+    alice = await create_node(data={"name": "alice"}, db=db, branch=default_branch, schema=owner_schema)
+    first = await create_node(data={"owner": {"id": alice.id}}, db=db, branch=default_branch, schema=stuff_schema)
+    assert first.name.value == "ALICE"
+
+    with pytest.raises(
+        HFIDViolatedError, match=r"Violates uniqueness constraint 'name' \(computed from: owner\.name\)"
+    ):
+        await create_node(data={"owner": {"id": alice.id}}, db=db, branch=default_branch, schema=stuff_schema)
+
+
+async def test_create_node_rejects_duplicate_computed_secondary_unique(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    stuff_schema_computed_secondary_unique: SchemaRoot,
+) -> None:
+    stuff_schema = registry.schema.get_node_schema(name="RandomStuff", branch=default_branch)
+
+    first = await create_node(
+        data={"name": "alpha", "description": "widget"}, db=db, branch=default_branch, schema=stuff_schema
+    )
+    assert first.code.value == "WIDGET"
+
+    with pytest.raises(
+        ValidationError, match=r"Violates uniqueness constraint 'code' \(computed from: description\)"
+    ) as exc_info:
+        await create_node(
+            data={"name": "beta", "description": "widget"}, db=db, branch=default_branch, schema=stuff_schema
+        )
+    assert not isinstance(exc_info.value, HFIDViolatedError)

--- a/backend/tests/component/core/schema/test_attribute_parameters.py
+++ b/backend/tests/component/core/schema/test_attribute_parameters.py
@@ -103,7 +103,7 @@ def test_number_pool_optional() -> None:
     node_schema = NodeSchema(**node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it can't be optional"
@@ -130,7 +130,7 @@ def test_number_pool_read_only() -> None:
     node_schema = NodeSchema(**node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"TestNumberAttribute.assigned_number is a NumberPool it has to be a read_only attribute"
@@ -174,7 +174,7 @@ def test_number_pool_override_generic() -> None:
     generic_schema = GenericSchema(**generic_node_schema_definition)
 
     schema = SchemaRoot(nodes=[node_schema], generics=[generic_schema])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError,
@@ -194,7 +194,7 @@ def test_number_pool_fail_on_multiple_generics() -> None:
 
     modified_incident.inherit_from.append("SnowOtherTask")
     schema = SchemaRoot(generics=[SNOW_TASK, alternate_base], nodes=[modified_incident])
-    schema_branch = SchemaBranch(cache={})
+    schema_branch = SchemaBranch(cache={}, name="test")
     schema_branch.load_schema(schema=schema)
     with pytest.raises(
         ValidationError, match=r"SnowIncident.number is a NumberPool inherited from more than one generic"

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -494,6 +494,47 @@ async def test_delete_branch_aware_node_with_agnostic_relationship(
     )
 
 
+async def test_error_only_includes_violation_node_during_cascade_delete(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+    person_jane_main: Node,
+    person_albert_main: Node,
+    car_camry_main: Node,
+) -> None:
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+    person_schema = schema_branch.get(name="TestPerson", duplicate=False)
+    person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
+
+    person_schema.relationships.append(
+        RelationshipSchema(
+            name="manager",
+            kind="Attribute",
+            optional=False,
+            peer="TestPerson",
+            cardinality="one",
+            identifier="person__manager",
+            on_delete=RelationshipDeleteBehavior.NO_ACTION,
+            branch=BranchSupportType.AWARE,
+        )
+    )
+
+    albert = await NodeManager.get_one(db=db, id=person_albert_main.id)
+    await albert.manager.update(db=db, data=person_jane_main.id)
+    await albert.save(db=db)
+
+    with pytest.raises(ValidationError) as exc:
+        await NodeManager.delete(db=db, branch=default_branch, nodes=[person_jane_main])
+
+    error_msg = str(exc.value)
+    expected_msg = (
+        f"Cannot delete TestPerson '{person_jane_main.id}'. "
+        f"It is linked to mandatory relationship manager on node TestPerson '{person_albert_main.id}' at TestPerson.manager"
+    )
+    assert error_msg == expected_msg
+
+
 async def test_delete_cascade_artifacts(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/backend/tests/helpers/schema_builders.py
+++ b/backend/tests/helpers/schema_builders.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from infrahub.core.constants import ComputedAttributeKind
+from infrahub.core.schema import AttributeSchema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
+
+
+def computed_jinja2_attr(name: str, template: str, **overrides: Any) -> AttributeSchema:
+    """Build a read-only Text attribute computed from a Jinja2 template.
+
+    Defaults suit a required, unique computed attribute; pass overrides such as
+    `unique=False` or `optional=True` for other shapes.
+    """
+    params: dict[str, Any] = {
+        "kind": "Text",
+        "read_only": True,
+        "unique": True,
+        "optional": False,
+        "computed_attribute": ComputedAttribute(kind=ComputedAttributeKind.JINJA2, jinja2_template=template),
+    }
+    params.update(overrides)
+    return AttributeSchema(name=name, **params)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,0 +1,79 @@
+import pytest
+
+from infrahub.core.constants import (
+    BranchSupportType,
+    RelationshipCardinality,
+    RelationshipDirection,
+    RelationshipKind,
+)
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
+
+
+@pytest.fixture
+def car_person_schema_root() -> SchemaRoot:
+    car = NodeSchema(
+        name="Car",
+        namespace="Test",
+        default_filter="name__value",
+        display_label="{{ name__value }} {{ color__value }}",
+        uniqueness_constraints=[["name__value"]],
+        branch=BranchSupportType.AWARE,
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="nbr_seats", kind="Number", optional=True),
+            AttributeSchema(name="color", kind="Text", default_value="#444444", max_length=7, optional=True),
+            AttributeSchema(name="is_electric", kind="Boolean", optional=True),
+            AttributeSchema(
+                name="transmission",
+                kind="Text",
+                optional=True,
+                enum=["manual", "automatic", "flintstone-feet"],
+            ),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="owner",
+                label="Commander of Car",
+                peer="TestPerson",
+                optional=False,
+                kind=RelationshipKind.PARENT,
+                cardinality=RelationshipCardinality.ONE,
+                direction=RelationshipDirection.OUTBOUND,
+            ),
+            RelationshipSchema(
+                name="driver",
+                label="Commander of Car",
+                peer="TestPerson",
+                optional=True,
+                cardinality=RelationshipCardinality.ONE,
+                identifier="cars_driven__driver",
+            ),
+        ],
+    )
+    person = NodeSchema(
+        name="Person",
+        namespace="Test",
+        default_filter="name__value",
+        display_label="name__value",
+        branch=BranchSupportType.AWARE,
+        uniqueness_constraints=[["name__value"]],
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="height", kind="Number", optional=True),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="cars",
+                peer="TestCar",
+                cardinality=RelationshipCardinality.MANY,
+                direction=RelationshipDirection.INBOUND,
+            ),
+            RelationshipSchema(
+                name="cars_driven",
+                peer="TestCar",
+                cardinality=RelationshipCardinality.MANY,
+                identifier="cars_driven__driver",
+            ),
+        ],
+    )
+    return SchemaRoot(nodes=[car, person])

--- a/backend/tests/unit/core/node/constraints/test_uniqueness_violation_message.py
+++ b/backend/tests/unit/core/node/constraints/test_uniqueness_violation_message.py
@@ -1,0 +1,94 @@
+import pytest
+
+from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from tests.helpers.schema_builders import computed_jinja2_attr
+
+
+@pytest.fixture
+def schema_root() -> SchemaRoot:
+    car = NodeSchema(
+        name="Car",
+        namespace="Test",
+        human_friendly_id=["name__value"],
+        attributes=[
+            computed_jinja2_attr(name="name", template="{{ model__value | upper }}-CAR"),
+            AttributeSchema(name="model", kind="Text"),
+            computed_jinja2_attr(
+                name="badge",
+                template="{{ owner__name__value }} :: {{ model__value }}",
+                unique=False,
+                optional=True,
+            ),
+        ],
+        relationships=[
+            RelationshipSchema(
+                name="owner",
+                peer="TestPerson",
+                cardinality=RelationshipCardinality.ONE,
+                optional=False,
+            ),
+        ],
+    )
+    person = NodeSchema(
+        name="Person",
+        namespace="Test",
+        human_friendly_id=["name__value"],
+        attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+    )
+    return SchemaRoot(nodes=[car, person])
+
+
+@pytest.fixture
+def schema_branch(schema_root: SchemaRoot) -> SchemaBranch:
+    branch = SchemaBranch(cache={}, name="test")
+    branch.load_schema(schema=schema_root)
+    branch.process()
+    return branch
+
+
+@pytest.fixture
+def builder(schema_branch: SchemaBranch) -> UniquenessViolationMessageBuilder:
+    return UniquenessViolationMessageBuilder(schema_branch=schema_branch)
+
+
+def test_non_computed_field_has_no_suffix(
+    builder: UniquenessViolationMessageBuilder, schema_branch: SchemaBranch
+) -> None:
+    car = schema_branch.get(name="TestCar", duplicate=False)
+    message = builder.build(node_schema=car, fields=["model"])
+    assert message == "Violates uniqueness constraint 'model'"
+
+
+def test_computed_attribute_input_is_named_in_suffix(
+    builder: UniquenessViolationMessageBuilder, schema_branch: SchemaBranch
+) -> None:
+    car = schema_branch.get(name="TestCar", duplicate=False)
+    message = builder.build(node_schema=car, fields=["name"])
+    assert message == "Violates uniqueness constraint 'name' (computed from: model)"
+
+
+def test_relationship_input_uses_dotted_form(
+    builder: UniquenessViolationMessageBuilder, schema_branch: SchemaBranch
+) -> None:
+    car = schema_branch.get(name="TestCar", duplicate=False)
+    message = builder.build(node_schema=car, fields=["badge"])
+    assert message == "Violates uniqueness constraint 'badge' (computed from: model, owner.name)"
+
+
+def test_multiple_computed_fields_deduplicate_shared_inputs(
+    builder: UniquenessViolationMessageBuilder, schema_branch: SchemaBranch
+) -> None:
+    car = schema_branch.get(name="TestCar", duplicate=False)
+    message = builder.build(node_schema=car, fields=["name", "badge"])
+    assert message == "Violates uniqueness constraint 'name-badge' (computed from: model, owner.name)"
+
+
+def test_unknown_field_is_skipped_silently(
+    builder: UniquenessViolationMessageBuilder, schema_branch: SchemaBranch
+) -> None:
+    car = schema_branch.get(name="TestCar", duplicate=False)
+    message = builder.build(node_schema=car, fields=["does_not_exist"])
+    assert message == "Violates uniqueness constraint 'does_not_exist'"

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -4,6 +4,22 @@ from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, Sch
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
+def test_single_relationship_uniqueness_constraint(car_person_schema_root: SchemaRoot) -> None:
+    """The HFID derivation must resolve a parent-only constraint without crashing."""
+    car_schema = next(n for n in car_person_schema_root.nodes if n.name == "Car")
+    car_schema.uniqueness_constraints = [["owner"]]
+    for attribute_schema in car_schema.attributes:
+        attribute_schema.unique = False
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=car_person_schema_root)
+    schema_branch.process()
+
+    processed_car_schema = schema_branch.get(name="TestCar", duplicate=False)
+    assert processed_car_schema.uniqueness_constraints == [["owner"]]
+    assert processed_car_schema.human_friendly_id is None
+
+
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:
     """Proves that schema processing produces the peer/hierarchical values in an expected manner."""
 

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -1,6 +1,6 @@
 import pytest
 
-from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 
@@ -18,6 +18,54 @@ def test_single_relationship_uniqueness_constraint(car_person_schema_root: Schem
     processed_car_schema = schema_branch.get(name="TestCar", duplicate=False)
     assert processed_car_schema.uniqueness_constraints == [["owner"]]
     assert processed_car_schema.human_friendly_id is None
+
+
+def test_validate_names_rejects_double_underscore_in_attribute_name() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Underscore",
+                    namespace="Testing",
+                    attributes=[
+                        AttributeSchema(name="name", kind="Text"),
+                        AttributeSchema(name="name__asc", kind="Text"),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"TestingUnderscore: 'name__asc' cannot be used as an attribute name",
+    ):
+        schema.validate_names()
+
+
+def test_validate_names_rejects_double_underscore_in_relationship_name() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Underscore",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(name="peer__link", peer="TestingUnderscore", optional=True),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"TestingUnderscore: 'peer__link' cannot be used as a relationship name",
+    ):
+        schema.validate_names()
 
 
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:

--- a/changelog/4483.fixed.md
+++ b/changelog/4483.fixed.md
@@ -1,0 +1,1 @@
+Fix schema processing crashing with `'NodeSchema' object has no attribute 'get'` when a node defines a single-element relationship-only `uniqueness_constraints` entry (e.g. `[["parent"]]`).

--- a/changelog/7924.fixed.md
+++ b/changelog/7924.fixed.md
@@ -1,0 +1,1 @@
+Fixed unique constraints not being enforced on computed attributes, and the violation message now names the input attributes to change.

--- a/changelog/9209.fixed.md
+++ b/changelog/9209.fixed.md
@@ -1,0 +1,1 @@
+Schema attribute and relationship names containing `__` are now rejected at load time, since `__` is reserved as the schema path separator. **Breaking change:** any existing schema using such names will fail to load after upgrading — rename the affected attributes or relationships in your schema files (and remove or rename the corresponding data) before upgrading.

--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -1,0 +1,48 @@
+---
+paths:
+  - "backend/infrahub/**/*.py"
+---
+
+# Backend Component Design (SOLID / DI)
+
+Applies when creating a new backend component or making significant changes to an existing one. Does not apply to small bug fixes, single-function tweaks, or changes confined to existing code paths. When in doubt for anything that introduces a new class or reshapes responsibilities, follow this rule.
+
+## Use modular components with dependency injection
+
+New logic should live in components that receive their collaborators through constructor injection rather than instantiating them internally. This keeps components composable, swappable, and testable without patching.
+
+## Build components near the application entry point
+
+Construct components as close to the application entry point as possible. Use a builder class or factory function when wiring is non-trivial, and inject each sub-component rather than constructing it inside a parent component's `__init__`.
+
+## Single entry point, operating on arguments
+
+A component should generally expose a single entry point method (occasionally more, when justified by cohesive responsibility). That method only accepts the entities being operated on as arguments — it should not require additional dependencies to be passed in alongside the work payload.
+
+## Constructor vs. method arguments
+
+- `db` is always injected to the constructor.
+- `branch` is usually injected to the constructor, but not always — inject it when the component's lifetime is tied to a single branch; pass it per-call when the component is reused across branches.
+- Entities being examined or updated (nodes, schemas, diffs, request payloads) are passed to the entry method, not stored on the instance.
+
+The boundary is: long-lived collaborators go in the constructor; transient work items go in the method.
+
+## Single Responsibility Principle
+
+Each component should have one reason to change. If a class is doing two unrelated things, split it. Prefer composition of small components over large multi-purpose ones.
+
+## Interfaces for multiple implementations
+
+When more than one implementation of a component is required (e.g. real vs. in-memory adapter, different backends, A/B variants), define a `Protocol` or abstract base class. The correct implementation is selected at the wiring layer and injected to the constructor — the consumer codes against the interface, not a concrete class.
+
+A single implementation does not need an interface yet; introduce one when the second implementation arrives. Note that the second implementation
+can be either a no-op version (such as in the case of an enterprise-only feature) or a testing version of a component (such as in the case of an
+in-memory version of a component typically backed by the database).
+
+## Why this matters
+
+Constructor-injected long-lived dependencies plus method-passed transient entities is the boundary that lets components be reused across requests/operations and mocked with adapter implementations instead of `unittest.mock`. The [testing rule](./testing-python.md) requires adapter/protocol patterns for tests — that requirement is only practical when production code follows this design.
+
+## Existing code
+
+If existing nearby code violates this pattern, do not refactor it as part of an unrelated change. Raise it as a separate discussion — drive-by refactors balloon scope and make reviews harder.

--- a/docs/docs/release-notes/infrahub/docs-restructure.mdx
+++ b/docs/docs/release-notes/infrahub/docs-restructure.mdx
@@ -16,7 +16,7 @@ The three main feature sections map directly to the three core jobs Infrahub is 
 
 - **Schema & Data** — Infrahub as the unified source of truth for infrastructure data: modeling your schema, managing objects, IPAM, and resource allocation.
 - **Branches & Change Control** — Infrahub's Git-like versioning layer: branching, proposed changes, checks, validation, and Git repository integration.
-- **Automation & Outputs** — Infrahub as the design surface for your automation stack: generators, transformations, artifacts, events, webhooks, and integrations with tools like Ansible and Nornir.
+- **Design & Integrate** — Infrahub as the design surface for your automation stack: generators, transformations, artifacts, events, webhooks, and integrations with tools like Ansible and Nornir.
 
 The remaining sections support those three jobs:
 
@@ -134,7 +134,7 @@ All pages pre-existing and unchanged.
 
 ---
 
-### Automation & Outputs
+### Design & Integrate
 
 - **Generators** · `generators/` · from `topics/generator` — moved as hub
   - **Build a generator** · `generators/build` · net new — recipe-form how-to; replaces the 528-line tutorial moved to Academy

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -256,7 +256,7 @@ const sidebars: SidebarsConfig = {
 
     {
       type: 'category',
-      label: 'Automation & Outputs',
+      label: 'Design & Integrate',
       collapsible: false,
       collapsed: false,
       link: { type: 'generated-index', slug: 'automation-and-outputs' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,6 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "infrahub.core.schema.schema_branch"
 disable_error_code = [
-    "arg-type",
     "assignment",
     "attr-defined",
     "index",

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -490,11 +490,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1355,11 +1355,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

Resolve a merge conflict between develop and stable

## What changed

* All changes from stable
* Trivial merge conflict for uv.lock
* Trivial merge conflict from backend/tests/unit/conftest.py 

```python

<<<<<<< HEAD
from infrahub.core import registry


@pytest.fixture(autouse=True)
def set_registry_default_branch() -> None:
    registry._default_branch = "main"
=======
from infrahub.core.constants import (
    BranchSupportType,
    RelationshipCardinality,
    RelationshipDirection,
    RelationshipKind,
)
from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
```

Kept both and reformatted to proper Python code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges `stable` into `develop` with resolved conflicts and brings backend fixes for computed-attribute uniqueness, schema validation, and delete behavior, plus small CI/docs updates. Users now see clearer uniqueness errors that point to the inputs to change.

- **Bug Fixes**
  - Enforce uniqueness for computed attributes; violation messages include input attributes (e.g., owner.name), covering grouped checks and HFID creation.
  - Prevent schema load crashes in HFID derivation when a uniqueness constraint is a single relationship path.
  - Reject attribute/relationship names containing `__` at load time (reserved path separator).
  - Exclude cascade-deleted nodes from deletion validation error output.

- **Refactors**
  - Extract `UniquenessViolationMessageBuilder` and inject it into `NodeGroupedUniquenessConstraint`; update the dependency builder to wire the branch `SchemaBranch`.
  - Tighten `SchemaBranch` typing: require `name`, add `SchemaBranchDict`, clean up node/generic typing, and drop the mypy arg-type exclusion.
  - CI/docs: disable bug-agent “report-failure-as-issue”, remove approval gating, rename docs section to “Design & Integrate”, fix README links, and bump `idna` to `3.15`.

<sup>Written for commit 6958a59d25a36e7be4812e18532bb6bfbcfc131d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9375?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

