### PR TITLE
docs(frontend): use pnpm in dev guides; document docs.lint step

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -165,6 +165,7 @@ partial_match
 passthrough
 performant
 pluggable
+pnpm
 pre
 prebuilt
 precomputed

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -68,6 +68,16 @@ Available 'docs' tasks:
   .validate                Validate that the generated documentation is committed to Git.
 ```
 
+## Linting before submitting
+
+Run the documentation linters locally before opening a pull request that touches files under `docs/docs/`. CI runs the same checks and will reject the PR otherwise.
+
+```shell
+invoke docs.lint
+```
+
+This task runs both `markdownlint-cli2` and `vale`. The markdownlint binary is provided by `docs/node_modules` after `cd docs && npm install`; Vale is a separate native binary and the task warns and skips it when it is not available locally. CI runs both regardless.
+
 ## Writing documentation with AI
 
 We are increasingly using AI to assist developers in writing technical documentation. To ensure consistency, we maintain a set of instructions that guide the AI when generating documentation for Infrahub.

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -331,11 +331,11 @@ E2E test commands are accessible through inside the `frontend/app` directory. To
 
 ```shell
 cd frontend/app
-npm run test:e2e:screenshots
+pnpm test:e2e:screenshots
 ```
 
 :::info
-By default, tests are run in headless mode. To run them in a visible browser, use `npm run test:e2e:screenshots:headed` instead.
+By default, tests are run in headless mode. To run them in a visible browser, use `pnpm test:e2e:screenshots:headed` instead.
 :::
 
 #### 3. Check the results

--- a/docs/docs/development/frontend/getting-set-up.mdx
+++ b/docs/docs/development/frontend/getting-set-up.mdx
@@ -14,24 +14,24 @@ invoke demo.destroy demo.start demo.load-infra-schema demo.load-infra-data
 
 :::
 
-Infrahub is built with React. Make sure you're running Node.js 24+ and npm 10+, to verify, run:
+Infrahub is built with React and uses [pnpm](https://pnpm.io/) as its package manager. Make sure you're running Node.js 24+ and pnpm 10+, to verify, run:
 
 ```shell
 node --version
-npm --version
+pnpm --version
 ```
 
 ## 1. Install dependencies
 
 ```shell
 cd frontend/app
-npm install
+pnpm install
 ```
 
 ## 2. Start a local server
 
 ```shell
-npm start
+pnpm start
 ```
 
 You can access your local server at [http://localhost:8080/](http://localhost:8080/). If you are not familiar with Infrahub, follow our [Overview Guide](../../overview/overview.mdx).
@@ -41,16 +41,16 @@ You can access your local server at [http://localhost:8080/](http://localhost:80
 ### Unit & integration tests
 
 ```shell
-npm run test
+pnpm test
 
 # same with coverage
-npm run test:coverage
+pnpm test:coverage
 ```
 
 ### E2E tests
 
 ```shell
-npm run test:e2e
+pnpm test:e2e
 ```
 
 All tests should succeed. For more information on testing, read [Running & Writing Tests](testing-guidelines.mdx).

--- a/docs/docs/development/frontend/testing-guidelines.mdx
+++ b/docs/docs/development/frontend/testing-guidelines.mdx
@@ -82,23 +82,23 @@ page.getByRole("button", { name: "Save" });
 
 ```shell
 # headless mode
-npm run test:e2e
+pnpm test:e2e
 
 # non-headless mode (headed)
-npm run test:e2e:headed
+pnpm test:e2e:headed
 
 # Debug mode
-npm run test:e2e:debug
+pnpm test:e2e:debug
 
 # UI mode
-npm run test:e2e:ui
+pnpm test:e2e:ui
 ```
 
 ## Unit & integration tests
 
 ```shell
-npm run test
+pnpm test
 
 # same with coverage
-npm run test:coverage
+pnpm test:coverage
 ```


### PR DESCRIPTION
## Summary

Two related docs corrections grouped into one PR.

**1. Frontend dev guides: npm → pnpm**

`frontend/app/` uses pnpm (`pnpm-lock.yaml`, CI pinned to pnpm 10 in `.github/workflows/ci.yml` and `chromatic.yml`), but the frontend dev guides instructed contributors to run `npm` commands. 

**Note:** The `docs/` Docusaurus site continues to use npm (`docs/package-lock.json`); those references were left intact.

**2. Documenting the `docs.lint` step**

Adds a short "Linting before submitting" section to `docs/docs/development/docs.mdx` so contributors are told to run `invoke docs.lint` before opening a PR that touches `docs/docs/`, so that it fails early

## Test plan

- [x] Verified all referenced pnpm scripts exist in `frontend/app/package.json`
- [x] Confirmed no remaining standalone `npm` references in `docs/docs/development/` (regex `(^|[^p])npm` returns nothing)
- [x] `invoke docs.markdownlint` — 161 files, 0 errors locally
- [ ] `invoke docs.vale` — Vale not installed locally; deferring to CI