### PR TITLE
Pin node version in frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,8 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # https://github.com/microsoft/playwright/issues/41000
+          node-version: 24.15.0
           cache: pnpm
           cache-dependency-path: frontend/app/pnpm-lock.yaml
       - name: "Install frontend"


### PR DESCRIPTION
# Why

The `frontend-tests` job started to fail when the runners switched from Node v24.15.0 to v24.16.0.

References:
* https://github.com/microsoft/playwright/issues/41000
* https://github.com/microsoft/playwright/issues/40724


## What changed

Pinned Node to v24.15.0 for now.