### PR TITLE
fix(frontend): add refresh button to artifact detail page

### DIFF
--- a/changelog/9335.fixed.md
+++ b/changelog/9335.fixed.md
@@ -1,0 +1,1 @@
+Added a refresh button to the artifact detail page so regenerated artifact content can be reloaded in place, without requiring a full browser refresh.

--- a/frontend/app/src/entities/artifacts/ui/artifact-header.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-header.tsx
@@ -3,6 +3,7 @@ import { ArtifactDetailsMenu } from "@/entities/artifacts/ui/artifact-details-me
 import { ArtifactGenerateButton } from "@/entities/artifacts/ui/artifact-generate-button";
 import { ArtifactStatusBadge } from "@/entities/artifacts/ui/artifact-status-badge";
 import { NodeMetadataPopover } from "@/entities/nodes/object/ui/object-details/node-metadata-popover";
+import { RefreshButton } from "@/entities/nodes/object/ui/object-details/refresh-button";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 
 interface ArtifactHeaderProps {
@@ -17,6 +18,8 @@ export function ArtifactHeader({ artifact }: ArtifactHeaderProps) {
       <ArtifactStatusBadge status={artifact.status.value} />
 
       <div className="ml-auto flex items-center gap-1">
+        <RefreshButton />
+
         <ArtifactGenerateButton
           label="Re-generate"
           artifactId={artifact.id}


### PR DESCRIPTION
# Why

When viewing an artifact on its detail page and triggering the regenerate action, there was no control to reload the artifact view once generation finished. The content stayed stale until the whole browser tab was refreshed.

Closes #9335

## What changed

The shared refresh button now appears in the artifact header, right next to the regenerate action. Clicking it refetches the artifact object and its rendered content directly on the page, so the updated output becomes visible without reloading the entire browser tab.

This reuses the existing refresh button component that object detail pages already rely on, so the appearance, the loading state, and the last refresh tooltip stay consistent across the application. No backend changes and no API changes were needed.

## How to test

1. Start a local instance with demo data that includes artifacts.
2. Open an artifact detail page at /objects/CoreArtifact/{id}.
3. Confirm a refresh button now sits to the left of the regenerate action.
4. Click regenerate, wait for the activity panel to report the artifact as ready, then click refresh and confirm the new content loads in place.

Automated checks:

```bash
cd frontend/app
pnpm biome check src/entities/artifacts/ui/artifact-header.tsx
pnpm test
```

The frontend unit suite passes (657 tests across 89 files) and Biome reports no issues on the changed file.

## Impact

Backward compatibility: no breaking changes, the behavior is additive only.

Performance: negligible, the refresh action runs the same query the page already performs.

Config or environment changes: none.

## Checklist

1. Changelog entry added.
2. Change verified in a running instance.
3. No new automated tests, since the change reuses a component that is already covered by existing tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a refresh button to the artifact detail page to show regenerated output without reloading the tab, addressing #9335. The shared `RefreshButton` sits next to Re-generate and refetches the artifact and its rendered content in place.

<sup>Written for commit c338a365db1bcf2943c02dec94837503e09b57b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9384?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

