### PR TITLE
fix(ci): replace chromium netlink binary patch with LD_PRELOAD shim, upgrade Playwright to 1.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1149,13 +1149,16 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium --no-shell
 
-      # Make chromium ignore netlink messages by returning ReadMessages early
-      - name: Chrome path
-        run: echo CHROME_BIN_PATH="$(pnpm exec playwright install chromium --no-shell --dry-run | grep Install | grep chromium- | awk '{print $3}')/chrome-linux/chrome" >> $GITHUB_ENV
-      - name: Chrome func offset
-        run: echo FUNC_OFFSET="$(objdump -C --file-offsets --disassemble='net::internal::AddressTrackerLinux::ReadMessages(bool*, bool*, bool*)' $CHROME_BIN_PATH | grep 'File Offset' | sed -n 1p | sed -E 's/.*File Offset. (.*)\).*/\1/')" >> $GITHUB_ENV
-      - name: Patch chromium
-        run: printf '\xc3' | dd of=$CHROME_BIN_PATH bs=1 seek=$(($FUNC_OFFSET)) conv=notrunc
+      # Make chromium ignore netlink messages so AddressTrackerLinux takes its "assume always
+      # online" path. The LD_PRELOAD shim fails NETLINK_ROUTE sockets at the libc level, which
+      # is robust across Playwright/Chromium versions (unlike patching the chrome binary). The
+      # shim is injected into the browser process via playwright.config.ts (NO_NETLINK_SO).
+      - name: Build no-netlink shim
+        run: |
+          gcc -shared -fPIC -Wall -Wextra \
+            -o "$RUNNER_TEMP/no_netlink.so" \
+            tests/e2e/fixtures/no_netlink.c -ldl
+          echo "NO_NETLINK_SO=$RUNNER_TEMP/no_netlink.so" >> "$GITHUB_ENV"
 
       - name: Wait for artifacts to be generated before restarting infrahub
         if: needs.files-changed.outputs.e2e_tests == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Responses must be direct and substantive. Do not use filler phrases, compliments
 
 - **Backend:** Python 3.12, FastAPI 0.121.1, Neo4j 5.28, Pydantic 2.10
 - **Frontend:** TypeScript 5.9, React 19.2, Vite 8.0, Tailwind CSS 4.2
-- **Testing:** pytest 9.0, Vitest 4.1, Playwright 1.56
+- **Testing:** pytest 9.0, Vitest 4.1, Playwright 1.60
 - **Linting:** ruff 0.15, mypy 1.15, Biome 2.4
 - **Package Managers:** uv (Python), pnpm (Frontend)
 - **Task Runner:** Invoke 2.2.0

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -115,7 +115,7 @@
     "@graphql-codegen/cli": "^6.3.1",
     "@graphql-codegen/typescript": "^5.0.10",
     "@graphql-codegen/typescript-operations": "^5.1.0",
-    "@playwright/test": "1.56.1",
+    "@playwright/test": "1.60.0",
     "@types/apollo-upload-client": "18.0.1",
     "@types/node": "^25.6.0",
     "@types/prismjs": "^1.26.6",
@@ -140,8 +140,8 @@
       "playwright-core"
     ],
     "overrides": {
-      "playwright": "1.56.1",
-      "playwright-core": "1.56.1"
+      "playwright": "1.60.0",
+      "playwright-core": "1.60.0"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -43,6 +43,19 @@ export default defineConfig({
     trace: process.env.CI ? "retain-on-failure" : "on",
     screenshot: process.env.CI ? "only-on-failure" : "on",
     video: process.env.CI ? "retain-on-failure" : "on",
+
+    /* Fail NETLINK_ROUTE sockets in the browser so Chromium's AddressTrackerLinux takes its
+       "assume always online" path. Avoids ERR_NETWORK_CHANGED flake from Docker/veth netlink
+       churn on CI. NO_NETLINK_SO is the compiled LD_PRELOAD shim, set in CI only. Scoped to the
+       browser process so it doesn't leak into node/pnpm subprocesses. */
+    launchOptions: process.env.NO_NETLINK_SO
+      ? {
+          env: {
+            ...process.env,
+            LD_PRELOAD: process.env.NO_NETLINK_SO,
+          } as Record<string, string>,
+        }
+      : undefined,
   },
 
   /* Configure projects for major browsers */

--- a/frontend/app/pnpm-lock.yaml
+++ b/frontend/app/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  playwright: 1.56.1
-  playwright-core: 1.56.1
+  playwright: 1.60.0
+  playwright-core: 1.60.0
 
 importers:
 
@@ -263,8 +263,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0(graphql@16.13.2)
       '@playwright/test':
-        specifier: 1.56.1
-        version: 1.56.1
+        specifier: 1.60.0
+        version: 1.60.0
       '@types/apollo-upload-client':
         specifier: 18.0.1
         version: 18.0.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.13.2)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -288,7 +288,7 @@ importers:
         version: 1.1.5
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.5(playwright@1.56.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)
+        version: 4.1.5(playwright@1.60.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
@@ -1727,8 +1727,8 @@ packages:
   '@phenomnomnominal/tstemplate@0.1.0':
     resolution: {integrity: sha512-/v+GIVNFHAz4+nQtgy9e5ZAXK3xj6TbP5s9JTpnFuqkcLB+gB2lJ6x/nsDhkKhzR6o4REuzhsYoWYnXqKC/UnQ==}
 
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3000,7 +3000,7 @@ packages:
   '@vitest/browser-playwright@4.1.5':
     resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
     peerDependencies:
-      playwright: 1.56.1
+      playwright: 1.60.0
       vitest: 4.1.5
 
   '@vitest/browser@4.1.5':
@@ -4664,13 +4664,13 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7070,9 +7070,9 @@ snapshots:
 
   '@phenomnomnominal/tstemplate@0.1.0': {}
 
-  '@playwright/test@1.56.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.56.1
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8244,11 +8244,11 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.5(playwright@1.56.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(playwright@1.60.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
-      playwright: 1.56.1
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
@@ -10163,11 +10163,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.56.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10993,7 +10993,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
-      '@vitest/browser-playwright': 4.1.5(playwright@1.56.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(playwright@1.60.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
     transitivePeerDependencies:
       - msw

--- a/frontend/app/tests/e2e/fixtures/no_netlink.c
+++ b/frontend/app/tests/e2e/fixtures/no_netlink.c
@@ -1,0 +1,28 @@
+// LD_PRELOAD shim that fails NETLINK_ROUTE sockets with EAFNOSUPPORT, so
+// Chromium's AddressTrackerLinux::Init takes its graceful "assume always
+// online" path (the same path FreeBSD's Linuxulator triggers). This avoids
+// netlink flake on CI runners where Docker/veth churn floods host netlink
+// and causes ERR_NETWORK_CHANGED mid-navigation.
+//
+// Build: gcc -shared -fPIC -o no_netlink.so no_netlink.c -ldl
+// Inject via Playwright launch env: {"LD_PRELOAD": "/path/to/no_netlink.so"}.
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <linux/netlink.h>
+#include <stddef.h>
+#include <sys/socket.h>
+
+int socket(int domain, int type, int protocol) {
+    if (domain == AF_NETLINK && protocol == NETLINK_ROUTE) {
+        errno = EAFNOSUPPORT;
+        return -1;
+    }
+    static int (*real_socket)(int, int, int) = NULL;
+    if (!real_socket) {
+        real_socket = dlsym(RTLD_NEXT, "socket");
+    }
+    return real_socket(domain, type, protocol);
+}


### PR DESCRIPTION
## Summary

Two commits:

1. **`ci:` replace the chromium netlink binary patch with an `LD_PRELOAD` shim.** The E2E job worked around `ERR_NETWORK_CHANGED` flake (Docker/veth netlink churn on the runners) by patching the installed chrome binary: `objdump` to locate `net::internal::AddressTrackerLinux::ReadMessages(...)`, then `dd` an `0xc3` (x86 `RET`) over its first instruction. That offset detection depends on an exact unstripped mangled symbol and the `--no-shell` binary layout — both of which newer Playwright/Chromium builds change, so the patch breaks. Replaced with an `LD_PRELOAD` shim (`frontend/app/tests/e2e/fixtures/no_netlink.c`, ported from styrmin) that fails `NETLINK_ROUTE` sockets with `EAFNOSUPPORT` at the libc level, so `AddressTrackerLinux::Init` takes its graceful "assume always online" path. Version-independent — it never inspects the chromium binary.

2. **`test:` upgrade Playwright `1.56.1 → 1.60.0`** (latest stable): `@playwright/test` + the `playwright`/`playwright-core` pnpm overrides, refreshed lockfile, and the AGENTS.md tech-stack note.

Ordered shim-first so the version bump doesn't ride on the already-broken `dd` patch.

## Implementation notes

- The shim is compiled in CI (`gcc -shared -fPIC … -ldl`) and exported as `NO_NETLINK_SO`. `playwright.config.ts` injects it via `launchOptions.env` scoped to the **browser process only**, so it doesn't leak into node/pnpm subprocesses (whose libuv interface enumeration also uses `NETLINK_ROUTE`).
- The lockfile change is surgical — only the Playwright version + 3 integrity hashes (20 lines). A plain `pnpm install` additionally re-tidied unrelated `schema-visualizer`/`@xyflow` entries (pnpm 10.33 cosmetic reformatting), which `--frozen-lockfile` does not require; that churn was kept out.

## Verification

- Shim compiles clean and exports `socket`.
- `playwright.config.ts` loads and enumerates 245 tests with and without `NO_NETLINK_SO`; Biome clean.
- `pnpm install --frozen-lockfile` passes and resolves `@playwright/test 1.60.0`; `pnpm exec playwright install chromium --no-shell` downloads the 1.60.0 build (Chrome for Testing 148).
- Local checks ran on arm64; CI runs x86_64 (the swap is arch-independent). Authoritative check is the `E2E-testing-playwright` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the brittle Chromium binary patch with an `LD_PRELOAD` shim to stop netlink churn from causing E2E flakes, and upgraded Playwright to 1.60.0.

- **Bug Fixes**
  - Removed the `objdump`/`dd` Chrome patch; build a `no_netlink.so` shim in CI and export `NO_NETLINK_SO`.
  - Inject the shim via `launchOptions.env.LD_PRELOAD` in `playwright.config.ts`, scoped to the browser process only.
  - The shim blocks `NETLINK_ROUTE` sockets so Chromium assumes “always online,” eliminating `ERR_NETWORK_CHANGED` flakes.

- **Dependencies**
  - Upgraded `@playwright/test` to `1.60.0` with `playwright`/`playwright-core` overrides.
  - Updated the lockfile and the testing version in AGENTS.md.

<sup>Written for commit 2a321bbbd0886d5ba2c88a1c5e79093e51d90bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9385?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

