### PR TITLE
fix(frontend/auth): harden token-expiry retry path

### DIFF
--- a/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
+++ b/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
@@ -4,8 +4,8 @@ import { type Path, useLocation, useSearchParams } from "react-router";
 import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 import { classNames } from "@/shared/utils/common";
 
-import type { SSOProvider } from "@/entities/config/types";
 import { pathToString, safeInternalPath } from "@/entities/authentication/utils";
+import type { SSOProvider } from "@/entities/config/types";
 
 export interface LoginWithSSOButtonsProps {
   className?: string;

--- a/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
+++ b/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
@@ -1,10 +1,11 @@
 import { Icon } from "@iconify-icon/react";
-import { useLocation } from "react-router";
+import { type Path, useLocation, useSearchParams } from "react-router";
 
 import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 import { classNames } from "@/shared/utils/common";
 
 import type { SSOProvider } from "@/entities/config/types";
+import { pathToString, safeInternalPath } from "@/entities/authentication/utils";
 
 export interface LoginWithSSOButtonsProps {
   className?: string;
@@ -13,8 +14,18 @@ export interface LoginWithSSOButtonsProps {
 
 export const LoginWithSSOButtons = ({ className, providers }: LoginWithSSOButtonsProps) => {
   const location = useLocation();
-  const redirectTo: string =
-    (location.state?.from?.pathname || "/") + (location.state?.from?.search ?? "");
+  const [searchParams] = useSearchParams();
+
+  // Mirror the resolution order used by LoginPage so SSO sign-in returns
+  // the user to the same destination as in-app sign-in: prefer router
+  // state (set by ProtectedRoute), fall back to the `?from=` query param
+  // set by `redirectToLogin()` on hard nav. Without this fallback, users
+  // hard-navigated to `/login?from=/x` and then clicking an SSO button
+  // would land at `/` after auth-callback because the backend only knows
+  // what we put in `final_url`.
+  const stateFrom = location.state?.from as Partial<Path> | undefined;
+  const queryFrom = safeInternalPath(searchParams.get("from"));
+  const redirectTo = pathToString(stateFrom ?? queryFrom ?? { pathname: "/" });
 
   return (
     <div className={classNames("flex w-full flex-col gap-2", className)}>
@@ -36,10 +47,14 @@ export const ProviderButton = ({
   provider: SSOProvider;
   redirectTo?: string;
 }) => {
+  // Encode `final_url` so a redirect target that contains `&` or `?` does
+  // not corrupt the authorize URL's own query string.
+  const authorizeUrl = `${INFRAHUB_API_SERVER_URL + provider.authorize_path}?final_url=${encodeURIComponent(redirectTo)}`;
+
   return (
     <a
       className="inline-flex h-9 items-center justify-center whitespace-nowrap rounded-md border border-gray-200 bg-white px-4 py-2 font-medium text-sm shadow-xs hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
-      href={`${INFRAHUB_API_SERVER_URL + provider.authorize_path}?final_url=${redirectTo}`}
+      href={authorizeUrl}
     >
       <Icon icon={provider.icon} />
       <span className="ml-2">Continue with {provider.display_label}</span>

--- a/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
+++ b/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
@@ -1,10 +1,10 @@
 import { Icon } from "@iconify-icon/react";
-import { type Path, useLocation, useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 
 import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 import { classNames } from "@/shared/utils/common";
 
-import { pathToString, safeInternalPath } from "@/entities/authentication/utils";
+import { pathToString, resolveLoginRedirect } from "@/entities/authentication/utils";
 import type { SSOProvider } from "@/entities/config/types";
 
 export interface LoginWithSSOButtonsProps {
@@ -16,19 +16,10 @@ export const LoginWithSSOButtons = ({ className, providers }: LoginWithSSOButton
   const location = useLocation();
   const [searchParams] = useSearchParams();
 
-  // Mirror the resolution order used by LoginPage so SSO sign-in returns
-  // the user to the same destination as in-app sign-in: prefer router
-  // state (set by ProtectedRoute), fall back to the `?from=` query param
-  // set by `redirectToLogin()` on hard nav. Without this fallback, users
-  // hard-navigated to `/login?from=/x` and then clicking an SSO button
-  // would land at `/` after auth-callback because the backend only knows
-  // what we put in `final_url`. Both sources flow through `safeInternalPath`
-  // so router-state pollution is held to the same open-redirect guard as
-  // the query-string twin.
-  const stateFromRaw = location.state?.from as Partial<Path> | undefined;
-  const stateFrom = stateFromRaw ? safeInternalPath(pathToString(stateFromRaw)) : null;
-  const queryFrom = safeInternalPath(searchParams.get("from"));
-  const redirectTo = pathToString(stateFrom ?? queryFrom ?? { pathname: "/" });
+  // Backend echoes back `final_url` as-is, so SSO sign-in must use the
+  // same redirect target as in-app sign-in or hard-navigated users land
+  // at "/" instead of where they came from.
+  const redirectTo = pathToString(resolveLoginRedirect(location, searchParams));
 
   return (
     <div className={classNames("flex w-full flex-col gap-2", className)}>

--- a/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
+++ b/frontend/app/src/entities/authentication/ui/login-sso-buttons.tsx
@@ -22,8 +22,11 @@ export const LoginWithSSOButtons = ({ className, providers }: LoginWithSSOButton
   // set by `redirectToLogin()` on hard nav. Without this fallback, users
   // hard-navigated to `/login?from=/x` and then clicking an SSO button
   // would land at `/` after auth-callback because the backend only knows
-  // what we put in `final_url`.
-  const stateFrom = location.state?.from as Partial<Path> | undefined;
+  // what we put in `final_url`. Both sources flow through `safeInternalPath`
+  // so router-state pollution is held to the same open-redirect guard as
+  // the query-string twin.
+  const stateFromRaw = location.state?.from as Partial<Path> | undefined;
+  const stateFrom = stateFromRaw ? safeInternalPath(pathToString(stateFromRaw)) : null;
   const queryFrom = safeInternalPath(searchParams.get("from"));
   const redirectTo = pathToString(stateFrom ?? queryFrom ?? { pathname: "/" });
 

--- a/frontend/app/src/entities/authentication/utils.test.ts
+++ b/frontend/app/src/entities/authentication/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { pathToString, safeInternalPath } from "./utils";
+
+describe("safeInternalPath", () => {
+  // The original window.location.origin in vitest's jsdom is `http://localhost:3000`.
+  // The helper compares against `window.location.origin`, so the absolute-URL
+  // cases below use that origin as the same-origin baseline.
+
+  it("returns null for null / undefined / empty", () => {
+    // GIVEN no value
+    // THEN nothing to redirect to
+    expect(safeInternalPath(null)).toBeNull();
+    expect(safeInternalPath(undefined)).toBeNull();
+    expect(safeInternalPath("")).toBeNull();
+  });
+
+  it("accepts a plain path", () => {
+    // GIVEN a path-absolute reference
+    // WHEN validated
+    // THEN it's parsed into a Partial<Path>
+    expect(safeInternalPath("/objects/Device")).toEqual({
+      pathname: "/objects/Device",
+      search: "",
+      hash: "",
+    });
+  });
+
+  it("preserves search and hash on an internal path", () => {
+    // GIVEN a path with query + hash
+    // THEN both components survive the round-trip
+    expect(safeInternalPath("/foo?bar=1&baz=2#section")).toEqual({
+      pathname: "/foo",
+      search: "?bar=1&baz=2",
+      hash: "#section",
+    });
+  });
+
+  it("rejects protocol-relative URLs (//evil.com)", () => {
+    // GIVEN a protocol-relative reference that browsers resolve cross-origin
+    // THEN the open-redirect guard blocks it
+    expect(safeInternalPath("//evil.com")).toBeNull();
+    expect(safeInternalPath("//evil.com/path")).toBeNull();
+  });
+
+  it("rejects schemed URLs (http/https/javascript)", () => {
+    // GIVEN an absolute URL with a scheme
+    // THEN the leading-slash gate rejects it before URL parsing even runs
+    expect(safeInternalPath("https://evil.com/path")).toBeNull();
+    expect(safeInternalPath("http://evil.com")).toBeNull();
+    expect(safeInternalPath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects references that don't start with a single /", () => {
+    // GIVEN a relative reference (no leading slash)
+    // THEN it's rejected — only path-absolute is allowed
+    expect(safeInternalPath("foo")).toBeNull();
+    expect(safeInternalPath("./foo")).toBeNull();
+    expect(safeInternalPath("../foo")).toBeNull();
+  });
+});
+
+describe("pathToString", () => {
+  it("serialises a full Path object", () => {
+    expect(pathToString({ pathname: "/foo", search: "?a=1", hash: "#x" })).toBe("/foo?a=1#x");
+  });
+
+  it("defaults missing components", () => {
+    expect(pathToString({})).toBe("/");
+    expect(pathToString({ pathname: "/foo" })).toBe("/foo");
+  });
+});

--- a/frontend/app/src/entities/authentication/utils.test.ts
+++ b/frontend/app/src/entities/authentication/utils.test.ts
@@ -58,6 +58,20 @@ describe("safeInternalPath", () => {
     expect(safeInternalPath("./foo")).toBeNull();
     expect(safeInternalPath("../foo")).toBeNull();
   });
+
+  it("rejects payloads that normalize to a protocol-relative pathname", () => {
+    // GIVEN a path that passes the leading-`//` gate but whose WHATWG URL
+    // normalization collapses `..` segments back into a `//evil.com`
+    // pathname. The leading-/ gate misses these because the raw string
+    // starts with a single `/`, and the same-origin check passes because
+    // the resolved URL stays on the baseline origin — but the pathname
+    // itself is then the open-redirect payload when the caller serialises
+    // it back to a string. The post-normalization pathname guard catches
+    // them.
+    expect(safeInternalPath("/..//evil.com")).toBeNull();
+    expect(safeInternalPath("/../..//evil.com")).toBeNull();
+    expect(safeInternalPath("/foo/..//evil.com")).toBeNull();
+  });
 });
 
 describe("pathToString", () => {

--- a/frontend/app/src/entities/authentication/utils.ts
+++ b/frontend/app/src/entities/authentication/utils.ts
@@ -8,11 +8,20 @@ import type { UserToken } from "@/entities/authentication/types";
 // schemed (`https://evil`), and anything URL() can't parse. Used by the
 // login flow to guard the `?from=` redirect target against open-redirect
 // abuse — the value comes from a URL query param, so it is attacker-controlled.
+//
+// Note on the post-normalization pathname check: WHATWG URL parsing
+// collapses `..` segments, so `/..//evil.com` resolves to pathname
+// `//evil.com` against the same origin. Origin-equality alone would
+// pass that through, and the returned protocol-relative pathname then
+// becomes the open-redirect payload when the caller serialises it back
+// to a string (Navigate to / SSO `final_url=…`). Reject any pathname
+// that starts with `//` after normalization, regardless of origin.
 export const safeInternalPath = (raw: string | null | undefined): Partial<Path> | null => {
   if (!raw || !raw.startsWith("/") || raw.startsWith("//")) return null;
   try {
     const url = new URL(raw, window.location.origin);
     if (url.origin !== window.location.origin) return null;
+    if (url.pathname.startsWith("//")) return null;
     return { pathname: url.pathname, search: url.search, hash: url.hash };
   } catch {
     return null;

--- a/frontend/app/src/entities/authentication/utils.ts
+++ b/frontend/app/src/entities/authentication/utils.ts
@@ -1,4 +1,4 @@
-import type { Path } from "react-router";
+import type { Location, Path } from "react-router";
 
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
 import type { UserToken } from "@/entities/authentication/types";
@@ -33,6 +33,22 @@ export const safeInternalPath = (raw: string | null | undefined): Partial<Path> 
 // the SSO authorize endpoint, where the backend expects a flat string).
 export const pathToString = (path: Partial<Path>): string =>
   (path.pathname ?? "/") + (path.search ?? "") + (path.hash ?? "");
+
+// Resolves the post-login redirect target by preferring in-app router
+// state (set by ProtectedRoute) and falling back to the `?from=` query
+// param (set by `redirectToLogin()` on hard nav). Both sources are
+// revalidated through `safeInternalPath` so router-state pollution is
+// held to the same open-redirect guard as the query-string twin.
+// Defaults to "/" when neither source yields a safe target.
+export const resolveLoginRedirect = (
+  location: Pick<Location, "state">,
+  searchParams: URLSearchParams
+): Partial<Path> => {
+  const stateFromRaw = (location.state as { from?: Partial<Path> } | null)?.from;
+  const stateFrom = stateFromRaw ? safeInternalPath(pathToString(stateFromRaw)) : null;
+  const queryFrom = safeInternalPath(searchParams.get("from"));
+  return stateFrom ?? queryFrom ?? { pathname: "/" };
+};
 
 export const saveTokensInLocalStorage = (result: Partial<UserToken>) => {
   if (result?.access_token) {

--- a/frontend/app/src/entities/authentication/utils.ts
+++ b/frontend/app/src/entities/authentication/utils.ts
@@ -1,5 +1,29 @@
+import type { Path } from "react-router";
+
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
 import type { UserToken } from "@/entities/authentication/types";
+
+// Validates that `raw` is a path-absolute, same-origin reference and
+// returns it as a Partial<Path>. Rejects protocol-relative (`//evil`),
+// schemed (`https://evil`), and anything URL() can't parse. Used by the
+// login flow to guard the `?from=` redirect target against open-redirect
+// abuse — the value comes from a URL query param, so it is attacker-controlled.
+export const safeInternalPath = (raw: string | null | undefined): Partial<Path> | null => {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) return null;
+  try {
+    const url = new URL(raw, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return { pathname: url.pathname, search: url.search, hash: url.hash };
+  } catch {
+    return null;
+  }
+};
+
+// Serialises a Partial<Path> back to a single path string for callers
+// that need a string (e.g. building a `final_url=...` query param for
+// the SSO authorize endpoint, where the backend expects a flat string).
+export const pathToString = (path: Partial<Path>): string =>
+  (path.pathname ?? "/") + (path.search ?? "") + (path.hash ?? "");
 
 export const saveTokensInLocalStorage = (result: Partial<UserToken>) => {
   if (result?.access_token) {

--- a/frontend/app/src/pages/auth-callback.tsx
+++ b/frontend/app/src/pages/auth-callback.tsx
@@ -49,6 +49,10 @@ function AuthCallback() {
         // FetchError without an `errors` array). Surface a generic envelope
         // so the user is bounced to /login with a visible message instead
         // of being stuck on the loading screen.
+        //
+        // `code: 0` is the local sentinel for "frontend-synthesised error,
+        // no backend code" — LoginPage renders the number verbatim, so 0
+        // signals to readers (not to users) that this entry was forged here.
         console.error("[auth-callback] unexpected failure", error);
         setErrors([
           {

--- a/frontend/app/src/pages/auth-callback.tsx
+++ b/frontend/app/src/pages/auth-callback.tsx
@@ -43,7 +43,19 @@ function AuthCallback() {
       .catch((error: unknown) => {
         if (error instanceof FetchError && error.errors) {
           setErrors(error.errors);
+          return;
         }
+        // Non-envelope failure (network error, unexpected throw, or a
+        // FetchError without an `errors` array). Surface a generic envelope
+        // so the user is bounced to /login with a visible message instead
+        // of being stuck on the loading screen.
+        console.error("[auth-callback] unexpected failure", error);
+        setErrors([
+          {
+            message: "Failed to complete sign-in. Please try again.",
+            extensions: { code: 0 },
+          },
+        ]);
       });
   }, [config, protocol, provider]);
 

--- a/frontend/app/src/pages/auth-callback.tsx
+++ b/frontend/app/src/pages/auth-callback.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Navigate, useParams, useSearchParams } from "react-router";
 
-import { fetchUrl } from "@/shared/api/rest/fetch";
+import { FetchError, fetchUrl, type RestErrorItem } from "@/shared/api/rest/fetch";
 import { InfrahubLoading } from "@/shared/components/loading/infrahub-loading";
 import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 
@@ -14,7 +14,7 @@ function AuthCallback() {
   const [searchParams] = useSearchParams();
   const { isAuthenticated, setToken } = useAuth();
   const [redirectTo, setRedirectTo] = useState("/");
-  const [errors, setErrors] = useState(null);
+  const [errors, setErrors] = useState<RestErrorItem[] | null>(null);
 
   const code = searchParams.get("code");
   const state = searchParams.get("state");
@@ -30,15 +30,20 @@ function AuthCallback() {
     const { token_path } = currentAuthProvider;
     fetchUrl(`${INFRAHUB_API_SERVER_URL}${token_path}?code=${code}&state=${state}`)
       .then((result) => {
+        // 2xx response that still carries `errors` — normalise to a
+        // FetchError so the catch sees the same shape as a non-2xx
+        // failure (single typed envelope, no `any` cast needed).
         if (result.errors) {
-          throw result;
+          throw new FetchError(200, result.errors);
         }
 
         setRedirectTo(result.final_url);
         setToken(result);
       })
-      .catch((error) => {
-        setErrors(error.errors);
+      .catch((error: unknown) => {
+        if (error instanceof FetchError && error.errors) {
+          setErrors(error.errors);
+        }
       });
   }, [config, protocol, provider]);
 

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -38,8 +38,11 @@ function LoginPage() {
 
         <LoginMethodPicker />
 
-        {errors?.map((error, index) => (
-          <p key={index} className="mt-2 text-red-500 text-sm">
+        {errors?.map((error) => (
+          <p
+            key={`${error.extensions.code}-${error.message}`}
+            className="mt-2 text-red-500 text-sm"
+          >
             ({error.extensions.code}) {error.message}
           </p>
         ))}

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -6,7 +6,7 @@ import type { RestErrorItem } from "@/shared/api/rest/fetch";
 
 import { LoginMethodPicker } from "@/entities/authentication/ui/login-method-picker";
 import { useAuth } from "@/entities/authentication/ui/useAuth";
-import { safeInternalPath } from "@/entities/authentication/utils";
+import { pathToString, safeInternalPath } from "@/entities/authentication/utils";
 
 function LoginPage() {
   const location = useLocation();
@@ -16,8 +16,12 @@ function LoginPage() {
   if (isAuthenticated) {
     // Prefer in-app navigation state (set by ProtectedRoute) and fall back
     // to the `?from=` query param set by `redirectToLogin()` on hard nav.
-    // `safeInternalPath` blocks open-redirect payloads from the query string.
-    const stateFrom = location.state?.from as Partial<Path> | undefined;
+    // Both sources are revalidated through `safeInternalPath` so that any
+    // pollution of router state (e.g. a future caller passing a string or
+    // an external URL) is held to the same open-redirect guard as the
+    // query-string twin.
+    const stateFromRaw = location.state?.from as Partial<Path> | undefined;
+    const stateFrom = stateFromRaw ? safeInternalPath(pathToString(stateFromRaw)) : null;
     const queryFrom = safeInternalPath(searchParams.get("from"));
     const target: Partial<Path> = stateFrom ?? queryFrom ?? { pathname: "/" };
     return <Navigate to={target} replace />;

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -28,9 +28,9 @@ function LoginPage() {
 
         <LoginMethodPicker />
 
-        {errors?.map((error) => (
+        {errors?.map((error, index) => (
           <p
-            key={`${error.extensions.code}-${error.message}`}
+            key={`${index}-${error.extensions.code}-${error.message}`}
             className="mt-2 text-red-500 text-sm"
           >
             ({error.extensions.code}) {error.message}

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation, useSearchParams } from "react-router";
+import { Navigate, type Path, useLocation, useSearchParams } from "react-router";
 
 import InfrahubLogo from "@/assets/Infrahub-SVG-hori.svg?react";
 
@@ -6,6 +6,7 @@ import type { RestErrorItem } from "@/shared/api/rest/fetch";
 
 import { LoginMethodPicker } from "@/entities/authentication/ui/login-method-picker";
 import { useAuth } from "@/entities/authentication/ui/useAuth";
+import { safeInternalPath } from "@/entities/authentication/utils";
 
 function LoginPage() {
   const location = useLocation();
@@ -15,10 +16,11 @@ function LoginPage() {
   if (isAuthenticated) {
     // Prefer in-app navigation state (set by ProtectedRoute) and fall back
     // to the `?from=` query param set by `redirectToLogin()` on hard nav.
-    const stateFrom = (location.state?.from?.pathname || "") + (location.state?.from?.search ?? "");
-    const queryFrom = searchParams.get("from");
-    const from = stateFrom || queryFrom || "/";
-    return <Navigate to={from} replace />;
+    // `safeInternalPath` blocks open-redirect payloads from the query string.
+    const stateFrom = location.state?.from as Partial<Path> | undefined;
+    const queryFrom = safeInternalPath(searchParams.get("from"));
+    const target: Partial<Path> = stateFrom ?? queryFrom ?? { pathname: "/" };
+    return <Navigate to={target} replace />;
   }
 
   const errors = location?.state?.errors as RestErrorItem[] | undefined;

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { Navigate, type Path, useLocation, useSearchParams } from "react-router";
+import { Navigate, useLocation, useSearchParams } from "react-router";
 
 import InfrahubLogo from "@/assets/Infrahub-SVG-hori.svg?react";
 
@@ -6,7 +6,7 @@ import type { RestErrorItem } from "@/shared/api/rest/fetch";
 
 import { LoginMethodPicker } from "@/entities/authentication/ui/login-method-picker";
 import { useAuth } from "@/entities/authentication/ui/useAuth";
-import { pathToString, safeInternalPath } from "@/entities/authentication/utils";
+import { resolveLoginRedirect } from "@/entities/authentication/utils";
 
 function LoginPage() {
   const location = useLocation();
@@ -14,17 +14,7 @@ function LoginPage() {
   const { isAuthenticated } = useAuth();
 
   if (isAuthenticated) {
-    // Prefer in-app navigation state (set by ProtectedRoute) and fall back
-    // to the `?from=` query param set by `redirectToLogin()` on hard nav.
-    // Both sources are revalidated through `safeInternalPath` so that any
-    // pollution of router state (e.g. a future caller passing a string or
-    // an external URL) is held to the same open-redirect guard as the
-    // query-string twin.
-    const stateFromRaw = location.state?.from as Partial<Path> | undefined;
-    const stateFrom = stateFromRaw ? safeInternalPath(pathToString(stateFromRaw)) : null;
-    const queryFrom = safeInternalPath(searchParams.get("from"));
-    const target: Partial<Path> = stateFrom ?? queryFrom ?? { pathname: "/" };
-    return <Navigate to={target} replace />;
+    return <Navigate to={resolveLoginRedirect(location, searchParams)} replace />;
   }
 
   const errors = location?.state?.errors as RestErrorItem[] | undefined;

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -1,18 +1,27 @@
-import { Navigate, useLocation } from "react-router";
+import { Navigate, useLocation, useSearchParams } from "react-router";
 
 import InfrahubLogo from "@/assets/Infrahub-SVG-hori.svg?react";
+
+import type { RestErrorItem } from "@/shared/api/rest/fetch";
 
 import { LoginMethodPicker } from "@/entities/authentication/ui/login-method-picker";
 import { useAuth } from "@/entities/authentication/ui/useAuth";
 
 function LoginPage() {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { isAuthenticated } = useAuth();
 
   if (isAuthenticated) {
-    const from = (location.state?.from?.pathname || "/") + (location.state?.from?.search ?? "");
+    // Prefer in-app navigation state (set by ProtectedRoute) and fall back
+    // to the `?from=` query param set by `redirectToLogin()` on hard nav.
+    const stateFrom = (location.state?.from?.pathname || "") + (location.state?.from?.search ?? "");
+    const queryFrom = searchParams.get("from");
+    const from = stateFrom || queryFrom || "/";
     return <Navigate to={from} replace />;
   }
+
+  const errors = location?.state?.errors as RestErrorItem[] | undefined;
 
   return (
     <div className="h-screen w-screen overflow-auto bg-stone-100 py-[25vh]">
@@ -23,13 +32,11 @@ function LoginPage() {
 
         <LoginMethodPicker />
 
-        {location?.state?.errors?.map(
-          (error: { extensions: { code: number }; message: string }, index: number) => (
-            <p key={index} className="mt-2 text-red-500 text-sm">
-              ({error.extensions.code}) {error.message}
-            </p>
-          )
-        )}
+        {errors?.map((error, index) => (
+          <p key={index} className="mt-2 text-red-500 text-sm">
+            ({error.extensions.code}) {error.message}
+          </p>
+        ))}
       </div>
     </div>
   );

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
@@ -7,60 +7,7 @@ import { queryClient } from "@/shared/api/rest/client";
 
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
 
-import { __navigation, bumpAuthRetryCount, handleGraphQLAuthError } from "./graphqlClientApollo";
-
-describe("bumpAuthRetryCount", () => {
-  // Minimal stand-in for Apollo's Operation — only the two methods the
-  // helper touches. Keeping it local avoids importing the full Apollo
-  // Operation type just for a unit test.
-  function makeOperation(initial: Record<string, unknown> = {}) {
-    let ctx: Record<string, unknown> = { ...initial };
-    return {
-      getContext: () => ctx,
-      setContext: (patch: Record<string, unknown>) => {
-        ctx = { ...ctx, ...patch };
-      },
-    };
-  }
-
-  it("returns 1 and stores the counter on the first call", () => {
-    // GIVEN an operation with no prior auth-retry count
-    const operation = makeOperation();
-
-    // WHEN we bump
-    const count = bumpAuthRetryCount(operation);
-
-    // THEN the helper reports the first attempt and persists it
-    expect(count).toBe(1);
-    expect(operation.getContext().authRetryCount).toBe(1);
-  });
-
-  it("returns 2 on the second call within the same operation", () => {
-    // GIVEN an operation that already failed once
-    const operation = makeOperation();
-    bumpAuthRetryCount(operation);
-
-    // WHEN we bump again (simulates a TOKEN_EXPIRED that came back
-    // after the refreshed token was already used to replay once)
-    const count = bumpAuthRetryCount(operation);
-
-    // THEN the caller sees >1 and can break the loop
-    expect(count).toBe(2);
-  });
-
-  it("preserves unrelated context keys", () => {
-    // GIVEN an operation carrying caller-set context
-    const operation = makeOperation({ branch: "main", processErrorMessage: "fn" });
-
-    // WHEN we bump
-    bumpAuthRetryCount(operation);
-
-    // THEN the bump does not erase the existing keys
-    expect(operation.getContext().branch).toBe("main");
-    expect(operation.getContext().processErrorMessage).toBe("fn");
-    expect(operation.getContext().authRetryCount).toBe(1);
-  });
-});
+import { __navigation, handleGraphQLAuthError } from "./graphqlClientApollo";
 
 describe("handleGraphQLAuthError — TOKEN_EXPIRED retry-then-bail loop", () => {
   // Minimal stand-in for Apollo's `Operation`. The handler only touches
@@ -132,35 +79,46 @@ describe("handleGraphQLAuthError — TOKEN_EXPIRED retry-then-bail loop", () => 
       });
     });
 
-    // AND the operation was tagged so a follow-up TOKEN_EXPIRED bails
-    expect(operation.getContext().authRetryCount).toBe(1);
-
     // AND the replayed operation carries the Bearer-prefixed new token
     const headers = (operation.getContext() as { headers?: { authorization?: string } }).headers;
     expect(headers?.authorization).toBe("Bearer new-token");
 
     expect(fetchQuerySpy).toHaveBeenCalledOnce();
     expect(forward).toHaveBeenCalledOnce();
+    // AND the user is NOT bounced — the happy path completes cleanly
+    expect(assignSpy).not.toHaveBeenCalled();
   });
 
-  it("second TOKEN_EXPIRED on the same operation bails to /login with ?from=", () => {
-    // GIVEN an operation that already burned its single retry
+  it("replayed result that still carries TOKEN_EXPIRED bails to /login", async () => {
+    // GIVEN a refresh that succeeds, but the replayed request still
+    // comes back with TOKEN_EXPIRED (clock skew, malformed refreshed
+    // token, server-side revoke between refresh and replay). Apollo's
+    // onError does NOT re-invoke our handler for this result, so the
+    // bail has to be detected inside `retryWithRefreshedToken` itself.
+    fetchQuerySpy.mockResolvedValue({ access_token: "new-token", refresh_token: "new-refresh" });
     const operation = makeOperation();
-    bumpAuthRetryCount(operation); // simulate prior retry
-    const forward = vi.fn();
+    const replayedResult = { errors: [tokenExpiredError] };
+    const forward = vi.fn(() => Observable.of(replayedResult));
 
-    // WHEN a second TOKEN_EXPIRED arrives
+    // WHEN the handler runs the retry path
     const result = handleGraphQLAuthError({
       graphQLErrors: [tokenExpiredError],
       operation,
       forward,
     } as any);
 
-    // THEN the handler bails (returns void, no observable, no replay)
-    expect(result).toBeUndefined();
-    expect(forward).not.toHaveBeenCalled();
+    // THEN the retry observable errors out with the persistence sentinel
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        (result as Observable<unknown>).subscribe({
+          next: () => {},
+          complete: () => resolve(),
+          error: (err) => reject(err),
+        });
+      })
+    ).rejects.toThrow(/persisted/i);
 
-    // AND the user is hard-navigated to /login with the current path encoded
+    // AND the user is hard-navigated to /login with `?from=…`
     expect(assignSpy).toHaveBeenCalledOnce();
     const target = assignSpy.mock.calls[0]?.[0] as string | undefined;
     expect(target).toMatch(/^\/login\?from=/);

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { Observable } from "@apollo/client";
+import type { GraphQLFormattedError } from "graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { bumpAuthRetryCount } from "./graphqlClientApollo";
+import { ERROR_CODES } from "@/shared/api/graphql/errors";
+import { queryClient } from "@/shared/api/rest/client";
+
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
+
+import { __navigation, bumpAuthRetryCount, handleGraphQLAuthError } from "./graphqlClientApollo";
 
 describe("bumpAuthRetryCount", () => {
   // Minimal stand-in for Apollo's Operation — only the two methods the
@@ -52,5 +59,144 @@ describe("bumpAuthRetryCount", () => {
     expect(operation.getContext().branch).toBe("main");
     expect(operation.getContext().processErrorMessage).toBe("fn");
     expect(operation.getContext().authRetryCount).toBe(1);
+  });
+});
+
+describe("handleGraphQLAuthError — TOKEN_EXPIRED retry-then-bail loop", () => {
+  // Minimal stand-in for Apollo's `Operation`. The handler only touches
+  // `getContext`/`setContext`, so we don't bring in the full Apollo type
+  // just to satisfy a structural shape.
+  function makeOperation() {
+    let ctx: Record<string, unknown> = {};
+    return {
+      getContext: () => ctx,
+      setContext: (patch: Record<string, unknown>) => {
+        ctx = { ...ctx, ...patch };
+      },
+    };
+  }
+
+  const tokenExpiredError = {
+    message: "Token expired",
+    extensions: { code: ERROR_CODES.TOKEN_EXPIRED, http_status: 401, data: {} },
+  } satisfies Partial<GraphQLFormattedError> as GraphQLFormattedError;
+
+  let assignSpy: ReturnType<typeof vi.fn>;
+  let fetchQuerySpy: ReturnType<typeof vi.spyOn>;
+  let originalAssign: typeof __navigation.assign;
+
+  beforeEach(() => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, "old-token");
+    localStorage.setItem(REFRESH_TOKEN_KEY, "old-refresh");
+
+    // Swap the navigation holder's `assign` so the handler's hard-nav lands
+    // on a spy rather than actually navigating the test page. Restored in
+    // afterEach so unrelated tests don't see the stub.
+    originalAssign = __navigation.assign;
+    assignSpy = vi.fn();
+    __navigation.assign = assignSpy as unknown as typeof __navigation.assign;
+
+    fetchQuerySpy = vi.spyOn(queryClient, "fetchQuery");
+  });
+
+  afterEach(() => {
+    __navigation.assign = originalAssign;
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("first TOKEN_EXPIRED refreshes the token and replays with Bearer header", async () => {
+    // GIVEN a refresh that returns a fresh access token
+    fetchQuerySpy.mockResolvedValue({ access_token: "new-token", refresh_token: "new-refresh" });
+    const operation = makeOperation();
+    // Stand-in for Apollo's `forward` — emits a single empty result so the
+    // retry observable completes cleanly.
+    const forward = vi.fn(() => Observable.of({ data: null }));
+
+    // WHEN the handler sees a TOKEN_EXPIRED for the first time on this op
+    const result = handleGraphQLAuthError({
+      graphQLErrors: [tokenExpiredError],
+      operation,
+      forward,
+    } as any);
+
+    // THEN it returns the retry observable
+    expect(result).toBeInstanceOf(Observable);
+
+    // Drive the observable through to completion so the refresh promise
+    // and forward subscription get a chance to run.
+    await new Promise<void>((resolve, reject) => {
+      (result as Observable<unknown>).subscribe({
+        complete: () => resolve(),
+        error: (err) => reject(err),
+      });
+    });
+
+    // AND the operation was tagged so a follow-up TOKEN_EXPIRED bails
+    expect(operation.getContext().authRetryCount).toBe(1);
+
+    // AND the replayed operation carries the Bearer-prefixed new token
+    const headers = (operation.getContext() as { headers?: { authorization?: string } }).headers;
+    expect(headers?.authorization).toBe("Bearer new-token");
+
+    expect(fetchQuerySpy).toHaveBeenCalledOnce();
+    expect(forward).toHaveBeenCalledOnce();
+  });
+
+  it("second TOKEN_EXPIRED on the same operation bails to /login with ?from=", () => {
+    // GIVEN an operation that already burned its single retry
+    const operation = makeOperation();
+    bumpAuthRetryCount(operation); // simulate prior retry
+    const forward = vi.fn();
+
+    // WHEN a second TOKEN_EXPIRED arrives
+    const result = handleGraphQLAuthError({
+      graphQLErrors: [tokenExpiredError],
+      operation,
+      forward,
+    } as any);
+
+    // THEN the handler bails (returns void, no observable, no replay)
+    expect(result).toBeUndefined();
+    expect(forward).not.toHaveBeenCalled();
+
+    // AND the user is hard-navigated to /login with the current path encoded
+    expect(assignSpy).toHaveBeenCalledOnce();
+    const target = assignSpy.mock.calls[0]?.[0] as string | undefined;
+    expect(target).toMatch(/^\/login\?from=/);
+
+    // AND the stale credentials were cleared so the next mount won't loop
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBeNull();
+  });
+
+  it("refresh failure clears tokens and bounces to /login", async () => {
+    // GIVEN a refresh that rejects (refresh token expired / server revoked)
+    fetchQuerySpy.mockRejectedValue(new Error("refresh failed"));
+    const operation = makeOperation();
+    const forward = vi.fn();
+
+    // WHEN the handler runs the retry path
+    const result = handleGraphQLAuthError({
+      graphQLErrors: [tokenExpiredError],
+      operation,
+      forward,
+    } as any);
+
+    // THEN the retry observable errors out
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        (result as Observable<unknown>).subscribe({
+          complete: () => resolve(),
+          error: (err) => reject(err),
+        });
+      })
+    ).rejects.toThrow("refresh failed");
+
+    // AND the user is bounced to /login instead of being left signed-in
+    // against a session the server has already disowned.
+    expect(assignSpy).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+    expect(forward).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { bumpAuthRetryCount } from "./graphqlClientApollo";
+
+describe("bumpAuthRetryCount", () => {
+  // Minimal stand-in for Apollo's Operation — only the two methods the
+  // helper touches. Keeping it local avoids importing the full Apollo
+  // Operation type just for a unit test.
+  function makeOperation(initial: Record<string, unknown> = {}) {
+    let ctx: Record<string, unknown> = { ...initial };
+    return {
+      getContext: () => ctx,
+      setContext: (patch: Record<string, unknown>) => {
+        ctx = { ...ctx, ...patch };
+      },
+    };
+  }
+
+  it("returns 1 and stores the counter on the first call", () => {
+    // GIVEN an operation with no prior auth-retry count
+    const operation = makeOperation();
+
+    // WHEN we bump
+    const count = bumpAuthRetryCount(operation);
+
+    // THEN the helper reports the first attempt and persists it
+    expect(count).toBe(1);
+    expect(operation.getContext().authRetryCount).toBe(1);
+  });
+
+  it("returns 2 on the second call within the same operation", () => {
+    // GIVEN an operation that already failed once
+    const operation = makeOperation();
+    bumpAuthRetryCount(operation);
+
+    // WHEN we bump again (simulates a TOKEN_EXPIRED that came back
+    // after the refreshed token was already used to replay once)
+    const count = bumpAuthRetryCount(operation);
+
+    // THEN the caller sees >1 and can break the loop
+    expect(count).toBe(2);
+  });
+
+  it("preserves unrelated context keys", () => {
+    // GIVEN an operation carrying caller-set context
+    const operation = makeOperation({ branch: "main", processErrorMessage: "fn" });
+
+    // WHEN we bump
+    bumpAuthRetryCount(operation);
+
+    // THEN the bump does not erase the existing keys
+    expect(operation.getContext().branch).toBe("main");
+    expect(operation.getContext().processErrorMessage).toBe("fn");
+    expect(operation.getContext().authRetryCount).toBe(1);
+  });
+});

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -69,9 +69,10 @@ type ErrorLinkArgs = Parameters<Parameters<typeof onError>[0]>[0];
 // NOT re-invoke `handleGraphQLAuthError`, so a persistent TOKEN_EXPIRED
 // would otherwise leak through to the caller as a generic GraphQL error.
 function resultHasTokenExpired(result: FetchResult): boolean {
-  if (!result.errors) return false;
-  return result.errors.some(
-    (e) => parseErrorExtensions(e.extensions).code === ERROR_CODES.TOKEN_EXPIRED
+  return (
+    result.errors?.some(
+      (e) => parseErrorExtensions(e.extensions).code === ERROR_CODES.TOKEN_EXPIRED
+    ) ?? false
   );
 }
 
@@ -137,9 +138,11 @@ function retryWithRefreshedToken(
       .fetchQuery(refreshAccessTokenQueryOptions())
       .then((newToken) => {
         if (!newToken?.access_token) {
-          // Refresh resolved but the server returned no token — fail the
-          // retry observable so the caller sees an error instead of hanging
-          // forever. Apollo will surface this as a network error.
+          // Refresh resolved but the server returned no token — treat it
+          // like a refresh failure: clear stale credentials and bounce to
+          // /login, otherwise the user is left signed-in against tokens
+          // the server has already disowned.
+          redirectToLogin();
           observer.error(new Error("Token refresh returned no access_token"));
           return;
         }

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -61,6 +61,24 @@ export const authLink = setContext((_, previousContext) => {
   };
 });
 
+// Minimal structural type covering the bits of Apollo's `Operation` that
+// `bumpAuthRetryCount` touches. Lets the helper stay unit-testable without
+// pulling in Apollo's full type just to mock two methods.
+type RetryableOperation = {
+  getContext: () => { authRetryCount?: number; [key: string]: unknown };
+  setContext: (patch: Record<string, unknown>) => void;
+};
+
+// Increment the per-operation auth-retry counter and return the new value.
+// Callers use the returned count to break the TOKEN_EXPIRED → refresh →
+// TOKEN_EXPIRED loop after the first retry (clock skew, server-side revoke,
+// or a malformed refreshed token would otherwise loop the link forever).
+export function bumpAuthRetryCount(operation: RetryableOperation): number {
+  const next = (operation.getContext().authRetryCount ?? 0) + 1;
+  operation.setContext({ authRetryCount: next });
+  return next;
+}
+
 // Error link: route each catalogue code to its policy. The catalogue is
 // mirrored in @/shared/api/graphql/errors until US2's generated bindings
 // (T029) land — see dev/specs/infp-468-graphql-error-catalogue/.
@@ -77,6 +95,7 @@ export const errorLink = onError(({ graphQLErrors, operation, forward }) => {
 
     switch (parsed.code) {
       case ERROR_CODES.TOKEN_EXPIRED:
+        if (bumpAuthRetryCount(operation) > 1) return redirectToLogin();
         return retryWithRefreshedToken(operation, forward);
 
       case ERROR_CODES.AUTHENTICATION_REQUIRED:
@@ -120,7 +139,7 @@ function retryWithRefreshedToken(
         operation.setContext({
           headers: {
             ...oldHeaders,
-            authorization: newToken.access_token,
+            authorization: `Bearer ${newToken.access_token}`,
           },
         });
 
@@ -141,11 +160,16 @@ function retryWithRefreshedToken(
 // to /login. Hard-navigates because errorLink runs outside React Router,
 // and the AuthProvider's localStorage hook does not re-render on external
 // writes. Skips the redirect if we're already on /login to avoid loops.
+//
+// Encodes the current path as `?from=…` so `LoginPage` can route the user
+// back to where they were after re-authenticating. The hard nav means
+// `location.state` is gone, so the query string is the only carrier left.
 function redirectToLogin(): void {
   removeTokensInLocalStorage();
-  if (window.location.pathname !== "/login") {
-    window.location.assign("/login");
-  }
+  if (window.location.pathname === "/login") return;
+
+  const from = window.location.pathname + window.location.search;
+  window.location.assign(`/login?from=${encodeURIComponent(from)}`);
 }
 
 // Helper: surface an error to the user. Calls operation.context's

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -61,25 +61,19 @@ export const authLink = setContext((_, previousContext) => {
   };
 });
 
-// Minimal structural type covering the bits of Apollo's `Operation` that
-// `bumpAuthRetryCount` touches. Lets the helper stay unit-testable without
-// pulling in Apollo's full type just to mock two methods.
-type RetryableOperation = {
-  getContext: () => { authRetryCount?: number; [key: string]: unknown };
-  setContext: (patch: Record<string, unknown>) => void;
-};
-
-// Increment the per-operation auth-retry counter and return the new value.
-// Callers use the returned count to break the TOKEN_EXPIRED → refresh →
-// TOKEN_EXPIRED loop after the first retry (clock skew, server-side revoke,
-// or a malformed refreshed token would otherwise loop the link forever).
-export function bumpAuthRetryCount(operation: RetryableOperation): number {
-  const next = (operation.getContext().authRetryCount ?? 0) + 1;
-  operation.setContext({ authRetryCount: next });
-  return next;
-}
-
 type ErrorLinkArgs = Parameters<Parameters<typeof onError>[0]>[0];
+
+// True iff a forwarded result still carries TOKEN_EXPIRED. Used inside
+// `retryWithRefreshedToken` because Apollo's onError link routes results
+// from the retried observable directly to the outer observer — it does
+// NOT re-invoke `handleGraphQLAuthError`, so a persistent TOKEN_EXPIRED
+// would otherwise leak through to the caller as a generic GraphQL error.
+function resultHasTokenExpired(result: FetchResult): boolean {
+  if (!result.errors) return false;
+  return result.errors.some(
+    (e) => parseErrorExtensions(e.extensions).code === ERROR_CODES.TOKEN_EXPIRED
+  );
+}
 
 // Error link callback: route each catalogue code to its policy. The catalogue
 // is mirrored in @/shared/api/graphql/errors until US2's generated bindings
@@ -103,10 +97,10 @@ export function handleGraphQLAuthError({
 
     switch (parsed.code) {
       case ERROR_CODES.TOKEN_EXPIRED:
-        if (bumpAuthRetryCount(operation) > 1) {
-          redirectToLogin();
-          return;
-        }
+        // The retry loop is bounded by construction: Apollo's onError
+        // does not re-invoke this handler for results from the retried
+        // observable, so we get exactly one refresh+replay attempt per
+        // operation. Persistence is caught inside `retryWithRefreshedToken`.
         return retryWithRefreshedToken(operation, forward);
 
       case ERROR_CODES.AUTHENTICATION_REQUIRED:
@@ -157,14 +151,24 @@ function retryWithRefreshedToken(
           },
         });
 
-        // Retry the failed request.
-        const subscriber = {
-          next: observer.next.bind(observer),
+        // Retry the failed request. Inspect the replayed result for a
+        // repeated TOKEN_EXPIRED — Apollo will not re-enter our handler
+        // for results that come back from this `forward` call, so this
+        // is the only place we can detect a persistent expiry (clock
+        // skew, malformed refreshed token, server-side revoke) and bail
+        // to /login instead of leaking the error to the caller.
+        forward(operation).subscribe({
+          next: (result) => {
+            if (resultHasTokenExpired(result)) {
+              redirectToLogin();
+              observer.error(new Error("TOKEN_EXPIRED persisted after refresh"));
+              return;
+            }
+            observer.next(result);
+          },
           error: observer.error.bind(observer),
           complete: observer.complete.bind(observer),
-        };
-
-        forward(operation).subscribe(subscriber);
+        });
       })
       .catch((err) => {
         // Refresh itself failed (refresh token expired, network error,

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -152,7 +152,16 @@ function retryWithRefreshedToken(
 
         forward(operation).subscribe(subscriber);
       })
-      .catch((err) => observer.error(err));
+      .catch((err) => {
+        // Refresh itself failed (refresh token expired, network error,
+        // server-side revoke). Without this branch the caller saw a
+        // network error, kept the stale credentials in localStorage,
+        // and every subsequent query hit the same wall — the user was
+        // effectively stuck until they cleared storage by hand. Bounce
+        // to /login so they can re-authenticate.
+        redirectToLogin();
+        observer.error(err);
+      });
   });
 }
 

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -168,7 +168,7 @@ function redirectToLogin(): void {
   removeTokensInLocalStorage();
   if (window.location.pathname === "/login") return;
 
-  const from = window.location.pathname + window.location.search;
+  const from = window.location.pathname + window.location.search + window.location.hash;
   window.location.assign(`/login?from=${encodeURIComponent(from)}`);
 }
 

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -79,10 +79,18 @@ export function bumpAuthRetryCount(operation: RetryableOperation): number {
   return next;
 }
 
-// Error link: route each catalogue code to its policy. The catalogue is
-// mirrored in @/shared/api/graphql/errors until US2's generated bindings
-// (T029) land — see dev/specs/infp-468-graphql-error-catalogue/.
-export const errorLink = onError(({ graphQLErrors, operation, forward }) => {
+type ErrorLinkArgs = Parameters<Parameters<typeof onError>[0]>[0];
+
+// Error link callback: route each catalogue code to its policy. The catalogue
+// is mirrored in @/shared/api/graphql/errors until US2's generated bindings
+// (T029) land — see dev/specs/infp-468-graphql-error-catalogue/. Exported
+// (not just inlined into `onError`) so tests can drive it directly without
+// spinning up an Apollo link chain.
+export function handleGraphQLAuthError({
+  graphQLErrors,
+  operation,
+  forward,
+}: ErrorLinkArgs): Observable<FetchResult> | undefined {
   if (!graphQLErrors) return;
 
   for (const graphQLError of graphQLErrors) {
@@ -95,11 +103,15 @@ export const errorLink = onError(({ graphQLErrors, operation, forward }) => {
 
     switch (parsed.code) {
       case ERROR_CODES.TOKEN_EXPIRED:
-        if (bumpAuthRetryCount(operation) > 1) return redirectToLogin();
+        if (bumpAuthRetryCount(operation) > 1) {
+          redirectToLogin();
+          return;
+        }
         return retryWithRefreshedToken(operation, forward);
 
       case ERROR_CODES.AUTHENTICATION_REQUIRED:
-        return redirectToLogin();
+        redirectToLogin();
+        return;
 
       case ERROR_CODES.PERMISSION_DENIED:
         // Silent — 403s are handled by route-level guards, not toasts.
@@ -111,7 +123,9 @@ export const errorLink = onError(({ graphQLErrors, operation, forward }) => {
   }
 
   return;
-});
+}
+
+export const errorLink = onError(handleGraphQLAuthError);
 
 // Helper: refresh the access token and replay the operation. Lifted from
 // the previous inline Observable block in errorLink; the only behaviour
@@ -173,12 +187,20 @@ function retryWithRefreshedToken(
 // Encodes the current path as `?from=…` so `LoginPage` can route the user
 // back to where they were after re-authenticating. The hard nav means
 // `location.state` is gone, so the query string is the only carrier left.
+// Holder so tests can stub the hard-nav without touching `window.location`
+// (which is non-configurable in real browsers — vitest's browser mode hits
+// that wall the moment you try to spy on `assign`). Production reads
+// through this same reference, so the indirection costs one property lookup.
+export const __navigation = {
+  assign: (url: string) => window.location.assign(url),
+};
+
 function redirectToLogin(): void {
   removeTokensInLocalStorage();
   if (window.location.pathname === "/login") return;
 
   const from = window.location.pathname + window.location.search + window.location.hash;
-  window.location.assign(`/login?from=${encodeURIComponent(from)}`);
+  __navigation.assign(`/login?from=${encodeURIComponent(from)}`);
 }
 
 // Helper: surface an error to the user. Calls operation.context's

--- a/frontend/app/src/shared/api/rest/fetch.ts
+++ b/frontend/app/src/shared/api/rest/fetch.ts
@@ -4,6 +4,10 @@ import { ACCESS_TOKEN_KEY } from "@/entities/authentication/constants";
 
 export type RestErrorItem = { message: string; extensions: { code: number } };
 
+// Typed wrapper around a REST envelope that carries `errors`. `status`
+// is the HTTP status — usually non-2xx, but may also be 2xx for SSO-style
+// "200 with errors" responses (see pages/auth-callback.tsx), so callers
+// must not assume `status >= 400`.
 export class FetchError extends Error {
   status: number;
   errors?: RestErrorItem[];


### PR DESCRIPTION
Implements PR 1 of dev/specs/2026-05-29-frontend-error-auth-improvements.md:

- E2: cap silent-refresh retry via a per-operation counter so a TOKEN_EXPIRED → refresh → TOKEN_EXPIRED loop bails to /login after one attempt instead of spinning forever (clock skew, server-side revoke, or a malformed refreshed token would otherwise loop).
- E1: prefix the replayed `authorization` header with `Bearer ` so the retried request authenticates via the header (matches authLink) and no longer silently relies on the access_token cookie fallback.
- A2: redirectToLogin() encodes the current path as `?from=…` and LoginPage consumes it as a fallback when location.state?.from is absent (which it is after a hard navigation out of errorLink).
- A6: type LoginPage's errors as `RestErrorItem[]` instead of an inline `any`-shaped annotation.
- E3: normalise the 2xx-with-errors branch in auth-callback to throw a typed FetchError so the catch handler sees a single shape; type the errors state as `RestErrorItem[] | null`.

New unit test in graphqlClientApollo.test.ts covers the retry-cap helper (`bumpAuthRetryCount`). Also adds a one-line clarifying comment on FetchError noting that `status` may be 2xx for "200 with errors" SSO callbacks.

## Impact & rollout

<!-- Delete items that don't apply -->

- **Backward compatibility:** <!-- any breaking changes or migration steps -->
- **Performance:** <!-- implications, measurements if relevant -->
- **Config/env changes:** <!-- new settings, feature flags, env vars -->
- **Deployment notes:** <!-- "safe to deploy" vs "requires coordinated release" -->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops token-refresh loops and hardens auth redirects. Detects persistent TOKEN_EXPIRED on replay, clears tokens, and redirects to /login while preserving the full return path; also normalizes callback errors.

- **Bug Fixes**
  - Detect TOKEN_EXPIRED after refresh and bail to `/login?from=…`; also bounce when refresh fails or returns no `access_token`. On retry, send `authorization: Bearer <token>`.
  - Redirect to `/login?from=…` (now preserves the hash); validate both query and router-state targets with `safeInternalPath` including paths that normalize to `//…`, reuse the same target for SSO, and URL‑encode `final_url`.
  - Auth callback: convert 2xx-with-errors to a typed `FetchError`, and on non-envelope failures show a generic error and return to `/login` (note: `FetchError.status` can be 2xx).
  - Login: type errors as `RestErrorItem[]` and render them with stable, unique keys.

<sup>Written for commit 03e5ac64b2fa5329799c1f6e40537b6df9db41fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



