### PR TITLE
add max results and max paths to dependencies search

### DIFF
--- a/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
+++ b/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
@@ -31,7 +31,7 @@ const pathFields = {
 };
 
 export async function getReachableNodesFromApi(params: GetReachableNodesParams) {
-  const { sourceId, targetKinds, maxDepth, maxResults, branchName, atDate } = params;
+  const { sourceId, targetKinds, maxDepth, maxResults, maxPaths, branchName, atDate } = params;
 
   const dataArgs: Record<string, unknown> = {
     source_id: sourceId,
@@ -39,6 +39,7 @@ export async function getReachableNodesFromApi(params: GetReachableNodesParams) 
   };
   if (maxDepth !== undefined) dataArgs.max_depth = maxDepth;
   if (maxResults !== undefined) dataArgs.max_results = maxResults;
+  if (maxPaths !== undefined) dataArgs.max_paths = maxPaths;
 
   const queryString = jsonToGraphQLQuery({
     query: {

--- a/frontend/app/src/entities/path-traversal/domain/path-traversal.types.ts
+++ b/frontend/app/src/entities/path-traversal/domain/path-traversal.types.ts
@@ -63,4 +63,5 @@ export type GetReachableNodesParams = ContextParams & {
   targetKinds: string[];
   maxDepth?: number;
   maxResults?: number;
+  maxPaths?: number;
 };

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -100,6 +100,60 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
                 </div>
               )}
             />
+
+            <FormField
+              name="maxResults"
+              rules={{
+                required: "Max results is required",
+                min: { value: 1, message: "Must be ≥ 1" },
+                max: { value: 200, message: "Must be ≤ 200" },
+              }}
+              render={({ field }) => (
+                <div className="space-y-1">
+                  <FormLabel>Max Results</FormLabel>
+                  <FormInput>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={200}
+                      value={(field.value as number) ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.valueAsNumber;
+                        field.onChange(isNaN(value) ? null : value);
+                      }}
+                    />
+                  </FormInput>
+                  <FormMessage />
+                </div>
+              )}
+            />
+
+            <FormField
+              name="maxPaths"
+              rules={{
+                required: "Max paths is required",
+                min: { value: 1, message: "Must be ≥ 1" },
+                max: { value: 5000, message: "Must be ≤ 5000" },
+              }}
+              render={({ field }) => (
+                <div className="space-y-1">
+                  <FormLabel>Max Paths</FormLabel>
+                  <FormInput>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={5000}
+                      value={(field.value as number) ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.valueAsNumber;
+                        field.onChange(isNaN(value) ? null : value);
+                      }}
+                    />
+                  </FormInput>
+                  <FormMessage />
+                </div>
+              )}
+            />
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-main.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-main.tsx
@@ -19,6 +19,8 @@ export function DependenciesModeMain({
       sourceId: params.source,
       targetKinds: params.targetKinds,
       maxDepth: params.depth,
+      maxResults: params.maxResults,
+      maxPaths: params.maxPaths,
     },
     { enabled: !!params.source && params.targetKinds.length > 0 }
   );

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
@@ -25,6 +25,8 @@ export function DependenciesModeSidebar() {
       sourceId: params.source,
       targetKinds: params.targetKinds,
       maxDepth: params.depth,
+      maxResults: params.maxResults,
+      maxPaths: params.maxPaths,
     },
     { enabled: !!params.source && params.targetKinds.length > 0 }
   );

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.test.ts
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.test.ts
@@ -9,12 +9,16 @@ describe("paramsToFormValues", () => {
         source: "src-id",
         targetKinds: ["InfraDevice", "InfraInterface"],
         depth: 8,
+        maxResults: 100,
+        maxPaths: 1000,
         selectedIndex: 0,
       })
     ).toEqual({
       sourceId: "src-id",
       targetKinds: ["InfraDevice", "InfraInterface"],
       maxDepth: 8,
+      maxResults: 100,
+      maxPaths: 1000,
     });
   });
 });
@@ -26,11 +30,15 @@ describe("formValuesToParams", () => {
         sourceId: "src-id",
         targetKinds: ["InfraDevice"],
         maxDepth: 3,
+        maxResults: 100,
+        maxPaths: 1000,
       })
     ).toEqual({
       source: "src-id",
       targetKinds: ["InfraDevice"],
       depth: 3,
+      maxResults: 100,
+      maxPaths: 1000,
       selectedIndex: 0,
     });
   });

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.ts
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.ts
@@ -4,6 +4,8 @@ export const DEPENDENCIES_MODE_PARAMS = {
   source: parseAsString.withDefault(""),
   targetKinds: parseAsNativeArrayOf(parseAsString).withDefault([]),
   depth: parseAsInteger.withDefault(5),
+  maxResults: parseAsInteger.withDefault(50),
+  maxPaths: parseAsInteger.withDefault(500),
   selectedIndex: parseAsInteger.withDefault(0),
 } as const;
 
@@ -11,6 +13,8 @@ export type DependenciesModeParams = {
   source: string;
   targetKinds: string[];
   depth: number;
+  maxResults: number;
+  maxPaths: number;
   selectedIndex: number;
 };
 
@@ -18,6 +22,8 @@ export type DependenciesModeFormValues = {
   sourceId: string;
   targetKinds: string[];
   maxDepth: number;
+  maxResults: number;
+  maxPaths: number;
 };
 
 export function paramsToFormValues(p: DependenciesModeParams): DependenciesModeFormValues {
@@ -25,6 +31,8 @@ export function paramsToFormValues(p: DependenciesModeParams): DependenciesModeF
     sourceId: p.source,
     targetKinds: p.targetKinds,
     maxDepth: p.depth,
+    maxResults: p.maxResults,
+    maxPaths: p.maxPaths,
   };
 }
 
@@ -33,6 +41,8 @@ export function formValuesToParams(v: DependenciesModeFormValues): Partial<Depen
     source: v.sourceId,
     targetKinds: v.targetKinds,
     depth: v.maxDepth,
+    maxResults: v.maxResults,
+    maxPaths: v.maxPaths,
     selectedIndex: 0,
   };
 }


### PR DESCRIPTION
backend changes on the dependencies query added/updated two control parameters for finding dependencies
- max paths is the maximum number paths to all objects the query will return. so even if there are 10 paths to NodeA and 10 paths to NodeB, a max paths of 15 would mean that only 15 of these paths will be returned
- max results (`max targets` in some parts of the backend) is the maximum number of terminal nodes returned by the query. if max results is 5, then only 5 objects of the given type(s) will be returned, regardless of how many paths exist to those objects