### PR TITLE
refactor(frontend/auth): consolidate logout side-effects behind logou…

### DIFF
--- a/frontend/app/src/entities/authentication/domain/redirect-to-login.ts
+++ b/frontend/app/src/entities/authentication/domain/redirect-to-login.ts
@@ -1,0 +1,27 @@
+import { removeTokensInLocalStorage } from "@/entities/authentication/utils";
+
+// Token is invalid or missing — clear local credentials and bounce to /login.
+// Hard-navigates because callers (Apollo errorLink, REST middleware) run
+// outside React Router, and the AuthProvider's state does not re-render on
+// external storage writes. Skips the redirect if we're already on /login to
+// avoid loops.
+//
+// Encodes the current path as `?from=…` so `LoginPage` can route the user
+// back after re-authenticating. The hard nav means `location.state` is gone,
+// so the query string is the only carrier left.
+
+// Holder so tests can stub the hard-nav without touching `window.location`
+// (which is non-configurable in real browsers — vitest's browser mode hits
+// that wall the moment you try to spy on `assign`). Production reads
+// through this same reference, so the indirection costs one property lookup.
+export const __navigation = {
+  assign: (url: string) => window.location.assign(url),
+};
+
+export function redirectToLogin(): void {
+  removeTokensInLocalStorage();
+  if (window.location.pathname === "/login") return;
+
+  const from = window.location.pathname + window.location.search + window.location.hash;
+  __navigation.assign(`/login?from=${encodeURIComponent(from)}`);
+}

--- a/frontend/app/src/entities/authentication/domain/refresh-access-token.ts
+++ b/frontend/app/src/entities/authentication/domain/refresh-access-token.ts
@@ -8,10 +8,10 @@ export type RefreshAccessToken = () => Promise<components["schemas"]["AccessToke
 
 // Throws on every failure mode (missing refresh token, API error). The caller
 // is responsible for handling the failure — `retryWithRefreshedToken` in
-// graphqlClientApollo.tsx catches the rejection and calls `logoutLocally`
-// with a "refresh-failed" reason. Previously this function did its own
-// `window.location.reload()`, which dropped in-flight React Query state and
-// double-navigated when the catch site also redirected.
+// graphqlClientApollo.tsx catches the rejection and calls `redirectToLogin`.
+// Previously this function did its own `window.location.reload()`, which
+// dropped in-flight React Query state and double-navigated when the catch
+// site also redirected.
 export const refreshAccessToken: RefreshAccessToken = async () => {
   const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
 

--- a/frontend/app/src/entities/authentication/domain/refresh-access-token.ts
+++ b/frontend/app/src/entities/authentication/domain/refresh-access-token.ts
@@ -2,29 +2,24 @@ import type { components } from "@/shared/api/rest/types.generated";
 
 import { refreshAccessTokenFromApi } from "@/entities/authentication/api/refresh-access-token-from-api";
 import { REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
-import {
-  removeTokensInLocalStorage,
-  saveTokensInLocalStorage,
-} from "@/entities/authentication/utils";
+import { saveTokensInLocalStorage } from "@/entities/authentication/utils";
 
 export type RefreshAccessToken = () => Promise<components["schemas"]["AccessTokenResponse"]>;
 
+// Throws on every failure mode (missing refresh token, API error). The caller
+// is responsible for handling the failure — `retryWithRefreshedToken` in
+// graphqlClientApollo.tsx catches the rejection and calls `logoutLocally`
+// with a "refresh-failed" reason. Previously this function did its own
+// `window.location.reload()`, which dropped in-flight React Query state and
+// double-navigated when the catch site also redirected.
 export const refreshAccessToken: RefreshAccessToken = async () => {
   const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
 
   if (!refreshToken) {
-    removeTokensInLocalStorage();
-    window.location.reload();
     throw new Error("Refresh token not found");
   }
 
-  try {
-    const data = await refreshAccessTokenFromApi(refreshToken);
-    saveTokensInLocalStorage(data);
-    return data;
-  } catch (error) {
-    removeTokensInLocalStorage();
-    window.location.reload();
-    throw error;
-  }
+  const data = await refreshAccessTokenFromApi(refreshToken);
+  saveTokensInLocalStorage(data);
+  return data;
 };

--- a/frontend/app/src/entities/authentication/ui/credentials-form.test.tsx
+++ b/frontend/app/src/entities/authentication/ui/credentials-form.test.tsx
@@ -12,7 +12,7 @@ const setToken = vi.fn();
 
 beforeEach(() => {
   vi.mocked(useAuth).mockReturnValue({
-    accessToken: null,
+    accessToken: "",
     isAuthenticated: false,
     setToken,
     user: null,

--- a/frontend/app/src/entities/authentication/ui/useAuth.test.tsx
+++ b/frontend/app/src/entities/authentication/ui/useAuth.test.tsx
@@ -93,4 +93,28 @@ describe("AuthProvider — cross-tab storage reconciliation", () => {
     await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
     await expect.element(component.getByTestId("token")).toHaveTextContent("still-good");
   });
+
+  it("logs the user out when another tab calls localStorage.clear()", async () => {
+    // GIVEN this tab is authenticated
+    localStorage.setItem(ACCESS_TOKEN_KEY, "tab-A-token");
+    const component = await render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+    await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
+
+    // WHEN another tab (or DevTools "Clear site data") wipes storage — the
+    // browser dispatches a `storage` event with `key: null` for `.clear()`,
+    // not a per-key event. The naive `event.key === ACCESS_TOKEN_KEY` guard
+    // skipped this case, leaving this tab signed-in against dead tokens.
+    localStorage.clear();
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: null, oldValue: null, newValue: null })
+    );
+
+    // THEN this tab reconciles to unauthenticated
+    await expect.element(component.getByTestId("status")).toHaveTextContent("anon");
+    await expect.element(component.getByTestId("token")).toHaveTextContent("");
+  });
 });

--- a/frontend/app/src/entities/authentication/ui/useAuth.test.tsx
+++ b/frontend/app/src/entities/authentication/ui/useAuth.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { render } from "../../../../tests/components/render";
+import { ACCESS_TOKEN_KEY } from "../constants";
+import { AuthProvider, useAuth } from "./useAuth";
+
+// Tiny probe component: renders the current auth state so the test can
+// observe AuthProvider's reaction to `storage` events without poking at
+// React internals.
+function AuthProbe() {
+  const { accessToken, isAuthenticated } = useAuth();
+  return (
+    <div>
+      <span data-testid="token">{accessToken ?? ""}</span>
+      <span data-testid="status">{isAuthenticated ? "auth" : "anon"}</span>
+    </div>
+  );
+}
+
+describe("AuthProvider — cross-tab storage reconciliation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("seeds state from localStorage on mount", async () => {
+    // GIVEN a populated access token before the provider mounts (mirrors
+    // a page load after the user is already signed in)
+    localStorage.setItem(ACCESS_TOKEN_KEY, "seeded-token");
+
+    // WHEN the provider mounts
+    const component = await render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    // THEN it picks up the existing token without waiting for a write
+    await expect.element(component.getByTestId("token")).toHaveTextContent("seeded-token");
+    await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
+  });
+
+  it("logs the user out when another tab clears the access token", async () => {
+    // GIVEN this tab is authenticated
+    localStorage.setItem(ACCESS_TOKEN_KEY, "tab-A-token");
+    const component = await render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+    await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
+
+    // WHEN another tab logs out — simulated by clearing storage and
+    // dispatching the same StorageEvent the browser would emit cross-tab
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: ACCESS_TOKEN_KEY,
+        oldValue: "tab-A-token",
+        newValue: null,
+      })
+    );
+
+    // THEN this tab follows: state flips to unauthenticated
+    await expect.element(component.getByTestId("status")).toHaveTextContent("anon");
+    await expect.element(component.getByTestId("token")).toHaveTextContent("");
+  });
+
+  it("ignores storage events for unrelated keys", async () => {
+    // GIVEN this tab is authenticated
+    localStorage.setItem(ACCESS_TOKEN_KEY, "still-good");
+    const component = await render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+    await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
+
+    // WHEN a storage event fires for something else (e.g. sidebar collapse,
+    // which also uses localStorage)
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "sidebar:collapsed",
+        oldValue: "false",
+        newValue: "true",
+      })
+    );
+
+    // THEN our auth state is undisturbed
+    await expect.element(component.getByTestId("status")).toHaveTextContent("auth");
+    await expect.element(component.getByTestId("token")).toHaveTextContent("still-good");
+  });
+});

--- a/frontend/app/src/entities/authentication/ui/useAuth.tsx
+++ b/frontend/app/src/entities/authentication/ui/useAuth.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 import { parseJwt } from "@/shared/utils/common";
 
 import { ACCESS_TOKEN_KEY } from "@/entities/authentication/constants";
@@ -37,17 +36,41 @@ export const AuthContext = React.createContext<AuthContextType>({
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [accessToken, setAccessToken] = useLocalStorage(ACCESS_TOKEN_KEY);
+  // Inline state instead of useLocalStorage so the cross-tab `storage`
+  // listener can update React without re-writing the value back to
+  // localStorage (which would cascade `storage` events between tabs and
+  // loop forever). Storage writes go through `setToken` / `logoutLocally`;
+  // pure state updates use `setAccessTokenState` directly.
+  const [accessToken, setAccessTokenState] = React.useState<string>(
+    () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ""
+  );
 
   const setToken: AuthContextType["setToken"] = (token) => {
     if (token) {
-      setAccessToken(token.access_token);
+      setAccessTokenState(token.access_token);
       saveTokensInLocalStorage(token);
     } else {
-      setAccessToken("");
+      setAccessTokenState("");
       removeTokensInLocalStorage();
     }
   };
+
+  // Reconcile with cross-tab logout: a `storage` event with the access-token
+  // key going empty in another tab means somebody signed out — drop our
+  // local state so this tab follows. Covers manual devtools edits too.
+  // State-only update; the originating tab already wrote to storage, so
+  // re-writing here would just bounce a redundant `storage` event around.
+  React.useEffect(() => {
+    function handleStorage(event: StorageEvent) {
+      if (event.key !== ACCESS_TOKEN_KEY) return;
+      // Re-read rather than trusting event.newValue — `localStorage.clear()`
+      // delivers `newValue: null`, and we want to match the post-clear state.
+      const current = localStorage.getItem(ACCESS_TOKEN_KEY) ?? "";
+      setAccessTokenState(current);
+    }
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   const value: AuthContextType = {
     accessToken,

--- a/frontend/app/src/entities/authentication/ui/useAuth.tsx
+++ b/frontend/app/src/entities/authentication/ui/useAuth.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/entities/authentication/utils";
 
 export type AuthContextType = {
-  accessToken: string | null;
+  accessToken: string;
   isAuthenticated: boolean;
   setToken: (token: UserToken | null) => void;
   user: User | null;
@@ -29,7 +29,7 @@ function extractUser(payload: unknown): User | null {
 }
 
 export const AuthContext = React.createContext<AuthContextType>({
-  accessToken: null,
+  accessToken: "",
   isAuthenticated: false,
   setToken: () => {},
   user: null,
@@ -38,9 +38,10 @@ export const AuthContext = React.createContext<AuthContextType>({
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Inline state instead of useLocalStorage so the cross-tab `storage`
   // listener can update React without re-writing the value back to
-  // localStorage (which would cascade `storage` events between tabs and
-  // loop forever). Storage writes go through `setToken` / `logoutLocally`;
-  // pure state updates use `setAccessTokenState` directly.
+  // localStorage. `storage` events only fire in *other* tabs, so a
+  // write-back wouldn't loop in one tab — but it would bounce a redundant
+  // event to peers, doubling work on every cross-tab sync. Storage writes
+  // go through `setToken`; pure state updates use `setAccessTokenState`.
   const [accessToken, setAccessTokenState] = React.useState<string>(
     () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ""
   );

--- a/frontend/app/src/entities/authentication/ui/useAuth.tsx
+++ b/frontend/app/src/entities/authentication/ui/useAuth.tsx
@@ -56,16 +56,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  // Reconcile with cross-tab logout: a `storage` event with the access-token
-  // key going empty in another tab means somebody signed out — drop our
+  // Reconcile with cross-tab logout: a `storage` event signalling the access
+  // token went empty in another tab means somebody signed out — drop our
   // local state so this tab follows. Covers manual devtools edits too.
   // State-only update; the originating tab already wrote to storage, so
   // re-writing here would just bounce a redundant `storage` event around.
   React.useEffect(() => {
     function handleStorage(event: StorageEvent) {
-      if (event.key !== ACCESS_TOKEN_KEY) return;
-      // Re-read rather than trusting event.newValue — `localStorage.clear()`
-      // delivers `newValue: null`, and we want to match the post-clear state.
+      // `localStorage.clear()` (DevTools "Clear site data", peer tab calling
+      // `.clear()`) delivers `event.key === null`; that case needs to
+      // reconcile too, so only skip events keyed at *other* specific keys.
+      if (event.key !== null && event.key !== ACCESS_TOKEN_KEY) return;
       const current = localStorage.getItem(ACCESS_TOKEN_KEY) ?? "";
       setAccessTokenState(current);
     }

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.test.ts
@@ -6,8 +6,9 @@ import { ERROR_CODES } from "@/shared/api/graphql/errors";
 import { queryClient } from "@/shared/api/rest/client";
 
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/constants";
+import { __navigation } from "@/entities/authentication/domain/redirect-to-login";
 
-import { __navigation, handleGraphQLAuthError } from "./graphqlClientApollo";
+import { handleGraphQLAuthError } from "./graphqlClientApollo";
 
 describe("handleGraphQLAuthError — TOKEN_EXPIRED retry-then-bail loop", () => {
   // Minimal stand-in for Apollo's `Operation`. The handler only touches

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -17,8 +17,8 @@ import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 import { CONFIG } from "@/shared/config/config";
 
 import { ACCESS_TOKEN_KEY } from "@/entities/authentication/constants";
+import { redirectToLogin } from "@/entities/authentication/domain/redirect-to-login";
 import { refreshAccessTokenQueryOptions } from "@/entities/authentication/ui/queries/refresh-access-token.query";
-import { removeTokensInLocalStorage } from "@/entities/authentication/utils";
 
 export const defaultOptions: DefaultOptions = {
   watchQuery: {
@@ -184,30 +184,6 @@ function retryWithRefreshedToken(
         observer.error(err);
       });
   });
-}
-
-// Helper: token is invalid or missing — clear local credentials and bounce
-// to /login. Hard-navigates because errorLink runs outside React Router,
-// and the AuthProvider's localStorage hook does not re-render on external
-// writes. Skips the redirect if we're already on /login to avoid loops.
-//
-// Encodes the current path as `?from=…` so `LoginPage` can route the user
-// back to where they were after re-authenticating. The hard nav means
-// `location.state` is gone, so the query string is the only carrier left.
-// Holder so tests can stub the hard-nav without touching `window.location`
-// (which is non-configurable in real browsers — vitest's browser mode hits
-// that wall the moment you try to spy on `assign`). Production reads
-// through this same reference, so the indirection costs one property lookup.
-export const __navigation = {
-  assign: (url: string) => window.location.assign(url),
-};
-
-function redirectToLogin(): void {
-  removeTokensInLocalStorage();
-  if (window.location.pathname === "/login") return;
-
-  const from = window.location.pathname + window.location.search + window.location.hash;
-  __navigation.assign(`/login?from=${encodeURIComponent(from)}`);
 }
 
 // Helper: surface an error to the user. Calls operation.context's

--- a/frontend/app/src/shared/api/rest/client.ts
+++ b/frontend/app/src/shared/api/rest/client.ts
@@ -5,6 +5,7 @@ import type { paths } from "@/shared/api/rest/types.generated";
 import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 
 import { ACCESS_TOKEN_KEY } from "@/entities/authentication/constants";
+import { redirectToLogin } from "@/entities/authentication/domain/redirect-to-login";
 import { refreshAccessTokenQueryOptions } from "@/entities/authentication/ui/queries/refresh-access-token.query";
 
 export const queryClient = new QueryClient({
@@ -54,6 +55,9 @@ const authMiddleware: Middleware = {
       const newToken = await queryClient.fetchQuery(refreshAccessTokenQueryOptions());
 
       if (!newToken?.access_token) {
+        // Refresh resolved but server returned no token — treat as failure
+        // and bounce to /login, matching the Apollo errorLink behaviour.
+        redirectToLogin();
         return response;
       }
 
@@ -61,6 +65,7 @@ const authMiddleware: Middleware = {
       return fetch(clonedRequest);
     } catch (error) {
       console.error("Token refresh failed:", error);
+      redirectToLogin();
       return response;
     }
   },


### PR DESCRIPTION
Summary

  Second PR in the auth cleanup series. Pulls hidden side-effects out of the refresh-token domain layer, keeps tabs in sync on logout, and tightens up the
  supporting code so the same redirectToLogin path is used everywhere.

  What changes

  - refreshAccessToken no longer has side-effects. It now throws on every failure mode (missing refresh token, API error) instead of doing its own
  removeTokensInLocalStorage() + window.location.reload(). Callers — retryWithRefreshedToken (Apollo) and the REST middleware — handle cleanup. The old in-place
   reload dropped in-flight React Query state and double-navigated when the catch site also redirected.
  - Cross-tab logout sync in AuthProvider. Listens to the storage event and re-reads localStorage when the access token key (or null, for localStorage.clear()
  from a peer tab / DevTools "Clear site data") changes. A peer tab signing out now drops this tab's React auth state without any write-back, avoiding redundant
   storage bounces.
  - redirectToLogin extracted to entities/authentication/domain/redirect-to-login.ts. Previously lived inside graphqlClientApollo.tsx, which forced REST to
  either duplicate the logic or import across layers. Apollo and REST now share one helper.
  - REST refresh-failure parity. The REST middleware's catch now calls redirectToLogin (token cleanup + ?from=… hard nav) instead of silently returning the
  original 401, matching the Apollo errorLink.
  - AuthContextType.accessToken tightened to string (default ""); drops a null union no caller relied on. Stale logoutLocally comment replaced with the real
  callback name.