### PR TITLE
feat(frontend/auth): catalogue-gap dev banner + stabilise SSO callbac…

### DIFF
--- a/frontend/app/src/pages/auth-callback.tsx
+++ b/frontend/app/src/pages/auth-callback.tsx
@@ -19,16 +19,22 @@ function AuthCallback() {
   const code = searchParams.get("code");
   const state = searchParams.get("state");
 
+  // Reduce the effect's deps to stable scalars. `config` is an object
+  // whose reference may change every time `useGetConfig` refetches —
+  // depending on it directly would re-fire the SSO token exchange on
+  // each refetch tick. The token exchange is one-shot, so re-running it
+  // would either succeed-then-error (code already consumed) or
+  // accidentally double-set tokens. The fields below are the only ones
+  // the effect actually reads.
+  const ssoEnabled = config?.sso?.enabled ?? false;
+  const tokenPath = config?.sso?.providers?.find(
+    (p) => p.protocol === protocol && p.name === provider
+  )?.token_path;
+
   useEffect(() => {
-    if (!config || !config.sso.enabled) return;
+    if (!ssoEnabled || !tokenPath) return;
 
-    const currentAuthProvider = config.sso.providers?.find(
-      (p) => p.protocol === protocol && p.name === provider
-    );
-    if (!currentAuthProvider) return;
-
-    const { token_path } = currentAuthProvider;
-    fetchUrl(`${INFRAHUB_API_SERVER_URL}${token_path}?code=${code}&state=${state}`)
+    fetchUrl(`${INFRAHUB_API_SERVER_URL}${tokenPath}?code=${code}&state=${state}`)
       .then((result) => {
         // 2xx response that still carries `errors` — normalise to a
         // FetchError so the catch sees the same shape as a non-2xx
@@ -61,9 +67,9 @@ function AuthCallback() {
           },
         ]);
       });
-  }, [config, protocol, provider]);
+  }, [ssoEnabled, tokenPath, code, state, setToken]);
 
-  if (!config || !config.sso.enabled) {
+  if (!ssoEnabled) {
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/app/src/pages/auth-callback.tsx
+++ b/frontend/app/src/pages/auth-callback.tsx
@@ -34,7 +34,11 @@ function AuthCallback() {
   useEffect(() => {
     if (!ssoEnabled || !tokenPath) return;
 
-    fetchUrl(`${INFRAHUB_API_SERVER_URL}${tokenPath}?code=${code}&state=${state}`)
+    const callbackUrl = new URL(`${INFRAHUB_API_SERVER_URL}${tokenPath}`);
+    if (code) callbackUrl.searchParams.set("code", code);
+    if (state) callbackUrl.searchParams.set("state", state);
+
+    fetchUrl(callbackUrl.toString())
       .then((result) => {
         // 2xx response that still carries `errors` — normalise to a
         // FetchError so the catch sees the same shape as a non-2xx

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -112,6 +112,26 @@ export function handleGraphQLAuthError({
         // Silent — 403s are handled by route-level guards, not toasts.
         return;
 
+      case ERROR_CODES.UNDEFINED_ERROR:
+        // Catalogue gap: the backend returned a code we don't recognise.
+        // In dev builds, surface this loudly so engineers see it without
+        // having to dig through devtools — a console.warn pointing at
+        // where to register the code, plus a prefix on the toast so the
+        // miss is visible during manual testing. Prod stays silent
+        // (just the generic toast) to avoid leaking implementation noise.
+        if (import.meta.env.DEV) {
+          console.warn(
+            "[catalogue gap] Unmatched error code surfaced as UNDEFINED_ERROR. " +
+              "Register it in backend/infrahub/errors/catalogue.py and mirror " +
+              "the entry in frontend/app/src/shared/api/graphql/errors.ts.",
+            { message: graphQLError.message, extensions: graphQLError.extensions }
+          );
+          notifyUser(`[catalogue gap] ${graphQLError.message}`, operation);
+          return;
+        }
+        notifyUser(graphQLError.message, operation);
+        return;
+
       default:
         notifyUser(graphQLError.message, operation);
     }

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -110,7 +110,9 @@ export function handleGraphQLAuthError({
 
       case ERROR_CODES.PERMISSION_DENIED:
         // Silent — 403s are handled by route-level guards, not toasts.
-        return;
+        // `continue` (not `return`) so any sibling errors in the same
+        // response still reach their handlers.
+        continue;
 
       case ERROR_CODES.UNDEFINED_ERROR:
         // Catalogue gap: the backend returned a code we don't recognise.

--- a/frontend/app/src/shared/api/rest/fetch.ts
+++ b/frontend/app/src/shared/api/rest/fetch.ts
@@ -2,6 +2,16 @@ import { QSP } from "@/shared/config/qsp";
 
 import { ACCESS_TOKEN_KEY } from "@/entities/authentication/constants";
 
+// REST error envelope item. The REST and GraphQL envelopes carry different
+// `code` shapes and must not be conflated:
+//
+//   REST     extensions.code = number  (HTTP status, e.g. 401)
+//   GraphQL  extensions.code = string  (catalogue identifier, e.g. "TOKEN_EXPIRED")
+//            extensions.http_status = number (the HTTP status lives here instead)
+//
+// The GraphQL mirror lives at @/shared/api/graphql/errors (GraphQLErrorExtensions).
+// If REST endpoints ever migrate to the catalogue, this type becomes a
+// discriminated union — until then, keep the two shapes distinct.
 export type RestErrorItem = { message: string; extensions: { code: number } };
 
 // Typed wrapper around a REST envelope that carries `errors`. `status`


### PR DESCRIPTION
Implements PR 4 of dev/specs/2026-05-29-frontend-error-auth-improvements.md.

- E7: route UNDEFINED_ERROR through its own switch arm in `handleGraphQLAuthError`. In dev builds, emit a console.warn with a pointer at where to register the missing code (backend catalogue + frontend mirror) and prefix the user-facing toast with `[catalogue gap]` so the miss is visible during manual testing. Prod stays silent — the toast there is unprefixed, identical to the prior generic-error path.

- A5: replace the SSO callback effect's `[config, protocol, provider]` dep array with stable scalars (`ssoEnabled`, `tokenPath`, `code`, `state`, `setToken`). `config` is an object whose reference may change every time `useGetConfig` refetches; depending on it directly would re-fire the one-shot SSO token exchange on each refetch tick. The early-return guard also switches from `config.sso.enabled` to the derived `ssoEnabled` for consistency.

- E4: header comment on `RestErrorItem` documenting the REST / GraphQL envelope split — REST carries `extensions.code = number` (HTTP status), GraphQL carries `extensions.code = string` (catalogue identifier) plus `extensions.http_status` separately. Conflating the two is the most likely future foot-gun; the comment points at the GraphQL mirror so readers find both sides.

A8 (render extensions.code on login page) and A4 (module-scope token cache in authLink) intentionally **not** in this PR. A8 already shipped with PR 1's A6 — login.tsx renders `({error.extensions.code}) {error.message}`. A4 was flagged in the spec as a micro-opt worth doing only once subscriptions or batch requests land; until then the extra coupling between useAuth and graphqlClient isn't worth it.

E9 (json-schema-to-typescript + pnpm scripts) was investigated and returned to INFP-468 US2: shipping the devDep ahead of T028's consumer trips knip's unused-dep check, so T027 belongs in the same PR as T028.

<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

Closes <!-- #issue -->

## What changed

<!-- Group changes by intent, not by file. -->

<!-- Behavioral changes: what users/systems will observe differently -->
-

<!-- Implementation notes: key design choices, tradeoffs, notable refactors -->

<!-- What stayed the same: especially useful if you touched sensitive areas -->
<!-- e.g., "No schema changes", "API contract unchanged", "Only affects branch X" -->

<!-- If the diff is large, add a suggested review order:
### Suggested review order
1. Start with ...
2. Then ...
3. Tests are ...
-->

## How to review

<!-- Key files/areas to focus on vs. mechanical/generated changes -->

<!-- Risky or uncertain parts where you want extra scrutiny -->

<!-- Alternatives considered (only if it affects future direction) -->

## How to test

<!-- Make it runnable and specific -->

```bash
# Commands to validate
```

<!-- Expected outputs, screenshots, or links to CI results -->

## Impact & rollout

<!-- Delete items that don't apply -->

- **Backward compatibility:** <!-- any breaking changes or migration steps -->
- **Performance:** <!-- implications, measurements if relevant -->
- **Config/env changes:** <!-- new settings, feature flags, env vars -->
- **Deployment notes:** <!-- "safe to deploy" vs "requires coordinated release" -->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only “[catalogue gap]” banner and console warning for unknown GraphQL error codes, stabilizes the SSO callback to prevent duplicate token exchanges, and documents the REST vs GraphQL error envelope split. Also keeps processing sibling errors after `PERMISSION_DENIED` and URL-encodes OAuth callback params.

- **New Features**
  - Route `UNDEFINED_ERROR` in `handleGraphQLAuthError`: dev shows a console.warn and `[catalogue gap]` toast; prod keeps the generic toast.

- **Bug Fixes**
  - SSO callback effect now uses stable deps (`ssoEnabled`, `tokenPath`, `code`, `state`, `setToken`) and builds the callback URL via `URL.searchParams` to encode `code`/`state`.
  - After `PERMISSION_DENIED`, use `continue` so sibling errors in the same GraphQL response still run their handlers.

<sup>Written for commit 46af96841ecc2f27824dba840a69b09865d260d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

