### PR TITLE
feat(dev/skills): add /feature-flow and /capture-knowledge

### DIFF
--- a/dev/commands/git-pr.md
+++ b/dev/commands/git-pr.md
@@ -1,0 +1,98 @@
+---
+description: Push the current branch and open a pull request via gh
+argument-hint: "[--title \"<title>\"] [--body \"<body>\"] [--draft] [--base <branch>]"
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - Bash(git push:*)
+  - Bash(gh pr create:*)
+  - Bash(gh pr view:*)
+---
+
+# Open Pull Request
+
+Push the current branch and open a GitHub PR. This command is the "PR" half of the commit → push → PR flow (use `/git-commit` for the commit + push half if commits aren't yet on remote).
+
+**Arguments:**
+
+- `--title "<title>"` (optional): PR title (≤70 chars). If omitted, derive from `git log <base>..HEAD --oneline` and the diff.
+- `--body "<body>"` (optional): PR body. If omitted, draft a `## Summary` / `## Test plan` body from the diff.
+- `--draft` (optional): Open as a draft PR.
+- `--base <branch>` (optional): Base branch. Defaults to `develop`.
+
+## Preconditions
+
+1. Working tree must be clean. If anything is uncommitted or staged, **stop** and surface it to the user — do not auto-commit drift.
+
+   ```bash
+   git status --porcelain
+   ```
+
+   If non-empty, instruct the user to commit (e.g. via `/git-commit`) before proceeding.
+
+2. The branch must have at least one commit ahead of `--base`:
+
+   ```bash
+   git log --oneline "${BASE:-develop}..HEAD"
+   ```
+
+   If empty, stop and inform the user there is nothing to PR.
+
+3. Never open a PR with `--base stable`, `--base develop` only if the current branch *is* a feature branch (refuse if HEAD is itself `develop` or `stable`).
+
+## Steps
+
+1. **Confirm intent**: show the user the proposed title, body, base, and `--draft` flag (if any). Wait for approval before pushing.
+
+2. **Push (set upstream if needed)**:
+
+   ```bash
+   if ! git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+     git push -u origin "$(git branch --show-current)"
+   else
+     git push
+   fi
+   ```
+
+3. **Open the PR** using a HEREDOC body to preserve formatting:
+
+   ```bash
+   gh pr create \
+     --base "${BASE:-develop}" \
+     --title "<approved title>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <bullets>
+
+   ## Test plan
+   <checklist>
+   EOF
+   )" \
+     ${DRAFT:+--draft}
+   ```
+
+4. **Report the PR URL** returned by `gh pr create`.
+
+## Drafting title and body from the diff (when arguments omitted)
+
+If `--title` is omitted:
+
+- Read `git log --oneline <base>..HEAD` and `git diff <base>...HEAD --stat`.
+- Compose `<type>(<scope>): <short description>` following the conventions in `dev/commands/git-commit.md`.
+- Keep ≤70 chars.
+
+If `--body` is omitted:
+
+- `## Summary`: 1-3 bullets explaining *what changed* and *why*.
+- `## Test plan`: bulleted checklist of how to verify the change locally.
+
+Show the drafted title and body to the user for approval before invoking `gh pr create`.
+
+## Notes
+
+- Use this command after commits are already on `origin/<branch>` or about to be pushed. It does not create commits.
+- For split-PR workflows (e.g. driven by `/feature-flow` Phase 6c), invoke this command per branch and add a `Depends on #<sibling-PR>` line at the top of dependent bodies.
+- If the PR already exists for the current branch, `gh pr create` will fail — use `gh pr view --web` to open the existing one instead.

--- a/dev/skills/capture-knowledge/SKILL.md
+++ b/dev/skills/capture-knowledge/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: "capture-knowledge"
+description: "Capture non-obvious facts learned while working into dev/knowledge/, dev/guidelines/, or dev/guides/ so future agents understand the code faster. Trigger when the user says 'capture this', 'document this', 'we should write that down', or autonomously at the end of a feature when something non-obvious was learned."
+argument-hint: "<short description of what to capture, or omit to let the skill scan the current session>"
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Capture Knowledge
+
+Grow the frontend docs **opportunistically** during real work, so each session leaves the codebase easier for the next agent to understand.
+
+## Where things go
+
+Three buckets in `dev/`:
+
+| Bucket | Path | What belongs here |
+|---|---|---|
+| **Knowledge** | `dev/knowledge/frontend/` | How the system actually works. Architecture, contracts, data flow, non-obvious invariants. Descriptive. |
+| **Guidelines** | `dev/guidelines/frontend/` | How code should be written. Conventions, rules, "do this not that". Prescriptive. |
+| **Guides** | `dev/guides/frontend/` | Step-by-step recipes for a specific task (e.g. "writing a unit test"). Procedural. |
+
+When in doubt: if removing the doc would make a future agent *misunderstand* the system, it's **knowledge**. If it would make them *write inconsistent code*, it's a **guideline**. If it would make them *unable to complete a specific task*, it's a **guide**.
+
+## What to capture
+
+Capture only things that are:
+
+- **Non-obvious from reading the code** — a hidden constraint, a subtle invariant, a "this looks wrong but it's correct because…", a deliberate choice that surprises.
+- **Stable** — architecture, contracts between layers, naming conventions, ownership boundaries. NOT specific implementations that change every sprint.
+- **Reusable** — applies to more than one file or future work.
+
+## What NOT to capture
+
+(Mirrors the rules for auto-memory.)
+
+- ❌ Anything obvious from reading the file: function signatures, what a component renders, prop names.
+- ❌ Recent changes / git history — `git log` and `git blame` are authoritative.
+- ❌ Debugging fix recipes — the fix is in the code; the commit message has the context.
+- ❌ Current-task state, in-progress work, who's doing what.
+- ❌ Anything already covered in CLAUDE.md, AGENTS.md, or an existing doc in the three buckets.
+
+## Workflow
+
+### 1. Identify the candidate fact
+
+If the user gave a description as `$ARGUMENTS`, use it. Otherwise, scan the current session for moments where you (the agent) thought *"I wish this had been documented"* — surprising patterns, repeated questions, hidden invariants. Surface 1-3 candidates.
+
+### 2. Classify
+
+For each candidate, decide bucket (knowledge / guideline / guide) using the table above. State the classification and the reasoning in one sentence.
+
+### 3. Check for duplication FIRST
+
+Before writing anything new:
+
+```bash
+grep -ri "<key phrase from the candidate>" dev/knowledge/frontend/ dev/guidelines/frontend/ dev/guides/frontend/
+```
+
+- If a relevant doc already exists → **prefer updating it** with an Edit. Add the new fact in the right section.
+- If multiple docs touch the topic → consolidate; do not scatter the same fact across files.
+- Only create a new file when there is **no existing home** for the fact AND the topic is broad enough to warrant its own page.
+
+### 4. Draft the change
+
+Write the smallest possible addition. One paragraph, or a bullet under an existing heading. Concrete examples beat abstract description — link to a real file path with line numbers when relevant (`src/foo/bar.ts:42`).
+
+If creating a new file, follow the structure of the most similar existing file in the same bucket. Keep frontmatter (if any) consistent.
+
+### 5. Confirm with user before writing
+
+Show the user:
+
+- The bucket + target file (existing or new)
+- The exact diff (or new file contents)
+- Why this is non-obvious / why it belongs
+
+Wait for approval. **Do not silently write docs** — the user owns what enters the canonical knowledge base.
+
+### 6. Update the index entries
+
+If the new doc is a new file, add a one-line pointer in the relevant `AGENTS.md` (`frontend/app/AGENTS.md` under "See Also") so it shows up in the skill-discovery surface for future agents.
+
+## Heuristics for sniffing capture candidates during a session
+
+- An `Explore` agent had to grep across multiple files to find a contract → capture that contract.
+- The user corrected your understanding of how something works → capture the corrected mental model.
+- A pattern was reused 3+ times without being named → name it as a guideline.
+- A non-trivial decision was made ("we don't do X because Y") → capture as knowledge or guideline depending on framing.
+- A workflow took >5 steps to figure out from scratch → consider a guide.
+
+## Anti-patterns
+
+- ❌ Writing docs that describe what code currently *does* (read the code instead).
+- ❌ Long aspirational docs that don't reflect reality on `develop`.
+- ❌ Creating a new file when an existing one has 80% of the same topic.
+- ❌ Capturing without user confirmation.
+- ❌ Capturing in-flight implementation details that will change next week.

--- a/dev/skills/feature-flow/SKILL.md
+++ b/dev/skills/feature-flow/SKILL.md
@@ -78,10 +78,43 @@ End-to-end orchestrator for a single feature. Reuses existing skills (`/speckit-
 
 ### Phase 6 — PR
 
-1. **1 `general-purpose` agent** drafts PR title (≤70 chars) and summary from `git diff develop...HEAD` plus the spec brief from Phase 1.
-2. Show draft to user.
-3. On approval, invoke `/commit-commands:commit-push-pr` to commit, push, and open the PR.
-4. Report the PR URL.
+#### 6a. Split assessment (bias toward single PR)
+
+Before drafting anything, **1 `general-purpose` agent** analyzes `git diff develop...HEAD` and `git log develop..HEAD` and decides: **single PR or split?**
+
+**Default to single PR.** Only propose a split when at least one of these clearly applies:
+
+- **Independent concerns** — e.g. an unrelated drive-by refactor mixed in with the feature, or backend + frontend changes that could be reviewed and reverted independently.
+- **Different reviewers** — e.g. infra/CI changes that need a platform reviewer separate from product reviewers.
+- **Different risk profiles** — e.g. a low-risk doc/config change you want to land fast, bundled with a higher-risk feature.
+- **Revertable in isolation** — splitting would let one part be reverted without affecting the rest.
+
+**Do NOT split when:**
+
+- ❌ Changes are coupled (feature + its own tests + its own docs).
+- ❌ Splitting would leave one PR with broken tests or builds.
+- ❌ The change has a single coherent narrative.
+- ❌ The split would create a chain of dependent PRs that must merge in order, and the value isn't worth that cost.
+
+The agent outputs one of:
+
+- **"Ship as one PR"** with a one-line justification.
+- **"Suggest split into N PRs"** with the proposed groupings (which commits / which files go where, in dependency order if any), plus an explicit *"but a single PR is also reasonable"* note when the case is borderline.
+
+**Checkpoint:** show the assessment to the user. User picks single PR, accepts the split, or proposes a different split. Never force a split without approval.
+
+#### 6b. Draft PR(s)
+
+For **each** PR (one or many):
+
+1. If splitting, create a new branch from `origin/develop` and cherry-pick the relevant commits onto it. Verify the branch builds (`/pre-ci --fast` at minimum on each split branch).
+2. **1 `general-purpose` agent** drafts title (≤70 chars) and summary from the diff of *that* PR plus the spec brief from Phase 1. For split PRs, the summary should note any dependencies on sibling PRs.
+3. Show draft(s) to user.
+
+#### 6c. Open
+
+4. On approval, invoke `/commit-commands:commit-push-pr` per branch.
+5. Report PR URL(s). For split PRs, note merge order if there are dependencies.
 
 ## Iteration notes
 
@@ -97,3 +130,4 @@ This skill is intentionally lightweight — it composes existing skills rather t
 - ❌ Chaining all phases unattended — checkpoints exist so the user can redirect early.
 - ❌ Opening a PR with a red `/pre-ci` — the hook would block it, but don't even try.
 - ❌ Reimplementing `/pre-ci`, `/speckit-*`, or commit/PR logic inside this skill. Call them.
+- ❌ Forcing a PR split when the changes are coupled — split assessment is a *suggestion*, not a mandate. Single PR is the default.

--- a/dev/skills/feature-flow/SKILL.md
+++ b/dev/skills/feature-flow/SKILL.md
@@ -12,11 +12,34 @@ End-to-end orchestrator for a single feature. Reuses existing skills (`/speckit-
 
 ## Core principles
 
-- **Parallel = divergent thinking** (specs, plans, reviews). Multiple agents with different framings, then one synthesizer to converge.
+- **Parallel = divergent thinking** (specs, plans, reviews, assessments). Multiple agents with different framings, then one synthesizer to converge.
 - **Sequential = convergent/deterministic** (CI checks, commit, PR).
 - **Always synthesize before acting.** Never feed N parallel outputs directly into N implementation agents — one human-approved synthesis between phases.
 - **Worktrees for implementation** so parallel implementers don't stomp each other (`isolation: "worktree"` on Agent calls).
-- **Stop at checkpoints.** The user approves at the end of phases 1, 2, 4, and 5. Do not chain phases unattended.
+- **Stop at checkpoints.** The user approves at the end of phases 1, 2, 4, 5, and 6a. Do not chain phases unattended.
+
+## The divergent-then-synthesize primitive
+
+This is the single most important pattern in this skill. **Any phase that involves judgment, opinion, or design choice uses it.** Any phase that is deterministic (running tests, formatting) does not.
+
+**Shape:**
+
+1. **Diverge:** Spawn 2-4 agents *in parallel in a single message* (multiple tool calls in one assistant turn). Each gets a **different framing** of the same problem — not the same prompt N times. The framings are deliberate: minimal vs. refactor-friendly, security vs. simplicity, single-PR vs. split, etc.
+2. **Synthesize:** Spawn **1** `general-purpose` agent that receives all N outputs and produces a single ranked recommendation. It must compare, dedup, and flag tradeoffs — not just concatenate.
+3. **Checkpoint:** Surface the synthesis to the user with the open tradeoffs. User approves, redirects, or asks for another framing.
+
+**Why it works:** One agent's first answer is often locally optimal but globally narrow. Diverse framings surface options that no single agent would explore. The synthesizer prevents you from drowning in N opinions.
+
+**Where this primitive is used in this skill:**
+
+| Phase | Diverge (parallel) | Synthesize |
+|---|---|---|
+| 1 — Specs | 3 `Explore` framings | 1 `general-purpose` |
+| 2 — Plan | 3 `Plan` framings | 1 `general-purpose` |
+| 4 — Review | `coderabbit:code-reviewer` + `code-simplifier` + `general-purpose` | 1 `general-purpose` |
+| 6a — Split assessment | 3 `general-purpose` framings | 1 `general-purpose` |
+
+Phase 3 (implement) is **also** parallel but is *not* divergent — each agent owns a different unit of work, not a different framing of the same problem. Don't conflate the two.
 
 ## Phases
 
@@ -80,28 +103,33 @@ End-to-end orchestrator for a single feature. Reuses existing skills (`/speckit-
 
 #### 6a. Split assessment (bias toward single PR)
 
-Before drafting anything, **1 `general-purpose` agent** analyzes `git diff develop...HEAD` and `git log develop..HEAD` and decides: **single PR or split?**
+Apply the **divergent-then-synthesize primitive** to the split decision. Before drafting any PR, run **3 `general-purpose` agents in parallel** against `git diff develop...HEAD` and `git log develop..HEAD`, each with a deliberately different framing:
 
-**Default to single PR.** Only propose a split when at least one of these clearly applies:
+- **Reviewer ergonomics** — "what split would make this fastest to review?" (favors small, focused PRs)
+- **Risk isolation** — "what split would let us revert one part without affecting the others?" (favors separating high-risk from low-risk changes)
+- **Coherence preservation** — "what's the simplest narrative? when would splitting break tests or tell a worse story?" (favors a single PR; this framing is the counterweight)
 
-- **Independent concerns** — e.g. an unrelated drive-by refactor mixed in with the feature, or backend + frontend changes that could be reviewed and reverted independently.
-- **Different reviewers** — e.g. infra/CI changes that need a platform reviewer separate from product reviewers.
-- **Different risk profiles** — e.g. a low-risk doc/config change you want to land fast, bundled with a higher-risk feature.
-- **Revertable in isolation** — splitting would let one part be reverted without affecting the rest.
+Each agent returns either *"ship as one"* or *"split into N groups: ..."* with its reasoning.
 
-**Do NOT split when:**
+**Synthesize** with **1 `general-purpose` agent**: compare the three framings, weigh tradeoffs, and produce a single recommendation. Apply the strong bias toward a single PR:
 
-- ❌ Changes are coupled (feature + its own tests + its own docs).
-- ❌ Splitting would leave one PR with broken tests or builds.
-- ❌ The change has a single coherent narrative.
-- ❌ The split would create a chain of dependent PRs that must merge in order, and the value isn't worth that cost.
+- **Only recommend a split when ≥2 of the 3 framings independently suggest it**, AND at least one of these clearly applies:
+  - Independent concerns (e.g. unrelated drive-by refactor, or backend + frontend independently reviewable).
+  - Different reviewers needed (e.g. infra/CI vs. product).
+  - Different risk profiles (e.g. low-risk config + high-risk feature).
+  - Revertable in isolation.
+- **Do NOT recommend a split when:**
+  - ❌ Changes are coupled (feature + its own tests + its own docs).
+  - ❌ Splitting would leave one PR with broken tests or builds.
+  - ❌ The change has a single coherent narrative.
+  - ❌ The split would create a chain of dependent PRs that must merge in order, and the value isn't worth that cost.
 
-The agent outputs one of:
+The synthesizer outputs one of:
 
 - **"Ship as one PR"** with a one-line justification.
 - **"Suggest split into N PRs"** with the proposed groupings (which commits / which files go where, in dependency order if any), plus an explicit *"but a single PR is also reasonable"* note when the case is borderline.
 
-**Checkpoint:** show the assessment to the user. User picks single PR, accepts the split, or proposes a different split. Never force a split without approval.
+**Checkpoint:** show the synthesis (and the three framings if useful) to the user. User picks single PR, accepts the split, or proposes a different split. Never force a split without approval.
 
 #### 6b. Draft PR(s)
 

--- a/dev/skills/feature-flow/SKILL.md
+++ b/dev/skills/feature-flow/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 # Feature Flow
 
-End-to-end orchestrator for a single feature. Reuses existing repo-level skills (`/speckit-*`, `/pre-ci`, `/git-commit`, `/capture-knowledge`) — does **not** reimplement them.
+End-to-end orchestrator for a single feature. Reuses existing repo-level slash commands and skills (`/speckit-*`, `/pre-ci`, `/git-commit`, `/git-pr`, `/capture-knowledge`) — does **not** reimplement them.
 
 ## Core principles
 
@@ -141,28 +141,19 @@ For **each** PR (one or many):
 
 #### 6c. Open
 
-For each approved PR branch:
+For each approved PR branch, invoke `/git-pr` with the approved title and body:
 
-4. Ensure the branch is pushed and tracking the remote:
-   ```bash
-   git push -u origin "$(git branch --show-current)"
-   ```
-   (If upstream is already set, `git push` is sufficient.)
-5. Open the PR with `gh pr create`, passing the body as a HEREDOC to preserve formatting:
-   ```bash
-   gh pr create --title "<approved title>" --body "$(cat <<'EOF'
-   ## Summary
-   <bullets from the synthesizer>
+```
+/git-pr --title "<approved title>" --body "<approved body>"
+```
 
-   ## Test plan
-   <checklist>
-   EOF
-   )"
-   ```
-   For split PRs with dependencies, add a "Depends on #<sibling-PR>" line at the top of dependent bodies and open in dependency order.
-6. Report PR URL(s). For split PRs, note merge order.
+`/git-pr` handles the push (setting upstream if needed) and `gh pr create` itself. It refuses to run if the working tree is dirty or if the branch has no commits ahead of base — surface either error to the user rather than working around it.
 
-Note: by this point, the work was already committed iteratively during Phase 3, so this sub-step is push + PR only — no commit step. If anything is uncommitted, stop and surface it; do not auto-commit drift.
+For split PRs with dependencies, prepend a `Depends on #<sibling-PR>` line to dependent bodies and open in dependency order.
+
+Report the PR URL(s) returned by `/git-pr`. For split PRs, note merge order.
+
+Note: by this point, the work was already committed iteratively during Phase 3. If anything is uncommitted, `/git-pr` will refuse — do not auto-commit drift to satisfy it; surface the dirty state to the user.
 
 ## Iteration notes
 

--- a/dev/skills/feature-flow/SKILL.md
+++ b/dev/skills/feature-flow/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 # Feature Flow
 
-End-to-end orchestrator for a single feature. Reuses existing skills (`/speckit-*`, `/pre-ci`, `/capture-knowledge`, `/commit-commands:commit-push-pr`) — does **not** reimplement them.
+End-to-end orchestrator for a single feature. Reuses existing repo-level skills (`/speckit-*`, `/pre-ci`, `/git-commit`, `/capture-knowledge`) — does **not** reimplement them.
 
 ## Core principles
 
@@ -141,8 +141,28 @@ For **each** PR (one or many):
 
 #### 6c. Open
 
-4. On approval, invoke `/commit-commands:commit-push-pr` per branch.
-5. Report PR URL(s). For split PRs, note merge order if there are dependencies.
+For each approved PR branch:
+
+4. Ensure the branch is pushed and tracking the remote:
+   ```bash
+   git push -u origin "$(git branch --show-current)"
+   ```
+   (If upstream is already set, `git push` is sufficient.)
+5. Open the PR with `gh pr create`, passing the body as a HEREDOC to preserve formatting:
+   ```bash
+   gh pr create --title "<approved title>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullets from the synthesizer>
+
+   ## Test plan
+   <checklist>
+   EOF
+   )"
+   ```
+   For split PRs with dependencies, add a "Depends on #<sibling-PR>" line at the top of dependent bodies and open in dependency order.
+6. Report PR URL(s). For split PRs, note merge order.
+
+Note: by this point, the work was already committed iteratively during Phase 3, so this sub-step is push + PR only — no commit step. If anything is uncommitted, stop and surface it; do not auto-commit drift.
 
 ## Iteration notes
 

--- a/dev/skills/feature-flow/SKILL.md
+++ b/dev/skills/feature-flow/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: "feature-flow"
+description: "Multi-phase orchestrator for a feature: spec → plan → implement → review → CI gate → PR. Uses parallel agents for divergent thinking and a single synthesizer between phases. Trigger when the user says 'start the feature flow', 'run feature-flow', or names a ticket and asks to drive it end to end."
+argument-hint: "<ticket-id or short description>"
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Feature Flow
+
+End-to-end orchestrator for a single feature. Reuses existing skills (`/speckit-*`, `/pre-ci`, `/capture-knowledge`, `/commit-commands:commit-push-pr`) — does **not** reimplement them.
+
+## Core principles
+
+- **Parallel = divergent thinking** (specs, plans, reviews). Multiple agents with different framings, then one synthesizer to converge.
+- **Sequential = convergent/deterministic** (CI checks, commit, PR).
+- **Always synthesize before acting.** Never feed N parallel outputs directly into N implementation agents — one human-approved synthesis between phases.
+- **Worktrees for implementation** so parallel implementers don't stomp each other (`isolation: "worktree"` on Agent calls).
+- **Stop at checkpoints.** The user approves at the end of phases 1, 2, 4, and 5. Do not chain phases unattended.
+
+## Phases
+
+### Phase 1 — Specs
+
+1. If the user provided a ticket ID or feature description, restate it in one sentence and confirm scope.
+2. Run **3 `Explore` agents in parallel** (single message, three tool calls), each with a different framing:
+   - **Existing patterns** — find prior art in the codebase for similar features.
+   - **Related entities & APIs** — what GraphQL types, routes, components, or backend services intersect this work.
+   - **Test coverage gaps** — what isn't tested today in the surface area that will change.
+3. **Synthesize** with **1 `general-purpose` agent**: merge the three findings into a draft spec brief (problem, constraints, affected files, open questions).
+4. Invoke `/speckit-specify` to formalize the spec, then `/speckit-clarify` to surface gaps.
+5. **Checkpoint:** show the spec summary, list open questions, wait for user approval.
+
+### Phase 2 — Plan
+
+1. Run **3 `Plan` agents in parallel** with deliberately different framings:
+   - **Minimal change** — smallest viable diff.
+   - **Refactor-friendly** — fix adjacent rough edges that the change exposes.
+   - **Test-first** — what tests would prove this works; what's the implementation that makes them pass.
+2. **Synthesize** with **1 `general-purpose` agent**: compare the three plans, pick the best approach per step, flag tradeoffs. Output as a single ordered task list.
+3. Invoke `/speckit-plan` then `/speckit-tasks` to formalize.
+4. Optionally run `/speckit-analyze` for cross-artifact consistency.
+5. **Checkpoint:** present the merged plan + tradeoffs, wait for user approval.
+
+### Phase 3 — Implement
+
+1. Group tasks into **independent units** (no shared file or sequential dependency).
+2. For each unit, spawn a `general-purpose` agent with `isolation: "worktree"`, instructed to follow the `superpowers:test-driven-development` skill.
+3. Send all independent units in a **single message with parallel tool calls**. Send dependent units sequentially.
+4. As each agent reports back, verify the actual diff (not just the summary). Trust-but-verify per the global rule.
+5. If any agent reports a blocker, surface it to the user before continuing.
+
+### Phase 4 — Review (pre-PR)
+
+1. Run in **parallel** in a single message:
+   - `coderabbit:code-reviewer` — broad correctness/security review.
+   - `code-simplifier` — simplification pass on the diff.
+   - `general-purpose` — custom prompt: "review for security, edge cases, and reuse against `dev/knowledge/frontend/shared-components.md`".
+2. **Synthesize** with **1 `general-purpose` agent**: dedup findings, rank by severity (blocker / nit / suggestion), output a fix list.
+3. **Checkpoint:** show the ranked fix list, wait for user approval.
+4. **Fix pass:** for approved fixes, spawn small parallel agents (one per independent file group) to apply.
+
+### Phase 4.5 — Knowledge capture (opportunistic)
+
+1. Invoke `/capture-knowledge` with no arguments — it will scan this session for non-obvious facts learned while building this feature.
+2. Common capture-worthy moments to flag to the skill:
+   - An `Explore` agent in Phase 1 had to hunt across multiple files to reconstruct a contract → that contract belongs in `dev/knowledge/frontend/`.
+   - The synthesizer in Phase 2 had to make a non-obvious tradeoff → the reasoning belongs in `dev/guidelines/frontend/` or a relevant knowledge doc.
+   - The review in Phase 4 flagged the same pattern multiple times → name it as a guideline.
+3. **Checkpoint:** user approves doc changes before they are written. Skip silently if nothing genuinely new was learned — empty captures are a feature, not a failure.
+4. If docs change, they become part of the same PR (no separate PR for docs unless the user asks).
+
+### Phase 5 — CI gate (must-pass before PR)
+
+1. Invoke `/pre-ci` (not `--fast`). This already runs biome, knip-equivalent, betterer, tests, schema validation, and lint.
+2. If anything fails, loop back to Phase 4 fix pass. **Do not proceed to Phase 6 with a red CI gate.**
+3. **Checkpoint:** show the `/pre-ci` results table, wait for user approval before opening the PR.
+
+### Phase 6 — PR
+
+1. **1 `general-purpose` agent** drafts PR title (≤70 chars) and summary from `git diff develop...HEAD` plus the spec brief from Phase 1.
+2. Show draft to user.
+3. On approval, invoke `/commit-commands:commit-push-pr` to commit, push, and open the PR.
+4. Report the PR URL.
+
+## Iteration notes
+
+This skill is intentionally lightweight — it composes existing skills rather than duplicating their logic. To customize:
+
+- Add new phase variants in this file.
+- If a phase grows large, extract it to `dev/skills/feature-flow/phases/<phase>.md` and reference it from here.
+- To add custom sub-agents (e.g. a project-specific reviewer), create `.claude/agents/<name>.md` at the repo root.
+
+## Anti-patterns
+
+- ❌ Skipping the synthesizer between parallel agents.
+- ❌ Chaining all phases unattended — checkpoints exist so the user can redirect early.
+- ❌ Opening a PR with a red `/pre-ci` — the hook would block it, but don't even try.
+- ❌ Reimplementing `/pre-ci`, `/speckit-*`, or commit/PR logic inside this skill. Call them.


### PR DESCRIPTION
## Summary

  - Adds `/feature-flow` — a six-phase end-to-end orchestrator skill (spec → plan → implement → review → knowledge capture → CI gate → PR) that composes
  existing skills (`/speckit-*`, `/pre-ci`, `/commit-commands:commit-push-pr`) rather than reimplementing them.
  - Adds `/capture-knowledge` — a standalone skill that opportunistically grows `dev/knowledge/frontend/`, `dev/guidelines/frontend/`, and
  `dev/guides/frontend/` from non-obvious facts learned during real work. Used as Phase 4.5 of `/feature-flow`, also callable ad hoc.
  - Names the **divergent-then-synthesize primitive** the orchestrator relies on: 2-4 parallel agents with deliberately different framings, then a single
  synthesizer to converge. Phase 6a (single vs. multi-PR split assessment) uses it, with a strong bias toward a single PR.

  ## Why

  Today the workflow (gather context → spec → plan → implement → review → CI → PR) is rebuilt from memory every session. This skill captures it so any teammate
  can run `/feature-flow <ticket>` and get the same flow, with checkpoints where the human approves between phases. Knowledge capture as a side effect means
  each session leaves the codebase easier to understand for the next agent.

  ## What's in scope

  - `dev/skills/feature-flow/SKILL.md` (new)
  - `dev/skills/capture-knowledge/SKILL.md` (new)

  Both pick up automatically via the existing `.claude/skills` → `dev/skills` symlink — no settings.json change required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/feature-flow` and `/capture-knowledge` skills to standardize feature delivery (spec → plan → implement → review → knowledge capture → CI → PR) and capture non‑obvious learnings. Adds `/git-pr` to reliably push a branch and open a PR via `gh`.

- **New Features**
  - `/feature-flow`: end‑to‑end orchestrator with checkpoints; uses divergent framings then a synthesizer in phases 1, 2, 4, and 6a; includes a single‑PR‑by‑default split check (never splits without approval); composes `\`/speckit-*\``, `\`/pre-ci\``, `\`/git-commit\``, and new `\`/git-pr\``.
  - `/capture-knowledge`: standalone and Phase 4.5; updates `dev/knowledge/frontend/`, `dev/guidelines/frontend/`, `dev/guides/frontend/` with de‑dupe and user confirmation.
  - `/git-pr`: push current branch and open a PR via `gh`; refuses dirty trees or empty diffs; can draft title/body from the diff; supports `--base` and `--draft`.

- **Bug Fixes**
  - Phase 6c: replaced a local plugin dependency with `\`/git-pr\``; keeps PR creation repo‑native and reusable (intro now references `\`/git-commit\``/`\`/git-pr\``).

<sup>Written for commit 214c35c11b455549587e0d9ee75d07849bd2ca1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

