### PR TITLE
Fix issues with docstrings

### DIFF
--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -29,6 +29,10 @@ def build_cache_connection_string(cache: CacheSettings) -> str:
     params are passed through to the connection. This keeps the Prefect result
     storage block in parity with lock.py and the cache adapter, which read the
     same INFRAHUB_CACHE_TLS_* settings directly.
+
+    Raises:
+        ValueError: When ``INFRAHUB_CACHE_USERNAME`` is set without ``INFRAHUB_CACHE_PASSWORD``.
+
     """
     if cache.username and not cache.password:
         raise ValueError("INFRAHUB_CACHE_USERNAME is set but INFRAHUB_CACHE_PASSWORD is not. Both are required.")

--- a/backend/tests/unit/workflows/test_initialization.py
+++ b/backend/tests/unit/workflows/test_initialization.py
@@ -251,9 +251,9 @@ class RoundTripCase:
     ],
 )
 def test_connection_string_round_trip_through_redis_py(case: RoundTripCase) -> None:
-    """The URL we build must parse back through redis.ConnectionPool.from_url
-    into a connection class and kwargs that match the cache configuration.
+    """The URL we build must parse back through redis.ConnectionPool.from_url.
 
+    The parsed connection class and kwargs must match the cache configuration.
     This guards against silent regressions where the URL is syntactically valid
     but semantically wrong (e.g. redis-py changing how it parses ssl_* params).
     """


### PR DESCRIPTION
# Why

Fix CI problems with ruff and docstrings after #9218 was merged

## What changed

* docstrings update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docstrings in `build_cache_connection_string` and related tests to satisfy `ruff` rules and clarify behavior. Adds a Raises section documenting the `ValueError` when `INFRAHUB_CACHE_USERNAME` is set without `INFRAHUB_CACHE_PASSWORD`; no runtime changes.

<sup>Written for commit f5d494921d2781e7716f26e332cd31aec57d5191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

