### PR TITLE
fix(security): map OIDC JWKS/key-resolution failures to 401

### DIFF
--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -27,7 +28,7 @@ from infrahub.auth import (
 from infrahub.auth_pkce import compute_code_challenge, generate_code_verifier
 from infrahub.core import registry
 from infrahub.events.account_action import AuthMethod
-from infrahub.exceptions import AuthorizationError, ProcessingError
+from infrahub.exceptions import AuthorizationError, HTTPServerError, ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
 
@@ -267,12 +268,18 @@ async def _get_id_token_groups(
         return []
     verify = provider_settings.id_token_verify_signature
 
+    jwks = await service.http.get(url=str(oidc_config.jwks_uri))
     try:
-        jwks = await service.http.get(url=str(oidc_config.jwks_uri))
+        jwks_payload = jwks.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPServerError(
+            message=f"OIDC provider returned a non-JSON JWKS response from {oidc_config.jwks_uri}"
+        ) from exc
 
+    try:
         jwk_client = jwt.PyJWKClient(uri=str(oidc_config.jwks_uri), cache_jwk_set=True)
         if jwk_client.jwk_set_cache:
-            jwk_client.jwk_set_cache.put(jwks.json())
+            jwk_client.jwk_set_cache.put(jwks_payload)
 
         signing_key = jwk_client.get_signing_key_from_jwt(id_token)
 

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -265,17 +265,17 @@ async def _get_id_token_groups(
     id_token = payload.get("id_token")
     if not id_token:
         return []
-    jwks = await service.http.get(url=str(oidc_config.jwks_uri))
-
-    jwk_client = jwt.PyJWKClient(uri=str(oidc_config.jwks_uri), cache_jwk_set=True)
-    if jwk_client.jwk_set_cache:
-        jwk_client.jwk_set_cache.put(jwks.json())
-
-    signing_key = jwk_client.get_signing_key_from_jwt(id_token)
-
     verify = provider_settings.id_token_verify_signature
 
     try:
+        jwks = await service.http.get(url=str(oidc_config.jwks_uri))
+
+        jwk_client = jwt.PyJWKClient(uri=str(oidc_config.jwks_uri), cache_jwk_set=True)
+        if jwk_client.jwk_set_cache:
+            jwk_client.jwk_set_cache.put(jwks.json())
+
+        signing_key = jwk_client.get_signing_key_from_jwt(id_token)
+
         decoded_token: dict[str, Any] = jwt.decode(
             jwt=id_token,
             key=signing_key.key,

--- a/backend/tests/unit/api/test_oidc.py
+++ b/backend/tests/unit/api/test_oidc.py
@@ -13,7 +13,7 @@ from pydantic import HttpUrl
 
 from infrahub.api.oidc import OIDCDiscoveryConfig, _get_id_token_groups
 from infrahub.config import SecurityOIDCSettings
-from infrahub.exceptions import AuthorizationError
+from infrahub.exceptions import AuthorizationError, HTTPServerError
 from infrahub.services import InfrahubServices
 from tests.adapters.http import MemoryHTTP
 
@@ -43,11 +43,15 @@ def helper() -> OIDCTestHelper:
     return OIDCTestHelper()
 
 
-def _serve_jwks(memory_http: MemoryHTTP, jwks: dict[str, Any]) -> None:
+def _serve_jwks_raw(memory_http: MemoryHTTP, content: bytes) -> None:
     memory_http.add_get_response(
         url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(jwks)),
+        response=httpx.Response(status_code=200, content=content),
     )
+
+
+def _serve_jwks(memory_http: MemoryHTTP, jwks: dict[str, Any]) -> None:
+    _serve_jwks_raw(memory_http, json.dumps(jwks).encode())
 
 
 @pytest.fixture
@@ -195,6 +199,27 @@ async def test_get_id_token_groups_empty_jwks_raises_authorization_error(
             payload=_token_response(helper),
             provider_settings=_make_provider(verify_signature=verify_signature),
         )
+
+
+@pytest.mark.parametrize("verify_signature", [True, False])
+async def test_get_id_token_groups_non_json_jwks_raises_http_server_error(
+    memory_http: MemoryHTTP, service: InfrahubServices, helper: OIDCTestHelper, verify_signature: bool
+) -> None:
+    """A JWKS endpoint returning a non-JSON body is an upstream failure, surfaced as a gateway error.
+
+    The parse happens before any claim/signature check, so the behavior is independent of the flag.
+    """
+    _serve_jwks_raw(memory_http, b"<html>Bad Gateway</html>")
+
+    with pytest.raises(HTTPServerError) as exc_info:
+        await _get_id_token_groups(
+            oidc_config=OIDC_CONFIG,
+            service=service,
+            payload=_token_response(helper),
+            provider_settings=_make_provider(verify_signature=verify_signature),
+        )
+
+    assert exc_info.value.message == f"OIDC provider returned a non-JSON JWKS response from {OIDC_CONFIG.jwks_uri}"
 
 
 @pytest.mark.parametrize("verify_signature", [True, False])

--- a/backend/tests/unit/api/test_oidc.py
+++ b/backend/tests/unit/api/test_oidc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import time
 import uuid
@@ -26,50 +28,66 @@ def _make_provider(verify_signature: bool = True) -> SecurityOIDCSettings:
     )
 
 
-async def test_get_id_token_groups_for_oidc() -> None:
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
+@pytest.fixture
+def memory_http() -> MemoryHTTP:
+    return MemoryHTTP()
 
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
+
+@pytest.fixture
+async def service(memory_http: MemoryHTTP) -> InfrahubServices:
+    return await InfrahubServices.new(http=memory_http)
+
+
+@pytest.fixture
+def helper() -> OIDCTestHelper:
+    return OIDCTestHelper()
+
+
+def _serve_jwks(memory_http: MemoryHTTP, jwks: dict[str, Any]) -> None:
+    memory_http.add_get_response(
+        url=str(OIDC_CONFIG.jwks_uri),
+        response=httpx.Response(status_code=200, content=json.dumps(jwks)),
+    )
+
+
+@pytest.fixture
+def publish_jwks(memory_http: MemoryHTTP, helper: OIDCTestHelper) -> None:
+    """Serve the helper's public key at the discovery JWKS endpoint so signatures validate."""
+    _serve_jwks(memory_http, helper.jwks_payload)
+
+
+def _token_response(helper: OIDCTestHelper, client_id: str = CLIENT_ID) -> dict[str, Any]:
+    return helper.generate_token_response(
         username="testuser",
         groups=["operators"],
-        client_id=CLIENT_ID,
+        client_id=client_id,
         issuer=str(OIDC_CONFIG.issuer),
     )
 
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
 
+def _forged_jwks(helper: OIDCTestHelper) -> dict[str, Any]:
+    """A JWKS whose key does not match the token signature, under the same kid so resolution still succeeds."""
+    attacker = OIDCTestHelper()
+    return {"keys": [{**json.loads(attacker.key.export_public()), "kid": helper.kid}]}
+
+
+async def test_get_id_token_groups_for_oidc(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None
+) -> None:
     groups = await _get_id_token_groups(
         oidc_config=OIDC_CONFIG,
         service=service,
-        payload=token_response,
+        payload=_token_response(helper),
         provider_settings=_make_provider(),
     )
 
     assert groups == ["operators"]
 
 
-async def test_get_id_token_groups_rejects_invalid_issuer_by_default() -> None:
+async def test_get_id_token_groups_rejects_invalid_issuer_by_default(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None
+) -> None:
     """With signature verification on (the default) a wrong issuer must abort, not be silently accepted."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
     discovery = deepcopy(OIDC_CONFIG)
     discovery.issuer = HttpUrl("https://something-incorrect.example.com")
 
@@ -77,151 +95,80 @@ async def test_get_id_token_groups_rejects_invalid_issuer_by_default() -> None:
         await _get_id_token_groups(
             oidc_config=discovery,
             service=service,
-            payload=token_response,
+            payload=_token_response(helper),
             provider_settings=_make_provider(),
         )
 
 
-async def test_get_id_token_groups_rejects_invalid_audience_by_default() -> None:
+async def test_get_id_token_groups_rejects_invalid_audience_by_default(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None
+) -> None:
     """With signature verification on (the default) a token issued for another client must be rejected."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id="some-other-client",
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
-
     with pytest.raises(AuthorizationError, match=r"^OIDC id_token verification failed: Audience doesn't match$"):
         await _get_id_token_groups(
             oidc_config=OIDC_CONFIG,
             service=service,
-            payload=token_response,
+            payload=_token_response(helper, client_id="some-other-client"),
             provider_settings=_make_provider(),
         )
 
 
-async def test_get_id_token_groups_accepts_invalid_issuer_when_verification_disabled() -> None:
+async def test_get_id_token_groups_accepts_invalid_issuer_when_verification_disabled(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None
+) -> None:
     """Explicit opt-out preserves the legacy unverified behavior for a misconfigured provider."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
     discovery = deepcopy(OIDC_CONFIG)
     discovery.issuer = HttpUrl("https://something-incorrect.example.com")
 
     groups = await _get_id_token_groups(
         oidc_config=discovery,
         service=service,
-        payload=token_response,
+        payload=_token_response(helper),
         provider_settings=_make_provider(verify_signature=False),
     )
 
     assert groups == ["operators"]
 
 
-async def test_get_id_token_groups_rejects_forged_signature() -> None:
+async def test_get_id_token_groups_rejects_forged_signature(
+    memory_http: MemoryHTTP, service: InfrahubServices, helper: OIDCTestHelper
+) -> None:
     """A token whose signature does not match the published key is rejected as an authorization error."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    # Publish a JWKS whose key does not match the one that signed the token, while
-    # reusing the same kid so the signing key is still resolved and the signature check runs.
-    attacker = OIDCTestHelper()
-    forged_jwks = {"keys": [{**json.loads(attacker.key.export_public()), "kid": helper.kid}]}
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(forged_jwks)),
-    )
+    _serve_jwks(memory_http, _forged_jwks(helper))
 
     with pytest.raises(AuthorizationError, match=r"^OIDC id_token verification failed: Signature verification failed$"):
         await _get_id_token_groups(
             oidc_config=OIDC_CONFIG,
             service=service,
-            payload=token_response,
+            payload=_token_response(helper),
             provider_settings=_make_provider(),
         )
 
 
-async def test_get_id_token_groups_accepts_invalid_audience_when_verification_disabled() -> None:
+async def test_get_id_token_groups_accepts_invalid_audience_when_verification_disabled(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None
+) -> None:
     """Explicit opt-out skips the audience claim check for a misconfigured provider."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id="some-other-client",
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
-
     groups = await _get_id_token_groups(
         oidc_config=OIDC_CONFIG,
         service=service,
-        payload=token_response,
+        payload=_token_response(helper, client_id="some-other-client"),
         provider_settings=_make_provider(verify_signature=False),
     )
 
     assert groups == ["operators"]
 
 
-async def test_get_id_token_groups_accepts_forged_signature_when_verification_disabled() -> None:
+async def test_get_id_token_groups_accepts_forged_signature_when_verification_disabled(
+    memory_http: MemoryHTTP, service: InfrahubServices, helper: OIDCTestHelper
+) -> None:
     """Explicit opt-out skips the signature check, so a key that does not match is still accepted."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    attacker = OIDCTestHelper()
-    forged_jwks = {"keys": [{**json.loads(attacker.key.export_public()), "kid": helper.kid}]}
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(forged_jwks)),
-    )
+    _serve_jwks(memory_http, _forged_jwks(helper))
 
     groups = await _get_id_token_groups(
         oidc_config=OIDC_CONFIG,
         service=service,
-        payload=token_response,
+        payload=_token_response(helper),
         provider_settings=_make_provider(verify_signature=False),
     )
 
@@ -229,27 +176,15 @@ async def test_get_id_token_groups_accepts_forged_signature_when_verification_di
 
 
 @pytest.mark.parametrize("verify_signature", [True, False])
-async def test_get_id_token_groups_empty_jwks_raises_authorization_error(verify_signature: bool) -> None:
+async def test_get_id_token_groups_empty_jwks_raises_authorization_error(
+    memory_http: MemoryHTTP, service: InfrahubServices, helper: OIDCTestHelper, verify_signature: bool
+) -> None:
     """An empty/broken JWKS endpoint is wrapped as a clean error regardless of the verification flag.
 
     Signing-key resolution happens before the claim/signature checks, so the encapsulation must
     hold whether or not verification is enabled.
     """
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps({"keys": []})),
-    )
+    _serve_jwks(memory_http, {"keys": []})
 
     with pytest.raises(
         AuthorizationError, match=r"^OIDC id_token verification failed: The JWK Set did not contain any keys$"
@@ -257,30 +192,18 @@ async def test_get_id_token_groups_empty_jwks_raises_authorization_error(verify_
         await _get_id_token_groups(
             oidc_config=OIDC_CONFIG,
             service=service,
-            payload=token_response,
+            payload=_token_response(helper),
             provider_settings=_make_provider(verify_signature=verify_signature),
         )
 
 
 @pytest.mark.parametrize("verify_signature", [True, False])
-async def test_get_id_token_groups_malformed_id_token_raises_authorization_error(verify_signature: bool) -> None:
+async def test_get_id_token_groups_malformed_id_token_raises_authorization_error(
+    service: InfrahubServices, helper: OIDCTestHelper, publish_jwks: None, verify_signature: bool
+) -> None:
     """A malformed id_token is wrapped as a clean error regardless of the verification flag."""
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
+    token_response = _token_response(helper)
     token_response["id_token"] = "not-a-jwt"
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
 
     with pytest.raises(AuthorizationError, match=r"^OIDC id_token verification failed: Not enough segments$"):
         await _get_id_token_groups(
@@ -291,23 +214,9 @@ async def test_get_id_token_groups_malformed_id_token_raises_authorization_error
         )
 
 
-async def test_get_id_token_groups_for_oidc_no_id_token() -> None:
-    memory_http = MemoryHTTP()
-    service = await InfrahubServices.new(http=memory_http)
-
-    helper = OIDCTestHelper()
-    token_response = helper.generate_token_response(
-        username="testuser",
-        groups=["operators"],
-        client_id=CLIENT_ID,
-        issuer=str(OIDC_CONFIG.issuer),
-    )
+async def test_get_id_token_groups_for_oidc_no_id_token(service: InfrahubServices, helper: OIDCTestHelper) -> None:
+    token_response = _token_response(helper)
     token_response.pop("id_token")
-
-    memory_http.add_get_response(
-        url=str(OIDC_CONFIG.jwks_uri),
-        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
-    )
 
     groups = await _get_id_token_groups(
         oidc_config=OIDC_CONFIG,

--- a/backend/tests/unit/api/test_oidc.py
+++ b/backend/tests/unit/api/test_oidc.py
@@ -170,6 +170,127 @@ async def test_get_id_token_groups_rejects_forged_signature() -> None:
         )
 
 
+async def test_get_id_token_groups_accepts_invalid_audience_when_verification_disabled() -> None:
+    """Explicit opt-out skips the audience claim check for a misconfigured provider."""
+    memory_http = MemoryHTTP()
+    service = await InfrahubServices.new(http=memory_http)
+
+    helper = OIDCTestHelper()
+    token_response = helper.generate_token_response(
+        username="testuser",
+        groups=["operators"],
+        client_id="some-other-client",
+        issuer=str(OIDC_CONFIG.issuer),
+    )
+
+    memory_http.add_get_response(
+        url=str(OIDC_CONFIG.jwks_uri),
+        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
+    )
+
+    groups = await _get_id_token_groups(
+        oidc_config=OIDC_CONFIG,
+        service=service,
+        payload=token_response,
+        provider_settings=_make_provider(verify_signature=False),
+    )
+
+    assert groups == ["operators"]
+
+
+async def test_get_id_token_groups_accepts_forged_signature_when_verification_disabled() -> None:
+    """Explicit opt-out skips the signature check, so a key that does not match is still accepted."""
+    memory_http = MemoryHTTP()
+    service = await InfrahubServices.new(http=memory_http)
+
+    helper = OIDCTestHelper()
+    token_response = helper.generate_token_response(
+        username="testuser",
+        groups=["operators"],
+        client_id=CLIENT_ID,
+        issuer=str(OIDC_CONFIG.issuer),
+    )
+
+    attacker = OIDCTestHelper()
+    forged_jwks = {"keys": [{**json.loads(attacker.key.export_public()), "kid": helper.kid}]}
+    memory_http.add_get_response(
+        url=str(OIDC_CONFIG.jwks_uri),
+        response=httpx.Response(status_code=200, content=json.dumps(forged_jwks)),
+    )
+
+    groups = await _get_id_token_groups(
+        oidc_config=OIDC_CONFIG,
+        service=service,
+        payload=token_response,
+        provider_settings=_make_provider(verify_signature=False),
+    )
+
+    assert groups == ["operators"]
+
+
+@pytest.mark.parametrize("verify_signature", [True, False])
+async def test_get_id_token_groups_empty_jwks_raises_authorization_error(verify_signature: bool) -> None:
+    """An empty/broken JWKS endpoint is wrapped as a clean error regardless of the verification flag.
+
+    Signing-key resolution happens before the claim/signature checks, so the encapsulation must
+    hold whether or not verification is enabled.
+    """
+    memory_http = MemoryHTTP()
+    service = await InfrahubServices.new(http=memory_http)
+
+    helper = OIDCTestHelper()
+    token_response = helper.generate_token_response(
+        username="testuser",
+        groups=["operators"],
+        client_id=CLIENT_ID,
+        issuer=str(OIDC_CONFIG.issuer),
+    )
+
+    memory_http.add_get_response(
+        url=str(OIDC_CONFIG.jwks_uri),
+        response=httpx.Response(status_code=200, content=json.dumps({"keys": []})),
+    )
+
+    with pytest.raises(
+        AuthorizationError, match=r"^OIDC id_token verification failed: The JWK Set did not contain any keys$"
+    ):
+        await _get_id_token_groups(
+            oidc_config=OIDC_CONFIG,
+            service=service,
+            payload=token_response,
+            provider_settings=_make_provider(verify_signature=verify_signature),
+        )
+
+
+@pytest.mark.parametrize("verify_signature", [True, False])
+async def test_get_id_token_groups_malformed_id_token_raises_authorization_error(verify_signature: bool) -> None:
+    """A malformed id_token is wrapped as a clean error regardless of the verification flag."""
+    memory_http = MemoryHTTP()
+    service = await InfrahubServices.new(http=memory_http)
+
+    helper = OIDCTestHelper()
+    token_response = helper.generate_token_response(
+        username="testuser",
+        groups=["operators"],
+        client_id=CLIENT_ID,
+        issuer=str(OIDC_CONFIG.issuer),
+    )
+    token_response["id_token"] = "not-a-jwt"
+
+    memory_http.add_get_response(
+        url=str(OIDC_CONFIG.jwks_uri),
+        response=httpx.Response(status_code=200, content=json.dumps(helper.jwks_payload)),
+    )
+
+    with pytest.raises(AuthorizationError, match=r"^OIDC id_token verification failed: Not enough segments$"):
+        await _get_id_token_groups(
+            oidc_config=OIDC_CONFIG,
+            service=service,
+            payload=token_response,
+            provider_settings=_make_provider(verify_signature=verify_signature),
+        )
+
+
 async def test_get_id_token_groups_for_oidc_no_id_token() -> None:
     memory_http = MemoryHTTP()
     service = await InfrahubServices.new(http=memory_http)

--- a/changelog/+oidc-id-token-verify-errors.fixed.md
+++ b/changelog/+oidc-id-token-verify-errors.fixed.md
@@ -1,0 +1,1 @@
+A failed OIDC `id_token` verification — invalid signature, audience, issuer, or an unresolvable signing key — now returns an authorization error (HTTP 401) instead of an unhandled server error.


### PR DESCRIPTION
# Why

The OIDC `id_token` verification added in #9403 wrapped only `jwt.decode(...)` in the `AuthorizationError` mapping. The JWKS fetch and signing-key resolution ran **before** the `try`, so a failure there — an unknown `kid`, an unmatched/empty JWKS, a malformed token — escaped as an unhandled **500** instead of a structured **401**.

This was flagged by **cubic** on #9420 (P1):

> `id_token_verify_signature=False` is ineffective because JWKS/key lookup is still mandatory before decode; failures occur before the new `AuthorizationError` mapping.

This PR widens the `try/except` to include the JWKS fetch and key resolution, so every `id_token` failure path returns a clean 401.
That said, the feedback is not as critical as Cubic is stating. This was already the case before the PR, and in the case where only the signature is falsified or wrong, the "false" behaves as expected and drops the signature verification.

## Behavior

Token-shaped failures map to **401**; JWKS-endpoint-shaped failures map to a **5xx gateway error** (the IdP is unreachable or returned something unusable — not a bad token). JWKS/key resolution runs regardless of the flag, so those rows are identical for `verify` on/off.

| Scenario | `verify` on (default) | `verify` off |
|---|---|---|
| Valid token | groups returned | groups returned |
| Bad signature | 401 | accepted |
| Wrong `aud` / `iss` | 401 | accepted |
| Unknown `kid` / unmatched JWKS | **401** (was 500) | **401** (was 500) |
| Malformed `id_token` | **401** (was 500) | **401** (was 500) |
| JWKS endpoint unreachable / timeout / TLS error | 502 / 504 / 503 | 502 / 504 / 503 |
| JWKS body not JSON | **502** (was 500) | **502** (was 500) |

Every failure path fails **closed**: a bad token returns 401, an unreachable or unparseable JWKS returns a 5xx gateway error, and no error path grants access.

## How to test

```bash
uv run pytest backend/tests/unit/api/test_oidc.py
```

## Checklist

- [x] Tests added/updated
- [x] Changelog entry (behavior refinement of the unreleased #9403 verification change)
- [x] I have reviewed AI generated content



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map OIDC `id_token` JWKS and signing-key lookup failures to 401 instead of 500. Non-JSON JWKS responses now return a gateway error (502). Verification opt-out still skips `aud`/signature checks but not key lookup.

- **Bug Fixes**
  - Expanded error handling to include JWKS key resolution; map `PyJWT`/`PyJWKClient` errors to `AuthorizationError` (401).
  - Return `HTTPServerError` when the JWKS endpoint serves a non-JSON body.

- **Refactors**
  - Extracted shared OIDC test setup into fixtures and parametrized cases; coverage includes empty/unmatched JWKS, malformed tokens, verify-disabled paths, and non-JSON JWKS.

<sup>Written for commit 50d5be05f59c0e5fc6b84ecb16857a043409bfa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
