### PR TITLE
chore(sdk): sync python_sdk to infrahub-develop

### DIFF
--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -93,7 +93,7 @@ class TestBranchMutations(TestInfrahubApp):
     async def test_branch_delete_async(self, initial_dataset: str, client: InfrahubClient) -> None:
         from infrahub.core import registry
 
-        branch = await client.branch.create(branch_name="branch_to_delete")
+        branch = await client.branch.create(branch_name="branch_to_delete", sync_with_git=True)
         branch_server_id = registry.branch[branch.name].uuid
 
         query = Mutation(
@@ -112,7 +112,7 @@ class TestBranchMutations(TestInfrahubApp):
         remove_git_worktree_branch(repository_id=initial_dataset, branch_id=str(branch_server_id))
 
     async def test_branch_delete(self, initial_dataset: str, client: InfrahubClient) -> None:
-        branch = await client.branch.create(branch_name="branch_to_delete_sync")
+        branch = await client.branch.create(branch_name="branch_to_delete_sync", sync_with_git=True)
         branch_server_id = registry.branch[branch.name].uuid
         query = Mutation(
             mutation="BranchDelete",

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -110,7 +110,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def happy_data_branch(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> str:
         branch_name = f"conflict_free-{uuid4()}"
-        branch1 = await client.branch.create(branch_name=branch_name)
+        branch1 = await client.branch.create(branch_name=branch_name, sync_with_git=True)
         richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1.name)
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)


### PR DESCRIPTION
## Summary

Bumps the `python_sdk` submodule to the current tip of `infrahub-develop` on the SDK side (`18e6486`), the merge commit from opsmill/infrahub-sdk-python#1053 which resolved the develop merge conflicts.

Submodule transition: `dec31010` → `18e6486`

## Related

- SDK PR: opsmill/infrahub-sdk-python#1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `python_sdk` to the latest `infrahub-develop` and updates branch tests to explicitly set `sync_with_git=True` after the upstream default flipped.

No production code changes; only the submodule pointer and minor test updates.

<sup>Written for commit 50fb8ed1e6dc4a6bb145a87ed85992cc1c5e5916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

