### PR TITLE
update quickstart

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,7 @@
+{
+  "setup": [
+    "uv sync"
+  ],
+  "teardown": [],
+  "run": []
+}

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,7 +1,0 @@
-{
-  "setup": [
-    "uv sync"
-  ],
-  "teardown": [],
-  "run": []
-}

--- a/docs/docs/overview/quickstart.mdx
+++ b/docs/docs/overview/quickstart.mdx
@@ -82,12 +82,10 @@ A schema defines the structure of your infrastructure data in Infrahub — the t
 
 Rather than writing a schema from scratch, use the [Infrahub Marketplace](https://marketplace.infrahub.app), a catalog of reusable schemas for common infrastructure domains maintained by the community and OpsMill.
 
-1. Browse [marketplace.infrahub.app](https://marketplace.infrahub.app) and identify the schema you need (for example, `opsmill/dcim`).
-
-2. Fetch the schema to your project:
+1. Download the [base](https://marketplace.infrahub.app/collections/infrahub/base-schemas) schema collection from the Infrahub Marketplace:
 
 ```bash
-infrahubctl marketplace get opsmill/dcim
+infrahubctl marketplace get infrahub/base-schemas --collection
 ```
 
 This downloads the schema YAML to `./schemas/`.
@@ -100,7 +98,7 @@ Browse the Marketplace to discover what is available and check each schema's dep
 
 :::
 
-3. Load the schema into your project:
+2. Load the schema into your project:
 
 ```bash
 infrahubctl schema load schemas/

--- a/docs/docs/overview/quickstart.mdx
+++ b/docs/docs/overview/quickstart.mdx
@@ -80,7 +80,7 @@ You should see the Infrahub web interface with a navigation menu on the left sid
 
 A schema defines the structure of your infrastructure data in Infrahub — the types of objects, their attributes, and how they relate to each other. [Learn more about schemas](../schema/overview).
 
-Rather than writing a schema from scratch, use the [Infrahub Marketplace](https://marketplace.infrahub.app), a catalog of reusable schemas for common infrastructure domains maintained by the community and OpsMill.
+Rather than writing a schema from scratch, use the [Infrahub Marketplace](https://marketplace.infrahub.app), a catalog of reusable schemas for common infrastructure domains maintained by OpsMill.
 
 1. Download the [base](https://marketplace.infrahub.app/collections/infrahub/base-schemas) schema collection from the Infrahub Marketplace:
 
@@ -89,14 +89,6 @@ infrahubctl marketplace get infrahub/base-schemas --collection
 ```
 
 This downloads the schema YAML to `./schemas/`.
-
-:::info
-
-The Marketplace organizes schemas into base schemas (core definitions) and extensions that build on top of a base.
-You need to load the base before loading extensions.
-Browse the Marketplace to discover what is available and check each schema's dependencies.
-
-:::
 
 2. Load the schema into your project:
 


### PR DESCRIPTION
Update quickstart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Quickstart to use the `infrahub/base-schemas` collection from the Infrahub Marketplace instead of `opsmill/dcim`, with the updated command (`infrahubctl marketplace get infrahub/base-schemas --collection`) and simplified step numbering. No changes to `.superset/config.json`, `frontend/packages/schema-visualizer`, or `python_sdk` — these remain at stable.

<sup>Written for commit 36fdc663d1f66d3ce8a78c1ef429e3e6c60320a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

