### PR TITLE
Fix versions and schema generation command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,12 @@ Responses must be direct and substantive. Do not use filler phrases, compliments
 
 ## Tech Stack
 
-- **Backend:** Python 3.12, FastAPI 0.121.1, Neo4j 5.28, Pydantic 2.10
+- **Backend:** Python 3.13, FastAPI 0.131.0, Neo4j 2025.10 (driver 6.0), Pydantic 2.12
 - **Frontend:** TypeScript 5.9, React 19.2, Vite 8.0, Tailwind CSS 4.2
 - **Testing:** pytest 9.0, Vitest 4.1, Playwright 1.56
 - **Linting:** ruff 0.15, mypy 1.15, Biome 2.4
 - **Package Managers:** uv (Python), pnpm (Frontend)
-- **Task Runner:** Invoke 2.2.0
+- **Task Runner:** Invoke 2.2.1
 
 ## File Structure
 
@@ -92,7 +92,8 @@ cd docs && npm run build              # Build documentation
 - `schema/openapi.json` - OpenAPI schema for the REST API
 
 Regenerate backend (offline): `uv run invoke backend.generate`
-Export GraphQL/OpenAPI schemas (requires running instance): `infrahub dev export-graphql-schema`
+Export GraphQL schema: `uv run invoke schema.generate-graphqlschema`
+Export OpenAPI schema: `uv run invoke schema.generate-jsonschema`
 Regenerate frontend types (offline, reads local schema files): `cd frontend/app && pnpm codegen`
 
 See `dev/knowledge/backend/code-generation.md` for the full pipeline.


### PR DESCRIPTION
# Why

I'm not sure that the versions need to be in AGENTS.md to begin with but they were currently getting outdated. That lead to SpecKit picking up the old versions and mentioning them in specs that then got flagged by cubic as invalid.

Also the command to generate the graphql schema was outdated

## What changed

* Use current versions
* Update command to generate graphql schema file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated AGENTS.md with current stack versions (`Python 3.13`, `FastAPI 0.131.0`, `Neo4j 2025.10` driver `6.0`, `Pydantic 2.12`) and bumped task runner to `Invoke 2.2.1`. Replaced schema export commands with `uv run invoke schema.generate-graphqlschema` and `uv run invoke schema.generate-jsonschema` to stop `SpecKit` from picking old versions flagged by `cubic`.

<sup>Written for commit 2e1764beb10df133c734435ff830d94f149cc7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

