### PR TITLE
test: reusable lock recording adapter

### DIFF
--- a/backend/tests/adapters/lock.py
+++ b/backend/tests/adapters/lock.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import itertools
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from infrahub import lock
 from infrahub.lock import InfrahubLock, InfrahubLockRegistry
+
+if TYPE_CHECKING:
+    import redis.asyncio as redis
+
+    from infrahub.services import InfrahubServices
 
 
 class LockAction(StrEnum):
@@ -100,8 +106,16 @@ class LockTimeline:
 class RecordingLock(InfrahubLock):
     """A local lock that logs its real (non-re-entrant) acquire/release boundaries to a timeline."""
 
-    def __init__(self, *args: object, timeline: LockTimeline, **kwargs: object) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+    def __init__(
+        self,
+        name: str,
+        connection: redis.Redis | InfrahubServices | None = None,
+        in_multi: bool = False,
+        metrics: bool = True,
+        *,
+        timeline: LockTimeline,
+    ) -> None:
+        super().__init__(name=name, connection=connection, in_multi=in_multi, metrics=metrics)
         self._timeline = timeline
 
     async def acquire(self) -> None:

--- a/backend/tests/adapters/lock.py
+++ b/backend/tests/adapters/lock.py
@@ -9,6 +9,8 @@ from infrahub import lock
 from infrahub.lock import InfrahubLock, InfrahubLockRegistry
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     import redis.asyncio as redis
 
     from infrahub.services import InfrahubServices
@@ -92,13 +94,21 @@ class LockTimeline:
                     f"Held at that point: {sorted(self.held_at(seq))}"
                 )
 
-    def assert_never_overlap(self, lock_a: str, lock_b: str) -> None:
+    def assert_never_overlap(self, lock_names: Collection[str]) -> None:
+        """Assert that no two of ``lock_names`` were ever held at the same time.
+
+        Raises:
+            AssertionError: if two or more of ``lock_names`` were held simultaneously.
+
+        """
+        watched = set(lock_names)
         held: set[str] = set()
         for event in self.events:
             if event.action == LockAction.ACQUIRE:
                 held.add(event.name)
-                if lock_a in held and lock_b in held:
-                    raise AssertionError(f"Locks {lock_a!r} and {lock_b!r} were held simultaneously")
+                overlap = held & watched
+                if len(overlap) > 1:
+                    raise AssertionError(f"Locks {sorted(overlap)} were held simultaneously")
             elif event.action == LockAction.RELEASE:
                 held.discard(event.name)
 

--- a/backend/tests/adapters/lock.py
+++ b/backend/tests/adapters/lock.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from enum import StrEnum
+
+from infrahub import lock
+from infrahub.lock import InfrahubLock, InfrahubLockRegistry
+
+
+class LockAction(StrEnum):
+    ACQUIRE = "acquire"
+    RELEASE = "release"
+    CHECKPOINT = "checkpoint"
+
+
+@dataclass
+class LockEvent:
+    """A single entry in a lock timeline: a lock transition or an arbitrary checkpoint."""
+
+    seq: int
+    name: str
+    action: LockAction
+    label: str | None = None
+
+
+class LockTimeline:
+    """Ordered, monotonic log of lock transitions shared by every recorder in a test.
+
+    asyncio is cooperative, so each ``record`` call is atomic with respect to the lock
+    operation that triggers it: there is no ``await`` between releasing/acquiring a lock
+    and writing its event, which keeps the ordering of the log faithful to reality.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[LockEvent] = []
+        self._seq = itertools.count()
+
+    def record(self, name: str, action: LockAction, label: str | None = None) -> int:
+        seq = next(self._seq)
+        self.events.append(LockEvent(seq=seq, name=name, action=action, label=label))
+        return seq
+
+    def checkpoint(self, label: str) -> int:
+        """Mark a point of interest in the timeline so tests can ask which locks were held at it."""
+        return self.record(name=label, action=LockAction.CHECKPOINT, label=label)
+
+    def held_at(self, seq: int) -> set[str]:
+        """Return the set of lock names held at the moment ``seq`` was recorded."""
+        held: set[str] = set()
+        for event in self.events:
+            if event.seq >= seq:
+                break
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)
+        return held
+
+    def currently_held(self) -> set[str]:
+        held: set[str] = set()
+        for event in self.events:
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)
+        return held
+
+    def acquire_sequence(self, prefix: str | None = None) -> list[str]:
+        """Return the lock names in the order they were acquired, optionally filtered by name prefix."""
+        return [
+            event.name
+            for event in self.events
+            if event.action == LockAction.ACQUIRE and (prefix is None or event.name.startswith(prefix))
+        ]
+
+    def checkpoint_seqs(self, label: str) -> list[int]:
+        return [event.seq for event in self.events if event.action == LockAction.CHECKPOINT and event.label == label]
+
+    # --- assertion helpers ---
+
+    def assert_held_at_checkpoint(self, lock_name: str, label: str, *, expected: bool) -> None:
+        seqs = self.checkpoint_seqs(label)
+        if not seqs:
+            raise AssertionError(f"No checkpoint named {label!r} was recorded")
+        for seq in seqs:
+            actually_held = lock_name in self.held_at(seq)
+            if actually_held is not expected:
+                raise AssertionError(
+                    f"At checkpoint {label!r}, expected lock {lock_name!r} held={expected} but held={actually_held}. "
+                    f"Held at that point: {sorted(self.held_at(seq))}"
+                )
+
+    def assert_never_overlap(self, lock_a: str, lock_b: str) -> None:
+        held: set[str] = set()
+        for event in self.events:
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+                if lock_a in held and lock_b in held:
+                    raise AssertionError(f"Locks {lock_a!r} and {lock_b!r} were held simultaneously")
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)
+
+
+class RecordingLock(InfrahubLock):
+    """A local lock that logs its real (non-re-entrant) acquire/release boundaries to a timeline."""
+
+    def __init__(self, *args: object, timeline: LockTimeline, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._timeline = timeline
+
+    async def acquire(self) -> None:
+        reentrant = self._recursion_var.get() is not None
+        await super().acquire()
+        if not reentrant:
+            self._timeline.record(self.name, LockAction.ACQUIRE)
+
+    async def release(self) -> None:
+        will_release = self._recursion_var.get() == 1
+        await super().release()
+        if will_release:
+            self._timeline.record(self.name, LockAction.RELEASE)
+
+
+class RecordingLockRegistry(InfrahubLockRegistry):
+    """Local-only lock registry that hands out ``RecordingLock`` instances backed by a shared timeline."""
+
+    def __init__(self, timeline: LockTimeline | None = None) -> None:
+        super().__init__(local_only=True)
+        self.timeline = timeline or LockTimeline()
+
+    def get(
+        self,
+        name: str,
+        namespace: str | None = None,
+        local: bool | None = None,
+        in_multi: bool = False,
+        metrics: bool = True,
+    ) -> InfrahubLock:
+        lock_name = self.name_generator.generate_name(name=name, namespace=namespace, local=local)
+        if lock_name not in self.locks:
+            self.locks[lock_name] = RecordingLock(
+                name=lock_name,
+                connection=self.connection,
+                in_multi=in_multi,
+                metrics=metrics,
+                timeline=self.timeline,
+            )
+        return self.locks[lock_name]
+
+
+def install_recording_lock_registry(timeline: LockTimeline | None = None) -> LockTimeline:
+    """Replace the global lock registry with a recording one and return its timeline."""
+    registry = RecordingLockRegistry(timeline=timeline)
+    lock.registry = registry
+    return registry.timeline

--- a/backend/tests/adapters/lock.py
+++ b/backend/tests/adapters/lock.py
@@ -80,9 +80,15 @@ class LockTimeline:
     def checkpoint_seqs(self, label: str) -> list[int]:
         return [event.seq for event in self.events if event.action == LockAction.CHECKPOINT and event.label == label]
 
-    # --- assertion helpers ---
+    def assert_held_at_checkpoint(self, lock_name: str, label: str) -> None:
+        """Assert that ``lock_name`` was held at every checkpoint named ``label``."""
+        self._assert_held_at_checkpoint(lock_name, label, expected=True)
 
-    def assert_held_at_checkpoint(self, lock_name: str, label: str, *, expected: bool) -> None:
+    def assert_not_held_at_checkpoint(self, lock_name: str, label: str) -> None:
+        """Assert that ``lock_name`` was not held at any checkpoint named ``label``."""
+        self._assert_held_at_checkpoint(lock_name, label, expected=False)
+
+    def _assert_held_at_checkpoint(self, lock_name: str, label: str, *, expected: bool) -> None:
         seqs = self.checkpoint_seqs(label)
         if not seqs:
             raise AssertionError(f"No checkpoint named {label!r} was recorded")
@@ -144,9 +150,9 @@ class RecordingLock(InfrahubLock):
 class RecordingLockRegistry(InfrahubLockRegistry):
     """Local-only lock registry that hands out ``RecordingLock`` instances backed by a shared timeline."""
 
-    def __init__(self, timeline: LockTimeline | None = None) -> None:
+    def __init__(self, timeline: LockTimeline) -> None:
         super().__init__(local_only=True)
-        self.timeline = timeline or LockTimeline()
+        self.timeline = timeline
 
     def get(
         self,
@@ -170,6 +176,6 @@ class RecordingLockRegistry(InfrahubLockRegistry):
 
 def install_recording_lock_registry(timeline: LockTimeline | None = None) -> LockTimeline:
     """Replace the global lock registry with a recording one and return its timeline."""
-    registry = RecordingLockRegistry(timeline=timeline)
-    lock.registry = registry
-    return registry.timeline
+    timeline = timeline or LockTimeline()
+    lock.registry = RecordingLockRegistry(timeline=timeline)
+    return timeline

--- a/backend/tests/adapters/lock.py
+++ b/backend/tests/adapters/lock.py
@@ -25,12 +25,7 @@ class LockEvent:
 
 
 class LockTimeline:
-    """Ordered, monotonic log of lock transitions shared by every recorder in a test.
-
-    asyncio is cooperative, so each ``record`` call is atomic with respect to the lock
-    operation that triggers it: there is no ``await`` between releasing/acquiring a lock
-    and writing its event, which keeps the ordering of the log faithful to reality.
-    """
+    """Ordered, monotonic log of lock transitions shared by every recorder in a test."""
 
     def __init__(self) -> None:
         self.events: list[LockEvent] = []

--- a/backend/tests/unit/adapters/conftest.py
+++ b/backend/tests/unit/adapters/conftest.py
@@ -1,0 +1,17 @@
+from collections.abc import Iterator
+
+import pytest
+
+from infrahub import lock
+from tests.adapters.lock import LockTimeline, install_recording_lock_registry
+
+
+@pytest.fixture
+def recording_lock_timeline() -> Iterator[LockTimeline]:
+    """Swap the global lock registry for a recording one, restoring the original on teardown."""
+    original = lock.registry
+    timeline = install_recording_lock_registry()
+    try:
+        yield timeline
+    finally:
+        lock.registry = original

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -53,7 +53,7 @@ async def test_assert_never_overlap(recording_lock_timeline: LockTimeline) -> No
     async with lock.registry.get(name="repo-b", namespace="repository"):
         pass
 
-    recording_lock_timeline.assert_never_overlap("repository.repo-a", "repository.repo-b")
+    recording_lock_timeline.assert_never_overlap(["repository.repo-a", "repository.repo-b"])
 
 
 async def test_fixture_swaps_registry_and_exposes_timeline(recording_lock_timeline: LockTimeline) -> None:

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -24,8 +24,8 @@ async def test_held_at_checkpoint(recording_lock_timeline: LockTimeline) -> None
         recording_lock_timeline.checkpoint("inside")
     recording_lock_timeline.checkpoint("outside")
 
-    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "inside", expected=True)
-    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "outside", expected=False)
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "inside")
+    recording_lock_timeline.assert_not_held_at_checkpoint("repository.repo-a", "outside")
 
 
 async def test_reentrant_acquire_records_single_boundary(recording_lock_timeline: LockTimeline) -> None:
@@ -36,7 +36,7 @@ async def test_reentrant_acquire_records_single_boundary(recording_lock_timeline
 
     assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a"]
     assert [event.action for event in recording_lock_timeline.events].count(LockAction.RELEASE) == 1
-    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "nested", expected=True)
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "nested")
 
 
 async def test_multi_lock_records_each_member(recording_lock_timeline: LockTimeline) -> None:

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -1,6 +1,6 @@
 from infrahub import lock
 from infrahub.lock import GLOBAL_GRAPH_LOCK, GLOBAL_SCHEMA_LOCK, LOCAL_SCHEMA_LOCK
-from tests.adapters.lock import LockTimeline, RecordingLockRegistry
+from tests.adapters.lock import LockAction, LockTimeline, RecordingLockRegistry
 
 
 async def test_records_acquire_and_release_order(recording_lock_timeline: LockTimeline) -> None:
@@ -10,7 +10,12 @@ async def test_records_acquire_and_release_order(recording_lock_timeline: LockTi
         pass
 
     assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a", "repository.repo-b"]
-    assert [event.action for event in recording_lock_timeline.events] == ["acquire", "release", "acquire", "release"]
+    assert [event.action for event in recording_lock_timeline.events] == [
+        LockAction.ACQUIRE,
+        LockAction.RELEASE,
+        LockAction.ACQUIRE,
+        LockAction.RELEASE,
+    ]
     assert recording_lock_timeline.currently_held() == set()
 
 
@@ -30,7 +35,7 @@ async def test_reentrant_acquire_records_single_boundary(recording_lock_timeline
             recording_lock_timeline.checkpoint("nested")
 
     assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a"]
-    assert [event.action for event in recording_lock_timeline.events].count("release") == 1
+    assert [event.action for event in recording_lock_timeline.events].count(LockAction.RELEASE) == 1
     recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "nested", expected=True)
 
 

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -1,4 +1,5 @@
 from infrahub import lock
+from infrahub.lock import GLOBAL_GRAPH_LOCK, GLOBAL_SCHEMA_LOCK, LOCAL_SCHEMA_LOCK
 from tests.adapters.lock import LockTimeline, RecordingLockRegistry
 
 
@@ -37,7 +38,7 @@ async def test_multi_lock_records_each_member(recording_lock_timeline: LockTimel
     async with lock.registry.global_graph_lock():
         held = recording_lock_timeline.currently_held()
 
-    assert held == {"local.schema", "global.graph", "global.schema"}
+    assert held == {LOCAL_SCHEMA_LOCK, GLOBAL_GRAPH_LOCK, GLOBAL_SCHEMA_LOCK}
     assert recording_lock_timeline.currently_held() == set()
 
 

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -1,0 +1,66 @@
+from infrahub import lock
+from tests.adapters.lock import LockTimeline, install_recording_lock_registry
+
+
+async def test_records_acquire_and_release_order() -> None:
+    timeline = install_recording_lock_registry()
+
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        pass
+    async with lock.registry.get(name="repo-b", namespace="repository"):
+        pass
+
+    assert timeline.acquire_sequence() == ["repository.repo-a", "repository.repo-b"]
+    assert [event.action for event in timeline.events] == ["acquire", "release", "acquire", "release"]
+    assert timeline.currently_held() == set()
+
+
+async def test_held_at_checkpoint() -> None:
+    timeline = install_recording_lock_registry()
+
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        timeline.checkpoint("inside")
+    timeline.checkpoint("outside")
+
+    timeline.assert_held_at_checkpoint("repository.repo-a", "inside", expected=True)
+    timeline.assert_held_at_checkpoint("repository.repo-a", "outside", expected=False)
+
+
+async def test_reentrant_acquire_records_single_boundary() -> None:
+    timeline = install_recording_lock_registry()
+
+    repo_lock = lock.registry.get(name="repo-a", namespace="repository")
+    async with repo_lock:  # noqa: SIM117 - nesting is the re-entrant scenario under test
+        async with repo_lock:
+            timeline.checkpoint("nested")
+
+    assert timeline.acquire_sequence() == ["repository.repo-a"]
+    assert [event.action for event in timeline.events].count("release") == 1
+    timeline.assert_held_at_checkpoint("repository.repo-a", "nested", expected=True)
+
+
+async def test_multi_lock_records_each_member() -> None:
+    timeline = install_recording_lock_registry()
+
+    async with lock.registry.global_graph_lock():
+        held = timeline.currently_held()
+
+    assert held == {"local.schema", "global.graph", "global.schema"}
+    assert timeline.currently_held() == set()
+
+
+async def test_assert_never_overlap() -> None:
+    timeline = install_recording_lock_registry()
+
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        pass
+    async with lock.registry.get(name="repo-b", namespace="repository"):
+        pass
+
+    timeline.assert_never_overlap("repository.repo-a", "repository.repo-b")
+
+
+async def test_install_returns_timeline_and_swaps_registry() -> None:
+    timeline = install_recording_lock_registry()
+    assert isinstance(timeline, LockTimeline)
+    assert lock.registry.timeline is timeline

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -1,66 +1,56 @@
 from infrahub import lock
-from tests.adapters.lock import LockTimeline, install_recording_lock_registry
+from tests.adapters.lock import LockTimeline, RecordingLockRegistry
 
 
-async def test_records_acquire_and_release_order() -> None:
-    timeline = install_recording_lock_registry()
-
+async def test_records_acquire_and_release_order(recording_lock_timeline: LockTimeline) -> None:
     async with lock.registry.get(name="repo-a", namespace="repository"):
         pass
     async with lock.registry.get(name="repo-b", namespace="repository"):
         pass
 
-    assert timeline.acquire_sequence() == ["repository.repo-a", "repository.repo-b"]
-    assert [event.action for event in timeline.events] == ["acquire", "release", "acquire", "release"]
-    assert timeline.currently_held() == set()
+    assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a", "repository.repo-b"]
+    assert [event.action for event in recording_lock_timeline.events] == ["acquire", "release", "acquire", "release"]
+    assert recording_lock_timeline.currently_held() == set()
 
 
-async def test_held_at_checkpoint() -> None:
-    timeline = install_recording_lock_registry()
-
+async def test_held_at_checkpoint(recording_lock_timeline: LockTimeline) -> None:
     async with lock.registry.get(name="repo-a", namespace="repository"):
-        timeline.checkpoint("inside")
-    timeline.checkpoint("outside")
+        recording_lock_timeline.checkpoint("inside")
+    recording_lock_timeline.checkpoint("outside")
 
-    timeline.assert_held_at_checkpoint("repository.repo-a", "inside", expected=True)
-    timeline.assert_held_at_checkpoint("repository.repo-a", "outside", expected=False)
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "inside", expected=True)
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "outside", expected=False)
 
 
-async def test_reentrant_acquire_records_single_boundary() -> None:
-    timeline = install_recording_lock_registry()
-
+async def test_reentrant_acquire_records_single_boundary(recording_lock_timeline: LockTimeline) -> None:
     repo_lock = lock.registry.get(name="repo-a", namespace="repository")
     async with repo_lock:  # noqa: SIM117 - nesting is the re-entrant scenario under test
         async with repo_lock:
-            timeline.checkpoint("nested")
+            recording_lock_timeline.checkpoint("nested")
 
-    assert timeline.acquire_sequence() == ["repository.repo-a"]
-    assert [event.action for event in timeline.events].count("release") == 1
-    timeline.assert_held_at_checkpoint("repository.repo-a", "nested", expected=True)
+    assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a"]
+    assert [event.action for event in recording_lock_timeline.events].count("release") == 1
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "nested", expected=True)
 
 
-async def test_multi_lock_records_each_member() -> None:
-    timeline = install_recording_lock_registry()
-
+async def test_multi_lock_records_each_member(recording_lock_timeline: LockTimeline) -> None:
     async with lock.registry.global_graph_lock():
-        held = timeline.currently_held()
+        held = recording_lock_timeline.currently_held()
 
     assert held == {"local.schema", "global.graph", "global.schema"}
-    assert timeline.currently_held() == set()
+    assert recording_lock_timeline.currently_held() == set()
 
 
-async def test_assert_never_overlap() -> None:
-    timeline = install_recording_lock_registry()
-
+async def test_assert_never_overlap(recording_lock_timeline: LockTimeline) -> None:
     async with lock.registry.get(name="repo-a", namespace="repository"):
         pass
     async with lock.registry.get(name="repo-b", namespace="repository"):
         pass
 
-    timeline.assert_never_overlap("repository.repo-a", "repository.repo-b")
+    recording_lock_timeline.assert_never_overlap("repository.repo-a", "repository.repo-b")
 
 
-async def test_install_returns_timeline_and_swaps_registry() -> None:
-    timeline = install_recording_lock_registry()
-    assert isinstance(timeline, LockTimeline)
-    assert lock.registry.timeline is timeline
+async def test_fixture_swaps_registry_and_exposes_timeline(recording_lock_timeline: LockTimeline) -> None:
+    assert isinstance(recording_lock_timeline, LockTimeline)
+    assert isinstance(lock.registry, RecordingLockRegistry)
+    assert lock.registry.timeline is recording_lock_timeline


### PR DESCRIPTION
## Why

Testing lock behavior in the backend previously required `unittest.mock`/`patch`, which the testing guidelines forbid. This adds a reusable, no-mock lock recording adapter so a test can observe exactly when a lock is acquired/released and which locks are held at any point. It injects a `RecordingLockRegistry` in place of the global one.

## What

- `RecordingLockRegistry` / `RecordingLock` backed by a shared `LockTimeline` that records acquire/release events (re-entrancy aware) plus arbitrary checkpoints.
- Query/assert helpers: `held_at`, `currently_held`, `acquire_sequence`, `assert_held_at_checkpoint`, `assert_never_overlap`.
- A `recording_lock_timeline` pytest fixture and unit tests covering the adapter itself.

## Context

Subtask [IFC-2672](https://opsmill.atlassian.net/browse/IFC-2672) of [IFC-1566](https://opsmill.atlassian.net/browse/IFC-1566) (git-sync long lock durations). The stacked follow-up PR uses this adapter to prove the repository lock is no longer held during the object import. Kept standalone because the adapter is reusable for any lock ordering / contention / scope test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2672]: https://opsmill.atlassian.net/browse/IFC-2672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IFC-1566]: https://opsmill.atlassian.net/browse/IFC-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reusable lock recording adapter for tests to assert acquire/release order and detect overlap without mocks. Now supports checking overlap across any number of locks and adds explicit checkpoint assertions.

- **New Features**
  - `RecordingLockRegistry` and `RecordingLock` with a shared `LockTimeline` that logs acquire/release and checkpoints; re-entrancy aware, and the registry requires an injected timeline.
  - Query/assert helpers: `held_at`, `currently_held`, `acquire_sequence`, `assert_held_at_checkpoint`, `assert_not_held_at_checkpoint`, `assert_never_overlap` (accepts a collection of lock names).
  - `pytest` fixture `recording_lock_timeline` and helper `install_recording_lock_registry` to install the recording registry per test and restore the original.
  - Unit tests for order, checkpoints, re-entrancy, multi-lock membership, and fixture swap.

- **Bug Fixes**
  - Explicit `RecordingLock` constructor mirroring `InfrahubLock` to satisfy CI type checking.

<sup>Written for commit 678b4b146054bb93d5cdedd244729a2801ccd3aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



