### PR TITLE
fix(git): run object import outside the repository lock during sync

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from cachetools import TTLCache
@@ -21,6 +22,15 @@ if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
 
 log = get_logger()
+
+
+@dataclass
+class BranchImport:
+    """One object import to run: the Infrahub branch to import into and the commit to import from."""
+
+    infrahub_branch_name: str
+    commit: str
+    git_branch_name: str | None = None
 
 
 class InfrahubRepository(InfrahubRepositoryIntegrator):
@@ -69,14 +79,34 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             GraphQLError: When creating a branch in the graph fails for a reason other than the branch already existing.
 
         """
+        for pending in await self.collect_pending_imports(staging_branch=staging_branch):
+            await self.import_objects_from_files(
+                infrahub_branch_name=pending.infrahub_branch_name,
+                git_branch_name=pending.git_branch_name,
+                commit=pending.commit,
+            )
+
+    async def collect_pending_imports(self, staging_branch: str | None = None) -> list[BranchImport]:
+        """Run the git working-copy side of a sync and return the imports it produced.
+
+        Performs the on-disk git mutations (fetch, branch creation, pull, commit-worktree pinning)
+        and returns one entry per branch whose objects must be imported. Leaving the import to the
+        caller lets it run after the repository lock is released; each entry points at the immutable
+        per-commit worktree pinned here.
+
+        Raises:
+            GraphQLError: When creating a branch in the graph fails for a reason other than the branch already existing.
+
+        """
         log.info("Starting the synchronization.", repository=self.name)
 
         await self.fetch()
 
         new_branches, updated_branches = await self.compare_local_remote()
 
+        pending_imports: list[BranchImport] = []
         if not new_branches and not updated_branches:
-            return
+            return pending_imports
 
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
 
@@ -101,7 +131,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                 self.create_commit_worktree(commit=commit)
                 await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
 
-                await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit)
+                pending_imports.append(BranchImport(infrahub_branch_name=infrahub_branch, commit=commit))
 
             for branch_name in updated_branches:
                 is_valid = self.validate_remote_branch(branch_name=branch_name)
@@ -112,7 +142,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 commit_after = await self.pull(branch_name=branch_name)
                 if isinstance(commit_after, str):
-                    await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit_after)
+                    pending_imports.append(BranchImport(infrahub_branch_name=infrahub_branch, commit=commit_after))
 
                 elif commit_after is True:
                     log.warning(
@@ -121,26 +151,36 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                         branch=branch_name,
                     )
 
-        await self._sync_staging(staging_branch=staging_branch, updated_branches=updated_branches)
+        pending_imports.extend(
+            await self._collect_staging_imports(staging_branch=staging_branch, updated_branches=updated_branches)
+        )
+        return pending_imports
 
-    async def _sync_staging(self, staging_branch: str | None, updated_branches: list[str]) -> None:
-        if (
+    async def _collect_staging_imports(
+        self, staging_branch: str | None, updated_branches: list[str]
+    ) -> list[BranchImport]:
+        if not (
             self.internal_status == RepositoryInternalStatus.STAGING.value
             and staging_branch
             and self.default_branch in updated_branches
         ):
-            commit_after = await self.pull(branch_name=self.default_branch)
-            if isinstance(commit_after, str):
-                await self.import_objects_from_files(
-                    git_branch_name=self.default_branch, infrahub_branch_name=staging_branch, commit=commit_after
-                )
+            return []
 
-            elif commit_after is True:
-                log.warning(
-                    f"An update was detected but the commit remained the same after pull() ({commit_after}).",
-                    repository=self.name,
-                    branch=self.default_branch,
+        commit_after = await self.pull(branch_name=self.default_branch)
+        if isinstance(commit_after, str):
+            return [
+                BranchImport(
+                    infrahub_branch_name=staging_branch, git_branch_name=self.default_branch, commit=commit_after
                 )
+            ]
+
+        if commit_after is True:
+            log.warning(
+                f"An update was detected but the commit remained the same after pull() ({commit_after}).",
+                repository=self.name,
+                branch=self.default_branch,
+            )
+        return []
 
     async def push(self, branch_name: str) -> bool:
         """Push a given branch to the remote Origin repository."""

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -90,9 +90,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         """Run the git working-copy side of a sync and return the imports it produced.
 
         Performs the on-disk git mutations (fetch, branch creation, pull, commit-worktree pinning)
-        and returns one entry per branch whose objects must be imported. Leaving the import to the
-        caller lets it run after the repository lock is released; each entry points at the immutable
-        per-commit worktree pinned here.
+        and returns one entry per branch whose objects must be imported.
 
         Raises:
             GraphQLError: When creating a branch in the graph fails for a reason other than the branch already existing.

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -25,8 +25,8 @@ log = get_logger()
 
 
 @dataclass
-class BranchImport:
-    """One object import to run: the Infrahub branch to import into and the commit to import from."""
+class PendingObjectImport:
+    """A repository object import waiting to run: which commit to import from and which Infrahub branch to import into."""
 
     infrahub_branch_name: str
     commit: str
@@ -86,7 +86,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                 commit=pending.commit,
             )
 
-    async def collect_pending_imports(self, staging_branch: str | None = None) -> list[BranchImport]:
+    async def collect_pending_imports(self, staging_branch: str | None = None) -> list[PendingObjectImport]:
         """Run the git working-copy side of a sync and return the imports it produced.
 
         Performs the on-disk git mutations (fetch, branch creation, pull, commit-worktree pinning)
@@ -102,7 +102,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         new_branches, updated_branches = await self.compare_local_remote()
 
-        pending_imports: list[BranchImport] = []
+        pending_imports: list[PendingObjectImport] = []
         if not new_branches and not updated_branches:
             return pending_imports
 
@@ -129,7 +129,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                 self.create_commit_worktree(commit=commit)
                 await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
 
-                pending_imports.append(BranchImport(infrahub_branch_name=infrahub_branch, commit=commit))
+                pending_imports.append(PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit))
 
             for branch_name in updated_branches:
                 is_valid = self.validate_remote_branch(branch_name=branch_name)
@@ -140,7 +140,9 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 commit_after = await self.pull(branch_name=branch_name)
                 if isinstance(commit_after, str):
-                    pending_imports.append(BranchImport(infrahub_branch_name=infrahub_branch, commit=commit_after))
+                    pending_imports.append(
+                        PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit_after)
+                    )
 
                 elif commit_after is True:
                     log.warning(
@@ -156,7 +158,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
     async def _collect_staging_imports(
         self, staging_branch: str | None, updated_branches: list[str]
-    ) -> list[BranchImport]:
+    ) -> list[PendingObjectImport]:
         if not (
             self.internal_status == RepositoryInternalStatus.STAGING.value
             and staging_branch
@@ -167,7 +169,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         commit_after = await self.pull(branch_name=self.default_branch)
         if isinstance(commit_after, str):
             return [
-                BranchImport(
+                PendingObjectImport(
                     infrahub_branch_name=staging_branch, git_branch_name=self.default_branch, commit=commit_after
                 )
             ]

--- a/backend/infrahub/git/sync.py
+++ b/backend/infrahub/git/sync.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrahub.lock import InfrahubLockRegistry
+
+    from .repository import BranchImport, InfrahubRepository
+
+
+class RepositoryImporter(ABC):
+    """Imports the objects of a single synced branch into the graph."""
+
+    @abstractmethod
+    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None: ...
+
+
+class RepositoryFileImporter(RepositoryImporter):
+    """Imports a branch by reading the object files of its pinned commit worktree."""
+
+    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None:
+        await repo.import_objects_from_files(  # type: ignore[call-overload]
+            infrahub_branch_name=branch_import.infrahub_branch_name,
+            git_branch_name=branch_import.git_branch_name,
+            commit=branch_import.commit,
+        )
+
+
+class RepositorySyncer:
+    """Synchronizes a repository, holding the repository lock only for the git working-copy mutations.
+
+    The lock serializes mutations of the repository's on-disk git state. The object import for each
+    synced branch runs after the lock is released; it reads from the per-commit worktree pinned during
+    the locked phase, so it does not need the lock.
+    """
+
+    def __init__(self, lock_registry: InfrahubLockRegistry, importer: RepositoryImporter) -> None:
+        self._lock_registry = lock_registry
+        self._importer = importer
+
+    async def sync(self, repo: InfrahubRepository, staging_branch: str | None = None) -> None:
+        async with self._lock_registry.get(name=repo.name, namespace="repository"):
+            pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
+        for branch_import in pending_imports:
+            await self._importer.import_branch(repo, branch_import)

--- a/backend/infrahub/git/sync.py
+++ b/backend/infrahub/git/sync.py
@@ -6,24 +6,24 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from infrahub.lock import InfrahubLockRegistry
 
-    from .repository import BranchImport, InfrahubRepository
+    from .repository import InfrahubRepository, PendingObjectImport
 
 
 class RepositoryImporter(ABC):
     """Imports the objects of a single synced branch into the graph."""
 
     @abstractmethod
-    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None: ...
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None: ...
 
 
 class RepositoryFileImporter(RepositoryImporter):
     """Imports a branch by reading the object files of its pinned commit worktree."""
 
-    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None:
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
         await repo.import_objects_from_files(  # type: ignore[call-overload]
-            infrahub_branch_name=branch_import.infrahub_branch_name,
-            git_branch_name=branch_import.git_branch_name,
-            commit=branch_import.commit,
+            infrahub_branch_name=pending_import.infrahub_branch_name,
+            git_branch_name=pending_import.git_branch_name,
+            commit=pending_import.commit,
         )
 
 
@@ -42,5 +42,5 @@ class RepositorySyncer:
     async def sync(self, repo: InfrahubRepository, staging_branch: str | None = None) -> None:
         async with self._lock_registry.get(name=repo.name, namespace="repository"):
             pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
-        for branch_import in pending_imports:
-            await self._importer.import_branch(repo, branch_import)
+        for pending_import in pending_imports:
+            await self._importer.import_branch(repo, pending_import)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,4 +1,3 @@
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 from git.exc import InvalidGitRepositoryError
@@ -63,6 +62,7 @@ from .models import (
     UserCheckDefinitionData,
 )
 from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_initialized_repo
+from .sync import RepositoryFileImporter, RepositorySyncer
 from .utils import fetch_artifact_definition_targets, fetch_check_definition_targets, get_repositories_commit_per_branch
 
 
@@ -208,29 +208,6 @@ async def delete_git_branch(branch: str) -> None:
         pass
 
 
-async def sync_repository(
-    repo: InfrahubRepository,
-    lock_registry: lock.InfrahubLockRegistry,
-    staging_branch: str | None = None,
-    import_objects: Callable[..., Awaitable[None]] | None = None,
-) -> None:
-    """Sync a repository, holding the repository lock only for the git working-copy mutations.
-
-    The object import for each synced branch runs after the lock is released; it reads from the
-    per-commit worktree pinned during the locked phase, so it does not need the lock that
-    serializes git working-copy mutations. The import callable is injectable for testing.
-    """
-    do_import: Callable[..., Awaitable[None]] = import_objects or repo.import_objects_from_files
-    async with lock_registry.get(name=repo.name, namespace="repository"):
-        pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
-    for pending in pending_imports:
-        await do_import(
-            infrahub_branch_name=pending.infrahub_branch_name,
-            git_branch_name=pending.git_branch_name,
-            commit=pending.commit,
-        )
-
-
 @flow(name="sync-git-repo-with-origin", flow_run_name="Sync git repo with origin")
 async def sync_git_repo_with_origin_and_tag_on_failure(
     client: InfrahubClient,
@@ -252,8 +229,9 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
         default_branch_name=default_branch_name,
     )
 
+    syncer = RepositorySyncer(lock_registry=lock.registry, importer=RepositoryFileImporter())
     try:
-        await sync_repository(repo, lock_registry=lock.registry, staging_branch=staging_branch)
+        await syncer.sync(repo, staging_branch=staging_branch)
     except RepositoryError:
         if operational_status == RepositoryOperationalStatus.ONLINE.value:
             params: dict[str, Any] = {
@@ -287,9 +265,7 @@ async def sync_remote_repositories() -> None:
 
         infrahub_branch = staging_branch or registry.default_branch
 
-        # Hold the repository lock only for the local git initialization. The default-branch
-        # import below and the origin sync that follows manage their own narrow lock scope and
-        # run their object imports after releasing it, so a slow import no longer keeps the lock
+        # Hold the repository lock only for the local git initialization, so a slow import no longer keeps the lock
         # reserved.
         default_import_git_branch: str | None = None
         async with lock.registry.get(name=repo_name, namespace="repository"):

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -265,8 +265,6 @@ async def sync_remote_repositories() -> None:
 
         infrahub_branch = staging_branch or registry.default_branch
 
-        # Hold the repository lock only for the local git initialization, so a slow import no longer keeps the lock
-        # reserved.
         default_import_git_branch: str | None = None
         async with lock.registry.get(name=repo_name, namespace="repository"):
             init_failed = False

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -207,6 +207,14 @@ async def delete_git_branch(branch: str) -> None:
         pass
 
 
+async def sync_repository(
+    repo: InfrahubRepository, lock_registry: lock.InfrahubLockRegistry, staging_branch: str | None = None
+) -> None:
+    """Run a repository sync under the repository lock."""
+    async with lock_registry.get(name=repo.name, namespace="repository"):
+        await repo.sync(staging_branch=staging_branch)
+
+
 @flow(name="sync-git-repo-with-origin", flow_run_name="Sync git repo with origin")
 async def sync_git_repo_with_origin_and_tag_on_failure(
     client: InfrahubClient,
@@ -229,7 +237,7 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
     )
 
     try:
-        await repo.sync(staging_branch=staging_branch)
+        await sync_repository(repo, lock_registry=lock.registry, staging_branch=staging_branch)
     except RepositoryError:
         if operational_status == RepositoryOperationalStatus.ONLINE.value:
             params: dict[str, Any] = {

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,3 +1,4 @@
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from git.exc import InvalidGitRepositoryError
@@ -208,11 +209,26 @@ async def delete_git_branch(branch: str) -> None:
 
 
 async def sync_repository(
-    repo: InfrahubRepository, lock_registry: lock.InfrahubLockRegistry, staging_branch: str | None = None
+    repo: InfrahubRepository,
+    lock_registry: lock.InfrahubLockRegistry,
+    staging_branch: str | None = None,
+    import_objects: Callable[..., Awaitable[None]] | None = None,
 ) -> None:
-    """Run a repository sync under the repository lock."""
+    """Sync a repository, holding the repository lock only for the git working-copy mutations.
+
+    The object import for each synced branch runs after the lock is released; it reads from the
+    per-commit worktree pinned during the locked phase, so it does not need the lock that
+    serializes git working-copy mutations. The import callable is injectable for testing.
+    """
+    do_import: Callable[..., Awaitable[None]] = import_objects or repo.import_objects_from_files
     async with lock_registry.get(name=repo.name, namespace="repository"):
-        await repo.sync(staging_branch=staging_branch)
+        pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
+    for pending in pending_imports:
+        await do_import(
+            infrahub_branch_name=pending.infrahub_branch_name,
+            git_branch_name=pending.git_branch_name,
+            commit=pending.commit,
+        )
 
 
 @flow(name="sync-git-repo-with-origin", flow_run_name="Sync git repo with origin")
@@ -271,6 +287,11 @@ async def sync_remote_repositories() -> None:
 
         infrahub_branch = staging_branch or registry.default_branch
 
+        # Hold the repository lock only for the local git initialization. The default-branch
+        # import below and the origin sync that follows manage their own narrow lock scope and
+        # run their object imports after releasing it, so a slow import no longer keeps the lock
+        # reserved.
+        default_import_git_branch: str | None = None
         async with lock.registry.get(name=repo_name, namespace="repository"):
             init_failed = False
             try:
@@ -296,55 +317,56 @@ async def sync_remote_repositories() -> None:
                         internal_status=active_internal_status,
                         default_branch_name=repository.default_branch.value,
                     )
-                    await repo.import_objects_from_files(  # type: ignore[call-overload]
-                        git_branch_name=registry.default_branch, infrahub_branch_name=infrahub_branch
-                    )
                 except RepositoryError as exc:
                     log.info(exc.message)
                     continue
+                default_import_git_branch = registry.default_branch
 
             if repo.reinitialized:
-                try:
-                    await repo.import_objects_from_files(  # type: ignore[call-overload]
-                        git_branch_name=repo.default_branch, infrahub_branch_name=infrahub_branch
-                    )
-                except RepositoryError as exc:
-                    log.info(exc.message)
-                    continue
+                default_import_git_branch = repo.default_branch
 
+        if default_import_git_branch is not None:
             try:
-                await sync_git_repo_with_origin_and_tag_on_failure(
-                    client=client,
-                    repository_id=repository.id,
-                    repository_name=repository.name.value,
-                    repository_location=repository.location.value,
-                    internal_status=active_internal_status,
-                    default_branch_name=repository.default_branch.value,
-                    operational_status=repository.operational_status.value,
-                    staging_branch=staging_branch,
-                    infrahub_branch=infrahub_branch,
+                await repo.import_objects_from_files(  # type: ignore[call-overload]
+                    git_branch_name=default_import_git_branch, infrahub_branch_name=infrahub_branch
                 )
-                try:
-                    pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
-                except (ValueError, InvalidGitRepositoryError) as exc:
-                    log.debug(f"Could not resolve pinned commit for {repo_name}, workers will fall back to pull: {exc}")
-                    pinned_commit = None
-                # Tell workers to fetch and check out the SHA pinned by this sync, so the whole
-                # pool converges on the same commit even if upstream advances during fan-out.
-                message = messages.RefreshGitFetch(
-                    meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
-                    location=repository.location.value,
-                    repository_id=repository.id,
-                    repository_name=repository.name.value,
-                    repository_kind=repository.get_kind(),
-                    infrahub_branch_name=infrahub_branch,
-                    infrahub_branch_id=branches[infrahub_branch].id,
-                    commit=pinned_commit,
-                )
-                message_bus = await get_message_bus()
-                await message_bus.send(message=message)
             except RepositoryError as exc:
                 log.info(exc.message)
+                continue
+
+        try:
+            await sync_git_repo_with_origin_and_tag_on_failure(
+                client=client,
+                repository_id=repository.id,
+                repository_name=repository.name.value,
+                repository_location=repository.location.value,
+                internal_status=active_internal_status,
+                default_branch_name=repository.default_branch.value,
+                operational_status=repository.operational_status.value,
+                staging_branch=staging_branch,
+                infrahub_branch=infrahub_branch,
+            )
+            try:
+                pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
+            except (ValueError, InvalidGitRepositoryError) as exc:
+                log.debug(f"Could not resolve pinned commit for {repo_name}, workers will fall back to pull: {exc}")
+                pinned_commit = None
+            # Tell workers to fetch and check out the SHA pinned by this sync, so the whole
+            # pool converges on the same commit even if upstream advances during fan-out.
+            message = messages.RefreshGitFetch(
+                meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
+                location=repository.location.value,
+                repository_id=repository.id,
+                repository_name=repository.name.value,
+                repository_kind=repository.get_kind(),
+                infrahub_branch_name=infrahub_branch,
+                infrahub_branch_id=branches[infrahub_branch].id,
+                commit=pinned_commit,
+            )
+            message_bus = await get_message_bus()
+            await message_bus.send(message=message)
+        except RepositoryError as exc:
+            log.info(exc.message)
 
 
 @task(  # type: ignore[arg-type]

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -3,8 +3,19 @@ from uuid import uuid4
 from infrahub.core.branch import Branch
 from infrahub.core.registry import registry
 from infrahub.git import InfrahubRepository
-from infrahub.git.tasks import sync_repository
+from infrahub.git.repository import BranchImport
+from infrahub.git.sync import RepositoryImporter, RepositorySyncer
 from tests.adapters.lock import LockTimeline, RecordingLockRegistry
+
+
+class _RecordingImporter(RepositoryImporter):
+    """Records a timeline checkpoint instead of importing, to capture the lock state at the import call."""
+
+    def __init__(self, timeline: LockTimeline) -> None:
+        self._timeline = timeline
+
+    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None:
+        self._timeline.checkpoint("import")
 
 
 async def test_repository_lock_released_before_import(
@@ -20,11 +31,10 @@ async def test_repository_lock_released_before_import(
     registry.branch[branch.name] = branch
 
     timeline = LockTimeline()
-    lock_registry = RecordingLockRegistry(timeline=timeline)
+    syncer = RepositorySyncer(
+        lock_registry=RecordingLockRegistry(timeline=timeline), importer=_RecordingImporter(timeline)
+    )
 
-    async def recording_import(**kwargs: object) -> None:
-        timeline.checkpoint("import")
-
-    await sync_repository(git_repo_04, lock_registry=lock_registry, import_objects=recording_import)
+    await syncer.sync(git_repo_04)
 
     timeline.assert_held_at_checkpoint(f"repository.{git_repo_04.name}", "import", expected=False)

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -37,4 +37,4 @@ async def test_repository_lock_released_before_import(
 
     await syncer.sync(git_repo_04)
 
-    timeline.assert_held_at_checkpoint(f"repository.{git_repo_04.name}", "import", expected=False)
+    timeline.assert_not_held_at_checkpoint(f"repository.{git_repo_04.name}", "import")

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from infrahub.core.branch import Branch
 from infrahub.core.registry import registry
 from infrahub.git import InfrahubRepository
-from infrahub.git.repository import BranchImport
+from infrahub.git.repository import PendingObjectImport
 from infrahub.git.sync import RepositoryImporter, RepositorySyncer
 from tests.adapters.lock import LockTimeline, RecordingLockRegistry
 
@@ -14,7 +14,7 @@ class _RecordingImporter(RepositoryImporter):
     def __init__(self, timeline: LockTimeline) -> None:
         self._timeline = timeline
 
-    async def import_branch(self, repo: InfrahubRepository, branch_import: BranchImport) -> None:
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
         self._timeline.checkpoint("import")
 
 

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -1,0 +1,30 @@
+from uuid import uuid4
+
+from infrahub.core.branch import Branch
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from infrahub.git.tasks import sync_repository
+from tests.adapters.lock import LockTimeline, RecordingLockRegistry
+
+
+async def test_repository_lock_released_before_import(
+    prefect_test_fixture: None, git_repo_04: InfrahubRepository
+) -> None:
+    """The object import must not run while the repository lock is held.
+
+    The lock serializes mutations of the repository's on-disk git state. The import reads file
+    content from the per-commit worktree pinned earlier in the sync, so it stays outside that
+    critical section.
+    """
+    branch = Branch(name="branch01", uuid=uuid4())
+    registry.branch[branch.name] = branch
+
+    timeline = LockTimeline()
+    lock_registry = RecordingLockRegistry(timeline=timeline)
+
+    async def recording_import(**kwargs: object) -> None:
+        timeline.checkpoint("import")
+
+    await sync_repository(git_repo_04, lock_registry=lock_registry, import_objects=recording_import)
+
+    timeline.assert_held_at_checkpoint(f"repository.{git_repo_04.name}", "import", expected=False)


### PR DESCRIPTION
## Why

During periodic git sync, the per-repository lock was held for the whole sync, including the object import. When a branch carries conflicting data the import/reconcile phase is slow, the lock stayed reserved during that time and degraded the platform. See [IFC-2673](https://opsmill.atlassian.net/browse/IFC-2673) (subtask of [IFC-1566](https://opsmill.atlassian.net/browse/IFC-1566)).

## What

- Split `repo.sync()` into `collect_pending_imports()` and the import loop.
- Narrow the lock: a `RepositorySyncer` component holds the repository lock only for the git phase and runs the imports after releasing it.
- `RepositoryImporter` (ABC) + `RepositoryFileImporter` make the import an injectable collaborator..
- Component test asserts the repository lock is not held when the import runs.

## Context

Stacked on top of #9439 (lock recording adapter), which this PR uses to assert the lock scope.

## Notes / residual risk
- `infrahub.git.base.InfrahubRepositoryBase.create_commit_worktree` currently performs a remote `fetch` inside the local worktree primitive; this will be removed in a dedicated PR targeting this feature branch.
- `add_git_repository` still imports under its own lock; it will be tackled in a dedicated PR targeting this feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2673]: https://opsmill.atlassian.net/browse/IFC-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IFC-1566]: https://opsmill.atlassian.net/browse/IFC-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move object import out of the repository lock during git sync by collecting pending imports first, then importing after the lock is released. This reduces long lock holds during slow reconciles and improves throughput (IFC-2673, IFC-1566).

- **Bug Fixes**
  - Split `InfrahubRepository.sync()` into `collect_pending_imports()` (fetch/branch/pull/worktree pinning) and a follow-up import loop.
  - Added `PendingObjectImport` and `_collect_staging_imports()` to return all imports, including staging/default-branch updates.
  - Introduced `RepositorySyncer` with `RepositoryImporter`/`RepositoryFileImporter`; `sync_git_repo_with_origin_and_tag_on_failure` now uses it to lock only the collection phase and import afterward.
  - Tightened `sync_remote_repositories` lock scope: only local init/reinit stay locked; default-branch import and origin sync now run outside the lock.
  - Component test verifies the lock is released before import using `RecordingLockRegistry.assert_not_held_at_checkpoint`.

<sup>Written for commit 5281cec93ba2b8815ff3ce58a218d6dd54b77a55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

