### PR TITLE
fix(ci): drop 'edited' trigger from bug reviewer agent

### DIFF
--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"8f2a5f68ce26cba2e0d0ec73e01f43727a784771449ae468da30813ee887be62","body_hash":"a5414da13c5462fdbb25e5751bd35acd2afdd54ad2262075a3f59ebe15811aba","compiler_version":"v0.77.5","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"d2a75355c2efb5daf1fa8a4e7e03128fbe51fe401c70020090aa00781567d617","body_hash":"a5414da13c5462fdbb25e5751bd35acd2afdd54ad2262075a3f59ebe15811aba","compiler_version":"v0.77.5","strict":true,"agent_id":"claude"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_APP_ID","GH_AW_APP_PRIVATE_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -65,7 +65,6 @@ on:
     types:
     - opened
     - synchronize
-    - edited
     - reopened
 
 permissions: {}
@@ -234,20 +233,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_7be36f541c4c0520_EOF'
           <system>
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_7be36f541c4c0520_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_7be36f541c4c0520_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), add_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_7be36f541c4c0520_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_7be36f541c4c0520_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -279,12 +278,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_7be36f541c4c0520_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a41bce5f7b2af731_EOF'
+          cat << 'GH_AW_PROMPT_7be36f541c4c0520_EOF'
           </system>
           {{#runtime-import .github/workflows/bug-agent-review.md}}
-          GH_AW_PROMPT_a41bce5f7b2af731_EOF
+          GH_AW_PROMPT_7be36f541c4c0520_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -541,9 +540,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b830a554564667d8_EOF'
           {"add_comment":{"max":3},"add_labels":{"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3db29d49c5d33a60_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b830a554564667d8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -754,7 +753,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3631fe890894ca07_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -797,7 +796,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a43dea29095f3bf5_EOF
+          GH_AW_MCP_CONFIG_3631fe890894ca07_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -2,7 +2,7 @@
 description: Review bug pipeline test and fix PRs (triggered on PR open/synchronize)
 on:
   pull_request:
-    types: [opened, synchronize, edited, reopened]
+    types: [opened, synchronize, reopened]
     branches: [stable]
     paths-ignore:
       - "**/*.md"


### PR DESCRIPTION
### Root cause

The bug reviewer agent triggers on `pull_request` `edited` events. On PR #9438, `cubic-dev-ai[bot]` edited the PR description. This spawned a second workflow run with `cubic-dev-ai[bot]` as the triggering actor, which:

1. **Cancelled the legitimate run** via the `cancel-in-progress: true` concurrency group keyed on the PR number: [cancelled run](https://github.com/opsmill/infrahub/actions/runs/26869687835)
2. **Failed the actor gate itself** — `cubic-dev-ai[bot]` is neither a team member nor in the allowed bots list, so `pre_activation` returned `activated=false` and the agent job was skipped: [skipped run](https://github.com/opsmill/infrahub/actions/runs/26869702160)

Net result: no review was ever posted. Since cubic edits the description of every PR it reviews, this race affects every bug-pipeline PR.

### Fix

Drop `edited` from the trigger types. It is redundant for the iteration loop: every pipeline step that needs a (re-)review ends with a push (`synchronize`).

Lock file recompiled with gh-aw v0.77.5.

This PR is chained with v0.77.5 gh aw upgrade PR https://github.com/opsmill/infrahub/pull/9358


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `edited` from the bug reviewer workflow’s `pull_request` triggers to prevent non-allowed bot description edits from canceling the in-flight reviewer run. Reviews still re-trigger on `synchronize`, with `opened` and `reopened` as entry points; lock file recompiled with `github/gh-aw-actions/setup` v0.77.5.

<sup>Written for commit 436878fedc7688b995c6a4457002d1e9bc2d639e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

