### PR TITLE
update changelog guidance for AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -61,6 +61,7 @@ See `dev/knowledge/backend/testing.md` for detailed testing infrastructure docum
 - Type hint all function parameters and returns
 - Use Pydantic models for data structures
 - Use Query class pattern for database operations
+- Create changelog fragments with `towncrier create` — never hand-write the file. See `dev/guidelines/changelog.md`.
 
 ### Ask First
 
@@ -79,6 +80,7 @@ See `dev/knowledge/backend/testing.md` for detailed testing infrastructure docum
 ### Guidelines
 
 - `dev/guidelines/backend/python.md` - Python coding standards
+- `dev/guidelines/changelog.md` - Changelog fragment creation
 
 ### Knowledge (How the system works)
 

--- a/dev/guidelines/changelog.md
+++ b/dev/guidelines/changelog.md
@@ -10,9 +10,13 @@ Every issue fix or new feature should include a changelog entry. The message sho
 
 ### Command
 
+Always create fragments with `towncrier create`. **Do not hand-write the file** — the command derives the location from the Towncrier config and places the fragment correctly no matter which directory you run it from.
+
 ```bash
 uv run towncrier create -c "content of changelog entry" ${ISSUE}.${TYPE}.md
 ```
+
+Fragments always live in the repo-root `changelog/` directory. They never belong under `backend/changelog/` or `frontend/changelog/` — if you find a fragment there, it was created by hand in the wrong place and must be moved to `changelog/`.
 
 ### File Naming
 


### PR DESCRIPTION
Claude and friends seem to have been adding changelogs by hand in the wrong place (fixed in #9436)
these updates are hopefully enough to prevent it going forward

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated changelog guidance to require `towncrier create` and clarify that fragments always live in the repo-root `changelog/` directory. Added reminders in `backend/AGENTS.md` and expanded `dev/guidelines/changelog.md` to prevent manual fragment files and incorrect locations.

<sup>Written for commit 70188e14edfa6420f9a26eaaf19c467cc72ad3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

