### PR TITLE
extract sidebar primitives with context-driven state + use @infrahub/ui

### DIFF
--- a/frontend/app/src/entities/navigation/constants.ts
+++ b/frontend/app/src/entities/navigation/constants.ts
@@ -1,1 +1,1 @@
-export const SIDEBAR_COLLAPSED_KEY = "sidebar_collapsed";
+export const SIDEBAR_STATE_KEY = "sidebar_state";

--- a/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere-trigger.tsx
+++ b/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere-trigger.tsx
@@ -1,46 +1,26 @@
 import { Icon } from "@iconify-icon/react";
 import { Button, type ButtonProps } from "@infrahub/ui";
 
-import { Tooltip } from "@/shared/components/aria/tooltip";
-import { Row } from "@/shared/components/container";
-import { useSidebar } from "@/shared/components/layout/sidebar";
 import Kbd from "@/shared/components/ui/kbd";
 import { classNames } from "@/shared/utils/common";
 
 export function SearchAnywhereTrigger({ className, ...props }: ButtonProps) {
-  const { isCollapsed } = useSidebar();
-
-  if (isCollapsed) {
-    return (
-      <Tooltip message="Search anywhere" placement="right">
-        <Button
-          variant="outline"
-          shape="square"
-          aria-label="Search anywhere"
-          data-testid="search-anywhere-trigger"
-          {...props}
-        >
-          <Icon icon="mdi:magnify" aria-hidden="true" className="text-base" />
-        </Button>
-      </Tooltip>
-    );
-  }
-
   const command = navigator.userAgent.includes("Macintosh") ? "command" : "ctrl";
 
   return (
     <Button
       variant="outline"
-      className={classNames("px-2 shadow-none", className)}
+      className={classNames(
+        "justify-start px-2 shadow-none group-data-[state=collapsed]:px-2.5",
+        className
+      )}
       data-testid="search-anywhere-trigger"
       {...props}
     >
-      <Row className="grow overflow-hidden">
-        <Icon icon="mdi:magnify" aria-hidden="true" className="text-base" />
-        <span className="truncate text-stone-700 group-data-[state=collapsed]:hidden">Search</span>
-      </Row>
+      <Icon icon="mdi:magnify" aria-hidden="true" className="text-base" />
+      <span className="truncate text-stone-700 group-data-[state=collapsed]:hidden">Search</span>
 
-      <Kbd keys={command} className="group-data-[state=collapsed]:hidden">
+      <Kbd keys={command} className="ml-auto group-data-[state=collapsed]:hidden">
         K
       </Kbd>
     </Button>

--- a/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere-trigger.tsx
+++ b/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere-trigger.tsx
@@ -1,28 +1,28 @@
 import { Icon } from "@iconify-icon/react";
 import { Button, type ButtonProps } from "@infrahub/ui";
 
+import { Tooltip } from "@/shared/components/aria/tooltip";
+import { Row } from "@/shared/components/container";
+import { useSidebar } from "@/shared/components/layout/sidebar";
 import Kbd from "@/shared/components/ui/kbd";
 import { classNames } from "@/shared/utils/common";
 
-import { CollapsedSidebarMenuItem } from "@/entities/navigation/ui/sidebar/collapsed-sidebar-menu-item";
+export function SearchAnywhereTrigger({ className, ...props }: ButtonProps) {
+  const { isCollapsed } = useSidebar();
 
-export interface SearchAnywhereTriggerButtonProps extends ButtonProps {
-  isCollapsed?: boolean;
-}
-
-export function SearchAnywhereTrigger({
-  className,
-  isCollapsed,
-  ...props
-}: SearchAnywhereTriggerButtonProps) {
   if (isCollapsed) {
     return (
-      <CollapsedSidebarMenuItem
-        tooltipContent="Search anywhere"
-        icon="mdi:search"
-        data-testid="search-anywhere-trigger"
-        {...props}
-      />
+      <Tooltip message="Search anywhere" placement="right">
+        <Button
+          variant="outline"
+          shape="square"
+          aria-label="Search anywhere"
+          data-testid="search-anywhere-trigger"
+          {...props}
+        >
+          <Icon icon="mdi:magnify" aria-hidden="true" className="text-base" />
+        </Button>
+      </Tooltip>
     );
   }
 
@@ -30,22 +30,17 @@ export function SearchAnywhereTrigger({
 
   return (
     <Button
-      variant="ghost"
-      className={classNames(
-        "justify-between gap-3 bg-neutral-100 px-3 py-2 text-neutral-800 shadow-none",
-        className
-      )}
+      variant="outline"
+      className={classNames("px-2 shadow-none", className)}
       data-testid="search-anywhere-trigger"
       {...props}
     >
-      <div className="flex items-center gap-2 overflow-hidden">
-        <Icon icon="mdi:magnify" aria-hidden="true" className="text-xl" />
-        <span className="truncate text-neutral-700 text-sm transition-all group-data-[collapsed=true]/sidebar:hidden">
-          Search
-        </span>
-      </div>
+      <Row className="grow overflow-hidden">
+        <Icon icon="mdi:magnify" aria-hidden="true" className="text-base" />
+        <span className="truncate text-stone-700 group-data-[state=collapsed]:hidden">Search</span>
+      </Row>
 
-      <Kbd keys={command} className="transition-all group-data-[collapsed=true]/sidebar:hidden">
+      <Kbd keys={command} className="group-data-[state=collapsed]:hidden">
         K
       </Kbd>
     </Button>

--- a/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere.tsx
+++ b/frontend/app/src/entities/navigation/ui/search-anywhere/search-anywhere.tsx
@@ -12,11 +12,7 @@ import { SearchDocs } from "./search-docs";
 import { SearchNodes } from "./search-nodes";
 import { SearchParentPrefixes } from "./search-parent-prefixes";
 
-type SearchModalProps = {
-  isCollapsed?: boolean;
-};
-
-export function SearchAnywhere({ isCollapsed }: SearchModalProps) {
+export function SearchAnywhere() {
   let [isOpen, setIsOpen] = useState(false);
 
   function closeDialog() {
@@ -48,7 +44,7 @@ export function SearchAnywhere({ isCollapsed }: SearchModalProps) {
         openDialog,
       }}
     >
-      <SearchAnywhereTrigger isCollapsed={isCollapsed} onClick={openDialog} />
+      <SearchAnywhereTrigger onClick={openDialog} />
 
       <SearchAnywhereDialog>
         <Command shouldFilter={false}>

--- a/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.tsx
@@ -1,75 +1,61 @@
-import { Button } from "@infrahub/ui";
-import { Card } from "@infrahub/ui/card";
-import { PanelLeftCloseIcon, PanelLeftOpenIcon } from "lucide-react";
 import { Link } from "react-router";
 
 import InfrahubWithTextLogo from "@/assets/Infrahub-SVG-hori.svg";
-import InfrahubLogo from "@/assets/infrahub-logo.svg";
 
 import { constructPath } from "@/shared/api/rest/fetch";
-import { Separator } from "@/shared/components/aria/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/shared/components/layout/sidebar";
 import { focusVisibleStyle } from "@/shared/components/ui/style";
-import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
 import { classNames } from "@/shared/utils/common";
 
-import { SIDEBAR_COLLAPSED_KEY } from "@/entities/navigation/constants";
 import { SearchAnywhere } from "@/entities/navigation/ui/search-anywhere/search-anywhere";
-import SidebarMenu from "@/entities/navigation/ui/sidebar/sidebar-menu";
+import { SidebarMenu } from "@/entities/navigation/ui/sidebar/sidebar-menu";
 import { AccountMenu } from "@/entities/user-profile/ui/account-menu";
 
 export function AppSidebar() {
-  const [collapsed, setCollapsed] = useLocalStorage(SIDEBAR_COLLAPSED_KEY);
-
-  const booleanCollapsed = collapsed === "true";
-
   return (
-    <Card
-      data-collapsed={booleanCollapsed}
-      className={classNames(
-        "relative flex w-[256px] shrink-0 flex-col gap-3 p-3",
-        "group/sidebar transition-all",
-        booleanCollapsed && "w-auto items-center px-2"
-      )}
-      data-testid="sidebar"
-    >
-      <div className="flex items-center justify-between">
-        <Link to={constructPath("/")} className={classNames(focusVisibleStyle, "rounded-md")}>
-          <img
-            src={booleanCollapsed ? InfrahubLogo : InfrahubWithTextLogo}
-            alt="Infrahub logo"
-            className={"m-0.5 h-8 px-1"}
-          />
-        </Link>
+    <SidebarProvider>
+      <Sidebar data-testid="sidebar" className="divide-y divide-neutral-200">
+        <SidebarHeader>
+          <AppSidebarHeader />
+          <SearchAnywhere />
+        </SidebarHeader>
 
-        {booleanCollapsed ? (
-          <Button
-            variant="outline"
-            size="xs"
-            shape="circle"
-            className="absolute top-11 -right-3.5 hidden transition-all group-hover/sidebar:inline-flex"
-            onPress={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
-          >
-            <PanelLeftOpenIcon className="size-4 text-neutral-600" />
-          </Button>
-        ) : (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="p-1 text-gray-400 data-hovered:text-neutral-600"
-            onPress={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
-          >
-            <PanelLeftCloseIcon className="size-5" />
-          </Button>
+        <SidebarContent>
+          <SidebarMenu />
+        </SidebarContent>
+
+        <SidebarFooter className="p-1.5">
+          <AccountMenu />
+        </SidebarFooter>
+      </Sidebar>
+    </SidebarProvider>
+  );
+}
+
+function AppSidebarHeader() {
+  return (
+    <div className="relative h-8 transition-[height] duration-200 ease-linear group-data-[state=collapsed]:h-17.5">
+      <Link
+        to={constructPath("/")}
+        aria-label="Infrahub home"
+        className={classNames(
+          focusVisibleStyle,
+          "absolute bottom-0 left-0 max-w-40 overflow-hidden rounded-md",
+          "transition-[left,max-width] duration-200 ease-linear",
+          "group-data-[state=collapsed]:left-1.75 group-data-[state=collapsed]:max-w-8"
         )}
-      </div>
+      >
+        <img src={InfrahubWithTextLogo} alt="Infrahub" className="h-8 max-w-none" />
+      </Link>
 
-      <SearchAnywhere isCollapsed={booleanCollapsed} />
-
-      <Separator />
-
-      <SidebarMenu isCollapsed={booleanCollapsed} />
-
-      <AccountMenu />
-    </Card>
+      <SidebarTrigger className="absolute top-0 right-0 transition-[right] duration-200 ease-linear group-data-[state=collapsed]:right-0.75" />
+    </div>
   );
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/collapsed-sidebar-menu-item.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/collapsed-sidebar-menu-item.tsx
@@ -2,7 +2,6 @@ import { Icon } from "@iconify-icon/react";
 import { Button, type ButtonProps } from "@infrahub/ui";
 
 import { Tooltip } from "@/shared/components/aria/tooltip";
-import { classNames } from "@/shared/utils/common";
 
 export interface CollapsedSidebarMenuItemProps extends ButtonProps {
   tooltipContent: string;
@@ -10,19 +9,13 @@ export interface CollapsedSidebarMenuItemProps extends ButtonProps {
 }
 
 export function CollapsedSidebarMenuItem({
-  className,
   icon,
   tooltipContent,
   ...props
 }: CollapsedSidebarMenuItemProps) {
   return (
     <Tooltip message={tooltipContent} placement="right">
-      <Button
-        variant="ghost"
-        shape="square"
-        className={classNames("h-10 w-10 p-2", className)}
-        {...props}
-      >
+      <Button variant="ghost" shape="square" {...props}>
         <Icon icon={icon} className="text-base" />
       </Button>
     </Tooltip>

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { Link } from "react-router";
 
 import { constructPath } from "@/shared/api/rest/fetch";
+import { useSidebar } from "@/shared/components/layout/sidebar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,43 +58,42 @@ const ExpandedMenuItemLink: React.FC<{ item: MenuItem }> = ({ item }) => (
     <span className="truncate text-sm">{item.label}</span>
     <Icon
       icon="mdi:arrow-top-right"
-      className="m-1 ml-auto text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-data-[state=open]:opacity-100"
+      className="m-1 ml-auto text-sm opacity-0 group-hover/menu-item:opacity-100 group-focus/menu-item:opacity-100 group-data-[state=open]/menu-item:opacity-100"
     />
   </Link>
 );
 
-const DropdownMenuTriggerButton: React.FC<{ item: MenuItem; isCollapsed: boolean }> = ({
-  item,
-  isCollapsed,
-}) => (
-  <DropdownMenuTrigger
-    className={classNames(menuNavigationItemStyle, isCollapsed && "p-0")}
-    asChild={isCollapsed}
-  >
-    {isCollapsed ? (
-      <CollapsedSidebarMenuItem tooltipContent={item.label} icon={item.icon} />
-    ) : (
-      <>
-        <Icon icon={item.icon} className="size-4" />
-        <span className="truncate text-sm">{item.label}</span>
-        <Icon
-          icon="mdi:dots-vertical"
-          className="m-1 ml-auto opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-data-[state=open]:opacity-100"
-        />
-      </>
-    )}
-  </DropdownMenuTrigger>
-);
+const DropdownMenuTriggerButton: React.FC<{ item: MenuItem }> = ({ item }) => {
+  const { isCollapsed } = useSidebar();
+
+  return (
+    <DropdownMenuTrigger
+      className={classNames(menuNavigationItemStyle, isCollapsed && "p-0")}
+      asChild={isCollapsed}
+    >
+      {isCollapsed ? (
+        <CollapsedSidebarMenuItem tooltipContent={item.label} icon={item.icon} />
+      ) : (
+        <>
+          <Icon icon={item.icon} className="size-4" />
+          <span className="truncate text-sm">{item.label}</span>
+          <Icon
+            icon="mdi:dots-vertical"
+            className="m-1 ml-auto opacity-0 group-hover/menu-item:opacity-100 group-focus/menu-item:opacity-100 group-data-[state=open]/menu-item:opacity-100"
+          />
+        </>
+      )}
+    </DropdownMenuTrigger>
+  );
+};
 
 export interface SidebarMenuSectionInternalProps {
   items: MenuItem[];
-  isCollapsed?: boolean;
 }
 
-export function SidebarMenuSectionInternal({
-  items,
-  isCollapsed,
-}: SidebarMenuSectionInternalProps) {
+export function SidebarMenuSectionInternal({ items }: SidebarMenuSectionInternalProps) {
+  const { isCollapsed } = useSidebar();
+
   return (
     <div className="mb-auto flex flex-col">
       {items.map((item) => {
@@ -107,7 +107,7 @@ export function SidebarMenuSectionInternal({
 
         return (
           <DropdownMenu key={item.identifier}>
-            <DropdownMenuTriggerButton item={item} isCollapsed={!!isCollapsed} />
+            <DropdownMenuTriggerButton item={item} />
             <DropdownMenuContent side="left" align="start" className="min-w-[200px]">
               {item.children.map((childItem) => (
                 <RecursiveInternalMenuItem key={childItem.identifier} item={childItem} />

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
@@ -53,12 +53,12 @@ const CollapsedMenuItemLink: React.FC<{ item: MenuItem }> = ({ item }) => (
 );
 
 const ExpandedMenuItemLink: React.FC<{ item: MenuItem }> = ({ item }) => (
-  <Link to={constructPath(item.path)} className={classNames(menuNavigationItemStyle, "h-10")}>
+  <Link to={constructPath(item.path)} className={menuNavigationItemStyle}>
     <Icon icon={item.icon} className="size-4" />
     <span className="truncate text-sm">{item.label}</span>
     <Icon
       icon="mdi:arrow-top-right"
-      className="m-1 ml-auto text-sm opacity-0 group-hover/menu-item:opacity-100 group-focus/menu-item:opacity-100 group-data-[state=open]/menu-item:opacity-100"
+      className="m-1 ml-auto opacity-0 group-hover/menu-item:opacity-100 group-focus/menu-item:opacity-100 group-data-[state=open]/menu-item:opacity-100"
     />
   </Link>
 );

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-internal.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { Link } from "react-router";
 
 import { constructPath } from "@/shared/api/rest/fetch";
+import { Col } from "@/shared/components/container";
 import { useSidebar } from "@/shared/components/layout/sidebar";
 import {
   DropdownMenu,
@@ -67,10 +68,7 @@ const DropdownMenuTriggerButton: React.FC<{ item: MenuItem }> = ({ item }) => {
   const { isCollapsed } = useSidebar();
 
   return (
-    <DropdownMenuTrigger
-      className={classNames(menuNavigationItemStyle, isCollapsed && "p-0")}
-      asChild={isCollapsed}
-    >
+    <DropdownMenuTrigger className={classNames(menuNavigationItemStyle)} asChild={isCollapsed}>
       {isCollapsed ? (
         <CollapsedSidebarMenuItem tooltipContent={item.label} icon={item.icon} />
       ) : (
@@ -95,7 +93,7 @@ export function SidebarMenuSectionInternal({ items }: SidebarMenuSectionInternal
   const { isCollapsed } = useSidebar();
 
   return (
-    <div className="mb-auto flex flex-col">
+    <Col className={classNames("gap-0 p-2", isCollapsed && "items-start")}>
       {items.map((item) => {
         if (!item.children?.length) {
           return isCollapsed ? (
@@ -108,7 +106,7 @@ export function SidebarMenuSectionInternal({ items }: SidebarMenuSectionInternal
         return (
           <DropdownMenu key={item.identifier}>
             <DropdownMenuTriggerButton item={item} />
-            <DropdownMenuContent side="left" align="start" className="min-w-[200px]">
+            <DropdownMenuContent side="left" align="start" className="min-w-50">
               {item.children.map((childItem) => (
                 <RecursiveInternalMenuItem key={childItem.identifier} item={childItem} />
               ))}
@@ -116,6 +114,6 @@ export function SidebarMenuSectionInternal({ items }: SidebarMenuSectionInternal
           </DropdownMenu>
         );
       })}
-    </div>
+    </Col>
   );
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
@@ -22,7 +22,7 @@ import { menuNavigationItemStyle } from "@/entities/navigation/ui/sidebar/styles
 
 const MenuItemIcon: React.FC<{ item: MenuItem }> = ({ item }) => {
   if (item.icon) {
-    return <Icon icon={item.icon} className="m-1 size-4 text-md" />;
+    return <Icon icon={item.icon} className="size-4" />;
   }
   return <SidebarMenuItemAvatar name={item.label} />;
 };

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { Link } from "react-router";
 
 import { constructPath } from "@/shared/api/rest/fetch";
+import { useSidebar } from "@/shared/components/layout/sidebar";
 import {
   DropdownMenu,
   DropdownMenuAccordion,
@@ -12,10 +13,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/shared/components/ui/dropdown-menu";
-import { Tooltip } from "@/shared/components/ui/tooltip";
 import { classNames } from "@/shared/utils/common";
 
 import type { MenuItem } from "@/entities/navigation/types";
+import { CollapsedSidebarMenuItem } from "@/entities/navigation/ui/sidebar/collapsed-sidebar-menu-item";
 import { SidebarMenuItemAvatar } from "@/entities/navigation/ui/sidebar/sidebar-menu-item-avatar";
 import { menuNavigationItemStyle } from "@/entities/navigation/ui/sidebar/styles";
 
@@ -28,9 +29,8 @@ const MenuItemIcon: React.FC<{ item: MenuItem }> = ({ item }) => {
 
 const RecursiveObjectMenuItem: React.FC<{
   item: MenuItem;
-  isCollapsed?: boolean;
   level?: number;
-}> = ({ item, isCollapsed, level = 0 }) => {
+}> = ({ item, level = 0 }) => {
   if (!item.children?.length) {
     return (
       <DropdownMenuItem className={menuNavigationItemStyle} asChild>
@@ -66,12 +66,7 @@ const RecursiveObjectMenuItem: React.FC<{
         className="border-neutral-200 border-l"
       >
         {item.children.map((child) => (
-          <RecursiveObjectMenuItem
-            key={child.identifier}
-            item={child}
-            isCollapsed={isCollapsed}
-            level={level + 1}
-          />
+          <RecursiveObjectMenuItem key={child.identifier} item={child} level={level + 1} />
         ))}
       </DropdownMenuAccordionContent>
     </DropdownMenuAccordion>
@@ -80,13 +75,14 @@ const RecursiveObjectMenuItem: React.FC<{
 
 const TopLevelMenuItem: React.FC<{
   item: MenuItem;
-  isCollapsed?: boolean;
-}> = ({ item, isCollapsed }) => {
+}> = ({ item }) => {
+  const { isCollapsed } = useSidebar();
+
   if (!item.children?.length) {
     return (
       <Link
         to={constructPath(item.path)}
-        className={classNames(menuNavigationItemStyle, isCollapsed ? "p-2" : "w-[224px]")}
+        className={classNames(menuNavigationItemStyle, isCollapsed ? "p-2" : "w-full")}
       >
         <MenuItemIcon item={item} />
         <span className={classNames("text-sm", isCollapsed && "hidden")}>{item.label}</span>
@@ -97,27 +93,26 @@ const TopLevelMenuItem: React.FC<{
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className={classNames(menuNavigationItemStyle, isCollapsed ? "p-2" : "w-[224px]")}
+        className={classNames(menuNavigationItemStyle, isCollapsed ? "p-2" : "w-full")}
+        asChild={isCollapsed}
       >
-        <Tooltip enabled={isCollapsed} content={item.label} side="right">
-          <span className="flex">
+        {isCollapsed ? (
+          <CollapsedSidebarMenuItem tooltipContent={item.label} icon={item.icon} />
+        ) : (
+          <>
             <MenuItemIcon item={item} />
-          </span>
-        </Tooltip>
-
-        <span className={classNames("truncate text-sm", isCollapsed && "hidden")}>
-          {item.label}
-        </span>
+            <span className="truncate text-sm">{item.label}</span>
+          </>
+        )}
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
         side="left"
         align="start"
-        sideOffset={isCollapsed ? 6 : 12}
         className="max-h-[calc(100vh-7rem)] min-w-60 overflow-auto"
       >
         {item.children.map((child) => (
-          <RecursiveObjectMenuItem key={child.identifier} item={child} isCollapsed={isCollapsed} />
+          <RecursiveObjectMenuItem key={child.identifier} item={child} />
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
@@ -126,11 +121,8 @@ const TopLevelMenuItem: React.FC<{
 
 export interface SidebarMenuSectionObjectProps {
   items: MenuItem[];
-  isCollapsed?: boolean;
 }
 
-export function SidebarMenuSectionObject({ isCollapsed, items }: SidebarMenuSectionObjectProps) {
-  return items.map((item) => (
-    <TopLevelMenuItem key={item.identifier} item={item} isCollapsed={isCollapsed} />
-  ));
+export function SidebarMenuSectionObject({ items }: SidebarMenuSectionObjectProps) {
+  return items.map((item) => <TopLevelMenuItem key={item.identifier} item={item} />);
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
@@ -7,11 +7,7 @@ import { useMenu } from "@/entities/navigation/ui/queries/get-menu.query";
 import { SidebarMenuSectionInternal } from "@/entities/navigation/ui/sidebar/sidebar-menu-section-internal";
 import { SidebarMenuSectionObject } from "@/entities/navigation/ui/sidebar/sidebar-menu-section-object";
 
-export interface SidebarMenuProps {
-  isCollapsed?: boolean;
-}
-
-export default function SidebarMenu({ isCollapsed }: SidebarMenuProps) {
+export function SidebarMenu() {
   const { data: menu, isPending, error } = useMenu();
 
   if (isPending) return <Spinner className="mx-auto grow p-4" />;
@@ -23,10 +19,14 @@ export default function SidebarMenu({ isCollapsed }: SidebarMenuProps) {
   return (
     <>
       <ScrollArea>
-        <SidebarMenuSectionObject items={menu.sections.object} isCollapsed={isCollapsed} />
+        <div className="p-2">
+          <SidebarMenuSectionObject items={menu.sections.object} />
+        </div>
       </ScrollArea>
       <Separator />
-      <SidebarMenuSectionInternal items={menu.sections.internal} isCollapsed={isCollapsed} />
+      <div className="p-2">
+        <SidebarMenuSectionInternal items={menu.sections.internal} />
+      </div>
     </>
   );
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
@@ -24,9 +24,7 @@ export function SidebarMenu() {
         </div>
       </ScrollArea>
       <Separator />
-      <div className="p-2">
-        <SidebarMenuSectionInternal items={menu.sections.internal} />
-      </div>
+      <SidebarMenuSectionInternal items={menu.sections.internal} />
     </>
   );
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
+++ b/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
@@ -1,2 +1,2 @@
 export const menuNavigationItemStyle =
-  "flex items-center outline-hidden gap-2 p-1.5 rounded-lg font-medium text-neutral-900 hover:bg-neutral-100 focus:bg-neutral-100 group/menu-item data-[state=open]:bg-indigo-50 data-[state=open]:text-indigo-700";
+  "flex items-center outline-hidden gap-2 px-2.5 py-2 rounded-lg font-medium text-neutral-900 hover:bg-neutral-100 focus:bg-neutral-100 group/menu-item data-[state=open]:bg-indigo-50 data-[state=open]:text-indigo-700";

--- a/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
+++ b/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
@@ -1,2 +1,2 @@
 export const menuNavigationItemStyle =
-  "flex items-center outline-hidden gap-2 p-2 rounded-sm font-medium text-neutral-900 hover:bg-neutral-100 focus:bg-neutral-100 group data-[state=open]:bg-indigo-50 data-[state=open]:text-indigo-700";
+  "flex items-center outline-hidden gap-2 p-1.5 rounded-lg font-medium text-neutral-900 hover:bg-neutral-100 focus:bg-neutral-100 group/menu-item data-[state=open]:bg-indigo-50 data-[state=open]:text-indigo-700";

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -97,17 +97,18 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
     <DropdownMenu>
       <LinkButton
         variant="ghost"
-        className="h-10 items-center px-2 pr-1.5 data-pressed:scale-100"
+        size="sm"
+        className="h-10 justify-stretch gap-2 data-pressed:scale-100"
         href="/login"
         routerOptions={{ state: { from: location } }}
       >
-        <div className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full border border-white bg-stone-200">
-          <Icon icon="mdi:user" className="relative top-1 text-3xl text-neutral-600" />
+        <div className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-stone-200">
+          <Icon icon="mdi:user" className="relative top-1 text-3xl text-stone-600" />
         </div>
 
         <div className="overflow-hidden group-data-[state=collapsed]:hidden">
           <div className="truncate font-medium leading-4">Log in</div>
-          <div className="truncate text-neutral-500 text-xs">anonymous</div>
+          <div className="truncate text-stone-500 text-xs">anonymous</div>
         </div>
 
         <DropdownMenuTrigger
@@ -172,7 +173,8 @@ const AuthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="h-10 data-pressed:scale-100"
+          size="sm"
+          className="h-10 justify-stretch gap-2 data-pressed:scale-100"
           data-testid="authenticated-menu-trigger"
         >
           <Avatar name={profile?.name?.value} className="size-6 shrink-0" />

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import { Button, LinkButton, Spinner } from "@infrahub/ui";
+import { EllipsisVerticalIcon } from "lucide-react";
 import React from "react";
 import { Link, useLocation } from "react-router";
 
@@ -96,16 +97,16 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
     <DropdownMenu>
       <LinkButton
         variant="ghost"
-        className="h-auto w-full shrink-0 gap-2 overflow-hidden rounded-lg p-2 data-hovered:bg-indigo-50"
+        className="h-10 items-center px-2 pr-1.5 data-pressed:scale-100"
         href="/login"
         routerOptions={{ state: { from: location } }}
       >
-        <div className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-white bg-indigo-50">
-          <Icon icon="mdi:user" className="relative top-1 text-5xl text-neutral-600" />
+        <div className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full border border-white bg-stone-200">
+          <Icon icon="mdi:user" className="relative top-1 text-3xl text-neutral-600" />
         </div>
 
-        <div className="overflow-hidden group-data-[collapsed=true]/sidebar:hidden">
-          <div className="truncate font-semibold text-sm">Log in</div>
+        <div className="overflow-hidden group-data-[state=collapsed]:hidden">
+          <div className="truncate font-medium leading-4">Log in</div>
           <div className="truncate text-neutral-500 text-xs">anonymous</div>
         </div>
 
@@ -118,10 +119,11 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
           <Button
             variant="ghost"
             shape="square"
+            size="xs"
             data-testid="unauthenticated-menu-trigger"
-            className="ml-auto shrink-0 data-hovered:bg-indigo-100 group-data-[collapsed=true]/sidebar:hidden"
+            className="ml-auto data-hovered:bg-stone-300 group-data-[state=collapsed]:hidden"
           >
-            <Icon icon="mdi:dots-vertical" className="text-lg" />
+            <EllipsisVerticalIcon />
           </Button>
         </DropdownMenuTrigger>
       </LinkButton>
@@ -170,19 +172,16 @@ const AuthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="h-auto w-full shrink-0 justify-start gap-2 overflow-hidden rounded-lg p-2 text-left data-hovered:bg-indigo-50"
+          className="h-10 data-pressed:scale-100"
           data-testid="authenticated-menu-trigger"
         >
-          <Avatar name={profile?.name?.value} className="size-9 shrink-0" />
+          <Avatar name={profile?.name?.value} className="size-6 shrink-0" />
 
-          <div className="overflow-hidden group-data-[collapsed=true]/sidebar:hidden">
-            <div className="truncate font-semibold text-sm">{profile?.label?.value}</div>
+          <div className="overflow-hidden group-data-[state=collapsed]:hidden">
+            <div className="truncate font-medium text-sm">{profile?.label?.value}</div>
           </div>
 
-          <Icon
-            icon="mdi:dots-vertical"
-            className="m-2 ml-auto text-lg transition-all group-data-[collapsed=true]/sidebar:hidden"
-          />
+          <EllipsisVerticalIcon className="ml-auto group-data-[state=collapsed]:hidden" />
         </Button>
       </DropdownMenuTrigger>
 
@@ -209,13 +208,9 @@ const AuthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }
 
 const AccountMenuSkeleton = () => {
   return (
-    <div className="flex shrink-0 items-center gap-2 border border-transparent p-2">
-      <Skeleton className="size-9 rounded-full" />
-
-      <div className="grow space-y-2 group-data-[collapsed=true]/sidebar:hidden">
-        <Skeleton className="h-4 w-4/5" />
-        <Skeleton className="h-2 w-3/5" />
-      </div>
+    <div className="flex h-10 shrink-0 items-center gap-2 px-2">
+      <Skeleton className="size-6 shrink-0 rounded-full" />
+      <Skeleton className="h-4 grow group-data-[state=collapsed]:hidden" />
     </div>
   );
 };

--- a/frontend/app/src/shared/components/layout/sidebar.tsx
+++ b/frontend/app/src/shared/components/layout/sidebar.tsx
@@ -1,0 +1,106 @@
+import { Button, type ButtonProps, Card } from "@infrahub/ui";
+import { PanelLeftCloseIcon, PanelLeftOpenIcon } from "lucide-react";
+import * as React from "react";
+
+import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
+import { classNames } from "@/shared/utils/common";
+
+import { SIDEBAR_STATE_KEY } from "@/entities/navigation/constants";
+
+type SidebarContextProps = {
+  isCollapsed: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}
+
+export function SidebarProvider({ children }: { children?: React.ReactNode }) {
+  const [storedState, setStoredState] = useLocalStorage(SIDEBAR_STATE_KEY);
+
+  // Default to expanded; only the explicit "collapsed" string collapses the sidebar.
+  // Storing the literal state (not a boolean) keeps localStorage self-describing and
+  // removes the "is collapsed" vs "is open" inversion bug class.
+  const isCollapsed = storedState === "collapsed";
+
+  return (
+    <SidebarContext.Provider
+      value={{
+        isCollapsed,
+        toggleSidebar: () => setStoredState(isCollapsed ? "expanded" : "collapsed"),
+      }}
+    >
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function Sidebar({ className, children, ...props }: React.ComponentProps<"div">) {
+  const { isCollapsed } = useSidebar();
+
+  return (
+    <Card
+      className={classNames(
+        "group w-64 shrink-0 overflow-hidden transition-[width] duration-200 ease-linear data-[state=collapsed]:w-14",
+        className
+      )}
+      data-state={isCollapsed ? "collapsed" : "expanded"}
+      {...props}
+    >
+      {children}
+    </Card>
+  );
+}
+
+export function SidebarTrigger({ className, onPress, ...props }: ButtonProps) {
+  const { isCollapsed, toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      variant="ghost"
+      shape="square"
+      size="sm"
+      className={classNames("text-gray-400 data-hovered:text-neutral-600", className)}
+      onPress={(event) => {
+        onPress?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      {isCollapsed ? (
+        <PanelLeftOpenIcon className="size-5" />
+      ) : (
+        <PanelLeftCloseIcon className="size-5" />
+      )}
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+export function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={classNames("flex flex-col gap-2 p-2", className)} {...props} />;
+}
+
+export function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={classNames(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={classNames("flex flex-col gap-2 p-2", className)} {...props} />;
+}

--- a/frontend/app/src/shared/components/ui/kbd.tsx
+++ b/frontend/app/src/shared/components/ui/kbd.tsx
@@ -57,7 +57,7 @@ function Kbd({ children, keys, keyClassName, className, ref }: KbdProps) {
     <kbd
       ref={ref}
       className={classNames(
-        "rounded-sm bg-gray-100 px-1.5 py-0.5 font-sans text-gray-600 text-xs",
+        "rounded-sm bg-stone-100 px-1.5 py-0.5 font-sans text-stone-600 text-xs",
         className
       )}
     >


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted reusable sidebar primitives with context-driven state and migrated the app sidebar, search trigger, menus, and account menu to use them with `@infrahub/ui`. This removes prop plumbing, standardizes styling and data attributes, improves accessibility, and persists sidebar state.

- **Refactors**
  - Added shared `SidebarProvider`, `Sidebar`, `SidebarHeader`, `SidebarContent`, `SidebarFooter`, `SidebarTrigger`, and `useSidebar` in `shared/components/layout/sidebar.tsx`.
  - Rewrote `AppSidebar` to use the primitives; header now has a labeled home link and inline `SidebarTrigger`; `SidebarMenu` in content; `AccountMenu` in footer.
  - Search modal: removed `isCollapsed` prop; trigger switched to `variant="outline"` and adapts to `data-state=collapsed` to hide label and `Kbd`.
  - Menus: `SidebarMenu` is now a named export; object/internal sections use `useSidebar`; simplified `CollapsedSidebarMenuItem`; updated `menuNavigationItemStyle` (rounded-lg, refined spacing, `group/menu-item` selectors).
  - UI/a11y: standardized with `@infrahub/ui`, root `data-state=collapsed|expanded`, updated icons (`EllipsisVerticalIcon`, `PanelLeftOpen/Close`), and refined `Kbd` colors.

- **Migration**
  - Local storage key renamed to `SIDEBAR_STATE_KEY`; values are "collapsed" or "expanded" (defaults to expanded).
  - No changes needed when using `AppSidebar`. If using the primitives directly, wrap with `SidebarProvider`.

<sup>Written for commit ef3efb9ba906b004b664549d908f7321981a4eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

