### PR TITLE
fix(graphql): wrap is_externally_managed_resolver in db session with trace/retry

### DIFF
--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -51,21 +51,24 @@ async def account_resolver(
         )
 
 
+@trace.get_tracer(__name__).start_as_current_span("is_externally_managed_resolver")
+@retry_db_transaction(name="is_externally_managed_resolver")
 async def is_externally_managed_resolver(parent: dict, info: GraphQLResolveInfo) -> bool:
     """Return True when the parent account has at least one linked external identity."""
     account_id = parent.get("id")
     if not account_id:
         return False
     graphql_context: GraphqlContext = info.context
-    identities = await NodeManager.query(
-        schema=InfrahubKind.EXTERNALIDENTITY,
-        filters={"account__ids": [account_id]},
-        db=graphql_context.db,
-        at=graphql_context.at,
-        branch=graphql_context.branch,
-        branch_agnostic=True,
-        limit=1,
-    )
+    async with graphql_context.db.start_session(read_only=True) as db:
+        identities = await NodeManager.query(
+            schema=InfrahubKind.EXTERNALIDENTITY,
+            filters={"account__ids": [account_id]},
+            db=db,
+            at=graphql_context.at,
+            branch=graphql_context.branch,
+            branch_agnostic=True,
+            limit=1,
+        )
     return bool(identities)
 
 


### PR DESCRIPTION
## Why

Upport of the review feedback applied to the 1.8.7 backport (#9444). The `is_externally_managed_resolver` added by #9391 diverges from the resolver pattern used everywhere else in `resolver.py`.

## What changed

- Acquire a read-only session via `start_session(read_only=True)` and pass `db=db` to `NodeManager.query`, instead of passing `graphql_context.db` directly.
- Add `@trace` and `@retry_db_transaction` decorators for observability and transient transaction-error retries.

Backend-only, no behavior change. Once merged to `stable`, forward-port to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns GraphQL `is_externally_managed_resolver` with the standard resolver pattern by using a read-only DB session and adding tracing and retry. Improves observability and resilience with no behavior change.

- **Refactors**
  - Use `start_session(read_only=True)` and pass the session `db` to `NodeManager.query` instead of `graphql_context.db`.
  - Add tracing via `trace.get_tracer(__name__).start_as_current_span(...)` and `@retry_db_transaction` to handle transient transaction errors.

<sup>Written for commit e8031576e1e595b51d1eb3349cee543c801d95b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

