### PR TITLE
ci(backport 1.8.7): pin node to 24.15.0 for Playwright jobs (#9383)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,7 +714,8 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # https://github.com/microsoft/playwright/issues/41000
+          node-version: 24.15.0
           cache: 'npm'
           cache-dependency-path: frontend/app/package-lock.json
       - name: "Install frontend"
@@ -988,7 +989,8 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # https://github.com/microsoft/playwright/issues/41000
+          node-version: 24.15.0
           cache: 'npm'
           cache-dependency-path: frontend/app/package-lock.json
       - name: Set up Python


### PR DESCRIPTION
## Why

Backport of #9383 to the `release-1.8.7` branch.

The floating `node-version: 24` triggers [microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000), which causes Playwright-installing CI jobs to hang until the 30-minute timeout and get cancelled (observed on #9444).

## What changed

Pin node to `24.15.0` on both jobs that run `npx playwright install`:

- `frontend-tests`
- `E2E-testing-playwright`

The upstream PR pinned a single job, but `release-1.8.7` has two Playwright jobs, both on the floating tag, so both are pinned. Non-Playwright jobs (lint, validate, docs) keep `node-version: 24`.

## Checklist

- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport to `release-1.8.7`: Pin `node-version` to `24.15.0` for Playwright CI jobs to prevent hangs during `npx playwright install`. Applies to `frontend-tests` and `E2E-testing-playwright`; other jobs remain on `24`.

<sup>Written for commit e21c13579aafb251b07ca4a926d3e1d300197b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

