### PR TITLE
fix(proposed-change): scope generator dispatch to fields the query reads

### DIFF
--- a/backend/infrahub/generators/models.py
+++ b/backend/infrahub/generators/models.py
@@ -74,4 +74,5 @@ class GeneratorDefinitionModel(BaseModel):
 
 class ProposedChangeGeneratorDefinition(GeneratorDefinitionModel):
     query_models: list[str] = Field(..., description="The models to use when collecting data.")
+    query_payload: str = Field(..., description="The GraphQL query string used to collect data.")
     repository_id: str = Field(..., description="The id of the repository.")

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -160,6 +160,7 @@ async def run_generator_definition(
                 file_path=generator.file_path.value,
                 query_name=generator.query.peer.name.value,
                 query_models=generator.query.peer.models.value,
+                query_payload=generator.query.peer.query.value,
                 repository_id=generator.repository.peer.id,
                 parameters=generator.parameters.value,
                 group_id=generator.targets.peer.id,

--- a/backend/infrahub/graphql/mutations/generator.py
+++ b/backend/infrahub/graphql/mutations/generator.py
@@ -64,6 +64,7 @@ class GeneratorDefinitionRequestRun(Mutation):
                 file_path=generator_definition.file_path.value,
                 query_name=query.name.value,
                 query_models=query.models.value or [],
+                query_payload=query.query.value,
                 repository_id=repository.id,
                 parameters=generator_definition.parameters.value
                 if isinstance(generator_definition.parameters.value, dict)

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -137,7 +137,6 @@ class ProposedChangeArtifactDefinition(BaseModel):
 
 class ProposedChangeBranchDiff(BaseModel):
     repositories: list[ProposedChangeRepository] = Field(default_factory=list)
-    subscribers: list[ProposedChangeSubscriber] = Field(default_factory=list)
     pipeline_id: uuid.UUID = Field(..., description="The unique ID of the execution of this pipeline")
 
     def get_repository(self, repository_id: str) -> ProposedChangeRepository:
@@ -145,9 +144,6 @@ class ProposedChangeBranchDiff(BaseModel):
             if repository_id == repository.repository_id:
                 return repository
         raise NodeNotFoundError(node_type="Repository", identifier=repository_id)
-
-    def get_subscribers_ids(self, kind: str) -> list[str]:
-        return [subscriber.subscriber_id for subscriber in self.subscribers if subscriber.kind == kind]
 
     @property
     def has_file_modifications(self) -> bool:

--- a/backend/infrahub/proposed_change/branch_diff.py
+++ b/backend/infrahub/proposed_change/branch_diff.py
@@ -130,13 +130,6 @@ def get_modified_kinds(diff_summary: list[NodeDiff], branch: str) -> list[str]:
     )
 
 
-def get_modified_node_ids(diff_summary: list[NodeDiff], branch: str) -> list[str]:
-    """Return a list of non schema nodes that have been modified on the branch."""
-    return [
-        entry["id"] for entry in diff_summary if entry["branch"] == branch and not SCHEMA_CHANGE.match(entry["kind"])
-    ]
-
-
 async def set_diff_summary_cache(pipeline_id: UUID, diff_summary: list[NodeDiff], cache: InfrahubCache) -> None:
     serialized = json.dumps(diff_summary)
     await cache.set(

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-from dataclasses import dataclass
-from enum import IntFlag
+from dataclasses import dataclass, field
+from enum import Enum, IntFlag
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -76,7 +76,6 @@ from infrahub.message_bus.types import (
 from infrahub.proposed_change.branch_diff import (
     GitRepositoryFileDiffer,
     RepositoryFileDiffPopulator,
-    get_modified_node_ids,
     has_data_changes,
     has_node_changes,
     set_diff_summary_cache,
@@ -118,6 +117,7 @@ from .checker import verify_proposed_change_is_mergeable
 
 if TYPE_CHECKING:
     import logging
+    from uuid import UUID
 
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
@@ -358,6 +358,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             file_path=generator.file_path.value,
             query_name=generator.query.peer.name.value,
             query_models=generator.query.peer.models.value,
+            query_payload=generator.query.peer.query.value,
             repository_id=generator.repository.peer.id,
             parameters=generator.parameters.value,
             group_id=generator.targets.peer.id,
@@ -683,6 +684,103 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) 
             log.info(msg=f"repository_tests_completed return_code={return_code}")
 
 
+class ImpactScope(Enum):
+    """How a data change maps onto the subscribers (artifacts or generator instances) to process."""
+
+    ALL = "all"  # the change cannot be mapped to specific targets; every target must be processed
+    NONE = "none"  # no queried field changed; no target needs processing
+    SPECIFIC = "specific"  # only the subscribers in `ids` are affected
+
+
+@dataclass
+class ImpactedSubscribers:
+    scope: ImpactScope
+    ids: list[str] = field(default_factory=list)
+
+
+def _relevant_node_changes(
+    diff_summary: list[NodeDiff], source_branch: str, readable_fields_by_kind: dict[str, set[str]]
+) -> list[str]:
+    """Return ids of nodes whose modified fields intersect the fields a query reads.
+
+    A change is relevant only when at least one modified field is also read by the query, so a
+    node whose only change is to a field the query ignores -- or whose kind the query never reads
+    -- is excluded. `readable_fields_by_kind` maps each kind the query reads to the set of its
+    attribute and relationship names that the query selects.
+    """
+    relevant_node_ids: list[str] = []
+    for node_diff in diff_summary:
+        if node_diff["branch"] != source_branch:
+            continue
+        readable_fields = readable_fields_by_kind.get(node_diff["kind"])
+        if not readable_fields:
+            continue
+        updated_fields = {element["name"] for element in node_diff["elements"]}
+        if updated_fields & readable_fields:
+            relevant_node_ids.append(node_diff["id"])
+    return relevant_node_ids
+
+
+async def get_field_level_impacted_subscribers(
+    query_payload: str,
+    source_branch: str,
+    pipeline_id: UUID,
+    subscriber_kind: str,
+    client: InfrahubClient,
+) -> ImpactedSubscribers:
+    """Map data changes in a branch to the subscribers a GraphQL query actually depends on.
+
+    A change is relevant only when at least one field that was modified is also read by the
+    query. This lets us skip regeneration when, for example, only a `description` field changed
+    but the query only reads `name` and `color`.
+
+    Returns an `ImpactedSubscribers` whose scope is:
+        SPECIFIC -- the query guarantees unique targets, so `ids` lists exactly the subscribers of
+                    `subscriber_kind` linked to the changed nodes (possibly empty).
+        ALL      -- the query does not guarantee unique targets but a relevant field changed, so the
+                    caller cannot map the change to specific targets and must process every target.
+        NONE     -- no node of a queried kind had any of its queried fields modified; nothing to do.
+    """
+    source_schema_branch = registry.schema.get_schema_branch(name=source_branch)
+    source_branch_obj = registry.get_branch_from_registry(branch=source_branch)
+
+    graphql_params = await prepare_graphql_params(db=await get_database(), branch=source_branch)
+    query_report = InfrahubGraphQLQueryAnalyzer(
+        query=query_payload,
+        branch=source_branch_obj,
+        schema_branch=source_schema_branch,
+        schema=graphql_params.schema,
+        document=cached_parse(query_payload),
+    ).query_report
+
+    diff_summary = await get_diff_summary_cache(pipeline_id=pipeline_id)
+    readable_fields_by_kind = {kind: access.fields for kind, access in query_report.requested_read.items()}
+    changed_node_ids = _relevant_node_changes(
+        diff_summary=diff_summary, source_branch=source_branch, readable_fields_by_kind=readable_fields_by_kind
+    )
+
+    # only_has_unique_targets is True when the query is guaranteed to return results for a
+    # specific set of nodes -- e.g. it uses an `ids` argument or a uniqueness constraint. When
+    # False, the query may return any number of nodes and we cannot map a changed node back to a
+    # specific subscriber without re-processing every target.
+    if query_report.only_has_unique_targets:
+        # The query targets specific nodes by id or unique constraint, so we can look up exactly
+        # which subscribers are linked to the changed nodes and limit processing to only those.
+        subscribers = await _get_subscribers_for_nodes(node_ids=changed_node_ids, branch=source_branch, client=client)
+        ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
+        return ImpactedSubscribers(scope=ImpactScope.SPECIFIC, ids=ids)
+
+    if changed_node_ids:
+        # The query does not guarantee unique targets, so we cannot determine which specific
+        # subscribers are affected. At least one relevant field changed, so the caller must fall
+        # back to processing all targets to be safe.
+        return ImpactedSubscribers(scope=ImpactScope.ALL)
+
+    # No node of a queried kind had any of its queried fields modified, so no subscriber can be
+    # stale regardless of query targeting capability.
+    return ImpactedSubscribers(scope=ImpactScope.NONE)
+
+
 @flow(
     name="artifacts-generation-validation",
     flow_run_name="Validating generation of artifacts for {model.artifact_definition.definition_name}",
@@ -747,66 +845,30 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
 
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
 
-    source_schema_branch = registry.schema.get_schema_branch(name=model.source_branch)
-    source_branch = registry.get_branch_from_registry(branch=model.source_branch)
-
-    graphql_params = await prepare_graphql_params(db=await get_database(), branch=model.source_branch)
-    query_analyzer = InfrahubGraphQLQueryAnalyzer(
-        query=model.artifact_definition.query_payload,
-        branch=source_branch,
-        schema_branch=source_schema_branch,
-        schema=graphql_params.schema,
-        document=cached_parse(model.artifact_definition.query_payload),
+    impacted = await get_field_level_impacted_subscribers(
+        query_payload=model.artifact_definition.query_payload,
+        source_branch=model.source_branch,
+        pipeline_id=model.branch_diff.pipeline_id,
+        subscriber_kind=InfrahubKind.ARTIFACT,
+        client=client,
     )
-
-    # only_has_unique_targets is True when the query is guaranteed to return results
-    # for a specific set of nodes — e.g. it uses an `ids` argument or a uniqueness
-    # constraint. When False, the query may return any number of nodes and we cannot
-    # map a changed node back to a specific artifact without re-running every target.
-    only_has_unique_targets = query_analyzer.query_report.only_has_unique_targets
-
-    # Collect the IDs of nodes whose changes are actually relevant to this query.
-    # A change is relevant only when at least one field that was modified is also
-    # read by the query. This lets us skip regeneration when, for example, only a
-    # `description` field changed but the query only reads `name` and `color`.
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    relevant_node_changes = []
-    for node_diff in diff_summary:
-        if (
-            node_diff["branch"] == model.source_branch
-            and node_diff["kind"] in query_analyzer.query_report.requested_read
-        ):
-            updated_fields = {element["name"] for element in node_diff["elements"]}
-            relevant_fields = set(query_analyzer.query_report.fields_by_kind(node_diff["kind"]))
-            if updated_fields & relevant_fields:
-                relevant_node_changes.append(node_diff["id"])
-
-    if only_has_unique_targets:
-        # The query targets specific nodes by ID or unique constraint, so we can
-        # look up exactly which artifacts are linked to the changed nodes and limit
-        # regeneration to only those artifacts.
-        subscribers = await _get_subscribers_for_nodes(
-            node_ids=relevant_node_changes, branch=model.source_branch, client=client
-        )
-        impacted_artifacts = [
-            subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == InfrahubKind.ARTIFACT
-        ]
-    elif relevant_node_changes:
-        # The query does not guarantee unique targets, so we cannot determine which
-        # specific artifacts are affected. At least one relevant field changed, so we
-        # must fall back to regenerating all artifacts for this definition to be safe.
+    if impacted.scope is ImpactScope.ALL:
+        # The query does not guarantee unique targets but a relevant field changed, so we must
+        # fall back to regenerating all artifacts for this definition to be safe.
         impacted_artifacts = list(artifacts_by_member.values())
         log.warning(
             f"Artifact definition {artifact_definition.name.value} query does not guarantee unique targets. All targets will be processed."
         )
-    else:
-        # No node of a queried kind had any of its queried fields modified, so no
-        # artifact can be stale regardless of query targeting capability.
+    elif impacted.scope is ImpactScope.NONE:
+        # No node of a queried kind had any of its queried fields modified.
         impacted_artifacts = []
         log.info(
             f"Artifact definition {artifact_definition.name.value} has no applicable node changes. Existing artifacts will not be re-rendered."
         )
+    else:
+        impacted_artifacts = impacted.ids
 
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
     repo_diff_for_definition = _repo_diff_or_none(
         branch_diff=model.branch_diff, repository_id=model.artifact_definition.repository_id
     )
@@ -1118,7 +1180,30 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
 
     repository = model.branch_diff.get_repository(repository_id=model.generator_definition.repository_id)
     requested_instances = 0
-    impacted_instances = model.branch_diff.get_subscribers_ids(kind=InfrahubKind.GENERATORINSTANCE)
+
+    impacted = await get_field_level_impacted_subscribers(
+        query_payload=model.generator_definition.query_payload,
+        source_branch=model.source_branch,
+        pipeline_id=model.branch_diff.pipeline_id,
+        subscriber_kind=InfrahubKind.GENERATORINSTANCE,
+        client=client,
+    )
+    definition_name = model.generator_definition.definition_name
+    if impacted.scope is ImpactScope.ALL:
+        # The query does not guarantee unique targets but a relevant field changed, so we cannot
+        # map the change to specific instances and must run every existing instance to be safe.
+        impacted_instances = list(instance_by_member.values())
+        log.warning(
+            f"Generator definition {definition_name} query does not guarantee unique targets. All targets will be processed."
+        )
+    elif impacted.scope is ImpactScope.NONE:
+        # No node of a queried kind had any of its queried fields modified.
+        impacted_instances = []
+        log.info(
+            f"Generator definition {definition_name} has no applicable node changes. Existing instances will not be re-run."
+        )
+    else:
+        impacted_instances = impacted.ids
 
     check_generator_run_models: list[RunGeneratorAsCheckModel] = []
     for relationship in group.members.peers:
@@ -1421,9 +1506,6 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
     diff_summary = await client.get_diff_summary(branch=model.source_branch)
     await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
     branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
-    branch_diff.subscribers.extend(
-        await _get_subscribers_from_diff(diff_summary=diff_summary, branch=model.source_branch, client=client)
-    )
 
     if model.check_type is CheckType.ARTIFACT:
         request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
@@ -1933,13 +2015,3 @@ async def _get_subscribers_for_nodes(
                 ProposedChangeSubscriber(subscriber_id=subscriber["node"]["id"], kind=subscriber["node"]["__typename"])
             )
     return subscribers
-
-
-async def _get_subscribers_from_diff(
-    diff_summary: list[NodeDiff], branch: str, client: InfrahubClient
-) -> list[ProposedChangeSubscriber]:
-    return await _get_subscribers_for_nodes(
-        node_ids=get_modified_node_ids(diff_summary=diff_summary, branch=branch),
-        branch=branch,
-        client=client,
-    )

--- a/backend/tests/component/graphql/test_mutation_generator.py
+++ b/backend/tests/component/graphql/test_mutation_generator.py
@@ -101,6 +101,7 @@ async def test_run_generator_definition(
                             file_path=definition1.file_path.value,
                             query_name=query.name.value,
                             query_models=query.models.value,
+                            query_payload=query.query.value,
                             repository_id=repository.id,
                             parameters=definition1.parameters.value,
                             group_id=group.id,

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -45,7 +45,6 @@ def branch_diff_01() -> ProposedChangeBranchDiff:
     return ProposedChangeBranchDiff(
         pipeline_id=uuid4(),
         repositories=[],
-        subscribers=[],
     )
 
 

--- a/backend/tests/component/proposed_change/conftest.py
+++ b/backend/tests/component/proposed_change/conftest.py
@@ -73,8 +73,13 @@ def make_node_diff(
     branch: str,
     field_names: list[str],
     action: str = "updated",
+    element_type: str = DiffElementType.ATTRIBUTE.value,
 ) -> NodeDiff:
-    """Build a NodeDiff for use in diff summary cache."""
+    """Build a NodeDiff for use in diff summary cache.
+
+    `element_type` accepts the raw diff value (e.g. "RELATIONSHIP_ONE") so tests can reproduce a
+    relationship endpoint flip exactly as the diff summary emits it.
+    """
     return NodeDiff(
         branch=branch,
         action=action,
@@ -84,7 +89,7 @@ def make_node_diff(
         elements=[
             NodeDiffElement(
                 name=field_name,
-                element_type=DiffElementType.ATTRIBUTE.value,
+                element_type=element_type,
                 action="updated",
                 summary=NodeDiffSummary(added=0, updated=1, removed=0),
             )

--- a/backend/tests/component/proposed_change/test_request_generator_definition_check.py
+++ b/backend/tests/component/proposed_change/test_request_generator_definition_check.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub import config
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import BranchContext, InfrahubContext
+from infrahub.core.constants import GeneratorInstanceStatus, InfrahubKind, RepositoryInternalStatus
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
+from infrahub.generators.models import ProposedChangeGeneratorDefinition
+from infrahub.message_bus.types import ProposedChangeBranchDiff, ProposedChangeRepository
+from infrahub.proposed_change.branch_diff import set_diff_summary_cache
+from infrahub.proposed_change.models import RequestGeneratorDefinitionCheck
+from infrahub.proposed_change.tasks import request_generator_definition_check
+from infrahub.server import app
+from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workflows.catalogue import RUN_GENERATOR_AS_CHECK
+from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.schema import load_schema
+from tests.helpers.test_app import TestInfrahubAppBase
+
+from .conftest import QUERY_NON_UNIQUE_TARGETS, QUERY_UNIQUE_TARGETS, make_node_diff
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from fast_depends import Provider
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+    from tests.adapters.cache import MemoryCache
+    from tests.adapters.message_bus import BusSimulator
+    from tests.helpers.test_client import InfrahubTestClient
+
+SOURCE_BRANCH = "feature/generator-test"
+
+# A unique-target query that reads the `tags` relationship in addition to `name`. Used to prove
+# that a relationship endpoint flip on a field the query reads does trigger dispatch, while the
+# same flip on a field the query ignores does not.
+QUERY_UNIQUE_WITH_TAGS = """
+query GetDeviceWithTags($ids: [ID!]!) {
+    TestNetworkDevice(ids: $ids) {
+        edges {
+            node {
+                name { value }
+                tags {
+                    edges { node { name { value } } }
+                }
+            }
+        }
+    }
+}
+"""
+
+GENERATOR_SCHEMA = SchemaRoot(
+    nodes=[
+        NodeSchema(
+            name="NetworkDevice",
+            namespace="Test",
+            default_filter="name__value",
+            display_label="name__value",
+            uniqueness_constraints=[["name__value"]],
+            attributes=[
+                AttributeSchema(name="name", kind="Text", unique=True),
+                AttributeSchema(name="description", kind="Text", optional=True),
+                AttributeSchema(name="color", kind="Text", optional=True),
+            ],
+            relationships=[
+                RelationshipSchema(
+                    name="tags",
+                    peer=InfrahubKind.TAG,
+                    optional=True,
+                    cardinality="many",
+                    kind="Attribute",
+                ),
+            ],
+        )
+    ]
+)
+
+
+@dataclass
+class DiffEntry:
+    id_key: str
+    kind: str
+    fields: list[str]
+    element_type: str = "ATTRIBUTE"
+    literal_id: bool = False
+
+
+@dataclass
+class GeneratorDispatchCase:
+    name: str
+    definition_key: str
+    diff: list[DiffEntry]
+    expected_keys: list[str]
+    source_branch_sync_with_git: bool = False
+    files_changed: list[str] | None = None
+
+
+GENERATOR_DISPATCH_CASES = [
+    GeneratorDispatchCase(
+        name="unique_query_dispatches_only_instances_whose_read_field_changed",
+        definition_key="gendef_unique",
+        diff=[
+            DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["name"]),
+            DiffEntry(id_key="dev2_id", kind="TestNetworkDevice", fields=["description"]),
+            DiffEntry(id_key="dev3_id", kind="TestNetworkDevice", fields=["name"]),
+        ],
+        expected_keys=["dev1_id", "dev3_id"],
+    ),
+    GeneratorDispatchCase(
+        name="unique_query_dispatches_nothing_when_only_unread_field_changed",
+        definition_key="gendef_unique",
+        diff=[
+            DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["description"]),
+            DiffEntry(id_key="dev2_id", kind="TestNetworkDevice", fields=["description"]),
+        ],
+        expected_keys=[],
+    ),
+    GeneratorDispatchCase(
+        name="unique_query_dispatches_nothing_when_changed_kind_not_queried",
+        definition_key="gendef_unique",
+        diff=[
+            DiffEntry(
+                id_key="00000000-0000-0000-0000-000000000000", kind=InfrahubKind.TAG, fields=["name"], literal_id=True
+            )
+        ],
+        expected_keys=[],
+    ),
+    GeneratorDispatchCase(
+        name="non_unique_query_dispatches_all_when_read_field_changed",
+        definition_key="gendef_non_unique",
+        diff=[DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["name"])],
+        expected_keys=["dev1_id", "dev2_id", "dev3_id", "dev4_id"],
+    ),
+    GeneratorDispatchCase(
+        name="non_unique_query_dispatches_nothing_when_no_read_field_changed",
+        definition_key="gendef_non_unique",
+        diff=[DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["description"])],
+        expected_keys=[],
+    ),
+    GeneratorDispatchCase(
+        name="managed_branch_dispatches_all_regardless_of_diff",
+        definition_key="gendef_unique",
+        diff=[DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["description"])],
+        expected_keys=["dev1_id", "dev2_id", "dev3_id", "dev4_id"],
+        source_branch_sync_with_git=True,
+        files_changed=["generators/device.py"],
+    ),
+    GeneratorDispatchCase(
+        name="new_target_without_instance_is_always_dispatched",
+        definition_key="gendef_new",
+        diff=[DiffEntry(id_key="dev_new_id", kind="TestNetworkDevice", fields=["name"])],
+        expected_keys=["dev_new_id"],
+    ),
+    GeneratorDispatchCase(
+        name="flip_on_unread_relationship_dispatches_nothing",
+        definition_key="gendef_unique",
+        diff=[DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["tags"], element_type="RELATIONSHIP_MANY")],
+        expected_keys=[],
+    ),
+    GeneratorDispatchCase(
+        name="flip_on_read_relationship_dispatches_matching_instance",
+        definition_key="gendef_tags",
+        diff=[DiffEntry(id_key="dev1_id", kind="TestNetworkDevice", fields=["tags"], element_type="RELATIONSHIP_MANY")],
+        expected_keys=["dev1_id"],
+    ),
+]
+
+
+class TestRequestGeneratorDefinitionCheck(TestInfrahubAppBase):
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_recorder(
+        self,
+        prefect: Generator[str, None, None],
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[WorkflowRecorder, None]:
+        original = config.OVERRIDE.workflow
+        recorder = WorkflowRecorder()
+        config.OVERRIDE.workflow = recorder
+        with dependency_provider.scope(build_workflow, lambda: recorder):
+            yield recorder
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+    @pytest.fixture(scope="class")
+    async def client(
+        self,
+        test_client: InfrahubTestClient,
+        api_admin_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[InfrahubClient, None]:
+        sdk_config = Config(
+            api_token=api_admin_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
+        )
+        sdk_client = InfrahubClient(config=sdk_config)
+        original_client = service._client
+        service._client = sdk_client
+        with dependency_provider.scope(build_client, lambda: sdk_client):
+            yield sdk_client
+        service._client = original_client
+
+    @pytest.fixture(autouse=True)
+    def clear_recorder(self, workflow_recorder: WorkflowRecorder) -> None:
+        workflow_recorder.execute_calls.clear()
+        workflow_recorder.submit_calls.clear()
+
+    @pytest.fixture(scope="class")
+    async def generator_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+        memory_cache: MemoryCache,
+        admin_account: CoreAccount,
+    ) -> dict[str, Any]:
+        await load_schema(db=db, schema=GENERATOR_SCHEMA, update_db=True)
+
+        # --- Devices on the default branch (inherited by the source branch on fork) ---
+        dev1 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev1.new(db=db, name="dev1", color="red", description="Device 1")
+        await dev1.save(db=db)
+
+        dev2 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev2.new(db=db, name="dev2", color="blue", description="Device 2")
+        await dev2.save(db=db)
+
+        dev3 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev3.new(db=db, name="dev3", color="green", description="Device 3")
+        await dev3.save(db=db)
+
+        dev4 = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev4.new(db=db, name="dev4", color="yellow", description="Device 4")
+        await dev4.save(db=db)
+
+        # A device with no generator instance, used to exercise the "new target" branch.
+        dev_new = await Node.init(db=db, schema="TestNetworkDevice")
+        await dev_new.new(db=db, name="dev-new", color="black", description="New device")
+        await dev_new.save(db=db)
+
+        repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await repo.new(
+            db=db,
+            name="test-generator-repo",
+            location="https://github.com/test/generator-repo.git",
+        )
+        await repo.save(db=db)
+
+        query_unique = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_unique.new(db=db, name="GetNetworkDevice", query=QUERY_UNIQUE_TARGETS)
+        await query_unique.save(db=db)
+
+        query_non_unique = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_non_unique.new(db=db, name="GetAllNetworkDevices", query=QUERY_NON_UNIQUE_TARGETS)
+        await query_non_unique.save(db=db)
+
+        query_tags = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_tags.new(db=db, name="GetDeviceWithTags", query=QUERY_UNIQUE_WITH_TAGS)
+        await query_tags.save(db=db)
+
+        # --- Target group with the four devices that have instances ---
+        targets_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await targets_group.new(db=db, name="generator-targets", members=[dev1, dev2, dev3, dev4])
+        await targets_group.save(db=db)
+
+        gendef_node = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION)
+        await gendef_node.new(
+            db=db,
+            name="device-generator",
+            query=query_unique,
+            repository=repo,
+            targets=targets_group,
+            file_path="generators/device.py",
+            class_name="DeviceGenerator",
+            parameters={"value": {"name": "name__value"}},
+            convert_query_response=False,
+            execute_in_proposed_change=True,
+            execute_after_merge=True,
+        )
+        await gendef_node.save(db=db)
+
+        # --- Separate definition + group for the new-target scenario ---
+        new_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await new_group.new(db=db, name="generator-targets-new", members=[dev_new])
+        await new_group.save(db=db)
+
+        gendef_new_node = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION)
+        await gendef_new_node.new(
+            db=db,
+            name="device-generator-new",
+            query=query_unique,
+            repository=repo,
+            targets=new_group,
+            file_path="generators/device.py",
+            class_name="DeviceGenerator",
+            parameters={"value": {"name": "name__value"}},
+            convert_query_response=False,
+            execute_in_proposed_change=True,
+            execute_after_merge=True,
+        )
+        await gendef_new_node.save(db=db)
+
+        # --- Source branch is created after all AWARE nodes exist on main ---
+        source_branch_obj = await create_branch(branch_name=SOURCE_BRANCH, db=db)
+        await load_schema(db=db, schema=GENERATOR_SCHEMA, branch_name=SOURCE_BRANCH, update_db=False)
+
+        # --- Generator instances on the source branch (one per device in the main group) ---
+        instances = {}
+        for device in (dev1, dev2, dev3, dev4):
+            instance = await Node.init(db=db, schema=InfrahubKind.GENERATORINSTANCE, branch=source_branch_obj)
+            await instance.new(
+                db=db,
+                name=f"instance-{device.name.value}",
+                status=GeneratorInstanceStatus.READY.value,
+                object=device,
+                definition=gendef_node,
+            )
+            await instance.save(db=db)
+            instances[device.id] = instance
+
+        # --- Query groups linking each device (member) to its instance (subscriber) ---
+        for device in (dev1, dev2, dev3, dev4):
+            query_group = await Node.init(db=db, schema="CoreGraphQLQueryGroup", branch=source_branch_obj)
+            await query_group.new(
+                db=db,
+                name=f"qg-{device.name.value}",
+                query=str(query_unique.id),
+                members=[device],
+                subscribers=[instances[device.id]],
+            )
+            await query_group.save(db=db)
+
+        pc = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+        await pc.new(
+            db=db,
+            name="test-generator-pc",
+            source_branch=SOURCE_BRANCH,
+            destination_branch=default_branch.name,
+        )
+        await pc.save(db=db)
+
+        repository = ProposedChangeRepository(
+            repository_id=repo.id,
+            repository_name="test-generator-repo",
+            read_only=False,
+            source_branch=SOURCE_BRANCH,
+            destination_branch=default_branch.name,
+            internal_status=RepositoryInternalStatus.ACTIVE.value,
+            source_commit="source-commit-sha",
+            destination_commit="dest-commit-sha",
+        )
+
+        def build_definition(query_name: str, query_payload: str, group_id: str) -> ProposedChangeGeneratorDefinition:
+            return ProposedChangeGeneratorDefinition(
+                definition_id=gendef_node.id if group_id == targets_group.id else gendef_new_node.id,
+                definition_name="device-generator",
+                query_name=query_name,
+                query_models=["TestNetworkDevice"],
+                query_payload=query_payload,
+                repository_id=repo.id,
+                class_name="DeviceGenerator",
+                file_path="generators/device.py",
+                group_id=group_id,
+                parameters={"name": "name__value"},
+                convert_query_response=False,
+                execute_in_proposed_change=True,
+                execute_after_merge=True,
+            )
+
+        return {
+            "source_branch": SOURCE_BRANCH,
+            "proposed_change_id": pc.id,
+            "dev1_id": dev1.id,
+            "dev2_id": dev2.id,
+            "dev3_id": dev3.id,
+            "dev4_id": dev4.id,
+            "dev_new_id": dev_new.id,
+            "repository": repository,
+            "gendef_unique": build_definition("GetNetworkDevice", QUERY_UNIQUE_TARGETS, targets_group.id),
+            "gendef_non_unique": build_definition("GetAllNetworkDevices", QUERY_NON_UNIQUE_TARGETS, targets_group.id),
+            "gendef_tags": build_definition("GetDeviceWithTags", QUERY_UNIQUE_WITH_TAGS, targets_group.id),
+            "gendef_new": build_definition("GetNetworkDevice", QUERY_UNIQUE_TARGETS, new_group.id),
+        }
+
+    def _make_context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext(
+            branch=BranchContext(name=default_branch.name),
+            account=AccountSession(account_id=account.id, auth_type=AuthType.API),
+        )
+
+    def _make_branch_diff(
+        self,
+        dataset: dict[str, Any],
+        pipeline_id: uuid.UUID,
+        files_changed: list[str] | None = None,
+    ) -> ProposedChangeBranchDiff:
+        repository = dataset["repository"]
+        if files_changed:
+            repository = ProposedChangeRepository(
+                repository_id=repository.repository_id,
+                repository_name=repository.repository_name,
+                read_only=repository.read_only,
+                source_branch=repository.source_branch,
+                destination_branch=repository.destination_branch,
+                internal_status=repository.internal_status,
+                source_commit=repository.source_commit,
+                destination_commit=repository.destination_commit,
+                files_changed=files_changed,
+            )
+        return ProposedChangeBranchDiff(pipeline_id=pipeline_id, repositories=[repository])
+
+    async def _run(
+        self,
+        definition: ProposedChangeGeneratorDefinition,
+        dataset: dict[str, Any],
+        context: InfrahubContext,
+        diff_summary: list[dict],
+        memory_cache: MemoryCache,
+        default_branch: Branch,
+        source_branch_sync_with_git: bool = False,
+        files_changed: list[str] | None = None,
+    ) -> None:
+        pipeline_id = uuid.uuid4()
+        branch_diff = self._make_branch_diff(dataset, pipeline_id, files_changed=files_changed)
+        await set_diff_summary_cache(pipeline_id=pipeline_id, diff_summary=diff_summary, cache=memory_cache)
+        model = RequestGeneratorDefinitionCheck(
+            generator_definition=definition,
+            branch_diff=branch_diff,
+            proposed_change=dataset["proposed_change_id"],
+            source_branch=SOURCE_BRANCH,
+            source_branch_sync_with_git=source_branch_sync_with_git,
+            destination_branch=default_branch.name,
+        )
+        await request_generator_definition_check(model=model, context=context)
+
+    @staticmethod
+    def _dispatched_target_ids(workflow_recorder: WorkflowRecorder) -> set[str]:
+        return {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(RUN_GENERATOR_AS_CHECK)
+        }
+
+    @pytest.mark.parametrize("case", GENERATOR_DISPATCH_CASES, ids=lambda case: case.name)
+    async def test_generator_dispatch(
+        self,
+        case: GeneratorDispatchCase,
+        generator_dataset: dict[str, Any],
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+    ) -> None:
+        context = self._make_context(admin_account, default_branch)
+        diff_summary = [
+            make_node_diff(
+                entry.id_key if entry.literal_id else generator_dataset[entry.id_key],
+                entry.kind,
+                SOURCE_BRANCH,
+                entry.fields,
+                element_type=entry.element_type,
+            )
+            for entry in case.diff
+        ]
+        await self._run(
+            generator_dataset[case.definition_key],
+            generator_dataset,
+            context,
+            diff_summary,
+            memory_cache,
+            default_branch,
+            source_branch_sync_with_git=case.source_branch_sync_with_git,
+            files_changed=case.files_changed,
+        )
+        expected_targets = {generator_dataset[key] for key in case.expected_keys}
+        assert self._dispatched_target_ids(workflow_recorder) == expected_targets

--- a/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
+++ b/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
@@ -21,7 +21,7 @@ from infrahub.message_bus.types import (
 )
 from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestArtifactDefinitionCheck
-from infrahub.proposed_change.tasks import _get_subscribers_from_diff, validate_artifacts_generation
+from infrahub.proposed_change.tasks import validate_artifacts_generation
 from infrahub.server import app
 from infrahub.workers.dependencies import build_client, build_workflow
 from tests.adapters.workflow import WorkflowRecorder
@@ -508,8 +508,6 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         self,
         dataset: dict[str, Any],
         pipeline_id: uuid.UUID,
-        diff_summary: list[dict],
-        client: InfrahubClient,
         files_changed: list[str] | None = None,
     ) -> ProposedChangeBranchDiff:
         repository = dataset["repository"]
@@ -525,11 +523,9 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
                 destination_commit=repository.destination_commit,
                 files_changed=files_changed,
             )
-        subscribers = await _get_subscribers_from_diff(diff_summary=diff_summary, branch=SOURCE_BRANCH, client=client)
         return ProposedChangeBranchDiff(
             pipeline_id=pipeline_id,
             repositories=[repository],
-            subscribers=subscribers,
         )
 
     async def _run(
@@ -566,9 +562,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
             make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full"],
@@ -605,9 +599,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
             make_node_diff(artifact_dataset["dev4_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full"],
@@ -643,9 +635,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
             make_node_diff(artifact_dataset["dev4_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full"],
@@ -685,9 +675,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         diff_summary = [
             make_node_diff(artifact_dataset["dev3_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_partial"],
@@ -723,9 +711,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
             make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
             make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full_non_unique"],
@@ -758,9 +744,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         diff_summary = [
             make_node_diff(artifact_dataset["dev2_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full_non_unique"],
@@ -801,13 +785,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         diff_summary = [
             make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["description"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset,
-            pipeline_id,
-            diff_summary=diff_summary,
-            client=client,
-            files_changed=["templates/device.j2"],
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id, files_changed=["templates/device.j2"])
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full"],
@@ -847,9 +825,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         pipeline_id = uuid.uuid4()
         context = self._make_context(admin_account, default_branch)
         diff_summary: list[dict] = []
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_orphan"],
@@ -885,9 +861,7 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         diff_summary = [
             make_node_diff(artifact_dataset["dev1_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"]),
         ]
-        branch_diff = await self._make_branch_diff(
-            artifact_dataset, pipeline_id, diff_summary=diff_summary, client=client
-        )
+        branch_diff = await self._make_branch_diff(artifact_dataset, pipeline_id)
 
         model = RequestArtifactDefinitionCheck(
             artifact_definition=artifact_dataset["artdef_full"],

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -251,7 +251,7 @@ class TestProposedChange(TestInfrahubApp):
             source_branch_sync_with_git=True,
             destination_branch="main",
             proposed_change=prepare_proposed_change,
-            branch_diff=ProposedChangeBranchDiff(pipeline_id=pipeline_id, repositories=[], subscribers=[]),
+            branch_diff=ProposedChangeBranchDiff(pipeline_id=pipeline_id, repositories=[]),
             refresh_artifacts=True,
             do_repository_checks=True,
         )

--- a/backend/tests/unit/proposed_change/test_tasks.py
+++ b/backend/tests/unit/proposed_change/test_tasks.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from infrahub_sdk.diff import NodeDiff, NodeDiffElement, NodeDiffSummary
+
+from infrahub.proposed_change.tasks import _relevant_node_changes
+
+BRANCH = "feature/test"
+
+
+def _node_diff(
+    node_id: str,
+    kind: str,
+    field_names: list[str],
+    *,
+    branch: str = BRANCH,
+    element_type: str = "ATTRIBUTE",
+) -> NodeDiff:
+    """Build a diff entry with the raw shape the diff summary emits.
+
+    `element_type` accepts the raw value (e.g. "RELATIONSHIP_MANY") so a relationship endpoint
+    flip can be reproduced exactly as it appears in production data.
+    """
+    return NodeDiff(
+        branch=branch,
+        kind=kind,
+        id=node_id,
+        action="updated",
+        display_label="",
+        elements=[
+            NodeDiffElement(
+                name=name,
+                element_type=element_type,
+                action="updated",
+                summary=NodeDiffSummary(added=0, updated=1, removed=0),
+            )
+            for name in field_names
+        ],
+    )
+
+
+@dataclass
+class RelevantChangeCase:
+    name: str
+    diff_summary: list[NodeDiff]
+    readable_fields_by_kind: dict[str, set[str]]
+    expected_ids: set[str]
+    source_branch: str = BRANCH
+
+
+RELEVANT_CHANGE_CASES = [
+    RelevantChangeCase(
+        name="attribute_read_field_changed_is_included",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["name"])],
+        readable_fields_by_kind={"TestDevice": {"name", "color"}},
+        expected_ids={"dev1"},
+    ),
+    RelevantChangeCase(
+        name="attribute_unread_field_changed_is_excluded",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["description"])],
+        readable_fields_by_kind={"TestDevice": {"name", "color"}},
+        expected_ids=set(),
+    ),
+    RelevantChangeCase(
+        name="kind_not_read_is_excluded",
+        diff_summary=[_node_diff("tag1", "BuiltinTag", ["name"])],
+        readable_fields_by_kind={"TestDevice": {"name"}},
+        expected_ids=set(),
+    ),
+    RelevantChangeCase(
+        name="kind_with_no_readable_fields_is_excluded",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["name"])],
+        readable_fields_by_kind={"TestDevice": set()},
+        expected_ids=set(),
+    ),
+    RelevantChangeCase(
+        name="read_relationship_flip_is_included",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["tags"], element_type="RELATIONSHIP_MANY")],
+        readable_fields_by_kind={"TestDevice": {"name", "tags"}},
+        expected_ids={"dev1"},
+    ),
+    RelevantChangeCase(
+        name="unread_relationship_flip_is_excluded",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["tags"], element_type="RELATIONSHIP_MANY")],
+        readable_fields_by_kind={"TestDevice": {"name", "color"}},
+        expected_ids=set(),
+    ),
+    RelevantChangeCase(
+        name="change_on_other_branch_is_excluded",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["name"], branch="some/other-branch")],
+        readable_fields_by_kind={"TestDevice": {"name"}},
+        expected_ids=set(),
+    ),
+    RelevantChangeCase(
+        name="node_with_one_read_and_one_unread_field_is_included",
+        diff_summary=[_node_diff("dev1", "TestDevice", ["description", "name"])],
+        readable_fields_by_kind={"TestDevice": {"name"}},
+        expected_ids={"dev1"},
+    ),
+    RelevantChangeCase(
+        name="mixed_nodes_returns_only_relevant",
+        diff_summary=[
+            _node_diff("dev1", "TestDevice", ["name"]),
+            _node_diff("dev2", "TestDevice", ["description"]),
+            _node_diff("dev3", "TestDevice", ["color"]),
+        ],
+        readable_fields_by_kind={"TestDevice": {"name", "color"}},
+        expected_ids={"dev1", "dev3"},
+    ),
+]
+
+
+@pytest.mark.parametrize("case", RELEVANT_CHANGE_CASES, ids=lambda case: case.name)
+def test_relevant_node_changes(case: RelevantChangeCase) -> None:
+    result = _relevant_node_changes(
+        diff_summary=case.diff_summary,
+        source_branch=case.source_branch,
+        readable_fields_by_kind=case.readable_fields_by_kind,
+    )
+    assert set(result) == case.expected_ids

--- a/changelog/9378.fixed.md
+++ b/changelog/9378.fixed.md
@@ -1,0 +1,1 @@
+Within a proposed change, generator instances are now only re-run when the diff touches a field that the generator's GraphQL query actually reads. Previously a generator was dispatched for every instance sharing a relationship target with a changed node, even when the change touched no field the query depended on.


### PR DESCRIPTION
# Why

Within a proposed change, generator instances were dispatched for every instance sharing a relationship target with a changed node, even when the change touched no field the generator's GraphQL query actually reads. This ports the field-level filter that artifacts already use to the generator path.

A shared helper resolves, from a query payload and the branch diff, which subscribers are impacted: the specific instances whose read fields changed (unique-target queries), all instances (non-unique query with a relevant change), or none. The artifact path is refactored onto the same helper with no change in behaviour.

Removes the now-unused subscriber plumbing whose only consumer was the generator instance check: get_subscribers_ids, _get_subscribers_from_diff, get_modified_node_ids, and the ProposedChangeBranchDiff.subscribers field.

Fixes #9378

Note that while the issue was marked as a bug this is also a new change of behavior that could use some more testing and as such might be better served as a performance improvement for 1.10.

The implementation follows what https://github.com/opsmill/infrahub/pull/8573 did for artifacts along with some improvements with the introduction of the `ImpactedSubscribers` dataclass to make it easier to understand when something should be regenerated as the previous method returned an optional list so `None` or `[]` would mean very different things which wasn't clear in the code, while we had code comments using a dedicated class should make this easier to understand.

## What changed

**Behavioral changes:**
- Generator instances in a proposed change are now only re-run when the diff
  modifies a field (attribute or relationship) that the generator's query
  reads. A relationship endpoint flip on a relationship the query doesn't
  read no longer triggers a run.
- Non-unique-target queries still fall back to running all instances when a
  read field changes (safe over-generation), and git-synced branches with
  file changes still run everything. Both unchanged.

**Implementation notes:**
- New shared helper `get_field_level_impacted_subscribers` resolves, from a
  query payload plus branch diff, an `ImpactedSubscribers` result with scope
  `SPECIFIC` (unique-target queries map to exact instances), `ALL`
  (non-unique query with a relevant change), or `NONE`. Used by both the
  artifact and generator paths.
- The field-matching core is extracted as a pure function
  (`_relevant_node_changes`) and unit-tested without infrastructure.
- `query_payload` added to `ProposedChangeGeneratorDefinition`, populated at
  all construction sites.
- Removed the now-unused subscriber plumbing whose only consumer was the
  generator instance check: `get_subscribers_ids`,
  `_get_subscribers_from_diff`, `get_modified_node_ids`, and the
  `ProposedChangeBranchDiff.subscribers` field.

**What stayed the same:**
- Artifact regeneration behavior is byte-for-byte equivalent to before
  (dispatched set and log lines). The refactor onto the shared helper is
  behavior-preserving, verified against the existing artifact test suite.
- No schema changes; no GraphQL/REST contract changes.

### Suggested review order
1. `get_field_level_impacted_subscribers` plus `_relevant_node_changes` in
   `backend/infrahub/proposed_change/tasks.py` (the core logic).
2. The two callers (`validate_artifacts_generation`,
   `request_generator_definition_check`). Note they map onto the same
   three-scope result.
3. The dead-code removal across `tasks.py`, `branch_diff.py`, `types.py`.
4. Tests.

## How to review

Focus area: the field-level matching and the unique/non-unique branching.
That's where a wrong call would either skip a needed run or over-generate.

Risk to scrutinize: behavior equivalence of the refactored artifact path.
It's guarded by the existing `test_validate_artifacts_generation.py` suite
(unchanged assertions) plus a diff against the original inline logic.

---
## Summary by cubic
Scopes generator instance dispatch to only changes that affect fields read by the generator’s GraphQL query, sharply reducing fan-out in Proposed Changes. Reuses the artifact field-level filter for generators and adds tests. Fixes #9378 and addresses IFC-2657.

- **Bug Fixes**
  - Generators now dispatch only when a queried field changes; unique-target queries run matching instances, non-unique run all only if a relevant field changed.
  - Added `query_payload` to `ProposedChangeGeneratorDefinition` and wired it through `run_generators` and generator mutations.
  - Updated PC pipeline to compute impacted subscribers from the query + diff; added unit and component tests; added changelog.

- **Refactors**
  - Introduced a shared helper to map branch diffs to impacted subscribers; artifacts now use it with no behavior change.
  - Removed unused subscriber plumbing: `ProposedChangeBranchDiff.subscribers`, `get_subscribers_ids`, `_get_subscribers_from_diff`, `get_modified_node_ids`.

<sup>Written for commit fb0a381407d34f1a19139bc7314dabad1acb9141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

