### PR TITLE
add openldap and cyrus_sasl to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,12 @@
             vale
             stdenv.cc.cc.lib
             nodejs_24
+          ] ++ lib.optionals stdenv.isLinux [
+            # bonsai (enterprise extra) has no Linux wheel, so it compiles from
+            # sdist and links libldap + libsasl2. macOS uses a prebuilt wheel
+            # against the system OpenLDAP, so neither is needed there.
+            openldap
+            cyrus_sasl
           ];
 
           shellHook = ''
@@ -30,9 +36,12 @@
             echo "  - lychee (link checker): $(lychee --version)"
             echo "  - vale (prose linter): $(vale --version)"
           '';
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath ([
             pkgs.stdenv.cc.cc.lib
-          ];
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.openldap
+            pkgs.cyrus_sasl
+          ]);
         };
       }
     );


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

The newly added Bonsai dependency (LDAP) does not have any pre build wheels for Linux. To be able to build Bonsai you need libldap2 and libsasl2 installed.


## What changed

- updated flake.nix 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `openldap` and `cyrus_sasl` to the Nix dev shell on Linux and extended `LD_LIBRARY_PATH` so `bonsai` can compile and link against `libldap`/`libsasl2`. This enables building the LDAP extra on Linux where no wheel exists; macOS remains unchanged.

<sup>Written for commit 2ea50a3b92422bcb75ce2adb8cde9cecddfc6f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

