### PR TITLE
ci: scope Claude Code concurrency group to genuine @claude requests

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -10,7 +10,17 @@ name: Claude Code
     types: [submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  # Only genuine "@claude" comments/reviews share a cancellable group (so a newer
+  # request supersedes an older one on the same PR). Every other event — including
+  # Claude's own "Claude Code is working…" status comments and unrelated review
+  # comments — gets a unique group via github.run_id so it cancels nothing. The
+  # concurrency group is evaluated before the job `if:`, so filtering there is not
+  # enough to prevent these incidental events from cancelling a running Claude job.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{
+      (contains(github.event.comment.body, '@claude') || contains(github.event.review.body, '@claude'))
+      && 'claude' || github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

`@claude` invocations on a PR were being cancelled mid-run with:

> Canceling since a higher priority waiting request for `Claude Code-<pr>` exists
> The operation was canceled.

(observed on #9025).

### Root cause

The workflow used a PR-wide concurrency group with `cancel-in-progress: true`:

```yaml
group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
cancel-in-progress: true
```

The concurrency group is evaluated **when a run is queued — before the job `if:`**. So *every* `issue_comment` / `pull_request_review` / `pull_request_review_comment` event on the PR entered the same `Claude Code-<pr>` group and cancelled the running job, including events the `if:` would skip.

The killer: Claude's own **"Claude Code is working…"** status comment fires `issue_comment: created`, queuing a new run (`actor=claude[bot]`) that cancels the very job that posted it. A single review submission (review body + N inline comments fans out to N+1 events) and rapid duplicate comments cause the same cross-cancellation.

Evidence on #9025 — the real `@claude` run `27003010652` was cancelled at 08:02:17, right after bot-comment-triggered runs `27003027326` / `27003150192` (both `actor=claude[bot]`, both skipped) entered the same group.

Filtering bots in the job `if:` does **not** help — cancellation happens before `if:` is evaluated.

## Fix

Scope the concurrency group so only comments/reviews actually containing `@claude` share the cancellable group:

```yaml
group: >-
  ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{
    (contains(github.event.comment.body, '@claude') || contains(github.event.review.body, '@claude'))
    && 'claude' || github.run_id
  }}
cancel-in-progress: true
```

- **Real `@claude` request** → group ends in `-claude` → preserves the intended "newest `@claude` on the PR supersedes the older one" debounce.
- **Everything else** (Claude's status comments, unrelated review comments, the review fan-out) → unique `-<run_id>` group → cancels nothing.

## Notes

- Must land on `stable` to take effect: `issue_comment` events always run the workflow file from the default branch.
- No changelog fragment (internal CI change, not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code jobs being cancelled by unrelated PR events by scoping concurrency to only genuine `@claude` requests. Bot status comments and review fan-out no longer kill active runs while keeping “newest `@claude` wins.”

- **Bug Fixes**
  - Concurrency group now appends `-claude` only when the comment/review body contains `@claude`; otherwise uses a unique `github.run_id`.
  - Preserves cancellable debounce for real `@claude` requests; all other events no longer cancel in-progress runs.

- **Migration**
  - Takes effect after merging to `stable` (workflows for `issue_comment` run from the default branch).

<sup>Written for commit 18bba8841dcd19c527676a9a9b92822ee16f403f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

