### PR TITLE
docs: allow "Agentic" in Vale spellcheck

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -1,4 +1,5 @@
 _updated_at
+Agentic
 Alibaba
 anonymized
 Ansible


### PR DESCRIPTION
## Problem

The `validate-documentation-style` job has been failing on `stable` because Vale's spelling rule flags "Agentic" in `docs/docs/overview/overview.mdx:77` (the "AI and Agentic Operations" link to opsmill.com/solutions/aiops). One error, build fails.

See the failing run: https://github.com/opsmill/infrahub/actions/runs/26994777809/job/79662169207

## Fix

Add `Agentic` to `.vale/styles/spelling-exceptions.txt`. The word is intentional and matches the linked OpsMill solution page; no doc copy change needed.

Local `vale --config=./.vale.ini` across `docs/` now reports 0 errors (was 1), 23 warnings unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow “Agentic” in Vale spellcheck to unblock the `validate-documentation-style` job on `stable`. Adds “Agentic” to `.vale/styles/spelling-exceptions.txt`; no doc content changes.

<sup>Written for commit 638f6bc322c83caf43ab9ede11e23866f508ef92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

