### PR TITLE
fix(graphql): reject `at` query times before branch creation

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from infrahub import config
 from infrahub.auth import AccountSession, authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
+from infrahub.branch.query_time_validator import BranchQueryTimeValidator
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.registry import registry
@@ -83,7 +84,7 @@ async def get_branch_params(
 
     at_ts = Timestamp(at)
     if at is not None:
-        branch.validate_query_time(at_ts)
+        BranchQueryTimeValidator(registry=registry).validate(branch=branch, at=at_ts)
 
     return BranchParams(branch=branch, at=at_ts)
 

--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -81,7 +81,11 @@ async def get_branch_params(
     branch = await registry.get_branch(db=db, branch=branch_name)
     request.state.branch_name = branch.name
 
-    return BranchParams(branch=branch, at=Timestamp(at))
+    at_ts = Timestamp(at)
+    if at is not None:
+        branch.validate_query_time(at_ts)
+
+    return BranchParams(branch=branch, at=at_ts)
 
 
 async def get_branch_dep(

--- a/backend/infrahub/branch/query_time_validator.py
+++ b/backend/infrahub/branch/query_time_validator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.registry import Registry
+
+
+class BranchQueryTimeValidator:
+    def __init__(self, registry: Registry) -> None:
+        self._registry = registry
+
+    def validate(self, branch: Branch, at: Timestamp) -> None:
+        """Validate that `at` falls within the branch's effective lifetime.
+
+        Raises:
+            ValidationError: When `at` is earlier than the branch's effective creation time.
+
+        """
+        if branch.is_default or branch.is_global or branch.origin_branch == branch.name:
+            boundary_branch_name = branch.name
+            boundary_created_at = branch.get_created_at()
+        else:
+            origin = self._registry.get_branch_from_registry(branch=branch.origin_branch)
+            boundary_branch_name = origin.name
+            boundary_created_at = origin.get_created_at()
+
+        if at < Timestamp(boundary_created_at):
+            raise ValidationError(
+                f"Requested time '{at.to_string()}' is before "
+                f"branch '{boundary_branch_name}' was created at '{boundary_created_at}'."
+            )

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -96,6 +96,27 @@ class Branch(StandardNode):
             raise RuntimeError(f"created_at not set for branch {self.name}")
         return self.created_at
 
+    def validate_query_time(self, at: Timestamp) -> None:
+        """Validate that `at` falls within this branch's effective lifetime.
+
+        Raises:
+            ValidationError: When `at` is earlier than the branch's effective creation time.
+
+        """
+        if self.is_default or self.is_global or self.origin_branch == self.name:
+            boundary_branch_name = self.name
+            boundary_created_at = self.get_created_at()
+        else:
+            origin = registry.get_branch_from_registry(branch=self.origin_branch)
+            boundary_branch_name = origin.name
+            boundary_created_at = origin.get_created_at()
+
+        if at < Timestamp(boundary_created_at):
+            raise ValidationError(
+                f"Requested time '{at.to_string()}' is before "
+                f"branch '{boundary_branch_name}' was created at '{boundary_created_at}'."
+            )
+
     @property
     def is_terminal(self) -> bool:
         return self.status in TERMINAL_BRANCH_STATUSES

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -96,27 +96,6 @@ class Branch(StandardNode):
             raise RuntimeError(f"created_at not set for branch {self.name}")
         return self.created_at
 
-    def validate_query_time(self, at: Timestamp) -> None:
-        """Validate that `at` falls within this branch's effective lifetime.
-
-        Raises:
-            ValidationError: When `at` is earlier than the branch's effective creation time.
-
-        """
-        if self.is_default or self.is_global or self.origin_branch == self.name:
-            boundary_branch_name = self.name
-            boundary_created_at = self.get_created_at()
-        else:
-            origin = registry.get_branch_from_registry(branch=self.origin_branch)
-            boundary_branch_name = origin.name
-            boundary_created_at = origin.get_created_at()
-
-        if at < Timestamp(boundary_created_at):
-            raise ValidationError(
-                f"Requested time '{at.to_string()}' is before "
-                f"branch '{boundary_branch_name}' was created at '{boundary_created_at}'."
-            )
-
     @property
     def is_terminal(self) -> bool:
         return self.status in TERMINAL_BRANCH_STATUSES

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -38,7 +38,7 @@ from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_sc
 from infrahub.auth import AccountSession, authentication_token
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError
+from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError, ValidationError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse, execute_graphql_query
 from infrahub.graphql.initialization import GraphqlParams, prepare_graphql_params
@@ -173,7 +173,7 @@ class InfrahubGraphQLApp:
 
         return response
 
-    async def _handle_http_request(
+    async def _handle_http_request(  # noqa: PLR0915
         self, request: Request, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
     ) -> JSONResponse:
         if request.app.state.response_delay:
@@ -216,18 +216,24 @@ class InfrahubGraphQLApp:
         # if the query contains some mutation, it's not currently supported to set AT manually
         if analyzed_query.contains_mutation:
             graphql_params.context.at = Timestamp()
-        elif at and branch.schema_changed_at and Timestamp(branch.schema_changed_at) > Timestamp(at):
-            schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=Timestamp(at))
-            db.add_schema(name=branch.name, schema=schema_branch)
-            analyzed_query = InfrahubGraphQLQueryAnalyzer(
-                query=query,
-                schema_branch=schema_branch,
-                query_variables=variable_values,
-                schema=graphql_params.schema,
-                operation_name=operation_name,
-                branch=branch,
-                document=cached_parse(query),
-            )
+        elif at:
+            at_ts = Timestamp(at)
+            try:
+                branch.validate_query_time(at_ts)
+            except ValidationError as exc:
+                return JSONResponse(exc.api_response(), status_code=exc.HTTP_CODE)
+            if branch.schema_changed_at and Timestamp(branch.schema_changed_at) > at_ts:
+                schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=at_ts)
+                db.add_schema(name=branch.name, schema=schema_branch)
+                analyzed_query = InfrahubGraphQLQueryAnalyzer(
+                    query=query,
+                    schema_branch=schema_branch,
+                    query_variables=variable_values,
+                    schema=graphql_params.schema,
+                    operation_name=operation_name,
+                    branch=branch,
+                    document=cached_parse(query),
+                )
         impacted_models = analyzed_query.query_report.impacted_models
 
         try:

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -36,6 +36,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_scheme
 from infrahub.auth import AccountSession, authentication_token
+from infrahub.branch.query_time_validator import BranchQueryTimeValidator
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError
@@ -218,7 +219,7 @@ class InfrahubGraphQLApp:
             graphql_params.context.at = Timestamp()
         elif at:
             at_ts = Timestamp(at)
-            branch.validate_query_time(at_ts)
+            BranchQueryTimeValidator(registry=registry).validate(branch=branch, at=at_ts)
             if branch.schema_changed_at and Timestamp(branch.schema_changed_at) > at_ts:
                 schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=at_ts)
                 db.add_schema(name=branch.name, schema=schema_branch)

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -38,7 +38,7 @@ from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_sc
 from infrahub.auth import AccountSession, authentication_token
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError, ValidationError
+from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse, execute_graphql_query
 from infrahub.graphql.initialization import GraphqlParams, prepare_graphql_params
@@ -218,10 +218,7 @@ class InfrahubGraphQLApp:
             graphql_params.context.at = Timestamp()
         elif at:
             at_ts = Timestamp(at)
-            try:
-                branch.validate_query_time(at_ts)
-            except ValidationError as exc:
-                return JSONResponse(exc.api_response(), status_code=exc.HTTP_CODE)
+            branch.validate_query_time(at_ts)
             if branch.schema_changed_at and Timestamp(branch.schema_changed_at) > at_ts:
                 schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=at_ts)
                 db.add_schema(name=branch.name, schema=schema_branch)

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -174,7 +174,7 @@ class InfrahubGraphQLApp:
 
         return response
 
-    async def _handle_http_request(  # noqa: PLR0915
+    async def _handle_http_request(
         self, request: Request, db: InfrahubDatabase, branch: Branch, account_session: AccountSession
     ) -> JSONResponse:
         if request.app.state.response_delay:

--- a/backend/tests/component/api/test_10_query.py
+++ b/backend/tests/component/api/test_10_query.py
@@ -9,6 +9,7 @@ from infrahub import config
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.initialization import create_branch
+from infrahub.core.timestamp import Timestamp
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.workflows.catalogue import GRAPHQL_QUERY_GROUP_UPDATE
 
@@ -265,6 +266,33 @@ async def test_query_endpoint_wrong_branch(
         )
 
     assert response.status_code == 400
+
+
+async def test_query_endpoint_at_before_branch_creation(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    create_test_admin: Node,
+    car_person_data: dict[str, Node],
+) -> None:
+    at_before_creation = Timestamp("2000-01-01T00:00:00Z")
+    assert at_before_creation < Timestamp(default_branch.get_created_at()), (
+        "Test precondition: the chosen `at` must be earlier than the branch's created_at"
+    )
+
+    with client:
+        response = client.get(
+            f"/api/query/query01?at={at_before_creation.to_string()}",
+            headers=admin_headers,
+        )
+
+    expected_message = (
+        f"Requested time '{at_before_creation.to_string()}' is before "
+        f"branch '{default_branch.name}' was created at '{default_branch.get_created_at()}'."
+    )
+    assert response.status_code == 422
+    assert response.json()["errors"][0]["message"] == expected_message
 
 
 async def test_query_endpoint_missing_privs(

--- a/backend/tests/component/api/test_20_graphql.py
+++ b/backend/tests/component/api/test_20_graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
@@ -14,6 +15,12 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class AtBeforeCreationCase:
+    name: str
+    query_branch_name: str | None
 
 
 async def test_graphql_endpoint_with_timestamp(
@@ -68,6 +75,72 @@ async def test_graphql_endpoint_with_timestamp(
     names = [result["node"]["name"]["value"] for result in result["TestPerson"]["edges"]]
 
     assert sorted(names) == ["Jane", "John"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(c, id=c.name)
+        for c in [
+            AtBeforeCreationCase(name="default_branch", query_branch_name=None),
+            AtBeforeCreationCase(name="user_branch_origin_main", query_branch_name="user-branch"),
+        ]
+    ],
+)
+async def test_graphql_endpoint_at_before_branch_creation(
+    case: AtBeforeCreationCase,
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    create_test_admin: Node,
+    car_person_data: dict[str, Node],
+) -> None:
+    """Querying with an `at` earlier than the branch's effective lifetime must produce a clear, user-facing error.
+
+    The error always references the floor branch — the default branch itself for default-branch queries, and the
+    origin branch (`main`) for user-branch queries — never the user branch's own `created_at` or `branched_from`.
+    """
+    if case.query_branch_name is not None:
+        user_branch = await create_branch(branch_name=case.query_branch_name, db=db)
+        assert user_branch.get_created_at() != default_branch.get_created_at(), (
+            "Test precondition: the user branch must be created at a distinct time from its origin "
+            "so the boundary lookup picks a different value in each parametrized case"
+        )
+
+    at_before_creation = Timestamp("2000-01-01T00:00:00Z")
+    assert at_before_creation < Timestamp(default_branch.get_created_at()), (
+        "Test precondition: the chosen `at` must be earlier than the (origin) branch's created_at"
+    )
+
+    query = """
+    query {
+        TestPerson {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    url_branch_suffix = f"/{case.query_branch_name}" if case.query_branch_name else ""
+    with client:
+        response = client.post(
+            f"/graphql{url_branch_suffix}?at={at_before_creation.to_string()}",
+            json={"query": query},
+            headers=admin_headers,
+        )
+
+    expected_message = (
+        f"Requested time '{at_before_creation.to_string()}' is before "
+        f"branch '{default_branch.name}' was created at '{default_branch.get_created_at()}'."
+    )
+    assert response.status_code == 422
+    assert response.json()["errors"][0]["message"] == expected_message
 
 
 @pytest.mark.xfail(reason="Need to investigate, Currently working alone but failing when it's part of the test suite")

--- a/backend/tests/component/api/test_20_graphql.py
+++ b/backend/tests/component/api/test_20_graphql.py
@@ -96,10 +96,10 @@ async def test_graphql_endpoint_at_before_branch_creation(
     create_test_admin: Node,
     car_person_data: dict[str, Node],
 ) -> None:
-    """Querying with an `at` earlier than the branch's effective lifetime must produce a clear, user-facing error.
+    """Querying with an `at` earlier than the default branch's creation must produce a clear, user-facing error.
 
-    The error always references the floor branch — the default branch itself for default-branch queries, and the
-    origin branch (`main`) for user-branch queries — never the user branch's own `created_at` or `branched_from`.
+    Since every user branch is currently rooted on the default branch, the error always references the default
+    branch — directly for default-branch queries and indirectly (via the origin) for user-branch queries.
     """
     if case.query_branch_name is not None:
         user_branch = await create_branch(branch_name=case.query_branch_name, db=db)

--- a/changelog/4076.fixed.md
+++ b/changelog/4076.fixed.md
@@ -1,0 +1,1 @@
+Fixed the unclear error message shown when picking a time earlier than the Infrahub instance was created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -723,6 +723,13 @@ allow-dunder-method-names = [
     "PLR0915", # Too many statements
 ]
 
+"backend/infrahub/graphql/app.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
 "backend/infrahub/graphql/manager.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule


### PR DESCRIPTION
## Why

When a user picked a time-travel timestamp earlier than the Infrahub instance was created, the backend silently loaded an empty schema at that time and surfaced a generic, unactionable error (typically a deep schema-lookup failure from a resolver).

This PR makes the backend reject out-of-range `at` values at the request boundary with a clear, user-facing 422 that names the offending timestamp and the branch's effective lifetime.

Closes #4076

## What changed

- Requests with `?at=<time earlier than the branch's effective creation>` now return HTTP 422 with a message like `Requested time '2000-01-01T00:00:00.000000Z' is before branch 'main' was created at '2026-06-05T...'.`.
- On a user branch, the floor is the *origin* branch's `created_at`, not the user branch's own `branched_from`, so legitimate historical-on-origin queries between `origin.created_at` and `self.branched_from` continue to work.
- Mutations are unaffected: the existing override forces `at = now` before the validator can run.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects GraphQL and REST requests where `at` is earlier than the branch’s effective creation time. Returns HTTP 422 with a clear message, fixing #4076 and preventing empty-schema resolver errors.

- **Bug Fixes**
  - Validate `at` at REST and GraphQL request boundaries; on failure, raise `ValidationError` and let the global handler return 422 with the requested time and the boundary branch’s creation time.
  - For user branches, use the origin branch’s `created_at` as the floor; mutations still force `at=now`. Added REST and GraphQL tests and a changelog entry.

- **Refactors**
  - Extracted `BranchQueryTimeValidator` (registry-injected) to encapsulate branch lifetime checks and replace previous branch-level validation.
  - Moved the `PLR0915` ignore for `_handle_http_request` to `pyproject.toml`.

<sup>Written for commit bdd4488de74e6d33f9b62c6db2b9d57f939db6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

