### PR TITLE
prevent adding multiple peers to card-one in RelationshipAdd

### DIFF
--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -99,7 +99,7 @@ class RelationshipAdd(Mutation):
         )
 
         existing_peers = await _collect_current_peers(info=info, data=data, source_node=source)
-        _validate_cardinality_add(rel_schema=rel_schema, existing_peers=existing_peers)
+        _validate_cardinality_add(data=data, rel_schema=rel_schema, existing_peers=existing_peers)
 
         group_event_type = _get_group_event_type(
             node=source, relationship_schema=rel_schema, relationship_name=relationship_name
@@ -490,9 +490,17 @@ async def _collect_current_peers(
     return {str(peer.peer_id): peer for peer in query.get_peers()}
 
 
-def _validate_cardinality_add(rel_schema: RelationshipSchema, existing_peers: dict[str, RelationshipPeerData]) -> None:
-    if rel_schema.cardinality == RelationshipCardinality.ONE and existing_peers:
+def _validate_cardinality_add(
+    data: RelationshipNodesInput, rel_schema: RelationshipSchema, existing_peers: dict[str, RelationshipPeerData]
+) -> None:
+    if rel_schema.cardinality != RelationshipCardinality.ONE:
+        return
+    if existing_peers:
         raise ValidationError(f"'{rel_schema.name}' is a cardinality-one relationship and already has a peer")
+    if len(data.get("nodes")) > 1:
+        raise ValidationError(
+            f"'{rel_schema.name}' is a cardinality-one relationship and cannot be assigned more than one peer"
+        )
 
 
 def _validate_optional_remove(

--- a/backend/tests/component/graphql/test_mutation_relationship.py
+++ b/backend/tests/component/graphql/test_mutation_relationship.py
@@ -1635,6 +1635,47 @@ async def test_relationship_add_cardinality_one_rejected(
     assert primary_tag.id == tag_blue_main.id
 
 
+async def test_relationship_add_cardinality_one_multiple_peers_rejected(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_jack_main: Node,
+    tag_blue_main: Node,
+    tag_red_main: Node,
+) -> None:
+    """RelationshipAdd on an empty cardinality-one relationship with more than one peer in a single request is rejected."""
+    query = """
+    mutation RelationshipAdd($id: String!, $node_id_1: String!, $node_id_2: String!) {
+        RelationshipAdd(data: {
+            id: $id,
+            name: "primary_tag",
+            nodes: [{id: $node_id_1}, {id: $node_id_2}],
+        }) {
+            ok
+        }
+    }
+    """
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person_jack_main.id, "node_id_1": tag_blue_main.id, "node_id_2": tag_red_main.id},
+    )
+    assert result.errors
+    assert (
+        result.errors[0].message
+        == "'primary_tag' is a cardinality-one relationship and cannot be assigned more than one peer"
+    )
+
+    refreshed = await NodeManager.get_one(db=db, id=person_jack_main.id, branch=default_branch)
+    primary_tag = await refreshed.get_relationship("primary_tag").get_peer(db=db)
+    assert primary_tag is None
+
+
 class TestRelationshipRemoveMandatory:
     @pytest.fixture
     async def mandatory_schemas(

--- a/changelog/+cardinality-one-multi-add.fixed.md
+++ b/changelog/+cardinality-one-multi-add.fixed.md
@@ -1,0 +1,1 @@
+`RelationshipAdd` now correctly rejects requests that supply more than one peer for a cardinality-one relationship.


### PR DESCRIPTION
recent changes to the RelationshipAdd mutation allowed submitting multiple relationships to an empty cardinality-one relationship. this PR correctly blocks that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents adding multiple peers to a cardinality-one relationship via `RelationshipAdd`. Requests that try to add more than one peer at once are now rejected.

- **Bug Fixes**
  - Updated `_validate_cardinality_add` to enforce single-peer input for cardinality-one and to reject when a peer already exists.
  - Added test `test_relationship_add_cardinality_one_multiple_peers_rejected`.
  - Added changelog entry.

<sup>Written for commit 2c9fe51053dab9266a99accf46257eaf51923658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

