### PR TITLE
test: disable coverage

### DIFF
--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -89,7 +89,7 @@ def lint(context: Context) -> None:
 def test_component(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run backend component tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub --durations=20 {MAIN_DIRECTORY}/tests/component"
+        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --no-cov --durations=20 {MAIN_DIRECTORY}/tests/component"
         if database == "neo4j":
             exec_cmd += " --neo4j"
         print(f"{exec_cmd}")
@@ -100,7 +100,7 @@ def test_component(context: Context, database: str = INFRAHUB_DATABASE) -> Resul
 def test_unit(context: Context) -> Result | None:
     """Run backend unit tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest --cov=infrahub {MAIN_DIRECTORY}/tests/unit"
+        exec_cmd = f"uv run pytest --no-cov {MAIN_DIRECTORY}/tests/unit"
         print(f"{exec_cmd}")
         return execute_command(context=context, command=f"{exec_cmd}")
 
@@ -109,7 +109,7 @@ def test_unit(context: Context) -> Result | None:
 def test_core(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run backend core component tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/component/core"
+        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --no-cov {MAIN_DIRECTORY}/tests/component/core"
         if database == "neo4j":
             exec_cmd += " --neo4j"
         print(f"{exec_cmd}")
@@ -120,7 +120,7 @@ def test_core(context: Context, database: str = INFRAHUB_DATABASE) -> Result | N
 def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run backend integration tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/integration"
+        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --no-cov {MAIN_DIRECTORY}/tests/integration"
         if database == "neo4j":
             exec_cmd += " --neo4j"
         print(f"{exec_cmd=}")
@@ -131,7 +131,7 @@ def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Res
 def test_functional(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run backend functional tests."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/functional"
+        exec_cmd = f"uv run pytest -n {NBR_WORKERS} -v --no-cov {MAIN_DIRECTORY}/tests/functional"
         if database == "neo4j":
             exec_cmd += " --neo4j"
         print(f"{exec_cmd=}")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled coverage collection for backend tests to speed up runs and reduce overhead.
All `uv` `pytest` commands now use `--no-cov` instead of `--cov=infrahub` across component, core, unit, integration, and functional test tasks.

<sup>Written for commit 8915117d9e5b3e8b02225613896755b637b7dbdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

