### PR TITLE
fix: prevent uv.lock/pyproject.toml clobbering in Dockerfile COPY

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -110,7 +110,9 @@ COPY --from=frontend /docs/build/ /opt/infrahub/docs/build
 #   Copy in only pyproject.toml/uv.lock to help with caching this layer if no updates to dependencies
 # --------------------------------------------
 ENV UV_PROJECT_ENVIRONMENT="/.venv"
-COPY uv.lock pyproject.toml python_sdk/pyproject.toml python_testcontainers/pyproject.toml python_testcontainers/uv.lock /source/
+COPY uv.lock pyproject.toml /source/
+COPY python_sdk/pyproject.toml /source/python_sdk/
+COPY python_testcontainers/pyproject.toml python_testcontainers/uv.lock /source/python_testcontainers/
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-dev --no-install-project --no-install-workspace
 
 # --------------------------------------------


### PR DESCRIPTION
The single multi-source COPY collapsed every source to its basename in /source/, so python_testcontainers' uv.lock and pyproject.toml overwrote the root workspace files. The dependency-cache layer then resolved against the testcontainers project instead of infrahub-server, defeating its purpose. Split into per-destination COPY statements that preserve the directory structure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Dockerfile COPY that collapsed multiple sources into /source/ and overwrote the root uv.lock and pyproject.toml with the `python_testcontainers` versions. Use per-destination COPY to preserve directory structure, so the dependency cache resolves against the `infrahub-server` workspace instead of the testcontainers project.

<sup>Written for commit 738ab6b0d0b87fe3f2d0406e8af57b124a040ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

