### PR TITLE
docs: deploy the observability stack on Kubernetes via Helm

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -26,6 +26,7 @@ bool
 boolean
 booleans
 Buildkite
+cAdvisor
 Ceph
 changelog
 check_color_tags_name
@@ -118,6 +119,7 @@ JSONSchema
 kbps
 Keycloak
 kubectl
+kubelet
 Kubernetes
 linter
 linting
@@ -208,6 +210,7 @@ Slurp'it
 snapshotting
 Streamlit
 string_type
+subchart
 subcommand
 submodule
 subnet

--- a/docs/docs/deploy-manage/install-configure/install/community.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/community.mdx
@@ -305,6 +305,10 @@ kubectl get pods -l app=infrahub
 
 :::
 
+### Observability (optional)
+
+To deploy the observability stack (Grafana, Prometheus, Loki, Tempo, Alloy) on Kubernetes, enable it on this release or install the `infrahub-observability` Helm chart alongside it. See [Observability stack](./observability-stack).
+
 </TabItem>
 </Tabs>
 

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -332,6 +332,10 @@ kubectl get pods -l app=infrahub
 
 :::
 
+### Observability (optional)
+
+To deploy the observability stack (Grafana, Prometheus, Loki, Tempo, Alloy) on Kubernetes, enable it on this release or install the `infrahub-observability` Helm chart alongside it. See [Observability stack](./observability-stack).
+
 </TabItem>
 <TabItem value="Bare metal">
 

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -92,52 +92,13 @@ sudo docker compose -p infrahub down -v
 
 ### Enable observability
 
-To deploy Infrahub with a built-in observability stack (Grafana, Prometheus, Loki, Alloy), add the `?observability=true` query parameter to the URL. This can be combined with existing parameters like `size`:
-
-<Tabs groupId="os" queryString>
-<TabItem value="macOS" default>
+Add the `?observability=true` query parameter when fetching the compose file to also deploy the observability stack (Grafana, Prometheus, Loki, Tempo, Alloy):
 
 ```bash
 curl "https://infrahub.opsmill.io/enterprise?observability=true" > docker-compose.yml
-docker compose -p infrahub up -d
 ```
 
-</TabItem>
-<TabItem value="Linux">
-
-```bash
-curl "https://infrahub.opsmill.io/enterprise?observability=true" > docker-compose.yml
-sudo docker compose -p infrahub up -d
-```
-
-</TabItem>
-</Tabs>
-
-Combined with a sizing preset:
-
-```bash
-curl "https://infrahub.opsmill.io/enterprise?size=small&observability=true" > docker-compose.yml
-```
-
-Once running, Grafana is accessible at [http://localhost:3500](http://localhost:3500) with default credentials `admin` / `admin`.
-
-For instructions on upgrading an existing observability stack, see the [Upgrade guide](../../maintain-upgrade/upgrade/observability-stack).
-
-:::tip Enable request tracing
-
-Infrahub can export OpenTelemetry traces so you can follow a single request as it moves across the API server, task workers, and the database. Traces are sent to the bundled Tempo instance and surfaced in Grafana under the Tempo data source.
-
-To enable it, add the following to a `.env` file alongside the compose file:
-
-```bash
-INFRAHUB_TRACE_ENABLE=true
-INFRAHUB_TRACE_EXPORTER_TYPE=otlp
-INFRAHUB_TRACE_EXPORTER_PROTOCOL=grpc
-INFRAHUB_TRACE_EXPORTER_ENDPOINT=http://infrahub-tempo:4317
-INFRAHUB_TRACE_INSECURE=true
-```
-
-:::
+It combines with other parameters such as `size`. See [Observability stack](./observability-stack) for Grafana access, request tracing, and configuration.
 
 </TabItem>
 <TabItem value="Kubernetes with Helm">

--- a/docs/docs/deploy-manage/install-configure/install/observability-stack.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/observability-stack.mdx
@@ -15,13 +15,48 @@ Infrahub ships an observability stack that runs alongside Infrahub:
 - **Grafana** — dashboards and visualization
 - **Prefect exporter** — task-manager metrics
 
-With Docker Compose the stack is bundled into the deployment (see the [Enterprise install guide](./enterprise)). On Kubernetes it is the `infrahub-observability` Helm chart, which you can deploy either bundled with your Infrahub release or as a standalone release.
-
-The chart wraps the upstream Grafana and Prometheus community charts, and provisions Grafana with pre-built dashboards and data sources for Infrahub, Neo4j, RabbitMQ, and Prefect.
+You can deploy it with **Docker Compose** (Infrahub Enterprise) or on **Kubernetes** with the `infrahub-observability` Helm chart. Grafana comes provisioned with pre-built dashboards and data sources for Infrahub, Neo4j, RabbitMQ, and Prefect.
 
 <ReferenceLink title="infrahub-observability Helm chart" url="https://github.com/opsmill/infrahub-helm/tree/stable/charts/infrahub-observability" openInNewTab />
 
-## Prerequisites
+## Docker Compose
+
+The Infrahub Enterprise Docker Compose deployment can include the observability stack. Add the `?observability=true` query parameter when you fetch the compose file:
+
+```bash
+curl "https://infrahub.opsmill.io/enterprise?observability=true" > docker-compose.yml
+docker compose -p infrahub up -d
+```
+
+It combines with other parameters such as a sizing preset:
+
+```bash
+curl "https://infrahub.opsmill.io/enterprise?size=small&observability=true" > docker-compose.yml
+```
+
+Once running, Grafana is available at [http://localhost:3500](http://localhost:3500) with the default credentials `admin` / `admin`.
+
+:::tip Enable request tracing
+
+Infrahub can export OpenTelemetry traces so you can follow a single request as it moves across the API server, task workers, and the database. Traces are sent to the bundled Tempo instance and surfaced in Grafana under the Tempo data source. To enable it, add the following to a `.env` file alongside the compose file:
+
+```bash
+INFRAHUB_TRACE_ENABLE=true
+INFRAHUB_TRACE_EXPORTER_TYPE=otlp
+INFRAHUB_TRACE_EXPORTER_PROTOCOL=grpc
+INFRAHUB_TRACE_EXPORTER_ENDPOINT=http://infrahub-tempo:4317
+INFRAHUB_TRACE_INSECURE=true
+```
+
+:::
+
+For the full Infrahub Enterprise Compose install, see the [Enterprise install guide](./enterprise).
+
+## Kubernetes with Helm
+
+On Kubernetes the stack is the `infrahub-observability` Helm chart, which wraps the upstream Grafana and Prometheus community charts. Deploy it bundled with your Infrahub release or as a standalone release.
+
+### Prerequisites
 
 - A Kubernetes cluster (version 1.24 or later)
 - [Helm](https://helm.sh/docs/intro/install/) (version 3 or later) installed on your system
@@ -29,11 +64,11 @@ The chart wraps the upstream Grafana and Prometheus community charts, and provis
 
 The stack installs and runs on its own. To collect Infrahub's own metrics and Prefect task data, install it in the same namespace as an Infrahub or Infrahub Enterprise release (or set `global.infrahubReleaseName` when the release name differs). Without a reachable Infrahub, the stack still starts, but the Prefect exporter stays unhealthy and the Infrahub scrape targets report no data.
 
-## Deploy the stack
+### Deploy
 
 Deploy the stack either bundled with your Infrahub release or as its own release.
 
-### Bundled with Infrahub
+#### Bundled with Infrahub
 
 The `infrahub` and `infrahub-enterprise` charts package the observability stack as a subchart, gated by `infrahub-observability.enabled` (default `false`). Enable it in your Infrahub values to deploy the stack as part of the same release and namespace — no separate install.
 
@@ -56,7 +91,7 @@ infrahub:
 
 Apply the change with `helm upgrade` on your Infrahub release. Enabling the bundled stack also turns tracing on automatically: Infrahub emits traces to the bundled Tempo at `<release>-tempo:4317` (where `<release>` is your Infrahub release name) with no further configuration.
 
-### Standalone release
+#### Standalone release
 
 To manage the stack on its own release lifecycle — for example, to add it next to an existing Infrahub release without changing that release — install the chart directly. The `--create-namespace` flag creates the target namespace if it does not already exist; drop it when installing into the namespace where Infrahub already runs:
 
@@ -78,7 +113,7 @@ global:
     insecure: true
 ```
 
-## Services and access
+### Services and access
 
 Every component is exposed through a `ClusterIP` service, reachable only from inside the cluster:
 
@@ -111,7 +146,7 @@ Change the default Grafana credentials before exposing it outside the cluster. S
 
 :::
 
-## Configure the stack
+### Configure the stack
 
 The component values below set the size, retention, and exposure of each part of the stack:
 
@@ -177,7 +212,7 @@ For the complete list of values, see the chart's `values.yaml`.
 
 <ReferenceLink title="infrahub-observability values.yaml" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-observability/values.yaml" openInNewTab />
 
-## Verify the deployment
+### Verify the deployment
 
 Check that the stack's pods are running:
 

--- a/docs/docs/deploy-manage/install-configure/install/observability-stack.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/observability-stack.mdx
@@ -1,0 +1,190 @@
+---
+title: Observability stack
+---
+
+import ReferenceLink from "../../../../src/components/Card";
+
+# Observability stack
+
+Infrahub ships an observability stack that runs alongside Infrahub:
+
+- **Grafana Alloy** — collects logs and metrics
+- **Loki** — log storage
+- **Prometheus** — metric storage
+- **Tempo** — distributed tracing
+- **Grafana** — dashboards and visualization
+- **Prefect exporter** — task-manager metrics
+
+With Docker Compose the stack is bundled into the deployment (see the [Enterprise install guide](./enterprise)). On Kubernetes it is the `infrahub-observability` Helm chart, which you can deploy either bundled with your Infrahub release or as a standalone release.
+
+The chart wraps the upstream Grafana and Prometheus community charts, and provisions Grafana with pre-built dashboards and data sources for Infrahub, Neo4j, RabbitMQ, and Prefect.
+
+<ReferenceLink title="infrahub-observability Helm chart" url="https://github.com/opsmill/infrahub-helm/tree/stable/charts/infrahub-observability" openInNewTab />
+
+## Prerequisites
+
+- A Kubernetes cluster (version 1.24 or later)
+- [Helm](https://helm.sh/docs/intro/install/) (version 3 or later) installed on your system
+- A persistent volume provisioner in the cluster. Loki, Prometheus, Tempo, and Grafana enable persistence by default
+
+The stack installs and runs on its own. To collect Infrahub's own metrics and Prefect task data, install it in the same namespace as an Infrahub or Infrahub Enterprise release (or set `global.infrahubReleaseName` when the release name differs). Without a reachable Infrahub, the stack still starts, but the Prefect exporter stays unhealthy and the Infrahub scrape targets report no data.
+
+## Deploy the stack
+
+Deploy the stack either bundled with your Infrahub release or as its own release.
+
+### Bundled with Infrahub
+
+The `infrahub` and `infrahub-enterprise` charts package the observability stack as a subchart, gated by `infrahub-observability.enabled` (default `false`). Enable it in your Infrahub values to deploy the stack as part of the same release and namespace — no separate install.
+
+For the `infrahub` (Community) chart:
+
+```yaml
+# infrahub values
+infrahub-observability:
+  enabled: true
+```
+
+For the `infrahub-enterprise` chart, nest the key under `infrahub`:
+
+```yaml
+# infrahub-enterprise values
+infrahub:
+  infrahub-observability:
+    enabled: true
+```
+
+Apply the change with `helm upgrade` on your Infrahub release. Enabling the bundled stack also turns tracing on automatically: Infrahub emits traces to the bundled Tempo at `<release>-tempo:4317` (where `<release>` is your Infrahub release name) with no further configuration.
+
+### Standalone release
+
+To manage the stack on its own release lifecycle — for example, to add it next to an existing Infrahub release without changing that release — install the chart directly. The `--create-namespace` flag creates the target namespace if it does not already exist; drop it when installing into the namespace where Infrahub already runs:
+
+```bash
+helm install obs oci://registry.opsmill.io/opsmill/chart/infrahub-observability --version 0.1.0 -n infrahub --create-namespace
+```
+
+The release name (`obs` above) prefixes the service names referenced throughout this guide.
+
+A standalone release does not wire Infrahub's tracing for you. To send traces to its Tempo, set `global.tracing` on the Infrahub release:
+
+```yaml
+# infrahub values
+global:
+  tracing:
+    enabled: true
+    endpoint: "obs-tempo:4317"
+    protocol: grpc
+    insecure: true
+```
+
+## Services and access
+
+Every component is exposed through a `ClusterIP` service, reachable only from inside the cluster:
+
+| Service | Purpose |
+|---------|---------|
+| `<release>-grafana` | Grafana UI |
+| `<release>-loki` | Log storage (Alloy pushes logs here) |
+| `<release>-prometheus-server` | Metric storage (Alloy remote-writes here) |
+| `<release>-tempo` | Trace storage (OTLP receiver on port 4317) |
+| `<release>-prometheus-node-exporter` | Host metrics |
+| `<release>-infrahub-observability-prefect-exporter` | Prefect metrics (scraped by Alloy on port 8000) |
+
+`<release>` is your Infrahub release name when bundled, or the observability release name (`obs` above) when standalone. Run `kubectl get svc -n infrahub` to list the exact service names for your release.
+
+The log, metric, and trace services only need to be reachable from inside the cluster, so keep them as `ClusterIP`. Grafana is the only component intended for people to browse.
+
+To open Grafana, forward its service to your machine (replace `obs` with your Infrahub release name if you bundled the stack):
+
+```bash
+kubectl port-forward svc/obs-grafana 3000:80 -n infrahub
+```
+
+Then browse to [http://localhost:3000](http://localhost:3000) and sign in with the default credentials `admin` / `admin`.
+
+To reach Grafana without port-forwarding, set `grafana.service.type` to `LoadBalancer` or `NodePort`, or enable an ingress with `grafana.ingress.enabled`.
+
+:::warning
+
+Change the default Grafana credentials before exposing it outside the cluster. Set `grafana.admin.existingSecret` to a secret you manage rather than relying on the default `admin` / `admin`.
+
+:::
+
+## Configure the stack
+
+The component values below set the size, retention, and exposure of each part of the stack:
+
+```yaml
+# Turn off components you don't need
+tempo:
+  enabled: false        # disable tracing
+
+# Persistence and retention
+loki:
+  singleBinary:
+    persistence:
+      size: 20Gi
+prometheus:
+  server:
+    retention: 7d
+    persistentVolume:
+      size: 50Gi
+
+# Expose Grafana through an ingress and use a managed admin secret
+grafana:
+  ingress:
+    enabled: true
+  admin:
+    existingSecret: grafana-admin
+```
+
+Where you place these values depends on how you deploy:
+
+- **Standalone** — set them at the top level of the observability `values.yml`.
+- **Bundled** — nest the same blocks under `infrahub-observability:` (or `infrahub.infrahub-observability:` for Enterprise) in your Infrahub values:
+
+```yaml
+# infrahub values (bundled)
+infrahub-observability:
+  tempo:
+    enabled: false
+  grafana:
+    ingress:
+      enabled: true
+```
+
+:::warning global values are shared, not nested
+
+`global.*` values are Helm global values, shared across Infrahub and the bundled subchart, so they always stay at the **top level** of your values — never nest them under `infrahub-observability:`. The same applies to the Infrahub chart's `global.tracing`. When bundled, the stack resolves the Infrahub release name and namespace from the release itself, so `global.infrahubReleaseName` and `global.infrahubNamespace` are only needed for a standalone release that points at a separately named or located Infrahub.
+
+:::
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `<component>.enabled` | `true` | Toggle any of `alloy`, `loki`, `tempo`, `grafana`, `prometheus`, `prometheus-node-exporter`, `prefectExporter` |
+| component persistence `size` | Loki `10Gi`, Tempo `10Gi`, Prometheus `20Gi`, Grafana `5Gi` | Persistent volume size per component |
+| `loki.loki.limits_config.retention_period` | `24h` | Log retention |
+| `tempo.tempo.retention`, `prometheus.server.retention` | `96h` | Trace and metric retention |
+| `grafana.service.type`, `grafana.ingress.enabled` | `ClusterIP`, `false` | How Grafana is exposed |
+| `grafana.adminPassword`, `grafana.admin.existingSecret` | `admin` | Grafana credentials |
+| `alloy.cadvisor.enabled` | `true` | Scrape per-container metrics from the kubelet cAdvisor endpoint. Disable where cluster policy forbids `nodes/proxy` access |
+| `tempo.tempo.metricsGenerator.enabled` | `false` | Generate request metrics from spans. Requires `tempo.tempo.metricsGenerator.remoteWriteUrl` |
+| `prefectExporter.enabled` | `true` | Deploy the Prefect metrics exporter |
+| `global.infrahubReleaseName`, `global.infrahubNamespace` | `infrahub`, release namespace | Standalone only (top-level, never nested): point the release at a separately named or located Infrahub. Auto-resolved when bundled |
+
+For the complete list of values, see the chart's `values.yaml`.
+
+<ReferenceLink title="infrahub-observability values.yaml" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-observability/values.yaml" openInNewTab />
+
+## Verify the deployment
+
+Check that the stack's pods are running:
+
+```bash
+kubectl get pods -n infrahub
+```
+
+You should see an Alloy pod on each node (deployed as a DaemonSet), single-instance Loki, Tempo, Prometheus, and Grafana pods, a node exporter on each node, and the Prefect exporter. The Prefect exporter only becomes healthy once it can reach the Infrahub task manager, so deploy it alongside an Infrahub release. Once Grafana is reachable, open it and confirm that the Infrahub dashboards render and that the Prometheus and Loki data sources connect successfully.
+
+To upgrade the stack later, see [Upgrade the observability stack](../../maintain-upgrade/upgrade/observability-stack).

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/observability-stack.mdx
@@ -4,8 +4,26 @@ title: Upgrade the observability stack
 
 # Upgrade the observability stack
 
+## Docker Compose
+
 When a new compose file changes the embedded observability configuration, services backed by Docker Compose `configs` do not pick up those changes on a regular `up -d`. Use `--force-recreate` on the affected services to reload the embedded configuration content:
 
 ```bash
 docker compose -p infrahub up -d --force-recreate infrahub-alloy infrahub-loki infrahub-tempo infrahub-grafana
 ```
+
+## Kubernetes with Helm
+
+How you upgrade the stack depends on how it was deployed.
+
+If it is **bundled** with your Infrahub release (`infrahub-observability.enabled`), the observability subchart version is pinned by the Infrahub chart, so it upgrades together with Infrahub — upgrade the Infrahub release as usual.
+
+If it is a **standalone** release, upgrade it to a new chart version directly:
+
+```bash
+helm upgrade obs oci://registry.opsmill.io/opsmill/chart/infrahub-observability --version <new-version> -n infrahub
+```
+
+Pass your `values.yml` with `-f` if you customized the deployment. Persistent volumes for Loki, Prometheus, Tempo, and Grafana are retained across upgrades, so dashboards and historical data survive the upgrade.
+
+For how to deploy and configure the stack, see [Observability stack](../../install-configure/install/observability-stack).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -354,6 +354,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 { type: 'doc', id: 'deploy-manage/install-configure/install/community', label: 'Community' },
                 { type: 'doc', id: 'deploy-manage/install-configure/install/enterprise', label: 'Enterprise' },
+                { type: 'doc', id: 'deploy-manage/install-configure/install/observability-stack', label: 'Observability stack' },
               ],
             },
             // Production Deployment hub + HA spoke (PR 3)


### PR DESCRIPTION
## Summary

Documents how to deploy and configure the Infrahub observability stack (Grafana Alloy, Loki, Prometheus, Tempo, Grafana, Prefect exporter) on Kubernetes with the `infrahub-observability` Helm chart. Previously the docs only covered the Docker Compose observability stack — the Kubernetes/Helm path was undocumented.

New page: **Deployment & Management → Install & configure → Installation → Observability stack**.

## What's covered

- **Two deployment paths:**
  - **Bundled** — set `infrahub-observability.enabled: true` on the `infrahub` release (or `infrahub.infrahub-observability.enabled` for `infrahub-enterprise`). The stack deploys as part of the Infrahub release and tracing auto-wires to the bundled Tempo (`<release>-tempo:4317`).
  - **Standalone** — `helm install obs oci://registry.opsmill.io/opsmill/chart/infrahub-observability` alongside an existing release, with manual `global.tracing` wiring.
- The `ClusterIP` services and how to reach Grafana (port-forward by default; `grafana.ingress`/`service.type` to expose).
- Tunable values: component `enabled` toggles, persistence/retention, Grafana exposure + credentials, `alloy.cadvisor.enabled`, `tempo.tempo.metricsGenerator`, `prefectExporter`.
- **Where values go per path**, including that Helm `global` values (and `global.tracing`) stay top-level and must not be nested under `infrahub-observability:`.

Also: cross-links from the Community/Enterprise install guides' Kubernetes tabs, a Helm upgrade path on the observability-stack upgrade page, and `cAdvisor`/`kubelet`/`subchart` added to the Vale spelling exceptions.

## Validation

Both paths were run end-to-end against a local Kubernetes cluster:

- **Standalone** `helm install` (with `--create-namespace`): all components reach Running, Grafana provisions the seven dashboards and the Prometheus/Loki/Tempo data sources, `admin`/`admin` confirmed.
- **Bundled** (`infrahub-observability.enabled=true` on the infrahub chart): the full stack deploys in the release and `infrahub-server` gets `INFRAHUB_TRACE_EXPORTER_ENDPOINT=<release>-tempo:4317` automatically.
- **`helm upgrade`** command verified.
- The `global`-nesting caveat was verified with `helm template`: a nested `infrahub-observability.global.tracing.*` is ignored, while top-level `global.tracing.*` takes effect.

`npm run build` (no broken links), markdownlint, and Vale all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Observability stack page covering deployment on Kubernetes via the `infrahub-observability` Helm chart and via Docker Compose, with clear setup, access, and upgrade steps. Updates install guides to point to this page and clarifies tracing wiring and `global` value placement for bundled vs standalone installs.

- **New Features**
  - New page: Deploy & Manage → Install & configure → Installation → Observability stack. Covers Helm installs (bundled under `infrahub`/`infrahub-enterprise` vs standalone) and Docker Compose (`?observability=true`), Grafana access, and tracing (`bundled` auto-wires to `<release>-tempo:4317`; `standalone` requires top-level `global.tracing`).
  - Guides updated: Community/Enterprise Kubernetes tabs now link to the page; the Enterprise Docker Compose step now points to it; sidebar entry added; spelling exceptions updated (`cAdvisor`, `kubelet`, `subchart`).
  - Access & config: components default to `ClusterIP`; Grafana via port-forward or `grafana.ingress`/`service.type`. Tunables include component toggles, persistence/retention, Grafana credentials/exposure, `alloy.cadvisor`, Tempo metrics generator, and the Prefect exporter. Note: `global.*` values stay top-level (never under `infrahub-observability:`).
  - Upgrades: adds Helm upgrade steps (bundled upgrades with Infrahub; standalone via `helm upgrade`) and Docker Compose guidance (`--force-recreate` for config-backed services).

<sup>Written for commit 56ad4ad7edfa24b20433a6b86aead2078348be3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

