### PR TITLE
docs: document least-privilege credentials for Infrahub backing services

### DIFF
--- a/.vale/styles/Infrahub/sentence-case.yml
+++ b/.vale/styles/Infrahub/sentence-case.yml
@@ -17,6 +17,7 @@ exceptions:
   - Neo4j
   - GraphQL
   - RabbitMQ
+  - PostgreSQL
   - Kubernetes
   - Helm
   - Terraform

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -93,7 +93,7 @@ Test your backup and restore process periodically to ensure it works as expected
 This section is informational and optional. Infrahub works with administrative credentials for its backing services, but it does not require them. The privileges below let you run Infrahub with restricted users if your security policy calls for it.
 :::
 
-Infrahub never administers its backing services: it does not manage users, roles, databases, or server configuration. The privileges it actually uses are the following.
+Infrahub does not manage users, roles, or server configuration. It primarily uses application-level privileges; only optional first-start Neo4j database bootstrap requires `CREATE DATABASE`.
 
 ### Neo4j
 
@@ -155,7 +155,7 @@ The task manager stores its state in PostgreSQL and runs its own schema migratio
 ```sql
 CREATE ROLE prefect WITH LOGIN PASSWORD '<strong-task-manager-db-password>';
 ALTER DATABASE prefect OWNER TO prefect;
-GRANT ALL ON SCHEMA public TO prefect;
+ALTER SCHEMA public OWNER TO prefect;
 ```
 
 Then point the task manager's database connection string at this role instead of a superuser.

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -127,12 +127,16 @@ Replace `neo4j` with the database name you set in `INFRAHUB_DB_DATABASE` if you 
 
 ### Redis
 
-Infrahub uses Redis for caching and distributed locks, so the user needs read and write access to keys, the connection commands used to authenticate, and the scripting commands used by the locks. It does not need administrative or destructive commands. With a Redis ACL file:
+Infrahub uses Redis for caching and distributed locks, and in distributed deployments the task manager also uses it for workflow coordination. The user needs read and write access to keys, the connection commands used to authenticate, the scripting commands used by the locks, and transactions (`MULTI`/`EXEC`) used by the task manager. It does not need administrative or destructive commands. With a Redis ACL file:
 
 ```text title="users.acl"
 user default off
-user infrahub on ><strong-cache-password> ~* resetchannels +@read +@write +@connection +@scripting -@dangerous
+user infrahub on ><strong-cache-password> ~* resetchannels +@read +@write +@connection +@scripting +@transaction -@dangerous
 ```
+
+:::note
+`+@transaction` is only exercised when the task manager is backed by Redis (distributed or high-availability deployments). It is harmless to grant otherwise.
+:::
 
 ### Point Infrahub at the restricted users
 

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -156,6 +156,7 @@ The task manager stores its state in PostgreSQL and runs its own schema migratio
 CREATE ROLE prefect WITH LOGIN PASSWORD '<strong-task-manager-db-password>';
 ALTER DATABASE prefect OWNER TO prefect;
 ALTER SCHEMA public OWNER TO prefect;
+GRANT ALL ON SCHEMA public TO prefect;
 ```
 
 Then point the task manager's database connection string at this role instead of a superuser.

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -87,6 +87,62 @@ Implement regular database backups to prevent data loss in case of hardware fail
 Test your backup and restore process periodically to ensure it works as expected.
 :::
 
+## Least-privilege database and cache credentials
+
+:::note
+This section is informational and optional. Infrahub works with administrative database and cache credentials, but it does not require them. The privileges below let you run Infrahub with restricted users if your security policy calls for it.
+:::
+
+Infrahub never administers its own data stores: it does not manage users, roles, databases, or server configuration. The privileges it actually uses are the following.
+
+### Neo4j
+
+Infrahub reads and writes graph data, declares new labels, relationship types and property names, and manages its own indexes and constraints. The matching privileges are:
+
+- `ACCESS` to the database, plus read (`MATCH`) and `WRITE` on the graph
+- `NAME MANAGEMENT` to declare new labels, relationship types, and property names
+- `INDEX MANAGEMENT` and `CONSTRAINT MANAGEMENT` for the indexes and constraints it maintains
+
+:::info
+Restricting privileges per user requires Neo4j Enterprise (role-based access control). Neo4j Community supports only the built-in `neo4j` user.
+:::
+
+A dedicated role and user, created by an administrator against the `system` database:
+
+```cypher
+CREATE ROLE infrahub IF NOT EXISTS;
+
+GRANT ACCESS ON DATABASE neo4j TO infrahub;
+GRANT MATCH {*} ON GRAPH neo4j TO infrahub;
+GRANT WRITE ON GRAPH neo4j TO infrahub;
+GRANT NAME MANAGEMENT ON DATABASE neo4j TO infrahub;
+GRANT INDEX MANAGEMENT ON DATABASE neo4j TO infrahub;
+GRANT CONSTRAINT MANAGEMENT ON DATABASE neo4j TO infrahub;
+
+CREATE USER infrahub IF NOT EXISTS SET PLAINTEXT PASSWORD '<strong-database-password>' CHANGE NOT REQUIRED;
+GRANT ROLE infrahub TO infrahub;
+```
+
+Replace `neo4j` with the database name you set in `INFRAHUB_DB_DATABASE` if you use a dedicated database. Infrahub creates that database on first start if it does not exist, which requires the `CREATE DATABASE` privilege, so pre-create it as an administrator to keep the application user restricted. If you collect telemetry, also `GRANT SHOW SERVERS ON DBMS` and `GRANT EXECUTE PROCEDURE dbms.queryJmx ON DBMS`, otherwise telemetry logs a harmless permission error.
+
+### Redis
+
+Infrahub uses Redis for caching and distributed locks, so the user needs read and write access to keys, the connection commands used to authenticate, and the scripting commands used by the locks. It does not need administrative or destructive commands. With a Redis ACL file:
+
+```text title="users.acl"
+user default off
+user infrahub on ><strong-cache-password> ~* resetchannels +@read +@write +@connection +@scripting -@dangerous
+```
+
+### Point Infrahub at the restricted users
+
+```shell title=".env"
+INFRAHUB_DB_USERNAME=infrahub
+INFRAHUB_DB_PASSWORD=<strong-database-password>
+INFRAHUB_CACHE_USERNAME=infrahub
+INFRAHUB_CACHE_PASSWORD=<strong-cache-password>
+```
+
 ## Operations and maintenance
 
 ### Upgrading Infrahub

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -87,13 +87,13 @@ Implement regular database backups to prevent data loss in case of hardware fail
 Test your backup and restore process periodically to ensure it works as expected.
 :::
 
-## Least-privilege database and cache credentials
+## Least-privilege service credentials
 
 :::note
-This section is informational and optional. Infrahub works with administrative database and cache credentials, but it does not require them. The privileges below let you run Infrahub with restricted users if your security policy calls for it.
+This section is informational and optional. Infrahub works with administrative credentials for its backing services, but it does not require them. The privileges below let you run Infrahub with restricted users if your security policy calls for it.
 :::
 
-Infrahub never administers its own data stores: it does not manage users, roles, databases, or server configuration. The privileges it actually uses are the following.
+Infrahub never administers its backing services: it does not manage users, roles, databases, or server configuration. The privileges it actually uses are the following.
 
 ### Neo4j
 
@@ -138,6 +138,28 @@ user infrahub on ><strong-cache-password> ~* resetchannels +@read +@write +@conn
 `+@transaction` is only exercised when the task manager is backed by Redis (distributed or high-availability deployments). It is harmless to grant otherwise.
 :::
 
+### RabbitMQ
+
+Infrahub talks to RabbitMQ over AMQP only: it declares its own exchanges and queues and publishes and consumes messages. It does not use the management API, so the user needs `configure`, `write` and `read` on the virtual host but no administrator or management tags.
+
+```shell
+rabbitmqctl add_user infrahub '<strong-broker-password>'
+rabbitmqctl set_permissions -p / infrahub ".*" ".*" ".*"
+# Do not set any user tags: the application does not need management access.
+```
+
+### PostgreSQL
+
+The task manager stores its state in PostgreSQL and runs its own schema migrations, so its role must be able to create and change objects in its own database, but it does not need to be a cluster superuser. Create a non-superuser role that owns its database and schema:
+
+```sql
+CREATE ROLE prefect WITH LOGIN PASSWORD '<strong-task-manager-db-password>';
+ALTER DATABASE prefect OWNER TO prefect;
+GRANT ALL ON SCHEMA public TO prefect;
+```
+
+Then point the task manager's database connection string at this role instead of a superuser.
+
 ### Point Infrahub at the restricted users
 
 ```shell title=".env"
@@ -145,6 +167,8 @@ INFRAHUB_DB_USERNAME=infrahub
 INFRAHUB_DB_PASSWORD=<strong-database-password>
 INFRAHUB_CACHE_USERNAME=infrahub
 INFRAHUB_CACHE_PASSWORD=<strong-cache-password>
+INFRAHUB_BROKER_USERNAME=infrahub
+INFRAHUB_BROKER_PASSWORD=<strong-broker-password>
 ```
 
 ## Operations and maintenance


### PR DESCRIPTION
## Summary

Adds an informational, optional section to the production deployment guide describing the least-privilege credentials Infrahub needs for each of its backing services, so operators can run it without administrative accounts.

The new **Least-privilege service credentials** section in `deploy-manage/install-configure/production-deployment/overview.mdx` covers:

- **Neo4j** — a non-admin role with data read/write, `NAME`/`INDEX`/`CONSTRAINT MANAGEMENT`, and the two telemetry privileges (no DBMS administration). Notes on the `CREATE DATABASE` bootstrap and the optional telemetry grants.
- **Redis** — an ACL user with `+@read +@write +@connection +@scripting +@transaction -@dangerous` (`@scripting` for the distributed lock, `@transaction` for the Redis-backed task manager), `default` disabled.
- **RabbitMQ** — a tagless user with `configure/write/read` on the vhost; Infrahub uses AMQP only, never the management API.
- **PostgreSQL** — a non-superuser role that owns only the task manager's database and schema.

It also adds the `INFRAHUB_BROKER_USERNAME`/`PASSWORD` to the example `.env`, and adds `PostgreSQL` to the Vale sentence-case exceptions.

The section is framed as informational/optional: Infrahub works with admin credentials but does not require them.

## Notes

- Documentation only — no application or compose changes in this repo.
- Companion to the infrahub-private change that runs the e2e stack with these least-privilege credentials.
- Vale and markdownlint pass on the changed doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new "Least-privilege service credentials" section to the production deployment guide so operators can run Infrahub with restricted users for Neo4j, Redis (including `+@transaction` for the Redis-backed task manager), RabbitMQ, and PostgreSQL. Also updates the example .env with `INFRAHUB_BROKER_USERNAME`/`INFRAHUB_BROKER_PASSWORD` and adds "PostgreSQL" to the Vale sentence-case exceptions.

<sup>Written for commit 82df509602afccd075f4511c57a45bdc45b338a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

