### PR TITLE
feat(ui): add Tooltip primitive to @infrahub/ui

### DIFF
--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./card": "./src/components/card/card.tsx",
     "./modal": "./src/components/modal/modal.tsx",
+    "./tooltip": "./src/components/tooltip/tooltip.tsx",
     "./styles.css": "./src/index.css"
   },
   "scripts": {

--- a/frontend/packages/ui/src/components/tooltip/tooltip.stories.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../button/button";
+import { Tooltip } from "./tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+  title: "Components/Tooltip",
+  component: Tooltip,
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {
+    message: "Helpful hint",
+    children: <Button>Hover me</Button>,
+  },
+};

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -27,8 +27,15 @@ const tooltipStyles = tv({
 });
 
 /** Accessible tooltip. Wraps a trigger child and shows `message` on hover/focus. */
-export function Tooltip({ children, message, isOpen, onOpenChange, ...props }: TooltipProps) {
-  if (!message) {
+export function Tooltip({
+  children,
+  message,
+  isOpen,
+  onOpenChange,
+  className,
+  ...props
+}: TooltipProps) {
+  if (message == null) {
     return children;
   }
 
@@ -44,10 +51,10 @@ export function Tooltip({ children, message, isOpen, onOpenChange, ...props }: T
 
       <AriaTooltip
         offset={10}
-        className={composeRenderProps(props.className, (className, renderProps) =>
-          tooltipStyles({ ...renderProps, className }),
-        )}
         {...props}
+        className={composeRenderProps(className, (resolvedClassName, renderProps) =>
+          tooltipStyles({ ...renderProps, className: resolvedClassName }),
+        )}
       >
         <OverlayArrow>
           <svg

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+import {
+  Tooltip as AriaTooltip,
+  type TooltipProps as AriaTooltipProps,
+  composeRenderProps,
+  OverlayArrow,
+  TooltipTrigger,
+} from "react-aria-components";
+import { tv } from "tailwind-variants";
+
+export interface TooltipProps extends Omit<AriaTooltipProps, "children"> {
+  children: ReactNode;
+  message: ReactNode;
+}
+
+const tooltipStyles = tv({
+  base: "group box-border rounded-xl border border-neutral-800 bg-neutral-700 px-2 py-1 font-sans text-white text-xs drop-shadow-lg will-change-transform",
+  variants: {
+    isEntering: {
+      true: "fade-in data-[placement=bottom]:slide-in-from-top-0.5 data-[placement=top]:slide-in-from-bottom-0.5 data-[placement=left]:slide-in-from-right-0.5 data-[placement=right]:slide-in-from-left-0.5 animate-in duration-200 ease-out",
+    },
+    isExiting: {
+      true: "fade-out data-[placement=bottom]:slide-out-to-top-0.5 data-[placement=top]:slide-out-to-bottom-0.5 data-[placement=left]:slide-out-to-right-0.5 data-[placement=right]:slide-out-to-left-0.5 animate-out duration-150 ease-in",
+    },
+  },
+});
+
+/** Accessible tooltip. Wraps a trigger child and shows `message` on hover/focus. */
+export function Tooltip({ children, message, isOpen, onOpenChange, ...props }: TooltipProps) {
+  if (!message) {
+    return children;
+  }
+
+  return (
+    <TooltipTrigger
+      delay={200}
+      closeDelay={300}
+      shouldCloseOnPress={false}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+    >
+      {children}
+
+      <AriaTooltip
+        offset={10}
+        className={composeRenderProps(props.className, (className, renderProps) =>
+          tooltipStyles({ ...renderProps, className }),
+        )}
+        {...props}
+      >
+        <OverlayArrow>
+          <svg
+            width={8}
+            height={8}
+            viewBox="0 0 8 8"
+            className="block fill-neutral-700 stroke-neutral-800 group-data-[placement=bottom]:rotate-180 group-data-[placement=left]:-rotate-90 group-data-[placement=right]:rotate-90"
+          >
+            <path d="M0 0 L4 4 L8 0" />
+          </svg>
+        </OverlayArrow>
+        {message}
+      </AriaTooltip>
+    </TooltipTrigger>
+  );
+}

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from "./components/resizable/resizable";
 export { ScrollArea, type ScrollAreaProps } from "./components/scroll-area/scroll-area";
 export { Spinner, type SpinnerProps } from "./components/spinner/spinner";
+export { Tooltip, type TooltipProps } from "./components/tooltip/tooltip";
 export {
   Tree,
   TreeItem,


### PR DESCRIPTION
## What

Adds a **`Tooltip`** primitive to the `@infrahub/ui` design system — a port of the app's existing react-aria tooltip (`shared/components/aria/tooltip`), converted to the design system's `tailwind-variants` convention.

Tooltip is one of the `shared/components/ui` primitives slated for migration into `@infrahub/ui` per `dev/knowledge/frontend/design-system.md`.

## Scope

- New `Tooltip` component + Storybook story; exported from the barrel and as a `./tooltip` subpath.
- **No call-site migration** — the 39 existing app usages keep the current shared tooltip (identical-looking) until the broader migration. This PR only adds the primitive.

## Why now

It's the base dependency for a follow-up `@infrahub/graph` package (graph-view primitives) whose `GraphControls` needs a tooltip that isn't coupled to the app. Splitting it out keeps that change reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Tooltip` primitive to `@infrahub/ui`, ported to `tailwind-variants`, and fixes falsy message rendering and className composition. No call-site changes; this unblocks `@infrahub/graph`’s `GraphControls`.

- **New Features**
  - `Tooltip` wraps a trigger child and shows a `message` on hover/focus, built on `react-aria-components`.
  - Exported from the index and via `@infrahub/ui/tooltip`.
  - Storybook story added under Components/Tooltip.

- **Bug Fixes**
  - Renders valid falsy `message` values (e.g., 0) with a nullish check.
  - Preserves variant/animation styles by composing `className` correctly.

<sup>Written for commit 4618b0771e41fd69cf71554dfdc6de9eeb7ee171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

