### PR TITLE
ci: upgrade Node.js 20 actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # In order for Chromatic to correctly determine baseline commits, tot access the full Git history graph.
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Chromatic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           submodules: true
       - name: Check for file changes
-        uses: opsmill/paths-filter@v3.0.2
+        uses: dorny/paths-filter@v4.0.1
         id: changes
         with:
           token: ${{ github.token }}
@@ -109,16 +109,16 @@ jobs:
         uses: "actions/checkout@v6"
         with:
           submodules: true
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: frontend/app/pnpm-lock.yaml
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: frontend/app/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Check formatting and linting (Biome)
@@ -142,16 +142,16 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: frontend/app/pnpm-lock.yaml
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: frontend/app/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate OpenAPI types
@@ -185,16 +185,16 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: frontend/app/pnpm-lock.yaml
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: frontend/app/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate GraphQL types
@@ -766,17 +766,17 @@ jobs:
         uses: "actions/checkout@v6"
         with:
           submodules: true
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
           # https://github.com/microsoft/playwright/issues/41000
           node-version: 24.15.0
-          cache: pnpm
-          cache-dependency-path: frontend/app/pnpm-lock.yaml
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: frontend/app/pnpm-lock.yaml
       - name: "Install frontend"
         working-directory: ./frontend/app
         run: pnpm install --frozen-lockfile
@@ -1072,16 +1072,16 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: frontend/app/pnpm-lock.yaml
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: frontend/app/pnpm-lock.yaml
       - name: Set up Python
         id: python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

GitHub is forcing Node.js 20 actions to Node.js 24 starting **2026-06-16** and removing Node 20 from runners on **2026-09-16**. CI was emitting deprecation warnings for two third-party actions still bundled on Node 20. This upgrades both to Node 24 compatible versions.

| File | Action | Before (Node 20) | After (Node 24) |
|------|--------|------------------|-----------------|
| `ci.yml` (5×), `chromatic.yml` (1×) | `pnpm/action-setup` | `@v4` | `@v6` |
| `ci.yml:65` | paths-filter | `opsmill/paths-filter@v3.0.2` | `dorny/paths-filter@v4.0.1` |

## Why this is safe

- **pnpm `v4` → `v6`**: the only input we use (`version: 10`) is unchanged in v6 — drop-in upgrade.
- **paths-filter `v3` → `v4`**: `opsmill/paths-filter` was a zero-diff mirror of `dorny/paths-filter@v3.0.2` (no custom commits), last synced Nov 2024. `dorny/paths-filter@v4.0.0` is **purely** the node24 runtime bump (single PR, no input/behavior changes); both inputs we use (`token`, `filters`) are intact. Switching to upstream removes the unmaintained fork.

## Out of scope

- `bug-agent-*.lock.yml` / `.md` files also reference these actions but are **gh-aw-generated** (SHA-pinned compiled output) — they weren't in the warning logs and must be updated via the gh-aw toolchain, not by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded CI actions to Node.js 24–compatible versions and reordered steps to run `actions/setup-node` before `pnpm/action-setup`, moving pnpm caching to `pnpm/action-setup`. This clears Node 20 deprecation warnings and avoids npm lookup failures on Node 24 runners.

- **Dependencies**
  - `pnpm/action-setup`: `@v4` → `@v6` in `ci.yml` and `chromatic.yml` (input `version: 10` unchanged; caching now via `cache: true` and `cache_dependency_path`)
  - `paths-filter`: `opsmill/paths-filter@v3.0.2` → `dorny/paths-filter@v4.0.1` in `ci.yml` (Node 24 runtime; `token` and `filters` unchanged)

<sup>Written for commit 10ff901fcd995b47e3f8ccf7dcf1f129dc86366c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

