### PR TITLE
test(e2e): upload valid PDFs in file-upload tests

### DIFF
--- a/frontend/app/tests/e2e/objects/file-upload/file-upload-helpers.ts
+++ b/frontend/app/tests/e2e/objects/file-upload/file-upload-helpers.ts
@@ -31,6 +31,42 @@ export async function uploadFile(
 }
 
 /**
+ * Build a valid, minimal single-page PDF document.
+ *
+ * The browser's PDF viewer (PDFium) validates the document structure when a
+ * saved file is previewed in an `<iframe src="data:application/pdf;...">`.
+ * Uploading plain text with a `application/pdf` mime type makes the viewer fail
+ * with "Failed to load PDF document", so PDF tests must use real PDF bytes.
+ */
+export function createMinimalPdfBuffer(text = "Mock PDF content for E2E testing"): Buffer {
+  const escaped = text.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+  const stream = `BT /F1 18 Tf 36 100 Td (${escaped}) Tj ET`;
+
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /Contents 4 0 R >>",
+    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
+  ];
+
+  let body = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(body));
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = Buffer.byteLength(body);
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    xref += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(body + xref + trailer);
+}
+
+/**
  * Common file types for testing
  */
 export const TEST_FILE_TYPES = {

--- a/frontend/app/tests/e2e/objects/file-upload/file-upload.spec.ts
+++ b/frontend/app/tests/e2e/objects/file-upload/file-upload.spec.ts
@@ -3,7 +3,11 @@ import { expect, test } from "@playwright/test";
 import { ACCOUNT_STATE_PATH } from "../../../constants";
 import { generateRandomBranchName } from "../../../utils";
 import { createBranchAPI, deleteBranchAPI } from "../../utils/graphql";
-import { fillCircuitContractFields, uploadFile } from "./file-upload-helpers";
+import {
+  createMinimalPdfBuffer,
+  fillCircuitContractFields,
+  uploadFile,
+} from "./file-upload-helpers";
 
 test.describe("File Upload - InfraCircuitContract", () => {
   test.describe.configure({ mode: "serial" });
@@ -57,7 +61,7 @@ test.describe("File Upload - InfraCircuitContract", () => {
         await uploadFile(page, {
           name: TEST_FILE_NAME,
           mimeType: "application/pdf",
-          content: TEST_FILE_CONTENT,
+          buffer: createMinimalPdfBuffer(TEST_FILE_CONTENT),
         });
 
         // Verify file info card is displayed
@@ -99,7 +103,7 @@ test.describe("File Upload - InfraCircuitContract", () => {
         await uploadFile(page, {
           name: "valid-contract.pdf",
           mimeType: "application/pdf",
-          content: "Valid contract content",
+          buffer: createMinimalPdfBuffer("Valid contract content"),
         });
 
         // Error should be cleared or file should be visible
@@ -118,7 +122,7 @@ test.describe("File Upload - InfraCircuitContract", () => {
         await uploadFile(page, {
           name: initialFileName,
           mimeType: "application/pdf",
-          content: "Initial contract content",
+          buffer: createMinimalPdfBuffer("Initial contract content"),
         });
 
         await fillCircuitContractFields(page, {
@@ -147,7 +151,7 @@ test.describe("File Upload - InfraCircuitContract", () => {
         await uploadFile(page, {
           name: updatedFileName,
           mimeType: "application/pdf",
-          content: "Updated contract content",
+          buffer: createMinimalPdfBuffer("Updated contract content"),
         });
 
         await expect(page.getByText(updatedFileName)).toBeVisible();


### PR DESCRIPTION
## Problem

`file-upload.spec.ts:110 › File Upload - InfraCircuitContract › when logged in as Admin › should update existing file` started failing on `stable` after the Playwright 1.60 upgrade (bundled Chromium bump).

The `should update existing file` test is the only one that re-opens a **saved** file object and clicks edit. That path renders the stored file via `DataViewer`, which for `application/pdf` mounts an `<iframe src="data:application/pdf;base64,…">` (`frontend/app/src/shared/components/data-viewer/data-viewer.tsx`). The fixtures uploaded plain text (e.g. `"Initial contract content"`) tagged as `application/pdf`. The newer bundled Chromium's PDFium viewer now strictly validates the document and renders **"Failed to load PDF document"**, breaking the test.

The other file-upload tests passed because they never re-render a saved PDF (they check the list link, never save, or use json/yaml/txt).

## Fix

- Add `createMinimalPdfBuffer()` to `file-upload-helpers.ts` — builds a valid single-page PDF (correct header, objects, byte-accurate xref offsets, trailer). `uploadFile` already accepts a `buffer`.
- Switch all four PDF uploads in `file-upload.spec.ts` from `content: "<text>"` to `buffer: createMinimalPdfBuffer("<text>")`.

## Verification

- `pdfinfo` parses the generated buffer cleanly (1 page, PDF 1.4, no errors).
- Against the upgraded Chromium locally:
  - `should update existing file` → **passed** (was failing)
  - `should successfully upload a file`, `should validate required file field`, `should handle different file types` → **passed**
- Biome and `tsc --noEmit` clean on both files.

Test-only change; no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix e2e file-upload tests by generating and uploading valid PDFs instead of plain text. Ensures saved PDF previews load correctly in the Chromium PDF viewer after the `@playwright/test` 1.60 upgrade.

- **Bug Fixes**
  - Added `createMinimalPdfBuffer()` to build a valid single-page PDF.
  - Updated PDF uploads in `file-upload.spec.ts` to use `buffer: createMinimalPdfBuffer(...)` instead of plain text.

<sup>Written for commit e5098c436dbee40407d2fac837d17b80c4441d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

