### PR TITLE
docs: add LDAP authentication documentation

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -221,6 +221,7 @@ subqueries
 subschema
 subschemas
 substring
+subtree
 subtyping
 supernet
 template_path
@@ -241,6 +242,7 @@ updated_by
 upsert
 upserting
 Upserting
+URIs
 userinfo
 Userinfo
 username

--- a/docs/docs/deploy-manage/user-management/authentication.mdx
+++ b/docs/docs/deploy-manage/user-management/authentication.mdx
@@ -121,6 +121,7 @@ When a user attempts to access Infrahub, the following authentication flow occur
    :::
 2. Upon successful authentication:
    - For local users: Credentials are verified against the local user store
+   - For LDAP users: Credentials are verified against the directory through a service-account lookup and a credential bind
    - For SSO users: The user is redirected to the identity provider, authenticated there, and returned to Infrahub
 3. A user session is created after successful authentication
 4. For first-time SSO users, a corresponding local user record is automatically created

--- a/docs/docs/deploy-manage/user-management/authentication.mdx
+++ b/docs/docs/deploy-manage/user-management/authentication.mdx
@@ -2,6 +2,7 @@
 title: Authentication
 ---
 import ReferenceLink from "../../../src/components/Card";
+import EnterpriseBadge from "../../../src/components/EnterpriseBadge";
 
 # Authentication
 
@@ -40,6 +41,20 @@ Key characteristics of SSO in Infrahub:
 :::info Recommendation
 Local user store is suitable for testing and development environments. For production use, integrating with an external identity provider via SSO is recommended for better security and user management.
 :::
+
+### LDAP <EnterpriseBadge />
+
+With LDAP authentication, users sign in with the credentials from an existing directory — Active Directory, OpenLDAP, or another RFC 4510-compliant LDAP server. It suits organizations that manage identities in a directory and do not run an OIDC or OAuth2 identity provider.
+
+Key characteristics of LDAP authentication in Infrahub:
+
+- Users authenticate against the directory through a service-account lookup followed by a credential bind
+- Accounts are auto-provisioned on first sign-in, the same as SSO
+- Directory group memberships map to local groups, with support for nested groups
+- LDAPS and STARTTLS encrypt the connection, with configurable certificate validation
+- Available in the Enterprise Edition
+
+<ReferenceLink title="LDAP authentication" url="ldap/overview"/>
 
 ## OAuth 2.0 vs OpenID Connect
 
@@ -100,7 +115,7 @@ Disabling anonymous access is recommended for production environments to ensure 
 
 When a user attempts to access Infrahub, the following authentication flow occurs:
 
-1. The user is presented with available authentication options (local login and configured SSO providers)
+1. The user is presented with available authentication options (local login, LDAP, and configured SSO providers)
    :::info
    Multiple SSO providers can be configured simultaneously. Even with SSO providers enabled, local login remains available for fallback scenarios (such as when an identity provider is unavailable).
    :::

--- a/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
@@ -78,7 +78,7 @@ group_bfs_max_depth = 16
 </TabItem>
 </Tabs>
 
-`group_bfs_max_depth` applies only to the `bfs` strategy. Cycles in the group structure are detected automatically.
+`group_bfs_max_depth` applies only to the `bfs` strategy. Cycles in the group structure are detected automatically. Raise it above the default of 16 only when groups nest deeper than that — common in large Active Directory forests with deeply nested organizational units. The `ad_in_chain` strategy has no depth limit but is available only against Active Directory.
 
 ## Auto-create groups from LDAP
 
@@ -114,6 +114,14 @@ per_server_timeout = 10
 </TabItem>
 </Tabs>
 
+## Tune for large directories
+
+In directories with many entries, keep each sign-in lookup fast and predictable:
+
+- **Scope `user_search_base` (and `group_base_dn`) to the narrowest subtree** that contains the relevant entries, so each search examines fewer objects.
+- **Index the sign-in attribute** (`attribute_username`, such as `sAMAccountName` or `uid`) on the directory side. An attribute that is not indexed forces a full scan on every sign-in.
+- **Account for `per_server_timeout` during failover.** Each unreachable server is given the full timeout before Infrahub moves to the next, so a sign-in attempt can wait up to `per_server_timeout` × the number of unreachable servers. Keep the timeout tight enough that failover stays within an acceptable sign-in latency.
+
 ## Harden the TLS connection
 
 For production, verify the directory's certificate against a trusted authority and set a minimum protocol version.
@@ -148,7 +156,14 @@ tls_minimum_version = "TLSv1.2"
 `tls_insecure` skips certificate validation entirely. Restrict it to test and development environments; never enable it in production.
 :::
 
-To upgrade a plain `ldap://` connection rather than connecting over `ldaps://`, set `tls_starttls = true`.
+### Choose LDAPS or STARTTLS
+
+Both modes give you an encrypted connection; pick one based on the port your directory exposes:
+
+- **LDAPS (implicit TLS)** — connect to `ldaps://` URIs on port 636. TLS is established before any LDAP traffic.
+- **STARTTLS** — connect to plain `ldap://` URIs on port 389 and set `tls_starttls = true` to upgrade the connection in place.
+
+Infrahub rejects contradictory combinations at startup: `tls_starttls` cannot be paired with an `ldaps://` URI, and `tls_insecure` cannot be combined with a `tls_ca_bundle`.
 
 ## Related resources
 

--- a/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
@@ -82,7 +82,7 @@ group_bfs_max_depth = 16
 
 ## Auto-create groups from LDAP
 
-By default, only directory groups that already exist as local groups take effect. Infrahub can instead create local groups on demand from the directory group names a user belongs to, so administrators do not have to mirror every directory group by hand. The feature is opt-in and scoped by a regular-expression filter.
+By default, only directory groups that already exist as local groups take effect. Infrahub can instead create local groups on demand from the directory group names a user belongs to, so administrators do not have to mirror every directory group manually. The feature is opt-in and scoped by a regular-expression filter.
 
 The same mechanism handles SSO claims and LDAP group names. For configuration — the filter syntax, the per-login cap, the `origin` provenance attribute, and the audit events — see [Auto-create groups from identity provider claims](../sso/advanced-sso.mdx#auto-create-groups-from-identity-provider-claims).
 

--- a/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
@@ -20,7 +20,7 @@ With group resolution enabled, Infrahub looks up the groups a user belongs to an
 export INFRAHUB_LDAP_GROUP_ENABLED=true
 export INFRAHUB_LDAP_GROUP_BASE_DN="OU=Groups,DC=corp,DC=example,DC=com"
 
-# Attribute read as the group name and matched against local group names
+# Group-name attribute, matched against local group names
 export INFRAHUB_LDAP_GROUP_NAME_ATTRIBUTE="cn"
 ```
 
@@ -32,7 +32,7 @@ export INFRAHUB_LDAP_GROUP_NAME_ATTRIBUTE="cn"
 group_enabled = true
 group_base_dn = "OU=Groups,DC=corp,DC=example,DC=com"
 
-# Attribute read as the group name and matched against local group names
+# Group-name attribute, matched against local group names
 group_name_attribute = "cn"
 ```
 

--- a/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
@@ -1,0 +1,158 @@
+---
+title: Advanced LDAP configuration
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+
+# Advanced LDAP configuration <EnterpriseBadge />
+
+These options extend a working LDAP setup with directory group resolution, nested-group handling, server failover, and stricter TLS. Configure the connection and user lookup first — see [Configure LDAP authentication](./configure-ldap.mdx).
+
+## Resolve directory groups
+
+With group resolution enabled, Infrahub looks up the groups a user belongs to and grants the permissions of the local groups whose names match. Group names are matched against **existing** local groups: create the matching `CoreAccountGroup`s first, or auto-create them (see [Auto-create groups](#auto-create-groups-from-ldap)).
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_GROUP_ENABLED=true
+export INFRAHUB_LDAP_GROUP_BASE_DN="OU=Groups,DC=corp,DC=example,DC=com"
+
+# Attribute read as the group name and matched against local group names
+export INFRAHUB_LDAP_GROUP_NAME_ATTRIBUTE="cn"
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+group_enabled = true
+group_base_dn = "OU=Groups,DC=corp,DC=example,DC=com"
+
+# Attribute read as the group name and matched against local group names
+group_name_attribute = "cn"
+```
+
+</TabItem>
+</Tabs>
+
+The group lookup filter defaults to `(member={user_dn})`. The `{user_dn}` placeholder is substituted with the user's distinguished name at sign-in time and escaped to prevent filter injection. Override it with `group_filter` for directories that record membership differently.
+
+:::info
+When group resolution is turned off, users sign in successfully but receive no permissions until they are assigned to local groups manually.
+:::
+
+## Nested groups
+
+Directories often nest groups inside other groups. Choose how Infrahub resolves transitive memberships with `group_strategy`:
+
+| Strategy | How it resolves nesting | Use when |
+|----------|-------------------------|----------|
+| `bfs` (default) | Walks group membership level by level | Any LDAP-compatible directory |
+| `ad_in_chain` | Uses Active Directory's transitive-membership search to retrieve all nested groups in one query | Active Directory, where it is the fastest option |
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_GROUP_STRATEGY="ad_in_chain"
+
+# bfs only: how many nesting levels to traverse (minimum 10)
+export INFRAHUB_LDAP_GROUP_BFS_MAX_DEPTH=16
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+group_strategy = "ad_in_chain"
+
+# bfs only: how many nesting levels to traverse (minimum 10)
+group_bfs_max_depth = 16
+```
+
+</TabItem>
+</Tabs>
+
+`group_bfs_max_depth` applies only to the `bfs` strategy. Cycles in the group structure are detected automatically.
+
+## Auto-create groups from LDAP
+
+By default, only directory groups that already exist as local groups take effect. Infrahub can instead create local groups on demand from the directory group names a user belongs to, so administrators do not have to mirror every directory group by hand. The feature is opt-in and scoped by a regular-expression filter.
+
+The same mechanism handles SSO claims and LDAP group names. For configuration — the filter syntax, the per-login cap, the `origin` provenance attribute, and the audit events — see [Auto-create groups from identity provider claims](../sso/advanced-sso.mdx#auto-create-groups-from-identity-provider-claims).
+
+## Multiple servers and failover
+
+List several server URIs to tolerate an unreachable directory. Infrahub tries them in declaration order, falling through to the next when one does not respond within `per_server_timeout`.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_SERVERS="ldaps://dc1.corp.example.com:636,ldaps://dc2.corp.example.com:636"
+
+# Seconds to wait for a server before trying the next
+export INFRAHUB_LDAP_PER_SERVER_TIMEOUT=10
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+servers = ["ldaps://dc1.corp.example.com:636", "ldaps://dc2.corp.example.com:636"]
+
+# Seconds to wait for a server before trying the next
+per_server_timeout = 10
+```
+
+</TabItem>
+</Tabs>
+
+## Harden the TLS connection
+
+For production, verify the directory's certificate against a trusted authority and set a minimum protocol version.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_TLS_ENABLED=true
+
+# Path to a PEM bundle, or the PEM contents directly; checked at startup
+export INFRAHUB_LDAP_TLS_CA_BUNDLE="/etc/infrahub/ldap-ca.pem"
+export INFRAHUB_LDAP_TLS_MINIMUM_VERSION="TLSv1.2"
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+tls_enabled = true
+
+# Path to a PEM bundle, or the PEM contents directly; checked at startup
+tls_ca_bundle = "/etc/infrahub/ldap-ca.pem"
+tls_minimum_version = "TLSv1.2"
+```
+
+</TabItem>
+</Tabs>
+
+:::warning
+`tls_insecure` skips certificate validation entirely. Restrict it to test and development environments; never enable it in production.
+:::
+
+To upgrade a plain `ldap://` connection rather than connecting over `ldaps://`, set `tls_starttls = true`.
+
+## Related resources
+
+- [LDAP authentication overview](./overview.mdx)
+- [Configure LDAP authentication](./configure-ldap.mdx)
+- [LDAP reference](../../../reference/ldap.mdx)
+- [Permissions and roles](../permissions-roles/overview.mdx)

--- a/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
@@ -1,0 +1,193 @@
+---
+title: Configure LDAP authentication
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+import ReferenceLink from "../../../../src/components/Card";
+
+# Configure LDAP authentication <EnterpriseBadge />
+
+This guide walks you through connecting Infrahub to your LDAP directory so users can sign in with their directory credentials.
+
+When complete, users will see an LDAP sign-in button on the login page and authenticate against your directory through a service-account lookup.
+
+## Prerequisites
+
+Before configuring LDAP, you need:
+
+- An Infrahub deployment running the Enterprise Edition. The Community Edition rejects LDAP sign-ins with an enterprise-required error.
+- A directory service account (distinguished name and password) that can search the user subtree.
+- The connection details for your directory: server URIs, the user search base, and the attribute that holds the sign-in name.
+- Administrative access to your Infrahub configuration.
+
+## Steps overview
+
+1. Collect directory information
+2. Configure the connection
+3. Configure the service account and user lookup
+4. Map user attributes
+5. Enable LDAP and restart
+6. Validate the configuration
+
+## Step 1: Collect directory information
+
+Gather the following from your directory administrator:
+
+| Information | Example | Notes |
+|-------------|---------|-------|
+| Server URIs | `ldaps://dc1.corp.example.com:636` | One or more; the `ldap` or `ldaps` scheme is required |
+| Service account DN | `CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com` | Used to look up users before verifying their credentials |
+| Service account password | — | Store as a secret |
+| User search base | `OU=Users,DC=corp,DC=example,DC=com` | Subtree where user entries live |
+| Sign-in name attribute | `sAMAccountName` (AD), `uid` (OpenLDAP) | Defaults to `sAMAccountName` |
+
+## Step 2: Configure the connection
+
+List your directory servers and choose how to encrypt the connection. Use `ldaps://` URIs for implicit TLS, or set `tls_starttls` to upgrade a plain `ldap://` connection.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# Tried in declaration order; list the primary first
+export INFRAHUB_LDAP_SERVERS="ldaps://dc1.corp.example.com:636,ldaps://dc2.corp.example.com:636"
+
+# Encrypt the connection
+export INFRAHUB_LDAP_TLS_ENABLED=true
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+# Tried in declaration order; list the primary first
+servers = ["ldaps://dc1.corp.example.com:636", "ldaps://dc2.corp.example.com:636"]
+
+# Encrypt the connection
+tls_enabled = true
+```
+
+</TabItem>
+</Tabs>
+
+:::warning
+Do not enable `tls_insecure` outside test and development environments — it skips certificate validation and exposes the connection to interception. For private certificate authorities, supply a CA bundle instead (see [Advanced LDAP configuration](./advanced-ldap.mdx#harden-the-tls-connection)).
+:::
+
+## Step 3: Configure the service account and user lookup
+
+Infrahub binds with the service account, searches the user subtree for the sign-in name, then re-binds as the located user to verify the password.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_SERVICE_ACCOUNT_DN="CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com"
+export INFRAHUB_LDAP_SERVICE_ACCOUNT_PASSWORD="service-account-password"
+export INFRAHUB_LDAP_USER_SEARCH_BASE="OU=Users,DC=corp,DC=example,DC=com"
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+service_account_dn = "CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com"
+service_account_password = "service-account-password"
+user_search_base = "OU=Users,DC=corp,DC=example,DC=com"
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+By default the user search filter is generated from the sign-in name attribute, so it stays aligned when you change `attribute_username`. To override it, set `user_search_filter`; the `{username}` placeholder is substituted at sign-in time and escaped to prevent filter injection.
+:::
+
+## Step 4: Map user attributes
+
+Map directory attributes to the Infrahub account fields. The defaults match Active Directory; adjust them for other directories.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+# sAMAccountName on AD, uid on OpenLDAP
+export INFRAHUB_LDAP_ATTRIBUTE_USERNAME="sAMAccountName"
+export INFRAHUB_LDAP_ATTRIBUTE_DISPLAY_NAME="displayName"
+
+# Skip the disabled-account check on directories without an equivalent attribute by leaving this empty
+export INFRAHUB_LDAP_ATTRIBUTE_DISABLED="userAccountControl"
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+# sAMAccountName on AD, uid on OpenLDAP
+attribute_username = "sAMAccountName"
+attribute_display_name = "displayName"
+
+# Skip the disabled-account check on directories without an equivalent attribute by leaving this empty
+attribute_disabled = "userAccountControl"
+```
+
+</TabItem>
+</Tabs>
+
+## Step 5: Enable LDAP and restart
+
+Set `enabled` to turn LDAP sign-in on, then restart the Infrahub server to apply the configuration.
+
+<Tabs groupId="config-method" queryString>
+<TabItem value="environment-variables" default>
+
+```bash
+export INFRAHUB_LDAP_ENABLED=true
+```
+
+</TabItem>
+<TabItem value="infrahub-toml">
+
+```toml
+[ldap]
+enabled = true
+```
+
+</TabItem>
+</Tabs>
+
+<ReferenceLink title="Configure Infrahub" url="../../install-configure/configure-infrahub" openInNewTab />
+
+## Step 6: Validate the configuration
+
+1. Navigate to your Infrahub login page.
+2. Look for the LDAP sign-in button next to the local login form. Its text comes from `display_label` (default `Sign in with LDAP`).
+3. Sign in with a set of directory credentials.
+4. Confirm a local account was created for the user under `Admin` > `Users and Permissions` > `Accounts`.
+
+:::success
+When correctly configured, directory users sign in with their existing credentials and an Infrahub account is provisioned on their first sign-in.
+:::
+
+## Troubleshooting
+
+Every LDAP sign-in attempt is recorded in the Infrahub server logs. Review them for the error returned by the directory.
+
+| Symptom | Possible cause | Solution |
+|---------|----------------|----------|
+| No LDAP button on the login page | `enabled` is false, or the deployment is running the Community Edition | Set `INFRAHUB_LDAP_ENABLED=true` and confirm the deployment is running the Enterprise Edition |
+| Sign-in returns `403 ENTERPRISE_REQUIRED` | The deployment is running the Community Edition | Run the Enterprise Edition (see [Community vs enterprise](../../../overview/community-vs-enterprise.mdx)) |
+| Sign-in fails with `401` | Wrong credentials, or the user is not found by the search base and filter | Verify the service account, `user_search_base`, and `attribute_username` |
+| Sign-in returns `409 LDAP_ACCOUNT_COLLISION` | The directory sign-in name matches an existing local-only account | Reconcile or rename the local account before the user signs in via LDAP |
+| Sign-in returns `502` | Every configured server was unreachable, or the TLS handshake failed | Check the server URIs and that the servers are reachable, and the TLS settings and CA bundle |
+
+## Related resources
+
+- [LDAP authentication overview](./overview.mdx)
+- [Advanced LDAP configuration](./advanced-ldap.mdx)
+- [LDAP reference](../../../reference/ldap.mdx)
+- [Authentication](../authentication.mdx)

--- a/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
@@ -118,7 +118,7 @@ Map directory attributes to the Infrahub account fields. The defaults match Acti
 export INFRAHUB_LDAP_ATTRIBUTE_USERNAME="sAMAccountName"
 export INFRAHUB_LDAP_ATTRIBUTE_DISPLAY_NAME="displayName"
 
-# Skip the disabled-account check on directories without an equivalent attribute by leaving this empty
+# AD's disabled-account flag; leave empty on directories without an equivalent attribute to skip the check
 export INFRAHUB_LDAP_ATTRIBUTE_DISABLED="userAccountControl"
 ```
 
@@ -131,7 +131,7 @@ export INFRAHUB_LDAP_ATTRIBUTE_DISABLED="userAccountControl"
 attribute_username = "sAMAccountName"
 attribute_display_name = "displayName"
 
-# Skip the disabled-account check on directories without an equivalent attribute by leaving this empty
+# AD's disabled-account flag; leave empty on directories without an equivalent attribute to skip the check
 attribute_disabled = "userAccountControl"
 ```
 

--- a/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
@@ -8,7 +8,7 @@ import ReferenceLink from "../../../../src/components/Card";
 
 # Configure LDAP authentication <EnterpriseBadge />
 
-This guide walks you through connecting Infrahub to your LDAP directory so users can sign in with their directory credentials.
+This guide explains how to connect Infrahub to your LDAP directory so users can sign in with their directory credentials.
 
 When complete, users will see an LDAP sign-in button on the login page and authenticate against your directory through a service-account lookup.
 

--- a/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/configure-ldap.mdx
@@ -17,7 +17,7 @@ When complete, users will see an LDAP sign-in button on the login page and authe
 Before configuring LDAP, you need:
 
 - An Infrahub deployment running the Enterprise Edition. The Community Edition rejects LDAP sign-ins with an enterprise-required error.
-- A directory service account (distinguished name and password) that can search the user subtree.
+- A directory service account (distinguished name and password) with **read-only** access to search the user subtree — and the group subtree, if you enable group resolution. It never needs write permissions; grant it the least privilege required.
 - The connection details for your directory: server URIs, the user search base, and the attribute that holds the sign-in name.
 - Administrative access to your Infrahub configuration.
 
@@ -37,14 +37,14 @@ Gather the following from your directory administrator:
 | Information | Example | Notes |
 |-------------|---------|-------|
 | Server URIs | `ldaps://dc1.corp.example.com:636` | One or more; the `ldap` or `ldaps` scheme is required |
-| Service account DN | `CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com` | Used to look up users before verifying their credentials |
+| Service account DN | `CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com` | Read-only access is sufficient; used to look up users before verifying their credentials |
 | Service account password | — | Store as a secret |
 | User search base | `OU=Users,DC=corp,DC=example,DC=com` | Subtree where user entries live |
 | Sign-in name attribute | `sAMAccountName` (AD), `uid` (OpenLDAP) | Defaults to `sAMAccountName` |
 
 ## Step 2: Configure the connection
 
-List your directory servers and choose how to encrypt the connection. Use `ldaps://` URIs for implicit TLS, or set `tls_starttls` to upgrade a plain `ldap://` connection.
+List your directory servers and choose how to encrypt the connection. Use `ldaps://` URIs (port 636) for implicit TLS, or keep plain `ldap://` URIs (port 389) and set `tls_starttls` to upgrade the connection with STARTTLS. Pick one — combining `tls_starttls` with an `ldaps://` URI is rejected at startup. For production certificate verification, see [Harden the TLS connection](./advanced-ldap.mdx#harden-the-tls-connection).
 
 <Tabs groupId="config-method" queryString>
 <TabItem value="environment-variables" default>
@@ -162,6 +162,10 @@ enabled = true
 
 <ReferenceLink title="Configure Infrahub" url="../../install-configure/configure-infrahub" openInNewTab />
 
+:::info Configuration is validated at startup
+With `enabled = true`, Infrahub refuses to start until `servers`, `service_account_dn`, `service_account_password`, and `user_search_base` are set — plus `group_base_dn` when group resolution is on. A missing or contradictory setting fails fast at startup with a message naming the problem, rather than surfacing later at sign-in.
+:::
+
 ## Step 6: Validate the configuration
 
 1. Navigate to your Infrahub login page.
@@ -184,6 +188,19 @@ Every LDAP sign-in attempt is recorded in the Infrahub server logs. Review them 
 | Sign-in fails with `401` | Wrong credentials, or the user is not found by the search base and filter | Verify the service account, `user_search_base`, and `attribute_username` |
 | Sign-in returns `409 LDAP_ACCOUNT_COLLISION` | The directory sign-in name matches an existing local-only account | Reconcile or rename the local account before the user signs in via LDAP |
 | Sign-in returns `502` | Every configured server was unreachable, or the TLS handshake failed | Check the server URIs and that the servers are reachable, and the TLS settings and CA bundle |
+
+### Check the directory independently
+
+When a sign-in fails, reproduce the service-account lookup directly against the directory with `ldapsearch`. This separates a directory-side problem (credentials, search base, filter) from an Infrahub one:
+
+```bash
+ldapsearch -H ldaps://dc1.corp.example.com:636 \
+  -D "CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com" -W \
+  -b "OU=Users,DC=corp,DC=example,DC=com" \
+  "(sAMAccountName=jdoe)"
+```
+
+A successful bind that returns the expected user entry confirms the service-account credentials, `user_search_base`, and sign-in attribute are correct — which narrows the problem to Infrahub's configuration. Add `-ZZ` to test STARTTLS on a plain `ldap://` connection.
 
 ## Related resources
 

--- a/docs/docs/deploy-manage/user-management/ldap/overview.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/overview.mdx
@@ -48,6 +48,14 @@ On each LDAP sign-in, Infrahub:
 
 Multiple directory servers can be configured for high availability, and connections can be encrypted with LDAPS or STARTTLS.
 
+## Account lifecycle
+
+Infrahub resolves identity and group membership on every sign-in rather than syncing the directory in the background. Plan for a few consequences:
+
+- **Provisioning is lazy.** A local account is created the first time a directory user signs in, not when they are added to the directory.
+- **Permission changes apply at the next sign-in.** Because groups resolve on each sign-in, a directory group change takes effect the next time the user authenticates — not immediately. Removing a user from a directory group does not revoke an already-active Infrahub session.
+- **Removal blocks future sign-ins but does not delete the account.** When a user is removed or disabled in the directory, their next sign-in fails — the service-account lookup no longer finds them, or the disabled-account check rejects the bind. Infrahub does not delete the local account or end active sessions on its own. To revoke access ahead of the directory change, disable or remove the local account under `Admin` > `Users and Permissions` > `Accounts`.
+
 ## Supported directories
 
 The implementation works against any RFC 4510-compliant LDAP server. The attribute defaults are tuned for Active Directory (`sAMAccountName` for the sign-in name, `userAccountControl` for disabled-account detection), and every attribute is configurable for directories such as OpenLDAP that use different conventions (`uid`, `posixGroup`).

--- a/docs/docs/deploy-manage/user-management/ldap/overview.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/overview.mdx
@@ -16,19 +16,25 @@ LDAP authentication is available exclusively in the Enterprise Edition. The Comm
 
 ## When to use LDAP
 
-Infrahub already supports single sign-on through OIDC and OAuth2. OIDC remains the recommended path when an identity provider is available, because it standardizes identity information and supports modern security features such as PKCE.
+Use LDAP authentication when your directory is the system of record for identity and you want Infrahub access to follow it directly:
 
-LDAP authentication covers the case where deploying an identity provider is not practical:
+- Infrahub access tracks the Active Directory or LDAP groups you already maintain — group membership in the directory maps to permissions in Infrahub.
+- There is no separate set of Infrahub credentials to provision, rotate, or revoke. Joiner, mover, and leaver changes flow through your existing directory processes.
+- Users sign in with the directory credentials they already have, with no parallel local accounts to keep in step.
 
-- Identities and group memberships live in Active Directory or another LDAP directory.
-- No OIDC or OAuth2 identity provider is deployed, and doing so is constrained by organizational, budget, or timeline factors.
-- Users should authenticate against the directory directly, without maintaining a parallel set of local Infrahub accounts.
+Infrahub also supports single sign-on through OIDC and OAuth2. OIDC remains the recommended path when an identity provider is available, because it standardizes identity information and supports modern security features such as PKCE. LDAP is the direct-to-directory option for organizations that run a directory but no OIDC or OAuth2 identity provider.
 
 ## How LDAP fits with other authentication methods
 
 LDAP runs alongside local accounts and SSO — all configured methods stay active at the same time. When LDAP is enabled, the login page shows an LDAP sign-in button next to the local login form and any SSO buttons.
 
 A successful LDAP sign-in produces the same session as a local or SSO login, so downstream behavior — tokens, permissions, and the activity log — is identical regardless of how the user authenticated.
+
+| Method | Choose when | Credentials live in |
+|--------|-------------|---------------------|
+| Local accounts | No central directory, small teams, or break-glass access kept for when the directory or identity provider is unreachable | Infrahub |
+| LDAP | A directory (Active Directory, OpenLDAP) is your source of truth for identity and you do not run an identity provider | Your directory |
+| SSO (OIDC / OAuth2) | You run an identity provider and want federation and features such as MFA and PKCE | Your identity provider |
 
 ## How authentication works
 

--- a/docs/docs/deploy-manage/user-management/ldap/overview.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: LDAP authentication
+---
+import EnterpriseBadge from "../../../../src/components/EnterpriseBadge";
+import ReferenceLink from "../../../../src/components/Card";
+
+# LDAP authentication <EnterpriseBadge />
+
+With LDAP authentication, users sign in to Infrahub with the credentials from your existing directory — Active Directory, OpenLDAP, or any RFC 4510-compliant LDAP server. Use it when your organization manages identities in a central directory and does not run an OIDC or OAuth2 identity provider.
+
+:::info Enterprise Edition
+
+LDAP authentication is available exclusively in the Enterprise Edition. The Community Edition includes the configuration model but rejects LDAP sign-ins with an enterprise-required error. See [Community vs enterprise](../../../overview/community-vs-enterprise.mdx) for details.
+
+:::
+
+## When to use LDAP
+
+Infrahub already supports single sign-on through OIDC and OAuth2. OIDC remains the recommended path when an identity provider is available, because it standardizes identity information and supports modern security features such as PKCE.
+
+LDAP authentication covers the case where deploying an identity provider is not practical:
+
+- Identities and group memberships live in Active Directory or another LDAP directory.
+- No OIDC or OAuth2 identity provider is deployed, and standing one up is constrained by organizational, budget, or timeline factors.
+- Users should authenticate against the directory directly, without maintaining a parallel set of local Infrahub accounts.
+
+## How LDAP fits with other authentication methods
+
+LDAP runs alongside local accounts and SSO — all configured methods stay active at the same time. When LDAP is enabled, the login page shows an LDAP sign-in button next to the local login form and any SSO buttons.
+
+A successful LDAP sign-in produces the same session as a local or SSO login, so downstream behavior — tokens, permissions, and the activity log — is identical regardless of how the user authenticated.
+
+## How authentication works
+
+On each LDAP sign-in, Infrahub:
+
+1. Binds to the directory with a configured service account and searches the user subtree for the entry matching the sign-in name.
+2. Re-binds as the located user with the supplied password to verify the credentials.
+3. Creates a local account on first sign-in (auto-provisioning), mapping directory attributes to the account's name and display label.
+4. Resolves the user's directory groups and maps them to local groups by name, when group resolution is enabled.
+5. Issues a session.
+
+Multiple directory servers can be configured for high availability, and connections can be encrypted with LDAPS or STARTTLS.
+
+## Supported directories
+
+The implementation works against any RFC 4510-compliant LDAP server. The attribute defaults are tuned for Active Directory (`sAMAccountName` for the sign-in name, `userAccountControl` for disabled-account detection), and every attribute is configurable for directories such as OpenLDAP that use different conventions (`uid`, `posixGroup`).
+
+## LDAP guides
+
+- [Configure LDAP authentication](./configure-ldap.mdx) — connect Infrahub to your directory and validate sign-in
+- [Advanced LDAP configuration](./advanced-ldap.mdx) — group resolution, nested groups, failover, and TLS hardening
+
+## Related resources
+
+- [Authentication](../authentication.mdx)
+- [Single sign-on (SSO)](../sso/overview.mdx)
+- [LDAP reference](../../../reference/ldap.mdx)
+- [Permissions and roles](../permissions-roles/overview.mdx)

--- a/docs/docs/deploy-manage/user-management/ldap/overview.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/overview.mdx
@@ -21,7 +21,7 @@ Infrahub already supports single sign-on through OIDC and OAuth2. OIDC remains t
 LDAP authentication covers the case where deploying an identity provider is not practical:
 
 - Identities and group memberships live in Active Directory or another LDAP directory.
-- No OIDC or OAuth2 identity provider is deployed, and standing one up is constrained by organizational, budget, or timeline factors.
+- No OIDC or OAuth2 identity provider is deployed, and doing so is constrained by organizational, budget, or timeline factors.
 - Users should authenticate against the directory directly, without maintaining a parallel set of local Infrahub accounts.
 
 ## How LDAP fits with other authentication methods

--- a/docs/docs/overview/community-vs-enterprise.mdx
+++ b/docs/docs/overview/community-vs-enterprise.mdx
@@ -192,6 +192,7 @@ Community Edition provides all the essential security features needed for most o
 
 #### Enterprise edition additions
 
+- **LDAP authentication**: Authenticate users against an LDAP directory such as Active Directory or OpenLDAP, with directory group resolution and nested-group support
 - **Advanced authorization**: Sophisticated workflow-based approval processes
 - **Change management**: Capability to require approvals for changes
 - **Log forwarding**: Export audit events and application logs to external SIEM systems via syslog

--- a/docs/docs/reference/ldap.mdx
+++ b/docs/docs/reference/ldap.mdx
@@ -59,6 +59,10 @@ All options live under the top-level `ldap` configuration group. Each maps to an
 | Insecure | `INFRAHUB_LDAP_TLS_INSECURE` | `ldap.tls_insecure` | Skip TLS certificate validation. Test and development only; never enable in production. | `false` |
 | Minimum TLS version | `INFRAHUB_LDAP_TLS_MINIMUM_VERSION` | `ldap.tls_minimum_version` | Minimum TLS protocol version accepted: `TLSv1.2` or `TLSv1.3`. | `TLSv1.2` |
 
+:::note
+`tls_starttls` and an `ldaps://` server URI are mutually exclusive, as are `tls_insecure` and `tls_ca_bundle`. Either combination is rejected when the server starts.
+:::
+
 ## Login button
 
 | Parameter | Environment Variable | TOML Path | Description | Default |

--- a/docs/docs/reference/ldap.mdx
+++ b/docs/docs/reference/ldap.mdx
@@ -1,0 +1,112 @@
+---
+title: LDAP
+---
+
+This reference document describes the configuration options for LDAP authentication in Infrahub.
+
+:::info Enterprise Edition
+
+LDAP authentication is available exclusively in the Enterprise Edition. The Community Edition includes the configuration model but rejects LDAP sign-ins with an enterprise-required error. See [Community vs enterprise](../overview/community-vs-enterprise.mdx) for details.
+
+:::
+
+All options live under the top-level `ldap` configuration group. Each maps to an environment variable prefixed with `INFRAHUB_LDAP_` and to a key under the `[ldap]` table in `infrahub.toml`.
+
+## Connection
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| Enabled | `INFRAHUB_LDAP_ENABLED` | `ldap.enabled` | Enable LDAP sign-in on this deployment. When off, new LDAP sign-ins are refused; existing sessions are unaffected. | `false` |
+| Servers | `INFRAHUB_LDAP_SERVERS` | `ldap.servers` | LDAP server URIs, tried in declaration order. Must use the `ldap` or `ldaps` scheme. As an environment variable, comma-separated. | none |
+| Per-server timeout | `INFRAHUB_LDAP_PER_SERVER_TIMEOUT` | `ldap.per_server_timeout` | Seconds to wait for a server to respond before treating it as unreachable and trying the next. | `10.0` |
+
+## Service account and user lookup
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| Service account DN | `INFRAHUB_LDAP_SERVICE_ACCOUNT_DN` | `ldap.service_account_dn` | Distinguished name of the directory account used to look up users before verifying their credentials. | none |
+| Service account password | `INFRAHUB_LDAP_SERVICE_ACCOUNT_PASSWORD` | `ldap.service_account_password` | Password for the service account used during the user lookup. | none |
+| User search base | `INFRAHUB_LDAP_USER_SEARCH_BASE` | `ldap.user_search_base` | Distinguished name of the subtree where user entries are stored, e.g. `OU=Users,DC=corp,DC=example,DC=com`. | none |
+| User search filter | `INFRAHUB_LDAP_USER_SEARCH_FILTER` | `ldap.user_search_filter` | Filter used to locate a user by sign-in name. The `{username}` placeholder is substituted at sign-in time and escaped. If empty, a default is generated from `attribute_username`. | generated |
+
+## User attribute mapping
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| Username attribute | `INFRAHUB_LDAP_ATTRIBUTE_USERNAME` | `ldap.attribute_username` | Attribute that holds a user's sign-in name. `sAMAccountName` is typical on Active Directory; `uid` is typical on OpenLDAP. | `sAMAccountName` |
+| Display name attribute | `INFRAHUB_LDAP_ATTRIBUTE_DISPLAY_NAME` | `ldap.attribute_display_name` | Attribute that holds a user's human-readable display name. | `displayName` |
+| Disabled attribute | `INFRAHUB_LDAP_ATTRIBUTE_DISABLED` | `ldap.attribute_disabled` | Attribute signaling whether an account is disabled. Leave empty to skip the disabled-account check. | `userAccountControl` |
+| Disabled bitmask | `INFRAHUB_LDAP_ATTRIBUTE_DISABLED_BITMASK` | `ldap.attribute_disabled_bitmask` | When `attribute_disabled` is set, its integer value is treated as a bitmask; the account is disabled if any of these bits are set. `0x2` matches Active Directory's standard disabled flag. | `2` |
+
+## Group resolution
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| Group resolution enabled | `INFRAHUB_LDAP_GROUP_ENABLED` | `ldap.group_enabled` | Resolve directory group memberships and map them to local groups. Requires `group_base_dn`. | `false` |
+| Group base DN | `INFRAHUB_LDAP_GROUP_BASE_DN` | `ldap.group_base_dn` | Distinguished name of the subtree where group entries are stored. Required when `group_enabled` is true. | none |
+| Group filter | `INFRAHUB_LDAP_GROUP_FILTER` | `ldap.group_filter` | Filter used to look up a user's groups. The `{user_dn}` placeholder is substituted with the user's distinguished name at sign-in time and escaped. | `(member={user_dn})` |
+| Group name attribute | `INFRAHUB_LDAP_GROUP_NAME_ATTRIBUTE` | `ldap.group_name_attribute` | Attribute read as the group's name and matched against local group names to grant permissions. | `cn` |
+| Group strategy | `INFRAHUB_LDAP_GROUP_STRATEGY` | `ldap.group_strategy` | How nested-group memberships are resolved: `bfs` (any directory) or `ad_in_chain` (Active Directory transitive-membership search). | `bfs` |
+| Group BFS max depth | `INFRAHUB_LDAP_GROUP_BFS_MAX_DEPTH` | `ldap.group_bfs_max_depth` | Maximum nesting levels traversed when `group_strategy` is `bfs`. Cycles are detected automatically. Minimum 10. | `16` |
+
+## TLS
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| TLS enabled | `INFRAHUB_LDAP_TLS_ENABLED` | `ldap.tls_enabled` | Encrypt the connection. Pair with `ldaps://` URIs, or set `tls_starttls`. | `false` |
+| STARTTLS | `INFRAHUB_LDAP_TLS_STARTTLS` | `ldap.tls_starttls` | Upgrade a plain `ldap://` connection to TLS using STARTTLS instead of connecting via `ldaps://`. | `false` |
+| CA bundle | `INFRAHUB_LDAP_TLS_CA_BUNDLE` | `ldap.tls_ca_bundle` | PEM-encoded CA bundle used to verify the server's certificate. A file path or the PEM contents directly. Checked at startup. | none |
+| Insecure | `INFRAHUB_LDAP_TLS_INSECURE` | `ldap.tls_insecure` | Skip TLS certificate validation. Test and development only; never enable in production. | `false` |
+| Minimum TLS version | `INFRAHUB_LDAP_TLS_MINIMUM_VERSION` | `ldap.tls_minimum_version` | Minimum TLS protocol version accepted: `TLSv1.2` or `TLSv1.3`. | `TLSv1.2` |
+
+## Login button
+
+| Parameter | Environment Variable | TOML Path | Description | Default |
+|-----------|---------------------|-----------|-------------|---------|
+| Display label | `INFRAHUB_LDAP_DISPLAY_LABEL` | `ldap.display_label` | Text shown on the LDAP sign-in button on the login page. | `Sign in with LDAP` |
+| Icon | `INFRAHUB_LDAP_ICON` | `ldap.icon` | Material Design icon name shown on the LDAP sign-in button. | `mdi:account-key-outline` |
+
+## Examples
+
+### Active Directory
+
+```toml
+[ldap]
+enabled = true
+servers = ["ldaps://dc1.corp.example.com:636", "ldaps://dc2.corp.example.com:636"]
+tls_enabled = true
+
+service_account_dn = "CN=infrahub-svc,OU=Service,DC=corp,DC=example,DC=com"
+service_account_password = "service-account-password"
+user_search_base = "OU=Users,DC=corp,DC=example,DC=com"
+
+group_enabled = true
+group_base_dn = "OU=Groups,DC=corp,DC=example,DC=com"
+group_strategy = "ad_in_chain"
+```
+
+### OpenLDAP
+
+```toml
+[ldap]
+enabled = true
+servers = ["ldaps://ldap.example.com:636"]
+tls_enabled = true
+
+service_account_dn = "cn=infrahub,ou=services,dc=example,dc=com"
+service_account_password = "service-account-password"
+user_search_base = "ou=people,dc=example,dc=com"
+attribute_username = "uid"
+attribute_disabled = ""
+
+group_enabled = true
+group_base_dn = "ou=groups,dc=example,dc=com"
+group_strategy = "bfs"
+```
+
+## Related resources
+
+- [LDAP authentication](../deploy-manage/user-management/ldap/overview)
+- [Configure LDAP authentication](../deploy-manage/user-management/ldap/configure-ldap)
+- [Authentication](../deploy-manage/user-management/authentication)
+- [SSO reference](./sso)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -448,6 +448,16 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'deploy-manage/user-management/sso/advanced-sso', label: 'Advanced SSO configuration' },
               ],
             },
+            // LDAP hub + spokes
+            {
+              type: 'category',
+              label: 'LDAP',
+              link: { type: 'doc', id: 'deploy-manage/user-management/ldap/overview' },
+              items: [
+                { type: 'doc', id: 'deploy-manage/user-management/ldap/configure-ldap', label: 'Configure LDAP authentication' },
+                { type: 'doc', id: 'deploy-manage/user-management/ldap/advanced-ldap', label: 'Advanced LDAP configuration' },
+              ],
+            },
             // Permissions & Roles hub + spoke (PR 13)
             {
               type: 'category',
@@ -582,6 +592,7 @@ const sidebars: SidebarsConfig = {
           link: { type: 'generated-index' },
           items: [
             { type: 'doc', id: 'reference/sso', label: 'SSO Reference' },
+            { type: 'doc', id: 'reference/ldap', label: 'LDAP Reference' },
           ],
         },
         { type: 'doc', id: 'reference/message-bus-events', label: 'Message Bus Events' },


### PR DESCRIPTION
## Summary

Document **LDAP authentication** (INFP-105), shipping as an Enterprise Edition feature in 1.10. Adds a hub + spokes sub-section under Deployment & Management → User Management & Security, mirroring the existing SSO structure, plus a configuration reference and a Community-vs-Enterprise entry.

## Content changes

**New pages**

- `deploy-manage/user-management/ldap/overview.mdx` — hub: what LDAP authentication is, when to use it, how it fits with local and SSO, the sign-in flow, supported directories
- `deploy-manage/user-management/ldap/configure-ldap.mdx` — how-to: connection, service-account bind, user search, attribute mapping, enable and validate, troubleshooting
- `deploy-manage/user-management/ldap/advanced-ldap.mdx` — group resolution, nested groups, auto-create cross-link, multi-server failover, TLS hardening
- `reference/ldap.mdx` — grouped `INFRAHUB_LDAP_*` / `[ldap]` parameter tables plus Active Directory and OpenLDAP examples

**Modified**

- `deploy-manage/user-management/authentication.mdx` — LDAP subsection in the auth-methods list and auth-flow mention
- `overview/community-vs-enterprise.mdx` — LDAP added to the Enterprise edition authentication additions
- `sidebars.ts` — LDAP hub+spokes category and LDAP reference entry
- `.vale/styles/spelling-exceptions.txt` — added `subtree` and `URIs` (precedent: APIs/UUIDs/VLANs)

## What needs reviewer attention

All prose is new — this is a net-new feature, not a docs-revamp migration. Facts are sourced from `backend/infrahub/config.py` (`LDAPSettings`), `backend/infrahub/api/ldap.py`, `backend/infrahub/ldap_auth/service.py`, and JPD INFP-105.

- **`ldap/overview.mdx`** — conceptual framing and the sign-in flow.
- **`ldap/configure-ldap.mdx`** — the step sequence and troubleshooting table (error codes 401/403/409/502 map to the API responses).
- **`reference/ldap.mdx`** — parameter defaults; cross-check against `config.py`.

Note: directory group names are matched against **existing** local groups. Auto-creation is the separate, SSO-shared feature — cross-linked to `advanced-sso.mdx`, not duplicated.

## What didn't change

- `reference/configuration.mdx` — auto-generated (`invoke docs.generate-config`); left untouched.
- `sso/advanced-sso.mdx` — the auto-create-groups section is cross-linked, not modified.
- Redirects: none — net-new pages, no moved or renamed files.

## Verification

- `cd docs && npm run build` succeeds
- `markdownlint-cli2`: 0 errors. `vale`: 0 errors (remaining warnings are sentence-case false positives on LDAP-acronym headings, identical to the shipped SSO pages)
- Pre-PR audit completed (Step 9 of infrahub-docs skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LDAP authentication docs for Enterprise Edition 1.10, covering setup, advanced options, and a full config reference. Aligns with INFP-105 by documenting the credential‑bind sign-in flow, group mapping (incl. nested), TLS (LDAPS/STARTTLS), failover, method selection, and account lifecycle.

- **New Features**
  - Added an LDAP hub under User Management & Security: overview (value framing + method-selection table), configure, and advanced (group resolution and nesting strategies `bfs`/`ad_in_chain`, multi-server failover with `per_server_timeout`, TLS hardening with LDAPS/STARTTLS notes, tuning for large directories, and an auto‑create groups cross-link). Includes startup validation requirements for required settings.
  - Added an LDAP reference with all `INFRAHUB_LDAP_*` and `[ldap]` options, including login button label/icon, disabled-bitmask support, and mutual-exclusivity notes, plus AD/OpenLDAP examples.
  - Updated Authentication with an LDAP subsection and detailed flow; added LDAP to Community vs Enterprise; updated `sidebars.ts`; added `subtree` and `URIs` to `.vale` spelling exceptions.

- **Bug Fixes**
  - Authentication flow now includes the LDAP service-account lookup, credential bind, and auto-provisioning steps.
  - Clarified the disabled-account attribute note to match the example and tightened the group-name attribute comment.
  - Replaced colloquial phrasing in LDAP pages with clearer wording.

<sup>Written for commit 6688fa4dcc29c56c32153f7aa89672c1204ac6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

