### PR TITLE
docs: document INFRAHUB_PRODUCTION and INFRAHUB_LOG_LEVEL settings

### DIFF
--- a/docs/_templates/infrahub_config.j2
+++ b/docs/_templates/infrahub_config.j2
@@ -48,4 +48,13 @@ Here are a few common methods of setting configuration:
 {% endfor -%}
   {% endif -%}
 {% endfor -%}
-{% endfor -%}
+{% endfor %}
+
+## Logging
+
+These variables configure logging at process startup. They are read directly from the environment and are not part of a `.toml` configuration file.
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `INFRAHUB_PRODUCTION` | Controls the logging output format. When `true`, logs are rendered as JSON with structured exception information, suitable for production log aggregation. When `false`, logs are rendered as human-readable, colorized console output with plain tracebacks, intended for local development. | boolean | True |
+| `INFRAHUB_LOG_LEVEL` | Minimum severity level of log messages emitted by Infrahub. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | INFO |

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -346,3 +346,12 @@ Configuration settings for the message bus.
 | `SHUTDOWN_DRAIN_TIMEOUT` | Seconds to wait for queue drain on graceful shutdown. | integer | 10 |
 | `FORWARD_APPLICATION_LOGS` | Forward application log messages to this destination. | boolean | False |
 | `MIN_LOG_SEVERITY` | Minimum Python log severity to forward when application log forwarding is enabled. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | WARNING |
+
+## Logging
+
+These variables configure logging at process startup. They are read directly from the environment and are not part of a `.toml` configuration file.
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `INFRAHUB_PRODUCTION` | Controls the logging output format. When `true`, logs are rendered as JSON with structured exception information, suitable for production log aggregation. When `false`, logs are rendered as human-readable, colorized console output with plain tracebacks, intended for local development. | boolean | True |
+| `INFRAHUB_LOG_LEVEL` | Minimum severity level of log messages emitted by Infrahub. | string (CRITICAL, ERROR, WARNING, INFO, DEBUG) | INFO |


### PR DESCRIPTION
## Summary

`INFRAHUB_PRODUCTION` had no documentation in the configuration reference. It (and the closely related `INFRAHUB_LOG_LEVEL`) are read directly from the environment in `backend/infrahub/log.py` at import time, rather than through the Pydantic `config.Settings` model. Since `docs/docs/reference/configuration.mdx` is generated by introspecting `Settings`, these two variables never appeared.

This adds a static **Logging** section to the config doc template and regenerates the reference.

## What `INFRAHUB_PRODUCTION` does

Controls log output format (`backend/infrahub/log.py`):
- `true` (default): JSON-rendered logs with structured exception info — for production log aggregation.
- `false`: human-readable, colorized console output with plain tracebacks — for local development.

## Changes

- `docs/_templates/infrahub_config.j2` — added a static "Logging" section documenting `INFRAHUB_PRODUCTION` and `INFRAHUB_LOG_LEVEL` (the template is the source of truth; the `.mdx` is generated and must not be hand-edited).
- `docs/docs/reference/configuration.mdx` — regenerated via `uv run invoke docs.generate-config`.
- Changelog fragment.

## Notes

This documents the variables but does not change their placement. Routing `INFRAHUB_PRODUCTION` through `config.Settings` (so it's auto-documented and `.toml`-configurable) would touch import-time logging setup and is left as a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented `INFRAHUB_PRODUCTION` and `INFRAHUB_LOG_LEVEL` in the config reference by adding a static Logging section to the docs template. These environment-only settings (read at startup from `backend/infrahub/log.py`, not `Settings`) now appear in the generated docs.

<sup>Written for commit 4560d0b14af28ab05a1a0b4f0e39347528af32fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

