### PR TITLE
Remove xfail from test to reenable

### DIFF
--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -69,13 +69,23 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)
 
-    @pytest.mark.xfail(reason="FIXME Works locally but it's failling in GitHub Actions")
+        # Generators are dispatched per field the query reads; touch one of John's so he is
+        # reselected on this branch rather than skipped as unchanged.
+        john_on_branch = await NodeManager.get_one(db=db, id=john.id, branch=branch1.name, raise_on_error=True)
+        john_on_branch.description.value = "The famous Joe Doe, updated on branch1"  # type: ignore[attr-defined]
+        await john_on_branch.save(db=db)
+
     async def test_create_proposed_change(
         self,
         db: InfrahubDatabase,
         initial_dataset: None,
         client: InfrahubClient,
     ) -> None:
+        """Run the full pipeline for a proposed change against a branch that links a repository.
+
+        Every definition in the repository's ``.infrahub.yml`` yields exactly one validator,
+        all of them succeed, and the generators emit their tags.
+        """
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,
             data={"source_branch": "branch1", "destination_branch": "main", "name": "add repository"},
@@ -91,22 +101,24 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
         validators_per_label = {peer.label.value: peer for peer in peers.values()}
 
         expected_validators = [
-            "Generator Validator: cartags",
-            "Artifact Validator: Ownership report",
-            "Generator Validator: cartags_convert_response",
             "Data Integrity",
+            "Schema Integrity",
             "Check: car_description_check",
             "Check: owner_age_check",
+            "Generator Validator: cartags",
+            "Generator Validator: cartags_convert_response",
+            "Generator Validator: cartags_title",
+            "Artifact Validator: Ownership report",
+            "Artifact Validator: Ownership report Yaml",
+            "Artifact Validator: name report",
+            "Artifact Validator: car spec markdown",
+            "Artifact Validator: converted-owner",
         ]
         assert set(expected_validators) == set(validators_per_label.keys())
 
         for validator in validators_per_label.values():
             assert validator.conclusion.value.value == ValidatorConclusion.SUCCESS.value
 
-        tags = await client.all(kind="BuiltinTag", branch="branch1")
-        # # The Generator defined in the repository is expected to have created this tag during the pipeline
+        tags = await client.all(kind=TestKind.TAG, branch="branch1")
         assert "john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
         assert "InfrahubNode-john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
-
-        proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
-        await proposed_change_create.save()


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

Reenable a test marked as `@pytest.mark.xfail(reason="FIXME Works locally but it's failling in GitHub Actions")` for quite some time. Had to make some small changes to account for other changes in the producation code.

The failures seems to have been related to additional validators introduced after the test was written.

## What changed

* Create new data based on recent changes to validators
* Add missing validators in assert
* Change tag to use TestingTag
* Remove merge operation at the end of the test as that wasn't what was tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the proposed change repository integration test by removing xfail and making the dataset update deterministic so generators and validators run reliably in CI.

- **Bug Fixes**
  - Removed `pytest.mark.xfail` and updated John's description on `branch1` to trigger generators.
  - Updated expected validator labels to match the repository config (data/schema integrity, checks, generators, artifacts).
  - Switched tag query to `TestKind.TAG` and assert generated tags.
  - Dropped the merge step to keep the test focused.

<sup>Written for commit 27b0183d7814d87d4e264176639738c43b8bc469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

