### PR TITLE
Fix add branch button overflowing in some browsers

### DIFF
--- a/frontend/app/src/shared/components/aria/autocomplete.tsx
+++ b/frontend/app/src/shared/components/aria/autocomplete.tsx
@@ -49,7 +49,7 @@ interface SearchInputProps extends AriaSearchFieldProps {
 function AutocompleteSearchField({ className, placeholder, ...props }: SearchInputProps) {
   return (
     <AriaSearchField
-      className={classNames("group flex items-center text-sm", className)}
+      className={classNames("group flex items-center overflow-hidden text-sm", className)}
       aria-label="Search"
       autoFocus
       {...props}


### PR DESCRIPTION
"add branch" button was overflow in some browsers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a layout issue where the "Add branch" button overflowed in some browsers. Adds overflow-hidden to the autocomplete search field container to keep the button and input aligned and clipped correctly.

<sup>Written for commit b9a9ec87dfa2203b2753606300787fc1faba60dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

