### PR TITLE
feat(ui): Button ref support, semantic Spinner, scoped lint config

### DIFF
--- a/frontend/packages/ui/oxlint.config.ts
+++ b/frontend/packages/ui/oxlint.config.ts
@@ -1,45 +1,23 @@
 import { defineConfig } from "oxlint";
 
+// Bug-catching categories only (matching the app's biome philosophy): style and
+// opinionated rules are oxfmt's / code review's job, not the linter's.
 export default defineConfig({
   env: {
     browser: true,
   },
   categories: {
     correctness: "error",
-    nursery: "error",
-    pedantic: "error",
     perf: "error",
-    restriction: "error",
-    style: "error",
     suspicious: "error",
   },
   plugins: ["oxc", "typescript", "react", "react-perf", "jsx-a11y", "vitest", "unicorn"],
   rules: {
-    "eslint/arrow-body-style": "off",
-    "eslint/func-style": "off",
-    "eslint/id-length": "off",
     "eslint/no-console": ["error", { allow: ["error"] }],
-    "eslint/no-empty-function": "off",
-    "eslint/no-magic-numbers": ["error", { ignore: [0, 1] }],
-    "eslint/max-lines-per-function": "off",
-    "eslint/no-ternary": "off",
-    "eslint/sort-imports": "off",
-    "eslint/sort-keys": "off",
-    "oxc/no-rest-spread-properties": "off",
+    // The React Compiler memoizes; inline values as props are not a re-render hazard here.
+    "react-perf/jsx-no-new-array-as-prop": "off",
+    "react-perf/jsx-no-new-function-as-prop": "off",
     "react-perf/jsx-no-new-object-as-prop": "off",
-    "react/button-has-type": "off",
-    "react/forbid-component-props": "off",
-    "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
-    "react/jsx-max-depth": "off",
-    "react/jsx-props-no-spreading": "off",
-    "react/no-multi-comp": "off",
-    "react/only-export-components": "off",
     "react/react-in-jsx-scope": "off",
-    "react_perf/jsx-no-new-function-as-prop": "off",
-    "typescript/explicit-function-return-type": "off",
-    "typescript/explicit-module-boundary-types": "off",
-    "typescript/no-empty-interface": "off",
-    "typescript/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
-    "unicorn/no-null": "off",
   },
 });

--- a/frontend/packages/ui/src/components/button/button.tsx
+++ b/frontend/packages/ui/src/components/button/button.tsx
@@ -1,3 +1,5 @@
+import type { RefAttributes } from "react";
+
 import {
   Button as AriaButton,
   type ButtonProps as AriaButtonProps,
@@ -84,7 +86,8 @@ const buttonVariants = tv({
   },
 });
 
-export interface ButtonProps extends AriaButtonProps, VariantProps<typeof buttonVariants> {
+export interface ButtonProps
+  extends AriaButtonProps, VariantProps<typeof buttonVariants>, RefAttributes<HTMLButtonElement> {
   /** Uses isPending internally to keep the button hoverable/focusable while appearing disabled. Useful for tooltip triggers. */
   isDisabledAndFocusable?: boolean;
 }

--- a/frontend/packages/ui/src/components/spinner/spinner.tsx
+++ b/frontend/packages/ui/src/components/spinner/spinner.tsx
@@ -2,13 +2,14 @@ import type React from "react";
 
 import { cn } from "tailwind-variants";
 
-export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "className"> {
+export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLOutputElement>, "className"> {
   className?: React.HTMLAttributes<SVGSVGElement>["className"];
 }
 
 export const Spinner = ({ className, ...props }: SpinnerProps) => {
   return (
-    <div role="status" {...props}>
+    // `block` keeps the previous div layout (output is inline by default).
+    <output className="block" {...props}>
       <svg
         aria-hidden="true"
         className={cn("size-4 animate-spin fill-cyan-600 text-neutral-200", className)}
@@ -26,6 +27,6 @@ export const Spinner = ({ className, ...props }: SpinnerProps) => {
         />
       </svg>
       <span className="sr-only">Loading...</span>
-    </div>
+    </output>
   );
 };

--- a/frontend/packages/ui/src/components/tree/tree.stories.tsx
+++ b/frontend/packages/ui/src/components/tree/tree.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Collection } from "react-aria-components";
 
 import { Tree, TreeItem, TreeItemContent } from "./tree";


### PR DESCRIPTION
## Summary

Extracts the `@infrahub/ui` changes from #9497 into a dedicated PR so the design-system package evolves independently of the graph work.

- **`Button` accepts `ref`** — `ButtonProps` now extends `RefAttributes<HTMLButtonElement>` (React 19 already forwards `ref` through the props spread at runtime; this exposes it in the types, same pattern as `Card`). Needed by consumers that manage focus programmatically, e.g. dropdown triggers.
- **`Spinner` is a semantic `<output>` element** instead of `<div role="status">` (`jsx-a11y/prefer-tag-over-role`). A hardcoded `block` class preserves the previous div layout since `<output>` is inline by default.
- **oxlint scoped to bug-catching categories** (`correctness`/`perf`/`suspicious` as errors, matching the app's biome philosophy). The previous config enabled *every* category as error — including mutually contradictory rules (`no-importing-vitest-globals` vs `prefer-importing-vitest-globals`), so no code could ever satisfy it, and `oxlint --fix` made things worse (157 → 219 errors). `pnpm lint` now passes and can become a CI gate.
- Formats `tree.stories.tsx` (pre-existing oxfmt drift that failed `pnpm format:check`).

## Verification

- `pnpm lint` exits 0 (previously failing)
- `pnpm format:check` exits 0 (previously failing)
- `tsc -b` — no new errors (only the pre-existing `baseUrl` TS5101 deprecation present on develop)
- Chromatic publishes these components from the sibling branch successfully

## Note

`ple-graph-primitives` contains these same changes (the graph package depends on the `Button` ref). Once this PR merges, rebasing that branch onto develop will absorb them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `ref` on `Button` for programmatic focus and make `Spinner` semantic. Scope `@infrahub/ui` linting to bug-catching rules and fix a small formatting drift so lint/format checks pass.

- **New Features**
  - `Button` now accepts `ref` (helps focus control, e.g. dropdown triggers).
  - `Spinner` uses a semantic `<output>` with a `block` class to preserve layout.

- **Refactors**
  - Scoped `oxlint` to `correctness`, `perf`, and `suspicious`; disabled conflicting perf rules aligned with React Compiler.
  - Formatted `tree.stories.tsx` to satisfy `pnpm format:check`.

<sup>Written for commit ce48a28f270cbc2c183bef2176c6acc7ed3e520a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

