### PR TITLE
Manual merge stable into release-1.10

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -705,7 +705,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Create a new worktree for a given commit.
 
         Raises:
-            RepositoryError: When the worktree cannot be created and the commit cannot be fetched from a remote.
+            CommitNotFoundError: When the commit does not exist in the local clone.
+            RepositoryError: When the worktree cannot be created for any other reason.
 
         """
         # Check of the worktree already exist
@@ -721,22 +722,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             log.debug(f"Commit worktree created {commit}", repository=self.name)
             return worktree
         except GitCommandError as exc:
-            if "invalid reference" not in exc.stderr:
-                raise RepositoryError(identifier=self.name, message=exc.stderr) from exc
-
-            if not self.has_origin:
-                raise RepositoryError(
-                    identifier=self.name,
-                    message=f"Commit {commit} not found and no remote origin configured to fetch from.",
-                ) from exc
-
-            # Commit may exist on the remote but hasn't been fetched to this worker yet
-            log.info(f"Commit {commit} not found locally, fetching from remote.", repository=self.name)
-            repo.remotes.origin.fetch()
-
-            repo.git.worktree("add", directory, commit)
-            log.debug(f"Commit worktree created {commit} after fetch", repository=self.name)
-            return worktree
+            if "invalid reference" in exc.stderr:
+                raise CommitNotFoundError(identifier=self.name, commit=commit) from exc
+            raise RepositoryError(identifier=self.name, message=exc.stderr) from exc
 
     def create_branch_worktree(self, branch_name: str, branch_id: str) -> bool:
         """Create a new worktree for a given branch.

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -45,7 +45,7 @@ from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
 from typing_extensions import Self
 
-from infrahub import config
+from infrahub import config, lock
 from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositoryObjects, RepositorySyncStatus
 from infrahub.core.registry import registry
 from infrahub.events.artifact_action import ArtifactCreatedEvent, ArtifactUpdatedEvent
@@ -53,6 +53,7 @@ from infrahub.events.models import EventMeta
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import (
     CheckError,
+    CommitNotFoundError,
     RepositoryConfigurationError,
     RepositoryInvalidFileSystemError,
     TransformError,
@@ -165,7 +166,16 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             log.info(f"Initialized the local directory for {self.name} because it was missing.")
 
         if commit:
-            self.get_commit_worktree(commit=commit)
+            try:
+                self.get_commit_worktree(commit=commit)
+            except CommitNotFoundError:
+                if not self.has_origin:
+                    raise
+                # The commit may exist on the remote but not yet in this worker's clone.
+                # Fetch under the repository lock, which serializes shared-clone mutations, and retry.
+                async with lock.registry.get(name=self.name, namespace="repository"):
+                    await self.fetch()
+                    self.get_commit_worktree(commit=commit)
 
         log.debug(
             f"Initiated the object on an existing directory for {self.name}",

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from cachetools import TTLCache
@@ -13,7 +14,7 @@ from pydantic import Field
 
 from infrahub import config
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus, RepositoryOperationalStatus
-from infrahub.exceptions import RepositoryError
+from infrahub.exceptions import CommitNotFoundError, RepositoryError
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from infrahub.log import get_logger
 
@@ -21,6 +22,15 @@ if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
 
 log = get_logger()
+
+
+@dataclass
+class PendingObjectImport:
+    """A repository object import waiting to run: which commit to import from and which Infrahub branch to import into."""
+
+    infrahub_branch_name: str
+    commit: str
+    git_branch_name: str | None = None
 
 
 class InfrahubRepository(InfrahubRepositoryIntegrator):
@@ -66,7 +76,26 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         By default the sync will focus only on the branches pulled from origin that have some differences with the local one.
 
         Raises:
-            GraphQLError: When creating a branch in the graph fails for a reason other than the branch already existing.
+            GraphQLError: When a branch or commit update against the database fails.
+
+        """
+        for pending in await self.collect_pending_imports(staging_branch=staging_branch):
+            await self.import_objects_from_files(
+                infrahub_branch_name=pending.infrahub_branch_name,
+                git_branch_name=pending.git_branch_name,
+                commit=pending.commit,
+            )
+
+    async def collect_pending_imports(self, staging_branch: str | None = None) -> list[PendingObjectImport]:
+        """Run the git and branch-setup side of a sync and return the imports it produced.
+
+        Brings the local clone in line with the remote and records the affected branches and their
+        commits in the database, pinning a per-commit worktree for each. Returns one entry per branch
+        whose objects still need importing into the graph. A per-branch git failure is logged and skipped so the
+        other branches' imports are still returned.
+
+        Raises:
+            GraphQLError: When a branch or commit update against the database fails.
 
         """
         log.info("Starting the synchronization.", repository=self.name)
@@ -75,8 +104,9 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         new_branches, updated_branches = await self.compare_local_remote()
 
+        pending_imports: list[PendingObjectImport] = []
         if not new_branches and not updated_branches:
-            return
+            return pending_imports
 
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
 
@@ -89,19 +119,30 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
                 try:
-                    branch = await self.create_branch_in_graph(branch_name=infrahub_branch)
-                except GraphQLError as exc:
-                    if "already exist" not in exc.errors[0]["message"]:
-                        raise
-                    branch = await self.sdk.branch.get(branch_name=infrahub_branch)
+                    try:
+                        branch = await self.create_branch_in_graph(branch_name=infrahub_branch)
+                    except GraphQLError as exc:
+                        if "already exist" not in exc.errors[0]["message"]:
+                            raise
+                        branch = await self.sdk.branch.get(branch_name=infrahub_branch)
 
-                await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id, push_origin=True)
+                    await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id, push_origin=True)
 
-                commit = self.get_commit_value(branch_name=branch_name, remote=False)
-                self.create_commit_worktree(commit=commit)
-                await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+                    commit = self.get_commit_value(branch_name=branch_name, remote=False)
+                    self.create_commit_worktree(commit=commit)
+                    await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+                except (RepositoryError, CommitNotFoundError, GitCommandError, ValueError) as exc:
+                    # Isolate per-branch git failures so imports already collected for the other
+                    # branches are still returned and applied.
+                    log.warning(
+                        "Failed to prepare branch for import, skipping it.",
+                        repository=self.name,
+                        branch=branch_name,
+                        exc_info=exc,
+                    )
+                    continue
 
-                await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit)
+                pending_imports.append(PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit))
 
             for branch_name in updated_branches:
                 is_valid = self.validate_remote_branch(branch_name=branch_name)
@@ -110,9 +151,23 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
 
-                commit_after = await self.pull(branch_name=branch_name)
+                try:
+                    commit_after = await self.pull(branch_name=branch_name)
+                except (RepositoryError, CommitNotFoundError, GitCommandError, ValueError) as exc:
+                    # Isolate per-branch git failures so imports already collected for the other
+                    # branches are still returned and applied; graph errors are left to propagate.
+                    log.warning(
+                        "Failed to pull branch for import, skipping it.",
+                        repository=self.name,
+                        branch=branch_name,
+                        exc_info=exc,
+                    )
+                    continue
+
                 if isinstance(commit_after, str):
-                    await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit_after)
+                    pending_imports.append(
+                        PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit_after)
+                    )
 
                 elif commit_after is True:
                     log.warning(
@@ -121,26 +176,36 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                         branch=branch_name,
                     )
 
-        await self._sync_staging(staging_branch=staging_branch, updated_branches=updated_branches)
+        pending_imports.extend(
+            await self._collect_staging_imports(staging_branch=staging_branch, updated_branches=updated_branches)
+        )
+        return pending_imports
 
-    async def _sync_staging(self, staging_branch: str | None, updated_branches: list[str]) -> None:
-        if (
+    async def _collect_staging_imports(
+        self, staging_branch: str | None, updated_branches: list[str]
+    ) -> list[PendingObjectImport]:
+        if not (
             self.internal_status == RepositoryInternalStatus.STAGING.value
             and staging_branch
             and self.default_branch in updated_branches
         ):
-            commit_after = await self.pull(branch_name=self.default_branch)
-            if isinstance(commit_after, str):
-                await self.import_objects_from_files(
-                    git_branch_name=self.default_branch, infrahub_branch_name=staging_branch, commit=commit_after
-                )
+            return []
 
-            elif commit_after is True:
-                log.warning(
-                    f"An update was detected but the commit remained the same after pull() ({commit_after}).",
-                    repository=self.name,
-                    branch=self.default_branch,
+        commit_after = await self.pull(branch_name=self.default_branch)
+        if isinstance(commit_after, str):
+            return [
+                PendingObjectImport(
+                    infrahub_branch_name=staging_branch, git_branch_name=self.default_branch, commit=commit_after
                 )
+            ]
+
+        if commit_after is True:
+            log.warning(
+                f"An update was detected but the commit remained the same after pull() ({commit_after}).",
+                repository=self.name,
+                branch=self.default_branch,
+            )
+        return []
 
     async def push(self, branch_name: str) -> bool:
         """Push a given branch to the remote Origin repository."""

--- a/backend/infrahub/git/sync.py
+++ b/backend/infrahub/git/sync.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from .repository import InfrahubRepository, PendingObjectImport
+
+if TYPE_CHECKING:
+    from infrahub_sdk.client import InfrahubClient
+
+    from infrahub.lock import InfrahubLockRegistry
+
+    from .models import GitRepositoryAdd
+
+
+class RepositoryImporter(ABC):
+    """Imports the objects of a single synced branch into the graph."""
+
+    @abstractmethod
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None: ...
+
+
+class RepositoryFileImporter(RepositoryImporter):
+    """Imports a branch by reading the object files of its pinned commit worktree."""
+
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
+        await repo.import_objects_from_files(  # type: ignore[call-overload]
+            infrahub_branch_name=pending_import.infrahub_branch_name,
+            git_branch_name=pending_import.git_branch_name,
+            commit=pending_import.commit,
+        )
+
+
+class RepositoryAdder:
+    """Adds a new repository, holding the repository lock across the clone and the recording of its pinned commit.
+
+    The locked phase covers the clone, the default-branch worktree creation, and writing the pinned
+    commit back to the graph, which must stay consistent with each other. The default-branch object
+    import runs after the lock is released; it reads from the per-commit worktree pinned during the
+    locked phase, so it does not need the lock.
+    """
+
+    def __init__(
+        self, lock_registry: InfrahubLockRegistry, importer: RepositoryImporter, client: InfrahubClient
+    ) -> None:
+        self._lock_registry = lock_registry
+        self._importer = importer
+        self._client = client
+
+    async def add(self, model: GitRepositoryAdd) -> InfrahubRepository:
+        async with self._lock_registry.get(name=model.repository_name, namespace="repository"):
+            repo = await InfrahubRepository.new(
+                id=model.repository_id,
+                name=model.repository_name,
+                location=model.location,
+                client=self._client,
+                infrahub_branch_name=model.infrahub_branch_name,
+                internal_status=model.internal_status,
+                default_branch_name=model.default_branch_name,
+            )
+            default_commit = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
+            repo.create_commit_worktree(commit=default_commit)
+
+        await self._importer.import_branch(
+            repo,
+            PendingObjectImport(
+                infrahub_branch_name=model.infrahub_branch_name,
+                git_branch_name=repo.default_branch,
+                commit=default_commit,
+            ),
+        )
+        return repo
+
+
+class RepositorySyncer:
+    """Synchronizes a repository, holding the repository lock only for the git working-copy mutations.
+
+    The lock serializes mutations of the repository's on-disk git state. The object import for each
+    synced branch runs after the lock is released; it reads from the per-commit worktree pinned during
+    the locked phase, so it does not need the lock.
+    """
+
+    def __init__(self, lock_registry: InfrahubLockRegistry, importer: RepositoryImporter) -> None:
+        self._lock_registry = lock_registry
+        self._importer = importer
+
+    async def sync(self, repo: InfrahubRepository, staging_branch: str | None = None) -> None:
+        async with self._lock_registry.get(name=repo.name, namespace="repository"):
+            pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
+        for pending_import in pending_imports:
+            await self._importer.import_branch(repo, pending_import)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -25,7 +25,7 @@ from infrahub.core.constants import (
 )
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
-from infrahub.exceptions import CheckError, RepositoryError
+from infrahub.exceptions import CheckError, CommitNotFoundError, RepositoryError
 from infrahub.message_bus import Meta, messages
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.validators.tasks import start_validator
@@ -62,6 +62,7 @@ from .models import (
     UserCheckDefinitionData,
 )
 from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_initialized_repo
+from .sync import RepositoryAdder, RepositoryFileImporter, RepositorySyncer
 from .utils import fetch_artifact_definition_targets, fetch_check_definition_targets, get_repositories_commit_per_branch
 
 
@@ -87,40 +88,32 @@ def format_check_log_entry(entry: dict[str, Any]) -> str:
 async def add_git_repository(model: GitRepositoryAdd) -> None:
     await add_tags(branches=[model.infrahub_branch_name], nodes=[model.repository_id])
 
-    async with lock.registry.get(name=model.repository_name, namespace="repository"):
-        repo = await InfrahubRepository.new(
-            id=model.repository_id,
-            name=model.repository_name,
-            location=model.location,
-            client=get_client(),
-            infrahub_branch_name=model.infrahub_branch_name,
-            internal_status=model.internal_status,
-            default_branch_name=model.default_branch_name,
-        )
-        await repo.import_objects_from_files(  # type: ignore[call-overload]
-            infrahub_branch_name=model.infrahub_branch_name, git_branch_name=model.default_branch_name
-        )
-        if model.internal_status == RepositoryInternalStatus.ACTIVE.value:
-            await repo.sync()
+    importer = RepositoryFileImporter()
+    repo = await RepositoryAdder(lock_registry=lock.registry, importer=importer, client=get_client()).add(model)
 
-            try:
-                pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
-            except (ValueError, InvalidGitRepositoryError):
-                pinned_commit = None
-            # Notify other workers they need to clone the repository and check out the SHA pinned
-            # by this initial sync, so the whole pool converges even if upstream advances meanwhile.
-            notification = messages.RefreshGitFetch(
-                meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
-                location=model.location,
-                repository_id=model.repository_id,
-                repository_name=model.repository_name,
-                repository_kind=InfrahubKind.REPOSITORY,
-                infrahub_branch_name=model.infrahub_branch_name,
-                infrahub_branch_id=model.infrahub_branch_id,
-                commit=pinned_commit,
-            )
-            message_bus = await get_message_bus()
-            await message_bus.send(message=notification)
+    if model.internal_status != RepositoryInternalStatus.ACTIVE.value:
+        return
+
+    await RepositorySyncer(lock_registry=lock.registry, importer=importer).sync(repo)
+
+    try:
+        pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
+    except (ValueError, InvalidGitRepositoryError):
+        pinned_commit = None
+    # Notify other workers they need to clone the repository and check out the SHA pinned
+    # by this initial sync, so the whole pool converges even if upstream advances meanwhile.
+    notification = messages.RefreshGitFetch(
+        meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
+        location=model.location,
+        repository_id=model.repository_id,
+        repository_name=model.repository_name,
+        repository_kind=InfrahubKind.REPOSITORY,
+        infrahub_branch_name=model.infrahub_branch_name,
+        infrahub_branch_id=model.infrahub_branch_id,
+        commit=pinned_commit,
+    )
+    message_bus = await get_message_bus()
+    await message_bus.send(message=notification)
 
 
 @flow(
@@ -228,9 +221,10 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
         default_branch_name=default_branch_name,
     )
 
+    syncer = RepositorySyncer(lock_registry=lock.registry, importer=RepositoryFileImporter())
     try:
-        await repo.sync(staging_branch=staging_branch)
-    except RepositoryError:
+        await syncer.sync(repo, staging_branch=staging_branch)
+    except (RepositoryError, CommitNotFoundError):
         if operational_status == RepositoryOperationalStatus.ONLINE.value:
             params: dict[str, Any] = {
                 "branches": [infrahub_branch] if infrahub_branch else [],
@@ -240,9 +234,124 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
         raise
 
 
+async def bootstrap_local_repository(
+    repo_name: str,
+    repository: CoreRepository,
+    active_internal_status: str,
+    infrahub_branch: str,
+    client: InfrahubClient,
+) -> InfrahubRepository | None:
+    """Ensure this worker has a usable local clone and seed the graph for a freshly created repo.
+
+    The repository lock covers the git working-copy mutations.
+    Returns None when the clone or the default-branch import fails and the repository should be
+    skipped.
+    """
+    log = get_run_logger()
+    default_import_git_branch: str | None = None
+    pinned_import_commit: str | None = None
+    async with lock.registry.get(name=repo_name, namespace="repository"):
+        init_failed = False
+        try:
+            repo = await InfrahubRepository.init(
+                id=repository.id,
+                name=repository.name.value,
+                location=repository.location.value,
+                client=client,
+                internal_status=active_internal_status,
+                default_branch_name=repository.default_branch.value,
+            )
+        except RepositoryError as exc:
+            get_logger().error(str(exc))
+            init_failed = True
+
+        if init_failed:
+            try:
+                repo = await InfrahubRepository.new(
+                    id=repository.id,
+                    name=repository.name.value,
+                    location=repository.location.value,
+                    client=client,
+                    internal_status=active_internal_status,
+                    default_branch_name=repository.default_branch.value,
+                )
+            except RepositoryError as exc:
+                log.info(exc.message)
+                return None
+            default_import_git_branch = registry.default_branch
+
+        if repo.reinitialized:
+            default_import_git_branch = repo.default_branch
+
+        if default_import_git_branch is not None:
+            # Pin the commit while the lock is held so the import below reads an immutable
+            # worktree even though it runs after the lock is released.
+            pinned_import_commit = repo.get_commit_value(branch_name=default_import_git_branch, remote=False)
+
+    if default_import_git_branch is not None:
+        try:
+            await repo.import_objects_from_files(  # type: ignore[call-overload]
+                git_branch_name=default_import_git_branch,
+                infrahub_branch_name=infrahub_branch,
+                commit=pinned_import_commit,
+            )
+        except (RepositoryError, CommitNotFoundError) as exc:
+            log.info(exc.message)
+            return None
+
+    return repo
+
+
+async def sync_repository_from_origin(
+    repository: CoreRepository,
+    repo: InfrahubRepository,
+    active_internal_status: str,
+    staging_branch: str | None,
+    infrahub_branch: str,
+    infrahub_branch_id: str,
+    client: InfrahubClient,
+) -> None:
+    """Sync the repository from its origin and notify the worker pool of the resulting commit."""
+    log = get_run_logger()
+    try:
+        await sync_git_repo_with_origin_and_tag_on_failure(
+            client=client,
+            repository_id=repository.id,
+            repository_name=repository.name.value,
+            repository_location=repository.location.value,
+            internal_status=active_internal_status,
+            default_branch_name=repository.default_branch.value,
+            operational_status=repository.operational_status.value,
+            staging_branch=staging_branch,
+            infrahub_branch=infrahub_branch,
+        )
+        try:
+            pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
+        except (ValueError, InvalidGitRepositoryError) as exc:
+            log.debug(
+                f"Could not resolve pinned commit for {repository.name.value}, workers will fall back to pull: {exc}"
+            )
+            pinned_commit = None
+        # Tell workers to fetch and check out the SHA pinned by this sync, so the whole
+        # pool converges on the same commit even if upstream advances during fan-out.
+        message = messages.RefreshGitFetch(
+            meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
+            location=repository.location.value,
+            repository_id=repository.id,
+            repository_name=repository.name.value,
+            repository_kind=repository.get_kind(),
+            infrahub_branch_name=infrahub_branch,
+            infrahub_branch_id=infrahub_branch_id,
+            commit=pinned_commit,
+        )
+        message_bus = await get_message_bus()
+        await message_bus.send(message=message)
+    except (RepositoryError, CommitNotFoundError) as exc:
+        log.info(exc.message)
+
+
 @flow(name="git_repositories_sync", flow_run_name="Sync Git Repositories")
 async def sync_remote_repositories() -> None:
-    log = get_run_logger()
     db = await get_database()
 
     client = get_client()
@@ -263,80 +372,25 @@ async def sync_remote_repositories() -> None:
 
         infrahub_branch = staging_branch or registry.default_branch
 
-        async with lock.registry.get(name=repo_name, namespace="repository"):
-            init_failed = False
-            try:
-                repo = await InfrahubRepository.init(
-                    id=repository.id,
-                    name=repository.name.value,
-                    location=repository.location.value,
-                    client=client,
-                    internal_status=active_internal_status,
-                    default_branch_name=repository.default_branch.value,
-                )
-            except RepositoryError as exc:
-                get_logger().error(str(exc))
-                init_failed = True
+        repo = await bootstrap_local_repository(
+            repo_name=repo_name,
+            repository=repository,
+            active_internal_status=active_internal_status,
+            infrahub_branch=infrahub_branch,
+            client=client,
+        )
+        if repo is None:
+            continue
 
-            if init_failed:
-                try:
-                    repo = await InfrahubRepository.new(
-                        id=repository.id,
-                        name=repository.name.value,
-                        location=repository.location.value,
-                        client=client,
-                        internal_status=active_internal_status,
-                        default_branch_name=repository.default_branch.value,
-                    )
-                    await repo.import_objects_from_files(  # type: ignore[call-overload]
-                        git_branch_name=registry.default_branch, infrahub_branch_name=infrahub_branch
-                    )
-                except RepositoryError as exc:
-                    log.info(exc.message)
-                    continue
-
-            if repo.reinitialized:
-                try:
-                    await repo.import_objects_from_files(  # type: ignore[call-overload]
-                        git_branch_name=repo.default_branch, infrahub_branch_name=infrahub_branch
-                    )
-                except RepositoryError as exc:
-                    log.info(exc.message)
-                    continue
-
-            try:
-                await sync_git_repo_with_origin_and_tag_on_failure(
-                    client=client,
-                    repository_id=repository.id,
-                    repository_name=repository.name.value,
-                    repository_location=repository.location.value,
-                    internal_status=active_internal_status,
-                    default_branch_name=repository.default_branch.value,
-                    operational_status=repository.operational_status.value,
-                    staging_branch=staging_branch,
-                    infrahub_branch=infrahub_branch,
-                )
-                try:
-                    pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
-                except (ValueError, InvalidGitRepositoryError) as exc:
-                    log.debug(f"Could not resolve pinned commit for {repo_name}, workers will fall back to pull: {exc}")
-                    pinned_commit = None
-                # Tell workers to fetch and check out the SHA pinned by this sync, so the whole
-                # pool converges on the same commit even if upstream advances during fan-out.
-                message = messages.RefreshGitFetch(
-                    meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
-                    location=repository.location.value,
-                    repository_id=repository.id,
-                    repository_name=repository.name.value,
-                    repository_kind=repository.get_kind(),
-                    infrahub_branch_name=infrahub_branch,
-                    infrahub_branch_id=branches[infrahub_branch].id,
-                    commit=pinned_commit,
-                )
-                message_bus = await get_message_bus()
-                await message_bus.send(message=message)
-            except RepositoryError as exc:
-                log.info(exc.message)
+        await sync_repository_from_origin(
+            repository=repository,
+            repo=repo,
+            active_internal_status=active_internal_status,
+            staging_branch=staging_branch,
+            infrahub_branch=infrahub_branch,
+            infrahub_branch_id=branches[infrahub_branch].id,
+            client=client,
+        )
 
 
 @task(  # type: ignore[arg-type]

--- a/backend/tests/adapters/lock/__init__.py
+++ b/backend/tests/adapters/lock/__init__.py
@@ -1,0 +1,13 @@
+from .mocks import RecordingImporter
+from .registry import RecordingLock, RecordingLockRegistry, install_recording_lock_registry
+from .timeline import LockAction, LockEvent, LockTimeline
+
+__all__ = [
+    "LockAction",
+    "LockEvent",
+    "LockTimeline",
+    "RecordingImporter",
+    "RecordingLock",
+    "RecordingLockRegistry",
+    "install_recording_lock_registry",
+]

--- a/backend/tests/adapters/lock/mocks/__init__.py
+++ b/backend/tests/adapters/lock/mocks/__init__.py
@@ -1,0 +1,3 @@
+from .importer import RecordingImporter
+
+__all__ = ["RecordingImporter"]

--- a/backend/tests/adapters/lock/mocks/importer.py
+++ b/backend/tests/adapters/lock/mocks/importer.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.git.sync import RepositoryImporter
+
+if TYPE_CHECKING:
+    from infrahub.git import InfrahubRepository
+    from infrahub.git.repository import PendingObjectImport
+    from tests.adapters.lock.timeline import LockTimeline
+
+
+class RecordingImporter(RepositoryImporter):
+    """Records a timeline checkpoint instead of importing, to capture the lock state at the import call."""
+
+    def __init__(self, timeline: LockTimeline) -> None:
+        self._timeline = timeline
+
+    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
+        self._timeline.checkpoint("import")

--- a/backend/tests/adapters/lock/registry.py
+++ b/backend/tests/adapters/lock/registry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub import lock
+from infrahub.lock import InfrahubLock, InfrahubLockRegistry
+
+from .timeline import LockAction, LockTimeline
+
+if TYPE_CHECKING:
+    import redis.asyncio as redis
+
+    from infrahub.services import InfrahubServices
+
+
+class RecordingLock(InfrahubLock):
+    """A local lock that logs its real (non-re-entrant) acquire/release boundaries to a timeline."""
+
+    def __init__(
+        self,
+        name: str,
+        connection: redis.Redis | InfrahubServices | None = None,
+        in_multi: bool = False,
+        metrics: bool = True,
+        *,
+        timeline: LockTimeline,
+    ) -> None:
+        super().__init__(name=name, connection=connection, in_multi=in_multi, metrics=metrics)
+        self._timeline = timeline
+
+    async def acquire(self) -> None:
+        reentrant = self._recursion_var.get() is not None
+        await super().acquire()
+        if not reentrant:
+            self._timeline.record(self.name, LockAction.ACQUIRE)
+
+    async def release(self) -> None:
+        will_release = self._recursion_var.get() == 1
+        await super().release()
+        if will_release:
+            self._timeline.record(self.name, LockAction.RELEASE)
+
+
+class RecordingLockRegistry(InfrahubLockRegistry):
+    """Local-only lock registry that hands out ``RecordingLock`` instances backed by a shared timeline."""
+
+    def __init__(self, timeline: LockTimeline) -> None:
+        super().__init__(local_only=True)
+        self.timeline = timeline
+
+    def get(
+        self,
+        name: str,
+        namespace: str | None = None,
+        local: bool | None = None,
+        in_multi: bool = False,
+        metrics: bool = True,
+    ) -> InfrahubLock:
+        lock_name = self.name_generator.generate_name(name=name, namespace=namespace, local=local)
+        if lock_name not in self.locks:
+            self.locks[lock_name] = RecordingLock(
+                name=lock_name,
+                connection=self.connection,
+                in_multi=in_multi,
+                metrics=metrics,
+                timeline=self.timeline,
+            )
+        return self.locks[lock_name]
+
+
+def install_recording_lock_registry(timeline: LockTimeline | None = None) -> LockTimeline:
+    """Replace the global lock registry with a recording one and return its timeline."""
+    timeline = timeline or LockTimeline()
+    lock.registry = RecordingLockRegistry(timeline=timeline)
+    return timeline

--- a/backend/tests/adapters/lock/timeline.py
+++ b/backend/tests/adapters/lock/timeline.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+
+class LockAction(StrEnum):
+    ACQUIRE = "acquire"
+    RELEASE = "release"
+    CHECKPOINT = "checkpoint"
+
+
+@dataclass
+class LockEvent:
+    """A single entry in a lock timeline: a lock transition or an arbitrary checkpoint."""
+
+    seq: int
+    name: str
+    action: LockAction
+    label: str | None = None
+
+
+class LockTimeline:
+    """Ordered, monotonic log of lock transitions shared by every recorder in a test."""
+
+    def __init__(self) -> None:
+        self.events: list[LockEvent] = []
+        self._seq = itertools.count()
+
+    def record(self, name: str, action: LockAction, label: str | None = None) -> int:
+        seq = next(self._seq)
+        self.events.append(LockEvent(seq=seq, name=name, action=action, label=label))
+        return seq
+
+    def checkpoint(self, label: str) -> int:
+        """Mark a point of interest in the timeline so tests can ask which locks were held at it."""
+        return self.record(name=label, action=LockAction.CHECKPOINT, label=label)
+
+    def held_at(self, seq: int) -> set[str]:
+        """Return the set of lock names held at the moment ``seq`` was recorded."""
+        held: set[str] = set()
+        for event in self.events:
+            if event.seq >= seq:
+                break
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)
+        return held
+
+    def currently_held(self) -> set[str]:
+        held: set[str] = set()
+        for event in self.events:
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)
+        return held
+
+    def acquire_sequence(self, prefix: str | None = None) -> list[str]:
+        """Return the lock names in the order they were acquired, optionally filtered by name prefix."""
+        return [
+            event.name
+            for event in self.events
+            if event.action == LockAction.ACQUIRE and (prefix is None or event.name.startswith(prefix))
+        ]
+
+    def checkpoint_seqs(self, label: str) -> list[int]:
+        return [event.seq for event in self.events if event.action == LockAction.CHECKPOINT and event.label == label]
+
+    def assert_held_at_checkpoint(self, lock_name: str, label: str) -> None:
+        """Assert that ``lock_name`` was held at every checkpoint named ``label``."""
+        self._assert_held_at_checkpoint(lock_name, label, expected=True)
+
+    def assert_not_held_at_checkpoint(self, lock_name: str, label: str) -> None:
+        """Assert that ``lock_name`` was not held at any checkpoint named ``label``."""
+        self._assert_held_at_checkpoint(lock_name, label, expected=False)
+
+    def _assert_held_at_checkpoint(self, lock_name: str, label: str, *, expected: bool) -> None:
+        seqs = self.checkpoint_seqs(label)
+        if not seqs:
+            raise AssertionError(f"No checkpoint named {label!r} was recorded")
+        for seq in seqs:
+            actually_held = lock_name in self.held_at(seq)
+            if actually_held is not expected:
+                raise AssertionError(
+                    f"At checkpoint {label!r}, expected lock {lock_name!r} held={expected} but held={actually_held}. "
+                    f"Held at that point: {sorted(self.held_at(seq))}"
+                )
+
+    def assert_never_overlap(self, lock_names: Collection[str]) -> None:
+        """Assert that no two of ``lock_names`` were ever held at the same time.
+
+        Raises:
+            AssertionError: if two or more of ``lock_names`` were held simultaneously.
+
+        """
+        watched = set(lock_names)
+        held: set[str] = set()
+        for event in self.events:
+            if event.action == LockAction.ACQUIRE:
+                held.add(event.name)
+                overlap = held & watched
+                if len(overlap) > 1:
+                    raise AssertionError(f"Locks {sorted(overlap)} were held simultaneously")
+            elif event.action == LockAction.RELEASE:
+                held.discard(event.name)

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -18,6 +18,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.registry import registry
 from infrahub.exceptions import (
     CheckError,
+    CommitNotFoundError,
     RepositoryError,
     RepositoryFileNotFoundError,
     RepositoryInvalidBranchError,
@@ -209,18 +210,51 @@ async def test_create_commit_worktree_wrong_commit(git_repo_01: InfrahubReposito
 
     commit = "ffff1c0c64122bb2a7b208f7a9452146685bc7dd"
 
-    with pytest.raises(GitCommandError, match="invalid reference"):
+    with pytest.raises(CommitNotFoundError, match=rf"Commit {commit} not found with GitRepository '{repo.name}'"):
         repo.create_commit_worktree(commit=commit)
 
 
-async def test_create_commit_worktree_wrong_commit_no_origin(git_repo_01: InfrahubRepository) -> None:
+async def test_init_fetches_missing_commit_under_repo_lock(
+    git_repo_01: InfrahubRepository, git_upstream_repo_01: dict[str, str | Path]
+) -> None:
     repo = git_repo_01
-    repo.has_origin = False
+
+    # Add a commit to the upstream main after the local clone exists, without fetching it locally.
+    upstream = Repo(git_upstream_repo_01["path"])
+    first_file = find_first_file_in_directory(git_upstream_repo_01["path"])
+    assert first_file
+    async with await anyio.open_file(first_file, mode="a", encoding="utf-8") as file:
+        await file.write("new line\n")
+    upstream.index.add([first_file])
+    new_commit = str(upstream.index.commit("Change first file"))
+
+    # The local clone has not fetched the new commit, so the local primitive cannot find it.
+    with pytest.raises(CommitNotFoundError, match=rf"Commit {new_commit} not found with GitRepository '{repo.name}'"):
+        repo.create_commit_worktree(commit=new_commit)
+
+    # init() recovers by fetching the missing commit and materializing its worktree.
+    recovered = await InfrahubRepository.init(id=repo.id, name=repo.name, commit=new_commit, client=repo.client)
+    assert recovered.has_worktree(identifier=new_commit) is True
+
+
+async def test_init_missing_commit_without_origin_raises(git_repo_01: InfrahubRepository) -> None:
+    repo = git_repo_01
+    repo.get_git_repo_main().git.remote("remove", "origin")
 
     commit = "ffff1c0c64122bb2a7b208f7a9452146685bc7dd"
 
-    with pytest.raises(RepositoryError, match="no remote origin configured"):
-        repo.create_commit_worktree(commit=commit)
+    with pytest.raises(CommitNotFoundError, match=rf"Commit {commit} not found with GitRepository '{repo.name}'"):
+        await InfrahubRepository.init(id=repo.id, name=repo.name, commit=commit, client=repo.client)
+
+
+async def test_init_missing_commit_absent_on_remote_raises(git_repo_01: InfrahubRepository) -> None:
+    repo = git_repo_01
+
+    commit = "ffff1c0c64122bb2a7b208f7a9452146685bc7dd"
+
+    # The commit exists neither locally nor on the remote, so init fetches once and still raises.
+    with pytest.raises(CommitNotFoundError, match=rf"Commit {commit} not found with GitRepository '{repo.name}'"):
+        await InfrahubRepository.init(id=repo.id, name=repo.name, commit=commit, client=repo.client)
 
 
 async def test_get_worktrees(git_repo_01: InfrahubRepository) -> None:

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -24,6 +24,7 @@ from infrahub.git.models import (
     GitRepositoryPullReadOnly,
 )
 from infrahub.git.repository import InfrahubReadOnlyRepository
+from infrahub.git.sync import RepositoryAdder
 from infrahub.git.tasks import add_git_repository, add_git_repository_read_only, pull_read_only
 from infrahub.lock import InfrahubLockRegistry
 from infrahub.message_bus.messages import RefreshGitFetch
@@ -31,6 +32,7 @@ from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_client, build_message_bus, build_workflow
 from infrahub.workflows.catalogue import GIT_REPOSITORIES_DIFF_NAMES_ONLY, GIT_REPOSITORIES_MERGE
+from tests.adapters.lock import LockTimeline, RecordingImporter, RecordingLockRegistry
 from tests.adapters.message_bus import BusSimulator
 from tests.helpers.test_client import dummy_async_request
 
@@ -79,7 +81,11 @@ class TestAddRepository:
             patch.stopall()
 
     async def test_git_rpc_create_successful(
-        self, prefect_test_fixture: None, git_upstream_repo_01: dict[str, str], setup: None
+        self,
+        prefect_test_fixture: None,
+        git_upstream_repo_01: dict[str, str],
+        setup: None,
+        recording_lock_timeline: LockTimeline,
     ) -> None:
         repo_id = str(UUIDT())
         model = GitRepositoryAdd(
@@ -92,19 +98,15 @@ class TestAddRepository:
             internal_status="active",
         )
 
+        self.mock_repo.name = git_upstream_repo_01["name"]
         self.mock_repo.import_objects_from_files = AsyncMock()
+        self.mock_repo.collect_pending_imports = AsyncMock(return_value=[])
 
-        with (
-            patch("infrahub.git.tasks.lock") as mock_infra_lock,
-            patch("infrahub.git.tasks.InfrahubRepository", spec=InfrahubRepository) as mock_repo_class,
-        ):
-            mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)
+        with patch("infrahub.git.sync.InfrahubRepository", spec=InfrahubRepository) as mock_repo_class:
             mock_repo_class.new.return_value = self.mock_repo
             await add_git_repository(model=model)
 
-            mock_infra_lock.registry.get.assert_called_once_with(
-                name=git_upstream_repo_01["name"], namespace="repository"
-            )
+            assert f"repository.{git_upstream_repo_01['name']}" in recording_lock_timeline.acquire_sequence()
 
             mock_repo_class.new.assert_awaited_once_with(
                 id=repo_id,
@@ -116,9 +118,10 @@ class TestAddRepository:
                 default_branch_name=self.default_branch_name,
             )
             self.mock_repo.import_objects_from_files.assert_awaited_once_with(
-                infrahub_branch_name=self.default_branch_name, git_branch_name=self.default_branch_name
+                infrahub_branch_name=self.default_branch_name,
+                git_branch_name=self.default_branch_name,
+                commit="0123456789abcdef0123456789abcdef01234567",
             )
-            self.mock_repo.sync.assert_awaited_once_with()
 
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)
@@ -380,3 +383,31 @@ class TestPullReadOnly:
 
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)
+
+
+@pytest.mark.usefixtures("git_repos_dir")
+async def test_add_git_repository_releases_lock_before_import(
+    prefect_test_fixture: None,
+    git_upstream_repo_01: dict[str, str],
+) -> None:
+    """The default-branch import must run after the repository lock held for the clone is released."""
+    timeline = LockTimeline()
+    client = InfrahubClient(config=Config(requester=dummy_async_request))
+    model = GitRepositoryAdd(
+        repository_id=str(UUIDT()),
+        repository_name=git_upstream_repo_01["name"],
+        location=str(git_upstream_repo_01["path"]),
+        default_branch_name="main",
+        infrahub_branch_name="main",
+        infrahub_branch_id=str(UUIDT()),
+        internal_status=RepositoryInternalStatus.INACTIVE.value,
+    )
+
+    adder = RepositoryAdder(
+        lock_registry=RecordingLockRegistry(timeline=timeline),
+        importer=RecordingImporter(timeline),
+        client=client,
+    )
+    await adder.add(model)
+
+    timeline.assert_not_held_at_checkpoint(f"repository.{git_upstream_repo_01['name']}", "import")

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -1,0 +1,29 @@
+from uuid import uuid4
+
+from infrahub.core.branch import Branch
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from infrahub.git.sync import RepositorySyncer
+from tests.adapters.lock import LockTimeline, RecordingImporter, RecordingLockRegistry
+
+
+async def test_repository_lock_released_before_import(
+    prefect_test_fixture: None, git_repo_04: InfrahubRepository
+) -> None:
+    """The object import must not run while the repository lock is held.
+
+    The lock serializes mutations of the repository's on-disk git state. The import reads file
+    content from the per-commit worktree pinned earlier in the sync, so it stays outside that
+    critical section.
+    """
+    branch = Branch(name="branch01", uuid=uuid4())
+    registry.branch[branch.name] = branch
+
+    timeline = LockTimeline()
+    syncer = RepositorySyncer(
+        lock_registry=RecordingLockRegistry(timeline=timeline), importer=RecordingImporter(timeline)
+    )
+
+    await syncer.sync(git_repo_04)
+
+    timeline.assert_not_held_at_checkpoint(f"repository.{git_repo_04.name}", "import")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,7 +21,7 @@ from prefect import settings as prefect_settings
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from infrahub import config
+from infrahub import config, lock
 from infrahub.config import load_and_exit
 from infrahub.constants.database import Neo4jRuntime
 from infrahub.core import registry
@@ -61,6 +61,7 @@ from infrahub.permissions import LocalPermissionBackend
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.workers.dependencies import build_database, get_database
+from tests.adapters.lock import LockTimeline, install_recording_lock_registry
 from tests.adapters.log import FakeLogger
 from tests.adapters.message_bus import BusRecorder, BusSimulator
 from tests.helpers.constants import (
@@ -1244,6 +1245,17 @@ class TestHelper:
 @pytest.fixture
 def fake_log() -> FakeLogger:
     return FakeLogger()
+
+
+@pytest.fixture
+def recording_lock_timeline() -> Generator[LockTimeline, None, None]:
+    """Swap the global lock registry for a recording one, restoring the original on teardown."""
+    original = lock.registry
+    timeline = install_recording_lock_registry()
+    try:
+        yield timeline
+    finally:
+        lock.registry = original
 
 
 @pytest.fixture

--- a/backend/tests/unit/adapters/test_lock.py
+++ b/backend/tests/unit/adapters/test_lock.py
@@ -1,0 +1,62 @@
+from infrahub import lock
+from infrahub.lock import GLOBAL_GRAPH_LOCK, GLOBAL_SCHEMA_LOCK, LOCAL_SCHEMA_LOCK
+from tests.adapters.lock import LockAction, LockTimeline, RecordingLockRegistry
+
+
+async def test_records_acquire_and_release_order(recording_lock_timeline: LockTimeline) -> None:
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        pass
+    async with lock.registry.get(name="repo-b", namespace="repository"):
+        pass
+
+    assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a", "repository.repo-b"]
+    assert [event.action for event in recording_lock_timeline.events] == [
+        LockAction.ACQUIRE,
+        LockAction.RELEASE,
+        LockAction.ACQUIRE,
+        LockAction.RELEASE,
+    ]
+    assert recording_lock_timeline.currently_held() == set()
+
+
+async def test_held_at_checkpoint(recording_lock_timeline: LockTimeline) -> None:
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        recording_lock_timeline.checkpoint("inside")
+    recording_lock_timeline.checkpoint("outside")
+
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "inside")
+    recording_lock_timeline.assert_not_held_at_checkpoint("repository.repo-a", "outside")
+
+
+async def test_reentrant_acquire_records_single_boundary(recording_lock_timeline: LockTimeline) -> None:
+    repo_lock = lock.registry.get(name="repo-a", namespace="repository")
+    async with repo_lock:  # noqa: SIM117 - nesting is the re-entrant scenario under test
+        async with repo_lock:
+            recording_lock_timeline.checkpoint("nested")
+
+    assert recording_lock_timeline.acquire_sequence() == ["repository.repo-a"]
+    assert [event.action for event in recording_lock_timeline.events].count(LockAction.RELEASE) == 1
+    recording_lock_timeline.assert_held_at_checkpoint("repository.repo-a", "nested")
+
+
+async def test_multi_lock_records_each_member(recording_lock_timeline: LockTimeline) -> None:
+    async with lock.registry.global_graph_lock():
+        held = recording_lock_timeline.currently_held()
+
+    assert held == {LOCAL_SCHEMA_LOCK, GLOBAL_GRAPH_LOCK, GLOBAL_SCHEMA_LOCK}
+    assert recording_lock_timeline.currently_held() == set()
+
+
+async def test_assert_never_overlap(recording_lock_timeline: LockTimeline) -> None:
+    async with lock.registry.get(name="repo-a", namespace="repository"):
+        pass
+    async with lock.registry.get(name="repo-b", namespace="repository"):
+        pass
+
+    recording_lock_timeline.assert_never_overlap(["repository.repo-a", "repository.repo-b"])
+
+
+async def test_fixture_swaps_registry_and_exposes_timeline(recording_lock_timeline: LockTimeline) -> None:
+    assert isinstance(recording_lock_timeline, LockTimeline)
+    assert isinstance(lock.registry, RecordingLockRegistry)
+    assert lock.registry.timeline is recording_lock_timeline

--- a/changelog/6639.fixed.md
+++ b/changelog/6639.fixed.md
@@ -1,0 +1,1 @@
+Narrowed the git repository lock so it only guards on-disk git working-copy mutations (clone, fetch, worktree creation) and no longer wraps importing repository objects into the graph.

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -213,6 +213,7 @@ async def test_message_sent(bus_simulator: BusSimulator, ...):
 
 - `MemoryCache` - In-memory cache for fast tests
 - `FakeLogger` - Captures log output for assertions
+- `RecordingLockRegistry` / `LockTimeline` - Records lock acquire/release order so tests can assert what runs inside versus outside a critical section
 
 ## Supporting Directories
 


### PR DESCRIPTION
Supersedes #9529, which was blocked on merge conflicts.

## Summary

Merges `stable` into `release-1.10`. This forward-ports the repository-lock-narrowing work (only guarding clone/fetch/worktree mutations, running object import after the lock is released) plus the `CommitNotFoundError` hardening.

## Conflicts resolved

- `backend/infrahub/git/integrator.py` — both sides edited the same import region. `stable` widened `from infrahub import config` to `config, lock`; `release-1.10` added `AnonymousSession` and `InfrahubContext`. Kept all three imports.
- `backend/infrahub/git/tasks.py` — both sides edited the same import region. `stable` added `CommitNotFoundError`; `release-1.10` added `GitRepositoryNodeQuery`. Kept both.

Both were mechanical import collisions. The rest of the refactor (`infrahub/git/sync.py`, `RepositorySyncer`/`RepositoryAdder`/`RepositoryFileImporter`, the `sync` → `collect_pending_imports` split, lock test adapter) auto-merged. Verified the auto-merge is correct: all kept imports are used, every `.sync(` call site uses the new component API (no stale old-API calls), and `release-1.10`'s `GitRepositoryNodeQuery` usages live in separate functions from the refactored sync path.

## Conflicts raised for review

None — both conflicts were mechanical.

## Generated files regenerated

None — the merge touched no generated files.

## Validation

- `py_compile`, `ruff check`, `ty check` — all pass on the changed git module.
- `backend/tests/unit/adapters/test_lock.py` — 6/6 pass.
- Not run locally (need a live stack): `backend/tests/component/git/{test_git_repository,test_git_rpc,test_sync_lock_scope}.py` and the integration suite — CI covers these.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges `stable` into `release-1.10`, forward‑porting narrower Git repository locking and `CommitNotFoundError` hardening. Imports now run outside the repo lock; missing commits are fetched once during init under the lock.

- **Refactors**
  - Narrow repository lock to only clone/fetch/worktree mutations; run object import after lock release via `RepositorySyncer`, `RepositoryAdder`, and `RepositoryFileImporter`.
  - Split sync into `collect_pending_imports` (under lock) and an import loop (outside lock); pin the exact commit during the locked phase before importing.
  - Isolate per-branch git failures while collecting imports so other branches still sync.

- **Bug Fixes**
  - `create_commit_worktree` raises `CommitNotFoundError` when a commit is missing locally; `InfrahubRepository.init` fetches once under the repository lock and retries.
  - Tasks catch `CommitNotFoundError` alongside `RepositoryError` to tag/skip instead of aborting; worker notifications include the pinned commit via `RefreshGitFetch`.
  - Added a recording lock test adapter to verify imports occur after the lock is released.

<sup>Written for commit 1c0ad67f50df86d2c3ff28be0ac52a10600fdd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

