### PR TITLE
fix(config): trim whitespace from groups_claim setting

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -632,7 +632,7 @@ class SecurityOIDCBaseSettings(BaseSettings):
     def _validate_groups_claim(cls, value: str) -> str:
         if not value.strip():
             raise ValueError("groups_claim must not be empty or whitespace-only")
-        return value
+        return value.strip()
 
 
 class SecurityOIDCSettings(SecurityOIDCBaseSettings):
@@ -702,7 +702,7 @@ class SecurityOAuth2BaseSettings(BaseSettings):
     def _validate_groups_claim(cls, value: str) -> str:
         if not value.strip():
             raise ValueError("groups_claim must not be empty or whitespace-only")
-        return value
+        return value.strip()
 
 
 class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):

--- a/backend/tests/unit/config/test_config.py
+++ b/backend/tests/unit/config/test_config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
@@ -160,6 +161,41 @@ def test_groups_claim_empty_string_is_rejected_at_startup_oauth2(empty_value: st
 def test_groups_claim_empty_string_is_rejected_at_startup_oidc(empty_value: str) -> None:
     with pytest.raises(ValidationError, match=r"groups_claim must not be empty or whitespace-only"):
         _build_oidc_provider(groups_claim=empty_value)
+
+
+@dataclass
+class GroupsClaimStripCase:
+    name: str
+    value: str
+    expected: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        GroupsClaimStripCase(name="trailing_space", value="groups ", expected="groups"),
+        GroupsClaimStripCase(name="leading_space", value=" groups", expected="groups"),
+        GroupsClaimStripCase(name="surrounding_whitespace", value="  roles\t\n", expected="roles"),
+    ],
+    ids=lambda case: case.name,
+)
+def test_groups_claim_is_stripped_oauth2(case: GroupsClaimStripCase) -> None:
+    assert _build_oauth2_provider(groups_claim=case.value).groups_claim == case.expected
+    assert _build_oauth2_provider_2(groups_claim=case.value).groups_claim == case.expected
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        GroupsClaimStripCase(name="trailing_space", value="groups ", expected="groups"),
+        GroupsClaimStripCase(name="leading_space", value=" groups", expected="groups"),
+        GroupsClaimStripCase(name="surrounding_whitespace", value="  roles\t\n", expected="roles"),
+    ],
+    ids=lambda case: case.name,
+)
+def test_groups_claim_is_stripped_oidc(case: GroupsClaimStripCase) -> None:
+    assert _build_oidc_provider(groups_claim=case.value).groups_claim == case.expected
+    assert _build_oidc_provider_2(groups_claim=case.value).groups_claim == case.expected
 
 
 def test_fixture_loaded_providers_have_expected_groups_claim(helper: TestHelper) -> None:


### PR DESCRIPTION
## Summary

The OAuth2/OIDC `groups_claim` provider setting validator rejected whitespace-only values but returned the raw value otherwise, so a padded value (e.g. `"groups "`) was used verbatim as a claim key and failed to resolve the group claim. The validator now returns the stripped value. Applies to both the OIDC and OAuth2 base settings.

No changelog fragment: the `groups_claim` feature is new and unreleased in 1.10, so this bugfix is covered by the feature's own changelog entry.

Surfaced by cubic's review of #9525.