### PR TITLE
fix: floor computed-attribute chunk size at 1; dedup ipam utilization children

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -50,6 +50,10 @@ def _chunk_ids(ids: list[str], chunk_size: int) -> list[list[str]]:
     return [ids[i : i + chunk_size] for i in range(0, len(ids), chunk_size)]
 
 
+def _get_submission_chunk_size() -> int:
+    return max(1, get_prefect_max_related_resources() // 2)
+
+
 UPDATE_ATTRIBUTE = """
 mutation UpdateAttribute(
     $id: String!,
@@ -212,7 +216,7 @@ async def trigger_update_python_computed_attributes(
     if not object_ids:
         return
 
-    chunk_size = get_prefect_max_related_resources() // 2
+    chunk_size = _get_submission_chunk_size()
     for chunk in _chunk_ids(object_ids, chunk_size):
         await get_workflow().submit_workflow(
             workflow=COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
@@ -554,7 +558,7 @@ async def query_transform_targets(
                 key = (subscriber.kind, computed_attribute.name)
                 batches.setdefault(key, []).append(subscriber.object_id)
 
-    chunk_size = get_prefect_max_related_resources() // 2
+    chunk_size = _get_submission_chunk_size()
     for (kind, attribute_name), batch_object_ids in batches.items():
         for chunk in _chunk_ids(batch_object_ids, chunk_size):
             await get_workflow().submit_workflow(

--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -67,8 +67,9 @@ class PrefixUtilizationGetter:
         if ip_prefixes is None:
             ip_prefixes = self.ip_prefixes
         result: list[PrefixChildDetails] = []
-        for prefix in ip_prefixes:
-            for child in self._results_by_prefix_id.get(prefix.get_id(), []):
+        prefix_ids = {prefix.get_id() for prefix in ip_prefixes}
+        for prefix_id in prefix_ids:
+            for child in self._results_by_prefix_id.get(prefix_id, []):
                 if prefix_member_type and child.child_type != prefix_member_type:
                     continue
                 result.append(child)

--- a/backend/tests/component/core/ipam/test_ipam_utilization.py
+++ b/backend/tests/component/core/ipam/test_ipam_utilization.py
@@ -192,3 +192,16 @@ async def test_graphql_utilization_main_addition_after_branch_creation(
     assert isinstance(branch_prefix, BuiltinIPPrefix)
     branch_response = await branch_prefix.to_graphql(db=db, fields={"utilization": None})
     assert branch_response["utilization"] == {"value": 3}
+
+
+async def test_get_children_deduplicates_repeated_prefixes(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01: dict[str, Node]
+) -> None:
+    net143 = ip_dataset_01["net143"]
+    utilization = PrefixUtilizationGetter(db=db, ip_prefixes=[net143], branch=default_branch)
+
+    single = await utilization.get_children(ip_prefixes=[net143])
+    duplicated = await utilization.get_children(ip_prefixes=[net143, net143])
+
+    assert len(single) > 0
+    assert len(duplicated) == len(single)

--- a/backend/tests/unit/computed_attribute/test_tasks.py
+++ b/backend/tests/unit/computed_attribute/test_tasks.py
@@ -1,0 +1,46 @@
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from infrahub.computed_attribute.tasks import (
+    _chunk_ids,
+    _get_submission_chunk_size,
+)
+
+ENV_VAR = "PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES"
+
+
+@pytest.fixture
+def configured_max(request: pytest.FixtureRequest) -> Iterator[str]:
+    value: str = request.param
+    original = os.environ.get(ENV_VAR)
+    os.environ[ENV_VAR] = value
+    yield value
+    if original is None:
+        os.environ.pop(ENV_VAR, None)
+    else:
+        os.environ[ENV_VAR] = original
+
+
+def test_chunk_ids_rejects_zero_chunk_size() -> None:
+    """A zero chunk size is invalid and must never reach the chunker."""
+    with pytest.raises(ValueError, match="must not be zero"):
+        _chunk_ids(["a", "b"], 0)
+
+
+@pytest.mark.parametrize(
+    ("configured_max", "expected"),
+    [
+        ("1", 1),  # 1 // 2 == 0 without the floor, which would break batching
+        ("2", 1),
+        ("10", 5),
+        ("500", 250),
+    ],
+    indirect=["configured_max"],
+)
+def test_submission_chunk_size_is_floored_at_one(configured_max: str, expected: int) -> None:
+    chunk_size = _get_submission_chunk_size()
+    assert chunk_size == expected
+    # The computed size is always usable by the chunker, never zero.
+    assert _chunk_ids(["a", "b", "c"], chunk_size)

--- a/changelog/+fix-computed-attribute-chunk-size.fixed.md
+++ b/changelog/+fix-computed-attribute-chunk-size.fixed.md
@@ -1,0 +1,1 @@
+Computed attribute updates no longer raise a `ValueError` when `PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES` is set to `1`. The workflow submission chunk size is now floored at 1.

--- a/dev/knowledge/backend/code-generation.md
+++ b/dev/knowledge/backend/code-generation.md
@@ -70,7 +70,7 @@ CI runs these checks to ensure generated files are committed.
 
 ## Documentation Generation
 
-Reference documentation under `docs/docs/reference/` (and `docs/reference/configuration.mdx`) is rendered from the backend source, not written by hand:
+Reference documentation under `docs/docs/reference/` (and `docs/docs/reference/configuration.mdx`) is rendered from the backend source, not written by hand:
 
 | Source | Output |
 |--------|--------|


### PR DESCRIPTION
## Summary

Two small, independent backend fixes plus a docs path correction.

### 1. Computed-attribute chunk size floored at 1 (primary)

When `PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES` is set to `1`, the computed-attribute submission chunk size (that value integer-divided by 2) became `0`, and `range(0, len(ids), 0)` raises `ValueError: range() arg 3 must not be zero`, breaking batch submission.

The chunk-size computation is extracted into `_get_submission_chunk_size()` in `backend/infrahub/computed_attribute/tasks.py`, which floors the result at 1 via `max(1, ...)`. Both submission call sites now route through it.

Surfaced by cubic's review of #9525.

### 2. Dedup prefixes in IPAM utilization child lookup

`get_children` in `backend/infrahub/core/ipam/utilization.py` iterated the input prefix list directly, so passing the same prefix more than once double-counted its children and inflated utilization counts/percentages. Prefix ids are now collected into a set before lookup. No current caller passes duplicates; this is defensive hardening.

### 3. Docs

Corrected a stale `configuration.mdx` path in `dev/knowledge/backend/code-generation.md`.
