### PR TITLE
fix(git): correct added/removed file action in repository diffs

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -749,7 +749,13 @@ class InfrahubRepositoryBase(BaseModel, ABC):
     async def calculate_diff_between_commits(
         self, first_commit: str, second_commit: str
     ) -> tuple[list[str], list[str], list[str]]:
-        """TODO need to refactor this function to return more information.
+        """Return the (changed, added, removed) files going from first_commit to second_commit.
+
+        Direction follows `git diff first_commit second_commit`: first_commit is the old/base side
+        and second_commit is the new/target side. A file present only in second_commit is "added";
+        a file present only in first_commit is "removed".
+
+        TODO need to refactor this function to return more information.
 
         Like :
           - What has changed inside the files
@@ -765,12 +771,12 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         added_files = []
 
         for x in commit_in_branch.diff(commit_to_compare, create_patch=True):
-            if x.a_blob and not x.b_blob and x.a_blob.path not in added_files:
-                added_files.append(x.a_blob.path)
+            if x.a_blob and not x.b_blob and x.a_blob.path not in removed_files:
+                removed_files.append(x.a_blob.path)
             elif x.a_blob and x.b_blob and x.a_blob.path not in changed_files:
                 changed_files.append(x.a_blob.path)
-            elif not x.a_blob and x.b_blob and x.b_blob.path not in removed_files:
-                removed_files.append(x.b_blob.path)
+            elif not x.a_blob and x.b_blob and x.b_blob.path not in added_files:
+                added_files.append(x.b_blob.path)
 
         return changed_files, added_files, removed_files
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1729,7 +1729,7 @@ async def _gather_repository_repository_diffs(
 
             if repo.destination_branch:
                 files_changed, files_added, files_removed = await git_repo.calculate_diff_between_commits(
-                    first_commit=repo.source_commit, second_commit=repo.destination_commit
+                    first_commit=repo.destination_commit, second_commit=repo.source_commit
                 )
             else:
                 files_added = await git_repo.list_all_files(commit=repo.source_commit)

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -974,8 +974,9 @@ async def test_calculate_diff_between_commits(
     commit_branch01 = repo.get_commit_value(branch_name=branch01.name, remote=False)
     commit_branch02 = repo.get_commit_value(branch_name=branch02.name, remote=False)
 
+    # branch02 is the base, branch01 holds the changes; first_commit is the old side, second_commit the new.
     changed, added, removed = await repo.calculate_diff_between_commits(
-        first_commit=commit_branch01, second_commit=commit_branch02
+        first_commit=commit_branch02, second_commit=commit_branch01
     )
     assert changed == ["README.md", "test_files/sports.yml"]
     assert added == ["mynewfile.txt"]

--- a/changelog/9530.fixed.md
+++ b/changelog/9530.fixed.md
@@ -1,0 +1,1 @@
+Fixed the file action reported by the repository diff so a file added on a branch is labelled `added` (and a deleted file `removed`) instead of being inverted in `GET /api/diff/files` and the Proposed Change Files tab.


### PR DESCRIPTION
## Summary

Fixes #9530 (IFC-2723).

`calculate_diff_between_commits` inverted the per-file action: a file present only in the new commit was labelled `removed`, and one present only in the old commit `added`. This surfaced as added files showing **removed** in `GET /api/diff/files` and the Proposed Change → Files tab. `updated` is symmetric and was unaffected.

## Root cause

The `a_blob`/`b_blob` → action mapping was backwards relative to the function's own git operation (`first.diff(second)` = `git diff first second`, where `first` is the old/base side). Two callers passed commits in opposite order, so one path was correct (proposed-change gathering, by accident) and one was wrong (`/api/diff/files`).

## Changes

- **`git/base.py`** — corrected the mapping so a file present only in `second_commit` (new) is `added` and only in `first_commit` (old) is `removed`; documented the `first`=old / `second`=new direction.
- **`proposed_change/tasks.py`** — corrected the caller's argument order so the proposed-change repo-diff path stays correct after the function fix (it previously relied on the inverted behaviour via reversed arguments).
- **`test_git_repository.py`** — the component test now calls in the API consumption direction and asserts git-ground-truth-correct actions.

## Testing

- `test_calculate_diff_between_commits` updated to call in the real API direction; confirmed it fails before the fix (added file reported as `removed`) and passes after.
- Full git component suite green: 61 passed, 1 xfailed (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inverted added/removed actions in repository diffs. Added files now show added and deleted files removed in `GET /api/diff/files` and the Proposed Change Files tab (IFC-2723).

- **Bug Fixes**
  - Fixed `calculate_diff_between_commits` to follow `git diff first second` (first=old, second=new); updated the docstring.
  - Corrected commit order in `proposed_change/tasks.py` for proposed-change diffs.
  - Updated the component test to assert actions in the API direction.

<sup>Written for commit 9267d6cb03aaf7be1ce2434428025f9c1c47a8b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

