### PR TITLE
fix(frontend): reconcile playwright pin in pnpm-lock graph importer

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -417,7 +417,7 @@ importers:
         version: 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.8(playwright@1.56.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
       '@xyflow/react':
         specifier: ^12.10.2
         version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -434,8 +434,8 @@ importers:
         specifier: ^1.62.0
         version: 1.69.0
       playwright:
-        specifier: 1.56.1
-        version: 1.56.1
+        specifier: 1.60.0
+        version: 1.60.0
       storybook:
         specifier: ^10.3.6
         version: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Problem

`develop` CI is red on every job that installs frontend deps (`frontend-lint`, `frontend-validate-graphql-types`, …) since this PR has been merged https://github.com/opsmill/infrahub/pull/9497/:

```
ERR_PNPM_OUTDATED_LOCKFILE  pnpm-lock.yaml is not up to date with packages/graph/package.json
  - playwright (lockfile: 1.56.1, manifest: 1.60.0)
```

## Root cause

The playwright `overrides` entry in `frontend/pnpm-lock.yaml` was bumped to `1.60.0` (matching `frontend/app/package.json`'s `@playwright/test: 1.60.0`), and the lockfile's top-level `overrides:` block + resolution were updated — but the `packages/graph` importer block was left pinned at `1.56.1`.

pnpm applies the override to compute the effective manifest specifier (`1.60.0`) and compares it against the stale importer entry (`1.56.1`), so `pnpm install --frozen-lockfile` fails.

## Fix

Regenerated the lockfile with the pinned `pnpm@10.33.2` (`--lockfile-only`). The diff is 3 lines — the `packages/graph` importer's playwright `specifier`/`version` reconcile to `1.60.0`, plus the dependent `@vitest/browser-playwright` resolution. No `package.json` changes needed: `1.60.0` is the already-intended version.

Verified locally: `pnpm install --frozen-lockfile` now reports `Lockfile is up to date`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI lockfile errors by aligning `playwright` in the `packages/graph` importer to 1.60.0. Regenerated the lockfile so `pnpm install --frozen-lockfile` passes again.

- **Bug Fixes**
  - Reconciled `playwright` specifier/version from 1.56.1 to 1.60.0 in `frontend/pnpm-lock.yaml` for the `packages/graph` importer to match top-level overrides and `@playwright/test@1.60.0`.
  - Updated `@vitest/browser-playwright` resolution to use `playwright@1.60.0`.
  - Regenerated lockfile with `pnpm@10.33.2` using `--lockfile-only`; verified `pnpm install --frozen-lockfile` is up to date.

<sup>Written for commit 5cb4231d3aa4ddeeb0294c6f77c391755f99fb4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

