### PR TITLE
Re-enable all rules in @infrahub/ui linter

### DIFF
--- a/frontend/packages/ui/oxlint.config.ts
+++ b/frontend/packages/ui/oxlint.config.ts
@@ -1,23 +1,48 @@
 import { defineConfig } from "oxlint";
 
-// Bug-catching categories only (matching the app's biome philosophy): style and
-// opinionated rules are oxfmt's / code review's job, not the linter's.
+// We enable all rules and disable irrelevant ones.
 export default defineConfig({
+  ignorePatterns: ["**/.storybook/**"],
+  categories: {
+    correctness: "error",
+    nursery: "error",
+    pedantic: "error",
+    perf: "error",
+    restriction: "error",
+    style: "error",
+    suspicious: "error",
+  },
   env: {
     browser: true,
   },
-  categories: {
-    correctness: "error",
-    perf: "error",
-    suspicious: "error",
-  },
   plugins: ["oxc", "typescript", "react", "react-perf", "jsx-a11y", "vitest", "unicorn"],
   rules: {
+    "eslint/arrow-body-style": "off",
+    "eslint/func-style": "off",
+    "eslint/id-length": "off",
     "eslint/no-console": ["error", { allow: ["error"] }],
-    // The React Compiler memoizes; inline values as props are not a re-render hazard here.
-    "react-perf/jsx-no-new-array-as-prop": "off",
-    "react-perf/jsx-no-new-function-as-prop": "off",
+    "eslint/no-empty-function": "off",
+    "eslint/no-magic-numbers": ["error", { ignore: [0, 1] }],
+    "eslint/max-lines-per-function": "off",
+    "eslint/no-ternary": "off",
+    "eslint/sort-imports": "off",
+    "eslint/sort-keys": "off",
+    "oxc/no-rest-spread-properties": "off",
     "react-perf/jsx-no-new-object-as-prop": "off",
+    "react/button-has-type": "off",
+    "react/forbid-component-props": "off",
+    "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
+    "react/jsx-max-depth": "off",
+    "react/jsx-props-no-spreading": "off",
+    "react/no-multi-comp": "off",
+    "react/only-export-components": "off",
     "react/react-in-jsx-scope": "off",
+    "react_perf/jsx-no-new-array-as-prop": "off",
+    "react_perf/jsx-no-new-function-as-prop": "off",
+    "typescript/explicit-function-return-type": "off",
+    "typescript/explicit-module-boundary-types": "off",
+    "typescript/no-empty-interface": "off",
+    "typescript/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
+    "unicorn/no-null": "off",
   },
 });

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -18,11 +18,6 @@
     "lint:fix": "oxlint --fix",
     "storybook": "storybook dev -p 6006"
   },
-  "peerDependencies": {
-    "react": "catalog:",
-    "react-dom": "catalog:",
-    "tailwindcss": "catalog:"
-  },
   "dependencies": {
     "@radix-ui/react-scroll-area": "^1.2.11",
     "lucide-react": "catalog:",
@@ -33,6 +28,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@rolldown/plugin-babel": "^0.2.3",
     "@storybook/react-vite": "^10.4.3",
     "@tailwindcss/vite": "catalog:",
     "@types/node": "catalog:",
@@ -50,5 +46,10 @@
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:"
   }
 }

--- a/frontend/packages/ui/src/components/spinner/spinner.tsx
+++ b/frontend/packages/ui/src/components/spinner/spinner.tsx
@@ -2,14 +2,14 @@ import type React from "react";
 
 import { cn } from "tailwind-variants";
 
-export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLOutputElement>, "className"> {
+export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "className"> {
   className?: React.HTMLAttributes<SVGSVGElement>["className"];
 }
 
 export const Spinner = ({ className, ...props }: SpinnerProps) => {
   return (
-    // `block` keeps the previous div layout (output is inline by default).
-    <output className="block" {...props}>
+    // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role This is a generic loading indicator, not an output value.
+    <div role="status" {...props}>
       <svg
         aria-hidden="true"
         className={cn("size-4 animate-spin fill-cyan-600 text-neutral-200", className)}
@@ -27,6 +27,6 @@ export const Spinner = ({ className, ...props }: SpinnerProps) => {
         />
       </svg>
       <span className="sr-only">Loading...</span>
-    </output>
+    </div>
   );
 };

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -35,7 +35,7 @@ export function Tooltip({
   className,
   ...props
 }: TooltipProps) {
-  if (message == null) {
+  if (message === null) {
     return children;
   }
 

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -35,7 +35,8 @@ export function Tooltip({
   className,
   ...props
 }: TooltipProps) {
-  if (message === null) {
+  const hasMessage = !message && message !== 0;
+  if (!hasMessage) {
     return children;
   }
 

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -35,8 +35,7 @@ export function Tooltip({
   className,
   ...props
 }: TooltipProps) {
-  const hasMessage = !message && message !== 0;
-  if (!hasMessage) {
+  if (!message && message !== 0) {
     return children;
   }
 

--- a/frontend/packages/ui/src/components/tree/tree.stories.tsx
+++ b/frontend/packages/ui/src/components/tree/tree.stories.tsx
@@ -4,11 +4,11 @@ import { Collection } from "react-aria-components";
 
 import { Tree, TreeItem, TreeItemContent } from "./tree";
 
-type FolderNode = {
+interface FolderNode {
   id: string;
   name: string;
   children?: FolderNode[];
-};
+}
 
 const TREE_DATA: FolderNode[] = [
   {

--- a/frontend/packages/ui/vite.config.ts
+++ b/frontend/packages/ui/vite.config.ts
@@ -1,14 +1,14 @@
+import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
-    react({
-      babel: {
-        plugins: [["babel-plugin-react-compiler"]],
-      },
+    react(),
+    babel({
+      presets: [reactCompilerPreset()],
     }),
     tailwindcss(),
   ],

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/react-vite':
         specifier: ^10.4.3
         version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-enabled all `oxlint` rule categories for `@infrahub/ui`, tuned the config, and integrated the React Compiler via `@rolldown/plugin-babel`. Improved Spinner semantics and refined Tooltip behavior.

- **Refactors**
  - Linter: enabled all categories; ignored `**/.storybook/**`; added targeted rule exceptions (e.g., `no-magic-numbers`); enforced `.tsx` for JSX; refined empty interface/object rules.
  - Tooltip: only renders when a message is provided; treats `0` as valid.
  - Tree stories: switched `FolderNode` to an `interface`.
  - Vite: integrated React Compiler using `@rolldown/plugin-babel` with `reactCompilerPreset()`.

- **Bug Fixes**
  - Spinner: replaced `<output>` with `<div role="status">`, typed props to `HTMLDivElement`, and silenced a false-positive a11y rule.

<sup>Written for commit d4b3697b98ecd2b516edf5f9742f8783da0065bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

