### PR TITLE
Switch output folder for generated schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ python_sdk/dist/*
 !backend/tests/unit/**/data_export/*.csv
 
 # Generated files
+/.generated/
 query_performance_results/
 sync/dist/
 helm/charts/

--- a/tasks/schema.py
+++ b/tasks/schema.py
@@ -5,8 +5,8 @@ from invoke.tasks import task
 
 from .utils import ESCAPED_REPO_PATH, REPO_BASE
 
-SDK_DIRECTORY = REPO_BASE / "generated" / "python-sdk"
-INFRAHUB_DIRECTORY = REPO_BASE / "generated" / "infrahub"
+SDK_DIRECTORY = REPO_BASE / ".generated" / "python-sdk"
+INFRAHUB_DIRECTORY = REPO_BASE / ".generated" / "infrahub"
 
 REPOSITORY_CONFIG_DIRECTORY = SDK_DIRECTORY / "repository-config"
 INFRAHUB_SCHEMA_DIRECTORY = INFRAHUB_DIRECTORY / "schema"
@@ -39,7 +39,7 @@ def generate_jsonschema(context: Context) -> None:
 
 @task
 def generate_repositoryconfig(context: Context) -> None:
-    """Generate repository config into generated/python-sdk/repository-config/develop.json."""
+    """Generate repository config into .generated/python-sdk/repository-config/develop.json."""
     from infrahub_sdk.schema.repository import InfrahubRepositoryConfig
 
     with context.cd(ESCAPED_REPO_PATH):
@@ -51,7 +51,7 @@ def generate_repositoryconfig(context: Context) -> None:
 
 @task
 def generate_infrahubnodeschema(context: Context) -> None:
-    """Generate infrahub node schema into generated/infrahub/schema/develop.json."""
+    """Generate infrahub node schema into .generated/infrahub/schema/develop.json."""
     with context.cd(ESCAPED_REPO_PATH):
         context.run(f"uv run infrahub dev export-node-schema --out {INFRAHUB_NODE_SCHEMA_PATH}")
         print(f"Wrote to {INFRAHUB_NODE_SCHEMA_PATH}")


### PR DESCRIPTION
# Why

When running `invoke schema.generate-jsonschema` we previously wrote to a ./generated folder at the root of the repo. The `./generated` folder used to be part of .gitignore but this was changed as we're using a matching folder for things related to the frontend. This PR changes the output directory to `./generated`

```bash
❯ inv schema.generate-jsonschema
Wrote to /Users/patrick/Code/opsmill/infrahub/schema/openapi.json
Wrote to /Users/patrick/Code/opsmill/infrahub/.generated/python-sdk/repository-config/develop.json
Wrote to /Users/patrick/Code/opsmill/infrahub/.generated/infrahub/schema/develop.json
```

## What changed

* Change output directory for schema files
* Update .gitignore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch schema generation output to `./.generated` to avoid conflicts with the frontend’s `generated` folder and keep build artifacts out of git.

- **Refactors**
  - Write schemas to `./.generated/python-sdk/repository-config/develop.json` and `./.generated/infrahub/schema/develop.json`.
  - Updated `.gitignore` to ignore `/.generated/`.

<sup>Written for commit f1e0bd545b5302f3bd8142d20526e200dbe4226a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

