### PR TITLE
feat: support DateTime kind for computed attributes

### DIFF
--- a/backend/infrahub/computed_attribute/constants.py
+++ b/backend/infrahub/computed_attribute/constants.py
@@ -7,4 +7,4 @@ QUERY_AUTOMATION_NAME_PREFIX = "Computed-attribute-query"
 PROCESS_AUTOMATION_NAME = "{prefix}::{scope}::{identifier}"
 QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{scope}::{identifier}"
 
-VALID_KINDS = ["Text", "URL"]
+VALID_KINDS = ["Text", "URL", "DateTime"]

--- a/backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py
+++ b/backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py
@@ -427,3 +427,83 @@ async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, exp
         schema.process()
 
     assert str(exc.value) == expected_error
+
+
+async def test_schema_computed_attribute_datetime_jinja2() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Person",
+                    namespace="Testing",
+                    attributes=[
+                        AttributeSchema(
+                            name="start_date",
+                            kind="DateTime",
+                        ),
+                        AttributeSchema(
+                            name="end_date",
+                            kind="DateTime",
+                            read_only=True,
+                            computed_attribute=ComputedAttribute(
+                                kind=ComputedAttributeKind.JINJA2,
+                                jinja2_template="{{ start_date__value }}",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+    schema.process()
+
+    node = schema.get_node(name="TestingPerson")
+    end_date = node.get_attribute(name="end_date")
+    assert end_date.kind == "DateTime"
+    assert end_date.read_only is True
+    assert end_date.computed_attribute is not None
+    assert end_date.computed_attribute.kind == ComputedAttributeKind.JINJA2
+    assert end_date.computed_attribute.jinja2_template == "{{ start_date__value }}"
+
+
+async def test_schema_computed_attribute_datetime_transform() -> None:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Person",
+                    namespace="Testing",
+                    attributes=[
+                        AttributeSchema(
+                            name="start_date",
+                            kind="DateTime",
+                        ),
+                        AttributeSchema(
+                            name="end_date",
+                            kind="DateTime",
+                            read_only=True,
+                            optional=True,
+                            computed_attribute=ComputedAttribute(
+                                kind=ComputedAttributeKind.TRANSFORM_PYTHON,
+                                transform="my_transform",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+    schema.process()
+
+    node = schema.get_node(name="TestingPerson")
+    end_date = node.get_attribute(name="end_date")
+    assert end_date.kind == "DateTime"
+    assert end_date.read_only is True
+    assert end_date.optional is True
+    assert end_date.computed_attribute is not None
+    assert end_date.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON
+    assert end_date.computed_attribute.transform == "my_transform"

--- a/backend/tests/component/graphql/mutations/test_computed_attribute.py
+++ b/backend/tests/component/graphql/mutations/test_computed_attribute.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.constants import ComputedAttributeKind, PermissionAction, PermissionDecision
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.computed_attribute import ComputedAttribute
 from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
@@ -96,3 +97,73 @@ async def test_update_computed_attribute_sends_node_updated_event(
     # The display label of the node within the event must include the correct label
     # even if the display label contains a related node
     assert event.changelog.display_label == "Ocean Blue"
+
+
+async def test_update_computed_attribute_rejects_invalid_datetime(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    default_permission_backend: None,
+    session_first_account: AccountSession,
+    first_account: Node,
+) -> None:
+    """UpdateComputedAttribute rejects an invalid DateTime value for a DateTime computed attribute."""
+    TASK = NodeSchema(
+        name="Task",
+        namespace="Testing",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(
+                name="due_date",
+                kind="DateTime",
+                read_only=True,
+                computed_attribute=ComputedAttribute(
+                    kind=ComputedAttributeKind.JINJA2,
+                    jinja2_template="{{ name__value }}",
+                ),
+            ),
+        ],
+    )
+
+    await load_schema(db, schema=SchemaRoot(nodes=[TASK]))
+
+    await define_permissions(
+        account=first_account,
+        db=db,
+        object_permissions=[
+            ObjectPermission(
+                namespace=TASK.namespace,
+                name=TASK.name,
+                action=PermissionAction.UPDATE.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ],
+    )
+
+    task = await Node.init(db=db, schema=TASK.kind, branch=default_branch)
+    await task.new(db=db, name="2026-06-11T00:00:00Z")
+    await task.save(db=db)
+
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, service=service, account_session=session_first_account
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_COMPUTED_ATTRIBUTE_MUTATION,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": task.id,
+            "kind": TASK.kind,
+            "attribute": "due_date",
+            "value": "123",
+        },
+    )
+
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "is not a valid DateTime" in str(result.errors[0])

--- a/docs/docs/computed-attributes/overview.mdx
+++ b/docs/docs/computed-attributes/overview.mdx
@@ -13,7 +13,7 @@ Currently, Infrahub supports two main types of computed attributes:
 
 Computed attributes have some inherent restrictions due to system constraints and performance considerations. Keep these in mind when designing your schema:
 
-* Only `URL` and `Text` attribute kinds are supported for computed attributes.
+* Only `Text`, `URL`, and `DateTime` attribute kinds are supported for computed attributes.
 
 ::::
 


### PR DESCRIPTION
# Why

Computed attributes only supported `Text` and `URL` kinds. Users cannot use DateTime for computed fields like auto-calculated end dates from start dates.

Closes #6738

Addressed the comments from #6753 as well

## What changed

- Added `"DateTime"` to `VALID_KINDS` in `computed_attribute/constants.py`
- Added tests to verify the behaviour.

## How to test

```bash
uv run pytest backend/tests/component/core/schema/schema_branch/test_validate_computed_attributes.py -v
uv run pytest backend/tests/component/graphql/mutations/test_computed_attribute.py -v
```

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [x] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `DateTime` computed attributes so schemas can auto-calculate dates/times (e.g., end_date from start_date). Closes #6738.

- **New Features**
  - Enable `DateTime` computed attributes by adding it to `VALID_KINDS`.
  - Add tests for Jinja2 and Python transform paths, plus GraphQL rejection of invalid DateTime values.
  - Update docs to list `DateTime` as a supported kind.

<sup>Written for commit 8593e3b59428d4333d99070e0e241a4e15b3f2cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

