### PR TITLE
Add filepaths impacted by development rules

### DIFF
--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "backend/infrahub/**/*.py"
+  - "python_testcontainers/infrahub_testcontainers/**/*.py"
 ---
 
 # Backend Component Design (SOLID / DI)

--- a/dev/rules/code-doc-style.md
+++ b/dev/rules/code-doc-style.md
@@ -1,6 +1,7 @@
 ---
 paths:
-  - "backend/infrahub/**/*.py"
+  - "backend/**/*.py"
+  - "python_testcontainers/**/*.py"
 ---
 
 # Code documentation style

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -5,6 +5,8 @@ paths:
   - "backend/tests/functional/**/*.py"
   - "backend/tests/integration/**/*.py"
   - "backend/tests/integration_docker/**/*.py"
+  - "python_testcontainers/tests/**/*.py"
+
 ---
 
 # Python Testing Rules


### PR DESCRIPTION
# Why

Ensure that rules covers tests and also include the testcontainers package

## What changed

Impacted filepaths for various dev rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand dev rule file paths to cover all backend Python files and the `python_testcontainers` package, including its tests. This ensures backend design, code doc style, and Python testing rules apply consistently across backend and `python_testcontainers`.

<sup>Written for commit 8c3863da1dcb0c5587268ac37f23d9e844c5231c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

