### PR TITLE
Add identified feedback to /dev/rules

### DIFF
--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -11,6 +11,12 @@ Applies when creating a new backend component or making significant changes to a
 
 New logic should live in components that receive their collaborators through constructor injection rather than instantiating them internally. This keeps components composable, swappable, and testable without patching.
 
+## Required dependencies, not optional
+
+Constructor dependencies for new code are required parameters - not `collaborator: Collaborator | None = None` with an internal default. Optional injection hides that the dependency exists and lets a caller silently skip wiring it. Make every collaborator an explicit, required constructor argument - explicit is better than implicit.
+
+The single exception is editing existing code where adding a required parameter would force a large change across many call sites. There, an optional parameter is a transitional compromise to keep the change small - not the target shape for new components.
+
 ## Build components near the application entry point
 
 Construct components as close to the application entry point as possible. Use a builder class or factory function when wiring is non-trivial, and inject each sub-component rather than constructing it inside a parent component's `__init__`.
@@ -38,6 +44,32 @@ When more than one implementation of a component is required (e.g. real vs. in-m
 A single implementation does not need an interface yet; introduce one when the second implementation arrives. Note that the second implementation
 can be either a no-op version (such as in the case of an enterprise-only feature) or a testing version of a component (such as in the case of an
 in-memory version of a component typically backed by the database).
+
+## Dispatching across implementations
+
+When a component must pick one of several implementations at runtime based on the input, do not branch with `isinstance` (or a `match` on the input's type) inside one class. Give each implementation a predicate on the shared interface (e.g. `supports(request) -> bool`) alongside its entry method, hold the implementations as an injected list in an aggregator component, and let the aggregator delegate to the first that supports the input:
+
+```python
+class CheckerInterface(ABC):
+    @abstractmethod
+    def supports(self, request: Request) -> bool: ...
+    @abstractmethod
+    def check(self, request: Request) -> Result: ...
+
+class AggregatedChecker:
+    def __init__(self, checkers: list[CheckerInterface]) -> None:
+        self.checkers = checkers
+
+    def run(self, request: Request) -> Result:
+        for checker in self.checkers:
+            if checker.supports(request):
+                return checker.check(request)
+        raise NoCheckerError(request)
+```
+
+The aggregator depends only on the interface; the concrete list is assembled by the factory at the wiring layer, so adding an implementation is one new class plus one line in the factory, with no edit to the dispatch logic. `AggregatedConstraintChecker` (`backend/infrahub/core/validators/`) is the canonical example in the codebase.
+
+This is for an open, extensible set of implementations. When the set is closed and fixed (an enum, a sealed union), an exhaustive `match` with `typing.assert_never` is the right tool instead.
 
 ## Why this matters
 

--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -71,9 +71,9 @@ The aggregator depends only on the interface; the concrete list is assembled by 
 
 This is for an open, extensible set of implementations. When the set is closed and fixed (an enum, a sealed union), an exhaustive `match` with `typing.assert_never` is the right tool instead.
 
-## Why this matters
+## Why this design matters
 
-Constructor-injected long-lived dependencies plus method-passed transient entities is the boundary that lets components be reused across requests/operations and mocked with adapter implementations instead of `unittest.mock`. The [testing rule](./testing-python.md) requires adapter/protocol patterns for tests — that requirement is only practical when production code follows this design.
+Stepping back from the individual rules above: constructor-injected long-lived dependencies plus method-passed transient entities is the boundary that lets components be reused across requests/operations and mocked with adapter implementations instead of `unittest.mock`. The [testing rule](./testing-python.md) requires adapter/protocol patterns for tests — that requirement is only practical when production code follows this design.
 
 Use this as a design driver, not just a constraint: the no-mock rule is the forcing function for this structure. When you make a component's decision logic testable without patching — collaborators injected through the constructor, a single entry point that is pure and operates only on its arguments — dependency inversion and single responsibility fall out as the path of least resistance rather than discipline you have to summon. The corollary is a useful smell test: if a component is hard to test without a mock, that is the signal it needs splitting or its dependencies injected, not that it needs a mock.
 

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -44,9 +44,11 @@ with pytest.raises(SomeError, match=r"expected message"):
     call_function()
 ```
 
+Make `match` cover the whole stable message (anchor with `^...$` where practical), not a short fragment of it. A fragment passes even when the rest of the wording regresses. Match only a substring when the message has a genuinely variable part (an id, a path, a count) that you cannot pin down.
+
 ## GraphQL error assertions
 
-Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes.
+Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. This applies to any exception assertion, not just GraphQL.
 
 ## Test file placement
 

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -48,7 +48,7 @@ Make `match` cover the whole stable message (anchor with `^...$` where practical
 
 ## GraphQL error assertions
 
-Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. This applies to any exception assertion, not just GraphQL.
+Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. The full-message-over-fragment preference applies to any exception assertion, not just GraphQL; with `pytest.raises` express it through an anchored `match` (above) rather than `==`.
 
 ## Test file placement
 


### PR DESCRIPTION
# Why

This PR adds feedback from various PRs of the epic that was merged in #9414. The feedback comes from the linked PRs going into 9414.

## What changed

* Added new sections to the rule
* Updated "Why this matters" header as it seemed to related to the section just above, but the header was just a bit confusing.

## How to review

Consider if this matches what we expect to see for new code moving forward.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates backend component design rules to require explicit, non-optional constructor injection (with a narrow transitional exception) and documents an aggregator pattern that dispatches via `supports(...)`; use exhaustive `match` for closed sets. Tightens Python testing rules to assert full, anchored exception messages with `pytest.raises(..., match=^...$)` (substring only when parts vary) and confirms this applies beyond GraphQL.

<sup>Written for commit 7543f8b3400a3df7dc1e256e052588e93ffb4e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



