### PR TITLE
ci: run component test shards with a single xdist worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
     timeout-minutes: 45
     env:
       INFRAHUB_DB_TYPE: neo4j
-      PYTEST_XDIST_WORKER_COUNT: 1
+      PYTEST_XDIST_WORKER_COUNT: 2
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,7 @@ jobs:
     timeout-minutes: 45
     env:
       INFRAHUB_DB_TYPE: neo4j
+      PYTEST_XDIST_WORKER_COUNT: 1
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"


### PR DESCRIPTION
Temporary measurement branch: compare shard wall time at 1 worker vs the inherited PYTEST_XDIST_WORKER_COUNT=4 to quantify what xdist parallelism contributes per shard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run component test shards with two `pytest-xdist` workers in CI to measure per-shard wall time and quantify parallelism benefits. Sets `PYTEST_XDIST_WORKER_COUNT=2` for the component test job to compare against earlier 1-worker and 4-worker runs.

<sup>Written for commit 73e237d55ebc1bbc05a678e27830731baaa1b156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

