### PR TITLE
perf(tests): pin Neo4j query plans in test container (on top of #9551)

### DIFF
--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -27,6 +27,13 @@ def start_neo4j_container(neo4j_image: str, extra_env: dict[str, str] | None = N
         .with_env("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
         .with_env("NEO4J_dbms_security_procedures_unrestricted", "apoc.*")
         .with_env("NEO4J_dbms_security_auth__minimum__password__length", "4")
+        # Tests churn data on every test, which trips Neo4j's statistics-divergence
+        # replanning and recompiles the same (complex, generated) Cypher repeatedly.
+        # On the tiny, ephemeral test dataset adaptive replanning buys nothing, so
+        # pin plans for the session. This is test-only; production must keep the
+        # defaults so plans adapt as data grows.
+        .with_env("NEO4J_dbms_cypher_statistics__divergence__threshold", "1.0")
+        .with_env("NEO4J_dbms_cypher_min__replan__interval", "1h")
         .with_exposed_ports(PORT_BOLT_NEO4J)
         .with_exposed_ports(PORT_HTTP_NEO4J)
     )


### PR DESCRIPTION
Experiment stacked on #9551 to measure whether disabling Neo4j statistics-divergence replanning further speeds up the sharded component tests.

## What
Adds two settings to the test Neo4j container (`start_neo4j_container`):
- `dbms.cypher.statistics_divergence_threshold = 1.0`
- `dbms.cypher.min_replan_interval = 1h`

## Why
Profiling the component suite showed the dominant per-test cost is Neo4j **query-plan compilation**, not execution (cached execution ~4ms; cold compile ~400ms). Each worker sees only ~300 distinct query shapes (under the 1000-entry plan cache, so **not** eviction), yet each is compiled ~3-4x — because per-test data churn trips statistics-divergence replanning.

Local A/B (full `graphql`, `-n4`):
- total compiles **4477 → 1790** (-60%)
- total compile time **2006s → 774s** (-61%)
- wall **796s → 494s** (~1.6x)

Compilation is CPU-bound, so the win should be larger on CI's smaller runners.

## Scope / safety
Test-only. Production must keep the defaults so plans adapt as data grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Neo4j query plans in the test container to stop statistics-divergence replanning, cutting plan compiles ~60% and speeding up sharded component tests. Configures `dbms.cypher.statistics_divergence_threshold=1.0` and `dbms.cypher.min_replan_interval=1h`; test-only (prod defaults unchanged).

<sup>Written for commit 6b63dfed7c475a879ca3e125afc3dc1b125e12e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

