### PR TITLE
Bump prefect-client to 3.7.4 in infrahub-testcontainers

### DIFF
--- a/changelog/+550ec66a.housekeeping.md
+++ b/changelog/+550ec66a.housekeeping.md
@@ -1,0 +1,1 @@
+Bump prefect-client to 3.7.4 in infrahub-testcontainers

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pytest",
     "httpx>=0.20",
     "pydantic>=2.10.6,<3",
-    "prefect-client==3.6.13",
+    "prefect-client==3.7.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

<!-- Problem statement: what's broken/slow/confusing/missing today? (1-3 sentences) -->

<!-- Goal: what outcome does this PR achieve? -->

<!-- Non-goals: what this PR intentionally does NOT do (prevents scope creep) -->

Started working on packaging `infrahub` for nix/NixOS - For that, some dependency bumping is needed, to align with the other versions of dependencies in nixpkgs
This bumps `prefect-client` in `infrahub-testcontainers`, to allow bumping `whenever` in `infrahub-sdk` and ultimately `infrahub` itself

## What changed

<!-- Group changes by intent, not by file. -->

<!-- Behavioral changes: what users/systems will observe differently -->
- Bumped `prefect-client` to v.3.7.4

<!-- Implementation notes: key design choices, tradeoffs, notable refactors -->

<!-- What stayed the same: especially useful if you touched sensitive areas -->
<!-- e.g., "No schema changes", "API contract unchanged", "Only affects branch X" -->

<!-- If the diff is large, add a suggested review order:
### Suggested review order
1. Start with ...
2. Then ...
3. Tests are ...
-->

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `prefect-client` to 3.7.4 in `infrahub-testcontainers` to align with `nixpkgs` and unblock Nix/NixOS packaging.

<sup>Written for commit 9b5b81dbee7f80fa81ec3ef18fcd95ae637e186c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

